### PR TITLE
dash: fix teardown-order UB — join compute pools before the members/objects their tasks touch (#1133)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7604,6 +7604,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         rpc_pool->join();
     }
 
+    // #1133 teardown-order fix (fault 2): drain the sharechain node's OWN compute
+    // pools (m_verify_pool X11 share-verify + m_think_pool run_think/clean
+    // election) HERE — right after ioc.run() returns and BEFORE stratum_server /
+    // oracle_shadow / web_server unwind — for the SAME reason rpc_pool is joined
+    // just above. p2p_node is declared FIRST (:998) so ~Node would otherwise run
+    // LAST, joining these pools only after every object a still-in-flight
+    // verify/think task can reach (the tracker's callback targets, the work
+    // refresh bound off m_on_best_share_changed) is already freed. run() has
+    // returned (ioc stopped) so no NEW task is posted; stop()+join() waits out
+    // the in-flight tail against still-live state. Any post-back to the stopped
+    // ioc simply never executes. Idempotent with the ~NodeImpl belt below.
+    p2p_node.join_compute_pools();
+
     // Tear the acceptor + sessions down while the work source and node_coin_state
     // it references are still alive -- explicit reset keeps destruction order safe
     // (stratum_server was declared before them, so it would otherwise outlive them).

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -505,6 +505,40 @@ public:
         m_chain = &m_tracker.chain;
     }
 
+    // ── Shutdown: drain the compute pools FIRST, before anything they touch ──
+    // (#1133 teardown-order fix.) m_verify_pool (X11 share_init_verify) and
+    // m_think_pool (the run_think/clean election, holding m_tracker_mutex
+    // EXCLUSIVELY) run tasks that lock m_tracker_mutex and read/write the
+    // m_think_running / m_clean_running / m_rethink_pending atomics + the
+    // tracker, snapshot and download/peer state. Every one of those members is
+    // declared AFTER the two pools, so under reverse-order member destruction it
+    // would be torn down while a pool thread still holds/reads it — destroying a
+    // std::shared_mutex another thread may lock is UB. Joining the pools here,
+    // and again from the destructor BODY (which runs before ANY member is
+    // destroyed), makes the hazard unreachable regardless of declaration order.
+    //
+    // Idempotent: stop()+join() on an already-joined pool is a no-op, so the
+    // main_dash explicit call (fault 2: join right after ioc.run() returns, so
+    // ~Node does not run after web_server/oracle_shadow/stratum_server unwind)
+    // and the ~NodeImpl belt-and-suspenders below can both run safely. Mirrors
+    // the main_dash rpc_pool stop()+join() shutdown idiom.
+    void join_compute_pools()
+    {
+        m_verify_pool.stop();
+        m_think_pool.stop();
+        m_verify_pool.join();
+        m_think_pool.join();
+    }
+
+    // Deterministic teardown order (#1133 fault 1): the destructor body runs
+    // before the members are destroyed, so joining the pools here guarantees no
+    // pool task is in flight when m_tracker_mutex / the think atomics / the
+    // tracker are destroyed — independent of where the pools are declared.
+    ~NodeImpl() override
+    {
+        join_compute_pools();
+    }
+
     // INetwork: a pool node does not initiate disconnect; the reception slice
     // overrides connected(). Slice A only needs disconnect() to satisfy the
     // pure-virtual INetwork contract.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -370,7 +370,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # the per-share split on an individual share's page. FOLDED in for the same
     # reason; needs the same link set plus the header-only mint/producer weight
     # walk and coinbase allocator, both already reachable from `dash`.
