### PR TITLE
dash(coin-p2p): header-sync stall watchdog — re-arm getheaders on the fresh bring-up path (#129)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3420,6 +3420,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // Phase-1 mempool-ingest telemetry (30s); constructed only under
     // --embedded-mempool-ingest.
     std::unique_ptr<core::Timer>                               mempool_ingest_timer;
+    // #129 fresh-path header-sync stall watchdog (coin-p2p arm only).
+    // Declared after header_chain/coin_p2p so it unwinds FIRST at return —
+    // its callback reads both.
+    std::unique_ptr<core::Timer>                               header_sync_watchdog_timer;
     // W5 integration: the fold engine the lane drives, and its consumer.
     std::unique_ptr<dash::coin::replay::DmlFoldEngine>         replay_fold_engine;
     std::unique_ptr<dash::coin::replay::FoldReplayConsumer>    replay_fold_consumer;
@@ -5163,6 +5167,95 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     if (batch.empty()) return;
                     cp->send_getheaders(70230, hc->get_locator(), uint256::ZERO);
                 }));
+
+        // ── #129 FRESH-PATH HEADER-SYNC RE-ARM (stall watchdog) ──────────
+        // The self-propel above is a ONE-TOKEN relay: exactly one getheaders
+        // in flight, re-armed ONLY by its own response arriving as a
+        // non-empty headers batch. Two ways the token dies on a FRESH
+        // (empty-data-dir, no --coin-rpc) node:
+        //   (a) the primary is busy computing the cold-start monsters the
+        //       SAME handshake kick queued on it (null-base mnlistdiff for
+        //       ~3200 MNs + qrinfo) — dashd answers a peer's requests
+        //       sequentially, so the next headers reply sits minutes behind
+        //       that computation; single-peer, effectively forever;
+        //   (b) the reply is lost (disconnect, reorg race) — nothing re-asks.
+        // Either way getheaders stops re-arming and the header chain parks
+        // below tip (the h=2406000 fresh-bring-up wedge: anchor + 3 batches,
+        // then silence). The per-block-inv rescue above cannot save a node
+        // whose only/announcing peer is the starved one, and send_getheaders
+        // is a silent no-op with a null primary. An EXISTING data-dir never
+        // sees this: the warm deficit is small and the cold monsters absent.
+        // This is the tip-lane analog of the bulk walker's
+        // maybe_kick_backfill (replay_bulk_fetch.hpp) and the same
+        // armed-once-never-re-armed class as #1151/#1162.
+        //
+        // Every 5 s: if the header chain is BEHIND the best peer-advertised
+        // height AND has not advanced for kStallSec, re-issue getheaders off
+        // the CURRENT locator, round-robining across ALL handshaked peers —
+        // not pinned to the possibly-starved primary. Wire-conservative and
+        // reward-safe by construction: it only re-sends an existing,
+        // well-formed message (no wire/consensus change); a duplicate reply
+        // de-dups as accepted==0; at/above the advertised tip the height
+        // guard makes it inert; and NO serve gate reads it — the freshness /
+        // is_synced gates that keep an incompletely-synced node from serving
+        // are untouched, a re-request grants no serve authority.
+        {
+            struct HeaderSyncWatchdogState {
+                uint32_t last_height{0};
+                int64_t  last_change{0};   // steady seconds of last advance
+                int64_t  last_kick{0};
+                uint64_t rr{0};            // peer round-robin cursor
+                uint64_t kicks{0};
+            };
+            constexpr int64_t kStallSec  = 20;  // no advance for this long
+            constexpr int64_t kRekickSec = 10;  // min spacing between kicks
+            header_sync_watchdog_timer =
+                std::make_unique<core::Timer>(&ioc, /*repeat=*/true);
+            header_sync_watchdog_timer->start(5,
+                [cp = coin_p2p.get(), hc = header_chain.get(),
+                 st = std::make_shared<HeaderSyncWatchdogState>()]() {
+                    const int64_t now =
+                        std::chrono::duration_cast<std::chrono::seconds>(
+                            std::chrono::steady_clock::now()
+                                .time_since_epoch()).count();
+                    const uint32_t h = hc->height();
+                    if (st->last_change == 0 || h != st->last_height) {
+                        st->last_height = h;
+                        st->last_change = now;   // progress — watchdog quiet
+                        return;
+                    }
+                    const uint32_t peer_tip = hc->peer_tip_height();
+                    // peer_tip is stamped from version handshakes; once our
+                    // height passes it in steady state the watchdog is inert
+                    // (tip follow is inv-driven there, by design).
+                    if (peer_tip == 0 || h >= peer_tip) return;
+                    if ((now - st->last_change) < kStallSec) return;
+                    if ((now - st->last_kick) < kRekickSec) return;
+                    st->last_kick = now;
+                    ++st->kicks;
+                    const auto locator = hc->get_locator();
+                    auto keys = cp->handshaked_peer_keys();
+                    bool sent = false;
+                    std::string target = "<primary>";
+                    if (!keys.empty()) {
+                        // Rotate so consecutive kicks reach DIFFERENT peers:
+                        // the whole point is escaping a starved primary.
+                        const std::string& key =
+                            keys[st->rr++ % keys.size()];
+                        sent = cp->send_getheaders_to(
+                            key, 70230, locator, uint256::ZERO);
+                        if (sent) target = key;
+                    }
+                    if (!sent)   // no named peer took it — primary fallback
+                        cp->send_getheaders(70230, locator, uint256::ZERO);
+                    LOG_INFO << "[COIN-P2P] header-sync stall watchdog:"
+                                " re-armed getheaders h=" << h
+                             << " peer_tip=" << peer_tip
+                             << " stalled_s=" << (now - st->last_change)
+                             << " peer=" << target
+                             << " kick#" << st->kicks;
+                });
+        }
 
         // ── BODY-FIRST SERVE TIP + bounded full-block buffer (operator
         // direction off soak0804e; the follow-up the #1089 thread scopes).


