### PR TITLE
dash(dstx): W5-B CoinJoin broadcast-tx intake — inv pull, BLS operator-sig gate, zero-fee prioritised admission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
                     core_test sharechain_test share_test btc_share_test \
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
-                    test_doge_chain test_compact_blocks test_dash_x11_kat test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify test_dash_isdlock test_dash_dashd_cut_arm \
+                    test_doge_chain test_compact_blocks test_dash_x11_kat test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify test_dash_isdlock test_dash_dashd_cut_arm test_dash_dstx \
                     test_multiaddress_pplns test_pplns_stress \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
@@ -598,7 +598,7 @@ jobs:
                     test_threading test_weights \
                     test_header_chain test_mempool test_template_builder \
                     test_doge_chain test_compact_blocks test_dash_x11_kat \
-                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify test_dash_isdlock test_dash_dashd_cut_arm \
+                    test_dash_header_chain test_dash_block_replay test_dash_conformance test_dash_subsidy test_dash_mempool test_dash_simplifiedmns test_dash_quorum test_dash_quorum_root test_dash_mn_state test_dash_embedded_gbt test_dash_underfill_guard test_dash_smldiff test_dash_p2p_messages test_dash_p2p_connection test_dash_p2p_node test_dash_node_interface test_dash_config test_dash_broadcaster test_dash_broadcaster_full test_dash_share_hash_link test_dash_block_relay test_dash_rpc_request test_dash_rpc_conf test_dash_block_producer test_dash_embedded_relay_e2e test_dash_block_relay_plan test_dash_version_activation_latch test_dash_embedded_startup_invariant test_dash_block_relay_binding test_dash_block_relay_dual_arm test_dash_coinbase_parity test_dash_coinbase_muldiv test_dash_donation_combined test_dash_g3_assembled test_dash_work_target test_dash_work_job_targets test_dash_stratum_binding test_dash_job_notify_roundtrip test_dash_cb_payee test_dash_stratum_notify_roundtrip test_dash_poolnode_messages test_dash_peer test_dash_share_tracker test_dash_node test_dash_share_messages test_dash_stratum_extranonce_split test_dash_stratum_submit_reassembly test_dash_difficulty_parity test_dash_auto_ratchet test_dash_min_protocol_gate test_dash_serve_gate_journal test_dash_work_source test_dash_node_coin_state test_dash_bestcl_gate test_dash_coin_state_maintainer test_dash_node_embedded_wire test_dash_node_reception_wire test_dash_get_work test_dash_stratum_work_source test_dash_superblock test_dash_oracle_byte_parity test_dash_chainlock_verify test_dash_isdlock test_dash_dashd_cut_arm test_dash_dstx \
                     test_hash_link test_decay_pplns \
                     test_pplns_consensus \
                     test_v36_script_sorting test_v36_cross_impl_refhash \
@@ -1748,7 +1748,7 @@ jobs:
             --target c2pool-dash \
                      test_dash_bls_verify test_dash_quorum_members \
                      test_dash_quorum_member_source test_dash_govvote_bls \
-                     test_dash_chainlock_verify test_dash_isdlock \
+                     test_dash_chainlock_verify test_dash_isdlock test_dash_dstx \
             -j8
 
       # LEG 2: the artefact itself carries the dashbls backend.
@@ -1773,6 +1773,7 @@ jobs:
           ./test/test_dash_quorum_members    >> bls_kat.log 2>&1 || true
           ./test/test_dash_chainlock_verify  >> bls_kat.log 2>&1 || true
           ./test/test_dash_isdlock           >> bls_kat.log 2>&1 || true
+          ./test/test_dash_dstx              >> bls_kat.log 2>&1 || true
           log="$(cat bls_kat.log)"
           missing=0
           for t in \
@@ -1789,7 +1790,8 @@ jobs:
             DashChainLockVerify.WrongQuorumKeyIsRejected \
             DashChainLockVerify.RejectedWhenSigningQuorumIsMissingFromTheSet \
             DashIsdlockBls.RealSignatureVerifiesEndToEnd \
-            DashIsdlockBls.TamperedSignatureIsRejectedAndNeverReachesMempool
+            DashIsdlockBls.TamperedSignatureIsRejectedAndNeverReachesMempool \
+            DashDstxFailClosed.BadBlsSignatureIsRejected
           do
             # Pure-shell match, not `grep -q` in a pipeline: under pipefail a
             # `grep -q` that matches SIGPIPEs its producer and the pipeline

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -409,7 +409,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
-        << "           [--embedded-ingest-isdlock]\n"
+        << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
         << "           [--pin-splice-block-budget] (EXCLUDE a pin that pushes the template past the block size cap; default OFF)\n"
@@ -900,7 +900,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // individually BLS-gated against the rotated LLMQ_60_75 quorum
              // dashd's SelectQuorumForSigning designates (islock_verify.hpp;
              // fail-closed at every hop).
-             bool embedded_ingest_isdlock = false)
+             bool embedded_ingest_isdlock = false,
+             // --embedded-ingest-dstx (W5-B): arm the CoinJoin DSTX lane —
+             // inv(MSG_DSTX=16) getdata pull (budgeted, shares the MSG_TX
+             // machinery) + the BLS-verified new_dstx adoption path
+             // (maintainer gate → Mempool::add_dstx: fee=0 base + dashd's
+             // +0.1 COIN prioritisation delta). DEFAULT OFF: no getdata
+             // type-16 is ever sent, the handler discards, and templates are
+             // byte-identical to master. Template EFFECT additionally
+             // requires --embedded-serve-mempool-txs; the #1218
+             // gbt-xcheck-txmerkle guard is untouched and stays the referee.
+             bool embedded_ingest_dstx = false)
 {
     namespace io = boost::asio;
 
@@ -5123,6 +5133,62 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     target->quorum.quorum_public_key, target->sign_hash, sig);
             });
 
+        // W5-B DSTX verifier: BLS-verify the mixing masternode's OPERATOR
+        // signature over SerializeHash(tx‖protxHash‖sigTime) against the
+        // SML's pubKeyOperator(protxHash) — dashd ValidateDSTX
+        // (net_processing.cpp:3549-3615). The pre-image is EXACT
+        // (coinjoin.h SERIALIZE_METHODS gates vchSig behind SER_GETHASH):
+        //   SHA256d( ser(tx) ‖ protxHash[32] ‖ sigTime[8 LE] )
+        // — full network tx serialization (pack(tx) IS the dash_txid base),
+        // no CompactSize framing around the trailing fields. The signature
+        // contract is byte-identical to the govvote operator verify
+        // (CBLSSignature::VerifyInsecure with the key's declared wire scheme
+        // vs post-V19 basic signing handled inside), so
+        // verify_govvote_operator_sig is REUSED, not re-implemented.
+        // Fail-closed at every arm: unknown proTxHash in the CURRENT SML =>
+        // refuse (dashd also walks <=24 blocks back for recently-removed
+        // MNs — a KNOWN phase-1 divergence: we refuse those, staying a
+        // SUBSET of dashd for that rare window; the tx-merkle guard covers
+        // it, and a tombstone ring is the phase-2 exactness fix).
+        maintainer->set_dstx_verify_fn(
+            [st = &node_coin_state](
+                const dash::coin::MutableTransaction& tx, const uint256& txid,
+                const uint256& protx_hash, const std::array<uint8_t, 96>& sig,
+                int64_t sig_time) -> bool {
+                (void)txid;
+                // Operator-key lookup in the live SML (mnlistdiff-sourced).
+                const auto& mn_list = st->sml().mnList;
+                const dash::coin::vendor::CSimplifiedMNListEntry* mn = nullptr;
+                for (const auto& e : mn_list) {
+                    if (e.proRegTxHash == protx_hash) { mn = &e; break; }
+                }
+                if (mn == nullptr) return false;   // unknown MN => refuse
+                // GetSignatureHash pre-image — the KAT-pinned helper
+                // (p2p_messages.hpp dstx_signature_hash).
+                const uint256 digest = dash::coin::p2p::dstx_signature_hash(
+                    tx, protx_hash, sig_time);
+                const bool key_legacy =
+                    mn->nVersion ==
+                    dash::coin::vendor::CSimplifiedMNListEntry::VER_LEGACY_BLS;
+                return dash::coin::vendor::verify_govvote_operator_sig(
+                    mn->pubKeyOperator, key_legacy, digest,
+                    std::vector<uint8_t>(sig.begin(), sig.end()));
+            });
+
+        // W5-B leg (dstx): Node::new_dstx -> maintainer.on_new_dstx. The
+        // event only fires when --embedded-ingest-dstx armed the pull; the
+        // maintainer gate then BLS-verifies via the verifier above and ONLY
+        // on pass admits via Mempool::add_dstx (fee=0 base + the +0.1 COIN
+        // prioritisation delta). Both hops fail closed, so subscribing
+        // unconditionally is inert without the flag.
+        coin_feed_subs.push_back(
+            coin_state.new_dstx.subscribe(
+                [m = maintainer.get()]
+                (const dash::interfaces::Node::DstxEvent& e) {
+                    m->on_new_dstx(e.tx, e.txid, e.protx_hash, e.sig,
+                                   e.sig_time);
+                }));
+
         // Leg 6 (ChainLock sig): Node::new_chainlock_sig -> maintainer
         // .on_new_chainlock. The clsig message carries the recovered 96-byte
         // threshold sig (new_chainlock above drops it); the maintainer adopts
@@ -5495,6 +5561,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // add_islock. OFF by default — off, an inv(MSG_ISDLOCK=31) never
         // earns a getdata and the handler decodes-and-discards, wire and
         // template behaviour byte-identical to master.
