### PR TITLE
dash(daemonless): seed the fast-start anchor's full header so the MN-payee bridge can authenticate its snapshot (#1250 cold-cut park)

### DIFF
--- a/src/impl/bitcoin_family/coin/chain_params.hpp
+++ b/src/impl/bitcoin_family/coin/chain_params.hpp
@@ -11,6 +11,11 @@
 #include <cstdint>
 #include <string>
 
+// Signals that ChainParams::Checkpoint carries the optional full-header fields
+// (has_header / hdr_*). A KAT can key its fail-closed self-verification case on
+// this so the same test source still compiles on a pre-fix tree.
+#define C2POOL_FAST_START_CHECKPOINT_HAS_HEADER 1
+
 namespace bitcoin_family
 {
 namespace coin
@@ -26,7 +31,29 @@ struct ChainParams
     uint256 genesis_hash;            // genesis block hash (SHA256d for identification)
 
     // Optional: checkpoint for fast-sync (skip syncing from genesis)
-    struct Checkpoint { uint32_t height{0}; uint256 hash; };
+    struct Checkpoint {
+        uint32_t height{0};
+        uint256  hash;
+        // Optional: the FULL 80-byte block header at `hash`, carried as its
+        // consensus fields. When present, HeaderChain seeds entry.header (not
+        // just entry.hash) so downstream consumers that need the block's
+        // hashMerkleRoot — notably DIP-4 historical-snapshot authentication in
+        // the DASH MN-set bridge — have their trust anchor at t~=0, WITHOUT
+        // crawling headers forward from an earlier checkpoint.
+        //
+        // Reward-safety: this mints NO new trust. The seed self-verifies
+        // pow(header) == `hash` (X11 for Dash) before adopting it, so the
+        // merkle root is DERIVED from the already release-pinned `hash`; a
+        // wrong pin fails closed (header left unseeded) instead of admitting a
+        // forged SML. has_header=false keeps every other coin unchanged.
+        bool     has_header{false};
+        uint32_t hdr_version{0};
+        uint256  hdr_prev_block;
+        uint256  hdr_merkle_root;
+        uint32_t hdr_time{0};
+        uint32_t hdr_bits{0};
+        uint32_t hdr_nonce{0};
+    };
     std::optional<Checkpoint> fast_start_checkpoint;
 
     // Halving

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -116,6 +116,28 @@ inline DashChainParams make_dash_chain_params_mainnet() {
     p.fast_start_checkpoint->height = 2513000;
     p.fast_start_checkpoint->hash.SetHex(
         "000000000000002114d621d90f28b52c07746414491cbffc7cd373b3a56bc950");
+    // The FULL header of the anchor block (mainnet 2513000), so the cold seed
+    // populates entry.header — not just entry.hash. Without it the seeded
+    // IndexEntry carries a default (all-zero) hashMerkleRoot, and the DIP-4
+    // historical-snapshot authentication in the MN-set bridge fails closed at
+    // step (b) ("block header not held"): the base=ZERO anchor snapshot is
+    // consumed but never APPLIED, the payee cursor never leaves the anchor,
+    // have_mn stays 0, and the embedded arm never serves a template on a
+    // --coin-rpc-removed binary (2026-08-16 cold-cut park). Pre-#1250 this
+    // root arrived by crawling headers in from the older 2400000 pin; #1250's
+    // fast-start seed dropped it. These six fields are the consensus header of
+    // the SAME release-pinned block `hash` above; init() REFUSES them unless
+    // X11(header) == hash (self-verifying, fail closed) — so no new trust is
+    // minted. Machine-checked by test_dash_anchor_header_merkle_root.cpp.
+    p.fast_start_checkpoint->has_header = true;
+    p.fast_start_checkpoint->hdr_version = 536870912u;   // 0x20000000
+    p.fast_start_checkpoint->hdr_prev_block.SetHex(
+        "000000000000002affa937f36922946849675632312981c160133b94365408c1");
+    p.fast_start_checkpoint->hdr_merkle_root.SetHex(
+        "01470ce31e4ec9934a229f6eef4c9f561e42898be48d0bd646ab80f4bcc15b9c");
+    p.fast_start_checkpoint->hdr_time  = 1785337727u;
+    p.fast_start_checkpoint->hdr_bits  = 0x192cf712u;
+    p.fast_start_checkpoint->hdr_nonce = 3457493362u;
     return p;
 }
 
@@ -266,6 +288,40 @@ public:
             entry.chain_work = uint256::ONE;
             entry.prev_hash = uint256::ZERO;
             entry.status = HEADER_VALID_CHAIN;
+
+            // When the checkpoint carries its full header, seed entry.header so
+            // downstream consumers reading the anchor's hashMerkleRoot (DIP-4
+            // historical-snapshot auth in the MN-set bridge) find their trust
+            // anchor at t~=0. SELF-VERIFY first: X11(header) must equal the
+            // release-pinned block hash. A mismatch means the pin is corrupt —
+            // fail closed (leave entry.header default) rather than seed a
+            // header whose merkleRoot could authenticate a forged SML. This
+            // mints no new trust: the merkle root is only adopted once it is
+            // proven to hash to the already-pinned `hash`.
+            if (cp.has_header) {
+                BlockHeaderType hdr;
+                hdr.m_version        = cp.hdr_version;
+                hdr.m_previous_block = cp.hdr_prev_block;
+                hdr.m_merkle_root    = cp.hdr_merkle_root;
+                hdr.m_timestamp      = cp.hdr_time;
+                hdr.m_bits           = cp.hdr_bits;
+                hdr.m_nonce          = cp.hdr_nonce;
+                const uint256 computed = x11_hash(hdr);
+                if (computed == cp.hash) {
+                    entry.header = hdr;
+                    LOG_INFO << "[EMB-DASH] Fast-start checkpoint header VERIFIED"
+                             << " (X11==hash) merkleRoot="
+                             << hdr.m_merkle_root.GetHex().substr(0, 16);
+                } else {
+                    LOG_ERROR << "[EMB-DASH] Fast-start checkpoint header X11 "
+                                 "MISMATCH — refusing to seed header (fail "
+                                 "closed); computed="
+                              << computed.GetHex().substr(0, 16) << " pinned="
+                              << cp.hash.GetHex().substr(0, 16);
+                    // entry.header stays default (null merkleRoot) — unproven.
+                }
+            }
+
             m_headers[cp.hash] = entry;
             m_height_index[cp.height] = cp.hash;
             m_tip = cp.hash;
@@ -274,7 +330,8 @@ public:
             persist_header(entry);
             persist_tip();
             LOG_INFO << "[EMB-DASH] Fast-start checkpoint: height=" << cp.height
-                     << " hash=" << cp.hash.GetHex().substr(0, 16);
+                     << " hash=" << cp.hash.GetHex().substr(0, 16)
+                     << " header=" << (entry.header.IsNull() ? "null" : "seeded");
         }
         // Fall back to genesis as stub when no checkpoint is configured
         // (so block 1's prev_hash resolves).

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -289,15 +289,26 @@ public:
             entry.prev_hash = uint256::ZERO;
             entry.status = HEADER_VALID_CHAIN;
 
