### PR TITLE
coin-p2p: port dashd CAddrMan — bucketed new/tried address DB behind every peer manager

### DIFF
--- a/src/c2pool/merged/coin_peer_manager.hpp
+++ b/src/c2pool/merged/coin_peer_manager.hpp
@@ -30,6 +30,7 @@
 #include <core/filesystem.hpp>
 #include <core/netaddress.hpp>
 #include <core/dns_seeder.hpp>
+#include <core/coin_addrman.hpp>
 
 namespace c2pool {
 namespace merged {
@@ -313,10 +314,15 @@ public:
 
     /// Add a peer discovered via P2P addr message.
     /// Validates via PeerEndpoint: rejects empty, unparseable, and non-routable addresses.
-    void add_discovered_peer(const NetService& addr)
+    /// source_host: the peer that gossiped this address (bucket-keys the
+    /// banked entry, bounding how far one source can spray the new table;
+    /// empty = self-announced). Existing call sites need no change.
+    void add_discovered_peer(const NetService& addr,
+                             const std::string& source_host = std::string())
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        try_add_peer_locked(addr, PeerInfo::Source::addr_crawl, /*require_routable=*/true);
+        try_add_peer_locked(addr, PeerInfo::Source::addr_crawl, /*require_routable=*/true,
+                            source_host);
     }
 
     /// Get list of peers that should be connected right now.
@@ -377,6 +383,47 @@ public:
             result.push_back(c.endpoint);
             connected_groups[c.group]++;
         }
+
+        // ── Addrman top-up (dashd CAddrMan port) ──
+        // The score-sorted working set above covers pinned/anchor/known
+        // peers; any remaining budget is drawn from the bucketed DB with
+        // dashd's stochastic quality-biased Select(), so dial plans explore
+        // the whole banked address space instead of re-hammering the same
+        // hand-picked few. One tried-collision incumbent is drawn first
+        // (the feeler leg): re-dialing it gives resolve_collisions() real
+        // evidence to keep or evict it. Group diversity and per-peer
+        // backoff (can_retry) gate the draws exactly like the legacy path.
+        if (static_cast<int>(result.size()) < budget) {
+            std::vector<NetService> draws;
+            if (auto incumbent = m_addrman.select_tried_collision())
+                draws.push_back(*incumbent);
+            const int deficit = budget - static_cast<int>(result.size());
+            for (int i = 0; i < deficit * 4
+                 && static_cast<int>(draws.size()) < deficit + 1; ++i) {
+                auto pick = m_addrman.select();
+                if (!pick) break;
+                draws.push_back(*pick);
+            }
+            for (auto& ns : draws) {
+                if (static_cast<int>(result.size()) >= budget) break;
+                auto ep = PeerEndpoint::from(ns);
+                if (!ep) continue;
+                const auto key = ep->to_string();
+                if (connected_keys.count(key)) continue;
+                bool dup = false;
+                for (auto& r : result)
+                    if (r.to_string() == key) { dup = true; break; }
+                if (dup) continue;
+                auto known = m_peers.find(key);
+                if (known != m_peers.end() && !known->second.can_retry())
+                    continue;
+                auto grp = get_network_group(ep->host());
+                if (connected_groups[grp] >= MAX_OUTBOUND_PER_GROUP
+                    && !grp.empty()) continue;
+                result.push_back(*ep);
+                connected_groups[grp]++;
+            }
+        }
         return result;
     }
 
@@ -384,11 +431,14 @@ public:
     void notify_connected(const std::string& key)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_connected();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_connected();
             // Track as anchor candidate (most recent successful connections)
             update_anchors(key);
+            // Promote in the bucketed DB: Good() moves the entry into the
+            // tried table (or parks a tried-collision for the feeler leg).
+            m_addrman.good(peer->address);
         }
         if (!m_bootstrapped) m_bootstrapped = true;
     }
@@ -400,6 +450,9 @@ public:
         auto it = m_peers.find(key);
         if (it != m_peers.end()) {
             it->second.record_disconnected();
+            // It completed a handshake earlier, so it WAS alive: refresh
+            // the bucketed DB's believed-alive stamp (dashd Connected()).
+            m_addrman.connected(it->second.address);
         }
     }
 
@@ -502,8 +555,12 @@ public:
     bool discovery_enabled() const
     {
         if (m_config.disable_discovery) return false;
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return static_cast<int>(m_peers.size()) < m_config.max_peers;
+        // The bucketed DB is the getaddr sink now: keep harvesting until
+        // it is of table order (~82k slots) — in practice always, exactly
+        // like dashd keeps banking addr gossip. The old working-set gate
+        // (m_peers.size() < max_peers) stopped discovery at a handful of
+        // peers and starved daemonless block download of dial candidates.
+        return m_addrman.size() < core::CoinAddrMan::soft_capacity();
     }
 
     /// Remove peers that are exhausted (max attempts reached, not protected).
@@ -572,6 +629,21 @@ public:
             if (!ep || !ep->is_routable()) continue;
             result.push_back(*ep);
         }
+        // Top up from the bucketed DB's tried sample so a node serves
+        // more than its small working set once the DB has grown (dashd
+        // GetAddr; tried-only + routable keeps the unverified out).
+        for (auto& ns : m_addrman.get_addr(
+                 /*max_pct=*/100,
+                 /*max_count=*/static_cast<size_t>(max_count) * 2,
+                 /*tried_only=*/true)) {
+            auto ep = PeerEndpoint::from(ns);
+            if (!ep || !ep->is_routable()) continue;
+            bool dup = false;
+            for (auto& r : result)
+                if (r.to_string() == ep->to_string()) { dup = true; break; }
+            if (dup) continue;
+            result.push_back(*ep);
+        }
         // Shuffle for privacy (don't reveal connection order/topology)
         if (result.size() > 1) {
             thread_local std::mt19937 rng(std::random_device{}());
@@ -581,6 +653,10 @@ public:
             result.erase(result.begin() + max_count, result.end());
         return result;
     }
+
+    /// Bucketed address DB (dashd CAddrMan port) — diagnostics/KATs.
+    core::CoinAddrMan& addrman() { return m_addrman; }
+    const core::CoinAddrMan& addrman() const { return m_addrman; }
 
 private:
     /// Unified peer validation and insertion (caller must hold m_mutex).
@@ -593,7 +669,8 @@ private:
     ///                          peers (getpeerinfo) which may be LAN hosts.
     /// @return true if the peer was added, false if rejected.
     bool try_add_peer_locked(const NetService& addr, PeerInfo::Source source,
-                             bool require_routable)
+                             bool require_routable,
+                             const std::string& source_host = std::string())
     {
         // ── Validate via PeerEndpoint (type-safe, Bitcoin Core classification) ──
         auto ep = PeerEndpoint::from(addr);
@@ -611,6 +688,18 @@ private:
 
         // ── Port filter ──
         if (!is_valid_port(ep->port())) return false;
+
+        // ── Bank in the bucketed address DB (dashd CAddrMan port) ──
+        // Every validated non-daemon candidate is banked BEFORE the
+        // working-set gates below: the capacity/dedup/group caps bound the
+        // small ACTIVE dial set, while the bank is the large archival
+        // history the dial planner draws from (repeat gossip refreshes
+        // freshness there instead of being dropped on the floor).
+        // Daemon-learned peers are deliberately NOT banked — the bank must
+        // stay an INDEPENDENT view of the network.
+        if (source != PeerInfo::Source::coind
+            && !m_coind_peers.count(ep->to_string()))
+            m_addrman.add(ep->to_net_service(), source_host);
 
         // ── Capacity gating ──
         if (static_cast<int>(m_peers.size()) >= m_config.max_peers) return false;
@@ -639,6 +728,37 @@ private:
         peer.last_seen = std::chrono::steady_clock::now();
         peer.max_attempts = m_config.max_connection_attempts;
         return true;
+    }
+
+    /// Materialize a working-set entry for an addrman-drawn dial target
+    /// (or any endpoint the transport reports on) so the notify_*
+    /// feedback — including the #940 dial-failure leg — always lands on
+    /// a scored entry. Returns nullptr for an unparseable key.
+    PeerInfo* ensure_working_entry_locked(const std::string& key)
+    {
+        auto it = m_peers.find(key);
+        if (it != m_peers.end()) return &it->second;
+        const auto colon = key.rfind(':');
+        if (colon == std::string::npos) return nullptr;
+        uint16_t port = 0;
+        try {
+            const unsigned long v = std::stoul(key.substr(colon + 1));
+            if (v == 0 || v > 65535) return nullptr;
+            port = static_cast<uint16_t>(v);
+        } catch (const std::exception&) {
+            return nullptr;
+        }
+        auto ep = PeerEndpoint::from(key.substr(0, colon), port);
+        if (!ep) return nullptr;
+        auto& peer = m_peers[key];
+        peer.address = ep->to_net_service();
+        peer.addr_class = ep->addr_class();
+        peer.source = PeerInfo::Source::addr_crawl;
+        peer.network_group = get_network_group(ep->host());
+        peer.first_seen = std::chrono::steady_clock::now();
+        peer.last_seen = std::chrono::steady_clock::now();
+        peer.max_attempts = m_config.max_connection_attempts;
+        return &peer;
     }
 
     bool is_valid_port(uint16_t port) const
@@ -754,6 +874,10 @@ private:
         m_maintenance_timer.async_wait([this](const boost::system::error_code& ec) {
             if (ec || !m_running) return;
             schedule_maintenance();
+
+            // Tried-collision resolution for the bucketed DB (dashd
+            // ResolveCollisions cadence rides the maintenance tick).
+            m_addrman.resolve_collisions();
         });
     }
 
@@ -781,6 +905,18 @@ private:
             sym = "unknown";
         }
         return (dir / ("peers_" + sym + ".json")).string();
+    }
+
+    /// Bucketed-DB file (peers.dat equivalent), beside the working-set
+    /// JSON in the same per-coin directory.
+    std::string addrman_db_path() const
+    {
+        const std::filesystem::path p = db_path();
+        const std::string stem = p.stem().string();   // "peers_<SYM>"
+        const std::string prefix = "peers_";
+        const std::string sym = stem.rfind(prefix, 0) == 0
+            ? stem.substr(prefix.size()) : stem;
+        return (p.parent_path() / ("addrman_" + sym + ".json")).string();
     }
 
     void save_peers()
@@ -822,6 +958,9 @@ private:
                 ofs << j.dump(2);
             }
             std::rename(tmp_path.c_str(), db_path().c_str());
