### PR TITLE
dash(bcast): #987 name a bad-chainlock reject instead of the no-creds path

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2539,9 +2539,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 p2p_relay, rpc_submit, block_bytes, block_hex,
                 /*prefer_rpc_first=*/height_race);
             if (!bcast.any()) {
-                std::cout << "[DASH-STRATUM-BLOCK] reached NEITHER sink "
-                             "(no embedded P2P peer AND no dashd RPC creds) -- "
-                             "won block NOT broadcast\n";
+                // #987: a submitblock RPC arm that FIRED and was REJECTED (e.g.
+                // bad-chainlock / bad-cb-payee) is NOT the no-creds path. The
+                // rejection REASON was already logged LOUDLY by
+                // NodeRPC::submit_block_hex above; name the cause here instead of
+                // the old hardcoded "no dashd RPC creds", which mislabelled a
+                // consensus rejection as an absent daemon.
+                if (bcast.rpc_rejected()) {
+                    std::cout << "[DASH-STRATUM-BLOCK] reached NEITHER sink: dashd "
+                                 "submitblock RPC REJECTED the block (see the "
+                                 "submit_block_hex reason logged above) and no "
+                                 "embedded P2P relay landed it -- won block NOT "
+                                 "broadcast\n";
+                } else {
+                    std::cout << "[DASH-STRATUM-BLOCK] reached NEITHER sink "
+                                 "(no embedded P2P peer AND no dashd RPC creds) -- "
+                                 "won block NOT broadcast\n";
+                }
                 return false;
             }
             std::cout << "[DASH-STRATUM-BLOCK] relayed: p2p="

--- a/src/impl/dash/coin/won_block_dispatch.hpp
+++ b/src/impl/dash/coin/won_block_dispatch.hpp
@@ -94,10 +94,20 @@ struct BlockBroadcast
 {
     bool        p2p_sent     = false;   // embedded P2P relay issued to a CONNECTED peer
     bool        rpc_ok       = false;   // submitblock returned ok OR duplicate
+    bool        rpc_armed    = false;   // submitblock RPC arm was WIRED (fired), regardless of accept/reject
     const char* landed_first = "none";  // "p2p" | "rpc" | "none"
 
     // The gate predicate: did the won block engage AT LEAST ONE broadcast sink?
     bool any() const { return p2p_sent || rpc_ok; }
+
+    // Neither-sink CAUSE disambiguation (telemetry #987). A submitblock RPC arm
+    // that was WIRED and returned false RESPONDED WITH A REJECTION (bad-chainlock
+    // / bad-cb-payee -- the reason is logged LOUDLY by NodeRPC::submit_block_hex),
+    // which is CATEGORICALLY different from an UNARMED arm (no dashd creds, the
+    // daemonless deployment). The old neither-sink line hardcoded "no dashd RPC
+    // creds", falsely reporting a consensus rejection as an absent daemon and
+    // burying the named cause. rpc_rejected() lets the caller name it correctly.
+    bool rpc_rejected() const { return rpc_armed && !rpc_ok; }
 };
 
 // Fire a won block down BOTH broadcast arms. `block_bytes` is the pre-serialized
@@ -114,6 +124,10 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
                                           bool prefer_rpc_first = false)
 {
     BlockBroadcast r;
+    // Record which arms were WIRED up-front so the caller can tell a REJECTION
+    // (arm fired, dashd said no -- reason already logged) apart from an UNARMED
+    // arm (no dashd creds). Independent of accept/reject, path, or ordering.
+    r.rpc_armed = static_cast<bool>(rpc_submit);
 
     // RPC-FIRST validation gate for a stale / height-race won block. The block
     // MIGHT be invalid at its real height, so when the caller asks for it AND a

--- a/test/test_dash_won_block_dualpath.cpp
+++ b/test/test_dash_won_block_dualpath.cpp
@@ -324,6 +324,92 @@ TEST(DashWonBlockDualPath, HeightRaceDaemonlessStillRelaysPrimary)
     EXPECT_TRUE(r.any());
 }
 