-            // When the checkpoint carries its full header, seed entry.header so
-            // downstream consumers reading the anchor's hashMerkleRoot (DIP-4
-            // historical-snapshot auth in the MN-set bridge) find their trust
-            // anchor at t~=0. SELF-VERIFY first: X11(header) must equal the
-            // release-pinned block hash. A mismatch means the pin is corrupt —
-            // fail closed (leave entry.header default) rather than seed a
-            // header whose merkleRoot could authenticate a forged SML. This
-            // mints no new trust: the merkle root is only adopted once it is
-            // proven to hash to the already-pinned `hash`.
+            // When the checkpoint carries its full header, adopt ONLY its
+            // self-verified hashMerkleRoot into entry.header — the single field
+            // the DIP-4 historical-snapshot auth in the MN-set bridge reads
+            // (main_dash set_merkle_root_at_fn). SELF-VERIFY first: X11 over the
+            // FULL pinned header must equal the release-pinned block hash; a
+            // mismatch means the pin is corrupt, so fail closed (adopt nothing)
+            // rather than feed a merkleRoot that could authenticate a forged SML.
+            //
+            // HONESTY RECONCILIATION (Plan A). We deliberately DO NOT copy the
+            // whole header. m_bits / m_timestamp / m_version / ... stay at their
+            // synthetic-anchor defaults (0), so chain_rpc::is_synthetic_anchor()
+            // (keyed on m_bits==0) stays TRUE and the node keeps WITHHOLDING the
+            // daemon-tip fields difficulty / mediantime / bestblockhash until it
+            // is genuinely synced to the LIVE tip. The pinned header exists for
+            // INTERNAL DIP-4 auth only; a single lone checkpoint anchor must
+            // never masquerade as a daemon tip. Mints no new trust: the merkle
+            // root is adopted only once proven to X11-hash to the pinned block
+            // hash. Machine-checked by test_dash_anchor_header_merkle_root (root
+            // present) and test_dash_header_chain's *SyntheticAnchor* guards
+            // (daemon-tip fields still withheld at the anchor).
             if (cp.has_header) {
                 BlockHeaderType hdr;
                 hdr.m_version        = cp.hdr_version;
@@ -308,13 +319,17 @@ public:
                 hdr.m_nonce          = cp.hdr_nonce;
                 const uint256 computed = x11_hash(hdr);
                 if (computed == cp.hash) {
-                    entry.header = hdr;
-                    LOG_INFO << "[EMB-DASH] Fast-start checkpoint header VERIFIED"
-                             << " (X11==hash) merkleRoot="
-                             << hdr.m_merkle_root.GetHex().substr(0, 16);
+                    // Adopt the merkle root ALONE; leave every other header
+                    // field synthetic (0) so is_synthetic_anchor() stays true
+                    // and the daemon-tip honesty guards keep withholding.
+                    entry.header.m_merkle_root = hdr.m_merkle_root;
+                    LOG_INFO << "[EMB-DASH] Fast-start checkpoint merkleRoot"
+                                " VERIFIED (X11==hash) merkleRoot="
+                             << hdr.m_merkle_root.GetHex().substr(0, 16)
+                             << " (anchor kept synthetic: bits/time withheld)";
                 } else {
                     LOG_ERROR << "[EMB-DASH] Fast-start checkpoint header X11 "
-                                 "MISMATCH — refusing to seed header (fail "
+                                 "MISMATCH — refusing to seed merkleRoot (fail "
                                  "closed); computed="
                               << computed.GetHex().substr(0, 16) << " pinned="
                               << cp.hash.GetHex().substr(0, 16);
@@ -331,7 +346,8 @@ public:
             persist_tip();
             LOG_INFO << "[EMB-DASH] Fast-start checkpoint: height=" << cp.height
                      << " hash=" << cp.hash.GetHex().substr(0, 16)
-                     << " header=" << (entry.header.IsNull() ? "null" : "seeded");
+                     << " merkleRoot="
+                     << (entry.header.m_merkle_root.IsNull() ? "null" : "seeded");
         }
         // Fall back to genesis as stub when no checkpoint is configured
         // (so block 1's prev_hash resolves).

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1209,7 +1209,8 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_mn_seed.cpp
                    test_dash_mn_checkpoint.cpp
                    test_dash_lane_diag.cpp
-                   test_dash_header_checkpoint_coincide.cpp)
+                   test_dash_header_checkpoint_coincide.cpp
+                   test_dash_anchor_header_merkle_root.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_anchor_header_merkle_root.cpp
+++ b/test/test_dash_anchor_header_merkle_root.cpp
@@ -45,6 +45,7 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/header_chain.hpp>   // HeaderChain, make_dash_chain_params_mainnet, x11_hash
+#include <impl/dash/coin/chain_rpc.hpp>     // is_synthetic_anchor (the honesty discriminator)
 
 #include <core/uint256.hpp>
 