-    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp test_dash_dashboard_views.cpp test_dash_dashboard_pplns.cpp)
+    add_executable(test_dash_node test_dash_node.cpp test_dash_dashboard_found_block.cpp test_dash_addrme.cpp test_dash_block_confirm_lane.cpp test_dash_dashboard_views.cpp test_dash_dashboard_pplns.cpp test_dash_shutdown_order.cpp)
     target_link_libraries(test_dash_node PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -387,6 +387,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # transitively; nothing outside src/impl/dash is added.
     target_link_libraries(test_dash_node PRIVATE dash sharechain)
     gtest_add_tests(test_dash_node "" AUTO)
+
+    # #1133 teardown-order guard reads the shipped node.hpp + main_dash.cpp
+    # source (dgb RACE913 DGB_NODE_SRC idiom) so the fix-site assertions are
+    # deterministic red/green on a nondeterministic destruction-order UB.
+    target_compile_definitions(test_dash_node PRIVATE
+        DASH_NODE_HPP_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/impl/dash/node.hpp"
+        DASH_MAIN_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../src/c2pool/main_dash.cpp")
 
     # DASH S8 per-miner work-target MODULATION KAT (work.py:308-326 oracle pin):
     # pool-share cap (1.67%) + dust-threshold ease + average_attempts_to_target.

--- a/test/test_dash_shutdown_order.cpp
+++ b/test/test_dash_shutdown_order.cpp
@@ -1,0 +1,225 @@
+// #1133 — dash teardown-order guard: the NodeImpl compute pools (m_verify_pool
+// X11 verify + m_think_pool run_think/clean) must be JOINED before the members
+// their tasks touch — m_tracker_mutex, the m_think_running / m_clean_running /
+// m_rethink_pending atomics, the tracker + snapshot — are destroyed, AND before
+// the main_dash-owned objects (web_server / oracle_shadow / stratum_server) a
+// task's callback can reach are unwound.
+//
+// On master the pools are declared BEFORE m_tracker_mutex (node.hpp), so
+// reverse-order member destruction tears the mutex down while ~thread_pool is
+// still joining a lock-holding think task — destroying a std::shared_mutex
+// another thread may lock is UB. And ~Node (p2p_node declared first in
+// main_dash) runs LAST, after web_server/oracle_shadow already died.
+//
+// The fix: NodeImpl::join_compute_pools() (stop()+join() both pools) called
+// explicitly right after ioc.run() returns in main_dash, and again from the
+// ~NodeImpl BODY (which runs before ANY member is destroyed) as a
+// declaration-order-independent belt-and-suspenders.
+//
+// Two lenses, both fold into the EXISTING allowlisted test_dash_node target:
+//   1. RUNTIME — construct a real NodeImpl, post in-flight verify+think tasks
+//      that hammer the exclusive m_tracker_mutex, then drive the shutdown join
+//      and let the object destruct. Proves the join drains in-flight tasks and
+//      the destructor is safe. Under ASan/TSAN the master ordering faults here.
+//   2. SOURCE-STRUCTURAL — a true UB repro is nondeterministic, so (mirroring
+//      the dgb RACE913 guard) parse the shipped node.hpp + main_dash.cpp and
+//      assert the join sites are present in the right places. Revert the fix ->
+//      RED; restore -> GREEN.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/node.hpp>
+
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+// Test-only subclass exposing the protected compute pools + think atomics so the
+// KAT can post the exact task shape a real think()/verify cycle runs, then drive
+// the public shutdown entrypoint. tracker_mutex() is already public on NodeImpl.
+class ShutdownProbeNode : public dash::NodeImpl
+{
+public:
+    using dash::NodeImpl::NodeImpl;  // rig-free default ctor
+    boost::asio::thread_pool& verify_pool() { return m_verify_pool; }
+    boost::asio::thread_pool& think_pool()  { return m_think_pool; }
+    // Touch the same atomics the real run_think()/clean cycle mutates under the
+    // exclusive lock — they are declared AFTER the pools too, so they share the
+    // teardown hazard the join closes.
+    void touch_think_atomics()
+    {
+        m_think_running.store(true, std::memory_order_relaxed);
+        m_rethink_pending.store(false, std::memory_order_relaxed);
+        m_clean_running.store(false, std::memory_order_relaxed);
+        m_think_running.store(false, std::memory_order_relaxed);
+    }
+};
+
+} // namespace
+
+// ── Lens 1: runtime shutdown with in-flight tasks ───────────────────────────
+
+// join_compute_pools() must drain a think task that is actively holding the
+// exclusive tracker mutex, so that when the object destructs nothing touches the
+// (about-to-be-destroyed) mutex/atomics. Deadlock/crash => the pipeline is
+// broken; clean return + destruct => the join contract holds.
+TEST(DashShutdownOrder, JoinDrainsInflightTrackerTask)
+{
+    std::atomic<int> think_iters{0};
+    std::atomic<int> verify_iters{0};
+    std::atomic<bool> keep_going{true};
+
+    {
+        ShutdownProbeNode node;
+
+        // A think-cycle stand-in: repeatedly take the EXCLUSIVE tracker lock and
+        // touch the think atomics, exactly the members destroyed before the pool
+        // join on master. It sleeps briefly WITHOUT the lock so the verify
+        // readers below get windows too (glibc's shared_mutex can starve an
+        // exclusive writer under a continuous reader flood — a fairness quirk we
+        // deliberately avoid so the KAT exercises SHUTDOWN, not lock fairness).
+        boost::asio::post(node.think_pool(), [&]() {
+            while (keep_going.load(std::memory_order_acquire)) {
+                {
+                    std::unique_lock<std::shared_mutex> lk(node.tracker_mutex());
+                    node.touch_think_atomics();
+                    think_iters.fetch_add(1, std::memory_order_relaxed);
+                }
+                std::this_thread::sleep_for(1ms);
+            }
+        });
+
+        // Verify-pool stand-ins: shared try-locks like attempt_verify's IO-side
+        // helpers, momentary hold, then a gap without the lock (leaves room for
+        // the exclusive writer above), on the 4 verify threads.
+        for (int i = 0; i < 4; ++i) {
+            boost::asio::post(node.verify_pool(), [&]() {
+                while (keep_going.load(std::memory_order_acquire)) {
+                    {
+                        std::shared_lock<std::shared_mutex> lk(node.tracker_mutex(),
+                                                               std::try_to_lock);
+                        verify_iters.fetch_add(1, std::memory_order_relaxed);
+                    }
+                    std::this_thread::sleep_for(2ms);
+                }
+            });
+        }
+
+        // Deterministically wait (bounded) until BOTH task classes are provably
+        // in flight before we begin teardown — no fixed sleep to race.
+        const auto deadline = std::chrono::steady_clock::now() + 3s;
+        while ((think_iters.load() == 0 || verify_iters.load() == 0)
+               && std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(1ms);
+        }
+        EXPECT_GT(think_iters.load(), 0) << "think task never ran";
+        EXPECT_GT(verify_iters.load(), 0) << "verify tasks never ran";
+
+        // Begin shutdown: signal the loops to end, then DRAIN via the fix's
+        // entrypoint. After this returns, no pool thread is running.
+        keep_going.store(false, std::memory_order_release);
+        node.join_compute_pools();
+
+        // Idempotency: the main_dash explicit call + the ~NodeImpl body call must
+        // both be able to run. A second join is a safe no-op on joined pools.
+        node.join_compute_pools();
+
+        // node destructs HERE: ~NodeImpl joins once more (no-op) BEFORE
+        // m_tracker_mutex / the atomics are destroyed. No task is in flight, so
+        // the teardown touches nothing live-then-dead.
+    }
+
+    SUCCEED();
+}
+
+// ── Lens 2: source-structural guards (deterministic red/green) ──────────────
+
+#ifndef DASH_NODE_HPP_SRC
+#error "DASH_NODE_HPP_SRC must be defined by CMake to src/impl/dash/node.hpp"
+#endif
+#ifndef DASH_MAIN_SRC
+#error "DASH_MAIN_SRC must be defined by CMake to src/c2pool/main_dash.cpp"
+#endif
+
+namespace {
+
+std::string slurp(const char* path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+} // namespace
+
+// node.hpp must declare an explicit ~NodeImpl that joins the pools first, and a
+// join_compute_pools() that stops+joins BOTH pools.
+TEST(DashShutdownOrder, NodeHppDeclaresJoinFirstDestructor)
+{
+    const std::string src = slurp(DASH_NODE_HPP_SRC);
+
+    ASSERT_NE(src.find("void join_compute_pools()"), std::string::npos)
+        << "join_compute_pools() shutdown entrypoint missing from node.hpp";
+
+    const auto jstart = src.find("void join_compute_pools()");
+    const auto jend = src.find('}', jstart);
+    ASSERT_NE(jend, std::string::npos);
+    const std::string jbody = src.substr(jstart, jend - jstart);
+    EXPECT_NE(jbody.find("m_verify_pool.join()"), std::string::npos)
+        << "join_compute_pools() must join m_verify_pool";
+    EXPECT_NE(jbody.find("m_think_pool.join()"), std::string::npos)
+        << "join_compute_pools() must join m_think_pool";
+
+    // Explicit destructor whose body joins the pools before any member dies.
+    const auto dstart = src.find("~NodeImpl()");
+    ASSERT_NE(dstart, std::string::npos)
+        << "explicit ~NodeImpl() missing — member reverse-destruction would tear "
+           "down m_tracker_mutex while ~thread_pool still joins m_think_pool";
+    const auto dend = src.find('}', dstart);
+    ASSERT_NE(dend, std::string::npos);
+    EXPECT_NE(src.substr(dstart, dend - dstart).find("join_compute_pools()"),
+              std::string::npos)
+        << "~NodeImpl() must join the compute pools in its body (runs before any "
+           "member is destroyed)";
+}
+
+// main_dash must join the node's pools after ioc.run() returns and BEFORE the
+// objects a verify/think task can reach (stratum_server/oracle_shadow/web_server)
+// are torn down.
+TEST(DashShutdownOrder, MainDashJoinsNodePoolsBeforeExternalTeardown)
+{
+    const std::string src = slurp(DASH_MAIN_SRC);
+
+    const auto join_at = src.find("p2p_node.join_compute_pools()");
+    ASSERT_NE(join_at, std::string::npos)
+        << "main_dash must explicitly join the node compute pools after ioc.run()";
+
+    // Ordering: the join must sit after the run loop and before the external
+    // objects unwind.
+    const auto run_at = src.rfind("ioc.run()", join_at);
+    ASSERT_NE(run_at, std::string::npos);
+    EXPECT_LT(run_at, join_at) << "join must come AFTER ioc.run() returns";
+
+    for (const char* later : {"stratum_server.reset()",
+                              "oracle_shadow.reset()",
+                              "web_server.reset()",
+                              "shutdown_persistence()"}) {
+        const auto pos = src.find(later, join_at);
+        EXPECT_NE(pos, std::string::npos)
+            << "expected teardown of '" << later << "' to follow the pool join";
+        EXPECT_LT(join_at, pos)
+            << "node pools must be joined BEFORE '" << later
+            << "' unwinds (a task's callback can still reach it)";
+    }
+}


### PR DESCRIPTION
## #1133 — dash teardown-order UB: worker pools joined after the objects their tasks touch are destroyed

Shutdown-only. Neither fault can fire while `ioc.run()` is running; both bite the first time a shutdown happens with work in flight (SIGTERM mid-think, systemd stop mid-sync). Fixes the two independent ordering faults in the issue.

### Fault 1 — `node.hpp`: `m_tracker_mutex` destroyed before `m_think_pool` joins
`m_verify_pool` (`:165`) / `m_think_pool` (`:175`) are declared **before** `m_tracker_mutex` (`:190`) and the `m_think_running`/`m_clean_running`/`m_rethink_pending` atomics. Reverse-order member destruction tears the mutex/atomics down **while** `~thread_pool` is still joining a think/verify task that holds/reads them — destroying a `std::shared_mutex` another thread may lock is UB.

**Fix:** an explicit `~NodeImpl()` whose **body** joins both pools first (runs before *any* member is destroyed), through a new `join_compute_pools()` entrypoint. This makes the fix **declaration-order-independent** — strictly more robust than relying on moving the (heavily-commented) declarations, and immune to a future member being added after the pools.

### Fault 2 — `main_dash.cpp`: `~Node` runs after `web_server`/`oracle_shadow`/`stratum_server`
`p2p_node` is declared first (`:998`) so `~Node` — and the pool joins from fault 1 — runs **last**, after those objects already unwound. An in-flight task reaching a callback bound into one of them runs against freed memory.

**Fix:** call `p2p_node.join_compute_pools()` right after `ioc.run()` returns and **before** those objects tear down — the same shutdown idiom the adjacent `rpc_pool` `stop()+join()` already uses.

### No other member-ordering hazard
`m_tracker` (`:109`) / `m_storage` (`:110`) are declared **before** the pools (outlive the join); the two pools are the only threads the node owns — every other worker is an asio timer on the (already-stopped) `ioc`.

### Reference mirrored
No sibling coin wires fault 1 correctly (btc/ltc/dgb/bch all share the identical pool-before-mutex layout — the same latent bug, tracked as siblings #1129–#1132), so this is robust-design territory, not a mirror. Fault 2's fix **mirrors** the existing `rpc_pool` `stop()+join()` teardown already in `main_dash.cpp`.

### KAT — `test/test_dash_shutdown_order.cpp` (folded into the allowlisted `test_dash_node` target, no new CI allowlist entry, no NOT_BUILT fake-green)
- **Runtime lens** `JoinDrainsInflightTrackerTask`: constructs a real `NodeImpl`, drives in-flight verify + think tasks hammering the **exclusive** tracker mutex, then `join_compute_pools()` + destruct — no crash/deadlock. Under ASan/TSAN the master ordering faults here.
- **Source-structural lenses** (dgb RACE913 idiom): parse the shipped `node.hpp` + `main_dash.cpp` and pin the two join sites. **Deterministically red on master** (fix strings absent), green after.

**Red→green proof:** the same compiled test binary pointed at master `node.hpp`/`main_dash.cpp` fails both structural guards; pointed at the fixed source, all 3 pass. Full `test_dash_node` suite: **53/53 pass** (new destructor runs on every node teardown — no regression). `c2pool-dash` links (main_dash.cpp compiles).

Author frstrtr; zero AI attribution. **DRAFT — integrator review, not for merge.**

Closes #1133.
