### PR TITLE
dash(coin-p2p): lost-body watchdog never abandons a needed block — rotate-and-recover + evict the staller (dashd net_processing port)

### DIFF
--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -573,10 +573,26 @@ private:
     // gap (~1-2 s), far below the 157.5 s block interval, and a false
     // positive costs one duplicate block-sized response — cheap. Re-requests
     // rotate through the pool's OTHER handshaked peers (post-#1082 up to 8),
-    // capped at 4 (~50 s total), after which the headers-driven re-request /
-    // inv-TTL expiry remains the backstop.
-    static constexpr time_t BODY_REREQUEST_SEC = 10;
-    static constexpr int    BODY_REREQUEST_MAX = 4;
+    // capped at BODY_REREQUEST_MAX consecutive stalls per peer-set, after which
+    // the STALLING peer is disconnected so the block is re-requested from a
+    // churned peer set — the slot is NEVER abandoned.
+    //
+    // dashd model (net_processing block download): a needed block stays in
+    // mapBlocksInFlight until it is delivered; a peer that stalls its window
+    // past BLOCK_STALLING_TIMEOUT (starts ~2 s, doubles, caps at 64 s) loses its
+    // in-flight slot and is disconnected, and FindNextBlocksToDownload
+    // re-assigns the block to any peer whose announced tip covers it. We mirror
+    // that: a tracked slot is removed ONLY when the body actually lands (the
+    // block handler), the per-slot stall window doubles per consecutive stall,
+    // and a chronic staller is disconnected so the pool churns to a peer that
+    // will serve the body. This closes the height-967736 wedge where the old
+    // fixed cap erased the slot and left the lane frozen with connected=8/8.
+    static constexpr int64_t BODY_STALL_TIMEOUT_INIT = 2;   // dashd start
+    static constexpr int64_t BODY_STALL_TIMEOUT_MAX  = 64;  // dashd doubling cap
+    // Consecutive stalls against the CURRENT peer set before the blamed peer is
+    // disconnected (releasing its slot; the peer-manager backoff keeps it from
+    // being re-dialed immediately) so recovery churns to a peer that has it.
+    static constexpr int      BODY_REREQUEST_MAX = 4;
     // Tracked slots are bounded by design: the tip body plus a short burst
     // of near-tip blocks; oldest evicted beyond this.
     static constexpr size_t PENDING_BODY_CAP  = 8;
@@ -702,10 +718,20 @@ private:
         int64_t     last_req{0};
         int         rerequests{0};
         std::string last_peer;    // don't re-ask the peer that just failed us
+        // dashd BLOCK_STALLING_TIMEOUT: fast first retry, doubling per stall,
+        // reset to INIT whenever the slot is (re)assigned to a fresh peer.
+        int64_t     stall_timeout{BODY_STALL_TIMEOUT_INIT};
+        // Consecutive stall-driven re-requests since the last staller eviction;
+        // at BODY_REREQUEST_MAX the blamed peer is disconnected to churn the set.
+        int         stalls_since_evict{0};
+        // Stallers disconnected to recover THIS body (per-slot telemetry).
+        int         evictions{0};
     };
     std::vector<PendingBody> m_pending_bodies;
     uint64_t m_body_rerequests_total{0};
-    uint64_t m_body_rerequests_exhausted{0};
+    // Stalling peers disconnected to keep a needed body from wedging the lane
+    // (dashd disconnect-on-stall). Surfaced as body_stall_evictions.
+    uint64_t m_body_stall_evictions{0};
 
     // ── tip-body announcer routing (#1082 pool + #1094 body-first) ───────
     // A block `inv` names a peer that HOLDS the block. The tip-body getdata
@@ -1451,7 +1477,7 @@ public:
     /// Watchdog observability (KATs + POOL-STATUS).
     std::size_t pending_body_count()    const { return m_pending_bodies.size(); }
     uint64_t body_rerequests_total()    const { return m_body_rerequests_total; }
-    uint64_t body_rerequests_exhausted() const { return m_body_rerequests_exhausted; }
+    uint64_t body_stall_evictions()     const { return m_body_stall_evictions; }
 
     /// Send a getmnlistd (SML diff request) — E2/E3 masternode-list sync seam.
     ///
@@ -2067,7 +2093,7 @@ private:
     }
 
     /// Lost-body watchdog service (one pass per pool tick). A tracked
-    /// getdata(block) unanswered for BODY_REREQUEST_SEC is re-issued — from a
+    /// getdata(block) unanswered for its per-slot stall window is re-issued — from a
     /// DIFFERENT handshaked peer when the pool holds one (the announcing peer
     /// may be slow/wedged; its neighbours demonstrably hold the block they
     /// all announced), rotating through the pool on successive attempts —