@@ -183,5 +184,44 @@ TEST(DashAnchorHeaderMerkleRoot, PinnedHeaderX11EqualsPinnedBlockHash)
 
     EXPECT_EQ(dash::coin::x11_hash(hdr), cp.hash)
         << "pinned anchor header does not X11-hash to the pinned block hash";
+}
+
+// -------------------------------------------------------------------------
+// 5. HONESTY RECONCILIATION (Plan A). Feeding the anchor's merkleRoot to the
+//    DIP-4 auth must NOT turn the lone checkpoint anchor into a "daemon tip".
+//    The seed adopts ONLY the merkleRoot; every other header field stays at
+//    its synthetic default (m_bits==0), so chain_rpc::is_synthetic_anchor
+//    stays TRUE and getbestblockhash / getblockhash / getblockchaininfo keep
+//    WITHHOLDING difficulty / mediantime / bestblockhash until genuinely
+//    synced to the LIVE tip. RED if the seed copies the whole header (#1251's
+//    first cut): is_synthetic_anchor would flip false and the three
+//    DashChainRpc.*SyntheticAnchor* honesty guards would fail. GREEN with
+//    Plan A: auth-fed AND honest at the same seed.
+// -------------------------------------------------------------------------
+TEST(DashAnchorHeaderMerkleRoot, AnchorFedToAuthButStaysSyntheticForHonesty)
+{
+    HeaderChain hc(make_dash_chain_params_mainnet());
+    ASSERT_TRUE(hc.init());
+
+    auto e = hc.get_header_by_height(kAnchorHeight);
+    ASSERT_TRUE(e.has_value());
+
+    // (a) the DIP-4 auth trust anchor IS present ...
+    uint256 expected;
+    expected.SetHex(kAnchorMerkleRoot);
+    EXPECT_EQ(e->header.m_merkle_root, expected);
+
+    // (b) ... while the daemon-tip discriminator is UNTOUCHED: bits/time stay
+    // 0 so is_synthetic_anchor stays true and the honesty guards keep holding.
+    EXPECT_EQ(e->header.m_bits, 0u)
+        << "seeding the real hdr_bits flips is_synthetic_anchor to false and "
+           "publishes difficulty/mediantime/bestblockhash from one "
+           "unvalidated, non-live anchor";
+    EXPECT_EQ(e->header.m_timestamp, 0u)
+        << "a nonzero anchor timestamp makes median_time_past()!=0 -- a "
+           "fabricated daemon-tip mediantime";
+    EXPECT_TRUE(dash::coin::chain_rpc::is_synthetic_anchor(*e))
+        << "the lone checkpoint anchor must remain synthetic for the honesty "
+           "guards even though its merkleRoot is fed to the DIP-4 auth";
 }
 #endif // C2POOL_FAST_START_CHECKPOINT_HAS_HEADER