+        // ── W5-B DSTX INGEST: arm the MSG_DSTX pull ──────────────────────
+        // The acquire half; the verify half is the maintainer BLS gate
+        // installed above (set_dstx_verify_fn), and only its PASS ever
+        // reaches Mempool::add_dstx. OFF by default — off, an inv(MSG_DSTX
+        // =16) never earns a getdata and the handler discards, wire and
+        // template behaviour byte-identical to master.
+        if (embedded_ingest_dstx) {
+            coin_p2p->set_dstx_pull(true);
+            std::cout << "[run] --embedded-ingest-dstx: coin-P2P MSG_DSTX"
+                         " pull ARMED (shares the tx-pull budget; yields to"
+                         " the tip body). Every dstx is individually"
+                         " BLS-verified against the SML operator key of its"
+                         " proTxHash before the zero-fee +0.1 COIN"
+                         " prioritised admission; any verification failure"
+                         " is a drop (fail-closed, no state change).\n";
+        }
+
         if (embedded_ingest_isdlock) {
             coin_p2p->set_isdlock_pull(true);
             std::cout << "[run] --embedded-ingest-isdlock: coin-P2P"
@@ -7903,6 +7986,10 @@ int main(int argc, char** argv)
     // byte-identical); on, every isdlock is still individually BLS-gated
     // before Mempool::add_islock (fail-closed at every hop).
     bool embedded_ingest_isdlock = false;
+    // --embedded-ingest-dstx (W5-B): arm the CoinJoin DSTX lane (getdata
+    // pull + BLS-verified zero-fee admission with dashd's +0.1 COIN
+    // prioritisation delta). DEFAULT OFF — wire and templates byte-identical.
+    bool embedded_ingest_dstx = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -8010,6 +8097,8 @@ int main(int argc, char** argv)
             embedded_null_arm = false;  // #127: explicit OFF (OFF-equivalence)
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
+        else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
+            embedded_ingest_dstx = true;      // W5-B CoinJoin DSTX feed
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;
@@ -8307,7 +8396,8 @@ int main(int argc, char** argv)
                         embedded_accrue_asset_locks,   // #107 PHASE 2
                         embedded_null_arm,             // #127
                         embedded_accrue_asset_unlocks, // #143 Variant B
-                        embedded_ingest_isdlock);      // G4 isdlock feed
+                        embedded_ingest_isdlock,       // G4 isdlock feed
+                        embedded_ingest_dstx);         // W5-B DSTX feed
     }
     return run_selftest();
 }

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -115,6 +115,13 @@ struct inventory_type
         wtx             = 5,            // MSG_WTX (BIP 339)
         // Dash-specific getdata/inv types (dashcore src/protocol.h:495-524,
         // enum GetDataMsg). Only the ones we actually request are listed.
+        dstx            = 16,           // MSG_DSTX (dashcore protocol.h:507,
+                                        // CoinJoin broadcast tx; the inv hash
+                                        // is the PLAIN TXID, not a payload
+                                        // hash — net_processing.cpp:2567.
+                                        // NOTE: 16, NOT the retired legacy
+                                        // MSG_ISLOCK=30 — protocol.h keeps
+                                        // this enum backwards compatible)
         quorum_final_commitment = 21,   // MSG_QUORUM_FINAL_COMMITMENT
         clsig           = 29,           // MSG_CLSIG (dashcore protocol.h:522)
         isdlock         = 31,           // MSG_ISDLOCK (dashcore protocol.h:524,

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -960,6 +960,62 @@ public:
         on_islock(txid, inputs);
     }
 
+    /// Verifier seam for DSTX adoption (W5-B CoinJoin broadcast tx):
+    /// BLS-verifies the mixing masternode's OPERATOR signature over
+    /// SerializeHash(tx‖protxHash‖sigTime) against the SML's
+    /// pubKeyOperator(protxHash) — dashd ValidateDSTX
+    /// (net_processing.cpp:3549-3615) / CCoinJoinBroadcastTx::CheckSignature
+    /// (coinjoin.cpp:73-81). Installed by main_dash; UNSET IS FAIL-CLOSED
+    /// (see on_new_dstx).
+    using DstxVerifyFn = std::function<bool(
+        const dash::coin::MutableTransaction& tx, const uint256& txid,
+        const uint256& protx_hash, const std::array<uint8_t, 96>& sig,
+        int64_t sig_time)>;
+
+    void set_dstx_verify_fn(DstxVerifyFn fn) {
+        m_dstx_verify = std::move(fn);
+    }
+
+    /// DSTX reception: admit a VERIFIED CoinJoin broadcast tx into the
+    /// mempool at fee=0 with dashd's +0.1 COIN prioritisation delta
+    /// (Mempool::add_dstx), so selection ranks it exactly where dashd's
+    /// GetModFeesWithAncestors sort puts it while the coinbase fee term
+    /// stays base (0) — both matching dashd bit-for-bit.
+    ///
+    /// ⚠ VERIFICATION IS MANDATORY. A DSTX is a zero-fee tx that enters the
+    /// served template at TOP modified-fee priority; adopting one unverified
+    /// would let an arbitrary peer stuff zero-fee txs into our templates
+    /// (template pollution ⇒ tx-merkle divergence from dashd ⇒ the #1218
+    /// guard refuses/swaps serving — availability, not validity, but still
+    /// an attack surface). When no verifier is installed, or verification
+    /// FAILS, we adopt NOTHING: the pool stays exactly as it was.
+    ///
+    /// KNOWN PHASE-1 DIVERGENCE (deliberate, documented): dashd additionally
+    /// rate-limits DSTX-es per masternode (IsValidForMixingTxes, MAX=5 since
+    /// the MN's last DSQ, masternode/meta.cpp:124-128). Mirroring that
+    /// counter without ingesting the DSQ queue stream (inv 32) would only
+    /// ever INCREMENT ⇒ permanent false refusals, so phase 1 omits it: an MN
+    /// spamming >5 DSTX between queues makes embedded a SUPERSET of dashd
+    /// for those txs and the tx-merkle guard refuses serving (never an
+    /// invalid block). If soak attributes mismatch events here, phase 2
+    /// adds the DSQ leg for exactness.
+    void on_new_dstx(const dash::coin::MutableTransaction& tx,
+                     const uint256& txid, const uint256& protx_hash,
+                     const std::array<uint8_t, 96>& sig, int64_t sig_time) {
+        if (!m_dstx_verify) return;                      // no verifier => fail closed
+        if (!m_dstx_verify(tx, txid, protx_hash, sig, sig_time)) {
+            LOG_WARNING << "[DSTX] rejected unverified dstx txid="
+                        << txid.GetHex().substr(0, 16) << "... protx="
+                        << protx_hash.GetHex().substr(0, 16) << "...";
+            return;
+        }
+        const bool admitted = m_state.mempool().add_dstx(tx);
+        LOG_INFO << "[DSTX] VERIFIED dstx txid=" << txid.GetHex().substr(0, 16)
+                 << "... protx=" << protx_hash.GetHex().substr(0, 16)
+                 << (admitted ? "... admitted fee=0 delta=+0.1 COIN"
+                              : "... delta applied to already-pooled tx");
+    }
+
     /// Reorg (SML axis): a chain reorganisation can invalidate the incremental
     /// SML/quorum state (the diffs we applied were relative to an orphaned
     /// branch). Wipe the SML + quorum set and drop have_sml so the embedded arm
@@ -2333,6 +2389,7 @@ private:
         m_on_new_quorum_commitments;
     ChainLockVerifyFn     m_chainlock_verify; // unset => live ChainLocks never adopted (fail closed)
     IslockVerifyFn        m_islock_verify;    // unset => isdlocks never adopted (fail closed, G4 stays dormant)