+            // Bucketed DB persists beside the working-set JSON (peers.dat
+            // equivalent; addrman does its own atomic tmp+rename).
+            m_addrman.save(addrman_db_path());
             LOG_DEBUG_COIND << "[" << m_symbol << "] Saved " << m_peers.size() << " peers";
         } catch (const std::exception& e) {
             LOG_WARNING << "[" << m_symbol << "] Failed to save peers: " << e.what();
@@ -830,6 +969,15 @@ private:
 
     void load_peers()
     {
+        // Bucketed DB (peers.dat equivalent). FAIL-SAFE: a corrupt or
+        // absent file loads EMPTY (load() never throws) and the seed
+        // ladder then bootstraps exactly as on first run.
+        if (m_addrman.load(addrman_db_path())) {
+            LOG_INFO << "[" << m_symbol << "] AddrMan loaded: "
+                     << m_addrman.size() << " known ("
+                     << m_addrman.tried_count() << " tried) from "
+                     << addrman_db_path();
+        }
         try {
             std::ifstream ifs(db_path());
             if (!ifs.is_open()) return;
@@ -1147,6 +1295,11 @@ private:
     int  m_emergency_attempts{0};
 
     mutable std::mutex m_mutex;
+    /// Bucketed new/tried address DB (dashd CAddrMan port). mutable:
+    /// draws and samples only permute internal iteration state, and the
+    /// DB carries its own lock (always taken AFTER m_mutex, never the
+    /// reverse — CoinAddrMan calls nothing back).
+    mutable core::CoinAddrMan m_addrman;
     std::map<std::string, PeerInfo> m_peers;        // key = "host:port"
     std::set<std::string> m_coind_peers;            // daemon's own peers (overlap filter)
     std::string m_local_node_key;

--- a/src/core/coin_addrman.hpp
+++ b/src/core/coin_addrman.hpp
@@ -1,0 +1,861 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// core::CoinAddrMan — bucketed new/tried address manager for the embedded
+/// coin-P2P arm: a port of the dashd / Bitcoin Core CAddrMan algorithm
+/// (addrman.h / addrman.cpp) onto c2pool's core networking types.
+///
+/// WHY: the per-coin CoinPeerManagers keep a small flat scored map (working
+/// set, ~max_peers entries). That is enough to DIAL well but not to REMEMBER
+/// well: getaddr harvests beyond the working-set capacity were dropped on the
+/// floor, so a daemonless node sat on a handful of seeds instead of growing a
+/// large, quality-ranked archival peer DB the way dashd does. This class is
+/// the missing DB. The algorithm is MIRRORED from dashd, not reinvented:
+///
+///   • AddrInfo equivalent (Entry): last_try / last_success / attempts /
+///     ref_count / in_tried, wall-clock epoch timestamps (survive restarts).
+///   • new table: 1024 buckets x 64 slots (entry may live in up to 8 new
+///     buckets, one per distinct source group, ref-counted).
+///   • tried table: 256 buckets x 64 slots (an address group maps into at
+///     most 8 distinct tried buckets).
+///   • Bucket coordinates are keyed by a persistent per-node random SipHash
+///     key + the /16 (IPv4) / /32 (IPv6) network group — an attacker cannot
+///     aim addresses at chosen buckets, and cannot fill more than a bounded
+///     slice of either table from one netgroup.
+///   • Add / Good / Attempt / Connected feedback, IsTerrible demotion (never
+///     silent deletion of history), GetChance quality bias, stochastic
+///     Select() (50/50 tried-vs-new, random bucket walk, acceptance
+///     probability chance*factor with factor *= 1.2 per rejection).
+///   • Tried-collision protocol: Good() onto an occupied tried slot parks the
+///     newcomer in m_collisions; the incumbent is handed out for a re-test
+///     (select_tried_collision) and resolve_collisions() applies dashd's
+///     eviction rules (recent success protects the incumbent; a recent failed
+///     attempt evicts it).
+///   • get_addr(): the 23% / 2500-cap random sample used to serve peers to
+///     others.
+///
+/// Constants are dashd's verbatim (ADDRMAN_* family). Persistence is a
+/// per-coin JSON file (peers.dat-equivalent): fail-safe — a corrupt or absent
+/// DB loads as EMPTY (never throws out of load()), so the seed ladder
+/// bootstraps exactly as before.
+///
+/// Scope fence: this class only remembers and ranks ADDRESSES. It has no
+/// influence on block/tx/share validation, serving, or reward paths.
+///
+/// Header-only over core (NetService/PeerEndpoint, log, nlohmann) to match
+/// the sibling core networking headers. SipHash-2-4 is inlined below
+/// (public-domain reference algorithm, same primitive as
+/// src/btclibs/crypto/siphash.{h,cpp}) so the header stays self-contained
+/// and link-free for every consumer target.
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <boost/asio/ip/address.hpp>
+#include <nlohmann/json.hpp>
+
+#include <core/log.hpp>
+#include <core/netaddress.hpp>
+
+namespace core {
+
+namespace addrman_detail {
+
+/// SipHash-2-4 over a byte string (reference algorithm; identical primitive
+/// to btclibs/crypto/siphash.cpp, restated header-only so core stays
+/// link-free). Used ONLY for bucket-coordinate derivation — not consensus.
+inline uint64_t rotl64(uint64_t x, int b) { return (x << b) | (x >> (64 - b)); }
+
+inline uint64_t siphash(uint64_t k0, uint64_t k1, const std::string& data)
+{
+    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
+    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
+    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
+    uint64_t v3 = 0x7465646279746573ULL ^ k1;
+
+    auto sipround = [&]() {
+        v0 += v1; v1 = rotl64(v1, 13); v1 ^= v0; v0 = rotl64(v0, 32);
+        v2 += v3; v3 = rotl64(v3, 16); v3 ^= v2;
+        v0 += v3; v3 = rotl64(v3, 21); v3 ^= v0;
+        v2 += v1; v1 = rotl64(v1, 17); v1 ^= v2; v2 = rotl64(v2, 32);
+    };
+
+    const auto* in = reinterpret_cast<const unsigned char*>(data.data());
+    const size_t len = data.size();
+    const size_t left = len & 7;
+    uint64_t b = static_cast<uint64_t>(len) << 56;
+
+    size_t i = 0;
+    for (; i + 8 <= len; i += 8) {
+        uint64_t m = 0;
+        for (int j = 7; j >= 0; --j) m = (m << 8) | in[i + j];
+        v3 ^= m;
+        sipround(); sipround();
+        v0 ^= m;
+    }
+    for (size_t j = 0; j < left; ++j)
+        b |= static_cast<uint64_t>(in[i + j]) << (8 * j);
+
+    v3 ^= b;
+    sipround(); sipround();
+    v0 ^= b;
+    v2 ^= 0xff;
+    sipround(); sipround(); sipround(); sipround();
+    return v0 ^ v1 ^ v2 ^ v3;
+}
+
+/// Network group for bucket keying: /16 for IPv4 (and v4-mapped v6), first
+/// 32 bits for IPv6, the raw string for anything unparseable. Same group
+/// semantics the per-coin peer managers already use for their Sybil caps
+/// (dashd-without-asmap: NetGroupManager/asmap is explicitly out of scope).
+inline std::string network_group(const std::string& ip)
+{
+    boost::system::error_code ec;
+    auto addr = boost::asio::ip::make_address(ip, ec);
+    if (!ec) {
+        if (addr.is_v4()) {
+            auto bytes = addr.to_v4().to_bytes();
+            return std::to_string(bytes[0]) + "." + std::to_string(bytes[1]);
+        }
+        if (addr.is_v6()) {
+            auto v6 = addr.to_v6();
+            if (v6.is_v4_mapped()) {
+                auto v4 = boost::asio::ip::make_address_v4(
+                    boost::asio::ip::v4_mapped, v6).to_bytes();
+                return std::to_string(v4[0]) + "." + std::to_string(v4[1]);
+            }
+            auto bytes = v6.to_bytes();
+            char buf[12];
+            std::snprintf(buf, sizeof(buf), "%02x%02x:%02x%02x",
+                          bytes[0], bytes[1], bytes[2], bytes[3]);
+            return std::string(buf);
+        }
+    }
+    return ip;
+}
+
+} // namespace addrman_detail
+
+class CoinAddrMan
+{
+public:
+    // ── dashd ADDRMAN_* constants, verbatim ─────────────────────────────────
+    static constexpr int TRIED_BUCKET_COUNT = 1 << 8;   // 256
+    static constexpr int NEW_BUCKET_COUNT = 1 << 10;    // 1024
+    static constexpr int BUCKET_SIZE = 1 << 6;          // 64
+    static constexpr int TRIED_BUCKETS_PER_GROUP = 8;
+    static constexpr int NEW_BUCKETS_PER_SOURCE_GROUP = 64;
+    static constexpr int NEW_BUCKETS_PER_ADDRESS = 8;
+    static constexpr int64_t HORIZON_SECONDS = 30LL * 24 * 3600;   // 30 days
+    static constexpr int RETRIES = 3;
+    static constexpr int MAX_FAILURES = 10;
+    static constexpr int64_t MIN_FAIL_SECONDS = 7LL * 24 * 3600;   // 7 days
+    static constexpr int64_t REPLACEMENT_SECONDS = 4LL * 3600;     // 4 hours
+    static constexpr int64_t TEST_WINDOW_SECONDS = 40LL * 60;      // 40 minutes
+    static constexpr size_t SET_TRIED_COLLISION_SIZE = 10;
+    static constexpr int64_t DEFAULT_TIME_PENALTY = 2LL * 3600;    // gossip 2h
+
+    /// AddrInfo equivalent. All timestamps are WALL-CLOCK epoch seconds so
+    /// history survives restarts (a steady_clock stamp dies with the process).
+    struct Entry
+    {
+        NetService  addr;
+        std::string source_group;       // netgroup of the first source
+        int64_t     ntime{0};           // last believed-alive
+        int64_t     last_try{0};
+        int64_t     last_success{0};
+        int64_t     last_count_attempt{0};
+        int         attempts{0};
+        int         ref_count{0};       // new-table references
+        bool        in_tried{false};
+        int         random_pos{-1};     // index into m_random
+
+        /// dashd AddrInfo::IsTerrible, verbatim thresholds. Terrible entries
+        /// are DEMOTED/overwritten in place, never proactively erased —
+        /// history survives until a better candidate needs the slot.
+        bool is_terrible(int64_t now) const
+        {
+            if (last_try && last_try >= now - 60) return false; // tried in the last minute
+            if (ntime > now + 10 * 60) return true;             // future timestamp
+            if (ntime == 0 || now - ntime > HORIZON_SECONDS) return true;
+            if (last_success == 0 && attempts >= RETRIES) return true;
+            if (now - last_success > MIN_FAIL_SECONDS && attempts >= MAX_FAILURES)
+                return true;
+            return false;
+        }
+
+        /// dashd AddrInfo::GetChance: 0.66^min(attempts,8), x0.01 if tried
+        /// within the last 10 minutes.
+        double get_chance(int64_t now) const
+        {
+            double chance = 1.0;
+            const int64_t since_try = std::max<int64_t>(now - last_try, 0);
+            if (since_try < 60 * 10) chance *= 0.01;
+            chance *= std::pow(0.66, std::min(attempts, 8));
+            return chance;
+        }
+    };
+
+    /// k0/k1 = persistent bucket-key halves. (0,0) => fresh random key (the
+    /// production path; load() restores the persisted key). Non-zero keys are
+    /// for deterministic KATs and for load().
+    explicit CoinAddrMan(uint64_t k0 = 0, uint64_t k1 = 0)
+    {
+        if (k0 == 0 && k1 == 0) {
+            std::random_device rd;
+            m_k0 = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+            m_k1 = (static_cast<uint64_t>(rd()) << 32) ^ rd();
+            // A pathological random_device could still yield (0,0).
+            if (m_k0 == 0 && m_k1 == 0) m_k1 = 1;
+        } else {
+            m_k0 = k0;
+            m_k1 = k1;
+        }
+        m_rng.seed(std::random_device{}());
+        clear_tables();
+    }
+
+    // ── dashd Add(): bank an address (gossip / seed / manual) ───────────────
+    /// source_ip = who told us (empty => self-announced; keyed by own group,
+    /// dashd's convention for DNS/fixed/manual sources). Returns true when a
+    /// NEW entry landed in a new-table slot.
+    bool add(const NetService& addr, const std::string& source_ip = std::string(),
+             int64_t time_penalty = DEFAULT_TIME_PENALTY, int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        if (source_ip.empty()) time_penalty = 0;    // self-announcement
+
+        const std::string key = addr.to_string();
+        const std::string src_group = addrman_detail::network_group(
+            source_ip.empty() ? addr.address() : source_ip);
+
+        Entry* e = nullptr;
+        int id = -1;
+        bool created = false;
+
+        auto it = m_index.find(key);
+        if (it != m_index.end()) {
+            id = it->second;
+            e = &m_info[id];
+            // Periodic freshness update (dashd's currently-online interval
+            // collapses to "seen again now" here because c2pool's addr intake
+            // does not carry the gossip nTime field).
+            const int64_t update_interval = 24 * 3600;
+            if (e->ntime < now - update_interval - time_penalty)
+                e->ntime = now - time_penalty;
+            if (e->in_tried) return false;
+            if (e->ref_count == NEW_BUCKETS_PER_ADDRESS) return false;
+            // Stochastic damping: with n references it is 2^n times harder
+            // to gain another one (dashd verbatim).
+            const int factor = 1 << e->ref_count;
+            if (factor > 1 && rand_uint(factor) != 0) return false;
+        } else {
+            id = m_next_id++;
+            Entry fresh;
+            fresh.addr = addr;
+            fresh.source_group = src_group;
+            fresh.ntime = std::max<int64_t>(0, now - time_penalty);
+            fresh.random_pos = static_cast<int>(m_random.size());
+            m_info[id] = std::move(fresh);
+            m_random.push_back(id);
+            m_index[key] = id;
+            ++m_new_count;
+            e = &m_info[id];
+            created = true;
+        }
+
+        const int bucket = new_bucket_of(*e, src_group);
+        const int pos = bucket_position_of(*e, /*is_new=*/true, bucket);
+        bool placed = false;
+        if (m_new[bucket][pos] != id) {
+            placed = (m_new[bucket][pos] == -1);
+            if (!placed) {
+                Entry& occupant = m_info[m_new[bucket][pos]];
+                // Evict a terrible occupant, or one that is redundant while
+                // the candidate has no slot at all (dashd verbatim).
+                if (occupant.is_terrible(now) ||
+                    (occupant.ref_count > 1 && e->ref_count == 0))
+                    placed = true;
+            }
+            if (placed) {
+                clear_new_slot(bucket, pos);
+                ++e->ref_count;
+                m_new[bucket][pos] = id;
+            } else if (e->ref_count == 0) {
+                erase_new_entry(id);
+                return false;
+            }
+        }
+        return created && placed;
+    }
+
+    // ── dashd Good(): a full successful handshake ───────────────────────────
+    void good(const NetService& addr, int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        auto it = m_index.find(addr.to_string());
+        if (it == m_index.end()) return;
+        good_locked(it->second, now);
+    }
+
+    // ── dashd Attempt(): a dial happened (typically: and failed) ────────────
+    void attempt(const NetService& addr, bool count_failure = true, int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        auto it = m_index.find(addr.to_string());
+        if (it == m_index.end()) return;
+        Entry& e = m_info[it->second];
+        e.last_try = now;
+        // Only count one failure per Good() era (dashd's nLastGood fence:
+        // repeated dials while offline don't stack into a permanent ban).
+        if (count_failure && e.last_count_attempt < m_last_good) {
+            e.last_count_attempt = now;
+            ++e.attempts;
+        }
+    }
+
+    // ── dashd Connected(): peer proved alive; refresh if >20min stale ───────
+    void connected(const NetService& addr, int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        auto it = m_index.find(addr.to_string());
+        if (it == m_index.end()) return;
+        Entry& e = m_info[it->second];
+        if (now - e.ntime > 20 * 60) e.ntime = now;
+    }
+
+    // ── dashd Select(): quality-biased stochastic draw ──────────────────────
+    /// 50/50 tried-vs-new (when both populated), then a random bucket + slot
+    /// walk accepting with probability get_chance()*factor, factor *= 1.2 per
+    /// rejection. new_only=true restricts to the new table (feeler-style).
+    std::optional<NetService> select(bool new_only = false, int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        if (m_random.empty()) return std::nullopt;
+        if (new_only && m_new_count == 0) return std::nullopt;
+
+        const bool use_tried =
+            !new_only && m_tried_count > 0 &&
+            (m_new_count == 0 || rand_uint(2) == 0);
+
+        double chance_factor = 1.0;
+        // dashd loops unboundedly; a defensive iteration ceiling keeps a
+        // (theoretically impossible) empty-walk from wedging the caller.
+        for (int iter = 0; iter < (1 << 16); ++iter) {
+            const int bucket_count = use_tried ? TRIED_BUCKET_COUNT : NEW_BUCKET_COUNT;
+            const int bucket = static_cast<int>(rand_uint(bucket_count));
+            const int start = static_cast<int>(rand_uint(BUCKET_SIZE));
+            int id = -1;
+            for (int i = 0; i < BUCKET_SIZE; ++i) {
+                const int pos = (start + i) % BUCKET_SIZE;
+                const int candidate =
+                    use_tried ? m_tried[bucket][pos] : m_new[bucket][pos];
+                if (candidate != -1) { id = candidate; break; }
+            }
+            if (id == -1) continue;
+            const Entry& e = m_info[id];
+            const double threshold = chance_factor * e.get_chance(now);
+            if (static_cast<double>(rand_uint(1 << 30)) <
+                threshold * static_cast<double>(1 << 30))
+                return e.addr;
+            chance_factor *= 1.2;
+        }
+        return std::nullopt;
+    }
+
+    // ── dashd SelectTriedCollision(): incumbent to re-test (feeler leg) ─────
+    /// Returns the TRIED INCUMBENT whose slot a collision newcomer wants.
+    /// Dial it: on success its Good() refreshes last_success and
+    /// resolve_collisions() keeps it; on dial failure Attempt() ages it and
+    /// resolve_collisions() evicts it in favour of the newcomer.
+    std::optional<NetService> select_tried_collision()
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_collisions.empty()) return std::nullopt;
+        auto it = m_collisions.begin();
+        std::advance(it, rand_uint(m_collisions.size()));
+        const int id_new = *it;
+        auto info_it = m_info.find(id_new);
+        if (info_it == m_info.end()) { m_collisions.erase(it); return std::nullopt; }
+        const Entry& e = info_it->second;
+        const int bucket = tried_bucket_of(e);
+        const int pos = bucket_position_of(e, /*is_new=*/false, bucket);
+        const int id_old = m_tried[bucket][pos];
+        if (id_old == -1) { m_collisions.erase(it); return std::nullopt; }
+        return m_info[id_old].addr;
+    }
+
+    // ── dashd ResolveCollisions() ───────────────────────────────────────────
+    void resolve_collisions(int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        for (auto it = m_collisions.begin(); it != m_collisions.end();) {
+            const int id_new = *it;
+            bool erase_collision = false;
+            auto info_it = m_info.find(id_new);
+            if (info_it == m_info.end() || info_it->second.in_tried) {
+                erase_collision = true;
+            } else {
+                Entry& info_new = info_it->second;
+                const int bucket = tried_bucket_of(info_new);
+                const int pos = bucket_position_of(info_new, false, bucket);
+                const int id_old = m_tried[bucket][pos];
+                if (id_old == -1) {
+                    // Slot freed since the collision was recorded.
+                    good_locked(id_new, now, /*test_before_evict=*/false);
+                    erase_collision = true;
+                } else {
+                    const Entry& info_old = m_info[id_old];
+                    if (now - info_old.last_success < REPLACEMENT_SECONDS) {
+                        // Incumbent recently proved alive — it stays.
+                        erase_collision = true;
+                    } else if (now - info_old.last_try < REPLACEMENT_SECONDS) {
+                        if (now - info_old.last_try > 60) {
+                            // Incumbent was re-tested and did NOT succeed —
+                            // the newcomer takes the slot.
+                            good_locked(id_new, now, /*test_before_evict=*/false);
+                            erase_collision = true;
+                        }
+                    } else if (now - info_new.last_success > TEST_WINDOW_SECONDS) {
+                        // Incumbent never got re-tested in a sane window;
+                        // don't hold the newcomer hostage forever.
+                        good_locked(id_new, now, /*test_before_evict=*/false);
+                        erase_collision = true;
+                    }
+                }
+            }
+            if (erase_collision) it = m_collisions.erase(it);
+            else ++it;
+        }
+    }
+
+    // ── dashd GetAddr(): random sample for serving to others ────────────────
+    std::vector<NetService> get_addr(size_t max_pct = 23, size_t max_count = 2500,
+                                     bool tried_only = false, int64_t now = 0)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (now == 0) now = wall_now();
+        size_t want = m_random.size() * max_pct / 100;
+        if (max_count && want > max_count) want = max_count;
+
+        std::vector<NetService> out;
+        for (size_t n = 0; n < m_random.size() && out.size() < want; ++n) {
+            swap_random(n, n + rand_uint(m_random.size() - n));
+            const Entry& e = m_info[m_random[n]];
+            if (e.is_terrible(now)) continue;
+            if (tried_only && !e.in_tried) continue;
+            out.push_back(e.addr);
+        }
+        return out;
+    }
+
+    // ── introspection ───────────────────────────────────────────────────────
+    size_t size() const { std::lock_guard<std::mutex> l(m_mutex); return m_random.size(); }
+    size_t tried_count() const { std::lock_guard<std::mutex> l(m_mutex); return m_tried_count; }
+    size_t new_count() const { std::lock_guard<std::mutex> l(m_mutex); return m_new_count; }
+    size_t collision_count() const { std::lock_guard<std::mutex> l(m_mutex); return m_collisions.size(); }
+
+    bool contains(const NetService& addr) const
+    {
+        std::lock_guard<std::mutex> l(m_mutex);
+        return m_index.count(addr.to_string()) > 0;
+    }
+
+    bool is_tried(const NetService& addr) const
+    {
+        std::lock_guard<std::mutex> l(m_mutex);
+        auto it = m_index.find(addr.to_string());
+        if (it == m_index.end()) return false;
+        return m_info.at(it->second).in_tried;
+    }
+
+    /// Soft table capacity (both tables' slot count) — the discovery layer
+    /// keeps harvesting getaddr until the DB is of this order, i.e. in
+    /// practice: always (dashd never stops listening to addr gossip either).
+    static constexpr size_t soft_capacity()
+    {
+        return static_cast<size_t>(NEW_BUCKET_COUNT + TRIED_BUCKET_COUNT) * BUCKET_SIZE;
+    }
+
+    // ── persistence (peers.dat equivalent, per-coin JSON) ───────────────────
+    /// Atomic tmp+rename write. Returns false (and logs) on any I/O error.
+    bool save(const std::string& path) const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        try {
+            nlohmann::json j;
+            j["version"] = 1;
+            // The bucket key MUST persist: bucket coordinates are keyed by it,
+            // so a fresh key would reshuffle every persisted tried placement.
+            j["k0"] = m_k0;
+            j["k1"] = m_k1;
+            nlohmann::json peers = nlohmann::json::array();
+            for (const auto& [id, e] : m_info) {
+                nlohmann::json pj;
+                pj["addr"] = e.addr.to_string();
+                pj["src"] = e.source_group;
+                pj["ntime"] = e.ntime;
+                pj["last_try"] = e.last_try;
+                pj["last_success"] = e.last_success;
+                pj["last_count_attempt"] = e.last_count_attempt;
+                pj["attempts"] = e.attempts;
+                pj["tried"] = e.in_tried;
+                peers.push_back(std::move(pj));
+            }
+            j["peers"] = std::move(peers);
+
+            const std::string tmp = path + ".tmp";
+            {
+                std::ofstream ofs(tmp);
+                if (!ofs.is_open()) return false;
+                ofs << j.dump();
+                if (!ofs.good()) return false;
+            }
+            if (std::rename(tmp.c_str(), path.c_str()) != 0) return false;
+            return true;
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[addrman] save failed: " << e.what();
+            return false;
+        }
+    }
+
+    /// FAIL-SAFE load: any parse/shape error clears the DB and returns false;
+    /// the caller's seed ladder then bootstraps exactly as on first run.
+    /// Entries are re-inserted through the placement rules (dashd's
+    /// incompatible-serialization recovery path): tried entries go straight
+    /// to their tried slot when free, and demote to new on collision.
+    bool load(const std::string& path)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        try {
+            std::ifstream ifs(path);
+            if (!ifs.is_open()) return false;   // absent DB: cold start
+            auto j = nlohmann::json::parse(ifs);
+            if (j.value("version", 0) != 1) { clear_all(); return false; }
+
+            const uint64_t k0 = j.at("k0").get<uint64_t>();
+            const uint64_t k1 = j.at("k1").get<uint64_t>();
+            clear_all();
+            m_k0 = k0;
+            m_k1 = k1;
+
+            const int64_t now = wall_now();
+            size_t rejected = 0;
+            for (const auto& pj : j.at("peers")) {
+                NetService addr(pj.at("addr").get<std::string>());
+                // Reject stale garbage the same way the managers validate.
+                auto ep = PeerEndpoint::from(addr);
+                if (!ep || addr.port() == 0) { ++rejected; continue; }
+                const std::string key = addr.to_string();
+                if (m_index.count(key)) continue;
+
+                const int id = m_next_id++;
+                Entry e;
+                e.addr = addr;
+                e.source_group = pj.value("src", std::string());
+                if (e.source_group.empty())
+                    e.source_group = addrman_detail::network_group(addr.address());
+                e.ntime = pj.value("ntime", int64_t{0});
+                e.last_try = pj.value("last_try", int64_t{0});
+                e.last_success = pj.value("last_success", int64_t{0});
+                e.last_count_attempt = pj.value("last_count_attempt", int64_t{0});
+                e.attempts = std::max(0, pj.value("attempts", 0));
+                const bool was_tried = pj.value("tried", false);
+
+                e.random_pos = static_cast<int>(m_random.size());
+                m_info[id] = e;
+                m_random.push_back(id);
+                m_index[key] = id;
+
+                Entry& stored = m_info[id];
+                if (was_tried) {
+                    const int bucket = tried_bucket_of(stored);
+                    const int pos = bucket_position_of(stored, false, bucket);
+                    if (m_tried[bucket][pos] == -1) {
+                        m_tried[bucket][pos] = id;
+                        stored.in_tried = true;
+                        ++m_tried_count;
+                        continue;
+                    }
+                }
+                // New entry, or tried whose slot is already taken: place in
+                // the new table under the Add() collision rules.
+                ++m_new_count;
+                place_in_new(id, stored, now);
+            }
+            if (rejected > 0)
+                LOG_WARNING << "[addrman] rejected " << rejected
+                            << " invalid persisted entries";
+            return true;
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[addrman] corrupt DB (" << e.what()
+                        << ") — starting empty, seeds will bootstrap";
+            clear_all();
+            return false;
+        }
+    }
+
+    // ── test hooks (deterministic KAT surface) ──────────────────────────────
+    std::pair<uint64_t, uint64_t> bucket_key() const { return {m_k0, m_k1}; }
+    void seed_rng(uint64_t seed) { std::lock_guard<std::mutex> l(m_mutex); m_rng.seed(seed); }
+
+    int test_tried_bucket(const NetService& addr) const
+    {
+        Entry e; e.addr = addr;
+        return tried_bucket_of(e);
+    }
+    int test_new_bucket(const NetService& addr, const std::string& source_ip) const
+    {
+        Entry e; e.addr = addr;
+        return new_bucket_of(e, addrman_detail::network_group(
+            source_ip.empty() ? addr.address() : source_ip));
+    }
+    int test_bucket_position(const NetService& addr, bool is_new, int bucket) const
+    {
+        Entry e; e.addr = addr;
+        return bucket_position_of(e, is_new, bucket);
+    }
+    /// Age an entry's timestamps / attempt counter (KATs simulate history
+    /// without wall time). attempts < 0 leaves the counter untouched.
+    bool test_set_times(const NetService& addr, int64_t ntime, int64_t last_try,
+                        int64_t last_success, int attempts = -1)
+    {
+        std::lock_guard<std::mutex> l(m_mutex);
+        auto it = m_index.find(addr.to_string());
+        if (it == m_index.end()) return false;
+        Entry& e = m_info[it->second];
+        e.ntime = ntime;
+        e.last_try = last_try;
+        e.last_success = last_success;
+        if (attempts >= 0) e.attempts = attempts;
+        return true;
+    }
+
+private:
+    static int64_t wall_now()
+    {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    }
+
+    uint64_t rand_uint(uint64_t n) const { return n <= 1 ? 0 : m_rng() % n; }
+
+    std::string group_of(const Entry& e) const
+    {
+        return addrman_detail::network_group(e.addr.address());
+    }
+
+    // dashd GetTriedBucket: hash1 = H(key, addr); hash2 = H(key, group,
+    // hash1 % TRIED_BUCKETS_PER_GROUP) — an address group can occupy at most
+    // 8 distinct tried buckets.
+    int tried_bucket_of(const Entry& e) const
+    {
+        const uint64_t h1 = addrman_detail::siphash(m_k0, m_k1, "T!" + e.addr.to_string());
+        const uint64_t h2 = addrman_detail::siphash(
+            m_k0, m_k1,
+            "TG!" + group_of(e) + "!" + std::to_string(h1 % TRIED_BUCKETS_PER_GROUP));
+        return static_cast<int>(h2 % TRIED_BUCKET_COUNT);
+    }
+
+    // dashd GetNewBucket: hash1 = H(key, addr_group, src_group); hash2 =
+    // H(key, src_group, hash1 % NEW_BUCKETS_PER_SOURCE_GROUP) — one source
+    // group can spray into at most 64 new buckets.
+    int new_bucket_of(const Entry& e, const std::string& src_group) const
+    {
+        const uint64_t h1 = addrman_detail::siphash(
+            m_k0, m_k1, "N!" + group_of(e) + "!" + src_group);
+        const uint64_t h2 = addrman_detail::siphash(
+            m_k0, m_k1,
+            "NG!" + src_group + "!" + std::to_string(h1 % NEW_BUCKETS_PER_SOURCE_GROUP));
+        return static_cast<int>(h2 % NEW_BUCKET_COUNT);
+    }
+
+    // dashd GetBucketPosition: H(key, 'N'/'K', bucket, addr) % 64.
+    int bucket_position_of(const Entry& e, bool is_new, int bucket) const
+    {
+        const uint64_t h = addrman_detail::siphash(
+            m_k0, m_k1,
+            std::string(is_new ? "n!" : "k!") + std::to_string(bucket) + "!" +
+                e.addr.to_string());
+        return static_cast<int>(h % BUCKET_SIZE);
+    }
+
+    void clear_tables()
+    {
+        for (auto& b : m_new) b.fill(-1);
+        for (auto& b : m_tried) b.fill(-1);
+    }
+
+    void clear_all()
+    {
+        m_info.clear();
+        m_index.clear();
+        m_random.clear();
+        m_collisions.clear();
+        m_new_count = 0;
+        m_tried_count = 0;
+        m_next_id = 0;
+        clear_tables();
+    }
+
+    void swap_random(size_t a, size_t b)
+    {
+        if (a == b) return;
+        const int id_a = m_random[a];
+        const int id_b = m_random[b];
+        m_info[id_a].random_pos = static_cast<int>(b);
+        m_info[id_b].random_pos = static_cast<int>(a);
+        std::swap(m_random[a], m_random[b]);
+    }
+
+    /// Clear one new-table slot, deleting the occupant when this was its last
+    /// reference and it is not tried (dashd ClearNew).
+    void clear_new_slot(int bucket, int pos)
+    {
+        const int id = m_new[bucket][pos];
+        if (id == -1) return;
+        m_new[bucket][pos] = -1;
+        Entry& e = m_info[id];
+        if (--e.ref_count <= 0 && !e.in_tried)
+            erase_new_entry(id);
+    }
+
+    /// Remove an entry that holds no new-table references and is not tried.
+    void erase_new_entry(int id)
+    {
+        auto it = m_info.find(id);
+        if (it == m_info.end()) return;
+        const Entry& e = it->second;
+        // Detach from m_random via swap-with-last.
+        if (e.random_pos >= 0) {
+            swap_random(static_cast<size_t>(e.random_pos), m_random.size() - 1);
+            m_random.pop_back();
+        }
+        m_index.erase(e.addr.to_string());
+        m_collisions.erase(id);
+        m_info.erase(it);
+        if (m_new_count > 0) --m_new_count;
+    }
+
+    /// dashd MakeTried: pull the entry out of every new bucket, then claim the
+    /// tried slot, evicting any incumbent back into the new table.
+    void make_tried(int id, Entry& e, int64_t now)
+    {
+        // Remove from all new buckets (dashd scans every bucket's computed
+        // position for this entry — positions are hash-derived, so this is
+        // NEW_BUCKET_COUNT hash evaluations, exactly like upstream).
+        for (int bucket = 0; bucket < NEW_BUCKET_COUNT; ++bucket) {
+            const int pos = bucket_position_of(e, true, bucket);
+            if (m_new[bucket][pos] == id) {
+                m_new[bucket][pos] = -1;
+                --e.ref_count;
+            }
+        }
+        e.ref_count = 0;
+        if (m_new_count > 0) --m_new_count;
+
+        const int bucket = tried_bucket_of(e);
+        const int pos = bucket_position_of(e, false, bucket);
+        if (m_tried[bucket][pos] != -1) {
+            // Evict the incumbent back into the new table.
+            const int id_evict = m_tried[bucket][pos];
+            Entry& evicted = m_info[id_evict];
+            evicted.in_tried = false;
+            m_tried[bucket][pos] = -1;
+            if (m_tried_count > 0) --m_tried_count;
+            ++m_new_count;
+            place_in_new(id_evict, evicted, now);
+        }
+        m_tried[bucket][pos] = id;
+        ++m_tried_count;
+        e.in_tried = true;
+    }
+
+    /// Insert an entry into its new-table slot under Add()'s collision rules.
+    void place_in_new(int id, Entry& e, int64_t now)
+    {
+        const int bucket = new_bucket_of(e, e.source_group);
+        const int pos = bucket_position_of(e, true, bucket);
+        if (m_new[bucket][pos] == id) return;
+        bool insert = (m_new[bucket][pos] == -1);
+        if (!insert) {
+            Entry& occupant = m_info[m_new[bucket][pos]];
+            if (occupant.is_terrible(now) ||
+                (occupant.ref_count > 1 && e.ref_count == 0))
+                insert = true;
+        }
+        if (insert) {
+            clear_new_slot(bucket, pos);
+            e.ref_count = std::max(1, e.ref_count);
+            m_new[bucket][pos] = id;
+        } else if (e.ref_count == 0) {
+            erase_new_entry(id);
+        }
+    }
+
+    /// Shared Good() body (assumes m_mutex held). test_before_evict mirrors
+    /// dashd's Good_() flag: the normal path parks an occupied-slot newcomer
+    /// as a collision (the incumbent gets a feeler re-test first), while the
+    /// resolve path — which has already applied the eviction rules — takes
+    /// the slot directly via MakeTried.
+    void good_locked(int id, int64_t now, bool test_before_evict = true)
+    {
+        auto it = m_info.find(id);
+        if (it == m_info.end()) return;
+        Entry& e = it->second;
+        e.last_success = now;
+        e.last_try = now;
+        e.attempts = 0;
+        m_last_good = now;
+        if (e.in_tried) return;
+
+        const int bucket = tried_bucket_of(e);
+        const int pos = bucket_position_of(e, false, bucket);
+        if (test_before_evict && m_tried[bucket][pos] != -1) {
+            // Occupied: park as a collision; the incumbent gets re-tested
+            // (select_tried_collision) before it can be evicted.
+            if (m_collisions.size() < SET_TRIED_COLLISION_SIZE)
+                m_collisions.insert(id);
+        } else {
+            make_tried(id, e, now);
+        }
+    }
+
+    // ── state ───────────────────────────────────────────────────────────────
+    mutable std::mutex m_mutex;
+    uint64_t m_k0{0};
+    uint64_t m_k1{0};
+    mutable std::mt19937_64 m_rng;
+
+    std::map<int, Entry> m_info;
+    std::map<std::string, int> m_index;        // "host:port" -> id
+    std::vector<int> m_random;                  // ids, GetAddr sampling order
+    std::set<int> m_collisions;                 // tried-collision newcomers
+    std::array<std::array<int, BUCKET_SIZE>, NEW_BUCKET_COUNT> m_new;
+    std::array<std::array<int, BUCKET_SIZE>, TRIED_BUCKET_COUNT> m_tried;
+    size_t m_new_count{0};
+    size_t m_tried_count{0};
+    int m_next_id{0};
+    int64_t m_last_good{1};
+};
+
+} // namespace core

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -54,11 +54,18 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # carries a source KAT pinning the is_wire_advertisable() guard into all ten
     # per-coin getaddrs handlers. Same reasoning as above: FOLDED into the
     # EXISTING allowlisted core_test target, never a new add_executable.
