### PR TITLE
dgb(compact-block): discard reconstruction on header Merkle mismatch (#976)

### DIFF
--- a/src/impl/dgb/coin/compact_blocks.hpp
+++ b/src/impl/dgb/coin/compact_blocks.hpp
@@ -241,9 +241,34 @@ inline CompactBlock BuildCompactBlock(const BlockHeaderType& header,
 /// Result of attempting to reconstruct a full block from a compact block.
 struct CompactBlockReconstructionResult {
     bool complete{false};
+    bool merkle_mismatch{false};  // reconstructed txs failed the header Merkle check -> DISCARD, never deliver
     BlockType block;
     std::vector<uint32_t> missing_indexes;  // absolute tx indexes still needed
 };
+
+/// Compute the SHA256d Merkle root over a block's transaction vector (txid-based).
+/// Mirrors template_builder::compute_merkle_root; kept self-contained here so this
+/// lightweight wire header need not pull the heavy template_builder include chain.
+inline uint256 ComputeTxMerkleRoot(const std::vector<MutableTransaction>& txs) {
+    if (txs.empty()) return uint256::ZERO;
+    std::vector<uint256> hashes;
+    hashes.reserve(txs.size());
+    for (const auto& tx : txs)
+        hashes.push_back(compute_txid(tx));
+    while (hashes.size() > 1) {
+        if (hashes.size() & 1u)
+            hashes.push_back(hashes.back());  // duplicate last for odd count
+        std::vector<uint256> next;
+        next.reserve(hashes.size() / 2);
+        for (size_t i = 0; i < hashes.size(); i += 2) {
+            auto sl = std::span<const uint8_t>(hashes[i].data(),     32);
+            auto sr = std::span<const uint8_t>(hashes[i + 1].data(), 32);
+            next.push_back(Hash(sl, sr));
+        }
+        hashes = std::move(next);
+    }
+    return hashes[0];
+}
 
 /// Attempt to reconstruct a full block from a compact block + known transactions.
 /// @param cb        The received compact block.
@@ -311,6 +336,16 @@ inline CompactBlockReconstructionResult ReconstructBlock(
     }
 
     if (result.missing_indexes.empty()) {
+        // BIP 152: a filled short-ID slot is NOT proof of correctness. Short IDs are
+        // 48-bit SipHash, so a collision can silently substitute the wrong tx. The
+        // header Merkle root is the ONLY backstop (Core tolerates mempool-based
+        // reconstruction only because of it) -- verify BEFORE delivery, and on
+        // mismatch DISCARD so the caller falls back to a full getdata/getblocktxn.
+        if (ComputeTxMerkleRoot(txs) != cb.header.m_merkle_root) {
+            result.complete = false;
+            result.merkle_mismatch = true;
+            return result;
+        }
         result.complete = true;
         static_cast<BlockHeaderType&>(result.block) = cb.header;
         result.block.m_txs = std::move(txs);

--- a/src/impl/dgb/coin/p2p_node.hpp
+++ b/src/impl/dgb/coin/p2p_node.hpp
@@ -864,6 +864,15 @@ private:
             auto header = static_cast<BlockHeaderType>(result.block);
             m_peer->get_header(blockhash, header);
             m_coin->full_block.happened(result.block);
+        } else if (result.merkle_mismatch) {
+            // #976: every slot filled but the reconstructed txs fail the header
+            // Merkle root -> a short-ID collision substituted a wrong tx. Discard and
+            // pull the authoritative full block; never deliver the mismatched one.
+            LOG_WARNING << "[" << m_chain_label << "] Compact block " << blockhash.GetHex()
+                        << " reconstructed but FAILED header Merkle check — discarding, "
+                        << "requesting full block via getdata";
+            auto getdata_msg = message_getdata::make_raw({inventory_type(inventory_type::block, blockhash)});
+            m_peer->write(getdata_msg);
         } else {
             LOG_INFO << "[" << m_chain_label << "] Compact block incomplete, "
                      << result.missing_indexes.size() << " txs missing — requesting via getblocktxn";

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -1226,7 +1226,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # from the BIP 152 spec, asserted against the on-the-wire serialiser output.
     # No call site rewired. MUST also be in BOTH build.yml --target allowlists
     # (#143 NOT_BUILT trap).
-    add_executable(dgb_compact_blocks_bip152_parity_test compact_blocks_bip152_parity_test.cpp)
+    add_executable(dgb_compact_blocks_bip152_parity_test compact_blocks_bip152_parity_test.cpp compact_block_merkle_test.cpp)
     target_link_libraries(dgb_compact_blocks_bip152_parity_test PRIVATE
         GTest::gtest_main GTest::gtest
         core dgb

--- a/src/impl/dgb/test/compact_block_merkle_test.cpp
+++ b/src/impl/dgb/test/compact_block_merkle_test.cpp
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// DGB compact-block reconstruction Merkle backstop (issue #976) KAT.
+// 1:1 mirror of src/impl/ltc/test/compact_block_merkle_test.cpp (Defect 1),
+// ported to the dgb:: coin namespace. LTC/BTC/BCH already carry this guard;
+// DGB's ReconstructBlock() was MISSING it.
+//
+// Defect: ReconstructBlock() used to declare a block complete the instant every
+// short-ID slot was filled, never checking the reconstructed tx vector against the
+// header Merkle root. A 48-bit SipHash short-ID collision could substitute the wrong
+// transaction and nothing would catch it before it reached the UTXO cache. The fix
+// computes the Merkle root over the reconstructed txids and DISCARDS on mismatch
+// (signalling a full getdata fallback) instead of delivering.
+//
+// A non-segwit tx has wtxid == txid, so this KAT also pins that such a tx
+// reconstructs identically under both id conventions -- the invariant the handler
+// fix relies on.
+//
+// Folded into the allowlisted dgb_compact_blocks_bip152_parity_test target (NOT a
+// standalone executable) to avoid the #143 NOT_BUILT / #769 "Not Run" CI trap.
+
+#include <cstdint>
+#include <map>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "../coin/compact_blocks.hpp"
+#include "../coin/transaction.hpp"
+#include "../coin/block.hpp"
+#include "../coin/mempool.hpp"
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+using dgb::coin::MutableTransaction;
+using dgb::coin::TxIn;
+using dgb::coin::TxOut;
+using dgb::coin::CompactBlock;
+using dgb::coin::BlockHeaderType;
+using dgb::coin::BuildCompactBlock;
+using dgb::coin::ReconstructBlock;
+using dgb::coin::ComputeTxMerkleRoot;
+using dgb::coin::compute_txid;
+using dgb::coin::TX_WITH_WITNESS;
+
+namespace {
+
+// A minimal non-segwit transaction (no witness -> wtxid == txid).
+MutableTransaction make_tx(int64_t value, uint32_t index)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = index;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+uint256 wtxid_of(const MutableTransaction& tx)
+{
+    MutableTransaction mtx(tx);
+    auto packed = pack(TX_WITH_WITNESS(mtx));
+    return Hash(packed.get_span());
+}
+
+// The non-coinbase txs (index >= 1) keyed by wtxid, as the cmpctblock handler does.
+// The coinbase (index 0) is carried prefilled by BuildCompactBlock.
+std::map<uint256, MutableTransaction> known_by_wtxid(const std::vector<MutableTransaction>& txs)
+{
+    std::map<uint256, MutableTransaction> known;
+    for (size_t i = 1; i < txs.size(); ++i)
+        known[wtxid_of(txs[i])] = txs[i];
+    return known;
+}
+
+std::vector<MutableTransaction> sample_block_txs()
+{
+    std::vector<MutableTransaction> txs;
+    for (int i = 0; i < 4; ++i)
+        txs.push_back(make_tx(5000 + i, static_cast<uint32_t>(i)));
+    return txs;
+}
+
+} // namespace
+
+// Correct header Merkle root -> reconstruction completes and delivers.
+TEST(DgbCompactBlockMerkle, ReconstructsWhenMerkleMatches)
+{
+    auto txs = sample_block_txs();
+    BlockHeaderType header;
+    header.SetNull();
+    header.m_merkle_root = ComputeTxMerkleRoot(txs);
+
+    auto cb = BuildCompactBlock(header, txs);
+    auto result = ReconstructBlock(cb, known_by_wtxid(txs));
+
+    ASSERT_TRUE(result.complete);
+    EXPECT_FALSE(result.merkle_mismatch);
+    ASSERT_EQ(result.block.m_txs.size(), txs.size());
+    EXPECT_EQ(ComputeTxMerkleRoot(result.block.m_txs), header.m_merkle_root);
+}
+
+// A header Merkle root that does NOT match the reconstructed txs must DISCARD, not
+// deliver. Simulates a short-ID collision substituting a wrong tx: every slot still
+// fills from known_txs, so only the Merkle check can catch it.
+//
+// RED on master DGB (no Merkle check): result.complete == true -> block ACCEPTED.
+// GREEN with the fix: result.complete == false, merkle_mismatch == true -> DISCARDED.
+TEST(DgbCompactBlockMerkle, DiscardsOnMerkleMismatch)
+{
+    auto txs = sample_block_txs();
+    BlockHeaderType header;
+    header.SetNull();
+    header.m_merkle_root = ComputeTxMerkleRoot(txs);
+    header.m_merkle_root.data()[0] ^= 0x01;  // flip one bit -> deliberately wrong root
+
+    auto cb = BuildCompactBlock(header, txs);
+    auto result = ReconstructBlock(cb, known_by_wtxid(txs));
+
+    EXPECT_FALSE(result.complete) << "must NOT deliver a block whose txs fail the header Merkle check";
+    EXPECT_TRUE(result.merkle_mismatch) << "must signal discard + full-block getdata fallback";
+    EXPECT_TRUE(result.block.m_txs.empty());
+}
+
+// A non-segwit tx has wtxid == txid, so the wtxid-keyed cmpctblock pass and a
+// txid-keyed pass compute the SAME short ID: reconstruction from a txid-keyed map
+// must still succeed for such a tx.
+TEST(DgbCompactBlockMerkle, NonSegwitTxIdPathsAgree)
+{
+    auto txs = sample_block_txs();
+    for (const auto& tx : txs)
+        EXPECT_EQ(compute_txid(tx), wtxid_of(tx)) << "non-segwit tx must have wtxid == txid";
+
+    BlockHeaderType header;
+    header.SetNull();
+    header.m_merkle_root = ComputeTxMerkleRoot(txs);
+    auto cb = BuildCompactBlock(header, txs);
+
+    std::map<uint256, MutableTransaction> known_by_txid;
+    for (size_t i = 1; i < txs.size(); ++i)
+        known_by_txid[compute_txid(txs[i])] = txs[i];
+
+    auto result = ReconstructBlock(cb, known_by_txid);
+    ASSERT_TRUE(result.complete);
+    EXPECT_FALSE(result.merkle_mismatch);
+}


### PR DESCRIPTION
## Issue #976 — DGB compact-block Merkle backstop

`src/impl/dgb/coin/compact_blocks.hpp` `ReconstructBlock()` declared a block **complete** the instant every BIP 152 short-ID slot was filled, **never checking the reconstructed transaction vector against the header Merkle root**. Short IDs are 48-bit SipHash, so a collision can silently substitute the wrong transaction with nothing to catch it before the block reaches the UTXO cache — a valid-block-loss / wrong-block-delivery risk.

LTC/BTC/BCH already carry this guard. **DGB was the only bitcoin-family lane missing it.**

## Fix — 1:1 mirror of the LTC reference
Mirrors `src/impl/ltc/coin/compact_blocks.hpp:341`:
- add `ComputeTxMerkleRoot()` over the reconstructed txids (self-contained helper, identical to LTC);
- add the `merkle_mismatch` result flag;
- on `ComputeTxMerkleRoot(txs) != cb.header.m_merkle_root` → `complete=false`, `merkle_mismatch=true`, return → **DISCARD, never deliver**;
- wire the caller (`coin/p2p_node.hpp`) `merkle_mismatch` branch to pull the authoritative full block via `getdata` (matching LTC's handler).

## KAT — red-then-green
`src/impl/dgb/test/compact_block_merkle_test.cpp`, folded into the already-allowlisted `dgb_compact_blocks_bip152_parity_test` target (no new executable → no #143 NOT_BUILT trap).

- `DgbCompactBlockMerkle.DiscardsOnMerkleMismatch`
  - **RED** on master DGB (guard absent): `result.complete == true` → block **ACCEPTED** (`m_txs.empty()` fails).
  - **GREEN** with the fix: `complete == false`, `merkle_mismatch == true`, txs discarded.
- Also `ReconstructsWhenMerkleMatches` and `NonSegwitTxIdPathsAgree` (wtxid == txid invariant).

Verified on vm905: red reproduced by neutralizing only the guard; green with guard restored (8/8 in the target binary). Full `c2pool-dgb` executable builds clean.

## Scope
**DGB only.** LTC/BTC/BCH untouched (already verify). Reward-safety / consensus paths untouched beyond this reconstruction guard.

Draft — for integrator review, not for merge.