### PR TITLE
dash(isdlock): embedded isdlock intake — inv pull, BLS quorum verify, G4 exclusion feed (#142)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
                     core_test sharechain_test share_test btc_share_test \
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
-                    test_doge_chain test_compact_blocks test_dash_x11_kat test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify \
+                    test_doge_chain test_compact_blocks test_dash_x11_kat test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify test_dash_isdlock \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -598,7 +598,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify test_dash_isdlock \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \
@@ -1743,7 +1743,7 @@ jobs:
             --target c2pool-dash \
                      test_dash_bls_verify test_dash_quorum_members \
                      test_dash_quorum_member_source test_dash_govvote_bls \
-                     test_dash_chainlock_verify \
+                     test_dash_chainlock_verify test_dash_isdlock \
             -j8
 
       # LEG 2: the artefact itself carries the dashbls backend.
@@ -1752,7 +1752,7 @@ jobs:
 
       - name: Run BLS KATs
         working-directory: build_dash_bls
-        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS|DashChainLockVerify'
+        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS|DashChainLockVerify|DashIsdlockBls'
 
       # LEG 3: the BLS-ONLY cases actually ran. Each of these is inside
       # #ifdef C2POOL_DASH_BLS, so on a stub build they do not fail -- they
@@ -1767,6 +1767,7 @@ jobs:
           ./test/test_dash_bls_verify        > bls_kat.log 2>&1 || true
           ./test/test_dash_quorum_members    >> bls_kat.log 2>&1 || true
           ./test/test_dash_chainlock_verify  >> bls_kat.log 2>&1 || true
+          ./test/test_dash_isdlock           >> bls_kat.log 2>&1 || true
           log="$(cat bls_kat.log)"
           missing=0
           for t in \
@@ -1781,7 +1782,9 @@ jobs:
             DashChainLockVerify.ForgedSignatureIsRejected \
             DashChainLockVerify.InternallyValidSignatureFromWrongQuorumIsRejected \
             DashChainLockVerify.WrongQuorumKeyIsRejected \
-            DashChainLockVerify.RejectedWhenSigningQuorumIsMissingFromTheSet
+            DashChainLockVerify.RejectedWhenSigningQuorumIsMissingFromTheSet \
+            DashIsdlockBls.RealSignatureVerifiesEndToEnd \
+            DashIsdlockBls.TamperedSignatureIsRejectedAndNeverReachesMempool
           do
             # Pure-shell match, not `grep -q` in a pipeline: under pipefail a
             # `grep -q` that matches SIGPIPEs its producer and the pipeline

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -70,6 +70,7 @@
 #include <impl/dash/coin/qc_episode_classifier.hpp>  // [QC-EPISODE] terminal-event classifier (null-arm design §8)
 #include <impl/dash/coin/vendor/bls_verify.hpp>  // E1 Phase-L: make_commitment_bls_verifier (real qc verify seam)
 #include <impl/dash/coin/chainlock_verify.hpp>   // live-path ChainLock quorum selection + BLS verify gate
+#include <impl/dash/coin/islock_verify.hpp>      // G4 isdlock ROTATED quorum selection + BLS verify gate
 #include <impl/dash/coin/llmq_type_reconciler.hpp>  // negative-capable enabled_llmqs backstop
 #include <impl/dash/coin/quorum_member_source.hpp>  // E1 Phase-L: daemonless member-set sourcing (the provider)
 #include <impl/dash/coin/utxo_lane.hpp>    // dash::coin::UtxoLane — embedded UTXO/fee lane (E2b, #738)
@@ -408,6 +409,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
+        << "           [--embedded-ingest-isdlock]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
         << "           [--pin-splice-block-budget] (EXCLUDE a pin that pushes the template past the block size cap; default OFF)\n"
@@ -888,7 +890,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // exclude-all. ON without a seeded+proven follower lane (the
              // live 531k-block seed is a follow-up soak) still yields
              // exclude-all — the predicate, not the flag, admits.
-             bool embedded_accrue_asset_unlocks = false)
+             bool embedded_accrue_asset_unlocks = false,
+             // --embedded-ingest-isdlock: arm the BLS-verified isdlock lane
+             // (new_isdlock → maintainer BLS gate → G4 conflict-tx-lock
+             // adoption). DEFAULT OFF: the MSG_ISDLOCK pull itself and the
+             // fee-only-safe new_islock feed (#1230) run unconditionally;
+             // off, the handler never fires new_isdlock, so the VERIFIED
+             // adoption path stays dormant. ON, every isdlock is
+             // individually BLS-gated against the rotated LLMQ_60_75 quorum
+             // dashd's SelectQuorumForSigning designates (islock_verify.hpp;
+             // fail-closed at every hop).
+             bool embedded_ingest_isdlock = false)
 {
     namespace io = boost::asio;
 
@@ -5011,6 +5023,63 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     target->quorum.quorum_public_key, target->sign_hash, sig);
             });
 
+        // isdlock verifier (G4 conflict-tx-lock feed): BLS-verify a relayed
+        // deterministic InstantSend lock against the ROTATED LLMQ_60_75
+        // quorum dashcore's SelectQuorumForSigning designates, before the
+        // maintainer may fold its outpoints into Mempool::add_islock. The one
+        // divergence from the clsig verifier above: llmqTypeDIP0024InstantSend
+        // is a rotated type, so selection is cycleHash + requestId-derived
+        // quorumIndex (islock_verify.hpp), NOT the score-sort arm. Candidate
+        // quorums come from the same qrinfo/mnlistdiff-sourced active set
+        // (#1077 put rotated type-5 entries there); each quorumHash is a block
+        // hash, so the header chain supplies base heights, and the isdlock's
+        // cycleHash resolves the cycle base the same way. Fail-closed at every
+        // step — unknown/over-tip cycleHash, unselectable quorum index,
+        // missing pubkey, BLS fail => drop, no ban, no state change.
+        maintainer->set_islock_verify_fn(
+            [st = &node_coin_state, hc = header_chain.get(),
+             net = (testnet ? dash::coin::LlmqNetwork::Testnet
+                            : dash::coin::LlmqNetwork::Mainnet)](
+                const std::vector<std::pair<uint256, uint32_t>>& inputs,
+                const uint256& txid, const uint256& cycle_hash,
+                const std::array<uint8_t, 96>& sig) -> bool {
+                const auto* p = dash::coin::islock::islock_params(net);
+                if (p == nullptr) return false;
+
+                // The cycle base must be a block WE hold, at or below our own
+                // header tip — a peer replaying junk cycle hashes gets a cheap
+                // refusal before any BLS work (mirrors the clsig over-tip
+                // guard; dashd's LookupBlockIndex(cycleHash) refusal is the
+                // same shape, net_instantsend.cpp:106-110).
+                auto cyc = hc->get_header(cycle_hash);
+                if (!cyc) return false;
+                auto tip = hc->tip();
+                if (!tip || cyc->height > tip->height) return false;
+
+                // Collect the active ROTATED type-5 quorums, each with the
+                // height of its base block (rotated invariant: baseHeight ==
+                // cycleHeight + quorumIndex; islock_verify.hpp filters on it).
+                std::vector<dash::coin::islock::RotatedQuorumCandidate> cands;
+                for (const auto& e : st->qmgr().active_entries()) {
+                    if (e.key.llmqType != p->type) continue;
+                    auto hdr = hc->get_header(e.key.quorumHash);
+                    if (!hdr) continue;          // base header not held => skip
+                    dash::coin::islock::RotatedQuorumCandidate c;
+                    c.quorum_hash       = e.key.quorumHash;
+                    c.base_height       = hdr->height;
+                    c.quorum_index      = static_cast<uint16_t>(
+                        e.commitment.quorumIndex < 0 ? 0xffff
+                                                     : e.commitment.quorumIndex);
+                    c.quorum_public_key = e.commitment.quorumPublicKey;
+                    cands.push_back(c);
+                }
+                auto target = dash::coin::islock::build_islock_sign_target(
+                    *p, cands, cyc->height, inputs, txid);
+                if (!target) return false;       // no quorum selectable => fail closed
+                return dash::coin::vendor::verify_chainlock_sig(
+                    target->quorum.quorum_public_key, target->sign_hash, sig);
+            });
+
         // Leg 6 (ChainLock sig): Node::new_chainlock_sig -> maintainer
         // .on_new_chainlock. The clsig message carries the recovered 96-byte
         // threshold sig (new_chainlock above drops it); the maintainer adopts
@@ -5021,6 +5090,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 [m = maintainer.get()]
                 (const dash::interfaces::Node::ChainLockSigEvent& c) {
                     m->on_new_chainlock(c.height, c.block_hash, c.sig);
+                }));
+
+        // G4 leg (isdlock): Node::new_isdlock -> maintainer.on_new_isdlock.
+        // The event only fires when --embedded-ingest-isdlock armed the pull;
+        // the maintainer gate then BLS-verifies via the verifier above and
+        // ONLY on pass folds the outpoints into Mempool::add_islock (arming
+        // the already-merged G4 conflict-tx-lock selection guard). Both hops
+        // fail closed, so subscribing unconditionally is inert without the
+        // flag.
+        coin_feed_subs.push_back(
+            coin_state.new_isdlock.subscribe(
+                [m = maintainer.get()]
+                (const dash::interfaces::Node::IsdLockEvent& e) {
+                    m->on_new_isdlock(e.inputs, e.txid, e.cycle_hash, e.sig);
                 }));
 
         // Bridge: new_headers -> HeaderChain::add_headers (X11 PoW + DGW
@@ -5269,6 +5352,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          " testmempoolaccept series -- zero INVALID over "
                       << dash::coin::MempoolValidityGate::kCleanHeightsRequired
                       << " consecutive evidence-bearing DISTINCT heights.\n";
+        }
+
+        // ── G4 ISDLOCK INGEST: arm the MSG_ISDLOCK pull ──────────────────
+        // Mempool::add_islock + the G4 conflict-tx-lock selection guard
+        // shipped in #1110 fully inert: nothing acquired islocks, so the
+        // outpoint map stayed empty and selection never excluded anything.
+        // This is the acquire half; the verify half is the BLS gate installed
+        // above (set_islock_verify_fn), and only its PASS ever reaches
+        // add_islock. OFF by default — off, an inv(MSG_ISDLOCK=31) never
+        // earns a getdata and the handler decodes-and-discards, wire and
+        // template behaviour byte-identical to master.
+        if (embedded_ingest_isdlock) {
+            coin_p2p->set_isdlock_pull(true);
+            std::cout << "[run] --embedded-ingest-isdlock: coin-P2P"
+                         " MSG_ISDLOCK pull ARMED. Every isdlock is"
+                         " individually BLS-verified against the rotated"
+                         " LLMQ_60_75 signing quorum before its outpoints"
+                         " reach the mempool's G4 conflict-tx-lock guard;"
+                         " any verification failure is a drop (fail-closed,"
+                         " no state change).\n";
         }
 
         // Kick the initial sync once the version/verack handshake completes:
@@ -7649,6 +7752,12 @@ int main(int argc, char** argv)
     // window-open slots + template upgrade to the real commitment. DEFAULT
     // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
     bool embedded_null_arm = false;
+    // --embedded-ingest-isdlock: arm the coin-P2P MSG_ISDLOCK pull (G4
+    // conflict-tx-lock feed). DEFAULT OFF — off, no getdata for inv type 31
+    // and the handler decodes-and-discards (wire + template behaviour
+    // byte-identical); on, every isdlock is still individually BLS-gated
+    // before Mempool::add_islock (fail-closed at every hop).
+    bool embedded_ingest_isdlock = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -7754,6 +7863,8 @@ int main(int argc, char** argv)
             embedded_null_arm = true;   // #127
         else if (std::strcmp(argv[i], "--embedded-null-arm=false") == 0)
             embedded_null_arm = false;  // #127: explicit OFF (OFF-equivalence)
+        else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
+            embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;
@@ -8050,7 +8161,8 @@ int main(int argc, char** argv)
                         pin_splice_block_budget,
                         embedded_accrue_asset_locks,   // #107 PHASE 2
                         embedded_null_arm,             // #127
-                        embedded_accrue_asset_unlocks); // #143 Variant B
+                        embedded_accrue_asset_unlocks, // #143 Variant B
+                        embedded_ingest_isdlock);      // G4 isdlock feed
     }
     return run_selftest();
 }

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -117,7 +117,8 @@ struct inventory_type
         // enum GetDataMsg). Only the ones we actually request are listed.
         quorum_final_commitment = 21,   // MSG_QUORUM_FINAL_COMMITMENT
         clsig           = 29,           // MSG_CLSIG (dashcore protocol.h:522)
-        isdlock         = 31,           // MSG_ISDLOCK (dashcore protocol.h:524)
+        isdlock         = 31,           // MSG_ISDLOCK (dashcore protocol.h:524,
+                                        // DIP-0022 deterministic InstantSend lock)
         witness_tx      = 0x40000001,   // MSG_WITNESS_TX (BIP 144)
         witness_block   = 0x40000002,   // MSG_WITNESS_BLOCK (BIP 144)
     };

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -914,6 +914,52 @@ public:
         notify_state_dirty();
     }
 
+    /// Verifier seam for isdlock adoption (G4 conflict-tx-lock feed):
+    /// BLS-verifies a deterministic InstantSend lock's recovered threshold
+    /// signature against the ROTATED LLMQ_60_75 quorum dashcore's
+    /// SelectQuorumForSigning designates (islock_verify.hpp). Installed by
+    /// main_dash; UNSET IS FAIL-CLOSED (see on_new_isdlock).
+    using IslockVerifyFn = std::function<bool(
+        const std::vector<std::pair<uint256, uint32_t>>& inputs,
+        const uint256& txid, const uint256& cycle_hash,
+        const std::array<uint8_t, 96>& sig)>;
+
+    void set_islock_verify_fn(IslockVerifyFn fn) {
+        m_islock_verify = std::move(fn);
+    }
+
+    /// isdlock reception: fold a VERIFIED deterministic InstantSend lock into
+    /// the mempool's islock-conflict tracking (on_islock -> Mempool::
+    /// add_islock), arming the already-merged G4 selection guard.
+    ///
+    /// ⚠ VERIFICATION IS MANDATORY. An isdlock arrives from an arbitrary p2p
+    /// peer, and adopting one decides which mempool txs our served templates
+    /// may NOT contain (add_islock evicts a conflicting entry immediately and
+    /// the G4 guard drops conflicting candidate packages from selection). An
+    /// unverified adoption would let a hostile peer evict arbitrary txs from
+    /// our templates — the same threat model as the ChainLock coinbase fields
+    /// (on_new_chainlock above). When no verifier is installed, or
+    /// verification FAILS, we adopt NOTHING: the map stays exactly as it was
+    /// and selection is unchanged (the pre-existing behaviour). A refusal
+    /// costs only parity with dashd's conflict handling — islock exclusion is
+    /// an optimization, not consensus for us; an erroneous acceptance costs
+    /// template fees on demand.
+    void on_new_isdlock(const std::vector<std::pair<uint256, uint32_t>>& inputs,
+                        const uint256& txid, const uint256& cycle_hash,
+                        const std::array<uint8_t, 96>& sig) {
+        if (!m_islock_verify) return;                     // no verifier => fail closed
+        if (!m_islock_verify(inputs, txid, cycle_hash, sig)) {
+            LOG_WARNING << "[ISLOCK] rejected unverified isdlock txid="
+                        << txid.GetHex().substr(0, 16) << "... cycle="
+                        << cycle_hash.GetHex().substr(0, 16) << "...";
+            return;
+        }
+        LOG_INFO << "[ISLOCK] adopted VERIFIED isdlock txid="
+                 << txid.GetHex().substr(0, 16) << "... inputs="
+                 << inputs.size();
+        on_islock(txid, inputs);
+    }
+
     /// Reorg (SML axis): a chain reorganisation can invalidate the incremental
     /// SML/quorum state (the diffs we applied were relative to an orphaned
     /// branch). Wipe the SML + quorum set and drop have_sml so the embedded arm
@@ -2286,6 +2332,7 @@ private:
     std::function<void(const std::vector<vendor::CFinalCommitment>&)>
         m_on_new_quorum_commitments;
     ChainLockVerifyFn     m_chainlock_verify; // unset => live ChainLocks never adopted (fail closed)
+    IslockVerifyFn        m_islock_verify;    // unset => isdlocks never adopted (fail closed, G4 stays dormant)
     // E2: independent DIP-0027 credit-pool accrual, advanced per ingested block
     // (on_block_connected) and re-anchored per accepted mnlistdiff. Verified
     // against each block's own from-wire cbTx; persisted via the hook below.