+    # coin_addrman_test.cpp: core::CoinAddrMan, the dashd CAddrMan port that
+    # backs every per-coin CoinPeerManager (bucketed new/tried tables, keyed
+    # SipHash bucketing, quality-biased Select, tried-collision protocol,
+    # fail-safe peers.dat-equivalent persistence). Header-only over core, so
+    # it is FOLDED into the EXISTING allowlisted core_test target -- never a
+    # new add_executable (the #769 "Not Run" trap) -- and one KAT covers all
+    # coin lanes because they all consume this single shared DB.
     # web_server_dashboard_data_test.cpp: the 2026-08-05 hotel-dashboard DATA
     # honesty KATs (luck/netdiff-at-find, junk-row enrichment, block-value
     # split vs the accepted coinbase, fee units, last_block, best-share
     # persistence). Same fold-into-core_test reasoning as every TU here.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp)
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/coin_addrman_test.cpp
+++ b/src/core/test/coin_addrman_test.cpp
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// core::CoinAddrMan — KATs for the dashd CAddrMan port (bucketed new/tried
+// address DB behind every per-coin CoinPeerManager).
+//
+// Covers the four properties the port promises:
+//   1. BUCKETING DETERMINISM — coordinates are a pure function of the
+//      persisted SipHash key + address/netgroup: identical across instances
+//      with the same key, reshuffled under a different key, and an entire
+//      /16 is confined to <= TRIED_BUCKETS_PER_GROUP tried buckets (the
+//      anti-Sybil table-slice bound).
+//   2. SELECT QUALITY BIAS — the stochastic draw prefers a clean entry over
+//      one with a failed-attempt history (GetChance = 0.66^attempts).
+//   3. PERSIST/RELOAD ROUND-TRIP — entries, tried membership, and the bucket
+//      key survive save()+load().
+//   4. FAIL-SAFE COLD/CORRUPT DB — absent or corrupt files load EMPTY and
+//      never throw, so the seed ladder bootstraps exactly as on first run.
+// Plus the tried-collision protocol (park -> feeler -> resolve) and the
+// new-table growth beyond the legacy 20-peer working-set ceiling.
+//
+// FOLDED into the EXISTING allowlisted core_test target (never a new
+// add_executable — the #769 "Not Run" trap).
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <set>
+#include <string>
+
+#include <core/coin_addrman.hpp>
+
+using core::CoinAddrMan;
+
+namespace {
+
+NetService ns(const std::string& host, uint16_t port = 9999)
+{
+    return NetService(host, port);
+}
+
+std::string tmp_db_path(const std::string& tag)
+{
+    return "/tmp/c2pool_addrman_kat_" + tag + "_" +
+           std::to_string(::getpid()) + ".json";
+}
+
+} // namespace
+
+TEST(CoinAddrMan, BucketingDeterministicUnderTheKey)
+{
+    CoinAddrMan a(/*k0=*/1, /*k1=*/2);
+    CoinAddrMan b(/*k0=*/1, /*k1=*/2);
+    CoinAddrMan c(/*k0=*/3, /*k1=*/4);
+
+    int moved = 0;
+    for (int i = 0; i < 50; ++i) {
+        const auto addr = ns("51." + std::to_string(i) + ".7.9");
+        const int tb = a.test_tried_bucket(addr);
+        const int nb = a.test_new_bucket(addr, "");
+        // Same key => identical coordinates on an independent instance.
+        EXPECT_EQ(tb, b.test_tried_bucket(addr));
+        EXPECT_EQ(nb, b.test_new_bucket(addr, ""));
+        EXPECT_EQ(a.test_bucket_position(addr, false, tb),
+                  b.test_bucket_position(addr, false, tb));
+        // Ranges.
+        EXPECT_GE(tb, 0);
+        EXPECT_LT(tb, CoinAddrMan::TRIED_BUCKET_COUNT);
+        EXPECT_GE(nb, 0);
+        EXPECT_LT(nb, CoinAddrMan::NEW_BUCKET_COUNT);
+        EXPECT_LT(a.test_bucket_position(addr, true, nb), CoinAddrMan::BUCKET_SIZE);
+        // Different key => coordinates reshuffle (count how many move).
+        if (tb != c.test_tried_bucket(addr)) ++moved;
+    }
+    // With 256 tried buckets, a different key must move nearly all of them.
+    EXPECT_GT(moved, 40);
+}
+
+TEST(CoinAddrMan, TriedBucketsPerGroupBoundConfinesASlash16)
+{
+    CoinAddrMan a(11, 22);
+    std::set<int> buckets;
+    // 100 addresses all inside 51.77/16 — one netgroup.
+    for (int i = 1; i <= 100; ++i)
+        buckets.insert(a.test_tried_bucket(ns("51.77.0." + std::to_string(i))));
+    EXPECT_LE(static_cast<int>(buckets.size()),
+              CoinAddrMan::TRIED_BUCKETS_PER_GROUP);
+
+    // And one source group can spray at most 64 distinct new buckets.
+    std::set<int> new_buckets;
+    for (int i = 1; i <= 200; ++i)
+        new_buckets.insert(a.test_new_bucket(
+            ns("52." + std::to_string(i) + ".3.4"), "198.51.100.7"));
+    EXPECT_LE(static_cast<int>(new_buckets.size()),
+              CoinAddrMan::NEW_BUCKETS_PER_SOURCE_GROUP);
+}
+
+TEST(CoinAddrMan, AddDedupsAndCapsNewBucketReferences)
+{
+    CoinAddrMan a(5, 6);
+    const auto addr = ns("51.68.10.20");
+    EXPECT_TRUE(a.add(addr));
+    EXPECT_EQ(a.size(), 1u);
+    // Re-announcing from many sources never duplicates the entry.
+    for (int i = 0; i < 100; ++i)
+        a.add(addr, "60." + std::to_string(i) + ".1.1");
+    EXPECT_EQ(a.size(), 1u);
+    EXPECT_EQ(a.new_count(), 1u);
+}
+
+TEST(CoinAddrMan, GrowsFarBeyondTheLegacyWorkingSetCeiling)
+{
+    CoinAddrMan a(7, 8);
+    // 500 addresses across 500 distinct /16 groups — the flat working set
+    // capped out at ~20; the bucketed DB must bank essentially all of them.
+    for (int i = 0; i < 500; ++i)
+        a.add(ns("51." + std::to_string(i % 250) + "." +
+                 std::to_string(i / 250) + ".9"));
+    EXPECT_GT(a.size(), 450u);
+    EXPECT_EQ(a.tried_count(), 0u);
+}
+
+TEST(CoinAddrMan, GoodPromotesToTriedAndAttemptCountsFailures)
+{
+    CoinAddrMan a(9, 10);
+    const auto addr = ns("51.15.30.40");
+    ASSERT_TRUE(a.add(addr));
+    EXPECT_FALSE(a.is_tried(addr));
+
+    a.good(addr);
+    EXPECT_TRUE(a.is_tried(addr));
+    EXPECT_EQ(a.tried_count(), 1u);
+    EXPECT_EQ(a.new_count(), 0u);
+
+    // Attempt() on an unknown address is a silent no-op.
+    a.attempt(ns("51.99.99.99"));
+    EXPECT_EQ(a.size(), 1u);
+}
+
+TEST(CoinAddrMan, SelectPrefersCleanOverFailureHistory)
+{
+    CoinAddrMan a(13, 37);
+    a.seed_rng(42);
+    const auto clean = ns("51.10.1.1");
+    const auto flaky = ns("52.20.2.2");
+    ASSERT_TRUE(a.add(clean));
+    ASSERT_TRUE(a.add(flaky));
+
+    const int64_t now = 1700000000;
+    // Both fresh (not terrible), both outside the 10-minute recent-try
+    // deprioritizer; the flaky one carries 8 counted failed attempts, so its
+    // GetChance is 0.66^8 ~ 3.6% of the clean one's.
+    ASSERT_TRUE(a.test_set_times(clean, now, now - 3600, 0, 0));
+    ASSERT_TRUE(a.test_set_times(flaky, now, now - 3600, 0, 8));
+
+    int clean_draws = 0, flaky_draws = 0;
+    for (int i = 0; i < 300; ++i) {
+        auto pick = a.select(/*new_only=*/false, now);
+        ASSERT_TRUE(pick.has_value());
+        if (pick->to_string() == clean.to_string()) ++clean_draws;
+        else if (pick->to_string() == flaky.to_string()) ++flaky_draws;
+    }
+    EXPECT_EQ(clean_draws + flaky_draws, 300);
+    // Expected flaky share ~ q/(1+q) with q ~ 0.036 => ~3-4%. Allow head
+    // room: it must stay far below parity.
+    EXPECT_GT(clean_draws, flaky_draws * 4);
+}
+
+TEST(CoinAddrMan, PersistReloadRoundTrip)
+{
+    const std::string path = tmp_db_path("roundtrip");
+    std::remove(path.c_str());
+
+    CoinAddrMan a(21, 43);
+    std::vector<NetService> tried_addrs;
+    for (int i = 0; i < 20; ++i) {
+        const auto addr = ns("51." + std::to_string(100 + i) + ".5.6");
+        ASSERT_TRUE(a.add(addr));
+        if (i < 10) {
+            a.good(addr);
+            tried_addrs.push_back(addr);
+        }
+    }
+    ASSERT_EQ(a.size(), 20u);
+    ASSERT_EQ(a.tried_count(), 10u);
+    ASSERT_TRUE(a.save(path));
+
+    CoinAddrMan b;   // fresh random key — load() must restore the saved one
+    EXPECT_TRUE(b.load(path));
+    EXPECT_EQ(b.size(), 20u);
+    EXPECT_EQ(b.tried_count(), 10u);
+    EXPECT_EQ(b.bucket_key(), a.bucket_key());
+    for (const auto& addr : tried_addrs) {
+        EXPECT_TRUE(b.contains(addr)) << addr.to_string();
+        EXPECT_TRUE(b.is_tried(addr)) << addr.to_string();
+    }
+    std::remove(path.c_str());
+}
+
+TEST(CoinAddrMan, ColdAndCorruptDbLoadEmptyNeverThrow)
+{
+    CoinAddrMan a(3, 9);
+    // Absent file: cold start, empty DB, false (seeds bootstrap).
+    EXPECT_FALSE(a.load("/tmp/c2pool_addrman_kat_definitely_absent.json"));
+    EXPECT_EQ(a.size(), 0u);
+
+    // Corrupt file: garbage bytes.
+    const std::string garbage = tmp_db_path("garbage");
+    { std::ofstream ofs(garbage); ofs << "{not json at all"; }
+    EXPECT_FALSE(a.load(garbage));
+    EXPECT_EQ(a.size(), 0u);
+    std::remove(garbage.c_str());
+
+    // Valid JSON, wrong shape/version: same fail-safe.
+    const std::string wrong = tmp_db_path("wrongshape");
+    { std::ofstream ofs(wrong); ofs << "{\"version\": 99}"; }
+    EXPECT_FALSE(a.load(wrong));
+    EXPECT_EQ(a.size(), 0u);
+    std::remove(wrong.c_str());
+}
+
+TEST(CoinAddrMan, TriedCollisionParksFeelerAndResolves)
+{
+    CoinAddrMan a(77, 88);
+    a.seed_rng(7);
+
+    // Incumbent takes its tried slot.
+    const auto incumbent = ns("51.30.1.1");
+    ASSERT_TRUE(a.add(incumbent));
+    a.good(incumbent);
+    const int bucket = a.test_tried_bucket(incumbent);
+    const int pos = a.test_bucket_position(incumbent, false, bucket);
+
+    // Find a challenger whose tried coordinates collide with the incumbent.
+    NetService challenger;
+    bool found = false;
+    for (int i = 0; i < 200000 && !found; ++i) {
+        NetService cand = ns("52." + std::to_string(i % 256) + "." +
+                             std::to_string((i / 256) % 256) + "." +
+                             std::to_string(1 + i / 65536));
+        if (a.test_tried_bucket(cand) == bucket &&
+            a.test_bucket_position(cand, false, bucket) == pos) {
+            challenger = cand;
+            found = true;
+        }
+    }
+    ASSERT_TRUE(found) << "no colliding address in the search space";
+
+    ASSERT_TRUE(a.add(challenger));
+    a.good(challenger);
+    // Parked as a collision, NOT tried yet; the feeler leg hands out the
+    // incumbent for a re-test.
+    EXPECT_FALSE(a.is_tried(challenger));
+    EXPECT_EQ(a.collision_count(), 1u);
+    auto feeler = a.select_tried_collision();
+    ASSERT_TRUE(feeler.has_value());
+    EXPECT_EQ(feeler->to_string(), incumbent.to_string());
+
+    // Incumbent just proved alive (good() stamped last_success=now):
+    // resolution keeps it and drops the challenge.
+    a.resolve_collisions();
+    EXPECT_EQ(a.collision_count(), 0u);
+    EXPECT_TRUE(a.is_tried(incumbent));
+    EXPECT_FALSE(a.is_tried(challenger));
+
+    // Challenge again, but now the incumbent's last re-test FAILED recently
+    // (last_try 2 minutes ago, last success long past): dashd's rules evict
+    // it in favour of the challenger.
+    a.good(challenger);
+    EXPECT_EQ(a.collision_count(), 1u);
+    const int64_t now = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    ASSERT_TRUE(a.test_set_times(incumbent, now, /*last_try=*/now - 120,
+                                 /*last_success=*/now - 6 * 3600));
+    a.resolve_collisions();
+    EXPECT_EQ(a.collision_count(), 0u);
+    EXPECT_TRUE(a.is_tried(challenger));
+    EXPECT_FALSE(a.is_tried(incumbent));
+    // The evicted incumbent is demoted to new — history kept, not erased.
+    EXPECT_TRUE(a.contains(incumbent));
+}
+
+TEST(CoinAddrMan, GetAddrSamplesAndHonorsTriedOnly)
+{
+    CoinAddrMan a(15, 16);
+    a.seed_rng(3);
+    const int64_t now = 1700000000;
+    for (int i = 0; i < 40; ++i) {
+        const auto addr = ns("51." + std::to_string(i) + ".8.8");
+        ASSERT_TRUE(a.add(addr, "", CoinAddrMan::DEFAULT_TIME_PENALTY, now));
+        if (i % 2 == 0) a.good(addr, now);
+    }
+    auto all = a.get_addr(/*max_pct=*/100, /*max_count=*/2500,
+                          /*tried_only=*/false, now);
+    EXPECT_EQ(all.size(), 40u);
+    auto tried = a.get_addr(100, 2500, /*tried_only=*/true, now);
+    EXPECT_EQ(tried.size(), 20u);
+    // 23%/2500 default shape.
+    auto sample = a.get_addr(23, 2500, false, now);
+    EXPECT_EQ(sample.size(), 40u * 23 / 100);
+}