+    DstxVerifyFn          m_dstx_verify;      // unset => DSTX-es never admitted (fail closed, W5-B stays dormant)
     // E2: independent DIP-0027 credit-pool accrual, advanced per ingested block
     // (on_block_connected) and re-anchored per accepted mnlistdiff. Verified
     // against each block's own from-wire cbTx; persisted via the hook below.

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -85,8 +85,19 @@ struct MempoolEntry {
     uint256  txid;
     uint32_t base_size{0};
     uint64_t fee{0};            // satoshi (computed from UTXO when available)
+    // W5-B: PrioritiseTransaction-style fee delta (dashd mapDeltas /
+    // CTxMemPoolEntry::GetModifiedFee). SCORING uses fee + fee_delta
+    // (feerate index, ancestor aggregates, blockMinFeeRate gate — dashd's
+    // nModFeesWithAncestors basis); ACCOUNTING (total_fees → coinbasevalue,
+    // SelectedTx.fee) stays BASE fee, exactly dashd's split (miner.cpp
+    // AddToBlock nFees += iter->GetFee()). Today's only writer is the
+    // BLS-verified DSTX admission (+0.1 COIN, net_processing.cpp:3609);
+    // 0 everywhere else = byte-identical ordering (modified == base).
+    uint64_t fee_delta{0};
     bool     fee_known{false};
     time_t   time_added{0};
+
+    uint64_t modified_fee() const { return fee + fee_delta; }
 
     double feerate_satvb() const {
         return (fee_known && base_size > 0)
@@ -353,9 +364,66 @@ public:
     bool add_tx(const MutableTransaction& tx,
                 ::core::coin::UTXOViewCache* utxo)
     {
-        uint256 txid = dash_txid(tx);
-
         std::lock_guard<std::mutex> lock(m_mutex);
+        return add_tx_locked(tx, utxo, /*is_dstx=*/false);
+    }
+
+    /// W5-B: dashd's DSTX prioritisation delta — PrioritiseTransaction(hash,
+    /// COIN/10) fired by ValidateDSTX on every BLS-verified CoinJoin
+    /// broadcast tx BEFORE mempool acceptance (net_processing.cpp:3609).
+    static constexpr uint64_t DSTX_FEE_DELTA = 10'000'000;   // 0.1 COIN, duffs
+
+    /// W5-B: admit a BLS-VERIFIED CoinJoin broadcast tx. ONLY caller is
+    /// CoinStateMaintainer::on_new_dstx AFTER the operator-signature BLS gate
+    /// passed (fail-closed; see the sole-ingestion-path invariant above —
+    /// this is a second, explicitly-audited seam: structural validity was
+    /// checked at the P2P handler, the tx is a protocol-forced denominated
+    /// mixing tx, and finality/script arguments carry over from the same
+    /// dashd-relay source).
+    ///
+    /// Mirrors dashd's ORDER exactly: the delta is recorded BEFORE admission
+    /// (mapDeltas pre-dates and survives acceptance), then the tx is admitted
+    /// with fee=0 when inputs are unpriceable — reward-SAFE because a DSTX's
+    /// protocol shape (vin.size()==vout.size(), all-denominated outputs)
+    /// forces fee≈0, and even a hostile signed nonzero-fee DSTX only makes
+    /// total_fees UNDERSTATE ⇒ coinbase pays ≤ allowed ⇒ never an invalid
+    /// block. If compute_fee_locked CAN price it, the computed base fee is
+    /// kept. If the plain MSG_TX body arrived first (already pooled), the
+    /// delta is applied RETROACTIVELY — we converge on dashd's STATE (the
+    /// prioritised pool), not its message-order accident.
+    bool add_dstx(const MutableTransaction& tx,
+                  uint64_t fee_delta = DSTX_FEE_DELTA)
+    {
+        const uint256 txid = dash_txid(tx);
+        std::lock_guard<std::mutex> lock(m_mutex);
+        record_fee_delta_locked(txid, fee_delta);
+        auto it = m_pool.find(txid);
+        if (it != m_pool.end()) {
+            // Retro-apply: re-key the feerate index under the new modified
+            // fee (every index site keys FeeKey{modified_fee(), size, txid}).
+            if (it->second.fee_delta != fee_delta) {
+                if (it->second.fee_known)
+                    m_feerate_index.erase(FeeKey{it->second.modified_fee(),
+                                                 it->second.base_size, txid});
+                it->second.fee_delta = fee_delta;
+                if (it->second.fee_known)
+                    m_feerate_index.insert(FeeKey{it->second.modified_fee(),
+                                                  it->second.base_size, txid});
+                LOG_INFO << "[MEMPOOL] dstx delta retro-applied txid="
+                         << txid.GetHex().substr(0, 16)
+                         << " delta=" << fee_delta;
+            }
+            return false;   // already known (same contract as add_tx)
+        }
+        return add_tx_locked(tx, m_utxo.load(), /*is_dstx=*/true);
+    }
+
+private:
+    bool add_tx_locked(const MutableTransaction& tx,
+                       ::core::coin::UTXOViewCache* utxo,
+                       bool is_dstx)
+    {
+        uint256 txid = dash_txid(tx);
         if (m_pool.count(txid)) return false;
 
         // #125 — REJECT ALREADY-CONFIRMED TRANSACTIONS AT ADMISSION.
@@ -427,8 +495,20 @@ public:
         auto packed      = ::pack(tx);
         entry.base_size  = static_cast<uint32_t>(packed.size());
         entry.time_added = std::time(nullptr);
+        // W5-B: a recorded prioritisation delta applies WHENEVER the tx is
+        // admitted, on either path (dashd mapDeltas semantics — the delta
+        // pre-dates and survives acceptance).
+        if (auto dit = m_fee_deltas.find(txid); dit != m_fee_deltas.end())
+            entry.fee_delta = dit->second;
 
         compute_fee_locked(entry, utxo);
+        // W5-B: a BLS-verified DSTX whose inputs the view cannot price is
+        // admitted at fee=0 (see add_dstx — understate-only, reward-safe);
+        // a priceable one keeps its computed base fee.
+        if (is_dstx && !entry.fee_known) {
+            entry.fee = 0;
+            entry.fee_known = true;
+        }
 
         // LRU eviction if over size cap.
         int evicted = 0;
@@ -452,9 +532,12 @@ public:
         // Feerate-sorted index (step 2) — only if fee was known.
         // Unknown-fee txs sit out of the sorted view until
         // recompute_unknown_fees() resolves them after a UTXO update.
-        // Uses negative feerate as the multimap key so begin() = best.
+        // Keyed by MODIFIED fee (W5-B) — every insert/erase site keys
+        // FeeKey{modified_fee(), size, txid}, one invariant; delta==0 for
+        // every non-DSTX entry keeps this byte-identical to the base key.
         if (stored.fee_known) {
-            m_feerate_index.insert(FeeKey{stored.fee, stored.base_size, txid});
+            m_feerate_index.insert(
+                FeeKey{stored.modified_fee(), stored.base_size, txid});
         }
 
         // Periodic stats — every 100 entries + first 5 + every eviction.
@@ -470,6 +553,22 @@ public:
         return true;
     }
 
+    /// W5-B: bounded mapDeltas (dashd CTxMemPool::mapDeltas). FIFO-evicted
+    /// beyond the cap (relay is untrusted input, same posture as the islock
+    /// maps); confirmed txids are pruned by remove_for_block.
+    void record_fee_delta_locked(const uint256& txid, uint64_t delta)
+    {
+        while (m_fee_delta_order.size() >= MAX_FEE_DELTAS
+               && !m_fee_delta_order.empty()) {
+            m_fee_deltas.erase(m_fee_delta_order.front());
+            m_fee_delta_order.pop_front();
+        }
+        auto [it, inserted] = m_fee_deltas.insert_or_assign(txid, delta);
+        (void)it;
+        if (inserted) m_fee_delta_order.push_back(txid);
+    }
+
+public:
     void remove_tx(const uint256& txid)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -525,6 +624,14 @@ public:
                     std::make_pair(vin.prevout.hash, vin.prevout.index));
             }
         }
+
+        // W5-B: a confirmed tx no longer needs its prioritisation delta
+        // (dashd also clears mapDeltas on block connect). Stale txids left
+        // in m_fee_delta_order are harmless — the FIFO eviction in
+        // record_fee_delta_locked erases them from the (already-pruned)
+        // map as it pops.
+        for (const auto& mtx : block.m_txs)
+            m_fee_deltas.erase(dash_txid(mtx));
 
         if (removed > 0 || conflicts > 0) {
             LOG_INFO << "[MEMPOOL] block cleanup removed=" << removed
@@ -641,6 +748,8 @@ public:
         m_islock_txids.clear();
         m_islock_txid_order.clear();
         m_last_islock_seen = 0;
+        m_fee_deltas.clear();
+        m_fee_delta_order.clear();
         m_total_bytes = 0;
     }
 
@@ -657,7 +766,8 @@ public:
         for (auto& [txid, entry] : m_pool) {
             if (entry.fee_known) continue;
             if (compute_fee_locked(entry, utxo)) {
-                m_feerate_index.insert(FeeKey{entry.fee, entry.base_size, txid});
+                m_feerate_index.insert(
+                    FeeKey{entry.modified_fee(), entry.base_size, txid});
                 resolved_fees += entry.fee;
                 ++resolved;
             } else {
@@ -856,7 +966,9 @@ public:
         for (const auto& [txid, e] : m_pool) {
             if (!e.fee_known) continue;
             if (anc.over_limit.count(txid)) continue;
-            anc_index.insert(anc_score_key(e.fee, e.base_size,
+            // W5-B: SCORE on the MODIFIED fee (dashd sorts on
+            // GetModFeesWithAncestors); delta==0 ⇒ byte-identical to base.
+            anc_index.insert(anc_score_key(e.modified_fee(), e.base_size,
                                            anc.modfee_wa.at(txid),
                                            anc.size_wa.at(txid), txid));
         }
@@ -1225,7 +1337,7 @@ public:
                         const auto& de = m_pool.at(desc);
                         ModEntry m;
                         m.txid          = desc;
-                        m.self_fee      = de.fee;
+                        m.self_fee      = de.modified_fee();   // scoring basis (W5-B)
                         m.self_size     = de.base_size;
                         m.mod_modfee_wa = anc.modfee_wa.at(desc);
                         m.mod_size_wa   = anc.size_wa.at(desc);
@@ -1234,8 +1346,8 @@ public:
                     } else {
                         mod_score.erase(mod_key(it->second));   // stale key out first (R2)
                     }
-                    it->second.mod_modfee_wa -= a->fee;         // update_for_parent_inclusion
-                    it->second.mod_size_wa   -= a->base_size;   // (miner.h:140-141)
+                    it->second.mod_modfee_wa -= a->modified_fee();  // update_for_parent_inclusion
+                    it->second.mod_size_wa   -= a->base_size;       // (miner.h:140-141; modified basis, W5-B)
                     mod_score.insert(mod_key(it->second));
                 }
             }
@@ -1264,6 +1376,12 @@ private:
     // FIFO posture as the outpoint map (relay is untrusted input).
     std::set<uint256>                                  m_islock_txids;
     std::deque<uint256>                                m_islock_txid_order;
+    // W5-B: dashd mapDeltas — txid → prioritisation delta (duffs), recorded
+    // pre-admission and applied on ANY later admission; bounded FIFO (relay
+    // is untrusted input), pruned on block confirm.
+    static constexpr size_t MAX_FEE_DELTAS = 10'000;
+    std::map<uint256, uint64_t>                        m_fee_deltas;
+    std::deque<uint256>                                m_fee_delta_order;
     // Feed-liveness tick (last add_islock wall time; 0 = never) — the hold's
     // ISLOCK_FEED_FRESH_SECS self-disarm reads this under m_mutex.
     time_t                                             m_last_islock_seen{0};
@@ -1458,11 +1576,14 @@ private:
             const auto& a = closure(txid);
             uint32_t cnt = static_cast<uint32_t>(a.size()) + 1;
             uint64_t szf = e.base_size;
-            uint64_t mff = e.fee;
+            // W5-B: modfee_wa IS dashd's nModFeesWithAncestors — MODIFIED
+            // fees (base + delta). Base-fee accounting (total_fees /
+            // SelectedTx.fee) never reads these aggregates.
+            uint64_t mff = e.modified_fee();
             for (const auto& at : a) {
                 const auto& ae = m_pool.at(at);
                 szf += ae.base_size;
-                mff += ae.fee;
+                mff += ae.modified_fee();
             }
             st.count_wa[txid]  = cnt;
             st.size_wa[txid]   = static_cast<uint32_t>(szf);
@@ -1511,9 +1632,11 @@ private:
             }
         }
 
