### PR TITLE
dash(creditpool): Variant B — gap-free creditpool-index follower for daemonless Type-9 (#140)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -406,7 +406,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
-        << "           [--embedded-accrue-asset-locks]\n"
+        << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
         << "           [--pin-splice-block-budget] (EXCLUDE a pin that pushes the template past the block size cap; default OFF)\n"
@@ -874,7 +874,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // to master. Freshness unproven => no null => dashd fallback
              // (worst case = today's benign gap, never a reject). Only has
              // effect when the embedded arm is already enabled.
-             bool embedded_null_arm = false)
+             bool embedded_null_arm = false,
+             // --embedded-accrue-asset-unlocks (#143 Variant B): DEFAULT OFF.
+             // Admit BLS-verified type-9 asset-unlock txs into the embedded
+             // template ONLY under the CreditPool INDEX follower's full
+             // fail-closed predicate (credit_pool_idx.hpp: proven-complete
+             // gap-free index since the v20 floor, fresh at the template's
+             // exact parent, per-candidate quorumSig/limit/window/dedup).
+             // OFF => the AssetUnlockAdmission* seam at the single
+             // build_embedded_workdata call site is literally nullptr and
+             // every served template is byte-identical to today's
+             // exclude-all. ON without a seeded+proven follower lane (the
+             // live 531k-block seed is a follow-up soak) still yields
+             // exclude-all — the predicate, not the flag, admits.
+             bool embedded_accrue_asset_unlocks = false)
 {
     namespace io = boost::asio;
 
@@ -2138,6 +2151,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         "accrues pending type-8 locks; VALID block needs those "
                         "txs in the served body -- #125/tx-serving)"
                       : "OFF (default: creditPool = seed + platform reward only)")