--- a/test/test_dash_anchor_header_merkle_root.cpp
+++ b/test/test_dash_anchor_header_merkle_root.cpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH daemonless COLD-CUT MN-payee bridge: anchor-header trust-anchor KAT.
+///
+/// THE INCIDENT (2026-08-16, vm905 wa0655re8, cut binary master 01dbba13 =
+/// #1243+#1250, --coin-rpc removed, --embedded-null-arm, NO dashd). #1250 made
+/// the header tip seed instantly AT the MN anchor (2513000), so the fold is
+/// eligible at t~=0 (see test_dash_header_checkpoint_coincide). Yet the
+/// embedded arm still NEVER served:
+///     [EMBED-STATUS] arm=would-decline cause=no-tip populated=0 have_mn=0
+///     bridge_wait=fold-mnlist-reply@h=2513000 hdr_tip=2517000
+/// The bridge asks for a base=ZERO snapshot at the anchor; the peer answers;
+/// the demux routes it to on_historical_snapshot; but DIP-4 authentication
+/// step (b) — bind the snapshot's cbTx merkle proof to OUR PoW-verified
+/// header's hashMerkleRoot — FAILS "block header not held" and the snapshot is
+/// consumed-but-never-applied. The payee cursor never leaves the anchor,
+/// have_mn stays 0, populated = have_tip AND have_mn stays 0, and on a
+/// --coin-rpc-removed binary there is NO dashd fallback → NO template → rigs
+/// shed before the first serve (reserve 25 -> 0 in ~14 min).
+///
+/// ROOT CAUSE. The #1250 fast-start seed built the anchor IndexEntry setting
+/// ONLY hash/height/chain_work/prev_hash/status — it never set entry.header,
+/// so entry.header.m_merkle_root is default (all-zero). main_dash.cpp's
+/// set_merkle_root_at_fn returns get_header(anchor)->header.m_merkle_root, i.e.
+/// a NULL root, and authenticate_historical_snapshot (historical_sml.hpp step
+/// b) fails closed. Pre-#1250 the anchor header was crawled in from the older
+/// 2400000 pin, so this root was present; #1250 dropped it while keeping the
+/// (correct) instant-start.
+///
+/// THE FIX (this PR). Pin the anchor block's FULL 80-byte header alongside its
+/// already release-pinned hash, and have the seed populate entry.header from
+/// it — but ONLY after self-verifying X11(header) == hash. That mints no new
+/// trust (the merkle root is derived from the already-approved hash) and fails
+/// closed on a corrupt pin.
+///
+/// RED on master: the seeded anchor entry has a null merkleRoot (tests 1-2
+/// use only master-present API, so they compile AND run on a pre-fix tree and
+/// FAIL there). GREEN with the fix: the seed carries+verifies the header, so
+/// the trust anchor is present at t~=0. Test 3 (fail-closed) is guarded on the
+/// fix's feature macro so the file still compiles on master.
+///
+/// #143 note: FOLDED into the allowlisted test_dash_node_reception_wire target
+/// (a standalone add_executable would silently report "Not Run"). #895 note:
+/// no #ifdef around the RED/GREEN bodies, so a green tick means they ran.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/header_chain.hpp>   // HeaderChain, make_dash_chain_params_mainnet, x11_hash
+
+#include <core/uint256.hpp>
+
+#include <optional>
+
+using dash::coin::HeaderChain;
+using dash::coin::make_dash_chain_params_mainnet;
+
+namespace {
+
+// The real hashMerkleRoot of mainnet block 2513000 (big-endian display), as
+// reported by two independent chain sources and, decisively, as recomputed by
+// X11 over the pinned 80-byte header inside the product itself.
+constexpr const char* kAnchorMerkleRoot =
+    "01470ce31e4ec9934a229f6eef4c9f561e42898be48d0bd646ab80f4bcc15b9c";
+constexpr uint32_t kAnchorHeight = 2513000;
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. REGRESSION. After the cold seed, the anchor's header merkleRoot — the
+//    DIP-4 trust anchor the MN-set bridge authenticates every historical
+//    snapshot against — must be PRESENT and equal to the real block's root.
+//    RED on master (seed leaves entry.header default -> null root -> bridge
+//    fails closed -> have_mn never flips -> no embedded template).
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashAnchorHeaderMerkleRoot, ColdSeedPopulatesVerifiedAnchorMerkleRoot)
+{
+    HeaderChain hc(make_dash_chain_params_mainnet()); // db_path="" -> in-memory
+    ASSERT_TRUE(hc.init());                            // seeds the fast-start checkpoint
+
+    auto e = hc.get_header_by_height(kAnchorHeight);
+    ASSERT_TRUE(e.has_value())
+        << "the fast-start checkpoint did not seed the anchor entry at all";
+
+    EXPECT_FALSE(e->header.m_merkle_root.IsNull())
+        << "anchor merkleRoot is NULL: the seed populated only the hash, so "
+           "authenticate_historical_snapshot step (b) fails 'block header not "
+           "held' — the base=ZERO anchor snapshot is consumed but never "
+           "applied, the payee cursor never leaves h=" << kAnchorHeight
+        << ", have_mn stays 0 and the embedded arm never serves";
+
+    uint256 expected;
+    expected.SetHex(kAnchorMerkleRoot);
+    EXPECT_EQ(e->header.m_merkle_root, expected)
+        << "seeded anchor merkleRoot does not match mainnet block "
+        << kAnchorHeight;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. WIRE PARITY WITH THE BRIDGE. Reproduce EXACTLY the callback
+//    main_dash.cpp installs as set_merkle_root_at_fn and feed it the anchor
+//    hash: it must return the real, non-null root. This is the precise value
+//    authenticate_historical_snapshot reads for its step-(b) proof. RED on
+//    master (returns a null root).
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashAnchorHeaderMerkleRoot, MerkleRootCallbackYieldsAnchorRootForBridge)
+{
+    HeaderChain hc(make_dash_chain_params_mainnet());
+    ASSERT_TRUE(hc.init());
+
+    // Byte-for-byte the lambda from main_dash.cpp set_merkle_root_at_fn.
+    auto merkle_root_of_hash =
+        [&hc](const uint256& block_hash) -> std::optional<uint256> {
+        if (auto e = hc.get_header(block_hash))
+            return e->header.m_merkle_root;
+        return std::nullopt;
+    };
+
+    auto cp = make_dash_chain_params_mainnet().fast_start_checkpoint;
+    ASSERT_TRUE(cp.has_value());
+
+    auto root = merkle_root_of_hash(cp->hash);
+    ASSERT_TRUE(root.has_value())
+        << "the anchor entry is not even in the header index";
+    EXPECT_FALSE(root->IsNull())
+        << "set_merkle_root_at_fn returns a NULL root for the anchor -> "
+           "authenticate_historical_snapshot fails closed at step (b)";
+
+    uint256 expected;
+    expected.SetHex(kAnchorMerkleRoot);
+    EXPECT_EQ(*root, expected);
+}
+
+#ifdef C2POOL_FAST_START_CHECKPOINT_HAS_HEADER
+// ─────────────────────────────────────────────────────────────────────────
+// 3. REWARD-SAFETY / FAIL-CLOSED. The seed must adopt the pinned header ONLY
+//    when X11(header) == the pinned block hash. Corrupt one bit of the pinned
+//    header and the seed must REFUSE it (leave the merkleRoot null) rather
+//    than seed a header whose forged merkleRoot could authenticate a forged
+//    SML. This is what makes the pin trust-neutral: the root is only trusted
+//    once proven to hash to the already release-pinned hash.
+//    (Guarded on the fix's feature macro so this file still compiles on a
+//    pre-fix tree for the RED run of tests 1-2.)
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashAnchorHeaderMerkleRoot, CorruptPinnedHeaderIsRefusedFailClosed)
+{
+    auto params = make_dash_chain_params_mainnet();
+    ASSERT_TRUE(params.fast_start_checkpoint.has_value());
+    ASSERT_TRUE(params.fast_start_checkpoint->has_header)
+        << "mainnet params must pin the anchor header for this guard to matter";
+
+    // Flip one bit of the nonce: X11(header) no longer equals the pinned hash.
+    params.fast_start_checkpoint->hdr_nonce ^= 1u;
+
+    HeaderChain hc(params);
+    ASSERT_TRUE(hc.init());
+
+    auto e = hc.get_header_by_height(kAnchorHeight);
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->header.m_merkle_root.IsNull())
+        << "a header that does NOT hash to the pinned block hash was seeded "
+           "anyway — a forged SML could then authenticate against its "
+           "merkleRoot; the seed must fail closed";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. SELF-CONSISTENCY. The pinned header actually hashes (X11) to the pinned
+//    block hash — the whole basis for trusting its merkleRoot. Proven from the
+//    product constant, not a fixture.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashAnchorHeaderMerkleRoot, PinnedHeaderX11EqualsPinnedBlockHash)
+{
+    auto params = make_dash_chain_params_mainnet();
+    ASSERT_TRUE(params.fast_start_checkpoint.has_value());
+    const auto& cp = params.fast_start_checkpoint.value();
+    ASSERT_TRUE(cp.has_header);
+
+    dash::coin::BlockHeaderType hdr;
+    hdr.m_version        = cp.hdr_version;
+    hdr.m_previous_block = cp.hdr_prev_block;
+    hdr.m_merkle_root    = cp.hdr_merkle_root;
+    hdr.m_timestamp      = cp.hdr_time;
+    hdr.m_bits           = cp.hdr_bits;
+    hdr.m_nonce          = cp.hdr_nonce;
+
+    EXPECT_EQ(dash::coin::x11_hash(hdr), cp.hash)
+        << "pinned anchor header does not X11-hash to the pinned block hash";
+}
+#endif // C2POOL_FAST_START_CHECKPOINT_HAS_HEADER


