### PR TITLE
dash(mnlist): base-continuity target-already-held carve-out — end the daemonless reseed livelock

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -538,6 +538,62 @@ public:
         // be papered over by a later clean incremental. Reject + keep prior state.
         const uint256 have_at = m_state.sml_current_hash();
         if (!diff.baseBlockHash.IsNull() && diff.baseBlockHash != have_at) {
+            // ── TARGET-ALREADY-HELD CARVE-OUT (reseed-wedge, soak-found) ──
+            // A getmnlistd(base=B, target=T) reply that lands AFTER the SML
+            // already advanced to T (a raced/duplicate reply: another diff
+            // won the advance first) has base != have_at but
+            // diff.blockHash == have_at. It is REDUNDANT, not
+            // out-of-sequence: the state it would produce is the state we
+            // already hold, so continuity is not at risk. Rejecting it as a
+            // base-continuity violation was wrong in exactly one costly way:
+            // the reject swallowed the very advance the payee-desync reseed
+            // latch (m_mn_needs_reseed, set on the wipe below) was waiting
+            // on, and the latch then stayed latched forever — the wedge log
+            // showed have_mn=0 mn_entries=0 with the SML advanced, serving
+            // nothing until a restart.
+            //
+            // DISJOINT from a genuinely out-of-sequence diff by
+            // construction: that one has BOTH base != have_at AND
+            // target != have_at, and still takes the reject below UNCHANGED
+            // (pinned by OutOfSequenceDiffStillRejectedAndKeepsLatch).
+            //
+            // Do NOT apply the diff — we are already at its target; the diff
+            // is evidence of currency, not of change. Clearing the latch
+            // alone cannot restore serving here (the desync wipe emptied the
+            // payee queue, and m_have_mn re-arms only off a NON-EMPTY
+            // authoritative snapshot), so also RE-DRIVE the existing
+            // authoritative re-seed transport (m_on_mn_reseed — the same ask
+            // the wipe itself fired): its daemonless answers gate on the SML
+            // being current, which this very diff has just proven, so an ask
+            // that was refused mid-advance can succeed now. Bounded: fires
+            // only while latched, i.e. once per wedge episode. Reward-safe
+            // either way: main_dash runs require_seeded_mn=true, so with the
+            // queue empty and m_mn_snapshot_height==0 MN-readiness stays
+            // DOWN until the authoritative on_mn_list_update lands — the
+            // carve-out unwedges the latch, it cannot mint a guessed payee.
+            if (diff.blockHash == have_at) {
+                if (m_mn_needs_reseed) {
+                    m_mn_needs_reseed = false;
+                    m_state.set_mn_needs_reseed(false);
+                    LOG_INFO << "[SML] diff target already held ..."
+                             << discriminating_hash_tail(diff.blockHash)
+                             << " (base ..."
+                             << discriminating_hash_tail(diff.baseBlockHash)
+                             << " raced the SML advance) — redundant no-op,"
+                                " NOT out-of-sequence; reseed latch cleared,"
+                                " re-driving the authoritative payee re-seed"
+                                " (the queue is still empty until it lands)";
+                    if (m_on_mn_reseed) m_on_mn_reseed();
+                } else {
+                    LOG_INFO << "[SML] diff target already held ..."
+                             << discriminating_hash_tail(diff.blockHash)
+                             << " (base ..."
+                             << discriminating_hash_tail(diff.baseBlockHash)
+                             << ") — redundant no-op (raced/duplicate reply);"
+                                " state unchanged";
+                }
+                return;
+            }
             // Discriminating TAILs: these two hashes are compared for
             // INEQUALITY, so rendering the difficulty padding they share made
             // the line unable to show the very difference it reports.

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -786,6 +786,141 @@ TEST(DashCoinStateMaintainer, MnlistdiffBaseContinuityRejectsMismatchedBase) {
     EXPECT_EQ(st.sml().size(), 3u);
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// RESEED-WEDGE KAT (daemonless soak wedge): a getmnlistd(base=B, target=T)
+// reply that lands AFTER the SML already advanced to T is REDUNDANT (target
+// already held), NOT out-of-sequence — have_at == T == diff.blockHash while
+// baseBlockHash == B != have_at. PRE-FIX the H-7 base-continuity guard
+// rejected it, and the payee-desync reseed latch (m_mn_needs_reseed), which
+// was waiting on exactly that advance, stayed latched forever: the node
+// served nothing (wedge log: have_mn=0 mn_entries=0, sml advanced).
+//
+// The fix must (a) NOT apply the redundant diff (we are already at its
+// target), (b) clear the latch, and (c) RE-DRIVE the existing authoritative
+// payee re-seed ask (m_on_mn_reseed): clearing the flag alone cannot restore
+// serving because the desync wipe emptied the payee queue and m_have_mn only
+// re-arms off a NON-EMPTY authoritative snapshot. Serving is then proven to
+// actually recover once that snapshot lands.
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashCoinStateMaintainer, TargetAlreadyHeldDiffIsNoOpAndClearsReseedLatch) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int reseed_asks = 0;
+    m.set_on_mn_reseed([&]() { ++reseed_asks; });
+
+    // SML current at A (cold full snapshot, height-paired via the cbTx seed).
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0xA0), H - 1,
+                                   1'000'000, sml_entry(0x40)));
+    ASSERT_TRUE(st.have_sml());
+    ASSERT_EQ(st.sml_current_hash(), raw256(0xA0));
+    const size_t sml_before = st.sml().size();
+
+    // Payee queue + tip -> the embedded arm serves.
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), H - 1);
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    ASSERT_TRUE(m.live());
+
+    // Payee DESYNC at H: coinbase pays a script that is NOT the projected
+    // MN's — the maintainer wipes the queue, latches, demotes, asks reseed.
+    BlockType blk;
+    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x77);
+    bind_block(blk);
+    auto r = m.on_block_connected(blk, H);
+    ASSERT_TRUE(r.payee_desync);
+    ASSERT_TRUE(m.mn_needs_reseed_latched());
+    ASSERT_TRUE(st.mn_needs_reseed());
+    ASSERT_EQ(st.mnstates().size(), 0u) << "the wipe empties the payee queue";
+    ASSERT_EQ(reseed_asks, 1);
+
+    // The raced reply: getmnlistd(base=B, target=A) landing after the SML
+    // already advanced to A. Target already held => redundant no-op.
+    m.on_mnlistdiff(diff_with_seed(raw256(0x90), raw256(0xA0), H - 1,
+                                   1'000'000, sml_entry(0x40)));
+
+    // RED ON MASTER: the base-continuity guard rejected the redundant diff
+    // and the latch stayed latched forever.
+    EXPECT_FALSE(m.mn_needs_reseed_latched())
+        << "a target-already-held diff is redundant, not out-of-sequence — "
+           "it must clear the reseed latch that was waiting on this advance";
+    EXPECT_FALSE(st.mn_needs_reseed());
+    EXPECT_EQ(reseed_asks, 2)
+        << "latch-clear alone cannot restore serving (the queue is EMPTY): "
+           "the redundant diff must re-drive the authoritative re-seed ask";
+
+    // No-op pins: the redundant diff must not have been APPLIED.
+    EXPECT_EQ(st.sml_current_hash(), raw256(0xA0));
+    EXPECT_EQ(st.sml().size(), sml_before);
+    EXPECT_EQ(st.mnstates().size(), 0u)
+        << "the SML diff itself must not repopulate the payee queue";
+
+    // SERVE-RESTORE, not just the flag: answer the re-driven ask with the
+    // authoritative snapshot — the arm must serve again.
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), H);
+    ASSERT_TRUE(m.live())
+        << "after the authoritative re-seed lands, the embedded arm re-arms";
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_FALSE(fb);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// CANNOT-WEAKEN PIN for the carve-out above: a genuinely OUT-OF-SEQUENCE
+// diff — base != have_at AND target != have_at — must still take the H-7
+// base-continuity reject UNCHANGED: no SML mutation, no currency advance,
+// the reseed latch STAYS latched and no re-seed ask is re-driven. The
+// carve-out condition (diff.blockHash == have_at) is disjoint from this
+// case by construction; this test keeps it that way.
+// ════════════════════════════════════════════════════════════════════════
+TEST(DashCoinStateMaintainer, OutOfSequenceDiffStillRejectedAndKeepsLatch) {
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    int reseed_asks = 0;
+    m.set_on_mn_reseed([&]() { ++reseed_asks; });
+
+    m.on_mnlistdiff(diff_with_seed(uint256::ZERO, raw256(0xA0), H - 1,
+                                   1'000'000, sml_entry(0x40)));
+    ASSERT_EQ(st.sml_current_hash(), raw256(0xA0));
+    const size_t sml_before = st.sml().size();
+
+    m.on_mn_list_update(single_mn(p2pkh_script(0x30)), H - 1);
+    m.on_new_tip(H - 1, PREV_HASH, BITS, MTP, DASH_PUBKEY_VER, DASH_P2SH_VER,
+                 CURTIME, VERSION);
+    ASSERT_TRUE(m.live());
+
+    BlockType blk;
+    blk.m_txs.push_back(make_spend(raw256(0x90), 0, 500000000, 1));
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = p2pkh_script(0x77);
+    bind_block(blk);
+    auto r = m.on_block_connected(blk, H);
+    ASSERT_TRUE(r.payee_desync);
+    ASSERT_TRUE(m.mn_needs_reseed_latched());
+    ASSERT_EQ(reseed_asks, 1);
+
+    // Genuinely out-of-sequence: base 0x90 != have_at 0xA0 AND target
+    // 0xC0 != have_at. The reject must fire exactly as before the carve-out.
+    m.on_mnlistdiff(diff_with_seed(raw256(0x90), raw256(0xC0), H,
+                                   1'000'000, sml_entry(0x80)));
+
+    EXPECT_EQ(st.sml().size(), sml_before)
+        << "an out-of-sequence diff must not mutate the SML";
+    EXPECT_EQ(st.sml_current_hash(), raw256(0xA0))
+        << "the currency marker must not advance off an out-of-sequence diff";
+    EXPECT_TRUE(m.mn_needs_reseed_latched())
+        << "an out-of-sequence diff proves NOTHING about the awaited advance "
+           "— the reseed latch must stay latched";
+    EXPECT_TRUE(st.mn_needs_reseed());
+    EXPECT_EQ(reseed_asks, 1)
+        << "no re-seed re-drive off a rejected out-of-sequence diff";
+
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb) << "the arm stays demoted until an authoritative re-seed";
+}
+
 // A1 cursor-derived getmnlistd base: the tip-advance / handshake send paths
 // (main_dash.cpp:5107 / :5226) now derive the getmnlistd request base from
 // CoinStateMaintainer::sml_current_hash() — the block the SML is ACTUALLY


