### PR TITLE
p2p(#1130,#1129): ShareMessage safety across 5 lanes — owned serve copies + unpack self-guard

### DIFF
--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -682,6 +682,13 @@ std::vector<bch::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hash
 	{
 		LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
 	}
+	// #1130: hand back OWNED copies. Until here `shares` aliased raw
+	// pointers the sharechain owns and frees under m_tracker_mutex; the
+	// sharereq handler (protocol_actual/legacy) serializes them AFTER this
+	// lock is released, so a concurrent think()/prune would free the share
+	// mid-pack — a use-after-free / double-free. clone() gives the caller
+	// independent memory it destroy()s. Same borrow-vs-own rule as #1131/#1163.
+	for (auto& s : shares) s = s.clone();
 	return shares;
 }
 

--- a/src/impl/bch/protocol_actual.cpp
+++ b/src/impl/bch/protocol_actual.cpp
@@ -214,6 +214,12 @@ void Actual::HANDLER(sharereq)
         auto reply_msg = bch::message_sharereply::make_raw(msg->m_id, bch::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Actual::HANDLER(sharereply)

--- a/src/impl/bch/protocol_legacy.cpp
+++ b/src/impl/bch/protocol_legacy.cpp
@@ -224,6 +224,12 @@ void Legacy::HANDLER(sharereq)
         auto reply_msg = bch::message_sharereply::make_raw(msg->m_id, bch::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Legacy::HANDLER(sharereply)

--- a/src/impl/bch/share_messages.hpp
+++ b/src/impl/bch/share_messages.hpp
@@ -121,7 +121,11 @@ struct ShareMessage
     static std::optional<size_t> unpack(const unsigned char* data, size_t len,
                                         size_t offset, ShareMessage& out)
     {
-        if (len - offset < 8) return std::nullopt;
+        // #1129: self-guard. offset and len are size_t; if a caller passes
+        // offset > len, `len - offset` underflows to a huge value and the
+        // `< 8` check passes, letting the memcpy read out of bounds. Reject
+        // offset past the end BEFORE the subtraction.
+        if (offset > len || len - offset < 8) return std::nullopt;
 
         std::memcpy(&out.msg_type, data + offset, 1);
         std::memcpy(&out.wire_flags, data + offset + 1, 1);

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -679,6 +679,13 @@ std::vector<btc::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hash
 	{
 		LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
 	}
+	// #1130: hand back OWNED copies. Until here `shares` aliased raw
+	// pointers the sharechain owns and frees under m_tracker_mutex; the
+	// sharereq handler (protocol_actual/legacy) serializes them AFTER this
+	// lock is released, so a concurrent think()/prune would free the share
+	// mid-pack — a use-after-free / double-free. clone() gives the caller
+	// independent memory it destroy()s. Same borrow-vs-own rule as #1131/#1163.
+	for (auto& s : shares) s = s.clone();
 	return shares;
 }
 

--- a/src/impl/btc/protocol_actual.cpp
+++ b/src/impl/btc/protocol_actual.cpp
@@ -167,6 +167,12 @@ void Actual::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, btc::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Actual::HANDLER(sharereply)

--- a/src/impl/btc/protocol_legacy.cpp
+++ b/src/impl/btc/protocol_legacy.cpp
@@ -197,6 +197,12 @@ void Legacy::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, btc::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Legacy::HANDLER(sharereply)

--- a/src/impl/btc/share_messages.hpp
+++ b/src/impl/btc/share_messages.hpp
@@ -121,7 +121,11 @@ struct ShareMessage
     static std::optional<size_t> unpack(const unsigned char* data, size_t len,
                                         size_t offset, ShareMessage& out)
     {
-        if (len - offset < 8) return std::nullopt;
+        // #1129: self-guard. offset and len are size_t; if a caller passes
+        // offset > len, `len - offset` underflows to a huge value and the
+        // `< 8` check passes, letting the memcpy read out of bounds. Reject
+        // offset past the end BEFORE the subtraction.
+        if (offset > len || len - offset < 8) return std::nullopt;
 
         std::memcpy(&out.msg_type, data + offset, 1);
         std::memcpy(&out.wire_flags, data + offset + 1, 1);

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -258,6 +258,13 @@ NodeImpl::handle_get_share(std::vector<uint256> hashes, uint64_t parents,
     if (!shares.empty())
         LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
 
+    // #1130: hand back OWNED copies. Until here `shares` aliased raw
+    // pointers the sharechain owns and frees under m_tracker_mutex; the
+    // sharereq handler (protocol_actual/legacy) serializes them AFTER this
+    // lock is released, so a concurrent think()/prune would free the share
+    // mid-pack — a use-after-free / double-free. clone() gives the caller
+    // independent memory it destroy()s. Same borrow-vs-own rule as #1131/#1163.
+    for (auto& s : shares) s = s.clone();
     return shares;
 }
 

--- a/src/impl/dash/protocol_actual.cpp
+++ b/src/impl/dash/protocol_actual.cpp
@@ -167,6 +167,12 @@ void Actual::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, dash::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Actual::HANDLER(sharereply)

--- a/src/impl/dash/protocol_legacy.cpp
+++ b/src/impl/dash/protocol_legacy.cpp
@@ -207,6 +207,12 @@ void Legacy::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, dash::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Legacy::HANDLER(sharereply)

--- a/src/impl/dash/share_messages.hpp
+++ b/src/impl/dash/share_messages.hpp
@@ -125,7 +125,11 @@ struct ShareMessage
     static std::optional<size_t> unpack(const unsigned char* data, size_t len,
                                         size_t offset, ShareMessage& out)
     {
-        if (len - offset < 8) return std::nullopt;
+        // #1129: self-guard. offset and len are size_t; if a caller passes
+        // offset > len, `len - offset` underflows to a huge value and the
+        // `< 8` check passes, letting the memcpy read out of bounds. Reject
+        // offset past the end BEFORE the subtraction.
+        if (offset > len || len - offset < 8) return std::nullopt;
 
         std::memcpy(&out.msg_type, data + offset, 1);
         std::memcpy(&out.wire_flags, data + offset + 1, 1);

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -658,6 +658,13 @@ std::vector<dgb::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hash
 	{
 		LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
 	}
+	// #1130: hand back OWNED copies. Until here `shares` aliased raw
+	// pointers the sharechain owns and frees under m_tracker_mutex; the
+	// sharereq handler (protocol_actual/legacy) serializes them AFTER this
+	// lock is released, so a concurrent think()/prune would free the share
+	// mid-pack — a use-after-free / double-free. clone() gives the caller
+	// independent memory it destroy()s. Same borrow-vs-own rule as #1131/#1163.
+	for (auto& s : shares) s = s.clone();
 	return shares;
 }
 

--- a/src/impl/dgb/protocol_actual.cpp
+++ b/src/impl/dgb/protocol_actual.cpp
@@ -167,6 +167,12 @@ void Actual::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, dgb::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Actual::HANDLER(sharereply)

--- a/src/impl/dgb/protocol_legacy.cpp
+++ b/src/impl/dgb/protocol_legacy.cpp
@@ -197,6 +197,12 @@ void Legacy::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, dgb::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Legacy::HANDLER(sharereply)

--- a/src/impl/dgb/share_messages.hpp
+++ b/src/impl/dgb/share_messages.hpp
@@ -123,7 +123,11 @@ struct ShareMessage
     static std::optional<size_t> unpack(const unsigned char* data, size_t len,
                                         size_t offset, ShareMessage& out)
     {
-        if (len - offset < 8) return std::nullopt;
+        // #1129: self-guard. offset and len are size_t; if a caller passes
+        // offset > len, `len - offset` underflows to a huge value and the
+        // `< 8` check passes, letting the memcpy read out of bounds. Reject
+        // offset past the end BEFORE the subtraction.
+        if (offset > len || len - offset < 8) return std::nullopt;
 
         std::memcpy(&out.msg_type, data + offset, 1);
         std::memcpy(&out.wire_flags, data + offset + 1, 1);

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -678,6 +678,13 @@ std::vector<ltc::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hash
 	{
 		LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
 	}
+	// #1130: hand back OWNED copies. Until here `shares` aliased raw
+	// pointers the sharechain owns and frees under m_tracker_mutex; the
+	// sharereq handler (protocol_actual/legacy) serializes them AFTER this
+	// lock is released, so a concurrent think()/prune would free the share
+	// mid-pack — a use-after-free / double-free. clone() gives the caller
+	// independent memory it destroy()s. Same borrow-vs-own rule as #1131/#1163.
+	for (auto& s : shares) s = s.clone();
 	return shares;
 }
 

--- a/src/impl/ltc/protocol_actual.cpp
+++ b/src/impl/ltc/protocol_actual.cpp
@@ -167,6 +167,12 @@ void Actual::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, ltc::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Actual::HANDLER(sharereply)

--- a/src/impl/ltc/protocol_legacy.cpp
+++ b/src/impl/ltc/protocol_legacy.cpp
@@ -197,6 +197,12 @@ void Legacy::HANDLER(sharereq)
         auto reply_msg = message_sharereply::make_raw(msg->m_id, ltc::ShareReplyResult::too_long, {});
         peer->write(std::move(reply_msg));
     }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
 }
 
 void Legacy::HANDLER(sharereply)

--- a/src/impl/ltc/share_messages.hpp
+++ b/src/impl/ltc/share_messages.hpp
@@ -121,7 +121,11 @@ struct ShareMessage
     static std::optional<size_t> unpack(const unsigned char* data, size_t len,
                                         size_t offset, ShareMessage& out)
     {
-        if (len - offset < 8) return std::nullopt;
+        // #1129: self-guard. offset and len are size_t; if a caller passes
+        // offset > len, `len - offset` underflows to a huge value and the
+        // `< 8` check passes, letting the memcpy read out of bounds. Reject
+        // offset past the end BEFORE the subtraction.
+        if (offset > len || len - offset < 8) return std::nullopt;
 
         std::memcpy(&out.msg_type, data + offset, 1);
         std::memcpy(&out.wire_flags, data + offset + 1, 1);

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # measurement that justifies it, and that an all-pass window logs no blocked
     # line and actually activates. Same folding rule: into the existing
     # allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc
@@ -27,7 +27,8 @@ if (BUILD_TESTING AND GTest_FOUND)
     # #1131 source-structural KAT: verified.remove(bad) must borrow (owns_data=false),
     # not own — folded into this EXISTING allowlisted target (no new executable).
     target_compile_definitions(share_test PRIVATE
-        LTC_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp")
+        LTC_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp"
+        C2POOL_IMPL_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../..")   # #1129 5-lane structural guard
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})

--- a/src/impl/ltc/test/share_message_unpack_bounds_test.cpp
+++ b/src/impl/ltc/test/share_message_unpack_bounds_test.cpp
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D-P2P.SHARE-MESSAGE-UNPACK-BOUNDS — #1129 out-of-bounds read in
+// ShareMessage::unpack from an unsigned-underflow bounds check.
+//
+// THE DEFECT (#1129):
+//   unpack(const unsigned char* data, size_t len, size_t offset, ShareMessage&)
+//   opened with
+//         if (len - offset < 8) return std::nullopt;
+//   `len` and `offset` are size_t. If a caller passes offset > len, `len - offset`
+//   WRAPS to a huge unsigned value, the `< 8` test is false, and the function
+//   proceeds to std::memcpy(&out.msg_type, data + offset, ...) — an out-of-bounds
+//   read past the buffer. Every one of the five lane copies (dash/ltc/dgb/bch/btc)
+//   shipped the bare form.
+//
+//   Reachable-today or not, it is a one-token self-guard: the fix rejects an
+//   offset past the end BEFORE the subtraction —
+//         if (offset > len || len - offset < 8) return std::nullopt;
+//
+// This file pins BOTH halves:
+//   (1) RUNTIME on the real ltc::ShareMessage::unpack — an offset past the end,
+//       and a truncated header, must both return std::nullopt (never read OOB).
+//       On the pre-fix form the overflow case does NOT return nullopt (and reads
+//       OOB — a hard abort under ASan): RED. With the self-guard: GREEN.
+//   (2) a source-structural guard that all five lanes carry the `offset > len`
+//       self-guard on the first bounds check — covers dash, which has no runtime
+//       test target of its own.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <impl/ltc/share_messages.hpp>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (1) Runtime: truncated / overflow offset returns nullopt, never OOB-reads.
+// ─────────────────────────────────────────────────────────────────────────────
+TEST(ShareMessageUnpackBounds_1129, OffsetPastEndReturnsNullopt)
+{
+    // 5-byte buffer, offset=10 (> len). The bare `len - offset < 8` underflows
+    // to ~2^64 and passes, then memcpy reads at data+10 — out of bounds. The
+    // self-guard must reject this and return nullopt.
+    std::vector<unsigned char> buf(5, 0x00);
+    ltc::ShareMessage msg;
+    const auto r = ltc::ShareMessage::unpack(buf.data(), buf.size(), /*offset=*/10, msg);
+    EXPECT_FALSE(r.has_value())
+        << "offset > len must return nullopt, not underflow the bounds check "
+           "and read out of bounds (#1129)";
+}
+
+TEST(ShareMessageUnpackBounds_1129, OffsetEqualsLenReturnsNullopt)
+{
+    // Boundary: offset == len, zero bytes remain — len - offset == 0 < 8.
+    std::vector<unsigned char> buf(8, 0x00);
+    ltc::ShareMessage msg;
+    const auto r = ltc::ShareMessage::unpack(buf.data(), buf.size(), /*offset=*/8, msg);
+    EXPECT_FALSE(r.has_value());
+}
+
+TEST(ShareMessageUnpackBounds_1129, TruncatedHeaderReturnsNullopt)
+{
+    // Fewer than the 8 header bytes present from offset 0 — the guard's original
+    // intent, which must keep working with the self-guard added.
+    std::vector<unsigned char> buf(4, 0x00);
+    ltc::ShareMessage msg;
+    const auto r = ltc::ShareMessage::unpack(buf.data(), buf.size(), /*offset=*/0, msg);
+    EXPECT_FALSE(r.has_value());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (2) Source-structural: every lane carries the offset>len self-guard.
+// ─────────────────────────────────────────────────────────────────────────────
+#ifndef C2POOL_IMPL_DIR
+#error "C2POOL_IMPL_DIR must be defined by CMake to the path of src/impl"
+#endif
+
+namespace {
+
+std::string read_text(const std::string& path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:  if (c == '\n') st = kCode; else out[i] = ' '; break;
+        case kBlock: if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+                     else if (c != '\n') out[i] = ' '; break;
+        case kStr:   if (c == '\\') ++i; else if (c == '"')  st = kCode; break;
+        case kChr:   if (c == '\\') ++i; else if (c == '\'') st = kCode; break;
+        }
+    }
+    return out;
+}
+
+const char* kLanes[] = {"dash", "ltc", "dgb", "bch", "btc"};
+
+} // namespace
+
+TEST(ShareMessageUnpackBounds_1129, SelfGuardPresentAllLanes)
+{
+    for (const char* lane : kLanes) {
+        const std::string code =
+            strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/" + lane + "/share_messages.hpp"));
+
+        ASSERT_NE(code.find("ShareMessage::unpack"), std::string::npos)
+            << lane << ": ShareMessage::unpack not found — test anchor is stale";
+
+        // The combined self-guard. The bare form `len - offset < 8` alone
+        // underflows on offset>len; the fix prepends `offset > len ||`.
+        EXPECT_NE(code.find("offset > len || len - offset < 8"), std::string::npos)
+            << lane << ": ShareMessage::unpack must self-guard offset > len BEFORE "
+                       "the size_t subtraction (#1129)";
+    }
+}