@@ -2077,26 +2103,23 @@ private:
         for (auto it = m_pending_bodies.begin(); it != m_pending_bodies.end();)
         {
             PendingBody& pb = *it;
-            if (now - pb.last_req < BODY_REREQUEST_SEC) { ++it; continue; }
-            if (pb.rerequests >= BODY_REREQUEST_MAX)
-            {
-                ++m_body_rerequests_exhausted;
-                LOG_WARNING << "[" << m_chain_label
-                            << "] body-rerequest EXHAUSTED hash="
-                            << pb.hash.GetHex().substr(0, 16) << "... after "
-                            << pb.rerequests << " re-request(s) over "
-                            << (now - pb.first_req)
-                            << "s — leaving recovery to the headers-driven"
-                               " re-request / inv-TTL backstop";
-                it = m_pending_bodies.erase(it);
-                continue;
-            }
+            // dashd BLOCK_STALLING_TIMEOUT: the per-slot window doubles on each
+            // consecutive stall (fast first retry; a chronically-missing block
+            // backs off). Not yet due — leave it.
+            if (now - pb.last_req < pb.stall_timeout) { ++it; continue; }
+
+            // The peer we last leaned on did not deliver within the window.
+            // A slot is NEVER erased here: dashd keeps a needed block in
+            // mapBlocksInFlight until the body actually lands (that removal
+            // lives in the block handler). Abandoning it is the wedge this
+            // replaces (height 967736: connected=8/8, slot dropped, lane frozen).
+            const std::string staller = pb.last_peer;
+            ++pb.stalls_since_evict;
+
             // Rotate through the handshaked peers, preferring one we did not
             // just ask; a single-peer pool re-asks the same peer (still
             // strictly better than the 600 s inv-TTL wait). The ANNOUNCER goes
-            // first — it holds the block by definition — so a re-request tries
-            // it before any neighbour that may not have it yet (the fixed-
-            // subset-that-never-has-it rotation was the #1082 warm-node bug).
+            // first — it holds the block by definition.
             std::vector<PeerSession*> cands;
             if (PeerSession* src = block_source(pb.hash))
                 if (src->handshake.complete()) cands.push_back(src);
@@ -2115,12 +2138,50 @@ private:
             target->write(msg);
             ++pb.rerequests;
             ++m_body_rerequests_total;
-            pb.last_req  = now;
+            pb.last_req = now;
+            // A freshly-assigned peer gets the full fast window (dashd resets
+            // the stall clock on (re)assignment); doubling, capped, only when
+            // the pool leaves us re-asking the same staller.
+            if (target->key != staller)
+                pb.stall_timeout = BODY_STALL_TIMEOUT_INIT;
+            else
+                pb.stall_timeout =
+                    std::min<int64_t>(pb.stall_timeout * 2, BODY_STALL_TIMEOUT_MAX);
             pb.last_peer = target->key;
             LOG_INFO << "[" << m_chain_label << "] cause=body-rerequest attempt="
                      << pb.rerequests << " peer=" << target->key << " hash="
                      << pb.hash.GetHex().substr(0, 16) << "... unanswered_for="
-                     << (now - pb.first_req) << "s";
+                     << (now - pb.first_req) << "s next_stall_window="
+                     << pb.stall_timeout << "s";
+
+            // dashd disconnect-on-stall + FindNextBlocksToDownload: with 8/8
+            // connected but none serving THIS body, rotation alone spins. Once
+            // the current peer set has stalled the slot BODY_REREQUEST_MAX times,
+            // DISCONNECT the blamed peer — this fires the peer-manager scorer,
+            // frees the in-flight slot, and arms a refill of a DIFFERENT address
+            // so the pool churns toward a peer that actually holds the body.
+            // Guarded: only when a real staller is still held AND a survivor (or
+            // an armed refill) can replace it, so one missing block can never
+            // drain the pool to zero.
+            if (pb.stalls_since_evict >= BODY_REREQUEST_MAX && !staller.empty())
+            {
+                PeerSession* bad = find_peer(staller);
+                const bool have_alternative =
+                    handshaked_peer_count() > 1 || m_reconnect_enabled;
+                if (bad && owns(bad) && have_alternative)
+                {
+                    ++pb.evictions;
+                    ++m_body_stall_evictions;
+                    pb.stalls_since_evict = 0;
+                    pb.stall_timeout = BODY_STALL_TIMEOUT_INIT;
+                    remove_peer(bad,
+                        "block-stall: body " + pb.hash.GetHex().substr(0, 16)
+                        + "... unanswered over "
+                        + std::to_string(now - pb.first_req)
+                        + "s — disconnecting the staller to re-request from"
+                          " another peer (dashd disconnect-on-stall)");
+                }
+            }
             ++it;
         }
     }
