### PR TITLE
dash(daemonless): coincide header fast-start checkpoint with MN-set anchor — cold-cut first-template gate

### DIFF
--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -90,19 +90,32 @@ inline DashChainParams make_dash_chain_params_mainnet() {
     };
     p.block_hash_func = p.pow_func;
 
-    // Fast-start checkpoint: Dash mainnet block 2400000 (2025-01-04).
-    // Cold start skips 2.4M headers of validation, saving ~30s syncing
-    // from genesis. A CLI override (--dash-header-checkpoint) can bump
-    // this forward for even faster first-starts. Matches c2pool-ltc's
-    // --header-checkpoint pattern.
+    // Fast-start checkpoint: PINNED TO COINCIDE WITH THE MN-SET BRIDGE
+    // ANCHOR (dash_mn_checkpoint_mainnet.inc, height 2513000). Cold start
+    // seeds the header tip AT the anchor, skipping ~2.5M headers of
+    // validation from genesis.
     //
-    // chosen to be ~50k blocks behind current tip; old enough that
-    // stale binaries still work without override, recent enough to
-    // skip nearly all historical sync cost.
+    // WHY IT MUST EQUAL THE MN ANCHOR (2026-08-16 cold-cut incident). The
+    // MN-set fold (mn_checkpoint_lane) cannot begin until the header tip
+    // REACHES its anchor height -- until then it reports
+    // waiting_for()=="header-tip-to-reach-anchor@h=2513000". When this
+    // checkpoint sat 113k blocks BELOW the anchor (the old 2400000 pin), a
+    // fresh --coin-rpc-removed data-dir spent ~113000/~60 hdr/s ~= 31 min
+    // crawling headers forward BEFORE the first fold could start, so every
+    // stratum rig timed out before the first embedded template was served
+    // (have_tip=0 / populated=0 for >14 min). Coinciding the two collapses
+    // that gap: hdr_tip >= anchor at t~=0, and only the residual
+    // anchor->tip folds. See test_dash_header_checkpoint_coincide.cpp.
+    //
+    // This mints NO new consensus data: the height/hash below are the SAME
+    // release-pinned trust anchor the MN checkpoint already commits to and
+    // cross-checks the header chain against (mn_checkpoint_lane position
+    // verify). The coincidence is machine-enforced by that KAT, so the two
+    // pins can never silently drift apart again.
     p.fast_start_checkpoint = DashChainParams::Checkpoint{};
-    p.fast_start_checkpoint->height = 2400000;
+    p.fast_start_checkpoint->height = 2513000;
     p.fast_start_checkpoint->hash.SetHex(
-        "000000000000002883c9151a37092287c1773c5a4d175a8f688373daa631f934");
+        "000000000000002114d621d90f28b52c07746414491cbffc7cd373b3a56bc950");
     return p;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1208,7 +1208,8 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_live_feed_bridge.cpp
                    test_dash_mn_seed.cpp
                    test_dash_mn_checkpoint.cpp