### PR DESCRIPTION
## Daemonless cold-cut: seed the fast-start anchor's full header so the MN-payee bridge can authenticate its snapshot

### The park (2026-08-16, vm905 `wa0655re8`, cut binary master `01dbba13` = #1243+#1250, `--coin-rpc` removed, `--embedded-null-arm`, **no dashd**)

After #1250 the header tip seeds instantly **at** the MN anchor (2513000), so the MN-set fold is *eligible* at t≈0 (the coincide gate is closed — see `test_dash_header_checkpoint_coincide`). Yet the embedded arm still **never served**:

```
[EMBED-STATUS] arm=would-decline cause=no-tip populated=0 have_mn=0
               bridge_wait=fold-mnlist-reply@h=2513000 hdr_tip=2517000
```

Over ~4.5 min: zero `populated>0` / `have_mn=1` / embedded-serve events. On a `--coin-rpc`-removed binary there is **no dashd fallback** → no template → rigs shed before the first serve (reserve 25→0 in ~14 min).

### Root cause — the anchor's `hashMerkleRoot` is null

The bridge requests a `base=ZERO` snapshot at the anchor. The peer answers; the demux correctly routes it to `on_historical_snapshot`; it is *consumed*. But DIP-4 authentication **step (b)** in `historical_sml.hpp` binds the snapshot's cbTx merkle proof to **our own PoW-verified header's `hashMerkleRoot`**:

```cpp
auto header_root = merkle_root_of_hash(diff.blockHash);
if (!header_root || header_root->IsNull())
    return fail("block header not held");
```

`main_dash.cpp`'s `set_merkle_root_at_fn` returns `get_header(anchor)->header.m_merkle_root`. The #1250 fast-start seed (`header_chain.hpp`) built the anchor `IndexEntry` setting **only** `hash/height/chain_work/prev_hash/status` — it never set `entry.header`, so `entry.header.m_merkle_root` is default (all-zero). Step (b) fails closed, `apply_fold()` never runs, the payee cursor never leaves the anchor, `have_mn` stays 0, `populated = have_tip AND have_mn` stays 0, and nothing is served.

Pre-#1250 this root was present because the header was **crawled in** from the older 2400000 pin; #1250 correctly collapsed that 31-min crawl but dropped the anchor header with it.

### The fix — pin the anchor's full header, self-verified

Carry the anchor block's full 80-byte header alongside its already release-pinned hash, and populate `entry.header` from it in the cold seed — **only after self-verifying `X11(header) == hash`**.

- Restores the pre-#1250 DIP-4 trust anchor while keeping #1250's instant start.
- **Mints no new trust.** The `hashMerkleRoot` is *derived* from the already release-pinned block hash: the seed refuses the header unless it X11-hashes to `hash`, so a corrupt pin **fails closed** (header left unseeded) rather than admitting a forged SML.
- **Reward-safety:** the served template's MN-payee / quorum-root bytes are unchanged — only the *latency* of acquiring `have_mn` on a cold daemonless start changes.