@@ -2167,7 +2228,7 @@ private:
                  << " evicted(cap/ttl)=" << st.evicted_capacity << "/" << st.evicted_ttl
                  << " pending_bodies=" << m_pending_bodies.size()
                  << " body_rerequests=" << m_body_rerequests_total
-                 << "/" << m_body_rerequests_exhausted;
+                 << " body_stall_evictions=" << m_body_stall_evictions;
     }
 
     // ── handshake ────────────────────────────────────────────────────────

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -928,9 +928,9 @@ TEST(DashCoinP2PPool, a_throwing_subscriber_costs_one_message_not_the_pool)
 // ══════════════════════════════════════════════════════════════════════════
 // LOST-BODY WATCHDOG (#1089 208 s tail; same defect class as the #1077
 // rotated-pending wedge: a request with no timeout). request_block_tracked's
-// getdata unanswered for BODY_REREQUEST_SEC=10 is re-issued from a DIFFERENT
-// handshaked peer, rotating on successive attempts, capped at
-// BODY_REREQUEST_MAX=4, each re-request named (`cause=body-rerequest`) —
+// getdata unanswered for its per-slot stall window is re-issued from a DIFFERENT
+// handshaked peer, rotating on successive attempts; a chronic staller is
+// disconnected after BODY_REREQUEST_MAX stalls, each named (`cause=body-rerequest`) —
 // killing the 208 s / 600 s inv-TTL tail. FAILS-ON-MASTER: request_block has
 // no tracking, no timeout, no re-request at all.
 // ══════════════════════════════════════════════════════════════════════════
@@ -951,15 +951,16 @@ TEST(DashCoinP2PPool, lost_tip_body_is_rerequested_from_a_rotated_peer_at_T)
     // The initial getdata goes to the primary (peer 1), like request_block.
     EXPECT_EQ(rig.session(1)->msgs_sent, p1_before + 1);
 
-    // T-1 seconds of silence: no re-request yet.
-    rig.run_seconds(9);
+    // One second of silence (< the 2 s initial stall window): no re-request.
+    rig.run_seconds(1);
     EXPECT_EQ(rig.client.body_rerequests_total(), 0u)
-        << "re-requested before the 10 s timeout";
+        << "re-requested before the initial stall window elapsed";
 
-    // Crossing T: exactly one re-request, and NOT to the peer that failed us.
+    // Crossing the window: exactly one re-request, and NOT to the failing peer.
     rig.run_seconds(1);
     EXPECT_EQ(rig.client.body_rerequests_total(), 1u)
-        << "an unanswered tracked body request must be re-requested at T=10 s";
+        << "an unanswered tracked body request must be re-requested at the"
+           " dashd stall window (2 s, doubling)";
     EXPECT_EQ(rig.session(1)->msgs_sent, p1_before + 1)
         << "the re-request must rotate OFF the peer that did not answer";
     EXPECT_EQ((rig.session(2)->msgs_sent - p2_before)
@@ -969,22 +970,86 @@ TEST(DashCoinP2PPool, lost_tip_body_is_rerequested_from_a_rotated_peer_at_T)
     EXPECT_EQ(rig.client.pending_body_count(), 1u) << "still unanswered";
 }
 