--- a/src/impl/btc/coin/coin_peer_manager.hpp
+++ b/src/impl/btc/coin/coin_peer_manager.hpp
@@ -57,6 +57,7 @@
 #include <core/filesystem.hpp>
 #include <core/netaddress.hpp>
 #include <core/dns_seeder.hpp>
+#include <core/coin_addrman.hpp>
 
 namespace btc {
 namespace coin {
@@ -360,10 +361,15 @@ public:
 
     /// Add a peer discovered via P2P addr message.
     /// Validates via PeerEndpoint: rejects empty, unparseable, and non-routable addresses.
-    void add_discovered_peer(const NetService& addr)
+    /// source_host: the peer that gossiped this address (bucket-keys the
+    /// banked entry, bounding how far one source can spray the new table;
+    /// empty = self-announced). Existing call sites need no change.
+    void add_discovered_peer(const NetService& addr,
+                             const std::string& source_host = std::string())
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        try_add_peer_locked(addr, BtcPeerInfo::Source::addr_crawl, /*require_routable=*/true);
+        try_add_peer_locked(addr, BtcPeerInfo::Source::addr_crawl, /*require_routable=*/true,
+                            source_host);
     }
 
     /// Get list of peers that should be connected right now.
@@ -422,6 +428,47 @@ public:
             result.push_back(c.endpoint);
             connected_groups[c.group]++;
         }