### PR DESCRIPTION
## Item #129 — FRESH daemonless node: coin-p2p header sync stops re-arming getheaders

**DASH lane only. No wire/consensus change. Draft — integrator review required, do NOT merge.**

### Defect

A FRESH cut node (EMPTY data-dir, NO `--coin-rpc`) wedged on coin-p2p header sync around h=2406000: `getheaders` stopped re-arming, the header chain never reached tip, the node could not bootstrap. Upgrading an EXISTING data-dir works (contabo cut node resumed a persisted cursor) — only the brand-new-from-empty path bites, which blocks standing up fresh public daemonless nodes.

### Root cause (main_dash.cpp, master f15d2310)

The tip-lane header sync is a **one-token relay with no token custodian**:

- **Armed once**: `set_on_handshake_complete` (main_dash.cpp:5379) fires `send_getheaders` — the same kick that also queues the cold-start monsters on the same primary: `mnlistdiff(base=null, ~3200 MNs)` + `qrinfo` + mempool.
- **Re-armed only by its own response**: the self-propel subscriber (main_dash.cpp:5160) re-issues `send_getheaders` **only when a non-empty headers batch arrives**, and `send_getheaders` (p2p_client.hpp:1296) targets **only `m_primary`** — silent no-op when the primary is null.
- **No timer, no stall watchdog, no height-vs-peer-tip condition anywhere.** Contrast the pre-anchor bulk walker, which has BOTH a self-propel AND a periodic re-kick backstop (`maybe_kick_backfill`, replay_bulk_fetch.hpp:1095, 15 s, peer round-robin). The tip lane has no analog.

On the FRESH path the token dies: dashd serves one peer's requests sequentially, so the next headers reply sits **minutes** behind the null-base mnlistdiff/qrinfo computation the same handshake queued. Live repro on vm905 (fresh empty dir, no `--coin-rpc`): first batch answered in 2 s, then **93 s of dead silence** (qrinfo + 3211-MN mnlistdiff arriving 09:08:29/09:08:35), after which sync only limped **one 2000-header batch per ~2.5-min block inv** via the per-block rescue (~19.5 hdr/s over a 121k deficit), with delayed duplicate batches (`accepted==0`) interleaving. Single-peer — or with the announcer falling back to the same starved primary — the rescue yields nothing and the chain parks forever. The historical wedge at h=2406000 = anchor 2400000 + 3 batches is exactly this signature. A warm data-dir never sees it: small deficit, no cold monsters (#1151 cursor restore).

Same **armed-once-never-re-armed** class as #1151 (cursor restore cold-start-only) and #1162 (`begin_fold` had to set `m_rerequest_from_cursor`).

### Fix

A 5 s watchdog timer on the coin-p2p arm — the tip-lane analog of `maybe_kick_backfill`:

- if `header_chain.height()` is **behind** the best peer-advertised height (`peer_tip_height`, stamped from version handshakes) **and** has not advanced for **20 s**, re-issue `getheaders` off the **current** locator;
- **round-robin across all handshaked peers** (`send_getheaders_to`), not pinned to the possibly-starved primary; primary fallback if no named peer takes it;
- min 10 s between kicks; logs `[COIN-P2P] header-sync stall watchdog: re-armed getheaders h=... peer_tip=... stalled_s=... peer=... kick#N`.

### Safety

- **No wire/consensus change** — only re-sends an existing, well-formed `getheaders`; a duplicate reply de-dups as `accepted==0`; at/above the advertised peer tip the height guard makes the watchdog inert (steady-state tip follow stays inv-driven, by design).
- **Reward safety unchanged** — no serve gate reads the watchdog; serving stays gated on chain freshness / `is_synced` (header_chain.hpp:486) exactly as before. A re-request grants no serve authority; a node still cannot serve from an incomplete header chain.
- **DASH lane only** — `main_dash.cpp` + the existing DASH `p2p_client.hpp` API; no other coin touched.

### Reproduction / proof (vm905)

- **Without fix** (binary 596a4b35, header path identical to f15d2310): `vm905:~/repro-129-fresh/{RUN.sh,run.log}` — fresh empty dir, no `--coin-rpc`; 93 s starvation after batch 1, then one-batch-per-block-inv limp (`rate=19.5hdr/s eta=1h40m`), duplicate `accepted==0` loops; the h=2406000 wedge signature.
- **With fix** (5ee18384): `vm905:~/repro-129-fix/{RUN.sh,run.log}` — same config, fresh empty dir; watchdog fires during the cold-monster starvation window and drives header sync continuously to the live tip.

(Exact with-fix log excerpts in the PR comments after the soak run completes.)