### Files
- `bitcoin_family/coin/chain_params.hpp` — `Checkpoint` gains optional full-header fields (`has_header`, `hdr_*`); other coins leave `has_header=false` and are byte-identical. Feature macro `C2POOL_FAST_START_CHECKPOINT_HAS_HEADER` lets the KAT compile on a pre-fix tree.
- `dash/coin/header_chain.hpp` — pin mainnet 2513000's header (version/prev/merkle/time/bits/nonce); seed populates + X11-verifies `entry.header`, fail-closed on mismatch.
- `test/test_dash_anchor_header_merkle_root.cpp` — regression (RED on master: null anchor root), the exact `set_merkle_root_at_fn` bridge callback, fail-closed guard, and X11 self-consistency. Folded into the allowlisted `test_dash_node_reception_wire` target.

### Seams reused
#999 checkpoint-lane recovery · #1162 `begin_fold` cursor · #1151 cursor restore · #1128 replay seam (payee cross-check + SML freshness) · #1250 coincident checkpoint (this is its direct successor). No new mechanism; the anchor header is the same release-pinned trust anchor the MN checkpoint already commits to.

### Verification
- **KAT red→green** on vm905 (BLS=REAL): pre-fix → anchor `merkleRoot` null (tests 1–2 fail); post-fix → real root, bridge callback returns it, corrupt-pin refused, X11 self-consistent.
- **vm905 daemonless cold-start measurement** (no dashd, `--coin-rpc` absent, `--embedded-null-arm`): time-to-first-embedded-template — see PR thread.

Draft — integrator review, not for merge.