+
+        // ── Addrman top-up (dashd CAddrMan port) ──
+        // The score-sorted working set above covers pinned/anchor/known
+        // peers; any remaining budget is drawn from the bucketed DB with
+        // dashd's stochastic quality-biased Select(), so dial plans explore
+        // the whole banked address space instead of re-hammering the same
+        // hand-picked few. One tried-collision incumbent is drawn first
+        // (the feeler leg): re-dialing it gives resolve_collisions() real
+        // evidence to keep or evict it. Group diversity and per-peer
+        // backoff (can_retry) gate the draws exactly like the legacy path.
+        if (static_cast<int>(result.size()) < budget) {
+            std::vector<NetService> draws;
+            if (auto incumbent = m_addrman.select_tried_collision())
+                draws.push_back(*incumbent);
+            const int deficit = budget - static_cast<int>(result.size());
+            for (int i = 0; i < deficit * 4
+                 && static_cast<int>(draws.size()) < deficit + 1; ++i) {
+                auto pick = m_addrman.select();
+                if (!pick) break;
+                draws.push_back(*pick);
+            }
+            for (auto& ns : draws) {
+                if (static_cast<int>(result.size()) >= budget) break;
+                auto ep = PeerEndpoint::from(ns);
+                if (!ep) continue;
+                const auto key = ep->to_string();
+                if (connected_keys.count(key)) continue;
+                bool dup = false;
+                for (auto& r : result)
+                    if (r.to_string() == key) { dup = true; break; }
+                if (dup) continue;
+                auto known = m_peers.find(key);
+                if (known != m_peers.end() && !known->second.can_retry())
+                    continue;
+                auto grp = peer_network_group(ep->host());
+                if (connected_groups[grp] >= MAX_OUTBOUND_PER_GROUP
+                    && !grp.empty()) continue;
+                result.push_back(*ep);
+                connected_groups[grp]++;
+            }
+        }
         return result;
     }
 
@@ -429,11 +476,14 @@ public:
     void notify_connected(const std::string& key)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_connected();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_connected();
             // Track as anchor candidate (most recent successful connections)
             update_anchors(key);
+            // Promote in the bucketed DB: Good() moves the entry into the
+            // tried table (or parks a tried-collision for the feeler leg).
+            m_addrman.good(peer->address);
             // Live-connection census: this key is now an established outbound
             // link. The maintenance loop's emergency starvation gate keys off
             // m_connected_keys.size() (see on_maintenance_tick).
@@ -450,6 +500,9 @@ public:
         auto it = m_peers.find(key);
         if (it != m_peers.end()) {
             it->second.record_disconnected();
+            // It completed a handshake earlier, so it WAS alive: refresh
+            // the bucketed DB's believed-alive stamp (dashd Connected()).
+            m_addrman.connected(it->second.address);
         }
     }
 
@@ -464,9 +517,13 @@ public:
     {
         std::lock_guard<std::mutex> lock(m_mutex);
         m_connected_keys.erase(key);   // a failed dial never became a live link
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_dial_failed();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_dial_failed();
+            // #940 feedback also reaches the bucketed DB: a counted
+            // failed attempt lowers GetChance() so Select() stops
+            // re-drawing the dead target (mirrors dashd Attempt()).
+            m_addrman.attempt(peer->address);
         }
     }
 
@@ -620,8 +677,12 @@ public:
     bool discovery_enabled() const
     {
         if (m_config.disable_discovery) return false;
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return static_cast<int>(m_peers.size()) < m_config.max_peers;
+        // The bucketed DB is the getaddr sink now: keep harvesting until
+        // it is of table order (~82k slots) — in practice always, exactly
+        // like dashd keeps banking addr gossip. The old working-set gate
+        // (m_peers.size() < max_peers) stopped discovery at a handful of
+        // peers and starved daemonless block download of dial candidates.
+        return m_addrman.size() < core::CoinAddrMan::soft_capacity();
     }
 
     /// Remove peers that are exhausted (max attempts reached, not protected).
@@ -688,6 +749,21 @@ public:
             if (!ep || !ep->is_routable()) continue;
             result.push_back(*ep);
         }
+        // Top up from the bucketed DB's tried sample so a node serves
+        // more than its small working set once the DB has grown (dashd
+        // GetAddr; tried-only + routable keeps the unverified out).
+        for (auto& ns : m_addrman.get_addr(
+                 /*max_pct=*/100,
+                 /*max_count=*/static_cast<size_t>(max_count) * 2,
+                 /*tried_only=*/true)) {
+            auto ep = PeerEndpoint::from(ns);
+            if (!ep || !ep->is_routable()) continue;
+            bool dup = false;
+            for (auto& r : result)
+                if (r.to_string() == ep->to_string()) { dup = true; break; }
+            if (dup) continue;
+            result.push_back(*ep);
+        }
         // Shuffle for privacy (don't reveal connection order/topology)
         if (result.size() > 1) {
             thread_local std::mt19937 rng(std::random_device{}());
@@ -697,6 +773,10 @@ public:
             result.erase(result.begin() + max_count, result.end());
         return result;
     }
+
+    /// Bucketed address DB (dashd CAddrMan port) — diagnostics/KATs.
+    core::CoinAddrMan& addrman() { return m_addrman; }
+    const core::CoinAddrMan& addrman() const { return m_addrman; }
 
 private:
     /// Unified peer validation and insertion (caller must hold m_mutex).
@@ -710,7 +790,8 @@ private:
     ///                          peers (getpeerinfo) which may be LAN hosts.
     /// @return true if the peer was added, false if rejected.
     bool try_add_peer_locked(const NetService& addr, BtcPeerInfo::Source source,
-                             bool require_routable)
+                             bool require_routable,
+                             const std::string& source_host = std::string())
     {
         // ── Validate via PeerEndpoint (type-safe, Bitcoin Core classification) ──
         auto ep = PeerEndpoint::from(addr);
@@ -728,6 +809,18 @@ private:
 
         // ── Port filter ──
         if (!is_valid_port(ep->port())) return false;
+
+        // ── Bank in the bucketed address DB (dashd CAddrMan port) ──
+        // Every validated non-daemon candidate is banked BEFORE the
+        // working-set gates below: the capacity/dedup/group caps bound the
+        // small ACTIVE dial set, while the bank is the large archival
+        // history the dial planner draws from (repeat gossip refreshes
+        // freshness there instead of being dropped on the floor).
+        // Daemon-learned peers are deliberately NOT banked — the bank must
+        // stay an INDEPENDENT view of the network.
+        if (source != BtcPeerInfo::Source::coind
+            && !m_coind_peers.count(ep->to_string()))
+            m_addrman.add(ep->to_net_service(), source_host);
 
         // ── Capacity gating ──
         if (static_cast<int>(m_peers.size()) >= m_config.max_peers) return false;
@@ -759,6 +852,37 @@ private:
         peer.last_seen = std::chrono::steady_clock::now();
         peer.max_attempts = m_config.max_connection_attempts;
         return true;
+    }
+
+    /// Materialize a working-set entry for an addrman-drawn dial target
+    /// (or any endpoint the transport reports on) so the notify_*
+    /// feedback — including the #940 dial-failure leg — always lands on
+    /// a scored entry. Returns nullptr for an unparseable key.
+    BtcPeerInfo* ensure_working_entry_locked(const std::string& key)
+    {
+        auto it = m_peers.find(key);
+        if (it != m_peers.end()) return &it->second;
+        const auto colon = key.rfind(':');
+        if (colon == std::string::npos) return nullptr;
+        uint16_t port = 0;
+        try {
+            const unsigned long v = std::stoul(key.substr(colon + 1));
+            if (v == 0 || v > 65535) return nullptr;
+            port = static_cast<uint16_t>(v);
+        } catch (const std::exception&) {
+            return nullptr;
+        }
+        auto ep = PeerEndpoint::from(key.substr(0, colon), port);
+        if (!ep) return nullptr;
+        auto& peer = m_peers[key];
+        peer.address = ep->to_net_service();
+        peer.addr_class = ep->addr_class();
+        peer.source = BtcPeerInfo::Source::addr_crawl;
+        peer.network_group = peer_network_group(ep->host());
+        peer.first_seen = std::chrono::steady_clock::now();
+        peer.last_seen = std::chrono::steady_clock::now();
+        peer.max_attempts = m_config.max_connection_attempts;
+        return &peer;
     }
 
     bool is_valid_port(uint16_t port) const