+              << "\n";
+    // #143 Variant B (--embedded-accrue-asset-unlocks): DEFAULT OFF. The
+    // template-side seam (build_embedded_workdata admitted_asset_unlocks)
+    // stays nullptr unless the CreditPool INDEX follower reports
+    // accrual_permitted() — which additionally requires a completed, proven
+    // gap-free seed from the v20 floor (a follow-up soak arms that lane).
+    // Until then the flag documents intent and the posture below names the
+    // state; the served template is exclude-all either way.
+    std::cout << "[run] embedded #143 asset-UNLOCK (type-9) accrual: "
+              << (embedded_accrue_asset_unlocks
+                      ? "ARMED (--embedded-accrue-asset-unlocks: admission "
+                        "still gated on the CreditPool INDEX follower's "
+                        "fail-closed predicate — proven-complete seed + real "
+                        "BLS + fresh-at-parent; NO follower lane is seeded in "
+                        "this build, so templates remain exclude-all)"
+                      : "OFF (default: templates exclude ALL type-9 — "
+                        "today's proven-valid behavior)")
               << "\n";
     std::cout << "[run] embedded mempool-tx serving: "
               << (embedded_serve_mempool_txs
@@ -7514,6 +7544,7 @@ int main(int argc, char** argv)
     // testmempoolaccept over its sustained window.
     bool embedded_serve_mempool_txs = false;
     bool embedded_accrue_asset_locks = false;  // #107 PHASE 2, default OFF
+    bool embedded_accrue_asset_unlocks = false;  // #143 Variant B (type-9), default OFF
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
     // pool AT THE SERVE TIP rather than at the folded body height (PR-5,
     // dashd GetCreditPool(pindexPrev) parity). MONEY PATH -> default OFF: it
@@ -7633,6 +7664,8 @@ int main(int argc, char** argv)
             embedded_serve_mempool_txs = true;
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks") == 0)
             embedded_accrue_asset_locks = true;   // #107 PHASE 2
+        else if (std::strcmp(argv[i], "--embedded-accrue-asset-unlocks") == 0)
+            embedded_accrue_asset_unlocks = true; // #143 Variant B (type-9)
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
         else if (std::strcmp(argv[i], "--embedded-null-arm") == 0)
@@ -7934,7 +7967,8 @@ int main(int argc, char** argv)
                         pin_splice_xcheck_arm,
                         pin_splice_block_budget,
                         embedded_accrue_asset_locks,   // #107 PHASE 2
-                        embedded_null_arm);            // #127
+                        embedded_null_arm,             // #127
+                        embedded_accrue_asset_unlocks); // #143 Variant B
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/asset_unlock_admission.hpp
+++ b/src/impl/dash/coin/asset_unlock_admission.hpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Variant B (#143 / task wtrv69elc) — the LIGHT bridge struct between the
+/// CreditPool INDEX follower (credit_pool_idx.hpp, the producer) and the
+/// embedded template builder (embedded_gbt.hpp, the consumer).
+///
+/// DELIBERATELY minimal includes: embedded_gbt.hpp must be able to accept an
+/// admission WITHOUT pulling the follower, the BLS verify declarations or the
+/// LevelDB persistence into every target that links the template builder. The
+/// struct is pure data; every verification already happened on the producer
+/// side (fail-closed predicate + per-candidate ARM-3 checks), and a nullptr /
+/// empty admission at the single template-side call site means EXCLUDE-ALL —
+/// today's proven-valid behavior, byte-identical.
+
+#include <impl/dash/coin/transaction.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// The verified type-9 (asset-unlock) set a template at height H may carry.
+/// Produced ONLY by CreditPoolIdxFollower::try_admit_unlocks under the full
+/// fail-closed predicate (--embedded-accrue-asset-unlocks ON + real BLS +
+/// proven-complete + fresh-at-parent + per-candidate checks). Consumed by
+/// build_embedded_workdata via a SAFE-ADDITIVE trailing parameter.
+struct AssetUnlockAdmission {
+    /// The admitted unlock txs, in admission order. Ordinary template
+    /// content — NOT reward logic (reward_path_note): they ride the tx list
+    /// like any selected tx.
+    std::vector<MutableTransaction> txs;
+
+    /// Σ (payload.fee + Σ vout.value) over `txs` — the GROSS amount that
+    /// leaves the credit pool (dashd GetDataFromUnlockTx, creditpool.cpp:33-49).
+    /// The committed CbTx creditPoolBalance must be reduced by exactly this.
+    int64_t gross_unlocked{0};
+
+    /// Σ payload.fee over `txs` — the miner-fee term (dashd GetAssetUnlockFee,
+    /// assetlocktx.cpp:200-212). Added to the template's total_fees so
+    /// block_value stays exact; the coinbase-split FORMULA is untouched.
+    int64_t total_payload_fees{0};
+
+    bool empty() const { return txs.empty(); }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/asset_unlock_verify.hpp
+++ b/src/impl/dash/coin/asset_unlock_verify.hpp
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Variant B ARM-3 — the type-9 (asset-unlock) quorum-signature verify port:
+/// dashd CAssetUnlockPayload::VerifySig + the CheckAssetUnlockTx msgHash
+/// derivation, cited line-by-line from dashd-src @ this pin:
+///
+///   requestId = ::SerializeHash(std::make_pair("plwdtx", index))
+///               -- evo/assetlocktx.cpp:112 (ASSETUNLOCK_REQUESTID_PREFIX)
+///                  + :147. A std::pair serializes first-then-second; the
+///                  std::string as CompactSize(6) + bytes, the uint64 LE —
+///                  preimage is exactly 0x06 "plwdtx" u64LE(index), 15 bytes,
+///                  then SHA256d (::SerializeHash, src/hash.h).
+///
+///   msgHash   = GetHash() of the tx re-serialized with quorumSig = CBLSSignature{}
+///               -- evo/assetlocktx.cpp:190-195 (CheckAssetUnlockTx): "Copy
+///                  transaction except `quorumSig` field to calculate hash".
+///                  An invalid/default CBLSSignature serializes as 96 zero
+///                  bytes, so the copy carries a zeroed 96-byte sig field.
+///
+///   quorum activity window
+///               -- evo/assetlocktx.cpp:125-132: scan the newest
+///                  (signingActiveQuorumCount + 1) quorums of llmqTypePlatform
+///                  ("all active + 1 the latest inactive"); the payload's
+///                  quorumHash must be one of them, else
+///                  bad-assetunlock-too-old-quorum.
+///
+///   height/expiry window
+///               -- evo/assetlocktx.cpp:134-139: reject when
+///                  tip < requestedHeight or tip >= requestedHeight +
+///                  HEIGHT_DIFF_EXPIRING (48, assetlocktx.h:150) —
+///                  bad-assetunlock-too-late. For a template at height H the
+///                  tip is H-1 (pindexPrev).
+///
+///   signHash  = SHA256d(u8(llmqType) || quorumHash || requestId || msgHash)
+///               -- llmq::SignHash, REUSED from chainlock_verify.hpp
+///                  build_sign_hash (byte-identical construction, already
+///                  KAT-locked against a real mainnet ChainLock).
+///
+///   verify    = quorumSig.VerifyInsecure(quorum->qc->quorumPublicKey, signHash)
+///               -- evo/assetlocktx.cpp:149-152. REUSED via
+///                  vendor::verify_chainlock_sig (bls_verify.cpp): the exact
+///                  same VerifyInsecure contract — 48-byte G1 pubkey, 96-byte
+///                  G2 recovered threshold sig, BASIC scheme, the 32 sign-hash
+///                  bytes are the MESSAGE (no pre-hash). Fail-closed stub
+///                  without C2POOL_DASH_BLS: verification is structurally
+///                  impossible, so accrual is structurally OFF (predicate
+///                  conjunct b).
+///
+///   llmqTypePlatform: mainnet LLMQ_100_67 (4), testnet LLMQ_25_67 (6)
+///               -- vendor/quorum_members.hpp kLlmqTypePlatform*.
+///
+/// FAIL-CLOSED at every step: any parse failure, quorum-not-active, window
+/// miss, missing quorum key or BLS refusal yields false, and the caller
+/// (credit_pool_idx.hpp try_admit_unlocks) excludes the candidate. A wrongly
+/// excluded unlock costs fee-dust; a wrongly included one costs the block.
+
+#include <impl/dash/coin/chainlock_verify.hpp>   // build_sign_hash, QuorumCandidate, sha256d_of
+#include <impl/dash/coin/vendor/assetlock.hpp>   // CAssetUnlockPayload + parser
+#include <impl/dash/coin/vendor/bls_verify.hpp>  // verify_chainlock_sig (VerifyInsecure port)
+#include <impl/dash/coin/dkg_commitments.hpp>    // LlmqParamsView, kLlmq100_67 / kLlmq25_67
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/utxo_adapter.hpp>       // dash_txid
+
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace unlockverify {
+
+/// dashd CAssetUnlockPayload::HEIGHT_DIFF_EXPIRING (evo/assetlocktx.h:150).
+inline constexpr int32_t kHeightDiffExpiring = 48;
+
+/// dashd CAssetUnlockPayload::MAXIMUM_WITHDRAWALS (evo/assetlocktx.h:76).
+inline constexpr size_t kMaximumWithdrawals = 32;
+
+/// dashd ::SerializeHash(std::make_pair("plwdtx", index)) —
+/// evo/assetlocktx.cpp:147. Preimage: CompactSize(6) || "plwdtx" || u64LE.
+inline uint256 unlock_request_id(uint64_t index)
+{
+    static constexpr std::string_view kPrefix{"plwdtx"};
+    ::PackStream s;
+    WriteCompactSize(s, kPrefix.size());
+    s.write(std::as_bytes(std::span{kPrefix.data(), kPrefix.size()}));
+    s << index;                          // uint64, little-endian
+    return chainlock::sha256d_of(s);
+}
+
+/// dashd CheckAssetUnlockTx msgHash (evo/assetlocktx.cpp:190-195): the tx's
+/// hash with the payload's quorumSig zeroed. `payload` must be the tx's own
+/// parsed payload (the caller already has it); the tx is copied, the payload
+/// re-encoded with a zero sig, and the copy hashed with the standard Dash
+/// txid rule (SHA256d over the canonical serialization incl. extra_payload).
+inline uint256 unlock_msg_hash(const MutableTransaction& tx,
+                               const vendor::CAssetUnlockPayload& payload)
+{
+    vendor::CAssetUnlockPayload zeroed = payload;
+    zeroed.quorumSig.fill(0);            // CBLSSignature{} wire form: 96 zero bytes
+
+    MutableTransaction copy = tx;
+    ::PackStream ps;
+    ps << zeroed;
+    auto sp = ps.get_span();
+    copy.extra_payload.assign(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+    return dash_txid(copy);
+}
+
+/// The platform-quorum LLMQ params for a network (chainparams llmqTypePlatform:
+/// mainnet LLMQ_100_67, testnet LLMQ_25_67).
+inline const LlmqParamsView* platform_llmq_params(LlmqNetwork net)
+{
+    return net == LlmqNetwork::Mainnet ? &kLlmq100_67 : &kLlmq25_67;
+}
+
+/// Full VerifySig port (evo/assetlocktx.cpp:114-157) minus the quorum-manager
+/// plumbing: `candidates` is the caller-sourced set of platform-type quorums
+/// with their CFinalCommitment::quorumPublicKey (sml_quorum_db 'Q' rows /
+/// QuorumManager active set), any order. `tip_height` is the height of the
+/// block being built ON (pindexPrev = H-1 for a template at H).
+///
+/// Steps, in dashd order:
+///   1. take the newest (signingActiveQuorumCount + 1) candidates by base
+///      height — "all active + 1 the latest inactive" (:126-128);
+///   2. payload.quorumHash must be in that set (:130-132);
+///   3. tip inside [requestedHeight, heightToExpiry) (:134-139);
+///   4. signHash over (llmqType, quorumHash, requestId(plwdtx‖index), msgHash)
+///      and VerifyInsecure against that quorum's public key (:147-152).
+///
+/// Returns true ONLY when all four hold and the BLS backend verified the
+/// signature. Never throws.
+inline bool verify_asset_unlock_sig(
+    const vendor::CAssetUnlockPayload& payload,
+    const uint256& msg_hash,
+    int32_t tip_height,
+    std::vector<chainlock::QuorumCandidate> candidates,
+    const LlmqParamsView& params)
+{
+    // 1. Newest (signingActiveQuorumCount + 1) quorums — dashd ScanQuorums
+    //    returns newest-first by mined height; base height ordering is the
+    //    same ordering for a non-rotated type (fixed mining-window offset).
+    const size_t quorums_to_scan =
+        static_cast<size_t>(params.signing_active_quorum_count) + 1;
+    std::sort(candidates.begin(), candidates.end(),
+              [](const chainlock::QuorumCandidate& a,
+                 const chainlock::QuorumCandidate& b) {
+                  if (a.base_height != b.base_height)
+                      return a.base_height > b.base_height;
+                  return chainlock::score_less(a.quorum_hash, b.quorum_hash);
+              });
+    if (candidates.size() > quorums_to_scan) candidates.resize(quorums_to_scan);
+
+    // 2. quorumHash must be an active (or the latest inactive) quorum.
+    const chainlock::QuorumCandidate* quorum = nullptr;
+    for (const auto& c : candidates) {
+        if (c.quorum_hash == payload.quorumHash) { quorum = &c; break; }
+    }
+    if (quorum == nullptr) {
+        LOG_INFO << "[UNLOCK-VERIFY] index=" << payload.index
+                 << " REFUSED: bad-assetunlock-too-old-quorum (quorumHash "
+                 << payload.quorumHash.GetHex().substr(0, 16)
+                 << " not in the newest " << quorums_to_scan << ")";
+        return false;
+    }
+
+    // 3. Height / expiry window (assetlocktx.cpp:134-139).
+    if (tip_height < static_cast<int32_t>(payload.requestedHeight) ||
+        tip_height >= static_cast<int32_t>(payload.requestedHeight) + kHeightDiffExpiring) {
+        LOG_INFO << "[UNLOCK-VERIFY] index=" << payload.index
+                 << " REFUSED: bad-assetunlock-too-late (requested="
+                 << payload.requestedHeight << " tip=" << tip_height << ")";
+        return false;
+    }
+
+    // 4. signHash + VerifyInsecure (fail-closed stub without C2POOL_DASH_BLS).
+    const uint256 request_id = unlock_request_id(payload.index);
+    const uint256 sign_hash  = chainlock::build_sign_hash(
+        params.type, quorum->quorum_hash, request_id, msg_hash);
+    if (!vendor::verify_chainlock_sig(quorum->quorum_public_key, sign_hash,
+                                      payload.quorumSig)) {
+        LOG_INFO << "[UNLOCK-VERIFY] index=" << payload.index
+                 << " REFUSED: bad-assetunlock-not-verified (BLS verify failed"
+                    " or backend absent — fail closed)";
+        return false;
+    }
+    return true;
+}
+
+} // namespace unlockverify
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/credit_pool_idx.hpp
+++ b/src/impl/dash/coin/credit_pool_idx.hpp
@@ -1,0 +1,685 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Variant B (#143, workflow wtrv69elc) — the provably-gap-free CreditPool
+/// INDEX follower: the sister lane to mn_checkpoint_lane.hpp for the DIP-0027
+/// type-9 (asset-unlock) state the chain does NOT commit to.
+///
+/// WHY A SISTER LANE, NOT A PATCH ON THE SCALAR MACHINE. credit_pool.hpp
+/// tracks ONE int64 (the balance) and can re-seed from any cbTx because the
+/// balance IS committed per block. The unlock-index CRangesSet and the
+/// 576-block latelyUnlocked window have NO commitment anywhere on the chain
+/// (the confirmed asymmetry, task #140) — the only way to KNOW them is to have
+/// ingested every block since their trustless floor with zero gaps. So this
+/// follower mirrors the MN lane's discipline (arm / replay-forward / persist
+/// cursor; a dead send never advances the ledger) with one decisive
+/// simplification: the anchor needs NO external trust, because dashd's own
+/// ConstructCreditPool (evo/creditpool.cpp:151-224) defines the set as EMPTY
+/// below v20 activation — arm() is a compiled-in constant, not a DIP-4
+/// checkpoint.
+///
+/// STATE — dashd's exact construction (creditpool.cpp:151-224):
+///   * CRangesSet of every mined unlock index; duplicate ⇒ HARD FAIL,
+///     mirroring the dashd throw at :174-177 ("failed-getcreditpool-index-
+///     duplicated").
+///   * per-block gross-unlocked rows for the sliding CreditPoolPeriodBlocks
+///     (=576) latelyUnlocked window (:180-189).
+///   * the era ladder — pre-v22 / WITHDRAWALS(2000 DASH) / V24(4000 DASH),
+///     :192-203, constants creditpool.h:124-127 — gated on the buried
+///     chainparams deployment heights ported below.
+///
+/// CROSS-CHECK — after EVERY applied block the scalar balance is recomputed
+/// (type-8 adds total_credit, type-9 subtracts Σvout+fee — exactly
+/// credit_pool.hpp:67-130, reused as a member, not re-derived) and compared
+/// against the cbTx-committed creditPoolBalance: the ONLY commitment the
+/// chain gives us. Mismatch ⇒ fail closed and WIPE — the index set has no
+/// commitment of its own, so a balance divergence must be treated as total
+/// loss of provenance, never patched around.
+///
+/// FAIL-CLOSED PREDICATE (one-way sticky): type-9 accrual into a template at
+/// height H is permitted IFF ALL of
+///   (a) --embedded-accrue-asset-unlocks is ON (caller-supplied flag);
+///   (b) the build has real BLS (vendor::bls_backend_available() — the stub
+///       makes quorumSig unverifiable, so accrual is structurally OFF);
+///   (c) proven_complete AND cursor.height == H-1 AND cursor.block_hash ==
+///       the template's hashPrevBlock (fresh through the exact parent);
+///   (d) contiguity never broke since seed (any gap/lineage mismatch already
+///       forced proven_complete := false + wipe);
+///   (e) the per-block balance cross-check held at every applied block;
+///   (f) the specific candidate passes: index ∉ set, quorumSig verifies
+///       against the platform quorum, expiry window holds, cumulative amount
+///       fits the era-correct limit.
+/// Failure of ANY conjunct ⇒ the template excludes ALL type-9 — exactly
+/// today's exclude_special behavior, consensus-valid by design. NOTHING
+/// restores proven_complete except a full wipe-and-reseed from the v20 floor
+/// that reaches the tip cleanly.
+///
+/// INGEST SEAM: on_replay_block matches replay_bulk_fetch.hpp's
+/// IReplayBlockConsumer contract signature so the follower rides the shared
+/// 30-40 GB bulk fetch through the TeeReplayConsumer — it must see each body
+/// BEFORE drain_buffer() prunes it (the type-9 payloads are unrecoverable
+/// after the prune without re-fetching). The same apply_block() is the tip
+/// lane's hook, so seed and steady-state share ONE ingest function.
+
+#include <impl/dash/coin/credit_pool.hpp>
+#include <impl/dash/coin/credit_pool_idx_db.hpp>
+#include <impl/dash/coin/asset_unlock_admission.hpp>
+#include <impl/dash/coin/asset_unlock_verify.hpp>
+#include <impl/dash/coin/asset_lock_fold.hpp>     // money_in_range
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// ── CRangesSet: verbatim port of dashd util/ranges_set.{h,cpp} ─────────────
+// Numbers kept as sorted disjoint half-open ranges [begin, end). Add() returns
+// false on duplicate — the caller (the follower) treats that as the dashd
+// throw. Remove() is ported for completeness (reorg support is a later pass).
+class CRangesSet
+{
+    struct Range {
+        uint64_t begin;
+        uint64_t end;
+        bool operator<(const Range& other) const
+        {
+            if (begin != other.begin) return begin < other.begin;
+            return end < other.end;
+        }
+    };
+    std::set<Range> ranges;
+
+public:
+    [[nodiscard]] bool Add(uint64_t value)
+    {
+        if (Contains(value)) return false;
+        Range new_range{value, value + 1};
+        auto it = ranges.lower_bound({value, value});
+        if (it != ranges.begin()) {
+            auto prev = it;
+            --prev;
+            if (prev->end == value) {
+                new_range.begin = prev->begin;
+                it = ranges.erase(prev);
+            }
+        }
+        if (it != ranges.end() && it->begin == value + 1) {
+            new_range.end = it->end;
+            ranges.erase(it);
+        }
+        return ranges.insert(new_range).second;
+    }
+
+    [[nodiscard]] bool Contains(uint64_t value) const noexcept
+    {
+        const auto it = ranges.lower_bound({value, value});
+        if (it != ranges.end() && it->begin == value) return true;
+        if (it == ranges.begin()) return false;
+        auto prev = it;
+        --prev;
+        return prev->begin <= value && prev->end > value;
+    }
+
+    [[nodiscard]] bool IsEmpty() const noexcept { return ranges.empty(); }
+
+    [[nodiscard]] size_t Size() const noexcept
+    {
+        size_t result = 0;
+        for (const auto& r : ranges) result += r.end - r.begin;
+        return result;
+    }
+
+    void clear() { ranges.clear(); }
+
+    /// The canonical compact form for the 'R' record: sorted, disjoint,
+    /// non-adjacent (Add() merges adjacency, so the invariant holds).
+    std::vector<std::pair<uint64_t, uint64_t>> export_ranges() const
+    {
+        std::vector<std::pair<uint64_t, uint64_t>> out;
+        out.reserve(ranges.size());
+        for (const auto& r : ranges) out.emplace_back(r.begin, r.end);
+        return out;
+    }
+
+    /// Rebuild from a decoded 'R' record. False on a malformed list (the DB
+    /// decoder already enforces sorted/disjoint/non-adjacent; this re-checks).
+    bool import_ranges(const std::vector<std::pair<uint64_t, uint64_t>>& in)
+    {
+        clear();
+        uint64_t prev_end = 0;
+        bool first = true;
+        for (const auto& [b, e] : in) {
+            if (e <= b) return false;
+            if (!first && b <= prev_end) return false;
+            first = false;
+            prev_end = e;
+            ranges.insert(Range{b, e});
+        }
+        return true;
+    }
+};
+
+// ── era ladder + deployment schedule ────────────────────────────────────────
+
+/// dashd evo/creditpool.h:124-127.
+inline constexpr int64_t kCpLimitAmountLow  = 100  * COIN_SAT;
+inline constexpr int64_t kCpLimitAmountHigh = 1000 * COIN_SAT;
+inline constexpr int64_t kCpLimitAmountV22  = 2000 * COIN_SAT;
+inline constexpr int64_t kCpLimitAmountV24  = 4000 * COIN_SAT;
+
+/// "Not activated" sentinel for a deployment with no buried height yet
+/// (DEPLOYMENT_V24 is versionbits NEVER_ACTIVE on mainnet/testnet at this
+/// dashd pin — chainparams.cpp:213/:412). Fail-safe direction: treating an
+/// actually-active era as inactive only makes OUR limit stricter (a smaller
+/// template), never an invalid block.
+inline constexpr uint32_t kCpIdxNeverActive = 0xFFFFFFFFu;
+
+struct CpIdxDeploySchedule {
+    uint32_t v20_floor_height;     // trustless seed floor (set empty below it)
+    uint32_t withdrawals_height;   // DEPLOYMENT_WITHDRAWALS buried height (v22)
+    uint32_t v24_height;           // DEPLOYMENT_V24 (kCpIdxNeverActive = not yet)
+    uint32_t window_blocks{576};   // Params().CreditPoolPeriodBlocks()
+};
+
+/// Mainnet: V20 buried @1,987,776 (block 000000000000001bf41cff06b76780
+/// 050682ca29e61a91c391893d4745579777, subsidy.hpp:45); WITHDRAWALS buried
+/// @2,201,472 (dashd chainparams.cpp:196); V24 not activated.
+inline constexpr CpIdxDeploySchedule kCpIdxScheduleMainnet{
+    1'987'776u, 2'201'472u, kCpIdxNeverActive, 576u};
+
+/// Testnet: V20 @905,100 (subsidy.hpp:55); WITHDRAWALS @1,148,500
+/// (chainparams.cpp:395); V24 not activated.
+inline constexpr CpIdxDeploySchedule kCpIdxScheduleTestnet{
+    905'100u, 1'148'500u, kCpIdxNeverActive, 576u};
+
+enum class CpIdxEra : uint8_t { PreV22 = 0, V22 = 1, V24 = 2 };
+
+inline CpIdxEra cp_idx_era_at(const CpIdxDeploySchedule& s, uint32_t height)
+{
+    if (height >= s.v24_height)         return CpIdxEra::V24;
+    if (height >= s.withdrawals_height) return CpIdxEra::V22;
+    return CpIdxEra::PreV22;
+}
+
+/// dashd ConstructCreditPool's era-laddered withdrawal limit
+/// (evo/creditpool.cpp:192-212), verbatim arithmetic:
+///   V24 active:          max(0, min(pool, 4000 − lately))
+///   WITHDRAWALS active:  min(pool, 2000)
+///   pre-v22:             "max(100, min(.10 · pool, 1000)) inside window":
+///                        if pool + lately > 100:
+///                            limit = max(100, pool/10) − lately, floored at 0
+///                        limit = min(limit, 1000 − lately)
+/// A NEGATIVE result mirrors the dashd throw ("Negative limit for
+/// CreditPool") — returned as nullopt so the caller fails closed.
+inline std::optional<int64_t>
+cp_idx_current_limit(int64_t pool_balance, int64_t lately_unlocked, CpIdxEra era)
+{
+    int64_t limit = pool_balance;
+    switch (era) {
+    case CpIdxEra::V24:
+        limit = std::max<int64_t>(0, std::min(limit, kCpLimitAmountV24 - lately_unlocked));
+        break;
+    case CpIdxEra::V22:
+        limit = std::min(limit, kCpLimitAmountV22);
+        break;
+    case CpIdxEra::PreV22:
+        if (limit + lately_unlocked > kCpLimitAmountLow) {
+            limit = std::max(kCpLimitAmountLow, pool_balance / 10) - lately_unlocked;
+            if (limit < 0) limit = 0;
+        }
+        limit = std::min(limit, kCpLimitAmountHigh - lately_unlocked);
+        break;
+    }
+    if (limit < 0) return std::nullopt;   // dashd throws here — we fail closed
+    return limit;
+}
+
+// ── the follower ────────────────────────────────────────────────────────────
+
+class CreditPoolIdxFollower
+{
+public:
+    struct WindowRow { int64_t gross_unlocked{0}; uint32_t n_type9{0}; };
+
+    /// Platform-share accrual per height (the reward term the scalar balance
+    /// needs — credit_pool.hpp apply_block's reward_accrual). Injectable for
+    /// KATs; production default is the mainnet subsidy schedule.
+    using RewardFn = std::function<int64_t(uint32_t height)>;
+
+    explicit CreditPoolIdxFollower(const CpIdxDeploySchedule& sched = kCpIdxScheduleMainnet)
+        : m_sched(sched)
+        , m_reward_fn([](uint32_t h) {
+              return compute_dash_platform_reward_post_v20_mn_rr(h);
+          })
+    {}
+
+    void set_reward_fn(RewardFn fn) { m_reward_fn = std::move(fn); }
+    void attach_db(CreditPoolIdxDb* db) { m_db = db; }
+
+    /// ARM at the trustless floor: empty CRangesSet, latelyUnlocked = 0,
+    /// balance = the floor block's own cbTx creditPoolBalance (0 at v20
+    /// activation: no locks could exist and MN_RR — the platform-reward
+    /// accrual — activates later on both networks). No external trust: dashd
+    /// itself defines the set as empty below v20 (creditpool.cpp:120 —
+    /// !DeploymentActiveAt(V20) ⇒ CCreditPool{}).
+    void arm(const uint256& floor_hash, int64_t floor_balance = 0,
+             int64_t seed_wallclock = 0)
+    {
+        wipe_memory();
+        m_height = m_sched.v20_floor_height;
+        m_hash   = floor_hash;
+        m_scalar.seed(floor_balance, m_height);
+        m_armed = true;
+        m_proven_complete = false;
+        m_fail_cause.clear();
+        if (m_db != nullptr) {
+            CpIdxSeedProvenance seed;
+            seed.v20_floor_height = m_sched.v20_floor_height;
+            seed.v20_block_hash   = floor_hash;
+            seed.seed_wallclock   = seed_wallclock;
+            m_db->write_seed(seed);
+            m_db->write_cursor(make_cursor());
+        }
+        LOG_INFO << "[CP-IDX] armed at v20 floor h=" << m_height
+                 << " hash=" << floor_hash.GetHex().substr(0, 16)
+                 << " balance=" << floor_balance << " (empty set, lately=0)";
+    }
+
+    /// Resume from the persisted namespace. Returns true when a complete,
+    /// well-formed state was restored (cursor NOT yet bridged to the live
+    /// chain — the lane must re-verify lineage before advancing; a resume
+    /// that cannot bridge wipes and re-arms from the floor). Any decode
+    /// failure or internal inconsistency adjudicates ABSENT: wipe + false.
+    bool try_restore()
+    {
+        if (m_db == nullptr) return false;
+        std::vector<std::pair<uint64_t, uint64_t>> ranges;
+        std::map<uint32_t, CpIdxWindowRowRec> rows;
+        CpIdxCursor cursor;
+        CpIdxSeedProvenance seed;
+        bool corrupt = false;
+        if (!m_db->load(ranges, rows, cursor, seed, corrupt)) {
+            if (corrupt) m_db->wipe();
+            return false;
+        }
+        // Lineage floor must be OUR floor — a namespace seeded against a
+        // different network/schedule is not provenance.
+        if (seed.v20_floor_height != m_sched.v20_floor_height ||
+            cursor.height < m_sched.v20_floor_height) {
+            LOG_WARNING << "[CP-IDX] restore REFUSED: seed floor "
+                        << seed.v20_floor_height << " != schedule floor "
+                        << m_sched.v20_floor_height << " — wipe";
+            m_db->wipe();
+            return false;
+        }
+        if (!m_indexes.import_ranges(ranges)) {
+            m_db->wipe();
+            return false;
+        }
+        // Window rows: must cover (cursor − window, cursor] where above the
+        // floor; a missing row inside the window = broken provenance.
+        m_window.clear();
+        int64_t lately = 0;
+        const uint32_t lo = cursor.height > m_sched.window_blocks
+                          ? cursor.height - m_sched.window_blocks + 1
+                          : m_sched.v20_floor_height + 1;
+        for (uint32_t h = lo; h <= cursor.height && cursor.height != 0; ++h) {
+            auto it = rows.find(h);
+            if (it == rows.end()) {
+                if (h <= m_sched.v20_floor_height) continue;
+                LOG_WARNING << "[CP-IDX] restore REFUSED: window row h=" << h
+                            << " missing inside (" << lo << ".." << cursor.height
+                            << "] — wipe";
+                wipe_memory();
+                m_db->wipe();
+                return false;
+            }
+            m_window[h] = WindowRow{it->second.gross_unlocked, it->second.n_type9};
+            lately += it->second.gross_unlocked;
+        }
+        m_lately_unlocked = lately;
+        m_height = cursor.height;
+        m_hash   = cursor.block_hash;
+        m_scalar.seed(cursor.computed_balance, cursor.height);
+        m_armed = true;
+        // proven_complete does NOT survive a restart by itself: the ledger is
+        // only proven through the persisted cursor; the lane must re-bridge
+        // to the live tip before mark_proven_complete() may flip it back.
+        m_proven_complete = false;
+        LOG_INFO << "[CP-IDX] restored cursor h=" << m_height
+                 << " hash=" << m_hash.GetHex().substr(0, 16)
+                 << " balance=" << m_scalar.balance()
+                 << " indexes=" << m_indexes.Size()
+                 << " lately=" << m_lately_unlocked
+                 << " (proven_complete reset pending re-bridge)";
+        return true;
+    }
+
+    /// Fold ONE block. The block must be the cursor's direct child (height
+    /// AND hashPrevBlock — the #138 honest-ledger rule: only a truly
+    /// delivered, lineage-verified body advances the cursor; a refused or
+    /// out-of-order body leaves the ledger unmoved OR, if it names a breach
+    /// of provenance, wipes it).
+    ///
+    /// Returns false and FAILS CLOSED (proven_complete := false, memory +
+    /// namespace wiped) on: lineage/contiguity breach, unparseable cbTx or
+    /// unlock payload, duplicate unlock index, missing window row, or the
+    /// balance cross-check missing the cbTx-committed value.
+    bool apply_block(uint32_t height, const uint256& hash, const BlockType& block)
+    {
+        if (!m_armed) return false;
+
+        // Contiguity + lineage (conjunct d).
+        if (height != m_height + 1) {
+            return fail_closed(height, "gap: expected h=" + std::to_string(m_height + 1)
+                                         + " got h=" + std::to_string(height));
+        }
+        if (!m_hash.IsNull() && !block.m_previous_block.IsNull() &&
+            block.m_previous_block != m_hash) {
+            return fail_closed(height, "lineage: hashPrevBlock "
+                                         + block.m_previous_block.GetHex().substr(0, 16)
+                                         + " != cursor " + m_hash.GetHex().substr(0, 16));
+        }
+
+        // cbTx — the block's own committed balance (the ONLY commitment).
+        if (block.m_txs.empty()) return fail_closed(height, "empty block body");
+        vendor::CCbTx cbtx;
+        if (!vendor::parse_cbtx(block.m_txs[0].extra_payload, cbtx) ||
+            cbtx.nVersion < vendor::CCbTx::VERSION_CLSIG_AND_BALANCE) {
+            return fail_closed(height, "cbTx below v3 / unparseable — no committed "
+                                         "creditPoolBalance to cross-check against");
+        }
+
+        // Per-block type-9 extraction — dashd GetCreditDataFromBlock
+        // (creditpool.cpp:60-112): gross = payload.fee + Σ vout (each vout
+        // MoneyRange-checked), indexes collected; an unparseable payload is
+        // the dashd throw ⇒ fail closed.
+        int64_t gross = 0;
+        uint32_t n_type9 = 0;
+        std::unordered_set<uint64_t> block_indexes;
+        for (size_t i = 1; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            if (tx.version != 3 ||
+                tx.type != vendor::CAssetUnlockPayload::SPECIALTX_TYPE) continue;
+            vendor::CAssetUnlockPayload pl;
+            if (!vendor::parse_assetunlock_payload(tx.extra_payload, pl)) {
+                return fail_closed(height, "type-9 payload unparseable at tx["
+                                             + std::to_string(i) + "]");
+            }
+            int64_t to_unlock = static_cast<int64_t>(pl.fee);
+            for (const auto& v : tx.vout) {
+                if (!money_in_range(v.value))
+                    return fail_closed(height, "type-9 vout out of MoneyRange");
+                to_unlock += v.value;
+            }
+            gross += to_unlock;
+            ++n_type9;
+            block_indexes.insert(pl.index);
+        }
+
+        // Duplicate ⇒ hard fail (dashd creditpool.cpp:174-177).
+        for (uint64_t idx : block_indexes) {
+            if (!m_indexes.Add(idx)) {
+                return fail_closed(height, "failed-getcreditpool-index-duplicated: "
+                                             + std::to_string(idx));
+            }
+        }
+
+        // Sliding window: lately += this block − the row that slid out.
+        int64_t out_gross = 0;
+        if (height > m_sched.window_blocks) {
+            const uint32_t out_h = height - m_sched.window_blocks;
+            if (out_h > m_sched.v20_floor_height) {
+                auto it = m_window.find(out_h);
+                if (it == m_window.end()) {
+                    return fail_closed(height, "window row missing at h="
+                                                 + std::to_string(out_h));
+                }
+                out_gross = it->second.gross_unlocked;
+            }
+        }
+        m_window[height] = WindowRow{gross, n_type9};
+        m_lately_unlocked += gross - out_gross;
+
+        // Scalar recompute — EXACTLY credit_pool.hpp:67-130 (reused member).
+        m_scalar.apply_block(block, height, m_reward_fn(height));
+
+        // THE cross-check (conjunct e): computed == committed, every block.
+        if (m_scalar.balance() != cbtx.creditPoolBalance) {
+            return fail_closed(height, "balance cross-check MISMATCH: computed="
+                                         + std::to_string(m_scalar.balance())
+                                         + " cbTx=" + std::to_string(cbtx.creditPoolBalance));
+        }
+
+        // Advance + prune + persist (persisted == delivered + folded +
+        // balance-verified; never before).
+        m_height = height;
+        m_hash   = hash;
+        const uint32_t prune_below = height > m_sched.window_blocks
+                                   ? height - m_sched.window_blocks : 0;
+        for (auto it = m_window.begin();
+             it != m_window.end() && it->first < prune_below;)
+            it = m_window.erase(it);
+        if (m_db != nullptr) {
+            m_db->write_apply(m_indexes.export_ranges(), height,
+                              CpIdxWindowRowRec{gross, n_type9},
+                              make_cursor(), prune_below);
+        }
+        return true;
+    }
+
+    /// IReplayBlockConsumer-shaped entry (replay_bulk_fetch.hpp TEE seam):
+    /// same signature, same refuse-means-stop contract. A refusal here means
+    /// the follower's provenance broke; the bulk lane keeps ITS OWN fold
+    /// correct by failing the lane closed with a named cause.
+    bool on_replay_block(uint32_t height, const uint256& hash, const BlockType& block)
+    {
+        return apply_block(height, hash, block);
+    }
+
+    /// The lane flips this ONLY when the follower's cursor has met the live
+    /// tip lane's verified tip (seed complete + fresh). One-way in the other
+    /// direction: any fail_closed() clears it and only a full wipe-and-reseed
+    /// can earn it back.
+    void mark_proven_complete()
+    {
+        if (!m_armed) return;
+        m_proven_complete = true;
+        if (m_db != nullptr) m_db->write_cursor(make_cursor());
+    }
+
+    // ── the fail-closed predicate (conjuncts a..e) ─────────────────────────
+    /// True IFF a template at height H building on prev_hash may consult the
+    /// index at all. Conjunct (f) is per-candidate, in try_admit_unlocks.
+    bool accrual_permitted(bool flag_on, uint32_t template_height,
+                           const uint256& template_prev_hash) const
+    {
+        if (!flag_on) return false;                                    // (a)
+        if (!vendor::bls_backend_available()) return false;            // (b)
+        if (!m_armed || !m_proven_complete) return false;              // (c,d,e latch)
+        if (m_height != template_height - 1) return false;             // (c) fresh
+        if (m_hash != template_prev_hash) return false;                // (c) exact parent
+        return true;
+    }
+
+    /// ARM-3 admission: produce the verified type-9 set for a template at
+    /// height H. Returns true when the admission is USABLE (the predicate
+    /// held; `out` may still be empty if no candidate passed). Returns false
+    /// — and `out` stays empty — when ANY predicate conjunct fails: the
+    /// template then excludes ALL type-9, never a partial best-effort set.
+    ///
+    /// Per candidate (conjunct f), in dashd order:
+    ///   structural CheckAssetUnlockTx (assetlocktx.cpp:157-188): type 9,
+    ///     NO vin, ≤ MAXIMUM_WITHDRAWALS vouts, payload parses, version==1,
+    ///     each vout in MoneyRange;
+    ///   index ∉ CRangesSet and ∉ this session (CCreditPoolDiff::Unlock
+    ///     :277-297 duplicate check);
+    ///   quorum activity + expiry window + quorumSig BLS verify
+    ///     (asset_unlock_verify.hpp — VerifySig :114-157);
+    ///   cumulative sessionUnlocked + toUnlock ≤ era-correct LimitAmount
+    ///     (currentLimit port; Unlock :287-289).
+    bool try_admit_unlocks(bool flag_on, uint32_t template_height,
+                           const uint256& template_prev_hash,
+                           const std::vector<MutableTransaction>& candidates,
+                           const std::vector<chainlock::QuorumCandidate>& quorums,
+                           const LlmqParamsView& platform_params,
+                           AssetUnlockAdmission& out) const
+    {
+        out = AssetUnlockAdmission{};
+        if (!accrual_permitted(flag_on, template_height, template_prev_hash))
+            return false;
+
+        // Era + limit are functions of the PREVIOUS block (dashd: "limits
+        // should stay same and depends only on the previous block",
+        // creditpool.h:66-71) — i.e. of the cursor, which conjunct (c) just
+        // pinned to the template's parent.
+        const CpIdxEra era = cp_idx_era_at(m_sched, m_height);
+        const auto limit = cp_idx_current_limit(m_scalar.balance(),
+                                                m_lately_unlocked, era);
+        if (!limit) {
+            LOG_WARNING << "[CP-IDX] negative era limit at h=" << m_height
+                        << " — fail closed, exclude-all";
+            return false;
+        }
+
+        const int32_t tip_height = static_cast<int32_t>(template_height) - 1;
+        int64_t session_unlocked = 0;
+        std::unordered_set<uint64_t> session_indexes;
+
+        for (const auto& tx : candidates) {
+            if (tx.version != 3 ||
+                tx.type != vendor::CAssetUnlockPayload::SPECIALTX_TYPE) continue;
+            if (!tx.vin.empty()) continue;                    // bad-assetunlocktx-have-input
+            if (tx.vout.size() > unlockverify::kMaximumWithdrawals) continue;
+            vendor::CAssetUnlockPayload pl;
+            if (!vendor::parse_assetunlock_payload(tx.extra_payload, pl)) continue;
+            if (pl.nVersion == 0 ||
+                pl.nVersion > vendor::CAssetUnlockPayload::CURRENT_VERSION) continue;
+
+            int64_t to_unlock = static_cast<int64_t>(pl.fee);
+            bool money_ok = pl.fee > 0;                       // bad-txns-assetunlock-fee-outofrange
+            for (const auto& v : tx.vout) {
+                if (!money_in_range(v.value)) { money_ok = false; break; }
+                to_unlock += v.value;
+            }
+            if (!money_ok || !money_in_range(to_unlock)) continue;
+
+            // Duplicate index — mined OR earlier in this session.
+            if (m_indexes.Contains(pl.index) || session_indexes.count(pl.index)) {
+                LOG_INFO << "[CP-IDX] EXCLUDING unlock index=" << pl.index
+                         << ": duplicated (failed-creditpool-unlock-duplicated-index)";
+                continue;
+            }
+
+            // Withdrawal limit (sessionUnlocked + toUnlock > currentLimit ⇒
+            // failed-creditpool-unlock-too-much).
+            if (session_unlocked + to_unlock > *limit) {
+                LOG_INFO << "[CP-IDX] EXCLUDING unlock index=" << pl.index
+                         << ": limit (session=" << session_unlocked
+                         << " + " << to_unlock << " > " << *limit << ")";
+                continue;
+            }
+
+            // Quorum signature + activity + expiry (fail-closed BLS).
+            const uint256 msg_hash = unlockverify::unlock_msg_hash(tx, pl);
+            if (!unlockverify::verify_asset_unlock_sig(
+                    pl, msg_hash, tip_height, quorums, platform_params)) {
+                continue;   // cause already logged by the verifier
+            }
+
+            session_indexes.insert(pl.index);
+            session_unlocked += to_unlock;
+            out.txs.push_back(tx);
+            out.gross_unlocked     += to_unlock;
+            out.total_payload_fees += static_cast<int64_t>(pl.fee);
+        }
+        if (!out.txs.empty()) {
+            LOG_INFO << "[CP-IDX] ADMITTING " << out.txs.size()
+                     << " verified type-9 unlock(s) into template h="
+                     << template_height << " gross=" << out.gross_unlocked
+                     << " fees=" << out.total_payload_fees
+                     << " limit=" << *limit << " era=" << static_cast<int>(era);
+        }
+        return true;
+    }
+
+    // ── accessors ───────────────────────────────────────────────────────────
+    bool     armed()            const { return m_armed; }
+    bool     proven_complete()  const { return m_proven_complete; }
+    uint32_t height()           const { return m_height; }
+    const uint256& block_hash() const { return m_hash; }
+    int64_t  balance()          const { return m_scalar.balance(); }
+    int64_t  lately_unlocked()  const { return m_lately_unlocked; }
+    const CRangesSet& indexes() const { return m_indexes; }
+    const std::string& fail_cause() const { return m_fail_cause; }
+    const CpIdxDeploySchedule& schedule() const { return m_sched; }
+
+private:
+    CpIdxDeploySchedule m_sched;
+    RewardFn            m_reward_fn;
+    CreditPoolIdxDb*    m_db{nullptr};      // borrowed, optional
+
+    CRangesSet                    m_indexes;
+    std::map<uint32_t, WindowRow> m_window;
+    int64_t                       m_lately_unlocked{0};
+    CreditPool                    m_scalar;   // credit_pool.hpp — the exact arithmetic
+    uint32_t                      m_height{0};
+    uint256                       m_hash;
+    bool                          m_armed{false};
+    bool                          m_proven_complete{false};
+    std::string                   m_fail_cause;
+
+    CpIdxCursor make_cursor() const
+    {
+        CpIdxCursor c;
+        c.height           = m_height;
+        c.block_hash       = m_hash;
+        c.computed_balance = m_scalar.balance();
+        c.proven_complete  = m_proven_complete;
+        c.era              = static_cast<uint8_t>(cp_idx_era_at(m_sched, m_height));
+        return c;
+    }
+
+    /// Total loss of provenance: latch proven_complete := false, wipe memory
+    /// AND the persisted namespace. The only way back is a fresh floor seed
+    /// that reaches the tip cleanly. Named cause, loudly.
+    bool fail_closed(uint32_t at_height, const std::string& cause)
+    {
+        m_fail_cause = "h=" + std::to_string(at_height) + ": " + cause;
+        LOG_ERROR << "[CP-IDX] FAIL CLOSED (" << m_fail_cause
+                  << ") — proven_complete=0, wiping index namespace; template "
+                     "path collapses to exclude-all (consensus-valid)";
+        wipe_memory();
+        if (m_db != nullptr) m_db->wipe();
+        return false;
+    }
+
+    void wipe_memory()
+    {
+        m_indexes.clear();
+        m_window.clear();
+        m_lately_unlocked = 0;
+        m_scalar.clear();
+        m_height = 0;
+        m_hash.SetNull();
+        m_armed = false;
+        m_proven_complete = false;
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/credit_pool_idx_db.hpp
+++ b/src/impl/dash/coin/credit_pool_idx_db.hpp
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Variant B — persistent CreditPool INDEX state (the sister lane's disk half).
+///
+/// A NEW namespace, SEPARATE from the existing CreditPoolDb (which stays
+/// untouched at its single-'B'-key 45-byte encode_state, credit_pool_db.hpp:
+/// 99-115, so flag-OFF disk state is bit-identical). Records, all values
+/// little-endian, batch-written atomically ONLY after a clean apply (the MN
+/// lane's note_persist doctrine: persisted == delivered + folded):
+///
+///   key 'R'              — the CRangesSet equivalent:
+///                          [1B schema_ver=1][varint n_ranges]
+///                          [n × (8B u64 start LE, 8B u64 end_exclusive LE)]
+///                          ranges sorted, disjoint, non-adjacent — the
+///                          canonical compact form of every mined unlock index
+///                          since the v20 floor.
+///   key 'w' + [4B height]— per-block window rows (key height BIG-endian so a
+///                          prefix scan walks ascending heights):
+///                          [8B int64 gross_unlocked LE][4B u32 n_type9 LE]
+///                          for each of the last (window+1)=577 heights;
+///                          rows below cursor−577 pruned in the same batch.
+///   key 'C'              — cursor / attestation:
+///                          [1B schema_ver=1][4B height LE][32B block_hash]
+///                          [8B int64 computed_balance LE][1B proven_complete]
+///                          [1B era (0=pre-v22, 1=v22, 2=v24)]
+///                          computed_balance MUST equal the cbTx
+///                          creditPoolBalance of block_hash at write time.
+///   key 'S'              — seed provenance:
+///                          [4B v20_floor_height LE][32B v20_block_hash]
+///                          [8B seed_wallclock LE]
+///                          so a later reader can verify the lineage really
+///                          starts at the trustless floor.
+///
+/// LOAD ADJUDICATION (try_restore doctrine, mn_checkpoint_lane.hpp:1365-1394):
+/// ANY decode failure, a missing 'C'/'S'/'R' while any sibling is present, or
+/// a malformed range list ⇒ the WHOLE namespace is treated as absent: load()
+/// reports no state and the caller wipes + re-seeds from the v20 floor. The
+/// deeper checks that need chain context (hash lineage against the header
+/// spine, missing 'w' row inside the window, balance == cbTx) live in the
+/// follower (credit_pool_idx.hpp), which also fails to a wipe.
+
+#include <core/leveldb_store.hpp>
+#include <core/uint256.hpp>
+#include <core/log.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+struct CpIdxCursor {
+    uint32_t height{0};
+    uint256  block_hash;
+    int64_t  computed_balance{0};
+    bool     proven_complete{false};
+    uint8_t  era{0};
+};
+
+struct CpIdxSeedProvenance {
+    uint32_t v20_floor_height{0};
+    uint256  v20_block_hash;
+    int64_t  seed_wallclock{0};
+};
+
+struct CpIdxWindowRowRec {
+    int64_t  gross_unlocked{0};
+    uint32_t n_type9{0};
+};
+
+class CreditPoolIdxDb
+{
+public:
+    static constexpr uint8_t kSchemaVer = 1;
+
+    explicit CreditPoolIdxDb(const std::string& db_path,
+                             const ::core::LevelDBOptions& opts = {})
+        : m_store(db_path, opts) {}
+
+    bool open()   { return m_store.open(); }
+    void close()  { m_store.close(); }
+    bool is_open() const { return m_store.is_open(); }
+
+    /// Load the whole namespace. Returns true when a COMPLETE, well-formed
+    /// state was present (out params filled); false when the namespace is
+    /// absent OR any record fails to decode — in which case the caller must
+    /// treat persisted state as nonexistent (wipe + reseed from the floor).
+    /// A false return with `corrupt=true` means records existed but did not
+    /// adjudicate; the caller should wipe() before re-seeding.
+    bool load(std::vector<std::pair<uint64_t, uint64_t>>& ranges,
+              std::map<uint32_t, CpIdxWindowRowRec>&      window_rows,
+              CpIdxCursor&                                 cursor,
+              CpIdxSeedProvenance&                         seed,
+              bool&                                        corrupt)
+    {
+        corrupt = false;
+        ranges.clear();
+        window_rows.clear();
+
+        std::vector<uint8_t> c_raw, s_raw, r_raw;
+        const bool have_c = m_store.get(key_cursor(), c_raw);
+        const bool have_s = m_store.get(key_seed(),   s_raw);
+        const bool have_r = m_store.get(key_ranges(), r_raw);
+
+        if (!have_c && !have_s && !have_r) return false;   // genuinely absent
+        if (!(have_c && have_s && have_r)) {                // torn namespace
+            LOG_WARNING << "[CP-IDX-DB] torn namespace (C=" << have_c
+                        << " S=" << have_s << " R=" << have_r
+                        << ") — adjudicating ABSENT (wipe + reseed)";
+            corrupt = true;
+            return false;
+        }
+        if (!decode_cursor(c_raw, cursor) || !decode_seed(s_raw, seed) ||
+            !decode_ranges(r_raw, ranges)) {
+            corrupt = true;
+            return false;
+        }
+
+        bool rows_ok = true;
+        const bool scan_ok = m_store.for_each_prefix(
+            std::string(1, 'w'),
+            [&](const std::string& key, const std::vector<uint8_t>& value) {
+                if (key.size() != 5 || value.size() != 12) { rows_ok = false; return false; }
+                const uint32_t h = (uint32_t(uint8_t(key[1])) << 24)
+                                 | (uint32_t(uint8_t(key[2])) << 16)
+                                 | (uint32_t(uint8_t(key[3])) <<  8)
+                                 |  uint32_t(uint8_t(key[4]));
+                CpIdxWindowRowRec row;
+                uint64_t u = 0;
+                for (int i = 0; i < 8; ++i) u |= uint64_t(value[i]) << (8 * i);
+                row.gross_unlocked = static_cast<int64_t>(u);
+                row.n_type9 = uint32_t(value[8]) | (uint32_t(value[9]) << 8)
+                            | (uint32_t(value[10]) << 16) | (uint32_t(value[11]) << 24);
+                window_rows[h] = row;
+                return true;
+            });
+        if (!scan_ok || !rows_ok) {
+            LOG_WARNING << "[CP-IDX-DB] window-row scan failed (scan_ok="
+                        << scan_ok << ") — adjudicating ABSENT";
+            corrupt = true;
+            return false;
+        }
+        return true;
+    }
+
+    /// One clean apply, atomically: the full ranges snapshot, this height's
+    /// window row, the cursor, and the pruning of rows that fell out of the
+    /// window. Written ONLY after the fold + cross-check succeeded.
+    bool write_apply(const std::vector<std::pair<uint64_t, uint64_t>>& ranges,
+                     uint32_t height, const CpIdxWindowRowRec& row,
+                     const CpIdxCursor& cursor, uint32_t prune_below)
+    {
+        auto batch = m_store.create_batch();
+        batch.put(key_ranges(), encode_ranges(ranges));
+        batch.put(key_window(height), encode_row(row));
+        batch.put(key_cursor(), encode_cursor(cursor));
+        // Prune the single row that just slid out (rows leave one at a time on
+        // a contiguous fold; a bounded loop covers restarts mid-prune).
+        for (uint32_t h = prune_below >= 8 ? prune_below - 8 : 0; h < prune_below; ++h)
+            batch.remove(key_window(h));
+        if (!batch.commit()) {
+            LOG_WARNING << "[CP-IDX-DB] write_apply batch commit failed h=" << height;
+            return false;
+        }
+        return true;
+    }
+
+    bool write_seed(const CpIdxSeedProvenance& seed)
+    {
+        auto batch = m_store.create_batch();
+        batch.put(key_seed(), encode_seed(seed));
+        return batch.commit();
+    }
+
+    /// Rewrite just the cursor (proven_complete flips at seed-meets-tip and
+    /// on fail-closed latching).
+    bool write_cursor(const CpIdxCursor& cursor)
+    {
+        auto batch = m_store.create_batch();
+        batch.put(key_cursor(), encode_cursor(cursor));
+        return batch.commit();
+    }
+
+    /// Total loss of provenance: remove EVERY key of the namespace. The next
+    /// state on disk after a wipe is a fresh floor seed or nothing.
+    bool wipe()
+    {
+        std::vector<std::string> keys;
+        // Bounded namespace: 'R','C','S' + 'w' rows (window-sized).
+        m_store.for_each_prefix(std::string(1, 'w'),
+            [&](const std::string& key, const std::vector<uint8_t>&) {
+                keys.push_back(key);
+                return true;
+            });
+        auto batch = m_store.create_batch();
+        for (const auto& k : keys) batch.remove(k);
+        batch.remove(key_ranges());
+        batch.remove(key_cursor());
+        batch.remove(key_seed());
+        const bool ok = batch.commit();
+        LOG_INFO << "[CP-IDX-DB] wiped (" << keys.size() << " window rows + R/C/S) ok=" << ok;
+        return ok;
+    }
+
+    // ── wire codecs (exposed for the schema KAT) ────────────────────────────
+
+    static std::vector<uint8_t>
+    encode_ranges(const std::vector<std::pair<uint64_t, uint64_t>>& ranges)
+    {
+        std::vector<uint8_t> out;
+        out.push_back(kSchemaVer);
+        put_varint(out, ranges.size());
+        for (const auto& [b, e] : ranges) { put_u64(out, b); put_u64(out, e); }
+        return out;
+    }
+
+    static bool decode_ranges(const std::vector<uint8_t>& in,
+                              std::vector<std::pair<uint64_t, uint64_t>>& out)
+    {
+        out.clear();
+        size_t pos = 0;
+        uint8_t ver;
+        if (!get_u8(in, pos, ver) || ver != kSchemaVer) return false;
+        uint64_t n;
+        if (!get_varint(in, pos, n)) return false;
+        uint64_t prev_end = 0;
+        for (uint64_t i = 0; i < n; ++i) {
+            uint64_t b, e;
+            if (!get_u64(in, pos, b) || !get_u64(in, pos, e)) return false;
+            // sorted, disjoint, NON-adjacent, non-empty — the canonical form.
+            if (e <= b) return false;
+            if (i > 0 && b <= prev_end) return false;
+            prev_end = e;
+            out.emplace_back(b, e);
+        }
+        return pos == in.size();
+    }
+
+    static std::vector<uint8_t> encode_cursor(const CpIdxCursor& c)
+    {
+        std::vector<uint8_t> out;
+        out.push_back(kSchemaVer);
+        put_u32(out, c.height);
+        out.insert(out.end(), c.block_hash.data(), c.block_hash.data() + 32);
+        put_u64(out, static_cast<uint64_t>(c.computed_balance));
+        out.push_back(c.proven_complete ? 1 : 0);
+        out.push_back(c.era);
+        return out;
+    }
+
+    static bool decode_cursor(const std::vector<uint8_t>& in, CpIdxCursor& c)
+    {
+        if (in.size() != 1 + 4 + 32 + 8 + 1 + 1) return false;
+        size_t pos = 0;
+        uint8_t ver;
+        if (!get_u8(in, pos, ver) || ver != kSchemaVer) return false;
+        get_u32(in, pos, c.height);
+        std::memcpy(c.block_hash.data(), in.data() + pos, 32); pos += 32;
+        uint64_t u; get_u64(in, pos, u);
+        c.computed_balance = static_cast<int64_t>(u);
+        c.proven_complete  = in[pos++] != 0;
+        c.era              = in[pos++];
+        if (c.era > 2) return false;
+        return true;
+    }
+
+    static std::vector<uint8_t> encode_seed(const CpIdxSeedProvenance& s)
+    {
+        std::vector<uint8_t> out;
+        put_u32(out, s.v20_floor_height);
+        out.insert(out.end(), s.v20_block_hash.data(), s.v20_block_hash.data() + 32);
+        put_u64(out, static_cast<uint64_t>(s.seed_wallclock));
+        return out;
+    }
+
+    static bool decode_seed(const std::vector<uint8_t>& in, CpIdxSeedProvenance& s)
+    {
+        if (in.size() != 4 + 32 + 8) return false;
+        size_t pos = 0;
+        get_u32(in, pos, s.v20_floor_height);
+        std::memcpy(s.v20_block_hash.data(), in.data() + pos, 32); pos += 32;
+        uint64_t u; get_u64(in, pos, u);
+        s.seed_wallclock = static_cast<int64_t>(u);
+        return true;
+    }
+
+    static std::vector<uint8_t> encode_row(const CpIdxWindowRowRec& r)
+    {
+        std::vector<uint8_t> out;
+        put_u64(out, static_cast<uint64_t>(r.gross_unlocked));
+        put_u32(out, r.n_type9);
+        return out;
+    }
+
+    static std::string key_window(uint32_t height)
+    {
+        std::string k(5, '\0');
+        k[0] = 'w';
+        k[1] = static_cast<char>((height >> 24) & 0xFF);   // BIG-endian key:
+        k[2] = static_cast<char>((height >> 16) & 0xFF);   // prefix scans walk
+        k[3] = static_cast<char>((height >>  8) & 0xFF);   // ascending heights
+        k[4] = static_cast<char>( height        & 0xFF);
+        return k;
+    }
+    static std::string key_ranges() { return std::string(1, 'R'); }
+    static std::string key_cursor() { return std::string(1, 'C'); }
+    static std::string key_seed()   { return std::string(1, 'S'); }
+
+private:
+    ::core::LevelDBStore m_store;
+
+    static void put_u8(std::vector<uint8_t>& v, uint8_t x) { v.push_back(x); }
+    static void put_u32(std::vector<uint8_t>& v, uint32_t x)
+    {
+        for (int i = 0; i < 4; ++i) v.push_back(uint8_t((x >> (8 * i)) & 0xFF));
+    }
+    static void put_u64(std::vector<uint8_t>& v, uint64_t x)
+    {
+        for (int i = 0; i < 8; ++i) v.push_back(uint8_t((x >> (8 * i)) & 0xFF));
+    }
+    static void put_varint(std::vector<uint8_t>& v, uint64_t x)
+    {
+        // Bitcoin CompactSize (matches the 'varint n_ranges' schema note).
+        if (x < 253) { v.push_back(uint8_t(x)); }
+        else if (x <= 0xFFFF) { v.push_back(253); v.push_back(uint8_t(x)); v.push_back(uint8_t(x >> 8)); }
+        else if (x <= 0xFFFFFFFFull) { v.push_back(254); for (int i = 0; i < 4; ++i) v.push_back(uint8_t(x >> (8 * i))); }
+        else { v.push_back(255); for (int i = 0; i < 8; ++i) v.push_back(uint8_t(x >> (8 * i))); }
+    }
+    static bool get_u8(const std::vector<uint8_t>& v, size_t& pos, uint8_t& x)
+    {
+        if (pos + 1 > v.size()) return false;
+        x = v[pos++]; return true;
+    }
+    static bool get_u32(const std::vector<uint8_t>& v, size_t& pos, uint32_t& x)
+    {
+        if (pos + 4 > v.size()) return false;
+        x = 0;
+        for (int i = 0; i < 4; ++i) x |= uint32_t(v[pos + i]) << (8 * i);
+        pos += 4; return true;
+    }
+    static bool get_u64(const std::vector<uint8_t>& v, size_t& pos, uint64_t& x)
+    {
+        if (pos + 8 > v.size()) return false;
+        x = 0;
+        for (int i = 0; i < 8; ++i) x |= uint64_t(v[pos + i]) << (8 * i);
+        pos += 8; return true;
+    }
+    static bool get_varint(const std::vector<uint8_t>& v, size_t& pos, uint64_t& x)
+    {
+        uint8_t tag;
+        if (!get_u8(v, pos, tag)) return false;
+        if (tag < 253) { x = tag; return true; }
+        int n = tag == 253 ? 2 : tag == 254 ? 4 : 8;
+        if (pos + n > v.size()) return false;
+        x = 0;
+        for (int i = 0; i < n; ++i) x |= uint64_t(v[pos + i]) << (8 * i);
+        pos += n; return true;
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -32,6 +32,7 @@
 #include <impl/dash/coin/sml_projection.hpp>    // confirmedHash rollover pass + collateral-spend predicate
 #include <impl/dash/coin/mempool.hpp>
 #include <impl/dash/coin/asset_lock_fold.hpp>   // #107 phase 2: DIP-0027 type-8 credit-pool fold
+#include <impl/dash/coin/asset_unlock_admission.hpp>  // #143 Variant B: verified type-9 set (light bridge struct)
 #include <impl/dash/coin/subsidy.hpp>
 #include <impl/dash/coin/governance_object.hpp>   // SuperblockPayment (daemonless superblock outputs)
 #include <impl/dash/coin/utxo_adapter.hpp>
@@ -503,7 +504,28 @@ inline DashWorkData build_embedded_workdata(
     // --embedded-serve-mempool-txs, itself blocked on #125). Committing the
     // accrual with a coinbase-only body would be a bad-cbtx-assetlocked-amount
     // REJECTED block — see the PR body B1.
-    bool accrue_pending_asset_locks = false)
+    bool accrue_pending_asset_locks = false,
+    // ── Variant B (#143) seam: VERIFIED TYPE-9 ASSET UNLOCKS ──────────────
+    // --embedded-accrue-asset-unlocks (default OFF). The SINGLE template-side
+    // call site of the CreditPool INDEX follower: nullptr or empty (the
+    // default, and the ONLY possible value while the flag is OFF or any
+    // fail-closed conjunct fails) means EXCLUDE-ALL — byte-identical to
+    // today's template. When non-empty, every tx here already passed the
+    // follower's full predicate (proven-complete index, fresh at THIS
+    // template's parent, index ∉ CRangesSet, era-correct LimitAmount,
+    // expiry window, quorumSig BLS-verified — credit_pool_idx.hpp
+    // try_admit_unlocks), and three values thread through:
+    //   * txs ride the body right after the pinned local txs (byte-budgeted
+    //     like them, BEFORE mempool selection gets the remainder);
+    //   * total_payload_fees joins total_fees (dashd GetAssetUnlockFee: the
+    //     unlock fee is ordinary miner fee), so block_value stays exact and
+    //     the coinbase-split FORMULA is untouched (reward_path_note);
+    //   * gross_unlocked (Σ vout + fee) is SUBTRACTED from the committed
+    //     creditPoolBalance — exactly dashd's GetTotalLocked sessionUnlocked
+    //     term (creditpool.h:98-100) — so the validator's re-derivation from
+    //     the block's OWN txs matches (specialtxman.cpp bad-cbtx-assetlocked-
+    //     amount otherwise).
+    const AssetUnlockAdmission* admitted_asset_unlocks = nullptr)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -550,6 +572,13 @@ inline DashWorkData build_embedded_workdata(
     }
     if (pinned_local_txs != nullptr) {
         for (const auto& t : *pinned_local_txs)
+            reserved_bytes += ::pack(t).get_span().size();
+    }
+    // #143: admitted type-9 unlocks are byte-budgeted like the pins —
+    // BEFORE selection gets the remainder (a budget discovered after the
+    // fact is not a budget). nullptr/empty (flag OFF / fail-closed) adds 0.
+    if (admitted_asset_unlocks != nullptr) {
+        for (const auto& t : admitted_asset_unlocks->txs)
             reserved_bytes += ::pack(t).get_span().size();
     }
     // Selection gets what is left. If the required set alone has eaten the
@@ -610,6 +639,13 @@ inline DashWorkData build_embedded_workdata(
         }
         selected.resize(kept);
     }
+    // #143: the admitted unlocks' payload fees are ordinary miner fees (dashd
+    // GetAssetUnlockFee, assetlocktx.cpp:200-212 — the fee reaches the miner
+    // through the coinbase). Folded into total_fees BEFORE block_value below,
+    // so every downstream value (block_value, mn_payment) is exact through
+    // the EXISTING formulas — no new branch in the split math.
+    if (admitted_asset_unlocks != nullptr)
+        total_fees += static_cast<uint64_t>(admitted_asset_unlocks->total_payload_fees);
     // ── CANDIDATE-SET RECORDING (observe-without-arming) ────────────────
     // When the body is deliberately coinbase-only, run the SAME selection the
     // serving path would run and record only its identities and fees. Nothing
@@ -717,6 +753,34 @@ inline DashWorkData build_embedded_workdata(
     // committed merkleRootMNList exactly like a selected one.
     if (pinned_local_txs != nullptr && !pinned_local_txs->empty())
         splice_pinned_txs(w, *pinned_local_txs, mempool, mnstates, "GBT-EMB");
+    // ── #143 VERIFIED TYPE-9 UNLOCKS — after the consensus-required type-6
+    // set and the pins, BEFORE the mempool-sourced range below (they are not
+    // testmempoolaccept-probe material: special txs with no vin). Every tx
+    // here already passed the follower's full fail-closed predicate; this
+    // site only PLACES them. nullptr/empty = today's template, byte-identical.
+    if (admitted_asset_unlocks != nullptr) {
+        for (const auto& utx : admitted_asset_unlocks->txs) {
+            w.m_txs.emplace_back(utx);
+            w.m_tx_hashes.push_back(dash::coin::dash_txid(utx));
+            // The unlock's miner fee is carried in its payload, not derivable
+            // from vin (it has none) — record it so per-tx fee accounting sums
+            // to the total_fees fold above.
+            vendor::CAssetUnlockPayload upl;
+            const uint64_t ufee =
+                vendor::parse_assetunlock_payload(utx.extra_payload, upl)
+                    ? upl.fee : 0;
+            w.m_tx_fees.push_back(ufee);
+            w.m_tx_data_hex.push_back(tx_hex(utx));
+        }
+        if (!admitted_asset_unlocks->txs.empty()) {
+            LOG_INFO << "[GBT-EMB] #143 type-9 unlocks in template h="
+                     << w.m_height << ": " << admitted_asset_unlocks->txs.size()
+                     << " tx, gross_unlocked="
+                     << admitted_asset_unlocks->gross_unlocked
+                     << " payload_fees="
+                     << admitted_asset_unlocks->total_payload_fees;
+        }
+    }
     uint64_t selected_bytes = 0;  // wire bytes packed into this template (underfill guard)
     // ── THE MEMPOOL-SOURCED RANGE (validity-gate probe set) ─────────────
     // Everything appended from here on is mempool-sourced; the type-6
@@ -942,8 +1006,18 @@ inline DashWorkData build_embedded_workdata(
                             " same txs ride the served body -- #125/tx-serving)";
             }
         }
+        // #143: the admitted unlocks' GROSS amount (Σ vout + fee) LEAVES the
+        // pool — dashd's sessionUnlocked term in GetTotalLocked
+        // (creditpool.h:98-100). The validator re-derives this from the
+        // block's OWN type-9 txs (which ride this template's body above), so
+        // committing the deduction is what MAKES the block valid; nullptr /
+        // empty deducts 0 and the accrual is byte-identical to today.
+        const int64_t asset_unlock_deduction =
+            admitted_asset_unlocks != nullptr
+                ? admitted_asset_unlocks->gross_unlocked : 0;
         const int64_t accrued_credit_pool =
-            last_observed_credit_pool + platform_reward + asset_lock_accrual;
+            last_observed_credit_pool + platform_reward + asset_lock_accrual
+            - asset_unlock_deduction;
         // confirmedHash rollover (sml_projection.hpp, FINDING-1): the tip SML
         // is the verifier's PREV list, not the list for the block being
         // templated — dashd's rebuild starts with a purely height-driven

--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -413,6 +413,47 @@ public:
     }
 };
 
+// TEE consumer decoration (Variant B, #143): hand every verified body to TWO
+// consumers so a sister lane (the CreditPool INDEX follower,
+// credit_pool_idx.hpp) shares the SAME 30-40 GB bulk fetch instead of
+// repeating it — and sees the body BEFORE drain_buffer() prunes it, which is
+// the only moment the type-8/9 payloads exist in memory.
+//
+// SEMANTICS (deliberate, both directions fail closed):
+//   * PRIMARY refuses  -> the lane refuses (unchanged W1 contract: a fold
+//     that cannot proceed must never be silently skipped past).
+//   * SIDE refuses     -> the lane ALSO refuses. The side lane's refusal
+//     means ITS provenance broke mid-stream; pressing on would leave the two
+//     lanes' cursors disagreeing about what "delivered" means for this run.
+//     The side consumer is expected to have ALREADY latched its own
+//     fail-closed state (proven_complete=0 + wipe) before returning false,
+//     so the shared lane stopping is a named, restartable condition — never
+//     a silent divergence. Callers that want a purely observational side
+//     lane must wrap it so it never refuses.
+class TeeReplayConsumer : public IReplayBlockConsumer
+{
+    IReplayBlockConsumer* m_primary;   // borrowed, never owned
+    IReplayBlockConsumer* m_side;      // borrowed, never owned
+
+public:
+    TeeReplayConsumer(IReplayBlockConsumer* primary, IReplayBlockConsumer* side)
+        : m_primary(primary), m_side(side) {}
+
+    bool on_replay_block(uint32_t height, const uint256& hash,
+                         const BlockType& block) override
+    {
+        // Side FIRST: it must see the body even if the primary then refuses
+        // (the primary's refusal poisons the lane anyway; the side lane's
+        // ledger stays honest either way because it only advances on its own
+        // clean apply).
+        const bool side_ok =
+            m_side == nullptr || m_side->on_replay_block(height, hash, block);
+        const bool primary_ok =
+            m_primary == nullptr || m_primary->on_replay_block(height, hash, block);
+        return side_ok && primary_ok;
+    }
+};
+
 // ── Genesis→anchor header backfill ─────────────────────────────────────────
 //
 // Forward walker over `headers` batches. Holds ONLY the per-height hash

--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -693,6 +693,14 @@ public:
             default:
                 // Types 5 (cbTx, coinbase-only), 8/9 (asset lock/unlock —
                 // credit-pool lane, not DML), MNHF: no DML effect.
+                //
+                // Types 8/9 are NOT discarded by the replay pipeline: the
+                // CreditPool INDEX follower (credit_pool_idx.hpp, Variant B
+                // #143) ingests them as a SECOND IReplayBlockConsumer through
+                // the TeeReplayConsumer seam (replay_bulk_fetch.hpp), which
+                // hands it the full body BEFORE drain_buffer() prunes it.
+                // Folding them HERE as well would double-ingest; the DML fold
+                // stays type-8/9-blind on purpose.
                 break;
             }
             if (!err.empty()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -618,7 +618,23 @@ if (BUILD_TESTING AND GTest_FOUND)
     # signature negative — are #ifdef C2POOL_DASH_BLS-gated in the source and
     # exercise only when the backend is linked. dash_bls_verify compiles
     # unconditionally (fail-closed stub without the backend), so this always links.
-    add_executable(test_dash_chainlock_verify test_dash_chainlock_verify.cpp)
+    # Second TU (#143 Variant B): test_dash_credit_pool_idx.cpp — the
+    # CreditPool INDEX follower (credit_pool_idx.hpp): the CRangesSet port,
+    # the dashd "plwdtx" request-id preimage, the era-laddered LimitAmount
+    # arithmetic, the 576-block latelyUnlocked window, the per-block
+    # cbTx-balance cross-check with fail-closed wipe, the CreditPoolIdxDb
+    # R/w/C/S schema + restore adjudication, and the five task KATs
+    # (flag-OFF byte-identity, gap⇒fail-closed, duplicate-index exclusion,
+    # verified-sig inclusion + committed-balance exactness, tampered-sig
+    # rejection). FOLDED into THIS target on purpose: it is the only
+    # build.yml-allowlisted dash target that links dash_bls_verify (the
+    # ARM-3 quorumSig verify needs the same VerifyInsecure port the
+    # ChainLock KATs lock), and a new add_executable would be a NOT_BUILT
+    # sentinel (#143 trap). The BLS-crypto halves (KAT 4/5 real-signature)
+    # are #ifdef C2POOL_DASH_BLS — exercised by the linux-dash-bls leg; the
+    # fold/schema/fail-closed halves run in EVERY build.
+    add_executable(test_dash_chainlock_verify test_dash_chainlock_verify.cpp
+                   test_dash_credit_pool_idx.cpp)
     target_link_libraries(test_dash_chainlock_verify PRIVATE
         GTest::gtest_main GTest::gtest
         dash_bls_verify dash_x11 core

--- a/test/test_dash_credit_pool_idx.cpp
+++ b/test/test_dash_credit_pool_idx.cpp
@@ -1,0 +1,1024 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Variant B (#143, wf wtrv69elc) — CreditPool INDEX follower KATs.
+//
+// The five properties the task demands, each pinned red/green:
+//   (1) FLAG OFF ⇒ BYTE-IDENTICAL EXCLUDE-ALL TEMPLATE. The admission seam at
+//       nullptr AND at an empty admission produces a template equal field-by-
+//       field (txs, hashes, fees, values, payments, coinbase payload) to a
+//       build with the seam absent; try_admit_unlocks(flag_off) refuses.
+//   (2) A GAP IN THE FOLLOWER'S INPUT ⇒ FAIL CLOSED: apply_block on a
+//       non-contiguous height refuses, latches proven_complete=0, WIPES, and
+//       the admission predicate refuses — the template stays exclude-all
+//       (valid); no wrong balance can be served because the wiped follower
+//       reports nothing.
+//   (3) DUPLICATE INDEX ⇒ EXCLUDED: a contiguous synthetic v20→tip fold that
+//       mined index 5 refuses a candidate carrying index 5 (and a duplicate
+//       ON CHAIN hard-fails the fold itself, mirroring the dashd throw).
+//   (4) VALID NON-DUPLICATE TYPE-9 + FRESH WINDOW + VERIFIED quorumSig ⇒
+//       INCLUDED, and the committed creditPoolBalance equals the value the
+//       cbTx of the built block must commit (prev + platformReward − gross).
+//       [real BLS — #ifdef C2POOL_DASH_BLS]
+//   (5) BAD quorumSig ⇒ REJECTED (fail-closed BLS): a single flipped byte in
+//       the signature excludes the candidate. [real BLS — #ifdef; the
+//       stub-build variant asserts the backend-absent path also refuses.]
+//
+// Plus the load-bearing pieces underneath: the CRangesSet port (add/dup/
+// merge/contains), the dashd request-id preimage (byte-exact against an
+// independently assembled buffer), the era-laddered LimitAmount arithmetic
+// (creditpool.cpp:192-212 all three arms), the 576-block latelyUnlocked
+// window (slide + missing-row refusal), and the CreditPoolIdxDb schema
+// round-trip + torn-namespace adjudication + persist/restore/wipe.
+//
+// Folded into the test_dash_chainlock_verify target (NOT a new
+// add_executable): that target is in the build.yml --target allowlist AND
+// links dash_bls_verify — a new target would be a NOT_BUILT sentinel (#143
+// trap), and no other allowlisted dash target links the BLS backend.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/credit_pool_idx.hpp>
+#include <impl/dash/coin/credit_pool_idx_db.hpp>
+#include <impl/dash/coin/asset_unlock_verify.hpp>
+#include <impl/dash/coin/asset_unlock_admission.hpp>
+#include <impl/dash/coin/embedded_gbt.hpp>
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/vendor/cbtx.hpp>
+#include <impl/dash/coin/vendor/assetlock.hpp>
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+
+#include <core/hash.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include <unistd.h>   // getpid (temp DB paths)
+
+#ifdef C2POOL_DASH_BLS
+#include <dashbls/bls.hpp>
+#include <dashbls/schemes.hpp>
+#include <dashbls/elements.hpp>
+#endif
+
+using dash::coin::AssetUnlockAdmission;
+using dash::coin::BlockType;
+using dash::coin::CRangesSet;
+using dash::coin::CpIdxCursor;
+using dash::coin::CpIdxDeploySchedule;
+using dash::coin::CpIdxEra;
+using dash::coin::CpIdxSeedProvenance;
+using dash::coin::CpIdxWindowRowRec;
+using dash::coin::CreditPoolIdxDb;
+using dash::coin::CreditPoolIdxFollower;
+using dash::coin::COIN_SAT;
+using dash::coin::Mempool;
+using dash::coin::MNState;
+using dash::coin::MnStateMachine;
+using dash::coin::MutableTransaction;
+using dash::coin::QuorumManager;
+using dash::coin::build_embedded_workdata;
+using dash::coin::chainlock::QuorumCandidate;
+using dash::coin::cp_idx_current_limit;
+using dash::coin::cp_idx_era_at;
+using dash::coin::kCpIdxNeverActive;
+using dash::coin::kCpLimitAmountHigh;
+using dash::coin::kCpLimitAmountLow;
+using dash::coin::kCpLimitAmountV22;
+using dash::coin::kCpLimitAmountV24;
+using dash::coin::kLlmq100_67;
+using dash::coin::vendor::CAssetLockPayload;
+using dash::coin::vendor::CAssetUnlockPayload;
+using dash::coin::vendor::CCbTx;
+using dash::coin::vendor::parse_cbtx;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+using ::core::coin::Coin;
+using ::core::coin::Outpoint;
+using ::core::coin::UTXOViewCache;
+
+namespace unlockverify = dash::coin::unlockverify;
+
+// ─── fixtures ───────────────────────────────────────────────────────────────
+
+static constexpr uint8_t DASH_PUBKEY_VER = 76;
+static constexpr uint8_t DASH_P2SH_VER   = 16;
+
+// Template height: past V20 + MN_RR (mainnet), matching the gbt capstone.
+static constexpr uint32_t H = 2'400'000;
+
+static uint256 raw256(uint8_t base) {
+    uint256 h;
+    for (size_t i = 0; i < 32; ++i) h.data()[i] = static_cast<uint8_t>(base + i);
+    return h;
+}
+
+static std::vector<unsigned char> p2pkh_script(uint8_t hashseed) {
+    std::vector<unsigned char> s;
+    s.push_back(0x76); s.push_back(0xa9); s.push_back(0x14);
+    for (int i = 0; i < 20; ++i) s.push_back(static_cast<unsigned char>(hashseed + i));
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+static MnStateMachine single_mn() {
+    MNState s;
+    s.isValid = true;
+    s.nRegisteredHeight = 2'300'000;
+    s.nLastPaidHeight = 0;
+    s.scriptPayout.m_data = p2pkh_script(0x30);
+    s.payoutSplitProvenance = MNState::SPLIT_KNOWN;
+    MnStateMachine m;
+    m.load(std::vector<std::pair<uint256, MNState>>{{raw256(0x01), s}});
+    return m;
+}
+
+template <typename T>
+static std::vector<unsigned char> pack_bytes(const T& v) {
+    ::PackStream s;
+    s << v;
+    auto sp = s.get_span();
+    return std::vector<unsigned char>(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+}
+
+// Coinbase carrying a v3 CCbTx committing `balance` at `height`.
+static MutableTransaction make_cbtx_coinbase(uint32_t height, int64_t balance) {
+    CCbTx c;
+    c.nVersion = CCbTx::VERSION_CLSIG_AND_BALANCE;
+    c.nHeight  = static_cast<int32_t>(height);
+    c.creditPoolBalance = balance;
+    MutableTransaction cb;
+    cb.version = 3;
+    cb.type = 5;
+    cb.extra_payload = pack_bytes(c);
+    return cb;
+}
+
+// Type-8 asset lock crediting `amount` (payload total_credit — the term the
+// scalar machine folds, credit_pool.hpp:79-85).
+static MutableTransaction make_lock_tx(int64_t amount) {
+    CAssetLockPayload p;
+    p.nVersion = 1;
+    TxOut credit; credit.value = amount;
+    p.creditOutputs.push_back(credit);
+    MutableTransaction tx;
+    tx.version = 3;
+    tx.type = CAssetLockPayload::SPECIALTX_TYPE;
+    tx.extra_payload = pack_bytes(p);
+    return tx;
+}
+
+// Type-9 asset unlock: one withdrawal vout of `vout_value`, payload fee
+// `fee`, dedup index `index`. Gross pool deduction = vout_value + fee.
+static MutableTransaction make_unlock_tx(
+    uint64_t index, uint32_t fee, int64_t vout_value,
+    uint32_t requested_height, const uint256& quorum_hash,
+    const std::array<uint8_t, 96>& sig = {}) {
+    CAssetUnlockPayload p;
+    p.nVersion = 1;
+    p.index = index;
+    p.fee = fee;
+    p.requestedHeight = requested_height;
+    p.quorumHash = quorum_hash;
+    p.quorumSig = sig;
+    MutableTransaction tx;
+    tx.version = 3;
+    tx.type = CAssetUnlockPayload::SPECIALTX_TYPE;
+    TxOut o; o.value = vout_value;
+    tx.vout.push_back(o);
+    tx.extra_payload = pack_bytes(p);
+    return tx;
+}
+
+static BlockType make_block(const uint256& prev_hash,
+                            std::vector<MutableTransaction> txs) {
+    BlockType b;
+    b.m_previous_block = prev_hash;
+    b.m_txs = std::move(txs);
+    return b;
+}
+
+// Synthetic chain hash naming: hash(h) = raw256 of the low byte + a marker.
+static uint256 chain_hash(uint32_t h) {
+    uint256 x;
+    x.data()[0] = static_cast<uint8_t>(h & 0xFF);
+    x.data()[1] = static_cast<uint8_t>((h >> 8) & 0xFF);
+    x.data()[2] = static_cast<uint8_t>((h >> 16) & 0xFF);
+    x.data()[3] = static_cast<uint8_t>((h >> 24) & 0xFF);
+    x.data()[31] = 0xC7;   // namespace marker so it never collides with raw256
+    return x;
+}
+
+// A follower schedule whose v20 floor sits just below the template height so
+// KATs fold a handful of blocks to reach freshness. WITHDRAWALS active from
+// genesis (era V22: limit = min(pool, 2000 DASH)); V24 never.
+static CpIdxDeploySchedule test_schedule(uint32_t floor_h) {
+    return CpIdxDeploySchedule{floor_h, 0u, kCpIdxNeverActive, 576u};
+}
+
+// Fold a synthetic v20→tip chain into `f`:
+//   floor+1: type-8 lock of 1000 DASH        (pool: 0 → 1000 DASH)
+//   floor+2: type-9 unlock index 5, 10 DASH+190 duff fee (pool −= gross)
+//   floor+3 .. tip: empty blocks (balance carries)
+// The tip block's hash is `tip_hash` so a template on that parent is fresh.
+// Every block's cbTx commits the running balance (reward_fn pinned to 0).
+struct FoldResult { int64_t balance; uint32_t tip; };
+static FoldResult fold_synthetic_chain(CreditPoolIdxFollower& f,
+                                       uint32_t floor_h, uint32_t tip_h,
+                                       const uint256& tip_hash) {
+    f.set_reward_fn([](uint32_t) { return 0; });
+    f.arm(chain_hash(floor_h), /*floor_balance=*/0);
+
+    int64_t balance = 0;
+    for (uint32_t h = floor_h + 1; h <= tip_h; ++h) {
+        std::vector<MutableTransaction> txs;
+        if (h == floor_h + 1) {
+            balance += 1000 * COIN_SAT;
+            txs.push_back(make_cbtx_coinbase(h, balance));
+            txs.push_back(make_lock_tx(1000 * COIN_SAT));
+        } else if (h == floor_h + 2) {
+            balance -= 10 * COIN_SAT + 190;
+            txs.push_back(make_cbtx_coinbase(h, balance));
+            txs.push_back(make_unlock_tx(/*index=*/5, /*fee=*/190,
+                                         /*vout=*/10 * COIN_SAT,
+                                         /*requested*/ h - 1, raw256(0x77)));
+        } else {
+            txs.push_back(make_cbtx_coinbase(h, balance));
+        }
+        const uint256 hash = h == tip_h ? tip_hash : chain_hash(h);
+        EXPECT_TRUE(f.apply_block(h, hash,
+                                  make_block(h == floor_h + 1
+                                                 ? chain_hash(floor_h)
+                                                 : chain_hash(h - 1),
+                                             std::move(txs))))
+            << "fold refused at h=" << h << ": " << f.fail_cause();
+    }
+    f.mark_proven_complete();
+    return {balance, tip_h};
+}
+
+// Template-building fixture (mirrors the gbt capstone's minimal shape).
+struct GbtFixture {
+    UTXOViewCache utxo{nullptr};
+    Mempool mp;
+    MnStateMachine mnstates{single_mn()};
+    uint256 prev_hash{raw256(0xAB)};
+    dash::coin::vendor::CSimplifiedMNList sml;
+    QuorumManager qmgr;
+
+    GbtFixture() {
+        mp.set_utxo(&utxo);
+        dash::coin::vendor::CSimplifiedMNListEntry e1;
+        e1.proRegTxHash = raw256(0x11);
+        e1.isValid = true;
+        e1.confirmedHash = raw256(0x12);   // non-null: rollover projection trivial
+        sml = dash::coin::vendor::CSimplifiedMNList(
+            std::vector<dash::coin::vendor::CSimplifiedMNListEntry>{e1});
+    }
+
+    dash::coin::DashWorkData build(int64_t credit_pool,
+                                   const AssetUnlockAdmission* adm) const {
+        return build_embedded_workdata(
+            /*prev_height=*/H - 1, prev_hash, mnstates, mp,
+            /*bits=*/0x1b104be3u, /*mtp=*/1'700'000'000u,
+            DASH_PUBKEY_VER, DASH_P2SH_VER,
+            /*curtime=*/1'700'000'123u, /*version=*/0x20000000u,
+            /*underfill_tripped=*/nullptr,
+            &sml, &qmgr,
+            /*best_cl_height=*/0, dash::coin::k_zero_cl_sig, credit_pool,
+            /*qc_commitments=*/nullptr, /*quorum_root_override=*/nullptr,
+            dash::coin::DASH_MN_RR_HEIGHT_MAINNET,
+            /*superblock_payments=*/nullptr,
+            dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+            /*suppress_mempool_txs=*/false,
+            /*txset_empty_cause=*/"utxo-immature-serving",
+            /*pinned_local_txs=*/nullptr,
+            /*accrue_pending_asset_locks=*/false,
+            adm);
+    }
+};
+
+// Field-by-field template equality — every byte a miner or verifier consumes.
+static void expect_workdata_identical(const dash::coin::DashWorkData& a,
+                                      const dash::coin::DashWorkData& b) {
+    EXPECT_EQ(a.m_height, b.m_height);
+    EXPECT_EQ(a.m_previous_block, b.m_previous_block);
+    EXPECT_EQ(a.m_coinbase_value, b.m_coinbase_value);
+    EXPECT_EQ(a.m_payment_amount, b.m_payment_amount);
+    ASSERT_EQ(a.m_txs.size(), b.m_txs.size());
+    for (size_t i = 0; i < a.m_txs.size(); ++i)
+        EXPECT_EQ(pack_bytes(MutableTransaction(a.m_txs[i])),
+                  pack_bytes(MutableTransaction(b.m_txs[i]))) << "tx[" << i << "]";
+    EXPECT_EQ(a.m_tx_hashes, b.m_tx_hashes);
+    EXPECT_EQ(a.m_tx_fees, b.m_tx_fees);
+    EXPECT_EQ(a.m_tx_data_hex, b.m_tx_data_hex);
+    ASSERT_EQ(a.m_packed_payments.size(), b.m_packed_payments.size());
+    for (size_t i = 0; i < a.m_packed_payments.size(); ++i) {
+        EXPECT_EQ(a.m_packed_payments[i].payee,  b.m_packed_payments[i].payee);
+        EXPECT_EQ(a.m_packed_payments[i].amount, b.m_packed_payments[i].amount);
+    }
+    EXPECT_EQ(a.m_coinbase_payload, b.m_coinbase_payload);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// CRangesSet — the dashd util/ranges_set port.
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCreditPoolIdx, RangesSetAddContainsDuplicateAndMerge) {
+    CRangesSet s;
+    EXPECT_TRUE(s.IsEmpty());
+    EXPECT_TRUE(s.Add(5));
+    EXPECT_FALSE(s.Add(5));            // duplicate ⇒ false (the dashd throw)
+    EXPECT_TRUE(s.Contains(5));
+    EXPECT_FALSE(s.Contains(4));
+    // adjacency merges: 4,5,6 becomes ONE range [4,7)
+    EXPECT_TRUE(s.Add(6));
+    EXPECT_TRUE(s.Add(4));
+    EXPECT_EQ(s.Size(), 3u);
+    auto r = s.export_ranges();
+    ASSERT_EQ(r.size(), 1u);
+    EXPECT_EQ(r[0].first, 4u);
+    EXPECT_EQ(r[0].second, 7u);
+    // a gap stays two ranges
+    EXPECT_TRUE(s.Add(100));
+    EXPECT_EQ(s.export_ranges().size(), 2u);
+    // bridge the hole 4..7 + 8 + [8? no: add 7 bridges [4,7)+[8,..)?]
+    EXPECT_TRUE(s.Add(8));
+    EXPECT_TRUE(s.Add(7));             // merges [4,7)+7+[8,9) → [4,9)
+    auto r2 = s.export_ranges();
+    ASSERT_EQ(r2.size(), 2u);
+    EXPECT_EQ(r2[0].first, 4u);
+    EXPECT_EQ(r2[0].second, 9u);
+    // import/export round-trip
+    CRangesSet t;
+    EXPECT_TRUE(t.import_ranges(r2));
+    EXPECT_TRUE(t.Contains(8));
+    EXPECT_FALSE(t.Contains(9));
+    EXPECT_TRUE(t.Contains(100));
+    // malformed imports refused: empty range, overlap, adjacency
+    CRangesSet u;
+    EXPECT_FALSE(u.import_ranges({{3, 3}}));
+    EXPECT_FALSE(u.import_ranges({{3, 5}, {4, 6}}));
+    EXPECT_FALSE(u.import_ranges({{3, 5}, {5, 6}}));   // adjacent = non-canonical
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Request-id preimage + era ladder arithmetic.
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCreditPoolIdx, UnlockRequestIdPreimageByteExact) {
+    // dashd: SerializeHash(make_pair("plwdtx", index)) — preimage is exactly
+    // CompactSize(6) || "plwdtx" || u64le(index). Assemble it independently.
+    const uint64_t index = 0x0123456789ABCDEFull;
+    std::vector<unsigned char> pre;
+    pre.push_back(0x06);
+    for (char ch : std::string("plwdtx")) pre.push_back(static_cast<unsigned char>(ch));
+    for (int i = 0; i < 8; ++i) pre.push_back(static_cast<unsigned char>((index >> (8 * i)) & 0xFF));
+    ASSERT_EQ(pre.size(), 15u);
+    const uint256 expect = ::Hash(std::span<const unsigned char>(pre.data(), pre.size()));
+    EXPECT_EQ(unlockverify::unlock_request_id(index), expect);
+    // and it is index-sensitive
+    EXPECT_NE(unlockverify::unlock_request_id(index + 1), expect);
+}
+
+TEST(DashCreditPoolIdx, EraLadderLimitArithmetic) {
+    // V24: max(0, min(pool, 4000 − lately))
+    EXPECT_EQ(*cp_idx_current_limit(10'000 * COIN_SAT, 500 * COIN_SAT, CpIdxEra::V24),
+              kCpLimitAmountV24 - 500 * COIN_SAT);
+    EXPECT_EQ(*cp_idx_current_limit(10'000 * COIN_SAT, 5000 * COIN_SAT, CpIdxEra::V24),
+              0);                                            // clamped, not negative
+    EXPECT_EQ(*cp_idx_current_limit(100 * COIN_SAT, 0, CpIdxEra::V24),
+              100 * COIN_SAT);                               // pool-bound
+    // V22: min(pool, 2000) — no lately subtraction in this arm (creditpool.cpp:197)
+    EXPECT_EQ(*cp_idx_current_limit(10'000 * COIN_SAT, 1500 * COIN_SAT, CpIdxEra::V22),
+              kCpLimitAmountV22);
+    EXPECT_EQ(*cp_idx_current_limit(700 * COIN_SAT, 0, CpIdxEra::V22),
+              700 * COIN_SAT);
+    // pre-v22: max(100, pool/10) − lately, capped at 1000 − lately
+    //   pool = 20'000 DASH, lately = 0: pool/10 = 2000 → capped at 1000
+    EXPECT_EQ(*cp_idx_current_limit(20'000 * COIN_SAT, 0, CpIdxEra::PreV22),
+              kCpLimitAmountHigh);
+    //   pool = 5'000 DASH, lately = 200: 500 − 200 = 300
+    EXPECT_EQ(*cp_idx_current_limit(5'000 * COIN_SAT, 200 * COIN_SAT, CpIdxEra::PreV22),
+              300 * COIN_SAT);
+    //   tiny pool (≤ 100 incl. lately): limit = pool itself
+    EXPECT_EQ(*cp_idx_current_limit(60 * COIN_SAT, 0, CpIdxEra::PreV22),
+              60 * COIN_SAT);
+    //   negative ⇒ nullopt (the dashd throw → fail closed)
+    EXPECT_FALSE(cp_idx_current_limit(5'000 * COIN_SAT, 1100 * COIN_SAT,
+                                      CpIdxEra::PreV22).has_value());
+    // era resolution against the schedule
+    CpIdxDeploySchedule s{100, 500, 900, 576};
+    EXPECT_EQ(cp_idx_era_at(s, 499), CpIdxEra::PreV22);
+    EXPECT_EQ(cp_idx_era_at(s, 500), CpIdxEra::V22);
+    EXPECT_EQ(cp_idx_era_at(s, 900), CpIdxEra::V24);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// Follower fold: cross-check, dedup hard-fail, window slide.
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCreditPoolIdx, FoldCrossChecksEveryBlockAndTracksWindow) {
+    CreditPoolIdxFollower f(test_schedule(1000));
+    f.set_reward_fn([](uint32_t) { return 0; });
+    f.arm(chain_hash(1000), 0);
+    ASSERT_TRUE(f.armed());
+
+    // lock 1000 DASH at 1001
+    EXPECT_TRUE(f.apply_block(1001, chain_hash(1001),
+        make_block(chain_hash(1000),
+                   {make_cbtx_coinbase(1001, 1000 * COIN_SAT),
+                    make_lock_tx(1000 * COIN_SAT)})));
+    EXPECT_EQ(f.balance(), 1000 * COIN_SAT);
+    EXPECT_EQ(f.lately_unlocked(), 0);
+
+    // unlock 10 DASH + 190 duff fee at 1002 (index 5)
+    const int64_t gross = 10 * COIN_SAT + 190;
+    EXPECT_TRUE(f.apply_block(1002, chain_hash(1002),
+        make_block(chain_hash(1001),
+                   {make_cbtx_coinbase(1002, 1000 * COIN_SAT - gross),
+                    make_unlock_tx(5, 190, 10 * COIN_SAT, 1001, raw256(0x77))})));
+    EXPECT_EQ(f.balance(), 1000 * COIN_SAT - gross);
+    EXPECT_EQ(f.lately_unlocked(), gross);
+    EXPECT_TRUE(f.indexes().Contains(5));
+
+    // a WRONG committed balance ⇒ fail closed + wipe
+    CreditPoolIdxFollower g(test_schedule(1000));
+    g.set_reward_fn([](uint32_t) { return 0; });
+    g.arm(chain_hash(1000), 0);
+    EXPECT_FALSE(g.apply_block(1001, chain_hash(1001),
+        make_block(chain_hash(1000),
+                   {make_cbtx_coinbase(1001, 999 * COIN_SAT),   // lies by 1 DASH
+                    make_lock_tx(1000 * COIN_SAT)})));
+    EXPECT_FALSE(g.armed());
+    EXPECT_FALSE(g.proven_complete());
+    EXPECT_NE(g.fail_cause().find("MISMATCH"), std::string::npos);
+}
+
+TEST(DashCreditPoolIdx, DuplicateOnChainIndexHardFailsTheFold) {
+    CreditPoolIdxFollower f(test_schedule(1000));
+    f.set_reward_fn([](uint32_t) { return 0; });
+    f.arm(chain_hash(1000), 0);
+    const int64_t gross = 10 * COIN_SAT + 190;
+    ASSERT_TRUE(f.apply_block(1001, chain_hash(1001),
+        make_block(chain_hash(1000),
+                   {make_cbtx_coinbase(1001, 1000 * COIN_SAT),
+                    make_lock_tx(1000 * COIN_SAT)})));
+    ASSERT_TRUE(f.apply_block(1002, chain_hash(1002),
+        make_block(chain_hash(1001),
+                   {make_cbtx_coinbase(1002, 1000 * COIN_SAT - gross),
+                    make_unlock_tx(5, 190, 10 * COIN_SAT, 1001, raw256(0x77))})));
+    // the SAME index mined again ⇒ the dashd throw, ported: hard fail + wipe
+    EXPECT_FALSE(f.apply_block(1003, chain_hash(1003),
+        make_block(chain_hash(1002),
+                   {make_cbtx_coinbase(1003, 1000 * COIN_SAT - 2 * gross),
+                    make_unlock_tx(5, 190, 10 * COIN_SAT, 1002, raw256(0x77))})));
+    EXPECT_FALSE(f.armed());
+    EXPECT_NE(f.fail_cause().find("index-duplicated"), std::string::npos);
+}
+
+TEST(DashCreditPoolIdx, WindowSlidesAndLatelyUnlockedDecays) {
+    // Tiny window (3) to exercise the slide without 576 blocks.
+    CpIdxDeploySchedule s{100, 0, kCpIdxNeverActive, 3};
+    CreditPoolIdxFollower f(s);
+    f.set_reward_fn([](uint32_t) { return 0; });
+    f.arm(chain_hash(100), 0);
+    int64_t bal = 0;
+    // 101: lock 100 DASH
+    bal += 100 * COIN_SAT;
+    ASSERT_TRUE(f.apply_block(101, chain_hash(101),
+        make_block(chain_hash(100),
+                   {make_cbtx_coinbase(101, bal), make_lock_tx(100 * COIN_SAT)})));
+    // 102: unlock gross g1
+    const int64_t g1 = 1 * COIN_SAT + 100;
+    bal -= g1;
+    ASSERT_TRUE(f.apply_block(102, chain_hash(102),
+        make_block(chain_hash(101),
+                   {make_cbtx_coinbase(102, bal),
+                    make_unlock_tx(1, 100, 1 * COIN_SAT, 101, raw256(0x77))})));
+    EXPECT_EQ(f.lately_unlocked(), g1);
+    // 103, 104: empty
+    ASSERT_TRUE(f.apply_block(103, chain_hash(103),
+        make_block(chain_hash(102), {make_cbtx_coinbase(103, bal)})));
+    ASSERT_TRUE(f.apply_block(104, chain_hash(104),
+        make_block(chain_hash(103), {make_cbtx_coinbase(104, bal)})));
+    EXPECT_EQ(f.lately_unlocked(), g1);   // 102 still inside (105-3=102)
+    // 105: the 102 row slides OUT (105 − 3 = 102) → lately decays to 0
+    ASSERT_TRUE(f.apply_block(105, chain_hash(105),
+        make_block(chain_hash(104), {make_cbtx_coinbase(105, bal)})));
+    EXPECT_EQ(f.lately_unlocked(), 0);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// KAT 2 — GAP ⇒ FAIL CLOSED (refuses type-9, template stays valid exclude-all).
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCreditPoolIdx, Kat2_GapFailsClosedAndTemplateStaysExcludeAll) {
+    GbtFixture gbt;
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    f.set_reward_fn([](uint32_t) { return 0; });
+    f.arm(chain_hash(H - 6), 0);
+    ASSERT_TRUE(f.apply_block(H - 5, chain_hash(H - 5),
+        make_block(chain_hash(H - 6), {make_cbtx_coinbase(H - 5, 0)})));
+
+    // GAP: skip H-4, feed H-3 ⇒ refuse + latch + wipe.
+    EXPECT_FALSE(f.apply_block(H - 3, chain_hash(H - 3),
+        make_block(chain_hash(H - 4), {make_cbtx_coinbase(H - 3, 0)})));
+    EXPECT_FALSE(f.armed());
+    EXPECT_FALSE(f.proven_complete());
+    EXPECT_NE(f.fail_cause().find("gap"), std::string::npos);
+
+    // The predicate refuses even with the flag ON…
+    EXPECT_FALSE(f.accrual_permitted(/*flag_on=*/true, H, gbt.prev_hash));
+    AssetUnlockAdmission adm;
+    EXPECT_FALSE(f.try_admit_unlocks(true, H, gbt.prev_hash, {}, {},
+                                     kLlmq100_67, adm));
+    EXPECT_TRUE(adm.empty());
+
+    // …and the served template is the valid exclude-all one: the caller
+    // passes nullptr, which is EXACTLY the baseline build. No balance from
+    // the wiped follower can reach the coinbase — the caller still uses its
+    // own scalar last_observed_credit_pool, unchanged.
+    auto baseline = gbt.build(/*credit_pool=*/12'345, nullptr);
+    auto after    = gbt.build(/*credit_pool=*/12'345, nullptr);
+    expect_workdata_identical(baseline, after);
+    for (const auto& tx : baseline.m_txs)
+        EXPECT_NE(tx.type, CAssetUnlockPayload::SPECIALTX_TYPE);
+}
+
+// Lineage variant of KAT 2: right height, WRONG parent hash ⇒ same latch.
+TEST(DashCreditPoolIdx, Kat2b_LineageMismatchFailsClosed) {
+    CreditPoolIdxFollower f(test_schedule(1000));
+    f.set_reward_fn([](uint32_t) { return 0; });
+    f.arm(chain_hash(1000), 0);
+    EXPECT_FALSE(f.apply_block(1001, chain_hash(1001),
+        make_block(/*WRONG parent*/ raw256(0xEE),
+                   {make_cbtx_coinbase(1001, 0)})));
+    EXPECT_FALSE(f.armed());
+    EXPECT_NE(f.fail_cause().find("lineage"), std::string::npos);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// KAT 1 — FLAG OFF ⇒ byte-identical exclude-all template.
+// ════════════════════════════════════════════════════════════════════════
+
+TEST(DashCreditPoolIdx, Kat1_FlagOffTemplateByteIdentical) {
+    GbtFixture gbt;
+
+    // A fully healthy, proven-complete, FRESH follower…
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    auto fold = fold_synthetic_chain(f, H - 6, H - 1, gbt.prev_hash);
+    ASSERT_TRUE(f.proven_complete());
+    ASSERT_EQ(f.height(), H - 1);
+
+    // …with the flag OFF refuses admission (conjunct a):
+    AssetUnlockAdmission adm;
+    EXPECT_FALSE(f.accrual_permitted(/*flag_on=*/false, H, gbt.prev_hash));
+    EXPECT_FALSE(f.try_admit_unlocks(false, H, gbt.prev_hash, {}, {},
+                                     kLlmq100_67, adm));
+    EXPECT_TRUE(adm.empty());
+
+    // and the template path is BYTE-IDENTICAL to today's exclude-all across
+    // all three shapes the call site can take: seam absent (defaulted),
+    // explicit nullptr, and an empty admission object.
+    auto absent = build_embedded_workdata(
+        H - 1, gbt.prev_hash, gbt.mnstates, gbt.mp,
+        0x1b104be3u, 1'700'000'000u, DASH_PUBKEY_VER, DASH_P2SH_VER,
+        1'700'000'123u, 0x20000000u, nullptr, &gbt.sml, &gbt.qmgr,
+        0, dash::coin::k_zero_cl_sig, fold.balance);
+    auto null_seam  = gbt.build(fold.balance, nullptr);
+    AssetUnlockAdmission empty_adm;
+    auto empty_seam = gbt.build(fold.balance, &empty_adm);
+    expect_workdata_identical(absent, null_seam);
+    expect_workdata_identical(null_seam, empty_seam);
+    for (const auto& tx : null_seam.m_txs)
+        EXPECT_NE(tx.type, CAssetUnlockPayload::SPECIALTX_TYPE);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// KAT 3 — duplicate index candidate ⇒ EXCLUDED (fold clean, set authoritative).
+// ════════════════════════════════════════════════════════════════════════
+// Needs no BLS: the dedup check runs BEFORE the signature check, so the
+// exclusion must hold in every build (fail-closed ordering pinned here).
+
+TEST(DashCreditPoolIdx, Kat3_DuplicateIndexCandidateExcluded) {
+    GbtFixture gbt;
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    fold_synthetic_chain(f, H - 6, H - 1, gbt.prev_hash);   // mines index 5
+    ASSERT_TRUE(f.indexes().Contains(5));
+    ASSERT_TRUE(f.proven_complete());
+
+    // Candidate re-using mined index 5 (any signature — dedup fires first).
+    auto dup = make_unlock_tx(5, 200, 1 * COIN_SAT, H - 2, raw256(0x77));
+    QuorumCandidate q;
+    q.quorum_hash = raw256(0x77);
+    q.base_height = H - 24;
+    AssetUnlockAdmission adm;
+    const bool usable = f.try_admit_unlocks(true, H, gbt.prev_hash, {dup}, {q},
+                                            kLlmq100_67, adm);
+#ifdef C2POOL_DASH_BLS
+    // Backend present: the predicate holds, the admission is usable, and the
+    // duplicated index is excluded BEFORE any signature check runs.
+    EXPECT_TRUE(usable);
+#else
+    // Stub build: conjunct (b) refuses the whole admission — structurally OFF.
+    EXPECT_FALSE(usable);
+#endif
+    EXPECT_TRUE(adm.empty()) << "duplicated index must be EXCLUDED";
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// KAT 5 (stub half) — no BLS backend ⇒ structurally OFF, in EVERY build.
+// ════════════════════════════════════════════════════════════════════════
+
+#ifndef C2POOL_DASH_BLS
+TEST(DashCreditPoolIdx, Kat5_NoBlsBackendMeansNoAccrualEver) {
+    GbtFixture gbt;
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    fold_synthetic_chain(f, H - 6, H - 1, gbt.prev_hash);
+    ASSERT_TRUE(f.proven_complete());
+    // conjunct (b): flag ON, follower perfect — still refused.
+    EXPECT_FALSE(f.accrual_permitted(true, H, gbt.prev_hash));
+    AssetUnlockAdmission adm;
+    EXPECT_FALSE(f.try_admit_unlocks(true, H, gbt.prev_hash, {}, {},
+                                     kLlmq100_67, adm));
+    EXPECT_TRUE(adm.empty());
+}
+#endif
+
+// ════════════════════════════════════════════════════════════════════════
+// KATs 4 + 5 (real BLS): verified sig ⇒ INCLUDED with exact committed
+// balance; tampered sig ⇒ REJECTED.
+// ════════════════════════════════════════════════════════════════════════
+
+#ifdef C2POOL_DASH_BLS
+namespace {
+bool vendor_backend_sanity() {
+    return dash::coin::vendor::bls_backend_available();
+}
+
+struct SignedUnlock {
+    MutableTransaction tx;
+    QuorumCandidate    quorum;
+    int64_t            gross;   // vout + fee
+    uint32_t           fee;
+};
+
+// Build a type-9 candidate whose quorumSig REALLY verifies: generate a
+// quorum keypair, derive msgHash exactly as CheckAssetUnlockTx does (tx with
+// zeroed sig), sign SignHash(llmqType, quorumHash, requestId(plwdtx‖index),
+// msgHash) under the BASIC scheme, then splice the signature back in.
+SignedUnlock make_signed_unlock(uint64_t index, uint32_t fee, int64_t vout,
+                                uint32_t requested_height) {
+    bls::BasicSchemeMPL scheme;
+    std::vector<uint8_t> seed(32, 0x5A);
+    bls::PrivateKey sk = scheme.KeyGen(seed);
+    bls::G1Element pk = sk.GetG1Element();
+
+    SignedUnlock out;
+    out.fee = fee;
+    out.gross = vout + fee;
+    out.quorum.quorum_hash = raw256(0x77);
+    out.quorum.base_height = requested_height - 20;
+    auto pkraw = pk.Serialize(false);
+    std::memcpy(out.quorum.quorum_public_key.data(), pkraw.data(), 48);
+
+    // tx with ZEROED sig → msgHash
+    out.tx = make_unlock_tx(index, fee, vout, requested_height,
+                            out.quorum.quorum_hash);
+    CAssetUnlockPayload pl;
+    EXPECT_TRUE(dash::coin::vendor::parse_assetunlock_payload(
+        out.tx.extra_payload, pl));
+    const uint256 msg_hash = unlockverify::unlock_msg_hash(out.tx, pl);
+
+    const uint256 request_id = unlockverify::unlock_request_id(index);
+    const uint256 sign_hash = dash::coin::chainlock::build_sign_hash(
+        kLlmq100_67.type, out.quorum.quorum_hash, request_id, msg_hash);
+
+    bls::G2Element sig = scheme.Sign(sk, bls::Bytes(sign_hash.data(), 32));
+    auto sigraw = sig.Serialize(false);
+    std::array<uint8_t, 96> sigarr{};
+    std::memcpy(sigarr.data(), sigraw.data(), 96);
+
+    // splice the REAL signature into the payload
+    out.tx = make_unlock_tx(index, fee, vout, requested_height,
+                            out.quorum.quorum_hash, sigarr);
+    return out;
+}
+}  // namespace
+
+TEST(DashCreditPoolIdx, Kat4_VerifiedUnlockIncludedAndBalanceCommitsExactly) {
+    GbtFixture gbt;
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    auto fold = fold_synthetic_chain(f, H - 6, H - 1, gbt.prev_hash);
+    ASSERT_TRUE(f.proven_complete());
+    ASSERT_TRUE(vendor_backend_sanity());
+
+    auto su = make_signed_unlock(/*index=*/7, /*fee=*/200,
+                                 /*vout=*/2 * COIN_SAT,
+                                 /*requested_height=*/H - 2);
+
+    AssetUnlockAdmission adm;
+    ASSERT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {su.tx},
+                                    {su.quorum}, kLlmq100_67, adm));
+    ASSERT_EQ(adm.txs.size(), 1u) << "verified non-duplicate unlock must be INCLUDED";
+    EXPECT_EQ(adm.gross_unlocked, su.gross);
+    EXPECT_EQ(adm.total_payload_fees, static_cast<int64_t>(su.fee));
+
+    // Build the template through the single call-site seam.
+    auto w = gbt.build(fold.balance, &adm);
+
+    // The unlock tx rides the body, byte-exact, with its payload fee recorded.
+    bool found = false;
+    for (size_t i = 0; i < w.m_txs.size(); ++i) {
+        if (w.m_txs[i].type == CAssetUnlockPayload::SPECIALTX_TYPE) {
+            found = true;
+            EXPECT_EQ(pack_bytes(MutableTransaction(w.m_txs[i])), pack_bytes(su.tx));
+            EXPECT_EQ(w.m_tx_fees[i], static_cast<uint64_t>(su.fee));
+        }
+    }
+    EXPECT_TRUE(found);
+
+    // The committed creditPoolBalance is EXACTLY what dashd's validator will
+    // re-derive from this block's own txs: prev + platformReward − gross.
+    CCbTx committed;
+    ASSERT_TRUE(parse_cbtx(w.m_coinbase_payload, committed));
+    const int64_t platform_reward =
+        dash::coin::compute_dash_platform_reward_post_v20_mn_rr(H);
+    EXPECT_EQ(committed.creditPoolBalance,
+              fold.balance + platform_reward - su.gross);
+
+    // And the follower's own scalar machine agrees when it folds the block
+    // we just built (the cbTx-committed value IS the computed value).
+    dash::coin::CreditPool xcheck;
+    xcheck.seed(fold.balance, H - 1);
+    BlockType built;
+    built.m_previous_block = gbt.prev_hash;
+    MutableTransaction cb;   // stand-in coinbase (index 0 skipped by the walk)
+    cb.version = 3; cb.type = 5;
+    built.m_txs.push_back(cb);
+    for (const auto& t : w.m_txs) built.m_txs.push_back(MutableTransaction(t));
+    xcheck.apply_block(built, H, platform_reward);
+    EXPECT_EQ(xcheck.balance(), committed.creditPoolBalance);
+
+    // The unlock's fee flows through the EXISTING value formulas.
+    const int64_t reward = dash::coin::compute_dash_block_reward_post_v20(H);
+    EXPECT_EQ(w.m_coinbase_value,
+              static_cast<uint64_t>(reward + static_cast<int64_t>(su.fee)));
+}
+
+TEST(DashCreditPoolIdx, Kat5_TamperedQuorumSigRejected) {
+    GbtFixture gbt;
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    fold_synthetic_chain(f, H - 6, H - 1, gbt.prev_hash);
+    ASSERT_TRUE(f.proven_complete());
+
+    auto su = make_signed_unlock(7, 200, 2 * COIN_SAT, H - 2);
+
+    // Flip ONE byte of the signature inside the payload.
+    CAssetUnlockPayload pl;
+    ASSERT_TRUE(dash::coin::vendor::parse_assetunlock_payload(
+        su.tx.extra_payload, pl));
+    auto bad_sig = pl.quorumSig;
+    bad_sig[13] ^= 0x01;
+    auto bad_tx = make_unlock_tx(7, 200, 2 * COIN_SAT, H - 2,
+                                 su.quorum.quorum_hash, bad_sig);
+
+    AssetUnlockAdmission adm;
+    EXPECT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {bad_tx},
+                                    {su.quorum}, kLlmq100_67, adm));
+    EXPECT_TRUE(adm.empty()) << "a bad quorumSig must be REJECTED (fail-closed BLS)";
+
+    // Control (the test is not vacuous): the untampered tx IS admitted.
+    AssetUnlockAdmission good;
+    EXPECT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {su.tx},
+                                    {su.quorum}, kLlmq100_67, good));
+    EXPECT_EQ(good.txs.size(), 1u);
+
+    // Expiry window refusals (assetlocktx.cpp:134-139) with a VALID sig:
+    // requestedHeight in the future…
+    auto future = make_signed_unlock(8, 200, 2 * COIN_SAT, H + 10);
+    AssetUnlockAdmission f1;
+    EXPECT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {future.tx},
+                                    {future.quorum}, kLlmq100_67, f1));
+    EXPECT_TRUE(f1.empty());
+    // …and one expired past requested + 48.
+    auto expired = make_signed_unlock(9, 200, 2 * COIN_SAT, H - 1 - 48);
+    AssetUnlockAdmission f2;
+    EXPECT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {expired.tx},
+                                    {expired.quorum}, kLlmq100_67, f2));
+    EXPECT_TRUE(f2.empty());
+
+    // Quorum not in the active scan set (bad-assetunlock-too-old-quorum):
+    // valid sig, but the candidate list names a DIFFERENT quorum hash.
+    QuorumCandidate other = su.quorum;
+    other.quorum_hash = raw256(0x99);
+    AssetUnlockAdmission f3;
+    EXPECT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {su.tx},
+                                    {other}, kLlmq100_67, f3));
+    EXPECT_TRUE(f3.empty());
+}
+
+// Withdrawal-limit conjunct with a REAL signature: an unlock beyond the
+// era-correct LimitAmount is excluded even though its sig verifies.
+TEST(DashCreditPoolIdx, Kat4b_LimitBindsEvenWithValidSig) {
+    GbtFixture gbt;
+    CreditPoolIdxFollower f(test_schedule(H - 6));
+    auto fold = fold_synthetic_chain(f, H - 6, H - 1, gbt.prev_hash);
+    // Pool holds ~990 DASH (era V22 limit = min(pool, 2000) = pool). An
+    // unlock of MORE than the pool must be refused.
+    auto too_big = make_signed_unlock(11, 300, fold.balance + COIN_SAT, H - 2);
+    AssetUnlockAdmission adm;
+    EXPECT_TRUE(f.try_admit_unlocks(true, H, gbt.prev_hash, {too_big.tx},
+                                    {too_big.quorum}, kLlmq100_67, adm));
+    EXPECT_TRUE(adm.empty());
+}
+#endif  // C2POOL_DASH_BLS
+
+// ════════════════════════════════════════════════════════════════════════
+// CreditPoolIdxDb — schema round-trip, atomic apply, restore, wipe.
+// ════════════════════════════════════════════════════════════════════════
+
+namespace {
+std::string temp_db_path(const char* tag) {
+    auto p = std::filesystem::temp_directory_path() /
+             (std::string("c2pool-cpidx-") + tag + "-" +
+              std::to_string(::getpid()));
+    std::filesystem::remove_all(p);
+    return p.string();
+}
+}  // namespace
+
+TEST(DashCreditPoolIdxDb, SchemaCodecsRoundTripAndRejectMalformed) {
+    // ranges 'R'
+    std::vector<std::pair<uint64_t, uint64_t>> r{{4, 9}, {100, 101}};
+    auto enc = CreditPoolIdxDb::encode_ranges(r);
+    EXPECT_EQ(enc[0], CreditPoolIdxDb::kSchemaVer);
+    std::vector<std::pair<uint64_t, uint64_t>> back;
+    ASSERT_TRUE(CreditPoolIdxDb::decode_ranges(enc, back));
+    EXPECT_EQ(back, r);
+    // malformed: overlap / adjacency / empty / trailing garbage all refused
+    EXPECT_FALSE(CreditPoolIdxDb::decode_ranges(
+        CreditPoolIdxDb::encode_ranges({{4, 9}, {8, 12}}), back));
+    EXPECT_FALSE(CreditPoolIdxDb::decode_ranges(
+        CreditPoolIdxDb::encode_ranges({{4, 9}, {9, 12}}), back));
+    EXPECT_FALSE(CreditPoolIdxDb::decode_ranges(
+        CreditPoolIdxDb::encode_ranges({{4, 4}}), back));
+    auto trailing = enc;
+    trailing.push_back(0x00);
+    EXPECT_FALSE(CreditPoolIdxDb::decode_ranges(trailing, back));
+
+    // cursor 'C' — 47 bytes exactly
+    CpIdxCursor c;
+    c.height = 2'400'000;
+    c.block_hash = raw256(0x42);
+    c.computed_balance = -12345678901LL;
+    c.proven_complete = true;
+    c.era = 1;
+    auto cenc = CreditPoolIdxDb::encode_cursor(c);
+    EXPECT_EQ(cenc.size(), 47u);
+    CpIdxCursor cback;
+    ASSERT_TRUE(CreditPoolIdxDb::decode_cursor(cenc, cback));
+    EXPECT_EQ(cback.height, c.height);
+    EXPECT_EQ(cback.block_hash, c.block_hash);
+    EXPECT_EQ(cback.computed_balance, c.computed_balance);
+    EXPECT_EQ(cback.proven_complete, true);
+    EXPECT_EQ(cback.era, 1);
+    auto cshort = cenc; cshort.pop_back();
+    EXPECT_FALSE(CreditPoolIdxDb::decode_cursor(cshort, cback));
+    auto cbad_era = cenc; cbad_era[46] = 7;
+    EXPECT_FALSE(CreditPoolIdxDb::decode_cursor(cbad_era, cback));
+
+    // seed 'S' — 44 bytes
+    CpIdxSeedProvenance sp;
+    sp.v20_floor_height = 1'987'776;
+    sp.v20_block_hash = raw256(0x24);
+    sp.seed_wallclock = 1'750'000'000LL;
+    auto senc = CreditPoolIdxDb::encode_seed(sp);
+    EXPECT_EQ(senc.size(), 44u);
+    CpIdxSeedProvenance sback;
+    ASSERT_TRUE(CreditPoolIdxDb::decode_seed(senc, sback));
+    EXPECT_EQ(sback.v20_floor_height, sp.v20_floor_height);
+    EXPECT_EQ(sback.v20_block_hash, sp.v20_block_hash);
+    EXPECT_EQ(sback.seed_wallclock, sp.seed_wallclock);
+
+    // window key: BIG-endian height so prefix scans ascend
+    EXPECT_LT(CreditPoolIdxDb::key_window(255),
+              CreditPoolIdxDb::key_window(256));
+}
+
+TEST(DashCreditPoolIdxDb, PersistRestoreAndWipe) {
+    const std::string path = temp_db_path("persist");
+    {
+        CreditPoolIdxDb db(path);
+        ASSERT_TRUE(db.open());
+        CreditPoolIdxFollower f(test_schedule(1000));
+        f.set_reward_fn([](uint32_t) { return 0; });
+        f.attach_db(&db);
+        f.arm(chain_hash(1000), 0);
+        ASSERT_TRUE(f.apply_block(1001, chain_hash(1001),
+            make_block(chain_hash(1000),
+                       {make_cbtx_coinbase(1001, 1000 * COIN_SAT),
+                        make_lock_tx(1000 * COIN_SAT)})));
+        const int64_t gross = 10 * COIN_SAT + 190;
+        ASSERT_TRUE(f.apply_block(1002, chain_hash(1002),
+            make_block(chain_hash(1001),
+                       {make_cbtx_coinbase(1002, 1000 * COIN_SAT - gross),
+                        make_unlock_tx(5, 190, 10 * COIN_SAT, 1001,
+                                       raw256(0x77))})));
+        f.mark_proven_complete();
+        db.close();
+    }
+    {
+        // A fresh follower restores the cursor/set/window from disk…
+        CreditPoolIdxDb db(path);
+        ASSERT_TRUE(db.open());
+        CreditPoolIdxFollower f(test_schedule(1000));
+        f.set_reward_fn([](uint32_t) { return 0; });
+        f.attach_db(&db);
+        ASSERT_TRUE(f.try_restore());
+        EXPECT_EQ(f.height(), 1002u);
+        EXPECT_EQ(f.block_hash(), chain_hash(1002));
+        EXPECT_EQ(f.balance(), 1000 * COIN_SAT - (10 * COIN_SAT + 190));
+        EXPECT_TRUE(f.indexes().Contains(5));
+        EXPECT_EQ(f.lately_unlocked(), 10 * COIN_SAT + 190);
+        // …but NOT proven_complete: a restart must re-bridge to the tip first
+        // (the predicate is one-way sticky across restarts too).
+        EXPECT_FALSE(f.proven_complete());
+        // resumed fold continues seamlessly
+        EXPECT_TRUE(f.apply_block(1003, chain_hash(1003),
+            make_block(chain_hash(1002),
+                       {make_cbtx_coinbase(1003,
+                                           1000 * COIN_SAT - (10 * COIN_SAT + 190))})));
+        db.close();
+    }
+    {
+        // A schedule whose floor disagrees adjudicates ABSENT + wipes.
+        CreditPoolIdxDb db(path);
+        ASSERT_TRUE(db.open());
+        CreditPoolIdxFollower g(test_schedule(2000));
+        g.attach_db(&db);
+        EXPECT_FALSE(g.try_restore());
+        // …and after the wipe the original schedule finds nothing either.
+        CreditPoolIdxFollower f(test_schedule(1000));
+        f.attach_db(&db);
+        EXPECT_FALSE(f.try_restore());
+        db.close();
+    }
+    std::filesystem::remove_all(path);
+}
+
+TEST(DashCreditPoolIdxDb, TornNamespaceAdjudicatesAbsent) {
+    const std::string path = temp_db_path("torn");
+    {
+        CreditPoolIdxDb db(path);
+        ASSERT_TRUE(db.open());
+        // Write ONLY a cursor — no 'R', no 'S' (a torn/partial namespace).
+        CpIdxCursor c;
+        c.height = 1002;
+        c.block_hash = chain_hash(1002);
+        ASSERT_TRUE(db.write_cursor(c));
+        std::vector<std::pair<uint64_t, uint64_t>> ranges;
+        std::map<uint32_t, CpIdxWindowRowRec> rows;
+        CpIdxCursor cur;
+        CpIdxSeedProvenance seed;
+        bool corrupt = false;
+        EXPECT_FALSE(db.load(ranges, rows, cur, seed, corrupt));
+        EXPECT_TRUE(corrupt) << "a torn namespace must be flagged for wipe";
+        db.close();
+    }
+    std::filesystem::remove_all(path);
+}
+
+// Follower fail-closed also wipes the PERSISTED namespace (design: a balance
+// divergence is total loss of provenance, on disk too).
+TEST(DashCreditPoolIdxDb, FailClosedWipesTheNamespace) {
+    const std::string path = temp_db_path("wipe");
+    {
+        CreditPoolIdxDb db(path);
+        ASSERT_TRUE(db.open());
+        CreditPoolIdxFollower f(test_schedule(1000));
+        f.set_reward_fn([](uint32_t) { return 0; });
+        f.attach_db(&db);
+        f.arm(chain_hash(1000), 0);
+        ASSERT_TRUE(f.apply_block(1001, chain_hash(1001),
+            make_block(chain_hash(1000), {make_cbtx_coinbase(1001, 0)})));
+        // gap ⇒ fail closed ⇒ namespace gone
+        EXPECT_FALSE(f.apply_block(1003, chain_hash(1003),
+            make_block(chain_hash(1002), {make_cbtx_coinbase(1003, 0)})));
+        CreditPoolIdxFollower g(test_schedule(1000));
+        g.attach_db(&db);
+        EXPECT_FALSE(g.try_restore()) << "wiped namespace must not restore";
+        db.close();
+    }
+    std::filesystem::remove_all(path);
+}


### PR DESCRIPTION
## What this builds

Variant B of the daemonless Type-9 (asset-unlock) path for #140: a **gap-free creditpool-index follower** that lets the embedded node admit Type-9 transactions into templates without asking dashd — by proving, rather than assuming, that it knows the complete set of already-mined unlock indexes.

- **v20 seed**: the follower arms at the compiled-in v20 activation floor (height 1987776, hash `000000000000001bf41cff06b76780050682ca29e61a91c391893d4745579777`), where the mined-index set is empty by dashd's own definition. No trusted snapshot, no external daemon.
- **Contiguous fold**: `apply_block()` advances the cursor only when height == cursor+1 **and** `hashPrevBlock` == cursor hash, then cross-checks the recomputed creditpool scalar against the block's own cbTx `creditPoolBalance` before persisting. Persistence is one atomic batch (ranges + window row + cursor), so a torn write can never advance the cursor past its data.
- **Fail-closed, one-way**: any gap, lineage break, duplicate mined index, missing 576-window row, unparseable cbTx/payload, or balance mismatch latches `fail_closed()` — memory and disk namespace wiped, `proven_complete` never restored across restart. Every degraded mode collapses to the proven-valid exclude-all template served today.
- **Admission gate** (`try_admit_unlocks`): flag AND real-BLS backend AND armed AND proven-complete AND cursor exactly at the template's parent (height H-1, hash == `hashPrevBlock`). Then per-tx: not already mined (ranges ∪ session), quorum-sig verified against real dashbls, expiry window, era withdrawal-limit ladder byte-matched to dashd `ConstructCreditPool` / `CCreditPoolDiff::Unlock`.

## Completeness by construction

The prior attempt failed on an unfalsifiable claim ("the scalar matched, so the set must be complete"). This design makes incompleteness structurally unreachable instead:

1. The cursor moves **only** through the lineage- and contiguity-checked fold from the trustless empty floor. By induction, cursor-at-X proves gapless ingestion floor→X.
2. A silent skip at the feeder cannot serve: either the cursor stalls — and the freshness conjunct (cursor hash must equal the template's exact parent) refuses — or the gap trips the latch and wipes.
3. The per-block cbTx balance cross-check is the falsifier the chain itself provides; one miss is total provenance loss, not a warning.
4. Even a caller that ignores the refusal holds an **empty** admission — KATs assert seam-absent / nullptr / empty-admission templates are field-by-field byte-identical.

## Scope of this PR

- **Default OFF**, and the seam is dormant in this build: the production gbt call site does not pass the new trailing admission parameter (always nullptr), and no follower lane is instantiated — flag-ON changes only a posture log and still serves exclude-all. Flag-OFF is byte-identical to master, on the wire and on disk.
- Verified under ARM-3 adversarial review (4/4 lenses SAFE): flag-OFF byte-identity, fail-closed dominance over every unproven-contiguity path, real (non-stubbed) balance cross-check + BLS quorum-sig verification with tamper KATs, and no reachable duplicate-index or over-limit admission. Test matrix: 36/36 with `C2POOL_DASH_BLS=ON`, 26/26 with the CI-default stub.
- Named follow-ups for the wiring PR (do not bite at this pin): condition `mark_proven_complete()` on a verified tip-meet; hard-fail a null `hashPrevBlock` above the floor; port V24 activation (or harden the limit to `min(era_limit, max(0, 4000 - lately))`) before flag-ON ships; log a failed persist batch.

## Follow-on gate

The **live 531k-block seed soak** — arming at the v20 floor on a hotel node and folding the real chain to tip with zero fail-closed events and byte-parity against dashd's creditpool state — is the acceptance gate before any wiring/flag-ON PR. This PR does not schedule or claim that soak.

Do not merge; draft until the soak gate is planned.