+// ── #987 NEITHER-SINK CAUSE: reject-with-reason vs no-creds ──────────────────
+//
+// The neither-sink telemetry defect. When a won block reaches NO sink, the
+// caller (main_dash.cpp) used to hardcode "no dashd RPC creds" -- but that is
+// FALSE when the submitblock RPC arm actually FIRED and dashd REJECTED the block
+// (bad-chainlock / bad-cb-payee). A rejection is a consensus verdict whose reason
+// is logged by NodeRPC::submit_block_hex; the no-creds path is a daemonless
+// deployment with no arm at all. broadcast_won_block must let the caller tell
+// them apart: rpc_armed records that the arm FIRED, and rpc_rejected() ==
+// (armed && !ok) is the "responded-with-a-rejection" predicate the neither-sink
+// branch keys on. These KATs lock that distinction at the dispatcher seam.
+
+// 11) An ARMED submitblock arm that dashd REJECTED, with no P2P peer, reaches
+//     neither sink -- but it is a REJECTION (reason logged), NOT the no-creds
+//     path: rpc_armed is true and rpc_rejected() is true.
+TEST(DashWonBlockDualPath, RpcRejectedIsNamedRejectionNotNoCreds)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    // ARM B fires and dashd REJECTS (e.g. bad-chainlock); no embedded P2P peer.
+    int submit_calls = 0;
+    RpcSubmitSink rpc = [&](const std::string&) -> bool { ++submit_calls; return false; };
+
+    const auto r = broadcast_won_block(/*p2p=*/{}, rpc, block, block_hex);
+
+    ASSERT_EQ(submit_calls, 1);        // the arm DID fire...
+    EXPECT_FALSE(r.any());             // ...and the block reached neither sink
+    EXPECT_TRUE(r.rpc_armed);          // arm was WIRED (fired)
+    EXPECT_FALSE(r.rpc_ok);            // dashd rejected it
+    EXPECT_TRUE(r.rpc_rejected());     // => a rejection with a reason, NOT no-creds
+}
+
+// 12) The genuine no-creds path stays no-creds: a daemonless deployment (no RPC
+//     arm) with no P2P peer reaches neither sink, but rpc_armed is false, so
+//     rpc_rejected() is false -- this really IS "no dashd RPC creds".
+TEST(DashWonBlockDualPath, DaemonlessNeitherSinkIsNotARejection)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    const auto r = broadcast_won_block(/*p2p=*/{}, /*rpc=*/{}, block, block_hex);
+
+    EXPECT_FALSE(r.any());
+    EXPECT_FALSE(r.rpc_armed);         // arm never wired -> genuinely no creds
+    EXPECT_FALSE(r.rpc_rejected());    // NOT a rejection
+}
+
+// 13) The height-race reject path is ALSO a named rejection, not no-creds: the
+//     RPC-first gate fires the arm, dashd rejects, the P2P relay is gated off,
+//     and the block reaches neither sink -- rpc_rejected() must still be true.
+TEST(DashWonBlockDualPath, HeightRaceRejectIsNamedRejectionNotNoCreds)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    RpcSubmitSink rpc = [&](const std::string&) -> bool { return false; };  // dashd REJECTS
+    P2pRelaySink  p2p = [&](const std::vector<unsigned char>&) -> bool { return true; };
+
+    const auto r = broadcast_won_block(p2p, rpc, block, block_hex,
+                                       /*prefer_rpc_first=*/true);
+
+    EXPECT_FALSE(r.any());
+    EXPECT_TRUE(r.rpc_armed);
+    EXPECT_FALSE(r.rpc_ok);
+    EXPECT_TRUE(r.rpc_rejected());     // named rejection, never "no dashd RPC creds"
+}
+
+// 14) Positive-arm sanity: whenever the RPC arm is wired, rpc_armed is true even
+//     on ACCEPT -- rpc_rejected() is then false (accepted, not rejected). Guards
+//     against rpc_armed collapsing into "rejected".
+TEST(DashWonBlockDualPath, RpcArmedTrueOnAcceptAndNotRejected)
+{
+    const auto block = make_block_bytes();
+    const std::string block_hex = to_hex(block);
+
+    RpcSubmitSink rpc = [&](const std::string&) -> bool { return true; };   // dashd ACCEPTS
+
+    const auto r = broadcast_won_block(/*p2p=*/{}, rpc, block, block_hex);
+
+    EXPECT_TRUE(r.any());
+    EXPECT_TRUE(r.rpc_armed);
+    EXPECT_TRUE(r.rpc_ok);
+    EXPECT_FALSE(r.rpc_rejected());    // accepted -> not a rejection
+}
+
 // 8) E5 --coin-p2p-magic override: the embedded coin-P2P wire magic selector.
 //    No override -> the mainnet/testnet defaults are returned BYTE-FOR-BYTE
 //    unchanged (guards the production ARM A dial from regression). An override


