### PR TITLE
ci(web-static): purge CWD-local partial Chrome dir, not just ~/.cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1029,17 +1029,22 @@ jobs:
             PIN="$(sed -nE "s/.*chrome: *.([0-9.]+).*/\\1/p" node_modules/puppeteer-core/lib/puppeteer/revisions.js | head -1)"
             test -n "$PIN" || { echo "could not read pinned Chrome revision from puppeteer-core"; exit 1; }
             echo "puppeteer-core pins Chrome-for-Testing $PIN"
-            CHROME_BIN="$(ls -1 "$HOME"/.cache/puppeteer/chrome/*"$PIN"/chrome-linux64/chrome 2>/dev/null | tail -1 || true)"
+            CHROME_BIN="$(ls -1 "$HOME"/.cache/puppeteer/chrome/*"$PIN"/chrome-linux64/chrome ./chrome/*"$PIN"/chrome-linux64/chrome 2>/dev/null | tail -1 || true)"
             if [ ! -x "$CHROME_BIN" ]; then
               # Partial-cache guard: an interrupted prior download can leave
               # the versioned dir present with NO chrome-linux64/chrome binary.
               # @puppeteer/browsers treats "dir exists" as installed and refuses
               # to re-fetch, so every retry short-circuits to the same broken
               # path and the gate false-reds (linux-151.0.7922.77 on
-              # actions-runner-8, run 31607961557). Purge any incomplete dir for
-              # this PIN before AND between fetch attempts so the download re-runs.
+              # actions-runner-8, run 31607961557). The install runs with no
+              # --path from working-directory web-static/sharechain-explorer, so
+              # the versioned dir lands under CWD ./chrome/*"$PIN", NOT only
+              # ~/.cache/puppeteer (the corrupt dir on actions-runner-2, run
+              # 31685136400, was ./chrome/linux-151.0.7922.77). Purge BOTH roots
+              # for this PIN before AND between fetch attempts so the download
+              # re-runs regardless of which layout holds the stale dir.
               purge_partial() {
-                for d in "$HOME"/.cache/puppeteer/chrome/*"$PIN"; do
+                for d in "$HOME"/.cache/puppeteer/chrome/*"$PIN" ./chrome/*"$PIN"; do
                   [ -d "$d" ] && [ ! -x "$d/chrome-linux64/chrome" ] && rm -rf "$d"
                 done
                 return 0


### PR DESCRIPTION
## Problem
Web-static verify still reds on master after #1228 (run 31685136400, headSha d55922c0, actions-runner-2):

```
Error: All providers failed for chrome 151.0.7922.77:
  - DefaultProvider: The browser folder (.../web-static/sharechain-explorer/chrome/linux-151.0.7922.77) exists but the executable (.../chrome-linux64/chrome) is missing
```

## Root cause
The Chrome-provision step runs with `working-directory: web-static/sharechain-explorer` (build.yml:975) and calls `@puppeteer/browsers install` with **no `--path`**, so the versioned build lands under **CWD** `./chrome/*PIN`, not `~/.cache/puppeteer`. The #1228 partial-cache guard (`purge_partial`) only swept `~/.cache/puppeteer`, so a torn download under `./chrome` (dir present, `chrome-linux64/chrome` missing) survived every retry — @puppeteer/browsers treats "dir exists" as installed and refuses to re-fetch, and all three attempts short-circuit to the same broken path.

## Fix
Warm-cache probe and `purge_partial` now cover **both** roots (`~/.cache/puppeteer` AND `./chrome`) for the pinned revision. A stale partial dir in either layout is purged before and between fetch attempts, so the download re-runs. No behavior change on a clean cache — the guard only removes a dir whose `chrome-linux64/chrome` is non-executable.

Signed c8f6f64b. HELD at merge gate — awaiting operator push-approval.