-                   test_dash_lane_diag.cpp)
+                   test_dash_lane_diag.cpp
+                   test_dash_header_checkpoint_coincide.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_header_checkpoint_coincide.cpp
+++ b/test/test_dash_header_checkpoint_coincide.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH daemonless COLD-CUT first-embedded-template latency KAT.
+///
+/// THE INCIDENT (2026-08-16, hotel-reserve). The first --coin-rpc-removed
+/// binary header-synced for >14 min without ever acquiring a tip: the status
+/// line held "[DASH] Waiting for block template (header sync in progress)",
+/// the embedded arm reported have_tip=0 / populated=0 / arm=would-decline, and
+/// every stratum rig timed out (25 -> 0) before the first serve.
+///
+/// ROOT CAUSE. It was NOT "state thrown away under dashd". The header
+/// fast-start checkpoint and the MN-set bridge anchor
+/// (dash_mn_checkpoint_mainnet.inc) were pinned at DIFFERENT heights and left
+/// to drift 113k blocks apart (2400000 vs 2513000). The MN-set fold
+/// (mn_checkpoint_lane) cannot begin until the header tip REACHES its anchor
+/// height -- until then it reports
+///     waiting_for() == "header-tip-to-reach-anchor@h=2513000"
+/// so a fresh (cold) data-dir spent ~113000 / ~60 hdr/s ~= 31 min crawling
+/// headers forward BEFORE the first fold could even start. have_tip=0 and
+/// populated=0 are downstream of that single gate.
+///
+/// THE FIX (this PR). Coincide the header fast-start checkpoint with the MN
+/// anchor, reusing the SAME release-pinned trust anchor the MN checkpoint
+/// already commits to and cross-checks against (no new consensus data). Then
+/// hdr_tip >= anchor at t~=0, the fold precondition is satisfied immediately,
+/// and only the residual anchor->tip folds.
+///
+/// This suite is RED on master (checkpoints 113k apart -> lane parked ->
+/// est. crawl >> work-timeout) and GREEN with the fix (coincident -> the fold
+/// is eligible at t~=0 -> < work-timeout). Both facts are read from the REAL
+/// product constant (make_dash_chain_params_mainnet) and the REAL pinned MN
+/// anchor, not from synthetic fixtures.
+///
+/// #143 note: FOLDED into the allowlisted test_dash_node_reception_wire target
+/// (a standalone add_executable would silently report "Not Run"). #895 note:
+/// no #ifdef guards, so a green tick means these bodies ran.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/header_chain.hpp>        // HeaderChain, make_dash_chain_params_mainnet
+#include <impl/dash/coin/mn_checkpoint.hpp>       // MnCheckpoint, parse_mn_checkpoint, MNState
+#include <impl/dash/coin/mn_checkpoint_lane.hpp>  // MnCheckpointLane
+
+#include <core/uint256.hpp>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using dash::coin::HeaderChain;
+using dash::coin::MnCheckpoint;
+using dash::coin::MnCheckpointLane;
+using dash::coin::MNState;
+using dash::coin::make_dash_chain_params_mainnet;
+using dash::coin::parse_mn_checkpoint;
+
+namespace {
+
+// The release-pinned mainnet MN-set checkpoint, compiled in exactly as
+// main_dash.cpp compiles it. Its `height`/`blockhash` are the authoritative
+// bridge anchor; the header fast-start checkpoint must equal them.
+const char* const kMainnetMnCheckpoint =
+#include <impl/dash/coin/checkpoints/dash_mn_checkpoint_mainnet.inc>
+    ;
+
+// The stratum work-timeout the cold cut must beat. Rigs dropped their work
+// (25 -> 0) once the first embedded template did not arrive within this window.
+constexpr double kWorkTimeoutS = 120.0;
+
+// MEASURED forward-sync rate on the 2026-08-16 cut repro: 18000 headers
+// ACCEPTED in 264 s == ~68 hdr/s (received/accepted ran ~4.4x redundant). 60
+// is the conservative floor used here, so the estimated crawl time is if
+// anything an UNDER-count of the incident's ~31 min.
+constexpr double kMeasuredFwdHdrPerSec = 60.0;
+
+MnCheckpoint mainnet_anchor()
+{
+    auto cp = parse_mn_checkpoint(kMainnetMnCheckpoint, "mainnet");
+    EXPECT_TRUE(cp.ok) << cp.error;
+    return cp;
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. ANTI-DRIFT INVARIANT. The header fast-start checkpoint MUST equal the
+//    MN-set bridge anchor, height AND hash. This is the guard that keeps the
+//    2026-08-16 incident from recurring: regenerate the .inc to a newer anchor
+//    and forget to bump the header checkpoint, and this test goes RED in CI
+//    before the drift can ship. RED on master (2400000 != 2513000).
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashHeaderCheckpointCoincide, HeaderFastStartEqualsMnAnchor)
+{
+    auto params = make_dash_chain_params_mainnet();
+    ASSERT_TRUE(params.fast_start_checkpoint.has_value())
+        << "no header fast-start checkpoint pinned at all";
+    auto cp = mainnet_anchor();
+
+    EXPECT_EQ(params.fast_start_checkpoint->height, cp.height)
+        << "header fast-start checkpoint (h=" << params.fast_start_checkpoint->height
+        << ") is not pinned at the MN-set bridge anchor (h=" << cp.height
+        << "); a cold start would gate the MN fold behind a forward header crawl of "
+        << (cp.height > params.fast_start_checkpoint->height
+                ? cp.height - params.fast_start_checkpoint->height : 0)
+        << " headers";
+    EXPECT_EQ(params.fast_start_checkpoint->hash, cp.blockhash)
+        << "header fast-start checkpoint hash does not match the MN anchor hash "
+           "at the same height — the anchor is for a different block";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. BEHAVIORAL. On a COLD data-dir the MN-set fold precondition must be
+//    satisfied at t~=0, not behind a multi-minute forward header crawl. This
+//    drives the REAL HeaderChain (seeded from the product constant) into the
+//    REAL MnCheckpointLane armed at the REAL pinned anchor.
+//
+//    RED on master: the header tip seeds at 2400000 < anchor 2513000, so the
+//    lane parks on "header-tip-to-reach-anchor@h=2513000", position is NOT
+//    verified, and the estimated cold crawl (113000 / 60 ~= 1883 s) dwarfs the
+//    work-timeout. GREEN with the fix: tip seeds AT 2513000, the fold is
+//    eligible immediately, residual crawl 0 s.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashHeaderCheckpointCoincide, ColdCutFoldEligibleBeforeWorkTimeout)
+{
+    HeaderChain hc(make_dash_chain_params_mainnet()); // db_path="" -> in-memory
+    ASSERT_TRUE(hc.init());                           // seeds the fast-start checkpoint
+
+    auto cp = mainnet_anchor();
+
+    MnCheckpointLane lane;
+    int64_t clock = 0;
+    lane.set_clock_fn([&clock] { return clock; });
+    lane.set_tip_height_fn([&hc] { return hc.height(); });
+    lane.set_header_hash_at_fn(
+        [&hc](uint32_t h) -> std::optional<uint256> {
+            auto e = hc.get_header_by_height(h);
+            if (!e) return std::nullopt;
+            return e->hash;
+        });
+    lane.set_publish_fn(
+        [](std::vector<std::pair<uint256, MNState>>, uint32_t) {});
+    lane.set_request_block_fn([](uint32_t) { return true; });
+    lane.set_request_snapshot_fn([](const uint256&) {});
+    lane.set_merkle_root_at_fn(
+        [](const uint256&) -> std::optional<uint256> { return std::nullopt; });
+
+    lane.arm(cp);
+    lane.pump();
+
+    const uint32_t tip   = hc.height();
+    const uint32_t crawl = tip >= cp.height ? 0u : cp.height - tip;
+    const double   crawl_s = crawl / kMeasuredFwdHdrPerSec;
+
+    EXPECT_TRUE(lane.position_verified())
+        << "MN fold gated on the header chain: tip h=" << tip
+        << " has not reached anchor h=" << cp.height
+        << " (waiting_for=" << lane.waiting_for()
+        << "); estimated cold forward-crawl " << crawl_s << " s at "
+        << kMeasuredFwdHdrPerSec << " hdr/s";
+
+    EXPECT_EQ(lane.waiting_for().find("header-tip-to-reach-anchor"),
+              std::string::npos)
+        << "the lane is still parked waiting for the header tip to climb to the "
+           "anchor: " << lane.waiting_for();
+
+    EXPECT_LT(crawl_s, kWorkTimeoutS)
+        << "cold-cut header backfill to the MN anchor (" << crawl
+        << " headers, ~" << crawl_s << " s at " << kMeasuredFwdHdrPerSec
+        << " hdr/s) exceeds the stratum work-timeout (" << kWorkTimeoutS
+        << " s): every rig times out before the first embedded template";
+}


### PR DESCRIPTION
## Cold-cut first-embedded-template gate: coincide the header fast-start checkpoint with the MN-set anchor

**Status: DRAFT — integrator review requested. Not for merge.**

### The incident (2026-08-16, hotel-reserve)
The first `--coin-rpc`-removed binary header-synced for **>14 min** on a fresh data-dir without ever acquiring a tip: status held `[DASH] Waiting for block template (header sync in progress)`, the embedded arm reported `have_tip=0 / populated=0 / arm=would-decline`, and every stratum rig timed out (25 → 0) before the first serve.

### Root cause — NOT "state thrown away under dashd"
The header fast-start checkpoint (`make_dash_chain_params_mainnet`, **h=2400000**) and the MN-set bridge anchor (`dash_mn_checkpoint_mainnet.inc`, **h=2513000**) were pinned at **different heights** and left to drift **113k blocks apart**. The MN-set fold (`mn_checkpoint_lane`) cannot begin until the header tip **reaches** its anchor — until then it reports `waiting_for()=="header-tip-to-reach-anchor@h=2513000"`. So a cold cut spent `~113000 / ~60 hdr/s ≈ 31 min` crawling headers forward *before the first fold could even start*. `have_tip=0 / populated=0` are downstream of that single gate.

### The fix (one product line + a guard test)
Pin the header fast-start checkpoint **at** the MN anchor (`h=2513000`, same block hash). The header tip then seeds at the anchor, the fold precondition `hdr_tip ≥ anchor` holds at `t≈0`, and only the residual `anchor→tip` folds. **No new consensus data is minted:** the height/hash are the *same* release-pinned trust anchor the MN checkpoint already commits to and cross-checks the header chain against (position verify). `#1128` replay seam, `#1162` fast fold, and `#999` checkpoint-lane recovery are engaged **verbatim** — only their anchors now coincide.

Warm restarts are unaffected: the fast-start seed only fires on an empty header DB (`m_tip.IsNull()`); a persisted chain keeps its real tip.

### KAT (red on master, green with the fix) — `test_dash_header_checkpoint_coincide.cpp`
Folded into the allowlisted `test_dash_node_reception_wire` target (avoids the #143 NOT_BUILT trap).

1. **`HeaderFastStartEqualsMnAnchor`** — anti-drift invariant: the header checkpoint height **and** hash must equal the pinned MN anchor, so the two constants can never silently diverge again. Master: `2400000 != 2513000` → RED.
2. **`ColdCutFoldEligibleBeforeWorkTimeout`** — drives the *real* `HeaderChain` (seeded from the product constant) into the *real* `MnCheckpointLane` armed at the *real* pinned anchor. Master: the lane parks on `header-tip-to-reach-anchor` and the estimated cold crawl (`113000 / 60 = ~1883 s`) exceeds the `120 s` work-timeout → RED. Fix: fold eligible at `t≈0` → GREEN.

Measured on this branch (BLS=REAL build, vm905):
- Reverting only the one-line checkpoint change → **both KATs FAIL** (`2400000 != 2513000`; `position_verified()=false`; `waiting_for=header-tip-to-reach-anchor@h=2513000`; `1883.3 s > 120 s`).
- With the fix → **both GREEN**; full folded target **158/158 pass**.

### Live proof (daemonless cold data-dir, vm905, no dashd)
- Header seeds at **height=2513000** (not 2400000); `[MN-CKPT] chain position VERIFIED: anchor h=2513000 matches our header chain` fires at **t+0.4s** (vs the ~31 min crawl on master).
- The `#129` header-sync stall watchdog then drives the residual `2513000→live tip` forward; the header chain reached the live tip (`h=2522469`, `peer_tip=2522468`) within ~3–4 min on a 3-peer test topology.

### Reward-safety — unchanged
The checkpoint is a sync anchor for **speed only**. The tip template's payee projection and `merkleRootQuorums` are computed by the same per-block fold over the same blocks `anchor→tip`, which cross-checks every folded block's projected payee against its committed cbTx root and fails closed on mismatch. Moving the anchor forward folds *fewer* blocks; the projection at the tip is unchanged.

### Scope note
This fixes the **header-tip→anchor** gate only. The separate downstream residual (`fold-mnlist-reply@h=anchor` advancing the payee queue) is pre-existing (#136 gapless follower / #1225 reseed) and independent of where the header seed starts.