--- a/src/sharechain/share.hpp
+++ b/src/sharechain/share.hpp
@@ -120,6 +120,22 @@ public:
         std::visit([](auto* ptr) { delete ptr; }, *this);
     }
 
+    /// Deep-copy the held share into a NEW heap allocation the returned variant
+    /// OWNS. Use when a BORROWED variant — one that aliases a raw pointer the
+    /// sharechain owns and frees under its lock — must outlive that lock. The
+    /// caller destroy()s the returned copy. Same borrow-vs-own discipline as the
+    /// #1131/#1163 verified.remove(owns_data=false) fix: a borrowing view must
+    /// never free, and a value that has to survive the lock must own its memory.
+    ShareVariants clone() const
+    {
+        return std::visit([](auto* ptr) {
+            using share_t = std::remove_const_t<std::remove_pointer_t<decltype(ptr)>>;
+            ShareVariants copy;
+            copy = new share_t(*ptr);
+            return copy;
+        }, *this);
+    }
+
     auto version() const
     {
         return std::visit([&](auto* share){ return share->version; }, *this);

--- a/src/sharechain/test/CMakeLists.txt
+++ b/src/sharechain/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (BUILD_TESTING AND GTest_FOUND)
-    add_executable(sharechain_test share_test.cpp)
+    add_executable(sharechain_test share_test.cpp share_variants_clone_ownership_test.cpp)
     target_link_libraries(sharechain_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc
@@ -8,5 +8,10 @@ if (BUILD_TESTING AND GTest_FOUND)
 
     include(GoogleTest)
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
+    # #1130 source-structural KAT reads the shipped node.cpp / protocol_*.cpp
+    # of all five lanes; give it the src/impl path.
+    target_compile_definitions(sharechain_test PRIVATE
+        C2POOL_IMPL_DIR="${CMAKE_CURRENT_SOURCE_DIR}/../../impl")
+
     gtest_add_tests(sharechain_test "" AUTO)
 endif()

--- a/src/sharechain/test/share_variants_clone_ownership_test.cpp
+++ b/src/sharechain/test/share_variants_clone_ownership_test.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// D-CORE.SHARE-VARIANTS-CLONE-OWNERSHIP — #1130 double-free / use-after-free in
+// NodeImpl::handle_get_share.
+//
+// THE DEFECT (#1130):
+//   handle_get_share() walks the sharechain under a try_to_lock shared_lock and
+//   pushes each `data.share` — a chain::ShareVariants that holds a RAW pointer
+//   the sharechain OWNS and frees under m_tracker_mutex — into the returned
+//   vector. That local shared_lock is RELEASED when handle_get_share returns.
+//   The sharereq handler (protocol_actual.cpp / protocol_legacy.cpp) then
+//   serializes those variants with pack(share) AFTER the lock is gone, so a
+//   concurrent think()/prune on the compute thread can destroy() the very
+//   pointer being packed: a use-after-free, and a double free once the pointer
+//   is freed twice. (send_shares() is NOT affected — its caller holds the lock
+//   across the pack, so its borrows never escape the critical section.)
+//
+// THE FIX: handle_get_share hands back OWNED copies — `for (auto& s : shares)
+//   s = s.clone();` — and the caller destroy()s them after the wire write. Same
+//   borrow-vs-own discipline as the #1131/#1163 verified.remove(owns_data=false)
+//   fix: a value that must outlive the lock owns its memory; a borrow never frees.
+//
+// This file pins BOTH halves:
+//   (1) a RUNTIME test of the clone() primitive — clone() returns an independent
+//       heap object, and destroy()ing the clone leaves the borrowed original
+//       intact (under ASan the aliasing bug would be a hard double-free abort);
+//   (2) a source-structural guard (mirror of share_remove_owns_data_test.cpp)
+//       that every lane's handle_get_share clone()s before returning and every
+//       sharereq handler destroy()s the owned copies — deterministic red/green
+//       covering all five lanes incl. dash, which has no runtime test target.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <variant>
+
+#include <sharechain/share.hpp>
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (1) Runtime: clone() ownership contract
+// ─────────────────────────────────────────────────────────────────────────────
+namespace {
+
+struct DummyFormatter {};   // clone()/destroy()/hash() never touch the formatter
+
+struct DummyShare : chain::BaseShare<uint64_t, 1>
+{
+    uint64_t payload{0};
+    DummyShare() = default;
+};
+
+using DummyVariant = chain::ShareVariants<DummyFormatter, DummyShare>;
+
+} // namespace
+
+TEST(ShareVariantsClone_1130, CloneYieldsIndependentOwnedCopy)
+{
+    auto* owned = new DummyShare();
+    owned->m_hash  = 0xABCDEFu;
+    owned->payload = 42u;
+
+    DummyVariant borrow;
+    borrow = owned;                        // BORROW — aliases a pointer we own here
+
+    DummyVariant copy = borrow.clone();    // OWNED — independent heap allocation
+
+    // Distinct heap object, not an alias of the borrowed pointer.
+    EXPECT_NE(std::get<DummyShare*>(copy), owned);
+    // Deep-copied value + identity hash.
+    EXPECT_EQ(std::get<DummyShare*>(copy)->payload, 42u);
+    EXPECT_EQ(copy.hash(), owned->m_hash);
+
+    // Destroying the clone must free ONLY the copy. If clone() had aliased the
+    // borrowed pointer (the #1130 bug), this destroy() + the delete below would
+    // free `owned` twice — a double free (ASan: heap-use-after-free / abort).
+    copy.destroy();
+
+    EXPECT_EQ(owned->payload, 42u);        // still readable → the original was NOT freed
+    EXPECT_EQ(owned->m_hash, 0xABCDEFu);
+
+    delete owned;                          // single, correct free of the original
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (2) Source-structural: every lane clones on serve, every handler frees.
+// ─────────────────────────────────────────────────────────────────────────────
+#ifndef C2POOL_IMPL_DIR
+#error "C2POOL_IMPL_DIR must be defined by CMake to the path of src/impl"
+#endif
+
+namespace {
+
+std::string read_text(const std::string& path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Blank every comment (preserving offsets) so the assertions run over real code
+// — the fix's own doc comments quote "clone()" / "destroy()" verbatim.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:  if (c == '\n') st = kCode; else out[i] = ' '; break;
+        case kBlock: if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+                     else if (c != '\n') out[i] = ' '; break;
+        case kStr:   if (c == '\\') ++i; else if (c == '"')  st = kCode; break;
+        case kChr:   if (c == '\\') ++i; else if (c == '\'') st = kCode; break;
+        }
+    }
+    return out;
+}
+
+const char* kLanes[] = {"dash", "ltc", "dgb", "bch", "btc"};
+
+} // namespace
+
+TEST(ShareVariantsClone_1130, HandleGetShareReturnsOwnedCopiesAllLanes)
+{
+    for (const char* lane : kLanes) {
+        const std::string node =
+            strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/" + lane + "/node.cpp"));
+
+        ASSERT_NE(node.find("handle_get_share"), std::string::npos)
+            << lane << ": handle_get_share not found — test anchor is stale";
+
+        // The served borrows must be turned into OWNED copies before the lock is
+        // released. Revert the clone() → RED.
+        EXPECT_NE(node.find(".clone()"), std::string::npos)
+            << lane << ": handle_get_share must hand back OWNED clone()s, not the "
+                       "raw pointers the sharechain frees under m_tracker_mutex (#1130)";
+    }
+}
+
+TEST(ShareVariantsClone_1130, SharereqHandlersFreeOwnedCopiesAllLanes)
+{
+    for (const char* lane : kLanes) {
+        for (const char* proto : {"protocol_actual.cpp", "protocol_legacy.cpp"}) {
+            const std::string code =
+                strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/" + lane + "/" + proto));
+
+            ASSERT_NE(code.find("handle_get_share"), std::string::npos)
+                << lane << "/" << proto << ": sharereq handler not found — anchor stale";
+
+            // The owned copies clone() produced must be freed exactly once, on
+            // every path. Drop the destroy() → RED (leak; and the whole point of
+            // owning the copy is lost).
+            EXPECT_NE(code.find("share.destroy()"), std::string::npos)
+                << lane << "/" << proto << ": sharereq handler must destroy() the "
+                           "OWNED copies handle_get_share cloned for it (#1130)";
+        }
+    }
+}


### PR DESCRIPTION
## Issues #1130 + #1129 — ShareMessage / share-serve safety, all 5 lanes

One cross-lane PR (dash / ltc / dgb / bch / btc). Reward-safety and consensus paths untouched; these are the two specific p2p defects only.

### #1130 — double-free / use-after-free on the share-serve path
`NodeImpl::handle_get_share` walks the sharechain under a `try_to_lock` shared_lock and returns `chain::ShareVariants` that **alias raw pointers the sharechain owns and frees under `m_tracker_mutex`**. That lock is a local shared_lock — released when `handle_get_share` returns. The `sharereq` handlers (`protocol_actual.cpp` / `protocol_legacy.cpp`) then serialize each variant with `pack(share)` **after** the lock is gone, so a concurrent `think()` / prune on the compute thread can `destroy()` the very pointer being packed: a use-after-free, and a double free once the pointer is freed twice.

(`send_shares` is **not** affected — its caller holds the lock across the pack, so its borrows never escape the critical section. Only `handle_get_share` releases first.)

**Fix — mirrors the #1131/#1163 borrow-vs-own discipline.** `handle_get_share` hands back **OWNED** copies via a new `ShareVariants::clone()` (`sharechain/share.hpp`), and each `sharereq` handler `destroy()`s those copies after the wire write. A value that must outlive the lock owns its memory; a borrow never frees. Applied to all five lanes, both the actual and legacy protocols.

### #1129 — out-of-bounds read from an unsigned-underflow bounds check
`ShareMessage::unpack` opened with `if (len - offset < 8) return nullopt;`. `len` and `offset` are `size_t`; an `offset > len` wraps `len - offset` to a huge value, the `< 8` test passes, and `memcpy` reads past the buffer. Added the one-token self-guard `if (offset > len || len - offset < 8) return nullopt;` at all five `unpack` sites.

### KATs (red-on-master → green), folded into existing allowlisted targets
- **`sharechain_test` `ShareVariantsClone_1130`** — runtime `clone()` ownership contract (clone yields an independent OWNED copy; destroying the clone leaves the borrowed original intact — the double-free), plus a source-structural guard that every lane's `handle_get_share` `clone()`s and every `sharereq` handler `destroy()`s.
- **`share_test` (ltc) `ShareMessageUnpackBounds_1129`** — runtime `offset > len` / truncated-buffer returns `nullopt` (never OOB-reads; this reproduces the real defect — it returns a value on master), plus a source-structural guard that all five lanes carry the `offset > len` self-guard (covers dash, which has no runtime test target).

**Red-on-master proof** (product source reverted to master, tests kept, rebuilt):
- #1130 structural tests FAIL naming all 5 lanes; clone runtime passes (new primitive).
- #1129 runtime `OffsetPastEndReturnsNullopt` FAILS (OOB defect reproduced) + structural FAILS all 5 lanes.

**Green on fix:** `sharechain_test` 3/3, ltc `share_test` 83/83 (incl. the 4 new). No new executable, no `build.yml` allowlist change.

Reference mirrored: #1131/#1163 (`fix(#1131): borrow don't own on think-P1 verified.remove(bad)`, commit `627fb31d`) — same borrow-vs-own ownership discipline for `ShareVariants` across the tracker lock.

Draft — integrator review, not for merge.