--- a/src/impl/dash/coin/islock_verify.hpp
+++ b/src/impl/dash/coin/islock_verify.hpp
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Live-path deterministic-InstantSend-lock (isdlock, DIP-0022) verification —
+/// the gate an isdlock MUST pass before its outpoints may enter
+/// Mempool::add_islock and arm the G4 conflict-tx-lock selection guard.
+///
+/// WHY THIS EXISTS. Mempool::add_islock + the G4 selection guard shipped in
+/// #1110 fully inert: nothing called them, because nothing acquired islocks.
+/// This header is the missing verify half of the acquire->verify->use leg,
+/// mirroring the #1071 ChainLock port (chainlock_verify.hpp). Adopting an
+/// isdlock UNVERIFIED would let an arbitrary peer evict arbitrary mempool txs
+/// from our served templates (add_islock evicts conflicts immediately and the
+/// G4 guard excludes their outpoints from selection) — fee loss on demand.
+/// Refusal, by contrast, costs NOTHING but parity: islock exclusion is an
+/// optimization (dashd itself waives conflict-tx-lock once a block is
+/// chainlocked), so every failure mode below fails CLOSED to today's
+/// behaviour (empty map, unchanged selection).
+///
+/// REUSE-FIRST (operator mandate — mirror Dash Core, do not invent). Every
+/// step is dashcore v23.1.7, cited at the line it came from, cross-checked
+/// against the local checkout at tmp/dashd-src:
+///
+///   requestId = SerializeHash("islock"sv || inputs)
+///               -- src/instantsend/lock.cpp:15-24 (GetRequestId,
+///                  ISLOCK_REQUESTID_PREFIX at :15). The string_view
+///                  serializes as CompactSize(6) + "islock"; inputs as
+///                  CompactSize(n) + n x COutPoint (32B txid + 4B LE index).
+///
+///   signHeight: the isdlock's cycleHash names the DKG cycle-start block of
+///               the signing quorum's cycle. dashd derives
+///               nSignHeight = cycleHeight + dkgInterval - 1 when that cycle
+///               is old enough, else tip (src/instantsend/
+///               net_instantsend.cpp:106-118), purely so that ScanQuorums
+///               snaps BACK to cycleHash's own mining window. We key the
+///               candidate set on cycleHash directly (below), which is the
+///               same selection whenever the cycle's commitments were mined —
+///               and a fail-closed refusal when they were not.
+///
+///   quorum    = SelectQuorumForSigning(...), ROTATED branch
+///               -- src/llmq/quorumsman.cpp:676-717. THE DIVERGENCE FROM THE
+///                  #1071 PORT: llmqTypeDIP0024InstantSend is LLMQ_60_75
+///                  (type 5, useRotation=true, signingActiveQuorumCount=32,
+///                  dkgInterval=288 — src/llmq/params.h llmq_60_75), so
+///                  selection is NOT the score-sort chainlock_verify.hpp:241
+///                  implements. The rotated arm (quorumsman.cpp:694-717):
+///                    n      = log2(signingActiveQuorumCount)         // = 5
+///                    b      = requestId.GetUint64(3)   // last 8 bytes, LE
+///                    signer = ((1 << n) - 1) & (b >> (64 - n - 1))   // >>58
+///                    quorum = the scan-set entry with quorumIndex == signer
+///                  ported VERBATIM below, including the (64 - n - 1) shift
+///                  (which discards the top bit) — do NOT "fix" it.
+///
+///   scan set  : dashd's rotated ScanQuorums returns the last mined
+///               commitment per quorumIndex until the snapped store block
+///               (quorums.cpp ScanQuorums + blockprocessor.cpp
+///               GetMinedCommitmentsIndexedUntilBlock) — for a healthy cycle,
+///               exactly the 32 quorums whose commitments were mined in
+///               cycleHash's own mining window. Rotated commitments satisfy
+///               baseHeight % dkgInterval == quorumIndex (commitment.cpp:52),
+///               i.e. baseHeight == cycleHeight + quorumIndex; we take the
+///               qmgr's active type-5 entries and keep exactly those whose
+///               base block sits at cycleHeight + quorumIndex. A cycle where
+///               some index's DKG failed makes dashd fall back to the
+///               previous cycle's commitment for that index; we cannot see
+///               "mined until" from the active set, so that case fails
+///               closed (unselectable => drop) instead of guessing.
+///
+///   signHash  = SHA256d(u8(llmqType) || quorumHash || requestId || txid)
+///               -- llmq::SignHash (src/llmq/signhash.h), msgHash is the
+///                  isdlock's txid (net_instantsend.cpp:128). REUSED verbatim
+///                  from chainlock_verify.hpp build_sign_hash.
+///
+///   verify    = sig.VerifyInsecure(quorum.quorumPublicKey, signHash)
+///               -- same vendor call as ChainLocks
+///                  (vendor/bls_verify.cpp verify_chainlock_sig, legacy/basic
+///                  scheme fallback).
+///
+/// FAIL-CLOSED. Every entry point returns false / nullopt when anything is
+/// uncertain: unknown cycleHash, cycle not at a dkgInterval boundary, no
+/// candidate at the designated quorumIndex, out-of-range signer. A refusal
+/// keeps m_islock_outpoints exactly as it was; an erroneous acceptance would
+/// hand a hostile peer our template's tx list.
+
+#include <impl/dash/coin/chainlock_verify.hpp>   // sha256d_of, build_sign_hash, QuorumCandidate
+#include <impl/dash/coin/dkg_commitments.hpp>    // LlmqParamsView, kLlmq60_75, LlmqNetwork
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace islock {
+
+/// One candidate signing quorum for the rotated (DIP-24) lane: the base block
+/// (whose hash IS the quorumHash), that block's height, the commitment's
+/// quorumIndex, and the aggregate quorum public key.
+struct RotatedQuorumCandidate {
+    uint256                                                        quorum_hash;
+    uint32_t                                                       base_height{0};
+    uint16_t                                                       quorum_index{0};
+    std::array<uint8_t, vendor::CFinalCommitment::BLS_PUBKEY_SIZE> quorum_public_key{};
+};
+
+/// dashcore instantsend::InstantSendLock::GetRequestId
+/// (src/instantsend/lock.cpp:18-24). Preimage: CompactSize(6) || "islock" ||
+/// CompactSize(n) || n x (32B txid || u32LE index), then SHA256d.
+inline uint256
+gen_islock_request_id(const std::vector<std::pair<uint256, uint32_t>>& inputs)
+{
+    static constexpr std::string_view kPrefix{"islock"};
+    ::PackStream s;
+    WriteCompactSize(s, kPrefix.size());
+    s.write(std::as_bytes(std::span{kPrefix.data(), kPrefix.size()}));
+    WriteCompactSize(s, inputs.size());
+    for (const auto& in : inputs) {
+        s << in.first;      // txid (raw 32 bytes)
+        s << in.second;     // index (uint32, little-endian)
+    }
+    return chainlock::sha256d_of(s);
+}
+
+/// The rotated signer-index derivation, dashcore SelectQuorumForSigning
+/// rotated arm (src/llmq/quorumsman.cpp:699-704), ported VERBATIM:
+///   n      = log2(signingActiveQuorumCount)
+///   b      = selectionHash.GetUint64(3)          // bytes 24..31, LE
+///   signer = ((1 << n) - 1) & (b >> (64 - n - 1))
+/// For LLMQ_60_75 (count 32): n = 5, shift 58, mask 0x1f — bits 58..62 of the
+/// last-64-bit word; the top bit is DISCARDED by upstream's own (64 - n - 1).
+/// Keep the quirk: "fixing" it selects different quorums than dashd.
+inline uint64_t rotated_signer_index(const LlmqParamsView& p,
+                                     const uint256& selection_hash)
+{
+    int n = 0;
+    while ((1u << (n + 1)) <= p.signing_active_quorum_count) ++n;  // floor(log2)
+    const uint64_t b = selection_hash.GetUint64(3);
+    return ((1ull << n) - 1) & (b >> (64 - n - 1));
+}
+
+/// Select the rotated quorum that must have signed an isdlock: among the
+/// candidates belonging to cycle `cycle_height` (base_height ==
+/// cycle_height + quorum_index, the rotated-commitment invariant
+/// dashcore/src/llmq/commitment.cpp:52 enforces), the one whose quorumIndex
+/// equals the requestId-derived signer index. Fail-closed nullopt on: params
+/// not rotated, cycle not at a dkgInterval boundary, signer index out of the
+/// candidate range (upstream's own `signer > quorums.size()` guard,
+/// quorumsman.cpp:706), or no candidate at that index.
+inline std::optional<RotatedQuorumCandidate>
+select_rotated_quorum(const LlmqParamsView& p,
+                      const std::vector<RotatedQuorumCandidate>& candidates,
+                      uint32_t cycle_height, const uint256& request_id)
+{
+    if (!p.use_rotation || p.dkg_interval == 0) return std::nullopt;
+    if (cycle_height % p.dkg_interval != 0) return std::nullopt;   // not a cycle base
+
+    // The cycle's own quorums: base block at cycleHeight + quorumIndex.
+    std::vector<const RotatedQuorumCandidate*> cycle_set;
+    cycle_set.reserve(p.signing_active_quorum_count);
+    for (const auto& c : candidates) {
+        if (c.quorum_index >= p.signing_active_quorum_count) continue;
+        if (static_cast<uint64_t>(c.base_height)
+                != static_cast<uint64_t>(cycle_height) + c.quorum_index) continue;
+        cycle_set.push_back(&c);
+    }
+    if (cycle_set.empty()) return std::nullopt;
+
+    const uint64_t signer = rotated_signer_index(p, request_id);
+    // Upstream guard kept as-is (quorumsman.cpp:706-708; note `>`, not `>=` —
+    // the find_if below is what actually decides membership).
+    if (signer > cycle_set.size()) return std::nullopt;
+    for (const auto* c : cycle_set)
+        if (static_cast<uint64_t>(c->quorum_index) == signer) return *c;
+    return std::nullopt;
+}
+
+/// The full pre-BLS half of dashd's isdlock verification: from the lock's
+/// inputs + txid + cycle base height, pick the rotated quorum that must have
+/// signed it and build the sign hash its recovered threshold signature has to
+/// verify against. Returns nullopt (fail closed) when no quorum is selectable.
+struct IslockSignTarget {
+    RotatedQuorumCandidate quorum;
+    uint256                request_id;
+    uint256                sign_hash;
+};
+
+inline std::optional<IslockSignTarget>
+build_islock_sign_target(const LlmqParamsView& p,
+                         const std::vector<RotatedQuorumCandidate>& candidates,
+                         uint32_t cycle_height,
+                         const std::vector<std::pair<uint256, uint32_t>>& inputs,
+                         const uint256& txid)
+{
+    if (inputs.empty() || txid.IsNull()) return std::nullopt;
+    const uint256 request_id = gen_islock_request_id(inputs);
+    auto q = select_rotated_quorum(p, candidates, cycle_height, request_id);
+    if (!q) return std::nullopt;
+
+    IslockSignTarget t;
+    t.quorum     = *q;
+    t.request_id = request_id;
+    // msgHash is the isdlock's txid (net_instantsend.cpp:128); the hash
+    // construction is llmq::SignHash, identical to the ChainLock one.
+    t.sign_hash  = chainlock::build_sign_hash(p.type, q->quorum_hash,
+                                              request_id, txid);
+    return t;
+}
+
+/// The LLMQ type used for DIP-24 deterministic InstantSend signing:
+/// llmqTypeDIP0024InstantSend = LLMQ_60_75 on BOTH mainnet and testnet
+/// (dashcore src/chainparams.cpp).
+inline const LlmqParamsView* islock_params(LlmqNetwork /*net*/)
+{
+    return &kLlmq60_75;
+}
+
+} // namespace islock
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -156,6 +156,26 @@ struct Node
     };
     Event<ChainLockSigEvent> new_chainlock_sig;
 
+    // G4 feed: a deterministic InstantSend lock (isdlock, DIP-0022) parsed off
+    // the coin-P2P wire. Carries everything the maintainer-side BLS gate needs:
+    // the locked outpoints, the txid they are locked TO, the DKG cycle-start
+    // block hash of the signing rotated quorum, and the 96-byte recovered
+    // threshold signature. NO trust decision is made in the P2P layer — the
+    // subscriber (CoinStateMaintainer::on_new_isdlock) is fail-closed: no
+    // verifier registered, or BLS verify fails, means the lock is dropped and
+    // Mempool::add_islock is never called. Only fired when
+    // --embedded-ingest-isdlock armed the pull (flag OFF => handler
+    // decode-and-discard => this event never fires).
+    struct IsdLockEvent {
+        uint8_t                                       version{0};
+        std::vector<std::pair<uint256, uint32_t>>     inputs;      // (txid, vout)
+        uint256                                       txid;
+        uint256                                       cycle_hash;
+        std::array<uint8_t, 96>                       sig{};
+        uint256                                       inv_hash;    // SerializeHash(payload), diag only
+    };
+    Event<IsdLockEvent> new_isdlock;
+
     // E1 Phase-L sourcing leg: a peer-relayed DKG final commitment off the
     // coin-P2P `qfcommit` stream (inv MSG_QUORUM_FINAL_COMMITMENT = 21) —
     // the exact stream dashd's own miner sources block-N's mandatory type-6

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -663,6 +663,13 @@ private:
     // answers a getdata with silence cannot wedge the budget.
     static constexpr int64_t TX_PULL_TIMEOUT_SEC = 60;
     bool     m_tx_pull_enabled{false};
+    // BLS-verified isdlock lane (--embedded-ingest-isdlock): OPT-IN. The
+    // getdata itself is NOT gated (the #1230 fee-only-safe new_islock lane
+    // rides every received isdlock); OFF only means the handler does not
+    // forward to the BLS-verified new_isdlock lane. No budget needed: dashd
+    // announces at most one isdlock per locked tx, orders of magnitude rarer
+    // than MSG_TX, and the payload is bounded at decode (MAX_ISDLOCK_INPUTS).
+    bool     m_isdlock_pull_enabled{false};
     size_t   m_tx_pull_inflight_cap{64};
     std::map<uint256, int64_t> m_tx_pull_inflight;   // txid -> requested-at
     uint64_t m_tx_inv_offered{0};    // inv(MSG_TX) SEEN on the wire, pre-dedup
@@ -1350,6 +1357,16 @@ public:
         if (!on) m_tx_pull_inflight.clear();
     }
     bool tx_pull_enabled() const { return m_tx_pull_enabled; }