-TEST(DashCoinP2PPool, body_rerequest_is_capped_then_backstop_owns_it)
+// ANTI-WEDGE (dashd mapBlocksInFlight + disconnect-on-stall). The height-967736
+// wedge: connected=8/8 but none serves THAT body; master ERASED the slot after
+// BODY_REREQUEST_MAX tries and the lane froze forever. dashd never abandons a
+// needed block — the slot stays in flight, the per-slot stall window doubles,
+// and a chronic staller is DISCONNECTED so the pool churns to a peer that has
+// it. FAILS-ON-MASTER: the exhaust branch erased the slot and stopped retrying.
+TEST(DashCoinP2PPool, stalled_body_is_never_abandoned_and_evicts_the_staller)
 {
     PoolRig rig;
     rig.use_fake_clock();
     for (int i = 1; i <= 2; ++i) rig.handshake(i);
 
     rig.client.request_block_tracked(hash_n(0xDEAD));
-    // Nothing ever answers: attempts must stop at the cap and the slot must
-    // be released to the headers-driven / inv-TTL backstop (bounded by
-    // design — not a forever-retry loop).
-    rig.run_seconds(120);
-    EXPECT_EQ(rig.client.body_rerequests_total(), 4u)
-        << "re-requests must be capped at BODY_REREQUEST_MAX";
-    EXPECT_EQ(rig.client.body_rerequests_exhausted(), 1u);
+
+    // Nothing ever answers, for a long time.
+    rig.run_seconds(300);
+
+    EXPECT_EQ(rig.client.pending_body_count(), 1u)
+        << "ANTI-WEDGE: a stalled slot must NEVER be erased (master released it "
+           "after 4 tries and the lane wedged forever)";
+    EXPECT_GT(rig.client.body_rerequests_total(), 4u)
+        << "re-requests must continue past the old BODY_REREQUEST_MAX cap";
+    EXPECT_GE(rig.client.body_stall_evictions(), 1u)
+        << "a chronic staller must be disconnected (dashd disconnect-on-stall)";
+    EXPECT_EQ(rig.client.connected_peer_count(), 1u)
+        << "the staller was churned out; the survivor keeps the slot live — the "
+           "pool is not drained to zero over one missing block";
+}
+
+// THE REQUIRED RECOVERY KAT. A block whose FIRST-tried peer never serves the
+// body is recovered from a SECOND peer, and the tracked cursor advances (the
+// slot disarms) — no permanent wedge. Recovery is by ROTATION, before any
+// staller eviction, so it is deterministic. FAILS-ON-MASTER: after the cap the
+// slot was erased, so a later delivery had nothing to disarm and the reseed
+// cursor never advanced.
+TEST(DashCoinP2PPool, lost_body_first_peer_stalls_recovers_from_the_second_peer)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    for (int i = 1; i <= 2; ++i) rig.handshake(i);   // peer 1 is primary
+
+    dash::coin::BlockType blk;
+    blk.m_version = 0x20000000;
+    blk.m_timestamp = 1'700'000'000u;
+    auto packed_hdr =
+        pack(static_cast<const dash::coin::BlockHeaderType&>(blk));
+    const uint256 bh = dash::crypto::hash_x11(packed_hdr.get_span());
+
+    const uint64_t p1_before = rig.session(1)->msgs_sent;
+    const uint64_t p2_before = rig.session(2)->msgs_sent;
+
+    // Initial getdata -> primary (peer 1) = the "first-tried peer".
+    rig.client.request_block_tracked(bh);
+    ASSERT_EQ(rig.client.pending_body_count(), 1u);
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before + 1)
+        << "the initial body getdata goes to the primary (peer 1)";
+
+    // Peer 1 never serves it. When its stall window (2 s) elapses the watchdog
+    // rotates OFF the staller and re-requests from the SECOND peer.
+    rig.run_seconds(2);
+    EXPECT_GE(rig.client.body_rerequests_total(), 1u);
+    EXPECT_EQ(rig.session(2)->msgs_sent, p2_before + 1)
+        << "the re-request must rotate to the second peer (peer 1 stalled)";
+    EXPECT_EQ(rig.client.pending_body_count(), 1u)
+        << "still outstanding — and NOT abandoned";
+    ASSERT_EQ(rig.client.connected_peer_count(), 2u)
+        << "recovery is by rotation; no eviction after a single stall";
+
+    // Peer 2 serves the body: RECOVERY. The tracked slot disarms — in
+    // production the reseed-tail cursor advances here — and no wedge remains.
+    rig.deliver(2, p2p::message_block::make_raw(blk));
     EXPECT_EQ(rig.client.pending_body_count(), 0u)
-        << "an exhausted slot must be released, not retried forever";
+        << "delivery from the rotated-to peer recovers the block; the cursor "
+           "advances instead of wedging";
+
+    // And nothing re-requests afterwards.
+    const uint64_t total_after = rig.client.body_rerequests_total();
+    rig.run_seconds(60);
+    EXPECT_EQ(rig.client.body_rerequests_total(), total_after)
+        << "a delivered body stops the watchdog";
 }
 
 TEST(DashCoinP2PPool, body_arrival_disarms_the_watchdog)
