### PR TITLE
dash(serve): per-cause TIME in ServeGateJournal (diagnostic)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3551,6 +3551,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         ? std::string()
                         : cause + " (value=" + c["no_work_value"].get<std::string>()
                                 + " threshold=" + c["no_work_threshold"].get<std::string>() + ")";
+                    // #119 follow-up, web leg: cumulative per-cause TIME
+                    // roll-up ({observed_sec, off_embedded_sec, per_cause}),
+                    // seconds beside the cause names above so the page can
+                    // rank by TIME the way [EMBED-GATE-ROLLUP] does — the
+                    // decline COUNT ranks the causes wrongly (the h=2518004
+                    // trap). ABSENT, never zeroed, when the serve-gate lock
+                    // was busy: a missing observation is not a claim of
+                    // health, and the degrade reason already rides `arm`.
+                    if (arm.contains("gate_rollup"))
+                        c["serve_gate_rollup"] = arm["gate_rollup"];
                     // SERVE-STALENESS: the height we actually handed to a miner
                     // versus an independently observed one. header_height and
                     // target_height above are about the HEADER chain and are

--- a/src/impl/dash/coin/serve_gate_rollup_json.hpp
+++ b/src/impl/dash/coin/serve_gate_rollup_json.hpp
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// #119 FOLLOW-UP, WEB LEG — the ONE JSON shape of the serve-gate per-cause
+/// TIME roll-up.
+///
+/// The per-cause clock itself already lives in ServeGateJournal (Decision
+/// cause_sec/prev_cause_sec, the banked m_cause_totals, rollup()) and the LOG
+/// already carries it (hourly [EMBED-GATE-ROLLUP], per-segment
+/// [EMBED-GATE-SEG] lines). What the operator surface still published was
+/// count-shaped only: arm + the last cause/value/threshold. That is exactly
+/// the count-vs-time trap #119 closed in the log (measured 2026-08-06: 109
+/// dmn-stale episodes vs 3 qc-plan-underivable BY COUNT, 5.6 s vs 351 s BY
+/// TIME — the prioritisation inverts depending on which number you read), so
+/// the web surface must carry seconds too, WITH the denominator.
+///
+/// This header exists so the serializer is a single definition shared by the
+/// producer (DASHWorkSource::embedded_arm_status_json) and the KAT
+/// (test_dash_serve_gate_journal.cpp): a test that rebuilt the shape by hand
+/// beside the producer would pin nothing. Kept OUT of serve_gate_journal.hpp
+/// deliberately — that header is pure policy (no I/O, no clock, no JSON) and
+/// stays that way.
+///
+/// Field names mirror the Rollup struct verbatim; per_cause preserves the
+/// roll-up's deterministic order (seconds desc, then name), so the web array
+/// ranks by TIME exactly as the log line does.
+
+#include <nlohmann/json.hpp>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+
+namespace dash {
+namespace coin {
+
+inline nlohmann::json serve_gate_rollup_json(const ServeGateJournal::Rollup& r)
+{
+    nlohmann::json j;
+    // DENOMINATOR FIRST, always present — a per-cause seconds figure with an
+    // implicit denominator is how the best-share percentage shipped.
+    j["observed_sec"]     = r.observed_sec;
+    j["off_embedded_sec"] = r.off_embedded_sec;
+    nlohmann::json causes = nlohmann::json::array();
+    for (const auto& c : r.per_cause)
+        causes.push_back(nlohmann::json{{"cause", c.first}, {"sec", c.second}});
+    j["per_cause"] = std::move(causes);
+    return j;
+}
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -36,6 +36,7 @@
 #include <impl/dash/stratum/work_source.hpp>
 
 #include <impl/dash/stratum/submit_payee_guard.hpp>  // check_submit_payee (won-block stale-payee gate)
+#include <impl/dash/coin/serve_gate_rollup_json.hpp>  // serve_gate_rollup_json — #119 follow-up web leg (per-cause TIME)
 #include <impl/dash/coinbase_builder.hpp>     // compute_dash_payouts, build, split_coinb, merkle helpers
 #include <impl/dash/coin/block_producer.hpp>  // compute_merkle_root, append_compact_size, target_from_nbits
 #include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11 (X11 PoW SSOT)
@@ -1567,6 +1568,25 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
         j["no_work_value"]     = "n/a";
         j["no_work_threshold"] = "n/a";
         return j;
+    }
+    // #119 FOLLOW-UP, WEB LEG — per-cause TIME, not just the last cause. The
+    // fields below publish WHICH condition last declined; without seconds
+    // beside them the surface reproduces the count-vs-time trap (109 dmn-stale
+    // episodes vs 3 qc-plan-underivable BY COUNT; 5.6 s vs 351 s BY TIME —
+    // measured 2026-08-06). rollup() is a const accessor over already-banked
+    // totals plus the open segment's partial: it mutates nothing, takes no new
+    // lock (serve_gate_mutex_ is already held via the try_lock above), and the
+    // clock is the SAME steady_clock-seconds the serve path feeds observe()
+    // (note_arm_decision), so the partial can never run backwards. On a busy
+    // gate the field is simply absent (the early return above), matching the
+    // existing degrade-with-a-named-reason pattern. Read-only status path;
+    // serve behavior untouched.
+    {
+        const auto now_sec = std::chrono::duration_cast<std::chrono::seconds>(
+                                 std::chrono::steady_clock::now().time_since_epoch())
+                                 .count();
+        j["gate_rollup"] =
+            coin::serve_gate_rollup_json(serve_gate_journal_.rollup(now_sec));
     }
     if (!arm_ever_observed_) {
         j["arm"]               = "unknown";

--- a/test/test_dash_serve_gate_journal.cpp
+++ b/test/test_dash_serve_gate_journal.cpp
@@ -28,6 +28,7 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/serve_gate_journal.hpp>
+#include <impl/dash/coin/serve_gate_rollup_json.hpp>
 
 #include <string>
 
@@ -334,6 +335,55 @@ TEST(DashServeGateJournal, SegTerminalNamesCoverClosuresOnly) {
     EXPECT_STREQ(ServeGateJournal::seg_terminal_name(resumed.trigger),
                  "resumed");
     EXPECT_EQ(resumed.prev_cause_sec, 15);
+}
+
+// ── #119 follow-up, WEB LEG: the JSON shape the operator surface publishes ───
+//
+// serve_gate_rollup_json is the ONE serializer shared by
+// DASHWorkSource::embedded_arm_status_json (the `gate_rollup` field, forwarded
+// by /api/node_topology as `serve_gate_rollup`) and this KAT — so this test
+// pins the bytes the web actually serves, not a hand-rebuilt lookalike. Shape:
+// {observed_sec, off_embedded_sec, per_cause:[{cause,sec}...]} with per_cause
+// preserving the roll-up's by-TIME order. The web surface previously published
+// only arm + last cause/value/threshold — count-shaped — which is the exact
+// trap #119 closed in the log (by count dmn-stale looked like 97% of the
+// problem; by time it was 5.6 s vs 351 s).
+TEST(DashServeGateJournal, RollupJsonShapePinsTheWebField) {
+    ServeGateJournal j(1000000);
+    // 20 s of cause-b (closed), then cause-a open for 500 s: a ranks first.
+    j.observe(false, "cause-b", 0);
+    j.observe(false, "cause-a", 20);        // closes b at 20 s, opens a
+    const int64_t now = 520;                 // a has 500 s of open partial
+
+    nlohmann::json json = dash::coin::serve_gate_rollup_json(j.rollup(now));
+
+    // The three fields, exactly — the denominator is never omitted.
+    ASSERT_TRUE(json.contains("observed_sec"));
+    ASSERT_TRUE(json.contains("off_embedded_sec"));
+    ASSERT_TRUE(json.contains("per_cause"));
+    EXPECT_EQ(json.size(), 3u);
+    EXPECT_EQ(json["observed_sec"].get<int64_t>(), 520);
+    EXPECT_EQ(json["off_embedded_sec"].get<int64_t>(), 520);
+
+    // per_cause: array of {cause,sec}, ranked by TIME desc (a=500 before b=20)
+    // — the same order the [EMBED-GATE-ROLLUP] log line prints.
+    const auto& pc = json["per_cause"];
+    ASSERT_TRUE(pc.is_array());
+    ASSERT_EQ(pc.size(), 2u);
+    EXPECT_EQ(pc[0]["cause"].get<std::string>(), "cause-a");
+    EXPECT_EQ(pc[0]["sec"].get<int64_t>(), 500);
+    EXPECT_EQ(pc[1]["cause"].get<std::string>(), "cause-b");
+    EXPECT_EQ(pc[1]["sec"].get<int64_t>(), 20);
+    EXPECT_EQ(pc[0].size(), 2u);  // {cause,sec} only — no extra fields
+
+    // An unobserved journal serializes the honest empty shape, not fabricated
+    // zeros-with-causes: empty array, zero denominator.
+    ServeGateJournal fresh(300);
+    nlohmann::json empty = dash::coin::serve_gate_rollup_json(fresh.rollup(99));
+    EXPECT_EQ(empty["observed_sec"].get<int64_t>(), 0);
+    EXPECT_EQ(empty["off_embedded_sec"].get<int64_t>(), 0);
+    EXPECT_TRUE(empty["per_cause"].is_array());
+    EXPECT_TRUE(empty["per_cause"].empty());
 }
 
 }  // namespace


### PR DESCRIPTION
## What

The **web leg** of the #119 follow-up ("add per-cause TIME to ServeGateJournal"). The journal side is already merged on master (#1192 per-cause clock, #1201 three-valued arm, #1202 cumulative rollup) and the log already carries it (hourly `[EMBED-GATE-ROLLUP]`, per-segment `[EMBED-GATE-SEG] cause=<name> dur=<n>s terminal=...`). What was still count-shaped is the **operator web surface**: `embedded_arm_status_json` / `/api/node_topology` published only `arm` + the LAST cause/value/threshold — no seconds at all.

## Why (the count-vs-time trap)

- Measured 2026-08-06 (hotel, 5h33m): **109** `dmn-stale` episodes vs **3** `qc-plan-underivable` — by COUNT dmn-stale looks like 97% of the problem. By TIME: **5.6 s vs 351 s** — the prioritisation inverts completely.
- h=2518004: a cause-change line attributed **512 s** to a cause that owned **0.89 s**.
- #119's verdict (bestCL slice = DO-NOT-FIX, orphan-guaranteed) named exactly one follow-up: per-cause TIME observability, so declines are never again ranked by count. A surface that names causes without seconds reproduces the trap.

## Change (130 insertions, zero deletions — purely diagnostic)

- `src/impl/dash/coin/serve_gate_rollup_json.hpp` (new): the ONE JSON serializer for `ServeGateJournal::Rollup` — `{observed_sec, off_embedded_sec, per_cause:[{cause,sec}...]}`. Denominator always present (an implicit denominator is how the best-share % shipped); `per_cause` keeps the roll-up's by-TIME order. Shared by producer and KAT so the test pins the served shape, not a lookalike. Kept out of `serve_gate_journal.hpp`, which stays pure policy.
- `work_source.cpp` `embedded_arm_status_json`: emit `gate_rollup` behind the **existing** `try_to_lock` — no new lock, no blocking; `rollup()` is a const accessor (banked totals + the open segment's partial, same steady_clock seconds the serve path feeds `observe()`). Busy gate ⇒ field **absent**, per the existing degrade-with-a-named-reason pattern.
- `main_dash.cpp` node_topology: forward as `serve_gate_rollup`; absent, never zeroed, when the gate was busy.
- `test_dash_serve_gate_journal.cpp`: `RollupJsonShapePinsTheWebField` — field set, by-time ordering, `{cause,sec}` pair shape, honest empty shape before any observation.

## Non-goals (settled, not reopened)

Not a fix for the 4.51% qc floor (DKG-window physics, closed by null-arm #127), the bestCL slice (DO-NOT-FIX per #119), or creditpool-stale (by-design exclude_special, ~1.7 s/h). Observability only.

## Safety

Serve path untouched: `note_arm_decision`, template sourcing, refresh timing, consensus — zero behavioral change. The only new code runs on the dashboard-thread status read, guarded by the pre-existing try_lock.

## Test

```
cmake --build build --target test_dash_serve_gate_journal && ./build/test/test_dash_serve_gate_journal
[  PASSED  ] 12 tests.   # 11 pre-existing + the new JSON-shape KAT
cmake --build build --target c2pool-dash   # links clean
```