-        // Drop from feerate index (only present if fee was known).
+        // Drop from feerate index (only present if fee was known). Same
+        // modified-fee key every insert site used (single invariant, W5-B).
         if (it->second.fee_known) {
-            m_feerate_index.erase(FeeKey{it->second.fee, it->second.base_size, txid});
+            m_feerate_index.erase(FeeKey{it->second.modified_fee(),
+                                         it->second.base_size, txid});
         }
 
         // Drop from spent-outputs index.

--- a/src/impl/dash/coin/node_interface.hpp
+++ b/src/impl/dash/coin/node_interface.hpp
@@ -176,6 +176,27 @@ struct Node
     };
     Event<IsdLockEvent> new_isdlock;
 
+    // W5-B: a CoinJoin broadcast tx (dstx, MSG_DSTX=16) parsed off the
+    // coin-P2P wire — dashd CCoinJoinBroadcastTx {tx, protxHash, vchSig,
+    // sigTime}. Carries everything the maintainer-side BLS gate needs: the
+    // full tx (a protocol-forced zero-fee denominated mixing tx), the mixing
+    // masternode's proTxHash (operator-key lookup in the SML), the 96-byte
+    // BLS operator signature over SerializeHash(tx‖protxHash‖sigTime), and
+    // sigTime. NO trust decision is made in the P2P layer — the subscriber
+    // (CoinStateMaintainer::on_new_dstx) is fail-closed: no verifier
+    // registered, or BLS verify fails, means the tx is dropped and
+    // Mempool::add_dstx is never called. Only fired when
+    // --embedded-ingest-dstx armed the pull (flag OFF => no getdata is ever
+    // sent AND the handler discards => this event never fires).
+    struct DstxEvent {
+        coin::MutableTransaction tx;
+        uint256                  txid;         // dash_txid(tx), self-computed
+        uint256                  protx_hash;
+        std::array<uint8_t, 96>  sig{};
+        int64_t                  sig_time{0};
+    };
+    Event<DstxEvent> new_dstx;
+
     // E1 Phase-L sourcing leg: a peer-relayed DKG final commitment off the
     // coin-P2P `qfcommit` stream (inv MSG_QUORUM_FINAL_COMMITMENT = 21) —
     // the exact stream dashd's own miner sources block-N's mandatory type-6

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -686,6 +686,17 @@ private:
     // announces at most one isdlock per locked tx, orders of magnitude rarer
     // than MSG_TX, and the payload is bounded at decode (MAX_ISDLOCK_INPUTS).
     bool     m_isdlock_pull_enabled{false};
+    // DSTX (CoinJoin broadcast tx) lane (--embedded-ingest-dstx): OPT-IN,
+    // and — unlike isdlock — the GETDATA ITSELF is gated: a DSTX has no
+    // fee-only-safe unconditional consumer (its whole effect is putting a
+    // zero-fee tx INTO templates at top priority), so off-flag there is no
+    // reason to spend bandwidth. The pull rides the SAME budget/inflight
+    // machinery as MSG_TX (the DSTX inv hash IS the plain txid,
+    // net_processing.cpp:2567, so the txid-keyed slots are correct).
+    bool     m_dstx_pull_enabled{false};
+    uint64_t m_dstx_inv_seen{0};     // inv(MSG_DSTX) admitted by the dedup
+    uint64_t m_dstx_pull_sent{0};    // getdata(MSG_DSTX) issued
+    uint64_t m_dstx_received{0};     // dstx bodies that arrived
     size_t   m_tx_pull_inflight_cap{64};
     std::map<uint256, int64_t> m_tx_pull_inflight;   // txid -> requested-at
     uint64_t m_tx_inv_offered{0};    // inv(MSG_TX) SEEN on the wire, pre-dedup
@@ -1393,6 +1404,14 @@ public:
     /// stays dormant.
     void set_isdlock_pull(bool on) { m_isdlock_pull_enabled = on; }
     bool isdlock_pull_enabled() const { return m_isdlock_pull_enabled; }
+
+    /// Arm the DSTX (CoinJoin broadcast tx) lane (--embedded-ingest-dstx).
+    /// OFF by default: an explicit operator decision. Unlike isdlock this
+    /// gates the GETDATA itself — no fee-only-safe unconditional consumer
+    /// exists for a DSTX, so off-flag no inv(MSG_DSTX=16) ever earns a
+    /// request and the wire is byte-identical to master.
+    void set_dstx_pull(bool on) { m_dstx_pull_enabled = on; }
+    bool dstx_pull_enabled() const { return m_dstx_pull_enabled; }
 
     /// One greppable line: what the ingest lane asked for and what it got.
     /// received < pull_sent is normal (notfound, races, peers that drop);
@@ -2384,12 +2403,18 @@ private:
             const bool is_block = (inv.base_type() == inventory_type::block);
             const bool is_tx = (inv.base_type() == inventory_type::tx)
                             && m_tx_pull_enabled;
+            // W5-B: MSG_DSTX rides the tx-pull budget path (same strict
+            // tip-body priority, same inflight cap and txid-keyed dedup —
+            // the DSTX inv hash IS the plain txid). Gated on its OWN flag:
+            // no fee-only-safe unconditional consumer exists for a DSTX.
+            const bool is_dstx = (inv.m_type == inventory_type::dstx)
+                              && m_dstx_pull_enabled;
             // Offered-vs-admitted (diagnosis, not policy): counted BEFORE the
             // dedup so "peers are not announcing" can be told apart from "we
             // are filtering". Same announcement from N peers = N offered, 1
             // admitted — that gap is the fan-in the pool exists to produce.
             if (inv.base_type() == inventory_type::tx) ++m_tx_inv_offered;
-            if (!pulled && !is_block && !is_tx)
+            if (!pulled && !is_block && !is_tx && !is_dstx)
                 continue;   // not actionable — do not spend a dedup slot on it
             if (!m_inv_dedup.admit(static_cast<uint32_t>(inv.m_type), inv.m_hash, now))
             {
@@ -2426,9 +2451,9 @@ private:
                 p->write(getdata_msg);
                 continue;
             }
-            if (is_tx)
+            if (is_tx || is_dstx)
             {
-                ++m_tx_inv_seen;
+                if (is_tx) ++m_tx_inv_seen; else ++m_dstx_inv_seen;
                 expire_tx_pulls(now);
                 // STRICT PRIORITY: the tip body always wins. A transaction is
                 // worth a fraction of a block's fees; a late tip body is a
@@ -2441,11 +2466,19 @@ private:
                     ++m_tx_pull_skipped_budget;
                     continue;
                 }
+                // Budget slots are keyed by TXID — correct for BOTH lanes
+                // because the DSTX inv hash IS the plain txid (dashd
+                // net_processing.cpp:2567); a type-1 and a type-16
+                // announcement of the same tx share one slot here even
+                // though InvDedup (keyed on type+hash) admitted both.
                 if (m_tx_pull_inflight.count(inv.m_hash)) continue;
                 m_tx_pull_inflight.emplace(inv.m_hash, now);
-                ++m_tx_pull_sent;
+                if (is_tx) ++m_tx_pull_sent; else ++m_dstx_pull_sent;
+                // Echo the ANNOUNCED type back: a getdata(MSG_TX) for a
+                // DSTX-only tx would get notfound from dashd until it leaves
+                // the DSTX relay window.
                 auto getdata_msg = message_getdata::make_raw(
-                    {inventory_type(inventory_type::tx, inv.m_hash)});
+                    {inventory_type(inv.m_type, inv.m_hash)});
                 p->write(getdata_msg);
                 continue;
             }
@@ -2686,6 +2719,63 @@ private:
                  << " cycle=" << msg->m_cycle_hash.GetHex().substr(0, 16)
                  << "...";
         m_coin->new_isdlock.happened(ev);
+    }
+
+    ADD_P2P_HANDLER(dstx)
+    {
+        // W5-B: CoinJoin broadcast tx (dashd CCoinJoinBroadcastTx). NO trust
+        // decision here — the maintainer-side BLS gate
+        // (CoinStateMaintainer::on_new_dstx, fail-closed without a verifier)
+        // decides whether the zero-fee admission path ever runs. This
+        // handler: (1) releases the shared tx-pull budget slot by the
+        // COMPUTED txid (never the announcement's — an unsolicited or
+        // substituted body cannot free a slot it never occupied, same rule
+        // as the tx handler); (2) applies dashd's STRUCTURAL refusals
+        // (CCoinJoinBroadcastTx::IsValidStructure, coinjoin.cpp:83-102 —
+        // local drop + log, no ban); (3) fires new_dstx when the lane is
+        // armed.
+        ++m_dstx_received;
+        const uint256 txid = dash_txid(msg->m_tx);
+        m_tx_pull_inflight.erase(txid);
+
+        if (!m_dstx_pull_enabled) {
+            // Off-flag no getdata was ever sent; an unsolicited dstx is
+            // decode-and-discard (belt-and-suspenders).
+            LOG_DEBUG_COIND << "[" << m_chain_label << "] dstx from "
+                            << (m_active ? m_active->key : std::string("?"))
+                            << " DISCARDED (--embedded-ingest-dstx off)";
+            return;
+        }
+
+        // dashd IsValidStructure, KAT-pinned free predicate
+        // (p2p_messages.hpp dstx_is_valid_structure).
+        if (!dstx_is_valid_structure(msg->m_tx, msg->m_protx_hash,
+                                     msg->m_sig.size())) {
+            LOG_INFO << "[" << m_chain_label << "] dstx from "
+                     << (m_active ? m_active->key : std::string("?"))
+                     << " REFUSED structure (txid="
+                     << txid.GetHex().substr(0, 16)
+                     << " vin=" << msg->m_tx.vin.size()
+                     << " vout=" << msg->m_tx.vout.size()
+                     << " sig_bytes=" << msg->m_sig.size()
+                     << " protx_null=" << (msg->m_protx_hash.IsNull() ? 1 : 0)
+                     << ")";
+            return;
+        }
+
+        ::dash::interfaces::Node::DstxEvent ev;
+        ev.tx         = msg->m_tx;
+        ev.txid       = txid;
+        ev.protx_hash = msg->m_protx_hash;
+        ev.sig_time   = msg->m_sig_time;
+        std::copy(msg->m_sig.begin(), msg->m_sig.end(), ev.sig.begin());
+        LOG_INFO << "[" << m_chain_label << "] dstx from "
+                 << (m_active ? m_active->key : std::string("?"))
+                 << ": txid=" << txid.GetHex().substr(0, 16)
+                 << "... vin=" << msg->m_tx.vin.size()
+                 << " protx=" << msg->m_protx_hash.GetHex().substr(0, 16)
+                 << "... sig_time=" << msg->m_sig_time;
+        m_coin->new_dstx.happened(ev);
     }
 
     ADD_P2P_HANDLER(qfcommit)

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -14,8 +14,11 @@
 
 #include <impl/bitcoin_family/coin/base_p2p_messages.hpp>
 