@@ -1070,7 +1135,7 @@ TEST(DashCoinP2PPool, tip_body_getdata_targets_the_announcing_peer_not_the_prima
 // body, primary churned out — is owned by service_pending_bodies() instead
 // of dying silently. FAILS-ON-MASTER twice over: request_block_tracked
 // returned void, and a dead initial send parked the slot for a full
-// BODY_REREQUEST_SEC before the first retry.
+// a full per-slot stall window before the first retry.
 // ══════════════════════════════════════════════════════════════════════════
 
 TEST(DashCoinP2PPool, tracked_request_that_died_locally_reports_it_and_recovers_via_watchdog)
@@ -1097,7 +1162,7 @@ TEST(DashCoinP2PPool, tracked_request_that_died_locally_reports_it_and_recovers_
     rig.run_seconds(1);
     EXPECT_EQ(rig.client.body_rerequests_total(), 1u)
         << "the armed slot must be serviced on the first tick after a"
-           " handshaked peer exists — not BODY_REREQUEST_SEC later";
+           " handshaked peer exists — not a full stall window later";
     EXPECT_EQ(rig.session(1)->msgs_sent, before + 1)
         << "exactly one getdata, to the peer that now exists";
 


### PR DESCRIPTION
## Problem — the W5 UTXO-fold bulk-replay wedge (live on vm905)

On a fresh daemonless reseed/replay the **tracked lost-body watchdog**
(`p2p_client.hpp::service_pending_bodies`) permanently **abandoned** a needed
block body. A near-tip block (observed at height ~967736) whose `connected=8/8`
peers do not serve *that* body was re-requested 4 times over ~50 s and then the
tracked slot was **erased**:

```
body-rerequest EXHAUSTED hash=… after 4 re-request(s) over 50s
  — leaving recovery to the headers-driven re-request / inv-TTL backstop
```

That "backstop" never fires for a block no peer re-announces, so the reseed-tail
cursor **wedged forever** (`connected=8/8`, CPU 0%). Same wedge class as the
#136/#137/#138 reseed-tail family, here reproduced through the watchdog's abandon
branch.

Rotation already existed; the missing property was dashd's **never-abandon +
evict-the-staller**.

## Fix — port dashd `net_processing` block-download recovery

dashd keeps a needed block in `mapBlocksInFlight` until it is delivered;
`BLOCK_STALLING_TIMEOUT` (2 s, doubling, cap 64 s) evicts a stalling peer's
in-flight slot; a peer that stalls the window is **disconnected**; and
`FindNextBlocksToDownload` re-assigns the block to any peer whose tip covers it.
Mirrored in `service_pending_bodies`:

- **Never abandon.** A tracked slot is removed in exactly ONE place — the block
  handler, when the body actually lands. The exhaust-then-erase branch is gone.
- **Doubling stall window** (`BODY_STALL_TIMEOUT_INIT=2s` →
  `BODY_STALL_TIMEOUT_MAX=64s`): fast first retry, chronic-miss backoff; reset to
  INIT whenever the slot is re-assigned to a fresh peer.
- **Evict the staller.** After `BODY_REREQUEST_MAX` consecutive stalls the blamed
  peer is disconnected (fires the peer-manager scorer + arms a refill of a
  *different* address) so the pool **churns** toward a peer that has the body.
  Guarded so one missing block can never drain the pool to zero (only when a
  survivor or an armed refill can replace the staller).
- **Telemetry:** `body_rerequests_exhausted` → `body_stall_evictions`
  (slots are no longer "exhausted"); surfaced in `POOL-STATUS`.

## Reward-safety — DELIVERY only

No change to block/tx/**consensus validation**. A body still must **merkle-bind**
before acceptance — `block_body_binds_to_header` and the block-arrival disarm are
untouched, and the bulk lane's `MERKLE-BIND FAIL` requeue is unchanged (that guard
caught the 842284 codec bug and stays). This only changes *how* bodies are
fetched/retried. The bulk scheduler (`replay_bulk_fetch.hpp::BulkBlockScheduler`)
already never abandons; this closes the anti-wedge gap on the **tracked** watchdog
only.

## Tests — `test_dash_p2p_node`, **127/127 green** (BLS=REAL build on vm905)

- **`lost_body_first_peer_stalls_recovers_from_the_second_peer`** *(the required
  KAT)* — a block whose first-tried peer never serves the body is recovered from a
  rotated-to second peer; the tracked cursor advances (no permanent wedge).
- **`stalled_body_is_never_abandoned_and_evicts_the_staller`** — under total
  silence the slot is NEVER erased, re-requests continue past the old cap, and a
  chronic staller is disconnected while the survivor keeps the slot live.
- `lost_tip_body_is_rerequested_from_a_rotated_peer_at_T` retimed to the 2 s
  doubling window.

## Notes for review

- DRAFT — **not** for merge; integrator review requested.
- Scope: DASH coin-p2p lane only. LTC/DGB/BCH/BTC untouched.
- Based on `origin/master` @ 539e0abe.