@@ -873,6 +997,10 @@ private:
         m_maintenance_timer.async_wait([this](const boost::system::error_code& ec) {
             if (ec || !m_running) return;
             schedule_maintenance();
+
+            // Tried-collision resolution for the bucketed DB (dashd
+            // ResolveCollisions cadence rides the maintenance tick).
+            m_addrman.resolve_collisions();
             // Emergency seed re-arm: was a no-op (the fallbacks never re-armed).
             // Drive the spec handler with the live connection count so a node
             // that churns below min_peers after the initial windows recovers.
@@ -915,6 +1043,18 @@ private:
         return (dir / ("peers_" + sym + ".json")).string();
     }
 
+    /// Bucketed-DB file (peers.dat equivalent), beside the working-set
+    /// JSON in the same per-coin directory.
+    std::string addrman_db_path() const
+    {
+        const std::filesystem::path p = db_path();
+        const std::string stem = p.stem().string();   // "peers_<SYM>"
+        const std::string prefix = "peers_";
+        const std::string sym = stem.rfind(prefix, 0) == 0
+            ? stem.substr(prefix.size()) : stem;
+        return (p.parent_path() / ("addrman_" + sym + ".json")).string();
+    }
+
     void save_peers()
     {
         try {
@@ -954,6 +1094,9 @@ private:
                 ofs << j.dump(2);
             }
             std::rename(tmp_path.c_str(), db_path().c_str());
+            // Bucketed DB persists beside the working-set JSON (peers.dat
+            // equivalent; addrman does its own atomic tmp+rename).
+            m_addrman.save(addrman_db_path());
             LOG_DEBUG_COIND << "[" << m_symbol << "] Saved " << m_peers.size() << " peers";
         } catch (const std::exception& e) {
             LOG_WARNING << "[" << m_symbol << "] Failed to save peers: " << e.what();
@@ -962,6 +1105,15 @@ private:
 
     void load_peers()
     {
+        // Bucketed DB (peers.dat equivalent). FAIL-SAFE: a corrupt or
+        // absent file loads EMPTY (load() never throws) and the seed
+        // ladder then bootstraps exactly as on first run.
+        if (m_addrman.load(addrman_db_path())) {
+            LOG_INFO << "[" << m_symbol << "] AddrMan loaded: "
+                     << m_addrman.size() << " known ("
+                     << m_addrman.tried_count() << " tried) from "
+                     << addrman_db_path();
+        }
         try {
             std::ifstream ifs(db_path());
             if (!ifs.is_open()) return;
@@ -1278,6 +1430,11 @@ private:
     boost::asio::steady_timer m_emergency_timer;    // dedicated emergency re-arm (never stomps the one-shots)
 
     mutable std::mutex m_mutex;
+    /// Bucketed new/tried address DB (dashd CAddrMan port). mutable:
+    /// draws and samples only permute internal iteration state, and the
+    /// DB carries its own lock (always taken AFTER m_mutex, never the
+    /// reverse — CoinAddrMan calls nothing back).
+    mutable core::CoinAddrMan m_addrman;
     std::map<std::string, BtcPeerInfo> m_peers;     // key = "host:port"
     std::set<std::string> m_coind_peers;            // daemon's own peers (overlap filter)
     std::string m_local_node_key;

--- a/src/impl/btc/test/coin_peer_manager_test.cpp
+++ b/src/impl/btc/test/coin_peer_manager_test.cpp
@@ -215,3 +215,81 @@ TEST(BtcCoinPeerManager, EmergencyRecoveryResetsBackoffToBase)
 
     mgr.stop();
 }
+
+// ---------------------------------------------------------------------------
+// Bucketed addrman integration KATs (dashd CAddrMan port,
+// core/coin_addrman.hpp behind every per-coin manager).
+//
+// Same zero-socket discipline as above: nothing here dials, resolves, or
+// fetches. The corrupt-DB KAT is the manager-level half of the fail-safe
+// contract (core_test carries the CoinAddrMan-level half): a bad DB file
+// must load EMPTY and leave the seed/admission path exactly as on first run.
+// ---------------------------------------------------------------------------
+
+TEST(BtcCoinPeerManager, AddrmanBanksBeyondWorkingSetCapacity)
+{
+    boost::asio::io_context ioc;
+    BtcPeerManagerConfig cfg;
+    cfg.max_peers = 3;
+    auto m = make_mgr(ioc, cfg);
+    for (int i = 0; i < 10; ++i)
+        m->add_discovered_peer(
+            NetService("51." + std::to_string(10 + i) + ".1.1", 8333));
+    // The working set stops at its capacity gate (unchanged behaviour)...
+    EXPECT_EQ(m->peer_stats().total, cfg.max_peers);
+    // ...but the bucketed DB banks EVERY validated candidate — the harvest
+    // that used to be dropped on the floor.
+    EXPECT_EQ(m->addrman().size(), 10u);
+}
+
+TEST(BtcCoinPeerManager, DialPlanDrawsFromAddrmanAndDialFailFeedbackLands)
+{
+    boost::asio::io_context ioc;
+    auto m = make_mgr(ioc, BtcPeerManagerConfig{});
+    // Bank straight into the DB; the working set stays EMPTY. The dial plan
+    // must still produce candidates — the stochastic addrman draw leg.
+    for (int i = 0; i < 8; ++i)
+        m->addrman().add(NetService("51." + std::to_string(30 + i) + ".2.2", 8333));
+    ASSERT_EQ(m->peer_stats().total, 0);
+    auto plan = m->get_peers_to_connect({});
+    ASSERT_FALSE(plan.empty());
+    // #940: a dial failure on a drawn candidate lands in BOTH scorers — the
+    // working-set entry is materialized on the fly.
+    m->notify_dial_failed(plan.front().to_string());
+    EXPECT_EQ(m->peer_stats().total, 1);
+    EXPECT_TRUE(m->addrman().contains(plan.front().to_net_service()));
+}
+
+TEST(BtcCoinPeerManager, ConnectPromotesToTriedInTheDb)
+{
+    boost::asio::io_context ioc;
+    auto m = make_mgr(ioc, BtcPeerManagerConfig{});
+    const NetService peer("51.50.5.5", 8333);
+    m->add_discovered_peer(peer);
+    m->notify_connected(peer.to_string());
+    EXPECT_TRUE(m->addrman().is_tried(peer));
+    EXPECT_EQ(m->addrman().tried_count(), 1u);
+}
+
+TEST(BtcCoinPeerManager, CorruptAddrmanDbIsFailSafe)
+{
+    boost::asio::io_context ioc;
+    const std::string dir =
+        "/tmp/c2pool_btc_addrman_kat_" + std::to_string(::getpid());
+    std::filesystem::create_directories(dir);
+    {
+        std::ofstream ofs(dir + "/addrman_BTC.json");
+        ofs << "definitely{not json";
+    }
+    BtcPeerManagerConfig cfg;
+    auto m = std::make_unique<BtcCoinPeerManager>(ioc, "BTC", dir, cfg);
+    // start() loads the corrupt DB: must not throw, must come up EMPTY, and
+    // discovery/admission keeps working exactly as on first run (timers are
+    // armed but the io_context is never run, so nothing fetches).
+    EXPECT_NO_THROW(m->start());
+    EXPECT_EQ(m->addrman().size(), 0u);
+    m->add_discovered_peer(NetService("51.60.6.6", 8333));
+    EXPECT_EQ(m->addrman().size(), 1u);
+    EXPECT_NO_THROW(m->stop());
+    std::filesystem::remove_all(dir);
+}

--- a/src/impl/dash/coin/coin_peer_manager.hpp
+++ b/src/impl/dash/coin/coin_peer_manager.hpp
@@ -58,6 +58,7 @@
 #include <core/filesystem.hpp>
 #include <core/netaddress.hpp>
 #include <core/dns_seeder.hpp>
+#include <core/coin_addrman.hpp>
 
 namespace dash {
 namespace coin {
@@ -361,10 +362,15 @@ public:
 
     /// Add a peer discovered via P2P addr message.
     /// Validates via PeerEndpoint: rejects empty, unparseable, and non-routable addresses.
-    void add_discovered_peer(const NetService& addr)
+    /// source_host: the peer that gossiped this address (bucket-keys the
+    /// banked entry, bounding how far one source can spray the new table;
+    /// empty = self-announced). Existing call sites need no change.
+    void add_discovered_peer(const NetService& addr,
+                             const std::string& source_host = std::string())
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        try_add_peer_locked(addr, DashPeerInfo::Source::addr_crawl, /*require_routable=*/true);
+        try_add_peer_locked(addr, DashPeerInfo::Source::addr_crawl, /*require_routable=*/true,
+                            source_host);
     }
 
     /// Get list of peers that should be connected right now.
@@ -423,6 +429,47 @@ public:
             result.push_back(c.endpoint);
             connected_groups[c.group]++;
         }
+
+        // ── Addrman top-up (dashd CAddrMan port) ──
+        // The score-sorted working set above covers pinned/anchor/known
+        // peers; any remaining budget is drawn from the bucketed DB with
+        // dashd's stochastic quality-biased Select(), so dial plans explore
+        // the whole banked address space instead of re-hammering the same
+        // hand-picked few. One tried-collision incumbent is drawn first
+        // (the feeler leg): re-dialing it gives resolve_collisions() real
+        // evidence to keep or evict it. Group diversity and per-peer
+        // backoff (can_retry) gate the draws exactly like the legacy path.
+        if (static_cast<int>(result.size()) < budget) {
+            std::vector<NetService> draws;
+            if (auto incumbent = m_addrman.select_tried_collision())
+                draws.push_back(*incumbent);
+            const int deficit = budget - static_cast<int>(result.size());
+            for (int i = 0; i < deficit * 4
+                 && static_cast<int>(draws.size()) < deficit + 1; ++i) {
+                auto pick = m_addrman.select();
+                if (!pick) break;
+                draws.push_back(*pick);
+            }
+            for (auto& ns : draws) {
+                if (static_cast<int>(result.size()) >= budget) break;
+                auto ep = PeerEndpoint::from(ns);
+                if (!ep) continue;
+                const auto key = ep->to_string();
+                if (connected_keys.count(key)) continue;
+                bool dup = false;
+                for (auto& r : result)
+                    if (r.to_string() == key) { dup = true; break; }
+                if (dup) continue;
+                auto known = m_peers.find(key);
+                if (known != m_peers.end() && !known->second.can_retry())
+                    continue;
+                auto grp = peer_network_group(ep->host());
+                if (connected_groups[grp] >= MAX_OUTBOUND_PER_GROUP
+                    && !grp.empty()) continue;
+                result.push_back(*ep);
+                connected_groups[grp]++;
+            }
+        }
         return result;
     }
 
@@ -430,11 +477,14 @@ public:
     void notify_connected(const std::string& key)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_connected();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_connected();
             // Track as anchor candidate (most recent successful connections)
             update_anchors(key);
+            // Promote in the bucketed DB: Good() moves the entry into the
+            // tried table (or parks a tried-collision for the feeler leg).
+            m_addrman.good(peer->address);
         }
         m_connected_keys.insert(key);           // live connected count (emergency drive)
         if (!m_bootstrapped) m_bootstrapped = true;
@@ -447,6 +497,9 @@ public:
         auto it = m_peers.find(key);
         if (it != m_peers.end()) {
             it->second.record_disconnected();
+            // It completed a handshake earlier, so it WAS alive: refresh
+            // the bucketed DB's believed-alive stamp (dashd Connected()).
+            m_addrman.connected(it->second.address);
         }
         m_connected_keys.erase(key);            // live connected count (emergency drive)
     }
@@ -461,9 +514,13 @@ public:
     void notify_dial_failed(const std::string& key)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_dial_failed();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_dial_failed();
+            // #940 feedback also reaches the bucketed DB: a counted
+            // failed attempt lowers GetChance() so Select() stops
+            // re-drawing the dead target (mirrors dashd Attempt()).
+            m_addrman.attempt(peer->address);
         }
     }
 
@@ -604,8 +661,12 @@ public:
     bool discovery_enabled() const
     {
         if (m_config.disable_discovery) return false;
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return static_cast<int>(m_peers.size()) < m_config.max_peers;
+        // The bucketed DB is the getaddr sink now: keep harvesting until
+        // it is of table order (~82k slots) — in practice always, exactly
+        // like dashd keeps banking addr gossip. The old working-set gate
+        // (m_peers.size() < max_peers) stopped discovery at a handful of
+        // peers and starved daemonless block download of dial candidates.
+        return m_addrman.size() < core::CoinAddrMan::soft_capacity();
     }
 
     /// Remove peers that are exhausted (max attempts reached, not protected).
@@ -672,6 +733,21 @@ public:
             if (!ep || !ep->is_routable()) continue;
             result.push_back(*ep);
         }
+        // Top up from the bucketed DB's tried sample so a node serves
+        // more than its small working set once the DB has grown (dashd
+        // GetAddr; tried-only + routable keeps the unverified out).
+        for (auto& ns : m_addrman.get_addr(
+                 /*max_pct=*/100,
+                 /*max_count=*/static_cast<size_t>(max_count) * 2,
+                 /*tried_only=*/true)) {
+            auto ep = PeerEndpoint::from(ns);
+            if (!ep || !ep->is_routable()) continue;
+            bool dup = false;
+            for (auto& r : result)
+                if (r.to_string() == ep->to_string()) { dup = true; break; }
+            if (dup) continue;
+            result.push_back(*ep);
+        }
         // Shuffle for privacy (don't reveal connection order/topology)
         if (result.size() > 1) {
             thread_local std::mt19937 rng(std::random_device{}());
@@ -681,6 +757,10 @@ public:
             result.erase(result.begin() + max_count, result.end());
         return result;
     }
+
+    /// Bucketed address DB (dashd CAddrMan port) — diagnostics/KATs.
+    core::CoinAddrMan& addrman() { return m_addrman; }
+    const core::CoinAddrMan& addrman() const { return m_addrman; }
 
 private:
     /// Unified peer validation and insertion (caller must hold m_mutex).