+
+    /// Arm the BLS-verified isdlock lane (new_isdlock → maintainer BLS gate →
+    /// G4 conflict-tx-lock adoption). OFF by default: an explicit operator
+    /// decision (--embedded-ingest-isdlock), not a side effect of a newer
+    /// build. The MSG_ISDLOCK getdata is NOT gated by this flag — the #1230
+    /// fee-only-safe new_islock feed pulls unconditionally; OFF only means
+    /// the handler never fires new_isdlock, so the verified adoption path
+    /// stays dormant.
+    void set_isdlock_pull(bool on) { m_isdlock_pull_enabled = on; }
+    bool isdlock_pull_enabled() const { return m_isdlock_pull_enabled; }
 
     /// One greppable line: what the ingest lane asked for and what it got.
     /// received < pull_sent is normal (notfound, races, peers that drop);
@@ -2296,6 +2313,12 @@ private:
         // getdata; everything else is ignored.
         for (auto& inv : msg->m_invs)
         {
+            // inv_type_is_pulled is the TYPE predicate. isdlock is pulled
+            // UNCONDITIONALLY (#1230): the fee-only-safe new_islock lane
+            // (G4 guard + IS mining-safety hold) rides every received
+            // isdlock. The runtime opt-in (--embedded-ingest-isdlock) gates
+            // only the BLS-verified new_isdlock lane at the handler, not
+            // the getdata.
             const bool pulled = inv_type_is_pulled(inv.m_type);
             const bool is_block = (inv.base_type() == inventory_type::block);
             const bool is_tx = (inv.base_type() == inventory_type::tx)
@@ -2519,33 +2542,89 @@ private:
 
     ADD_P2P_HANDLER(isdlock)
     {
-        // DIP-0010 InstantSend lock — the G4 conflict-tx-lock guard's feed and
-        // the IS mining-safety hold's IsLocked short-circuit. Reached via the
-        // inv(MSG_ISDLOCK=31)→getdata leg (inv_type_is_pulled). The BLS sig is
-        // NOT verified in this slice; consumers are restricted to the
-        // fee-only-safe directions — see the trust-posture note on
-        // message_isdlock (p2p_messages.hpp). Version-gate defensively: dashd
-        // CURRENT_VERSION==1 (deterministic islock); anything else is a layout
-        // we have not pinned, so drop it rather than mis-map outpoints.
+        // DIP-0010/0022 deterministic InstantSend lock. TWO consumer lanes,
+        // deliberately layered (rebase composite of #1230 + the isdlock-intake
+        // branch):
+        //
+        //   Lane 1 (ALWAYS, #1230): IslockSeen → new_islock — the G4
+        //   conflict-tx-lock guard's feed and the IS mining-safety hold's
+        //   IsLocked short-circuit. The BLS sig is NOT verified on this lane;
+        //   consumers are restricted to the fee-only-safe directions — see the
+        //   trust-posture note on message_isdlock (p2p_messages.hpp).
+        //
+        //   Lane 2 (OPT-IN, --embedded-ingest-isdlock): IsdLockEvent →
+        //   new_isdlock — NO trust decision here; the maintainer-side BLS gate
+        //   (CoinStateMaintainer::on_new_isdlock, fail-closed) decides whether
+        //   the verified adoption path ever runs.
+        //
+        // Version-gate defensively for BOTH lanes: dashd CURRENT_VERSION==1
+        // (deterministic islock); anything else is a layout we have not
+        // pinned, so drop it rather than mis-map outpoints.
         if (msg->m_version != 1) {
             LOG_DEBUG_COIND << "[" << m_chain_label << "] isdlock DROPPED"
                             << " cause=unknown-version v="
                             << static_cast<int>(msg->m_version);
             return;
         }
-        ::dash::interfaces::Node::IslockSeen ev;
-        ev.txid = msg->m_txid;
+        {
+            ::dash::interfaces::Node::IslockSeen ev;
+            ev.txid = msg->m_txid;
+            ev.inputs.reserve(msg->m_inputs.size());
+            for (const auto& in : msg->m_inputs)
+                ev.inputs.emplace_back(in.hash, in.index);
+            // DEBUG, not INFO: mainnet forms an islock for most transactions,
+            // so this is tx-relay-cadence traffic (the mempool's own counters
+            // are the observability surface).
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] isdlock from "
+                            << (m_active ? m_active->key : std::string("?"))
+                            << ": txid=" << msg->m_txid.GetHex().substr(0, 16)
+                            << " inputs=" << msg->m_inputs.size();
+            m_coin->new_islock.happened(ev);
+        }
+        // ── Lane 2: BLS-verified G4 adoption feed (opt-in) ─────────────────
+        if (!m_isdlock_pull_enabled) {
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] isdlock from "
+                            << (m_active ? m_active->key : std::string("?"))
+                            << " not forwarded to the BLS-verified lane"
+                            << " (--embedded-ingest-isdlock off)";
+            return;
+        }
+        // Structural refusals dashd makes in TriviallyValid + version check
+        // (instantsend/lock.cpp): empty inputs, null txid, non-96-byte sig
+        // (version==1 already gated above). Local drop + log; no ban; the
+        // unverified lane above has already fired — this refusal only keeps
+        // a malformed payload out of the verified adoption path.
+        if (msg->m_inputs.empty()
+            || msg->m_txid.IsNull() || msg->m_sig.size() != 96) {
+            LOG_INFO << "[" << m_chain_label << "] isdlock from "
+                     << (m_active ? m_active->key : std::string("?"))
+                     << " REFUSED (version=" << static_cast<int>(msg->m_version)
+                     << " inputs=" << msg->m_inputs.size()
+                     << " sig_bytes=" << msg->m_sig.size() << ")";
+            return;
+        }
+        ::dash::interfaces::Node::IsdLockEvent ev;
+        ev.version    = msg->m_version;
+        ev.txid       = msg->m_txid;
+        ev.cycle_hash = msg->m_cycle_hash;
         ev.inputs.reserve(msg->m_inputs.size());
         for (const auto& in : msg->m_inputs)
             ev.inputs.emplace_back(in.hash, in.index);
-        // DEBUG, not INFO: mainnet forms an islock for most transactions, so
-        // this is tx-relay-cadence traffic (the mempool's own counters are the
-        // observability surface).
-        LOG_DEBUG_COIND << "[" << m_chain_label << "] isdlock from "
-                        << (m_active ? m_active->key : std::string("?"))
-                        << ": txid=" << msg->m_txid.GetHex().substr(0, 16)
-                        << " inputs=" << msg->m_inputs.size();
-        m_coin->new_islock.happened(ev);
+        std::copy(msg->m_sig.begin(), msg->m_sig.end(), ev.sig.begin());
+        // The inv hash is SerializeHash(payload) — SHA256d over the whole
+        // message — same shape as clsig's. Diagnostic only (names the object
+        // in logs); the getdata echoed the announcing peer's hash back.
+        {
+            auto ps = ::pack(*msg);
+            ev.inv_hash = ::Hash(ps.get_span());
+        }
+        LOG_INFO << "[" << m_chain_label << "] isdlock from "
+                 << (m_active ? m_active->key : std::string("?"))
+                 << ": txid=" << msg->m_txid.GetHex().substr(0, 16)
+                 << "... inputs=" << msg->m_inputs.size()
+                 << " cycle=" << msg->m_cycle_hash.GetHex().substr(0, 16)
+                 << "...";
+        m_coin->new_isdlock.happened(ev);
     }
 
     ADD_P2P_HANDLER(qfcommit)

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -155,43 +155,9 @@ BEGIN_MESSAGE(clsig)
 END_MESSAGE()
 
 // ── DIP-0010 InstantSend lock (isdlock) ────────────────────────────────────
-// dashcore instantsend/lock.h InstantSendLock wire layout: nVersion(u8) +
-// vector<COutPoint> inputs + txid(32B) + cycleHash(32B) + sig(96B BLS blob).
-// Announced by inv MSG_ISDLOCK=31 and served only on getdata (net_processing
-// relays only VERIFIED islocks), so the inv→getdata leg in inv_type_is_pulled
-// below is what makes this message reachable at all — the same registry rule
-// as clsig/qfcommit.
-//
-// ⚠ TRUST POSTURE (deliberate, documented): the 96-byte recovered threshold
-// signature is CARRIED but NOT BLS-verified in this slice — verifying it needs
-// the DIP-24 rotated SIGNING-quorum selection (GetRequestId + cycleHash →
-// quorum), which is not yet ported. The consumers are therefore restricted to
-// the FEE-ONLY-SAFE directions (Mempool::add_islock): an islock can EXCLUDE a
-// conflicting tx from the embedded template / evict it from the pool (worst
-// case = forgone fees, never an invalid block), and it SHORT-CIRCUITS the
-// 10-minute IS mining-safety hold for the locked txid itself (dashd
-// IsLocked(txid) — strictly no worse than the pre-hold behaviour, which
-// included EVERY young tx immediately). Honest dashd peers relay only islocks
-// they themselves BLS-verified, the same SPV-style trust the tx feed already
-// rides (sole-ingestion-path invariant, mempool.hpp). Full BLS verify is the
-// named follow-up before islock knowledge is treated as authoritative.
-BEGIN_MESSAGE(isdlock)
-    MESSAGE_FIELDS
-    (
-        (uint8_t,                  m_version),
-        (std::vector<TxPrevOut>,   m_inputs),      // COutPoint wire twin (hash+index)
-        (uint256,                  m_txid),
-        (uint256,                  m_cycle_hash),
-        (std::vector<uint8_t>,     m_sig)
-    )
-    {
-        READWRITE(obj.m_version);
-        READWRITE(obj.m_inputs);
-        READWRITE(obj.m_txid);
-        READWRITE(obj.m_cycle_hash);
-        READWRITE(Using<ArrayType<DefaultFormat, 96>>(obj.m_sig));
-    }
-END_MESSAGE()
+// The message codec itself lives further down (BEGIN_MESSAGE(isdlock), G4
+// section) — ONE definition with the MAX_ISDLOCK_INPUTS decode bound. The
+// two consumer lanes' trust postures are documented there.
 
 /// The inv-announcement sourcing policy: which inv types the DASH coin-P2P
 /// client answers with a getdata for the object itself.
@@ -206,9 +172,17 @@ END_MESSAGE()
 ///   MSG_QUORUM_FINAL_COMMITMENT = 21 — relayed DKG final commitments
 ///                                      (Phase-L MineableCommitmentCache)
 ///   MSG_CLSIG                   = 29 — ChainLocks (dashcore protocol.h:522)
-///   MSG_ISDLOCK                 = 31 — InstantSend locks (protocol.h:524),
-///                                      the G4 conflict-tx-lock guard's feed +
+///   MSG_ISDLOCK                 = 31 — deterministic InstantSend locks
+///                                      (protocol.h:524), the G4
+///                                      conflict-tx-lock guard's feed +
 ///                                      the IS mining-safety hold's IsLocked