### PR DESCRIPTION
Closes #987 (telemetry/observability; no reward/consensus change).

## Problem
`broadcast_won_block`'s neither-sink log conflated two distinct won-block loss causes. A submitblock RPC arm that **fired and was rejected** by dashd (e.g. `bad-chainlock` / `bad-cb-payee`) was logged with the **same** wording as an **unarmed** arm:

> `[DASH-STRATUM-BLOCK] reached NEITHER sink (no embedded P2P peer AND no dashd RPC creds) -- won block NOT broadcast`

That mislabels a consensus rejection as an absent daemon and buries the named cause -- the exact reward-critical diagnosis the earlier lost-subsidy + ignore_failure fixes set out to surface. Only the neither-sink wording/branch was wrong.

## Fix
The rejection **reason** is already logged loudly by `NodeRPC::submit_block_hex` (`ignore_failure=false`). The defect was purely the branch claiming *no creds* over it. Carry the distinction on the dispatcher result:

- `BlockBroadcast` gains `rpc_armed` (the submitblock arm was **wired/fired**) and `rpc_rejected()` = `armed && !ok`. `broadcast_won_block` sets `rpc_armed` up-front from sink presence -- independent of accept/reject, path, or ordering (covers the normal and RPC-first/height-race paths).
- `main_dash.cpp`'s neither-sink branch keys on `rpc_rejected()`: a fired-and-rejected arm now logs *dashd submitblock RPC REJECTED the block (see the submit_block_hex reason logged above)*; the genuine daemonless no-creds case keeps its original wording.

## KAT (red -> green)
`test/test_dash_won_block_dualpath.cpp` (target `test_dash_broadcaster_full`, already in the build.yml allowlist) gains 4 cases: armed reject -> rpc_rejected() (not no-creds); daemonless neither-sink -> NOT a rejection; height-race reject -> also named; armed accept -> rpc_armed true, rpc_rejected() false. **Red** proven by neutralising the setter (3 fail); **green** with it: 16/16 DashWonBlockDualPath, 25/25 in the executable. `c2pool-dash` builds clean.

## Reference mirrored
The sibling dispatcher summary log already tri-states `rpc=` as ok / no-ack / unarmed (the h=2516595 bad-cb-payee fix, #1106 lineage). This PR extends that same armed-vs-unarmed distinction onto the `BlockBroadcast` result so the **caller's** neither-sink line can name the cause too -- mirroring the existing in-dispatcher wording, not a new scheme.

## Safety
Telemetry only. No PoW, share format, coinbase commitment, or PPLNS math touched; both broadcast arms fire exactly as before -- only the neither-sink log line is disambiguated. Per-coin isolation: `src/impl/dash/` + the DASH main + its KAT.