@@ -694,7 +774,8 @@ private:
     ///                          peers (getpeerinfo) which may be LAN hosts.
     /// @return true if the peer was added, false if rejected.
     bool try_add_peer_locked(const NetService& addr, DashPeerInfo::Source source,
-                             bool require_routable)
+                             bool require_routable,
+                             const std::string& source_host = std::string())
     {
         // ── Validate via PeerEndpoint (type-safe, Bitcoin Core classification) ──
         auto ep = PeerEndpoint::from(addr);
@@ -712,6 +793,18 @@ private:
 
         // ── Port filter ──
         if (!is_valid_port(ep->port())) return false;
+
+        // ── Bank in the bucketed address DB (dashd CAddrMan port) ──
+        // Every validated non-daemon candidate is banked BEFORE the
+        // working-set gates below: the capacity/dedup/group caps bound the
+        // small ACTIVE dial set, while the bank is the large archival
+        // history the dial planner draws from (repeat gossip refreshes
+        // freshness there instead of being dropped on the floor).
+        // Daemon-learned peers are deliberately NOT banked — the bank must
+        // stay an INDEPENDENT view of the network.
+        if (source != DashPeerInfo::Source::coind
+            && !m_coind_peers.count(ep->to_string()))
+            m_addrman.add(ep->to_net_service(), source_host);
 
         // ── Capacity gating ──
         if (static_cast<int>(m_peers.size()) >= m_config.max_peers) return false;
@@ -743,6 +836,37 @@ private:
         peer.last_seen = std::chrono::steady_clock::now();
         peer.max_attempts = m_config.max_connection_attempts;
         return true;
+    }
+
+    /// Materialize a working-set entry for an addrman-drawn dial target
+    /// (or any endpoint the transport reports on) so the notify_*
+    /// feedback — including the #940 dial-failure leg — always lands on
+    /// a scored entry. Returns nullptr for an unparseable key.
+    DashPeerInfo* ensure_working_entry_locked(const std::string& key)
+    {
+        auto it = m_peers.find(key);
+        if (it != m_peers.end()) return &it->second;
+        const auto colon = key.rfind(':');
+        if (colon == std::string::npos) return nullptr;
+        uint16_t port = 0;
+        try {
+            const unsigned long v = std::stoul(key.substr(colon + 1));
+            if (v == 0 || v > 65535) return nullptr;
+            port = static_cast<uint16_t>(v);
+        } catch (const std::exception&) {
+            return nullptr;
+        }
+        auto ep = PeerEndpoint::from(key.substr(0, colon), port);
+        if (!ep) return nullptr;
+        auto& peer = m_peers[key];
+        peer.address = ep->to_net_service();
+        peer.addr_class = ep->addr_class();
+        peer.source = DashPeerInfo::Source::addr_crawl;
+        peer.network_group = peer_network_group(ep->host());
+        peer.first_seen = std::chrono::steady_clock::now();
+        peer.last_seen = std::chrono::steady_clock::now();
+        peer.max_attempts = m_config.max_connection_attempts;
+        return &peer;
     }
 
     bool is_valid_port(uint16_t port) const
@@ -858,6 +982,10 @@ private:
             if (ec || !m_running) return;
             schedule_maintenance();
 
+            // Tried-collision resolution for the bucketed DB (dashd
+            // ResolveCollisions cadence rides the maintenance tick).
+            m_addrman.resolve_collisions();
+
             // Emergency seed re-arm drive (never-re-arm defect fix): observe the
             // live connected-peer count and, while starved below min_peers, run a
             // self-backing-off fallback cycle guarded by the re-entry latch;
@@ -899,6 +1027,18 @@ private:
         return (dir / ("peers_" + sym + ".json")).string();
     }
 
+    /// Bucketed-DB file (peers.dat equivalent), beside the working-set
+    /// JSON in the same per-coin directory.
+    std::string addrman_db_path() const
+    {
+        const std::filesystem::path p = db_path();
+        const std::string stem = p.stem().string();   // "peers_<SYM>"
+        const std::string prefix = "peers_";
+        const std::string sym = stem.rfind(prefix, 0) == 0
+            ? stem.substr(prefix.size()) : stem;
+        return (p.parent_path() / ("addrman_" + sym + ".json")).string();
+    }
+
     void save_peers()
     {
         try {
@@ -938,6 +1078,9 @@ private:
                 ofs << j.dump(2);
             }
             std::rename(tmp_path.c_str(), db_path().c_str());
+            // Bucketed DB persists beside the working-set JSON (peers.dat
+            // equivalent; addrman does its own atomic tmp+rename).
+            m_addrman.save(addrman_db_path());
             LOG_DEBUG_COIND << "[" << m_symbol << "] Saved " << m_peers.size() << " peers";
         } catch (const std::exception& e) {
             LOG_WARNING << "[" << m_symbol << "] Failed to save peers: " << e.what();
@@ -946,6 +1089,15 @@ private:
 
     void load_peers()
     {
+        // Bucketed DB (peers.dat equivalent). FAIL-SAFE: a corrupt or
+        // absent file loads EMPTY (load() never throws) and the seed
+        // ladder then bootstraps exactly as on first run.
+        if (m_addrman.load(addrman_db_path())) {
+            LOG_INFO << "[" << m_symbol << "] AddrMan loaded: "
+                     << m_addrman.size() << " known ("
+                     << m_addrman.tried_count() << " tried) from "
+                     << addrman_db_path();
+        }
         try {
             std::ifstream ifs(db_path());
             if (!ifs.is_open()) return;
@@ -1262,6 +1414,11 @@ private:
     int  m_emergency_attempt{0};                    // consecutive-attempt counter n
 
     mutable std::mutex m_mutex;
+    /// Bucketed new/tried address DB (dashd CAddrMan port). mutable:
+    /// draws and samples only permute internal iteration state, and the
+    /// DB carries its own lock (always taken AFTER m_mutex, never the
+    /// reverse — CoinAddrMan calls nothing back).
+    mutable core::CoinAddrMan m_addrman;
     std::map<std::string, DashPeerInfo> m_peers;    // key = "host:port"
     std::set<std::string> m_coind_peers;            // daemon's own peers (overlap filter)
     std::set<std::string> m_connected_keys;         // live-connected keys (emergency drive; under m_mutex)

--- a/src/impl/dgb/coin/coin_peer_manager.hpp
+++ b/src/impl/dgb/coin/coin_peer_manager.hpp
@@ -57,6 +57,7 @@
 #include <core/filesystem.hpp>
 #include <core/netaddress.hpp>
 #include <core/dns_seeder.hpp>
+#include <core/coin_addrman.hpp>
 
 namespace dgb {
 namespace coin {
@@ -360,10 +361,15 @@ public:
 
     /// Add a peer discovered via P2P addr message.
     /// Validates via PeerEndpoint: rejects empty, unparseable, and non-routable addresses.
-    void add_discovered_peer(const NetService& addr)
+    /// source_host: the peer that gossiped this address (bucket-keys the
+    /// banked entry, bounding how far one source can spray the new table;
+    /// empty = self-announced). Existing call sites need no change.
+    void add_discovered_peer(const NetService& addr,
+                             const std::string& source_host = std::string())
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        try_add_peer_locked(addr, DgbPeerInfo::Source::addr_crawl, /*require_routable=*/true);
+        try_add_peer_locked(addr, DgbPeerInfo::Source::addr_crawl, /*require_routable=*/true,
+                            source_host);
     }
 
     /// Get list of peers that should be connected right now.
@@ -422,6 +428,47 @@ public:
             result.push_back(c.endpoint);
             connected_groups[c.group]++;
         }
+
+        // ── Addrman top-up (dashd CAddrMan port) ──
+        // The score-sorted working set above covers pinned/anchor/known
+        // peers; any remaining budget is drawn from the bucketed DB with
+        // dashd's stochastic quality-biased Select(), so dial plans explore
+        // the whole banked address space instead of re-hammering the same
+        // hand-picked few. One tried-collision incumbent is drawn first
+        // (the feeler leg): re-dialing it gives resolve_collisions() real
+        // evidence to keep or evict it. Group diversity and per-peer
+        // backoff (can_retry) gate the draws exactly like the legacy path.
+        if (static_cast<int>(result.size()) < budget) {
+            std::vector<NetService> draws;
+            if (auto incumbent = m_addrman.select_tried_collision())
+                draws.push_back(*incumbent);
+            const int deficit = budget - static_cast<int>(result.size());
+            for (int i = 0; i < deficit * 4
+                 && static_cast<int>(draws.size()) < deficit + 1; ++i) {
+                auto pick = m_addrman.select();
+                if (!pick) break;
+                draws.push_back(*pick);
+            }
+            for (auto& ns : draws) {
+                if (static_cast<int>(result.size()) >= budget) break;
+                auto ep = PeerEndpoint::from(ns);
+                if (!ep) continue;
+                const auto key = ep->to_string();
+                if (connected_keys.count(key)) continue;
+                bool dup = false;
+                for (auto& r : result)
+                    if (r.to_string() == key) { dup = true; break; }
+                if (dup) continue;
+                auto known = m_peers.find(key);
+                if (known != m_peers.end() && !known->second.can_retry())
+                    continue;
+                auto grp = peer_network_group(ep->host());
+                if (connected_groups[grp] >= MAX_OUTBOUND_PER_GROUP
+                    && !grp.empty()) continue;
+                result.push_back(*ep);
+                connected_groups[grp]++;
+            }
+        }
         return result;
     }
 
@@ -432,11 +479,14 @@ public:
         // Track this key as a LIVE connection so the maintenance-tick
         // emergency-refresh gate (connected_count()) reflects real peers.
         m_live_connections.insert(key);
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_connected();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_connected();
             // Track as anchor candidate (most recent successful connections)
             update_anchors(key);
+            // Promote in the bucketed DB: Good() moves the entry into the
+            // tried table (or parks a tried-collision for the feeler leg).
+            m_addrman.good(peer->address);
         }
         if (!m_bootstrapped) m_bootstrapped = true;
     }
@@ -449,6 +499,9 @@ public:
         auto it = m_peers.find(key);
         if (it != m_peers.end()) {
             it->second.record_disconnected();
+            // It completed a handshake earlier, so it WAS alive: refresh
+            // the bucketed DB's believed-alive stamp (dashd Connected()).
+            m_addrman.connected(it->second.address);
         }
     }
 
@@ -462,9 +515,13 @@ public:
     void notify_dial_failed(const std::string& key)
     {
         std::lock_guard<std::mutex> lock(m_mutex);
-        auto it = m_peers.find(key);
-        if (it != m_peers.end()) {
-            it->second.record_dial_failed();
+        auto* peer = ensure_working_entry_locked(key);
+        if (peer) {
+            peer->record_dial_failed();
+            // #940 feedback also reaches the bucketed DB: a counted
+            // failed attempt lowers GetChance() so Select() stops
+            // re-drawing the dead target (mirrors dashd Attempt()).
+            m_addrman.attempt(peer->address);
         }
     }
 
@@ -603,8 +660,12 @@ public:
     bool discovery_enabled() const
     {
         if (m_config.disable_discovery) return false;
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return static_cast<int>(m_peers.size()) < m_config.max_peers;
+        // The bucketed DB is the getaddr sink now: keep harvesting until
+        // it is of table order (~82k slots) — in practice always, exactly
+        // like dashd keeps banking addr gossip. The old working-set gate
+        // (m_peers.size() < max_peers) stopped discovery at a handful of
+        // peers and starved daemonless block download of dial candidates.
+        return m_addrman.size() < core::CoinAddrMan::soft_capacity();
     }
 
     /// Remove peers that are exhausted (max attempts reached, not protected).
@@ -671,6 +732,21 @@ public:
             if (!ep || !ep->is_routable()) continue;
             result.push_back(*ep);
         }
+        // Top up from the bucketed DB's tried sample so a node serves
+        // more than its small working set once the DB has grown (dashd
+        // GetAddr; tried-only + routable keeps the unverified out).
+        for (auto& ns : m_addrman.get_addr(
+                 /*max_pct=*/100,
+                 /*max_count=*/static_cast<size_t>(max_count) * 2,
+                 /*tried_only=*/true)) {
+            auto ep = PeerEndpoint::from(ns);
+            if (!ep || !ep->is_routable()) continue;
+            bool dup = false;
+            for (auto& r : result)
+                if (r.to_string() == ep->to_string()) { dup = true; break; }
+            if (dup) continue;
+            result.push_back(*ep);
+        }
         // Shuffle for privacy (don't reveal connection order/topology)
         if (result.size() > 1) {
             thread_local std::mt19937 rng(std::random_device{}());
@@ -680,6 +756,10 @@ public:
             result.erase(result.begin() + max_count, result.end());
         return result;
     }
+
+    /// Bucketed address DB (dashd CAddrMan port) — diagnostics/KATs.
+    core::CoinAddrMan& addrman() { return m_addrman; }
+    const core::CoinAddrMan& addrman() const { return m_addrman; }
 
 private:
     /// Unified peer validation and insertion (caller must hold m_mutex).