+#include <span>
 #include <vector>
 
+#include <core/hash.hpp>      // CHash256 — dstx_signature_hash (W5-B)
+#include <core/pack.hpp>      // PackStream — dstx_signature_hash (W5-B)
 #include <core/uint256.hpp>
 #include <core/netaddress.hpp>
 #include <core/message.hpp>
@@ -455,6 +458,122 @@ BEGIN_MESSAGE(isdlock)
     }
 END_MESSAGE()
 
+// ── W5-B: CoinJoin broadcast tx (DSTX) ────────────────────────────────────
+// "dstx" — dashd coinjoin/coinjoin.h CCoinJoinBroadcastTx, v23 wire form
+// (SERIALIZE_METHODS, coinjoin.h:255-263; the legacy masternodeOutpoint arm
+// is gone at proto 70230 — protxHash only):
+//   tx        (full network tx serialization — Dash has no witness)
+//   protxHash (uint256 — the mixing masternode's registration txid)
+//   vchSig    (CompactSize-prefixed byte vector; 96-byte BLS operator sig.
+//              The 96B check is a HANDLER refusal, not a codec bound —
+//              mirrors isdlock's "structural refusal is peer-local" posture)
+//   sigTime   (int64 LE)
+//
+// ACQUISITION: dashd relays a mixing tx as inv(MSG_DSTX=16) where the inv
+// hash is the PLAIN TXID (net_processing.cpp:2567 — unlike isdlock/clsig,
+// whose inv hash is SerializeHash(payload)), and serves the object from
+// CDSTXManager::GetDSTX(txid) on getdata (:2868-2873). The pull is OPT-IN
+// (--embedded-ingest-dstx, CoinClient::set_dstx_pull) and rides the SAME
+// budgeted tx-pull machinery as MSG_TX (slot keyed by txid — correct here
+// precisely because the DSTX inv hash IS the txid); flag OFF ⇒ no getdata
+// type-16 is ever sent ⇒ zero wire and zero template change.
+//
+// ⚠ THE SIGNATURE IS NOT OPAQUE. A DSTX is a ZERO-FEE tx dashd admits and
+// then PRIORITISES (+0.1 COIN modified fee, net_processing.cpp:3609) ONLY
+// after BLS-verifying vchSig against the mixing MN's operator key
+// (ValidateDSTX, :3549-3615). Adopting one unverified would let an arbitrary
+// peer stuff zero-fee txs into our served templates at top priority. The
+// maintainer-side gate (CoinStateMaintainer::on_new_dstx, fail-closed
+// without a verifier) must BLS-verify
+//     SerializeHash(tx ‖ protxHash ‖ sigTime)      (SER_GETHASH drops vchSig;
+//                                                   coinjoin.cpp:68-80)
+// against SML pubKeyOperator(protxHash) before Mempool::add_dstx runs.
+BEGIN_MESSAGE(dstx)
+    MESSAGE_FIELDS
+    (
+        (MutableTransaction,   m_tx),
+        (uint256,              m_protx_hash),
+        (std::vector<uint8_t>, m_sig),
+        (int64_t,              m_sig_time)
+    )
+    {
+        READWRITE(obj.m_tx);
+        READWRITE(obj.m_protx_hash);
+        READWRITE(obj.m_sig);
+        READWRITE(obj.m_sig_time);
+    }
+END_MESSAGE()
+
+/// dashd CCoinJoinBroadcastTx::IsValidStructure (coinjoin.cpp:83-102) — the
+/// STRUCTURAL refusals a DSTX must clear before the BLS gate ever runs.
+/// Mainnet constants: nPoolMinParticipants=3 / nPoolMaxParticipants=20
+/// (chainparams.cpp:287-288), COINJOIN_ENTRY_MAX_SIZE=9 (coinjoin.h:47) ⇒
+/// vin ∈ [3, 180]; every vout must be a standard CoinJoin denomination
+/// (coinjoin/common.h:38-44) paid to P2PKH. No sigTime bound — dashd's
+/// ValidateDSTX has none (the time bound is queue-only). A refusal is a
+/// peer-local drop, never a ban. Free function so it is unit-testable
+/// without a live socket peer (same reason as inv_type_is_pulled).
+inline bool dstx_is_valid_structure(const MutableTransaction& tx,
+                                    const uint256& protx_hash,
+                                    size_t sig_size)
+{
+    static constexpr size_t kMinVin = 3;        // nPoolMinParticipants
+    static constexpr size_t kMaxVin = 20 * 9;   // nPoolMaxParticipants * ENTRY_MAX
+    auto is_denomination = [](int64_t v) {
+        return v == 1000010000LL   // 10.00010000 DASH
+            || v == 100001000LL    //  1.00001000
+            || v == 10000100LL     //  0.10000100
+            || v == 1000010LL      //  0.01000010
+            || v == 100001LL;      //  0.00100001
+    };
+    auto is_p2pkh = [](const std::vector<uint8_t>& s) {
+        return s.size() == 25 && s[0] == 0x76 && s[1] == 0xa9 && s[2] == 0x14
+            && s[23] == 0x88 && s[24] == 0xac;
+    };
+    if (protx_hash.IsNull()) return false;
+    if (tx.vin.size() != tx.vout.size()) return false;
+    if (tx.vin.size() < kMinVin || tx.vin.size() > kMaxVin) return false;
+    if (sig_size != 96) return false;
+    for (const auto& out : tx.vout) {
+        if (!is_denomination(out.value)) return false;
+        if (!is_p2pkh(out.scriptPubKey.m_data)) return false;
+    }
+    return true;
+}
+
+/// dashd CCoinJoinBroadcastTx::GetSignatureHash() — SerializeHash(*this,
+/// SER_GETHASH, PROTOCOL_VERSION) with vchSig EXCLUDED by the SER_GETHASH
+/// guard in SERIALIZE_METHODS (coinjoin.h:257-262, coinjoin.cpp:68-71):
+///
+///     digest = SHA256d( ser(tx) ‖ protxHash[32] ‖ sigTime[8 LE] )
+///
+/// Full network tx serialization (Dash txs have no witness, so SER_GETHASH
+/// does not alter the tx bytes; ::pack(MutableTransaction) IS the dash_txid
+/// byte source), raw 32-byte protxHash, plain 8-byte LE sigTime — NO
+/// CompactSize framing around the trailing fields. This is the pre-image the
+/// mixing MN's BLS operator key signs; pinned by test_dash_dstx.cpp against
+/// an independently hand-assembled byte stream.
+inline uint256 dstx_signature_hash(const MutableTransaction& tx,
+                                   const uint256& protx_hash,
+                                   int64_t sig_time)
+{
+    ::PackStream ps;
+    ps << tx;
+    auto sp = ps.get_span();
+    std::vector<uint8_t> pre(
+        reinterpret_cast<const uint8_t*>(sp.data()),
+        reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+    pre.insert(pre.end(), protx_hash.data(), protx_hash.data() + 32);
+    for (int i = 0; i < 8; ++i)
+        pre.push_back(static_cast<uint8_t>(
+            (static_cast<uint64_t>(sig_time) >> (8 * i)) & 0xFF));
+    uint256 digest;
+    CHash256()
+        .Write(std::span<const unsigned char>(pre.data(), pre.size()))
+        .Finalize(std::span<unsigned char>(digest.data(), 32));
+    return digest;
+}
+
 // ── SPORK listener ────────────────────────────────────────────────────────
 // "spork" — CSporkMessage (dashd src/spork.h SERIALIZE_METHODS): nSporkID(i32)
 // + nValue(i64) + nTimeSigned(i64) + vchSig (LIMITED_VECTOR, 65-byte compact
@@ -524,6 +643,16 @@ using Handler = MessageHandler<
     // #1230 x isdlock-intake). test_dash_isdlock.cpp gates the registry
     // membership directly.
     message_isdlock,
+    // ⚠ DSTX lane — same registry rule as isdlock above (#1077): a handler
+    // that exists but whose message type is absent from this list can never
+    // run; the payload dies on the unhandled-command path at DEBUG, and the
+    // CoinJoin leg silently stays feed-less. Membership here is
+    // UNCONDITIONAL (compile-time); the --embedded-ingest-dstx flag gates
+    // BEHAVIOUR (the getdata pull + the BLS-verified new_dstx lane), never
+    // parsing. ONE entry only: a type listed twice is a duplicate variant
+    // alternative = compile error (rebase trap). test_dash_dstx.cpp gates
+    // the registry membership directly.
+    message_dstx,
     message_qfcommit,
     message_getmnlistd,
     message_mnlistdiff,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -688,6 +688,32 @@ if (BUILD_TESTING AND GTest_FOUND)
     #     a non-conflicting one; no verifier / refusing verifier => no change;
     #   * BLS-gated (C2POOL_DASH_BLS): real threshold sig verifies end-to-end,
     #     every tampered bit is rejected and never reaches add_islock.
+    # W5-B DSTX intake (acquire -> BLS-verify -> zero-fee prioritised
+    # admission, all fail-closed):
+    #   * p2p::Handler REGISTRY membership gate (the DIP-24 qrinfo
+    #     silent-drop failure mode; a de-registered dstx fails RED here);
+    #   * wire-codec KAT against hand-assembled dashd CCoinJoinBroadcastTx
+    #     bytes + byte-exact re-encode;
+    #   * GetSignatureHash pre-image KAT vs an INDEPENDENTLY hand-assembled
+    #     byte stream (also pins pack(tx) network serialization);
+    #   * IsValidStructure refusal matrix;
+    #   * the USE red/green: plain zero-fee admission stays OUT (min-feerate
+    #     floor, master's behaviour) vs the REAL verified maintainer path
+    #     ranking it FIRST on the +0.1 COIN modified fee while total_fees
+    #     stays BASE (coinbasevalue parity);
+    #   * fail-closed: no verifier / bad BLS sig through the real
+    #     verify_govvote_operator_sig entry point admits nothing.
+    add_executable(test_dash_dstx test_dash_dstx.cpp)
+    target_link_libraries(test_dash_dstx PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_block_replay   # full p2p Handler instantiation (registry gate)
+        dash_bls_verify dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_dstx PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39)
+    gtest_add_tests(test_dash_dstx "" AUTO)
+
     add_executable(test_dash_isdlock test_dash_isdlock.cpp)
     target_link_libraries(test_dash_isdlock PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_dstx.cpp
+++ b/test/test_dash_dstx.cpp
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// W5-B DSTX intake — acquire -> BLS-verify -> zero-fee prioritised admission,
+/// all fail-closed.
+///
+/// The claims this suite pins, in dependency order:
+///
+///   1. WIRE. `dstx` is registered in the p2p::Handler type list (the DIP-24
+///      qrinfo silent-drop failure mode, #1077, gets its own RED-able test)
+///      and the codec decodes the dashd CCoinJoinBroadcastTx v23 wire layout
+///      byte-exactly (KAT: hand-assembled golden bytes, independent of the
+///      codec) and re-encodes byte-identically.
+///
+///   2. PRE-IMAGE. dstx_signature_hash reproduces dashd
+///      CCoinJoinBroadcastTx::GetSignatureHash — SHA256d over an
+///      INDEPENDENTLY hand-assembled byte stream
+///      (tx-wire-bytes ‖ protxHash ‖ sigTime LE), with the tx wire bytes
+///      themselves hand-assembled (pins pack(tx) too). SER_GETHASH excludes
+///      vchSig; changing the sig must NOT change the digest.
+///
+///   3. STRUCTURE. dstx_is_valid_structure applies dashd IsValidStructure's
+///      refusals: null protx, vin!=vout, vin<3, vin>180, non-denominated
+///      vout, non-P2PKH vout, sig!=96B.
+///
+///   4. USE (the red/green pair). A dstx-shaped ZERO-fee tx admitted as a
+///      PLAIN tx is left OUT of the template (blockMinFeeRate floor) — the
+///      baseline, master's behaviour. The SAME tx through the REAL verified
+///      path (CoinStateMaintainer::on_new_dstx -> Mempool::add_dstx) enters
+///      the template FIRST (modified ancestor score = +0.1 COIN, dashd's
+///      GetModFeesWithAncestors sort) while total_fees still EXCLUDES the
+///      delta (coinbasevalue byte-parity: dashd accounts base fees).
+///
+///   5. FAIL-CLOSED. No verifier registered => nothing admitted. A verifier
+///      running the REAL BLS entry point (verify_govvote_operator_sig)
+///      against a bad signature => REJECTED, add_dstx never called.
+///
+///   6. FEE SAFETY. A DSTX whose inputs the view cannot price is admitted at
+///      fee=0 (understate-only) — never fee-unknown-excluded, never a
+///      guessed positive fee.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/p2p_messages.hpp>
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/utxo_lane.hpp>
+#include <impl/dash/coin/vendor/bls_verify.hpp>
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using dash::coin::CoinStateMaintainer;
+using dash::coin::NodeCoinState;
+using dash::coin::Mempool;
+using dash::coin::MutableTransaction;
+using dash::coin::UtxoLane;
+using dash::coin::dash_txid;
+using dash::coin::p2p::dstx_is_valid_structure;
+using dash::coin::p2p::dstx_signature_hash;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+namespace {
+
+// The 0.10000100 DASH denomination (coinjoin/common.h), duffs.
+constexpr int64_t kDenom = 10000100;
+
+/// uint256 whose RAW WIRE BYTES are 32 consecutive values starting at `base`.
+uint256 raw256(uint8_t base)
+{
+    uint256 h;
+    for (size_t i = 0; i < 32; ++i)
+        h.data()[i] = static_cast<uint8_t>(base + i);
+    return h;
+}
+
+std::vector<uint8_t> p2pkh_script(uint8_t tag)
+{
+    std::vector<uint8_t> s = {0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(tag);
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
+TxIn make_input(const uint256& prev_hash, uint32_t prev_index)
+{
+    TxIn in;
+    in.prevout.hash = prev_hash;
+    in.prevout.index = prev_index;
+    in.sequence = 0xffffffffu;
+    return in;
+}
+
+TxOut make_output(int64_t value, std::vector<uint8_t> script = {})
+{
+    TxOut out;
+    out.value = value;
+    out.scriptPubKey.m_data = std::move(script);
+    return out;
+}
+
+/// The canonical synthetic DSTX this suite reuses: 3-in/3-out, every output
+/// the 0.10000100 denomination to P2PKH, spending (prev_base..)+vout 0..2.
+MutableTransaction make_dstx_tx(const uint256& prev, uint32_t salt = 0)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = salt;
+    for (uint32_t i = 0; i < 3; ++i)
+        tx.vin.push_back(make_input(prev, i));
+    for (uint8_t i = 0; i < 3; ++i)
+        tx.vout.push_back(make_output(kDenom, p2pkh_script(0x40 + i)));
+    return tx;
+}
+
+// ─── INDEPENDENT byte assembly (deliberately NOT the codec / pack layer) ────
+
+void put_le32(std::vector<uint8_t>& v, uint32_t x)
+{
+    for (int i = 0; i < 4; ++i)
+        v.push_back(static_cast<uint8_t>((x >> (8 * i)) & 0xFF));
+}
+void put_le64(std::vector<uint8_t>& v, uint64_t x)
+{
+    for (int i = 0; i < 8; ++i)
+        v.push_back(static_cast<uint8_t>((x >> (8 * i)) & 0xFF));
+}
+void put_u256(std::vector<uint8_t>& v, const uint256& h)
+{
+    v.insert(v.end(), h.data(), h.data() + 32);
+}
+
+/// Hand-assembled network serialization of make_dstx_tx(prev, salt) — the
+/// dashd tx wire: version|type<<16 (4B LE), vin count, per-vin prevout(36B) +
+/// scriptSig(compactsize 0) + sequence, vout count, per-vout value(8B LE) +
+/// script(compactsize + bytes), locktime (4B LE). Type 0 => no extra payload.
+std::vector<uint8_t> hand_tx_bytes(const uint256& prev, uint32_t salt = 0)
+{
+    std::vector<uint8_t> w;
+    put_le32(w, 1u);            // version 1, type 0
+    w.push_back(0x03);          // vin count
+    for (uint32_t i = 0; i < 3; ++i) {
+        put_u256(w, prev);
+        put_le32(w, i);
+        w.push_back(0x00);      // empty scriptSig
+        put_le32(w, 0xffffffffu);
+    }
+    w.push_back(0x03);          // vout count
+    for (uint8_t i = 0; i < 3; ++i) {
+        put_le64(w, static_cast<uint64_t>(kDenom));
+        auto s = p2pkh_script(0x40 + i);
+        w.push_back(static_cast<uint8_t>(s.size()));   // 0x19
+        w.insert(w.end(), s.begin(), s.end());
+    }
+    put_le32(w, salt);          // locktime
+    return w;
+}
+
+/// Hand-assembled `dstx` message payload: tx ‖ protxHash ‖ vchSig
+/// (CompactSize 0x60 + 96 bytes) ‖ sigTime (8B LE).
+std::vector<uint8_t> golden_dstx_bytes(const uint256& prev,
+                                       const uint256& protx,
+                                       uint8_t sig_fill, int64_t sig_time)
+{
+    std::vector<uint8_t> w = hand_tx_bytes(prev);
+    put_u256(w, protx);
+    w.push_back(0x60);
+    for (int i = 0; i < 96; ++i) w.push_back(sig_fill);
+    put_le64(w, static_cast<uint64_t>(sig_time));
+    return w;
+}
+
+/// Deliver `payload` to the coin p2p Handler exactly as the socket read loop
+/// does (mirrors test_dash_isdlock.cpp).
+dash::coin::p2p::Handler::result_t deliver(const std::string& command,
+                                           const std::vector<unsigned char>& payload)
+{
+    auto raw = std::make_unique<RawMessage>(command, PackStream(payload));
+    dash::coin::p2p::Handler handler;
+    return handler.parse(raw);
+}
+
+std::string parsed_command(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m) {
+        return m ? m->m_command : std::string{};
+    }, r);
+}
+
+std::optional<uint256> parsed_dstx_protx(const dash::coin::p2p::Handler::result_t& r)
+{
+    return std::visit([](const auto& m) -> std::optional<uint256> {
+        if constexpr (requires { m->m_protx_hash; m->m_sig_time; }) {
+            if (m) return m->m_protx_hash;
+        }
+        return std::nullopt;
+    }, r);
+}
+
+// ─── mempool fixtures (mirror test_dash_isdlock.cpp) ────────────────────────
+
+MutableTransaction make_coinbase(std::vector<std::pair<int64_t, uint8_t>> outs,
+                                 uint32_t salt)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.type = 0;
+    tx.locktime = 0x0cb00000u ^ salt;
+    for (auto [v, tag] : outs)
+        tx.vout.push_back(make_output(v, p2pkh_script(tag)));
+    return tx;
+}
+
+dash::coin::BlockType make_block(std::vector<MutableTransaction> txs,
+                                 uint32_t salt)
+{
+    dash::coin::BlockType b;
+    b.m_nonce = salt;
+    b.m_previous_block = raw256(static_cast<uint8_t>(salt));
+    b.m_txs = std::move(txs);
+    return b;
+}
+
+std::vector<uint256> selected_order(Mempool& mp)
+{
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    std::vector<uint256> out;
+    for (const auto& e : sel) out.push_back(dash_txid(e.tx));
+    return out;
+}
+
+} // namespace
+
+// ═══ 1. WIRE ════════════════════════════════════════════════════════════════
+
+// Registry membership: a message type absent from p2p::Handler is not merely
+// unhandled — parse() throws and CoinClient::handle drops the payload at
+// DEBUG. This test is the gate that keeps dstx out of that failure mode.
+TEST(DashDstxWire, HandlerRegistryDispatchesDstx)
+{
+    dash::coin::p2p::Handler::result_t res;
+    ASSERT_NO_THROW(res = deliver(
+        "dstx", golden_dstx_bytes(raw256(0x00), raw256(0x22), 0xab, 1720000000)))
+        << "dstx is missing from the p2p::Handler type list — every dstx "
+           "reply to our own getdata would be discarded at DEBUG (the DIP-24 "
+           "qrinfo silent-drop failure mode, #1077)";
+    EXPECT_EQ(parsed_command(res), "dstx");
+    auto protx = parsed_dstx_protx(res);
+    ASSERT_TRUE(protx.has_value());
+    EXPECT_EQ(*protx, raw256(0x22));
+}
+
+// Codec KAT: golden bytes (hand-assembled from the dashd wire layout, not
+// produced by the codec) decode to the expected fields AND re-encode
+// byte-exactly.
+TEST(DashDstxWire, CodecDecodesGoldenBytesAndRoundtrips)
+{
+    const auto golden =
+        golden_dstx_bytes(raw256(0x00), raw256(0x22), 0xab, 1720000000);
+
+    PackStream in{golden};
+    dash::coin::p2p::message_dstx msg;
+    ASSERT_NO_THROW(in >> msg);
+
+    EXPECT_EQ(msg.m_tx.vin.size(), 3u);
+    EXPECT_EQ(msg.m_tx.vout.size(), 3u);
+    EXPECT_EQ(msg.m_tx.vin[1].prevout.hash, raw256(0x00));
+    EXPECT_EQ(msg.m_tx.vin[1].prevout.index, 1u);
+    EXPECT_EQ(msg.m_tx.vout[0].value, kDenom);
+    EXPECT_EQ(msg.m_protx_hash, raw256(0x22));
+    ASSERT_EQ(msg.m_sig.size(), 96u);
+    EXPECT_EQ(msg.m_sig[0], 0xab);
+    EXPECT_EQ(msg.m_sig_time, 1720000000);
+
+    PackStream out;
+    out << msg;
+    auto sp = out.get_span();
+    ASSERT_EQ(sp.size(), golden.size());
+    EXPECT_EQ(0, std::memcmp(sp.data(), golden.data(), golden.size()));
+}
+
+// ═══ 2. PRE-IMAGE ═══════════════════════════════════════════════════════════
+
+// dstx_signature_hash == SHA256d over the INDEPENDENTLY assembled preimage
+// (hand tx bytes ‖ protx ‖ sigTime LE) — which also pins that pack(tx)
+// produces exactly the hand-assembled network tx serialization.
+TEST(DashDstxSigHash, MatchesIndependentPreimage)
+{
+    const uint256 prev = raw256(0x00);
+    const uint256 protx = raw256(0x22);
+    const int64_t sig_time = 1720000000;
+    auto tx = make_dstx_tx(prev);
+
+    // pack(tx) is byte-identical to the hand assembly (dash_txid base).
+    auto hand = hand_tx_bytes(prev);
+    auto ps = ::pack(tx);
+    auto sp = ps.get_span();
+    ASSERT_EQ(sp.size(), hand.size());
+    ASSERT_EQ(0, std::memcmp(sp.data(), hand.data(), hand.size()));
+
+    std::vector<uint8_t> pre = hand;
+    put_u256(pre, protx);
+    put_le64(pre, static_cast<uint64_t>(sig_time));
+    const uint256 want = ::Hash(pre);   // double SHA256
+
+    EXPECT_EQ(dstx_signature_hash(tx, protx, sig_time), want);
+    // The sig is EXCLUDED (SER_GETHASH guard) — no sig argument exists, so
+    // the digest is a pure function of (tx, protx, sigTime); a different
+    // sigTime must change it.
+    EXPECT_NE(dstx_signature_hash(tx, protx, sig_time + 1), want);
+    EXPECT_NE(dstx_signature_hash(tx, raw256(0x23), sig_time), want);
+}
+
+// ═══ 3. STRUCTURE ═══════════════════════════════════════════════════════════
+
+TEST(DashDstxStructure, RefusalsMatchIsValidStructure)
+{
+    const uint256 prev = raw256(0x00);
+    const uint256 protx = raw256(0x22);
+    auto good = make_dstx_tx(prev);
+    EXPECT_TRUE(dstx_is_valid_structure(good, protx, 96));
+
+    // Null protx.
+    EXPECT_FALSE(dstx_is_valid_structure(good, uint256(), 96));
+    // Sig != 96 bytes.
+    EXPECT_FALSE(dstx_is_valid_structure(good, protx, 95));
+    // vin != vout.
+    auto lop = good;
+    lop.vout.pop_back();
+    EXPECT_FALSE(dstx_is_valid_structure(lop, protx, 96));
+    // vin < 3 (nPoolMinParticipants).
+    auto small = good;
+    small.vin.resize(2);
+    small.vout.resize(2);
+    EXPECT_FALSE(dstx_is_valid_structure(small, protx, 96));
+    // vin > 180 (20 participants x 9 entries).
+    auto big = good;
+    while (big.vin.size() <= 180) {
+        big.vin.push_back(make_input(prev, static_cast<uint32_t>(big.vin.size())));
+        big.vout.push_back(make_output(kDenom, p2pkh_script(0x40)));
+    }
+    EXPECT_FALSE(dstx_is_valid_structure(big, protx, 96));
+    // Non-denominated output value.
+    auto baddenom = good;
+    baddenom.vout[1].value = kDenom + 1;
+    EXPECT_FALSE(dstx_is_valid_structure(baddenom, protx, 96));
+    // Non-P2PKH output script.
+    auto badscript = good;
+    badscript.vout[2].scriptPubKey.m_data = {0x6a};   // OP_RETURN
+    EXPECT_FALSE(dstx_is_valid_structure(badscript, protx, 96));
+}
+
+// ═══ 4. USE — the red/green pair (KAT b) ════════════════════════════════════
+
+// PLAIN admission of the zero-fee mixing tx (the network also relays it as
+// MSG_TX): priced fee=0, and the blockMinFeeRate floor keeps it OUT of the
+// template — the baseline, byte-identical to master. The SAME tx through the
+// REAL verified DSTX path enters FIRST (modified ancestor score +0.1 COIN)
+// while total_fees still excludes the delta AND the zero base fee.
+TEST(DashDstxUse, VerifiedDstxRanksFirstAndFeesStayBase)
+{
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    Mempool& mp = st.mempool();
+
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));          // ephemeral cache-only
+    lane.attach(mp);
+
+    // Coinbase: three denomination coins (the DSTX inputs) + one 200k coin
+    // (the fee-paying competitor's input).
+    auto cb = make_coinbase(
+        {{kDenom, 0x01}, {kDenom, 0x02}, {kDenom, 0x03}, {200'000, 0x04}},
+        /*salt=*/1);
+    lane.on_block_connected(make_block({cb}, /*salt=*/1), /*height=*/1);
+    const uint256 cb_txid = dash_txid(cb);
+
+    auto dstx_tx = make_dstx_tx(cb_txid, /*salt=*/7);
+    const uint256 dstx_txid = dash_txid(dstx_tx);
+
+    MutableTransaction competitor;
+    competitor.version = 1;
+    competitor.type = 0;
+    competitor.locktime = 9;
+    competitor.vin.push_back(make_input(cb_txid, 3));
+    competitor.vout.push_back(make_output(150'000, p2pkh_script(0x50)));
+    const uint256 comp_txid = dash_txid(competitor);
+    ASSERT_TRUE(mp.add_tx(competitor));   // fee 50'000
+
+    // ── BASELINE (plain admission): fee computes to 0, and the
+    // blockMinFeeRate floor (dashd DEFAULT_BLOCK_MIN_TX_FEE) leaves the
+    // zero-fee tx OUT. This is master's behaviour — the assertion that goes
+    // RED when the delta is applied. ─────────────────────────────────────────
+    ASSERT_TRUE(mp.add_tx(dstx_tx));
+    {
+        auto e = mp.get_entry(dstx_txid);
+        ASSERT_TRUE(e.has_value());
+        EXPECT_TRUE(e->fee_known);
+        EXPECT_EQ(e->fee, 0u);
+        EXPECT_EQ(e->fee_delta, 0u);
+        auto order = selected_order(mp);
+        ASSERT_EQ(order.size(), 1u)
+            << "baseline: a zero-fee tx must not clear the min-feerate floor";
+        EXPECT_EQ(order[0], comp_txid);
+    }
+
+    // ── FEED: the SAME tx through the REAL verified path. Stub verifier ==
+    // true stands in for the BLS gate (fail-closed halves have their own
+    // tests below); the USE path is the production one:
+    // on_new_dstx -> add_dstx -> retro-applied delta -> modified scoring. ────
+    m.set_dstx_verify_fn(
+        [](const MutableTransaction&, const uint256&, const uint256&,
+           const std::array<uint8_t, 96>&, int64_t) { return true; });
+    std::array<uint8_t, 96> sig{};
+    sig.fill(0xab);
+    m.on_new_dstx(dstx_tx, dstx_txid, raw256(0x22), sig, 1720000000);
+
+    {
+        auto e = mp.get_entry(dstx_txid);
+        ASSERT_TRUE(e.has_value());
+        EXPECT_TRUE(e->fee_known);
+        EXPECT_EQ(e->fee, 0u);                        // BASE fee stays 0
+        EXPECT_EQ(e->fee_delta, Mempool::DSTX_FEE_DELTA);
+        auto [sel, fees] = mp.get_sorted_txs_with_fees(1u << 20);
+        ASSERT_EQ(sel.size(), 2u)
+            << "the +0.1 COIN modified fee must clear the floor";
+        // dashd sorts on GetModFeesWithAncestors: the DSTX (modified 10M
+        // over ~a few hundred bytes) outranks the 50k-fee competitor.
+        EXPECT_EQ(dash_txid(sel[0].tx), dstx_txid);
+        EXPECT_EQ(dash_txid(sel[1].tx), comp_txid);
+        // ACCOUNTING stays BASE: coinbasevalue parity — dashd's nFees is
+        // unmodified fees, so the delta must NEVER reach total_fees.
+        EXPECT_EQ(fees, 50'000u);
+        EXPECT_EQ(sel[0].fee, 0u);
+    }
+}
+
+// Admission BEFORE the plain tx ever arrives (the dashd message order):
+// delta recorded pre-admission, fee=0 forced when inputs are unpriceable —
+// never fee-unknown-excluded, never a guessed positive fee (KAT: fee
+// safety). Inputs unknown to the view => the selection guard still refuses
+// the vin (correctly — nothing vouches for the coins), but the ENTRY is
+// priced and indexed, and prices exactly 0.
+TEST(DashDstxUse, UnpriceableInputsAdmitAtZeroFee)
+{
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    Mempool& mp = st.mempool();
+    UtxoLane lane;
+    ASSERT_TRUE(lane.open(""));
+    lane.attach(mp);
+
+    auto dstx_tx = make_dstx_tx(raw256(0x66), /*salt=*/8);   // unknown prevouts
+    m.set_dstx_verify_fn(
+        [](const MutableTransaction&, const uint256&, const uint256&,
+           const std::array<uint8_t, 96>&, int64_t) { return true; });
+    std::array<uint8_t, 96> sig{};
+    sig.fill(0xab);
+    m.on_new_dstx(dstx_tx, dash_txid(dstx_tx), raw256(0x22), sig, 1720000000);
+
+    auto e = mp.get_entry(dash_txid(dstx_tx));
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->fee_known);
+    EXPECT_EQ(e->fee, 0u);
+    EXPECT_EQ(e->fee_delta, Mempool::DSTX_FEE_DELTA);
+}
+
+// ═══ 5. FAIL-CLOSED (KAT d) ═════════════════════════════════════════════════
+
+// No verifier registered: nothing is ever admitted.
+TEST(DashDstxFailClosed, NoVerifierAdmitsNothing)
+{
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    auto dstx_tx = make_dstx_tx(raw256(0x66));
+    std::array<uint8_t, 96> sig{};
+    sig.fill(0xab);
+    m.on_new_dstx(dstx_tx, dash_txid(dstx_tx), raw256(0x22), sig, 1720000000);
+    EXPECT_EQ(st.mempool().size(), 0u);
+}
+
+// A bad BLS signature through the REAL BLS entry point
+// (verify_govvote_operator_sig — the byte-identical VerifyInsecure contract
+// dashd's CheckSignature uses) is REJECTED and add_dstx is never called.
+// Fail-closed in BOTH postures: with the BLS backend absent the entry point
+// returns false unconditionally; with it present, an all-zero operator key /
+// garbage signature fails point deserialization or the pairing check.
+TEST(DashDstxFailClosed, BadBlsSignatureIsRejected)
+{
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_dstx_verify_fn(
+        [](const MutableTransaction& tx, const uint256&,
+           const uint256& protx, const std::array<uint8_t, 96>& s,
+           int64_t t) -> bool {
+            std::array<uint8_t,
+                       dash::coin::vendor::CFinalCommitment::BLS_PUBKEY_SIZE>
+                zero_key{};
+            return dash::coin::vendor::verify_govvote_operator_sig(
+                zero_key, /*key_legacy_scheme=*/false,
+                dstx_signature_hash(tx, protx, t),
+                std::vector<uint8_t>(s.begin(), s.end()));
+        });
+    auto dstx_tx = make_dstx_tx(raw256(0x66));
+    std::array<uint8_t, 96> bad{};
+    bad.fill(0xcd);
+    m.on_new_dstx(dstx_tx, dash_txid(dstx_tx), raw256(0x22), bad, 1720000000);
+    EXPECT_EQ(st.mempool().size(), 0u)
+        << "an unverifiable DSTX must never reach add_dstx";
+}


### PR DESCRIPTION
## W5-B: CoinJoin DSTX intake — inv pull, BLS operator-sig gate, zero-fee prioritised admission

**Goal (dashd-cut Tier-2 "W5", leg B):** close the second dashd-only tx class behind the `gbt-xcheck-txmerkle` mismatches — 14/34 txs across the 26-event diagnosis are zero-fee CoinJoin DSTX-es. dashd admits every BLS-verified `CCoinJoinBroadcastTx` at base fee 0, prioritises it +0.1 COIN (`net_processing.cpp:3609`) and sorts on `GetModFeesWithAncestors`; embedded never even pulled the object. Mirrors the #1232 isdlock architecture at every hop, fail-closed at every arm. Necessary-but-not-sufficient by the diagnosis: this leg alone closes 0/26 events (every event also contains ≥1 fee-unknown ordinary tx — the sibling W5-A fold PR).

### Load-bearing corrections vs the original brief
- **MSG_DSTX = 16**, not 30 (dashd `protocol.h:507`; 30 is the RETIRED legacy `MSG_ISLOCK` — a getdata for 30 gets notfound from every v23 peer).
- **The DSTX inv hash is the PLAIN TXID** (`net_processing.cpp:2567`), not `SerializeHash(payload)` — so the pull shares the budgeted MSG_TX machinery keyed by txid.

### DARK / flag-gated
`--embedded-ingest-dstx`, **default OFF**: no getdata type-16 is ever sent, the handler discards, wire and templates byte-identical to master. Unlike isdlock the GETDATA itself is gated — a DSTX has no fee-only-safe unconditional consumer. Template EFFECT additionally requires `--embedded-serve-mempool-txs`. DASH lane only; no wire/consensus/share-format change. **The #1218 gbt-xcheck-txmerkle guard is untouched and stays the referee.**

### Pipeline (acquire → verify → use, fail-closed)
1. **Wire**: `dstx = 16` inv type; `message_dstx` codec (v23 `CCoinJoinBroadcastTx`: tx, protxHash, vchSig, sigTime); UNCONDITIONAL registry membership (#1077 silent-drop rule — the flag gates behaviour, never parsing). Pull rides the MSG_TX budget (strict tip-body priority, inflight cap, txid-keyed slots; getdata echoes the announced type). Handler releases the slot by COMPUTED txid, applies dashd's `IsValidStructure` refusals (KAT-pinned free predicate `dstx_is_valid_structure`: vin∈[3,180], vin==vout, all-denominated P2PKH vouts, 96B sig), fires `new_dstx` only when armed.
2. **Verify**: `CoinStateMaintainer::on_new_dstx` — UNSET verifier IS FAIL-CLOSED. The installed verifier BLS-verifies the mixing MN's OPERATOR signature over the KAT-pinned pre-image `dstx_signature_hash` = SHA256d(ser(tx) ‖ protxHash ‖ sigTime LE) (SER_GETHASH excludes vchSig, `coinjoin.cpp:68-80`) against the SML `pubKeyOperator(protxHash)` — REUSING `verify_govvote_operator_sig` (the byte-identical `VerifyInsecure` contract, key wire-scheme vs post-V19 basic signing handled inside).
3. **Use**: `Mempool::add_dstx` — bounded `mapDeltas` (recorded pre-admission, retro-applied if the plain tx arrived first, pruned on confirm); fee=0 forced only when inputs are unpriceable (**understate-only**: a hostile signed nonzero-fee DSTX can only understate `total_fees` ⇒ coinbase pays ≤ allowed ⇒ never an invalid block). **SCORE everywhere MODIFIED, ACCOUNT everywhere BASE** — dashd's exact split: feerate index, ancestor `modfee_wa` (== `nModFeesWithAncestors`), `ModEntry`, `update_for_parent_inclusion`, and the blockMinFeeRate gate use `modified_fee()`; `total_fees` and `SelectedTx.fee` stay base (coinbasevalue byte-parity). `delta==0` for every non-DSTX entry keeps all ordering byte-identical to master.

### Documented phase-1 divergences (both guard-covered, subset/superset only, never validity)
- **No per-MN rate limit** (dashd `IsValidForMixingTxes`, MAX=5 since last DSQ): mirroring the counter without the DSQ leg (inv 32) would only ever increment ⇒ permanent false refusals. An MN spamming >5 DSTX between queues makes embedded a SUPERSET; the tx-merkle guard refuses serving. Phase 2 = the DSQ leg if soak attributes mismatches here.
- **Current-SML-only operator lookup** (dashd walks ≤24 blocks back for recently-removed MNs): we refuse those ⇒ SUBSET for that rare window; phase 2 = operator-key tombstone ring.

### KATs (`test_dash_dstx.cpp`, new target)
Registry gate (RED if de-registered); codec golden decode + byte-exact re-encode (hand-assembled wire bytes); `GetSignatureHash` pre-image vs an independently hand-assembled stream (also pins `pack(tx)` network serialization); `IsValidStructure` refusal matrix; **the USE red/green** — plain zero-fee admission stays OUT on the min-feerate floor (master's behaviour) vs the verified maintainer path ranking it FIRST on the +0.1 COIN modified fee with `total_fees` still base; fail-closed — no verifier / bad BLS sig through the real `verify_govvote_operator_sig` entry point admits nothing; unpriceable-inputs admission at exactly fee=0.

### Measurement plan
Rides the W5-A plan (same canary posture, `--coin-rpc` kept, guards active): AFTER-2 arms both flags; per-event dashd-only decomposition should show the DSTX class → 0; count any embedded-only (superset) events attributable to the omitted rate limit — expected 0. Acceptance = 24 h, ZERO `gbt-xcheck-txmerkle-mismatch` events, guard still armed.