### PR DESCRIPTION
## The wedge (daemonless reseed livelock)

A `getmnlistd(base=B, target=T)` reply that lands **after** the SML has already advanced to `T` (raced/duplicate reply) has `base != have_at` but `target == have_at`. The H-7 base-continuity guard in `on_mnlistdiff` treated it as out-of-sequence and rejected it — and the payee-desync reseed latch (`m_mn_needs_reseed`), which was waiting on exactly that advance, stayed latched **forever**. The node served nothing (`have_mn=0 mn_entries=0`, SML advanced) until a restart. This is the wedge the daemonless reseed soak proved live (#1225 family / task #138): reconstruction replays the MN set byte-correct, then stalls with the latch never clearing.

## The carve-out

Inside the H-7 guard, **before** the reject, for `diff.blockHash == have_at` only:

- do **NOT** apply the diff — we already hold its target; it is evidence of currency, not of change. The early return fires before `apply_diff`/`parse_quorum_tail`/`parse_cbtx`, so `sml_current_hash` never advances and the SML/quorum sets (the sole inputs to `merkleRootMNList`/`merkleRootQuorums`) cannot change from this branch; a crafted target-held diff with poisoned contents is discarded unparsed;
- clear the reseed latch (`m_mn_needs_reseed` + `m_state.set_mn_needs_reseed(false)`);
- re-drive the existing authoritative re-seed transport (`m_on_mn_reseed` — the same ask the desync wipe fired). Clearing the flag alone cannot restore serving: the wipe emptied the payee queue and `m_have_mn` only re-arms off a NON-EMPTY authoritative snapshot (`on_mn_list_update`, or the block-connect recompute). Bounded: fires only while latched — once per wedge episode.

The change is purely additive (56 insertions, 0 deletions). The genuinely out-of-sequence reject (`base != have_at` AND `target != have_at`) is byte-untouched and disjoint by construction.

Reward-safe: `main_dash` runs `require_seeded_mn=true`, so with the queue empty MN-readiness stays DOWN until the authoritative `on_mn_list_update` lands — the carve-out unwedges the latch; it cannot mint a guessed payee or arm serving off a stale set.

## Proof

KATs in `test/test_dash_coin_state_maintainer.cpp`:

- **`TargetAlreadyHeldDiffIsNoOpAndClearsReseedLatch`** — **red on master** (latch stayed latched, no re-drive), green with the fix. Also pins the no-op (SML size/currency unchanged, payee queue untouched) and the actual serve-restore once the authoritative snapshot lands.
- **`OutOfSequenceDiffStillRejectedAndKeepsLatch`** — the cannot-weaken pin: green on master, must stay green.

Prod build verified clean, **BLS=REAL**.

## Status

**DRAFT** — integrator will review and gate on a standalone soak before merge.