@@ -693,7 +773,8 @@ private:
     ///                          peers (getpeerinfo) which may be LAN hosts.
     /// @return true if the peer was added, false if rejected.
     bool try_add_peer_locked(const NetService& addr, DgbPeerInfo::Source source,
-                             bool require_routable)
+                             bool require_routable,
+                             const std::string& source_host = std::string())
     {
         // ── Validate via PeerEndpoint (type-safe, Bitcoin Core classification) ──
         auto ep = PeerEndpoint::from(addr);
@@ -711,6 +792,18 @@ private:
 
         // ── Port filter ──
         if (!is_valid_port(ep->port())) return false;
+
+        // ── Bank in the bucketed address DB (dashd CAddrMan port) ──
+        // Every validated non-daemon candidate is banked BEFORE the
+        // working-set gates below: the capacity/dedup/group caps bound the
+        // small ACTIVE dial set, while the bank is the large archival
+        // history the dial planner draws from (repeat gossip refreshes
+        // freshness there instead of being dropped on the floor).
+        // Daemon-learned peers are deliberately NOT banked — the bank must
+        // stay an INDEPENDENT view of the network.
+        if (source != DgbPeerInfo::Source::coind
+            && !m_coind_peers.count(ep->to_string()))
+            m_addrman.add(ep->to_net_service(), source_host);
 
         // ── Capacity gating ──
         if (static_cast<int>(m_peers.size()) >= m_config.max_peers) return false;
@@ -742,6 +835,37 @@ private:
         peer.last_seen = std::chrono::steady_clock::now();
         peer.max_attempts = m_config.max_connection_attempts;
         return true;
+    }
+
+    /// Materialize a working-set entry for an addrman-drawn dial target
+    /// (or any endpoint the transport reports on) so the notify_*
+    /// feedback — including the #940 dial-failure leg — always lands on
+    /// a scored entry. Returns nullptr for an unparseable key.
+    DgbPeerInfo* ensure_working_entry_locked(const std::string& key)
+    {
+        auto it = m_peers.find(key);
+        if (it != m_peers.end()) return &it->second;
+        const auto colon = key.rfind(':');
+        if (colon == std::string::npos) return nullptr;
+        uint16_t port = 0;
+        try {
+            const unsigned long v = std::stoul(key.substr(colon + 1));
+            if (v == 0 || v > 65535) return nullptr;
+            port = static_cast<uint16_t>(v);
+        } catch (const std::exception&) {
+            return nullptr;
+        }
+        auto ep = PeerEndpoint::from(key.substr(0, colon), port);
+        if (!ep) return nullptr;
+        auto& peer = m_peers[key];
+        peer.address = ep->to_net_service();
+        peer.addr_class = ep->addr_class();
+        peer.source = DgbPeerInfo::Source::addr_crawl;
+        peer.network_group = peer_network_group(ep->host());
+        peer.first_seen = std::chrono::steady_clock::now();
+        peer.last_seen = std::chrono::steady_clock::now();
+        peer.max_attempts = m_config.max_connection_attempts;
+        return &peer;
     }
 
     bool is_valid_port(uint16_t port) const
@@ -856,6 +980,10 @@ private:
         m_maintenance_timer.async_wait([this](const boost::system::error_code& ec) {
             if (ec || !m_running) return;
             schedule_maintenance();
+
+            // Tried-collision resolution for the bucketed DB (dashd
+            // ResolveCollisions cadence rides the maintenance tick).
+            m_addrman.resolve_collisions();
             // Never-re-arm defect fix (docs/coin-peer-manager-rearm.md §2.4):
             // drive the self-backing-off emergency re-arm off the live peer
             // count. arm_* is storm-guarded by the latch; clear_* resets the
@@ -891,6 +1019,18 @@ private:
             sym = "unknown";
         }
         return (dir / ("peers_" + sym + ".json")).string();
+    }
+
+    /// Bucketed-DB file (peers.dat equivalent), beside the working-set
+    /// JSON in the same per-coin directory.
+    std::string addrman_db_path() const
+    {
+        const std::filesystem::path p = db_path();
+        const std::string stem = p.stem().string();   // "peers_<SYM>"
+        const std::string prefix = "peers_";
+        const std::string sym = stem.rfind(prefix, 0) == 0
+            ? stem.substr(prefix.size()) : stem;
+        return (p.parent_path() / ("addrman_" + sym + ".json")).string();
     }
 
     void save_peers()
@@ -932,6 +1072,9 @@ private:
                 ofs << j.dump(2);
             }
             std::rename(tmp_path.c_str(), db_path().c_str());
+            // Bucketed DB persists beside the working-set JSON (peers.dat
+            // equivalent; addrman does its own atomic tmp+rename).
+            m_addrman.save(addrman_db_path());
             LOG_DEBUG_COIND << "[" << m_symbol << "] Saved " << m_peers.size() << " peers";
         } catch (const std::exception& e) {
             LOG_WARNING << "[" << m_symbol << "] Failed to save peers: " << e.what();
@@ -940,6 +1083,15 @@ private:
 
     void load_peers()
     {
+        // Bucketed DB (peers.dat equivalent). FAIL-SAFE: a corrupt or
+        // absent file loads EMPTY (load() never throws) and the seed
+        // ladder then bootstraps exactly as on first run.
+        if (m_addrman.load(addrman_db_path())) {
+            LOG_INFO << "[" << m_symbol << "] AddrMan loaded: "
+                     << m_addrman.size() << " known ("
+                     << m_addrman.tried_count() << " tried) from "
+                     << addrman_db_path();
+        }
         try {
             std::ifstream ifs(db_path());
             if (!ifs.is_open()) return;
@@ -1258,6 +1410,11 @@ private:
     int  m_emergency_attempt{0};      // consecutive-attempt counter n (backoff key)
 
     mutable std::mutex m_mutex;
+    /// Bucketed new/tried address DB (dashd CAddrMan port). mutable:
+    /// draws and samples only permute internal iteration state, and the
+    /// DB carries its own lock (always taken AFTER m_mutex, never the
+    /// reverse — CoinAddrMan calls nothing back).
+    mutable core::CoinAddrMan m_addrman;
     std::map<std::string, DgbPeerInfo> m_peers;     // key = "host:port"
     std::set<std::string> m_live_connections;       // keys with a live socket (connected_count)
     std::set<std::string> m_coind_peers;            // daemon's own peers (overlap filter)

--- a/test/test_coin_broadcaster.cpp
+++ b/test/test_coin_broadcaster.cpp
@@ -382,15 +382,30 @@ TEST(CoinPeerManager, DiscoveryEnabled_MaxPeers)
     PeerManagerConfig cfg;
     cfg.max_peers = 2;
     CoinPeerManager pm(ioc, "LTC", "/tmp", cfg);
-    
+    // No start() here, so the bucketed addrman is not loaded from disk and
+    // begins empty regardless of any stale /tmp DB -> its size is exact.
+
     EXPECT_TRUE(pm.discovery_enabled());
-    
+
     pm.add_discovered_peer(NetService("45.33.32.1", 9333));
     pm.add_discovered_peer(NetService("45.33.32.2", 9333));
-    EXPECT_FALSE(pm.discovery_enabled()); // at max
-    
-    pm.add_discovered_peer(NetService("45.33.32.3", 9333)); // rejected
-    EXPECT_EQ(pm.peer_count(), 2);
+    // max_peers is now ONLY the working-set / outbound-dial cap: the active
+    // dial set stays capped at 2 ...
+    EXPECT_EQ(pm.peer_count(), 2u);
+    // ... but discovery does NOT stop at the cap anymore. The bucketed
+    // addrman is the getaddr sink and keeps banking gossip until it reaches
+    // table capacity (dashd behaviour). The old assertion that discovery
+    // halts at max_peers encoded the pre-port bug that starved daemonless
+    // block download of dial candidates.
+    EXPECT_TRUE(pm.discovery_enabled());
+
+    // A candidate beyond the working-set cap is still banked into the
+    // addrman (up to bucket capacity) even though it does not enter the
+    // active dial set -- exactly the memory the flat working set lacked.
+    pm.add_discovered_peer(NetService("45.33.32.3", 9333));
+    EXPECT_EQ(pm.peer_count(), 2u);        // outbound set stays capped
+    EXPECT_EQ(pm.addrman().size(), 3u);    // addrman banked all three
+    EXPECT_TRUE(pm.discovery_enabled());   // and keeps harvesting
 }
 
 TEST(CoinPeerManager, PruneDead)

--- a/test/test_coin_broadcaster.cpp
+++ b/test/test_coin_broadcaster.cpp
@@ -387,8 +387,15 @@ TEST(CoinPeerManager, DiscoveryEnabled_MaxPeers)
 
     EXPECT_TRUE(pm.discovery_enabled());
 
+    // These three peers sit in THREE DISTINCT /16 network groups (45.33 /
+    // 66.42 / 89.35) so the bucketed addrman keys each into an independent
+    // new-table bucket. Same-group IPs would share one bucket and race for a
+    // single position, so a birthday collision could drop the third add and
+    // make size() flake to 2 -- dashd-correct per-netgroup bucketing, but not
+    // what this test means to measure (that discovery banks a peer past the
+    // working-set cap of 2).
     pm.add_discovered_peer(NetService("45.33.32.1", 9333));
-    pm.add_discovered_peer(NetService("45.33.32.2", 9333));
+    pm.add_discovered_peer(NetService("66.42.10.2", 9333));
     // max_peers is now ONLY the working-set / outbound-dial cap: the active
     // dial set stays capped at 2 ...
     EXPECT_EQ(pm.peer_count(), 2u);
@@ -402,7 +409,7 @@ TEST(CoinPeerManager, DiscoveryEnabled_MaxPeers)
     // A candidate beyond the working-set cap is still banked into the
     // addrman (up to bucket capacity) even though it does not enter the
     // active dial set -- exactly the memory the flat working set lacked.
-    pm.add_discovered_peer(NetService("45.33.32.3", 9333));
+    pm.add_discovered_peer(NetService("89.35.131.3", 9333));
     EXPECT_EQ(pm.peer_count(), 2u);        // outbound set stays capped
     EXPECT_EQ(pm.addrman().size(), 3u);    // addrman banked all three
     EXPECT_TRUE(pm.discovery_enabled());   // and keeps harvesting


### PR DESCRIPTION
## What

Ports the dashd/Bitcoin Core **CAddrMan** algorithm into c2pool core as `core::CoinAddrMan` (`src/core/coin_addrman.hpp`, header-only) and wires it behind all four coin-p2p peer managers (merged/LTC, DASH, BTC, DGB). This is the missing archival address DB behind the daemonless block-download stalls: the flat scored working set (capped at `max_peers≈20`) dials fine but cannot REMEMBER — getaddr harvests beyond ~20 entries were dropped on the floor, `discovery_enabled()` stopped asking for addresses once the tiny map was full, and dial plans re-hammered the same hand-picked few.

## Algorithm (mirrored from dashd `addrman.{h,cpp}`, not reinvented)

- **Entry ≈ AddrInfo**: `ntime / last_try / last_success / last_count_attempt / attempts / ref_count / in_tried`, wall-clock epoch stamps (history survives restarts — the old steady_clock stamps died with the process).
- **Tables**: `new[1024][64]`, `tried[256][64]` (dashd `ADDRMAN_*` constants verbatim; ~82k slot capacity vs today's 20). Bucket coordinates keyed by a **persistent per-node random SipHash key + /16 (v4) // 32-bit (v6) netgroup**: one netgroup is confined to ≤8 tried buckets; one source group to ≤64 new buckets; an entry to ≤8 new-bucket refs (2^n-damped).
- **Add / Good / Attempt / Connected** with dashd semantics incl. the `nLastGood` fence (one counted failure per Good era) and gossip time-penalty.
- **IsTerrible / GetChance** verbatim thresholds (30d horizon, 3 retries never-success, 10 failures/7d, `0.66^min(attempts,8)`, ×0.01 within 10min of a try). Terrible entries are demoted/overwritten in place — never proactively erased.
- **Select()**: dashd's stochastic quality-biased draw — 50/50 tried-vs-new, random bucket+slot walk, acceptance `chance*factor`, `factor *= 1.2` per rejection.
- **Tried-collision protocol**: Good() onto an occupied tried slot parks the newcomer; `select_tried_collision()` hands the incumbent out for a feeler re-test; `resolve_collisions()` applies dashd's eviction rules (recent success protects; a recent failed re-test evicts) on the maintenance tick.
- **GetAddr()**: 23%/2500 random sample (tried-only variant feeds `/api/coin_peers`).

## Wiring (identical minimal seam in all four managers; external contracts unchanged)

- `try_add_peer_locked` **banks every validated non-daemon candidate** (post validation/port filter, pre working-set gates) — repeat gossip refreshes freshness instead of being dropped. Daemon(`coind`)-learned peers are NOT banked (independent-view invariant preserved).
- `get_peers_to_connect` keeps the legacy score-sorted working-set pass (pinned local node, anchors, backoff, group diversity all unchanged), then **fills the remaining budget from `Select()`** — plus one collision incumbent first (the feeler leg). Signature and constness unchanged.
- `notify_connected → Good()`, `notify_disconnected → Connected()` (freshness), `notify_dial_failed → Attempt()` — **#940 dial-failure feedback now lands in BOTH scorers**; addrman-drawn targets are materialized into the working set on first feedback so the existing scorer path is never bypassed.
- `discovery_enabled()` now gates on DB order (~82k) instead of `m_peers.size() < 20` — the getaddr harvest no longer self-strangles.
- **Persistence**: per-coin `addrman_<SYM>.json` beside the existing `peers_<SYM>.json` (same validated per-coin dir, atomic tmp+rename, bucket key persisted so tried placements survive restarts). **FAIL-SAFE**: corrupt/absent DB loads EMPTY, never throws — the DNS/fixed/HTTP seed ladder bootstraps exactly as on first run.
- `get_tried_peers` (serves `/api/coin_peers`) tops up from the DB's tried+routable sample.

**Untouched**: block/tx/share validation, serving, reward/PPLNS paths, wire formats, `main_*.cpp` wiring, seed ladders, Sybil caps on the working set, anchors, emergency re-arm. BCH has no coin peer manager today and stays out of scope. The isolation fence between per-coin trees is respected — each manager keeps its own copy of the seam; the shared piece lives in `core/` like NetService/DnsSeeder already do.

## Verification (vm905, fresh clone, Release + ccache)

- **Phase-1 re-audit**: no addrman/bucket structure existed anywhere under `src/` (flat `std::map<std::string,PeerInfo>` + `in_tried` bool bonus only) — confirmed "partial, port proceeds".
- Build: `core_test` (178/178 PASS, includes 10 new `CoinAddrMan.*` KATs), `btc_share_test` (`BtcCoinPeerManager.*` 13/13 PASS = 9 pre-existing pins + 4 new integration KATs), and full `c2pool-dash`, `c2pool-dgb`, `c2pool-ltc` binaries link clean (cross-coin compile proof).
- New KATs cover: bucketing determinism under the persisted key + netgroup confinement bounds; Select quality bias (clean ≫ 8-failure peer); persist/reload round-trip (entries, tried membership, bucket key); cold/corrupt/wrong-version DB fail-safe; tried-collision park→feeler→resolve (both keep-incumbent and evict-incumbent branches); new-bucket ref damping; growth beyond the legacy 20-cap; manager-level banking beyond `max_peers`, dial-plan draws from a cold working set, #940 feedback landing in both scorers, corrupt-DB manager start.

## Review focus

- The addrman draw leg in `get_peers_to_connect` (group caps + `can_retry` gating on drawn candidates).
- Lock order: manager `m_mutex` → addrman internal lock, never reversed (CoinAddrMan calls nothing back).
- The merged lane has no `notify_dial_failed` surface (pre-#940 transport) — its Attempt() leg lands only via the other three managers; a follow-up when merged grows dial-failure reporting.

Draft for integrator review — do not merge.