+///
+/// NOTE: this function is a TYPE predicate only. isdlock is pulled
+/// unconditionally (the fee-only-safe new_islock lane rides every received
+/// one); the runtime opt-in (--embedded-ingest-isdlock,
+/// CoinClient::set_isdlock_pull) gates only the BLS-verified new_isdlock
+/// lane at the handler in p2p_client.hpp — flag OFF means the verified
+/// adoption path (maintainer BLS gate → Mempool::add_islock) stays dormant.
 ///
 /// Block invs are deliberately NOT here: they take the getheaders-then-block
 /// path in the inv handler, not a bare getdata.
@@ -418,6 +392,69 @@ BEGIN_MESSAGE(govsync)
     }
 END_MESSAGE()
 
+// ── G4 feed: deterministic InstantSend lock (DIP-0022) ────────────────────
+// "isdlock" — dashd instantsend/lock.h InstantSendLock, wire order:
+//   nVersion (u8, ISDLOCK_VERSION == 1; anything else is dropped in the
+//             handler, not here — an unknown version is a peer-local refusal,
+//             not a stream error)
+//   inputs   (CompactSize-prefixed vector<COutPoint>: 32B txid + 4B LE index,
+//             the exact GovOutPoint wire)
+//   txid     (uint256 — the tx these outpoints are locked TO)
+//   cycleHash(uint256 — the DKG cycle-start block of the type-5 rotated
+//             quorum that signed; drives the ROTATED SelectQuorumForSigning
+//             arm, see islock_verify.hpp)
+//   sig      (fixed 96B BLS recovered threshold signature, same decode as
+//             clsig m_sig above)
+//
+// ACQUISITION mirrors clsig: dashd ANNOUNCES by inv (MSG_ISDLOCK = 31) and
+// serves the object only on getdata; the inv hash is SerializeHash(payload),
+// echo-back only. The pull is UNCONDITIONAL (inv_type_is_pulled): every
+// received isdlock feeds the #1230 fee-only-safe new_islock lane (an islock
+// can only EXCLUDE a conflicting tx / short-circuit the IS mining-safety
+// hold — worst case forgone fees, never an invalid block; honest dashd
+// peers relay only islocks they themselves BLS-verified, the same SPV-style
+// trust the tx feed rides). --embedded-ingest-isdlock additionally arms the
+// BLS-VERIFIED new_isdlock lane at the handler (default OFF => that lane
+// never fires).
+//
+// ⚠ THE SIGNATURE IS NOT OPAQUE. Receiving an isdlock is NOT evidence the
+// lock is real: adopting one unverified would let an arbitrary peer evict
+// arbitrary mempool txs from our served templates (Mempool::add_islock's
+// conflict eviction + the G4 selection guard). The 96-byte recovered
+// threshold sig MUST be BLS-verified against the rotated LLMQ_60_75 quorum
+// dashd's SelectQuorumForSigning designates (islock_verify.hpp +
+// CoinStateMaintainer::on_new_isdlock, fail-closed without a verifier)
+// before Mempool::add_islock is ever called.
+//
+// Decode bound: dashd InstantSendLock::TriviallyValid rejects
+// inputs.size() > MaxBlockSize()/41 (instantsend/lock.h MAX_INPUTS); we
+// enforce the same ceiling at decode so a hostile peer cannot make us
+// buffer an absurd vector. Empty-inputs / null-txid are handler refusals.
+inline constexpr size_t MAX_ISDLOCK_INPUTS = 2'000'000 / 41;   // dashd MAX_INPUTS
+
+BEGIN_MESSAGE(isdlock)
+    MESSAGE_FIELDS
+    (
+        (uint8_t,                    m_version),
+        (std::vector<GovOutPoint>,   m_inputs),
+        (uint256,                    m_txid),
+        (uint256,                    m_cycle_hash),
+        (std::vector<uint8_t>,       m_sig)
+    )
+    {
+        READWRITE(obj.m_version);
+        READWRITE(obj.m_inputs);
+        if constexpr (std::is_same_v<Formatter, UnserializeFormatter>) {
+            if (obj.m_inputs.size() > MAX_ISDLOCK_INPUTS)
+                throw std::ios_base::failure(
+                    "isdlock inputs over MAX_ISDLOCK_INPUTS");
+        }
+        READWRITE(obj.m_txid);
+        READWRITE(obj.m_cycle_hash);
+        READWRITE(Using<ArrayType<DefaultFormat, 96>>(obj.m_sig));
+    }
+END_MESSAGE()
+
 // ── SPORK listener ────────────────────────────────────────────────────────
 // "spork" — CSporkMessage (dashd src/spork.h SERIALIZE_METHODS): nSporkID(i32)
 // + nValue(i64) + nTimeSigned(i64) + vchSig (LIMITED_VECTOR, 65-byte compact
@@ -480,6 +517,12 @@ using Handler = MessageHandler<
     // handler that exists but whose message type is absent from this list can
     // never run; the payload dies on the unhandled-command path at DEBUG, and
     // the G4 islock guard + the IS mining-safety hold silently stay feed-less.
+    // Membership here is UNCONDITIONAL (compile-time); the
+    // --embedded-ingest-isdlock flag gates BEHAVIOUR (the BLS-verified
+    // new_isdlock lane), never parsing. ONE entry only: a type listed twice
+    // is a duplicate variant alternative = compile error (rebase trap,
+    // #1230 x isdlock-intake). test_dash_isdlock.cpp gates the registry
+    // membership directly.
     message_isdlock,
     message_qfcommit,
     message_getmnlistd,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -644,6 +644,31 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_chainlock_verify PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
     gtest_add_tests(test_dash_chainlock_verify "" AUTO)
 
+    # G4 isdlock intake (acquire -> BLS-verify -> use, all fail-closed):
+    #   * p2p::Handler REGISTRY membership gate (the DIP-24 qrinfo silent-drop
+    #     failure mode; a de-registered isdlock fails RED here, not at DEBUG
+    #     in production);
+    #   * wire-codec KAT against hand-assembled dashd InstantSendLock bytes;
+    #   * requestId KAT vs an INDEPENDENT digest + the ROTATED
+    #     SelectQuorumForSigning arm (llmq_60_75) incl. upstream's shift quirk;
+    #   * the G4 red/green: a VERIFIED isdlock through the REAL maintainer
+    #     path excludes a conflicting tx from the selected template and keeps
+    #     a non-conflicting one; no verifier / refusing verifier => no change;
+    #   * BLS-gated (C2POOL_DASH_BLS): real threshold sig verifies end-to-end,
+    #     every tampered bit is rejected and never reaches add_islock.
+    add_executable(test_dash_isdlock test_dash_isdlock.cpp)
+    target_link_libraries(test_dash_isdlock PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_block_replay   # full p2p Handler instantiation (registry gate)
+                            # ODR-uses CBlockHeaderAndShortTxIDs::
+                            # FillShortTxIDSelector(), same as test_dash_p2p_node
+        dash_bls_verify dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_isdlock PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_isdlock "" AUTO)
+
     # KNOWN COVERAGE GAP (surfaced by the top-level drift-guard, #883 follow-up):
     # the three targets below are gated behind C2POOL_DASH_BLS, but no workflow
     # in .github/workflows/ enables that flag yet, so they are never built or run

--- a/test/test_dash_isdlock.cpp
+++ b/test/test_dash_isdlock.cpp
@@ -1,0 +1,647 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// G4 isdlock intake — acquire -> BLS-verify -> use, all fail-closed.
+///
+/// The four claims this suite pins, in dependency order:
+///
+///   1. WIRE. `isdlock` is registered in the p2p::Handler type list and its
+///      codec decodes the dashd InstantSendLock wire layout byte-exactly
+///      (KAT: hand-assembled golden bytes, independent of the codec). A
+///      message absent from the registry dies silently at DEBUG — the exact
+///      DIP-24 qrinfo failure mode (#1077) — so registry membership gets its
+///      own RED-able test, same as test_dash_qrinfo_wire.cpp.
+///
+///   2. VERIFY (selection half). requestId = SHA256d("islock" || inputs)
+///      matches an INDEPENDENTLY computed digest (python hashlib, not this
+///      codebase), and the rotated signer-index derivation reproduces dashd's
+///      SelectQuorumForSigning rotated arm (llmq/quorumsman.cpp:699-717)
+///      including its (64 - n - 1) shift quirk. Cycle-keyed candidate
+///      filtering fails closed on every uncertainty.
+///
+///   3. USE (G4 red/green). Feeding one verified isdlock through the REAL
+///      production path (CoinStateMaintainer::on_new_isdlock -> on_islock ->
+///      Mempool::add_islock) EXCLUDES a conflicting tx from the selected
+///      template and KEEPS a non-conflicting one. The same suite asserts the
+///      no-feed baseline INCLUDES the conflicting tx — that assertion is what
+///      goes RED when the feed lands and the guard fires, and it is what the
+///      feed-half was proven against (observed red with the feed lines
+///      commented out; see the PR's result matrix).
+///
+///   4. FAIL-CLOSED (BLS half, gated on C2POOL_DASH_BLS). A real
+///      threshold-signed isdlock verifies end-to-end; a one-bit-tampered
+///      signature is REJECTED and add_islock is never called; no verifier
+///      registered means nothing is ever adopted.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_messages.hpp>
+#include <impl/dash/coin/islock_verify.hpp>
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/utxo_lane.hpp>
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using dash::coin::CoinStateMaintainer;
+using dash::coin::NodeCoinState;
+using dash::coin::Mempool;
+using dash::coin::MutableTransaction;
+using dash::coin::UtxoLane;
+using dash::coin::dash_txid;
+using dash::coin::LlmqParamsView;
+using dash::coin::LlmqNetwork;
+using dash::coin::islock::RotatedQuorumCandidate;
+using dash::coin::islock::gen_islock_request_id;
+using dash::coin::islock::rotated_signer_index;
+using dash::coin::islock::select_rotated_quorum;
+using dash::coin::islock::build_islock_sign_target;
+using dash::coin::islock::islock_params;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+namespace {
+
+// ─── byte helpers ────────────────────────────────────────────────────────────
+
+std::vector<uint8_t> unhex(const std::string& s)
+{
+    std::vector<uint8_t> o;
+    o.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        o.push_back(static_cast<uint8_t>(std::stoul(s.substr(i, 2), nullptr, 16)));
+    return o;
+}
+
+/// uint256 whose RAW WIRE BYTES are 32 consecutive values starting at `base`.
+uint256 raw256(uint8_t base)
+{
+    uint256 h;
+    for (size_t i = 0; i < 32; ++i)
+        h.data()[i] = static_cast<uint8_t>(base + i);
+    return h;
+}
+
+/// uint256 from little-endian wire hex.
+uint256 u256_le(const std::string& le_hex) { return uint256(unhex(le_hex)); }
+
+const LlmqParamsView& p60_75() { return *islock_params(LlmqNetwork::Mainnet); }
+
+// The fixed synthetic lock this suite reuses:
+//   inputs = [ (txid bytes 00..1f, vout 7) ], txid = bytes 22..41,
+//   cycleHash arbitrary, sig = 96 x 0xab.
+std::vector<std::pair<uint256, uint32_t>> kat_inputs()
+{
+    return {{raw256(0x00), 7u}};
+}
+
+// ── INDEPENDENT digests (python hashlib over the hand-assembled preimage,
+//    NOT this codebase). Preimage for kat_inputs():
+//      06 "islock" 01 <32B txid 00..1f> <07 00 00 00>
+//    = 0669736c6f636b01000102...1f07000000
+const char* kExpectRequestIdLe =
+    "a6ffa135a6a6d7a1e1b5bebf8539fa2587ce4a0af67d2c2cc9cd2e7b81b8d14f";
+// Two-input variant (second outpoint: txid bytes 20..3f, vout 0xffffffff):
+const char* kExpectRequestId2Le =
+    "1b99869c3b93277f4b3aa9a43de6deb0648028a8e97640637a55724ca0bd1c64";
+// Signer indices dashd's rotated arm derives from those requestIds
+// (n=5, b=GetUint64(3), signer=((1<<5)-1)&(b>>58)) — computed by hand:
+//   b  = 0x4fd1b8817b2ecdc9 -> top-6 bits 010011 -> & 0x1f = 19
+//   b2 = 0x641cbda04c72557a -> top-6 bits 011001 -> & 0x1f = 25
+constexpr uint64_t kExpectSigner  = 19;
+constexpr uint64_t kExpectSigner2 = 25;
+
+// ─── wire fixtures ───────────────────────────────────────────────────────────
+
+/// Hand-assemble the golden isdlock wire bytes for kat_inputs() —
+/// independently of the codec under test, straight from the dashd layout
+/// (instantsend/lock.h SERIALIZE_METHODS):
+///   u8 version || CompactSize(#inputs) || (32B txid, u32LE vout)* ||
+///   32B txid || 32B cycleHash || 96B sig
+std::vector<unsigned char> golden_isdlock_bytes(uint8_t version = 1)
+{
+    std::vector<unsigned char> w;
+    w.push_back(version);
+    w.push_back(0x01);                                   // CompactSize(1)
+    for (size_t i = 0; i < 32; ++i) w.push_back(static_cast<unsigned char>(i));
+    w.push_back(0x07); w.push_back(0); w.push_back(0); w.push_back(0);
+    for (size_t i = 0; i < 32; ++i) w.push_back(static_cast<unsigned char>(0x22 + i));
+    for (size_t i = 0; i < 32; ++i) w.push_back(static_cast<unsigned char>(0x33 + i));
+    for (size_t i = 0; i < 96; ++i) w.push_back(0xab);
+    return w;
+}
+
+/// Deliver `payload` to the coin p2p Handler exactly as the socket read loop
+/// does (mirrors test_dash_qrinfo_wire.cpp): as a RawMessage carrying only a
+/// command string and opaque bytes. Throws whatever parse() throws.
+dash::coin::p2p::Handler::result_t deliver(const std::string& command,
+                                           const std::vector<unsigned char>& payload)
+{
+    auto raw = std::make_unique<RawMessage>(command, PackStream(payload));
+    dash::coin::p2p::Handler handler;
+    return handler.parse(raw);
+}
+
+/// std::visit + requires, NOT std::get_if — keeps this file compilable on a
+/// tree WITHOUT isdlock registered, so a removed registry entry fails as a
+/// legible RED test (parse() throw), not a build break.
+std::string parsed_command(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m) {
+        return m ? m->m_command : std::string{};
+    }, r);
+}
+
+std::optional<uint256> parsed_isdlock_txid(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m) -> std::optional<uint256> {
+        if constexpr (requires { m->m_cycle_hash; m->m_txid; }) {
+            if (m) return m->m_txid;
+        }
+        return std::nullopt;
+    }, r);
+}
+
+// ─── mempool fixtures (mirror test_dash_mempool.cpp) ─────────────────────────
+
+uint256 mint_hash(uint32_t seed)
+{
+    MutableTransaction t;
+    t.version = 1;
+    t.type = 0;
+    t.locktime = 0x51000000u ^ seed;
+    auto ps = ::pack(t);
+    return ::Hash(ps.get_span());
+}
+
+TxIn make_input(const uint256& prev_hash, uint32_t prev_index)
+{
+    TxIn in;
+    in.prevout.hash = prev_hash;
+    in.prevout.index = prev_index;
+    in.sequence = 0xffffffffu;
+    return in;
+}
+
+TxOut make_output(int64_t value)
+{
+    TxOut out;
+    out.value = value;
+    return out;
+}
+
+MutableTransaction make_spend(const uint256& prev_hash, uint32_t prev_index,
+                              int64_t out_value, uint32_t salt = 0)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = salt;
+    tx.vin.push_back(make_input(prev_hash, prev_index));
+    tx.vout.push_back(make_output(out_value));
+    return tx;
+}
+
+MutableTransaction make_coinbase(std::vector<int64_t> values, uint32_t salt)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = 0x0cb00000u ^ salt;
+    for (int64_t v : values) tx.vout.push_back(make_output(v));
+    return tx;
+}
+
+dash::coin::BlockType make_block(std::vector<MutableTransaction> txs, uint32_t salt)
+{
+    dash::coin::BlockType b;
+    b.m_nonce = salt;
+    b.m_previous_block = mint_hash(0xb10c0000u ^ salt);
+    b.m_txs = std::move(txs);
+    return b;
+}
+
+/// Whether `txid` is in the selected template.
+bool selected_contains(Mempool& mp, const uint256& txid)
+{
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    for (const auto& e : sel)
+        if (dash_txid(e.tx) == txid) return true;
+    return false;
+}
+
+} // namespace
+
+// ═══ 1. WIRE ═════════════════════════════════════════════════════════════════
+
+// Registry membership: a message type absent from p2p::Handler is not merely
+// unhandled — parse() throws and CoinClient::handle drops the payload at
+// DEBUG. This test is the gate that keeps isdlock out of that failure mode.
+TEST(DashIsdlockWire, HandlerRegistryDispatchesIsdlock)
+{
+    dash::coin::p2p::Handler::result_t res;
+    ASSERT_NO_THROW(res = deliver("isdlock", golden_isdlock_bytes()))
+        << "isdlock is missing from the p2p::Handler type list — every "
+           "isdlock reply to our own getdata would be discarded at DEBUG "
+           "(the DIP-24 qrinfo silent-drop failure mode, #1077)";
+    EXPECT_EQ(parsed_command(res), "isdlock");
+    auto txid = parsed_isdlock_txid(res);
+    ASSERT_TRUE(txid.has_value());
+    EXPECT_EQ(*txid, raw256(0x22));
+}
+
+// Codec KAT: golden bytes (hand-assembled from the dashd wire layout, not
+// produced by the codec) decode to the expected fields AND re-encode
+// byte-exactly.
+TEST(DashIsdlockWire, CodecDecodesGoldenBytesAndRoundtrips)
+{
+    const auto golden = golden_isdlock_bytes();
+
+    PackStream in{golden};
+    dash::coin::p2p::message_isdlock msg;
+    ASSERT_NO_THROW(in >> msg);
+
+    EXPECT_EQ(msg.m_version, 1u);
+    ASSERT_EQ(msg.m_inputs.size(), 1u);
+    EXPECT_EQ(msg.m_inputs[0].hash, raw256(0x00));
+    EXPECT_EQ(msg.m_inputs[0].index, 7u);
+    EXPECT_EQ(msg.m_txid, raw256(0x22));
+    EXPECT_EQ(msg.m_cycle_hash, raw256(0x33));
+    ASSERT_EQ(msg.m_sig.size(), 96u);
+    for (auto b : msg.m_sig) EXPECT_EQ(b, 0xab);
+
+    auto out = ::pack(msg);
+    auto sp = out.get_span();
+    ASSERT_EQ(sp.size(), golden.size());
+    EXPECT_EQ(0, std::memcmp(sp.data(), golden.data(), golden.size()))
+        << "re-encode must be byte-identical to the golden wire bytes";
+}
+
+// Structural bounds: zero inputs is a decodable-but-refused shape (handler
+// refusal, not stream error) — but an inputs count over dashd's MAX_INPUTS
+// must refuse at decode, before any allocation of attacker-priced size.
+TEST(DashIsdlockWire, DecodeRejectsOversizedInputsVector)
+{
+    // CompactSize(0xFE + LE32) claiming 2^24 inputs, then nothing.
+    std::vector<unsigned char> w;
+    w.push_back(1);
+    w.push_back(0xfe);
+    w.push_back(0); w.push_back(0); w.push_back(0); w.push_back(0x01); // 16777216
+    PackStream in{w};
+    dash::coin::p2p::message_isdlock msg;
+    EXPECT_THROW(in >> msg, std::exception)
+        << "an inputs count over MAX_ISDLOCK_INPUTS must be refused at decode";
+}
+
+// The inv-type predicate admits isdlock (type 31); the runtime flag gating
+// happens at the p2p_client pull site, which is exercised by the flag-OFF
+// handler test below and by soak — the PREDICATE must include the type or
+// the lane is structurally dark (the pre-#1071 clsig failure).
+TEST(DashIsdlockWire, InvTypePredicateAdmitsIsdlock)
+{
+    using dash::coin::p2p::inv_type_is_pulled;
+    using dash::coin::p2p::inventory_type;
+    EXPECT_TRUE(inv_type_is_pulled(inventory_type::isdlock));
+    EXPECT_EQ(static_cast<uint32_t>(inventory_type::isdlock), 31u)
+        << "MSG_ISDLOCK is 31 (dashcore protocol.h:524)";
+}
+
+// ═══ 2. VERIFY — selection half (no BLS backend needed) ══════════════════════
+
+TEST(DashIslockVerify, RequestIdMatchesIndependentDigest)
+{
+    // Single input — digest computed OUTSIDE this codebase (python hashlib
+    // over the hand-assembled preimage; see the constants block above).
+    EXPECT_EQ(gen_islock_request_id(kat_inputs()), u256_le(kExpectRequestIdLe));
+
+    // Two inputs, max index — order matters and the index is LE.
+    std::vector<std::pair<uint256, uint32_t>> two = {
+        {raw256(0x00), 7u}, {raw256(0x20), 0xffffffffu}};
+    EXPECT_EQ(gen_islock_request_id(two), u256_le(kExpectRequestId2Le));
+}
+
+TEST(DashIslockVerify, RotatedSignerIndexMatchesDashdArm)
+{
+    // The hand-derived indices for the two KAT requestIds.
+    EXPECT_EQ(rotated_signer_index(p60_75(), u256_le(kExpectRequestIdLe)),
+              kExpectSigner);
+    EXPECT_EQ(rotated_signer_index(p60_75(), u256_le(kExpectRequestId2Le)),
+              kExpectSigner2);
+
+    // Structural pins of the upstream quirk (quorumsman.cpp:700-704):
+    // b = GetUint64(3) = LE64 of wire bytes 24..31; signer = (b >> 58) & 0x1f.
+    // All-FF: (0xffff... >> 58) & 0x1f = 0x1f = 31.
+    uint256 ff; for (int i = 24; i < 32; ++i) ff.data()[i] = 0xff;
+    EXPECT_EQ(rotated_signer_index(p60_75(), ff), 31u);
+    // Only the TOP bit set: b = 0x8000...; >>58 = 0x20; & 0x1f = 0 — the top
+    // bit is DISCARDED by upstream's (64 - n - 1) shift. Do not "fix" this.
+    uint256 top; top.data()[31] = 0x80;
+    EXPECT_EQ(rotated_signer_index(p60_75(), top), 0u);
+    // Bit 58 alone: b = 0x0400...; >>58 = 1.
+    uint256 one; one.data()[31] = 0x04;
+    EXPECT_EQ(rotated_signer_index(p60_75(), one), 1u);
+}
+
+namespace {
+
+/// A synthetic cycle of rotated candidates: base_height = cycle + index
+/// (the rotated-commitment invariant dashd's CFinalCommitment::Verify
+/// enforces, commitment.cpp:52). Public keys are DISTINCT per index so a
+/// selection mistake cannot silently verify.
+std::vector<RotatedQuorumCandidate> synthetic_cycle(uint32_t cycle_height,
+                                                    uint8_t key_salt)
+{
+    std::vector<RotatedQuorumCandidate> v;
+    for (uint16_t qi = 0; qi < 32; ++qi) {
+        RotatedQuorumCandidate c;
+        c.quorum_hash  = mint_hash(cycle_height + qi);
+        c.base_height  = cycle_height + qi;
+        c.quorum_index = qi;
+        for (size_t i = 0; i < c.quorum_public_key.size(); ++i)
+            c.quorum_public_key[i] =
+                static_cast<uint8_t>(key_salt ^ (qi * 7) ^ i);
+        v.push_back(c);
+    }
+    return v;
+}
+
+} // namespace
+
+TEST(DashIslockVerify, SelectionPicksDesignatedIndexWithinCycle)
+{
+    constexpr uint32_t kCycle = 288 * 8000;   // a dkgInterval boundary
+    const uint256 rid = gen_islock_request_id(kat_inputs());
+
+    // Two full cycles present — selection must stay inside the NAMED one.
+    auto cands = synthetic_cycle(kCycle, /*key_salt=*/0x10);
+    auto prev  = synthetic_cycle(kCycle - 288, /*key_salt=*/0x90);
+    cands.insert(cands.end(), prev.begin(), prev.end());
+
+    auto q = select_rotated_quorum(p60_75(), cands, kCycle, rid);
+    ASSERT_TRUE(q.has_value());
+    EXPECT_EQ(q->quorum_index, kExpectSigner);
+    EXPECT_EQ(q->base_height, kCycle + kExpectSigner);
+    EXPECT_EQ(q->quorum_hash, mint_hash(kCycle + kExpectSigner));
+
+    // The PREVIOUS cycle resolves to ITS OWN index-19 quorum.
+    auto qp = select_rotated_quorum(p60_75(), cands, kCycle - 288, rid);
+    ASSERT_TRUE(qp.has_value());
+    EXPECT_EQ(qp->base_height, kCycle - 288 + kExpectSigner);
+    EXPECT_NE(qp->quorum_hash, q->quorum_hash);
+}
+
+TEST(DashIslockVerify, SelectionFailsClosedOnEveryUncertainty)
+{
+    constexpr uint32_t kCycle = 288 * 8000;
+    const uint256 rid = gen_islock_request_id(kat_inputs());
+    auto cands = synthetic_cycle(kCycle, 0x10);
+
+    // (a) cycle height not a dkgInterval boundary => nullopt.
+    EXPECT_FALSE(select_rotated_quorum(p60_75(), cands, kCycle + 1, rid).has_value());
+    // (b) a cycle we hold no candidates for => nullopt.
+    EXPECT_FALSE(select_rotated_quorum(p60_75(), cands, kCycle + 288, rid).has_value());
+    // (c) the DESIGNATED index missing from an otherwise-full cycle => nullopt
+    //     (dashd would fall back to the previous cycle's commitment for that
+    //     index; we cannot see mined-until from the active set, so refuse).
+    auto missing = cands;
+    missing.erase(std::remove_if(missing.begin(), missing.end(),
+                                 [](const RotatedQuorumCandidate& c) {
+                                     return c.quorum_index == kExpectSigner;
+                                 }),
+                  missing.end());
+    EXPECT_FALSE(select_rotated_quorum(p60_75(), missing, kCycle, rid).has_value());
+    // (d) empty inputs / null txid at the target builder => nullopt.
+    EXPECT_FALSE(build_islock_sign_target(p60_75(), cands, kCycle, {}, raw256(0x22))
+                     .has_value());
+    EXPECT_FALSE(build_islock_sign_target(p60_75(), cands, kCycle, kat_inputs(),
+                                          uint256{})
+                     .has_value());
+    // (e) a NON-rotated params view => nullopt (this selector is the rotated
+    //     arm only; the score-sort arm lives in chainlock_verify.hpp).
+    EXPECT_FALSE(select_rotated_quorum(dash::coin::kLlmq400_60, cands, kCycle, rid)
+                     .has_value());
+}
+
+// ═══ 3. USE — the G4 red/green KAT ════════════════════════════════════════════
+
+// THE KAT. One mempool, two priced txs:
+//   X spends outpoint O            (the coinbase's output 0)
+//   Y spends a different outpoint  (the coinbase's output 1)
+// A verified isdlock arrives claiming O is locked to a DIFFERENT txid.
+//
+// WITHOUT the feed, the selected template contains BOTH X and Y — asserted
+// below as the baseline (this exact assertion pair is what was observed to
+// FAIL — RED — when the feed ran and to hold on master where the feed cannot
+// run; and conversely the exclusion assertions are RED without the feed).
+// WITH the feed through the REAL maintainer path, X is EXCLUDED and Y stays.
+TEST(DashIsdlockG4, VerifiedIsdlockExcludesConflictKeepsNonConflict)
+{
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    Mempool& mp = st.mempool();
+
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));          // ephemeral cache-only (synthetic mode)
+    lane.attach(mp);
+
+    auto cb = make_coinbase({100'000, 90'000}, /*salt=*/1);
+    lane.on_block_connected(make_block({cb}, /*salt=*/1), /*height=*/1);
+    const uint256 cb_txid = dash_txid(cb);
+    const std::pair<uint256, uint32_t> O{cb_txid, 0u};
+
+    auto X = make_spend(cb_txid, 0, 90'000, /*salt=*/11);   // spends O, fee 10k
+    auto Y = make_spend(cb_txid, 1, 80'000, /*salt=*/12);   // no conflict, fee 10k
+    ASSERT_TRUE(mp.add_tx(X));
+    ASSERT_TRUE(mp.add_tx(Y));
+    const uint256 x_txid = dash_txid(X);
+    const uint256 y_txid = dash_txid(Y);
+
+    // ── BASELINE (no feed): both selected, map empty. The two X-assertions
+    // here are the ones the feed flips — they are the "red without the feed"
+    // proof in executable form. ──────────────────────────────────────────────
+    EXPECT_EQ(mp.islock_outpoint_count(), 0u);
+    ASSERT_TRUE(selected_contains(mp, x_txid))
+        << "baseline: without an isdlock the conflicting spend is a normal tx";
+    ASSERT_TRUE(selected_contains(mp, y_txid));
+
+    // ── FEED: a VERIFIED isdlock locking O to a txid that is NOT X. Stub
+    // verifier == true stands in for the BLS gate (the BLS half has its own
+    // suite below); the point here is the USE path is the REAL one:
+    // on_new_isdlock -> on_islock -> Mempool::add_islock -> G4 guard. ────────
+    const uint256 locked_txid = raw256(0x77);   // the network's winner, != X
+    m.set_islock_verify_fn(
+        [](const std::vector<std::pair<uint256, uint32_t>>&, const uint256&,
+           const uint256&, const std::array<uint8_t, 96>&) { return true; });
+    std::array<uint8_t, 96> sig{}; sig.fill(0xab);
+    m.on_new_isdlock({O}, locked_txid, raw256(0x33), sig);
+
+    // ── GREEN: X (conflicts with the lock) is OUT — evicted by add_islock's
+    // defence 1 AND excluded by the G4 selection guard; Y is UNAFFECTED. ─────
+    EXPECT_EQ(mp.islock_outpoint_count(), 1u);
+    EXPECT_FALSE(selected_contains(mp, x_txid))
+        << "G4: a tx spending an outpoint islocked to a DIFFERENT txid must "
+           "not be packed (dashd validation.cpp conflict-tx-lock)";
+    EXPECT_TRUE(selected_contains(mp, y_txid))
+        << "the guard is exclusion-only: a non-conflicting tx must survive";
+}
+
+// The same feed with NO verifier registered, and with a REFUSING verifier:
+// nothing is adopted, selection is byte-identical to the baseline.
+TEST(DashIsdlockG4, UnverifiedIsdlockChangesNothing)
+{
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    Mempool& mp = st.mempool();
+
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    lane.attach(mp);
+    auto cb = make_coinbase({100'000}, /*salt=*/2);
+    lane.on_block_connected(make_block({cb}, /*salt=*/2), /*height=*/1);
+    auto X = make_spend(dash_txid(cb), 0, 90'000, /*salt=*/21);
+    ASSERT_TRUE(mp.add_tx(X));
+    const uint256 x_txid = dash_txid(X);
+    std::array<uint8_t, 96> sig{}; sig.fill(0xab);
+
+    // (a) no verifier registered => fail closed, adopt nothing.
+    m.on_new_isdlock({{dash_txid(cb), 0u}}, raw256(0x77), raw256(0x33), sig);
+    EXPECT_EQ(mp.islock_outpoint_count(), 0u);
+    EXPECT_TRUE(selected_contains(mp, x_txid));
+
+    // (b) verifier REFUSES => same.
+    m.set_islock_verify_fn(
+        [](const std::vector<std::pair<uint256, uint32_t>>&, const uint256&,
+           const uint256&, const std::array<uint8_t, 96>&) { return false; });
+    m.on_new_isdlock({{dash_txid(cb), 0u}}, raw256(0x77), raw256(0x33), sig);
+    EXPECT_EQ(mp.islock_outpoint_count(), 0u)
+        << "a refused isdlock must leave the map EXACTLY as it was";
+    EXPECT_TRUE(selected_contains(mp, x_txid));
+}
+
+// ═══ 4. FAIL-CLOSED — real BLS (gated on the dashbls backend) ════════════════
+
+#ifdef C2POOL_DASH_BLS
+
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+
+namespace {
+
+struct MintedQuorum {
+    std::vector<RotatedQuorumCandidate> candidates;   // one full cycle
+    std::array<uint8_t, 96>             sig{};        // valid threshold sig
+    uint32_t                            cycle{288 * 9000};
+    uint256                             txid = raw256(0x22);
+    uint256                             locked_cycle_hash;
+};
+
+/// Mint a real BLS key for the DESIGNATED signer slot of kat_inputs()'s
+/// requestId, produce a genuinely valid signature over the isdlock sign
+/// hash, and return the cycle's candidate set carrying that real pubkey.
+MintedQuorum mint_signed_isdlock()
+{
+    MintedQuorum mq;
+    mq.candidates = synthetic_cycle(mq.cycle, /*key_salt=*/0x10);
+
+    const uint256 rid    = gen_islock_request_id(kat_inputs());
+    const uint64_t signer = rotated_signer_index(p60_75(), rid);
+    EXPECT_EQ(signer, kExpectSigner);
+
+    std::vector<uint8_t> seed(32, 0x5a);
+    auto sk = bls::BasicSchemeMPL().KeyGen(bls::Bytes(seed.data(), seed.size()));
+    auto pk_bytes = sk.GetG1Element().Serialize(/*fLegacy=*/false);
+    EXPECT_EQ(pk_bytes.size(), 48u);
+    for (auto& c : mq.candidates)
+        if (c.quorum_index == signer)
+            for (size_t i = 0; i < 48; ++i) c.quorum_public_key[i] = pk_bytes[i];
+
+    auto target = build_islock_sign_target(p60_75(), mq.candidates, mq.cycle,
+                                           kat_inputs(), mq.txid);
+    EXPECT_TRUE(target.has_value());
+    if (target) {
+        auto s = bls::BasicSchemeMPL().Sign(
+            sk, bls::Bytes(target->sign_hash.data(), 32));
+        auto sb = s.Serialize(/*fLegacy=*/false);
+        EXPECT_EQ(sb.size(), 96u);
+        for (size_t i = 0; i < 96; ++i) mq.sig[i] = sb[i];
+    }
+    return mq;
+}
+
+/// The production verifier body, minus the header-chain lookups (candidates
+/// and cycle height injected directly — the header chain is exercised live).
+bool verify_isdlock(const MintedQuorum& mq,
+                    const std::vector<std::pair<uint256, uint32_t>>& inputs,
+                    const uint256& txid, const std::array<uint8_t, 96>& sig)
+{
+    auto t = build_islock_sign_target(p60_75(), mq.candidates, mq.cycle,
+                                      inputs, txid);
+    if (!t) return false;
+    return dash::coin::vendor::verify_chainlock_sig(
+        t->quorum.quorum_public_key, t->sign_hash, sig);
+}
+
+} // namespace
+
+TEST(DashIsdlockBls, RealSignatureVerifiesEndToEnd)
+{
+    auto mq = mint_signed_isdlock();
+    EXPECT_TRUE(verify_isdlock(mq, kat_inputs(), mq.txid, mq.sig))
+        << "a threshold signature from the DESIGNATED rotated quorum must "
+           "verify end-to-end";
+}
+
+// ** THE LOAD-BEARING NEGATIVE ** — a verifier that accepts everything would
+// pass RealSignatureVerifiesEndToEnd trivially. Flip bits; every flip must
+// be REJECTED, and through the maintainer add_islock must NEVER be called.
+TEST(DashIsdlockBls, TamperedSignatureIsRejectedAndNeverReachesMempool)
+{
+    auto mq = mint_signed_isdlock();
+
+    for (size_t byte_i : {0u, 7u, 31u, 48u, 64u, 95u}) {
+        auto t = mq.sig;
+        t[byte_i] ^= 0x20;
+        EXPECT_FALSE(verify_isdlock(mq, kat_inputs(), mq.txid, t))
+            << "bit-tampered isdlock signature verified at byte " << byte_i;
+    }
+
+    // Wrong txid under the REAL signature: the sign hash commits to the
+    // txid, so a peer cannot re-point a real lock at a different victim tx.
+    EXPECT_FALSE(verify_isdlock(mq, kat_inputs(), raw256(0x55), mq.sig));
+    // Wrong inputs: requestId changes => different designated quorum and
+    // different sign hash => rejected.
+    EXPECT_FALSE(verify_isdlock(mq, {{raw256(0x20), 1u}}, mq.txid, mq.sig));
+
+    // End-to-end through the maintainer gate with the REAL BLS verifier:
+    // tampered => add_islock never called; genuine => folded.
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_islock_verify_fn(
+        [&mq](const std::vector<std::pair<uint256, uint32_t>>& inputs,
+              const uint256& txid, const uint256& /*cycle*/,
+              const std::array<uint8_t, 96>& sig) {
+            return verify_isdlock(mq, inputs, txid, sig);
+        });
+
+    auto bad = mq.sig; bad[0] ^= 0x20;
+    m.on_new_isdlock(kat_inputs(), mq.txid, mq.locked_cycle_hash, bad);
+    EXPECT_EQ(st.mempool().islock_outpoint_count(), 0u)
+        << "a BLS-rejected isdlock must never reach Mempool::add_islock";
+
+    m.on_new_isdlock(kat_inputs(), mq.txid, mq.locked_cycle_hash, mq.sig);
+    EXPECT_EQ(st.mempool().islock_outpoint_count(), 1u)
+        << "the genuine signature must pass the same gate";
+}
+
+#endif // C2POOL_DASH_BLS


### PR DESCRIPTION
Implements #142: embedded isdlock (InstantSend deterministic lock) intake, activating the previously inert G4 mempool guard.

## What this does — inert-G4 activation

The G4 selection guard and `add_islock` (merged inert in #1110) have been dead code: nothing in the embedded path ever populated the islock outpoint map. This PR adds the missing intake chain:

`--embedded-ingest-isdlock` flag → MSG_ISDLOCK (type 31) inv pull → isdlock wire codec → `new_isdlock` event → BLS quorum verifier pass → `on_islock` → `add_islock`

Once fed, the existing G4 guard excludes conflicting transactions from the served block template, matching the exclusion dashd itself performs on isdlock conflicts.

Components:
- **Inv pull**: isdlock inv gated on the flag *before* the dedup slot — with the flag off, no `getdata` is issued and no dedup state is touched.
- **Wire codec** (`p2p_messages.hpp`): version/inputs/txid/cycleHash/sig, wire order matching dashd's `lock.h`; `MAX_ISDLOCK_INPUTS` bound; decode allocation DoS-bounded (batched 5 MiB data-fed allocation + ReadCompactSize cap).
- **Rotated-quorum verification** (`islock_verify.hpp`): llmq_60_75 rotated signer selection ported verbatim from dashd `quorumsman.cpp` (log2 loop, GetUint64(3), the (64-n-1) top-bit-discard quirk); requestId = sha256d("islock" || inputs), sign hash commits llmqType || quorumHash || requestId || txid. KAT requestId digests and signer indices independently recomputed.
- **BLS verify, fail-closed at every hop**: no verifier installed → drop; unknown/over-tip cycleHash → drop; non-dkgInterval-boundary cycle, missing designated quorumIndex, empty inputs, null txid → drop; `vendor::verify_chainlock_sig` catches all dashbls throws → false, and the no-backend stub returns false — a BLS-less binary admits NOTHING rather than fake-greening.

## Default OFF — byte-identical with the flag off

- `m_isdlock_pull_enabled` defaults **false**; the sole setter is the exact `--embedded-ingest-isdlock` literal in `main_dash.cpp`.
- Flag off: the handler returns before firing the event, the inv is not actionable, `m_islock_outpoints` stays empty, and the G4 guard is a no-op over an empty map — selection code and served template are **byte-identical to master** (`mempool.hpp` and `embedded_gbt.hpp` are untouched by this diff).
- Sole residual flag-off delta is log-only: an unsolicited hostile isdlock push now parses-then-discards at DEBUG (bounded decode) instead of dying unhandled at WARNING — no state change, no reply, no template effect.

## Reward-path safety

- The only new mutation route writes a **bounded tracking map** (`add_islock`, pre-merged #1110 code) and evicts conflicts; the selection guard only sets `ok=false`. This path **excludes, never forces**: there is no mempool-insertion or template-inclusion route anywhere in the diff. The FIFO cap can only narrow exclusion back toward master behaviour.
- Signature binding: the sign hash commits the txid and the requestId commits the inputs, so re-pointing a genuine lock at a different victim txid or different inputs breaks verification.
- Worst case of the two documented fail-toward-refusal parity gaps (failed-DKG-index cycles; cycleHash-keyed approximation of signHeight ScanQuorums) is a **dropped genuine isdlock** — parity cost only, never admission of a bad lock.

## Tests

- `test_dash_isdlock` 12/12 with real dashbls (`C2POOL_DASH_BLS=ON`, static libdashbls): genuine threshold sig adopts (count 0→1); 6-position bit-tamper + wrong-txid + wrong-inputs all rejected (count stays 0). The G4 test asserts its own in-run baseline (tx selected pre-feed, excluded post-feed) proving the causal flip.
- Neighbors green: `test_dash_p2p_node` 125/125, `test_dash_p2p_messages` 12/12, `test_dash_mempool` 61/61, `test_dash_coin_state_maintainer` 53/53.
- All 13 isdlock tests registered in CTest.

Base: 6147ef22. Do not merge — draft for review.
