### PR TITLE
dash(daemonless): rotate the MN-checkpoint anchor->tip bulk fold body getdata across the handshaked pool (dashd IBD parity)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5857,26 +5857,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     // mn-needs-reseed latch holds the embedded arm down.
                     auto e = hc->get_header_by_height(h);
                     if (!e) return false;
-                    // #138 TAIL-TRACKED. The last bodies before the header tip
-                    // are the reseed-tail wedge surface: the announcer FIFO
-                    // (ANNOUNCER_CAP) has usually evicted them by the time the
-                    // bridge's cursor arrives, and the lane's own stall probe
-                    // can only re-ask down the SAME block_source() route once
-                    // per pump (~2.5 min) — a connected-but-silent peer eats
-                    // every re-ask identically. Tracking hands those requests
-                    // to the p2p lost-body watchdog (service_pending_bodies),
-                    // which rotates the re-request to a NEIGHBOUR after 10 s,
-                    // bounded at BODY_REREQUEST_MAX; the redelivered body rides
-                    // the ordinary full_block -> on_block_connected ingest the
-                    // lane already consumes. The BULK leg stays UNTRACKED by
-                    // design: kWindow=64 asks per window would defeat
-                    // PENDING_BODY_CAP=8 (see the request_block_tracked doc),
-                    // and bulk already has the lane's windowed re-request loop.
-                    // <=3 tracked heights per window, well under the cap.
-                    const uint32_t tip = hc->height();
-                    if (tip != 0 && h + 2 >= tip)
-                        return cp->request_block_tracked(e->hash);
-                    return cp->request_block(e->hash);
+                    // BULK + TAIL both TRACKED. The whole anchor->tip fold now
+                    // rides the dashd-style lost-body watchdog
+                    // (service_pending_bodies): the initial getdata is spread
+                    // round-robin across the handshaked pool
+                    // (request_block -> select_block_peer, dashd
+                    // FindNextBlocksToDownload), a stalled window is re-requested
+                    // from a DIFFERENT peer, and the chronic staller is
+                    // disconnected so the pool churns to one that serves the
+                    // body. The in-flight bound is dashd's per-peer window x pool
+                    // size (effective_pending_cap = MAX_BLOCKS_IN_TRANSIT_PER_PEER
+                    // x handshaked peers), so a full kWindow no longer defeats
+                    // the tracker. This closes the deep (~9.5k-block) cut cold
+                    // fold's single-primary wedge, where every body funnelled at
+                    // m_primary and only that peer was re-asked — freezing at the
+                    // first window when it churned or rate-limited. Reward-safe:
+                    // getdata routing only; the derived MN/quorum/credit-pool
+                    // bytes and every publish() hold are unchanged.
+                    return cp->request_block_tracked(e->hash);
                 });
             mn_ckpt_lane->set_tip_height_fn(
                 [hc = header_chain.get()]() { return hc->height(); });

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -593,9 +593,19 @@ private:
     // disconnected (releasing its slot; the peer-manager backoff keeps it from
     // being re-dialed immediately) so recovery churns to a peer that has it.
     static constexpr int      BODY_REREQUEST_MAX = 4;
-    // Tracked slots are bounded by design: the tip body plus a short burst
-    // of near-tip blocks; oldest evicted beyond this.
+    // Tracked slots floor: the tip body plus a short burst of near-tip
+    // blocks. The tip-follow path never needs more than this.
     static constexpr size_t PENDING_BODY_CAP  = 8;
+    // dashd MAX_BLOCKS_IN_TRANSIT_PER_PEER: the parallel in-flight window it
+    // keeps PER PEER during IBD (net_processing.cpp). The tracked-body watchdog
+    // now also carries the mn-checkpoint anchor->tip BULK fold (a ~9.5k-block
+    // deep replay on a cut cold start), so the in-flight bound is dashd's
+    // per-peer window times the handshaked pool size (effective_pending_cap),
+    // never below PENDING_BODY_CAP. This lets a full fold window
+    // (MnCheckpointLane::kWindow) stay tracked and spread across the pool
+    // instead of being evicted at a fixed 8 — the eviction that used to strand
+    // bulk-fold slots and leave the whole fold funnelled at one primary.
+    static constexpr size_t MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
     // Pool-status log cadence (the soak's direct read on peer count + durability).
     static constexpr time_t POOL_STATUS_INTERVAL_SEC = 60;
     // A dial that never calls back (no connected(), no connect_failed()) must not
@@ -633,6 +643,14 @@ private:
     // completes its handshake and re-elected from the surviving handshaked
     // peers when that one is lost. nullptr => no peer is ready to be asked.
     PeerSession* m_primary{nullptr};
+    // Round-robin cursor over m_pool for bulk/historical block-body getdata
+    // (dashd FindNextBlocksToDownload spreads a deep IBD window across peers,
+    // never funnelling it at one peer).
+    std::size_t  m_bulk_rr{0};
+    // The peer select_block_peer() last sent a block getdata to, so
+    // request_block_tracked() arms the watchdog against the peer actually
+    // asked (not an unrelated primary).
+    std::string  m_last_requested_peer;
     // Dispatch cursor: the peer whose message is being handled RIGHT NOW.
     // Valid only inside handle(); this client is single-thread-confined to the
     // io_context (main_dash.cpp:1613), so this is a parameter, not shared state.
@@ -1427,7 +1445,10 @@ public:
     /// their own re-request loops may keep ignoring the return value.
     bool request_block(const uint256& block_hash)
     {
-        PeerSession* p = block_source(block_hash);
+        // Announcer for a tip body; round-robin across the handshaked pool for
+        // a bulk/historical body (dashd IBD spread). select_block_peer records
+        // the chosen peer for the watchdog.
+        PeerSession* p = select_block_peer(block_hash);
         if (!p) return false;
         auto msg = message_getdata::make_raw(
             {inventory_type(inventory_type::block, block_hash)});
@@ -1460,16 +1481,17 @@ public:
                 if (sent) pb.last_req = now;
                 return sent;
             }
-        if (m_pending_bodies.size() >= PENDING_BODY_CAP)
+        if (m_pending_bodies.size() >= effective_pending_cap())
             m_pending_bodies.erase(m_pending_bodies.begin());   // oldest slot
         PendingBody pb;
         pb.hash      = block_hash;
         pb.first_req = now;
         pb.last_req  = sent ? now : 0;
-        // The announcer just got the initial getdata; record it so the watchdog
-        // rotates AWAY from it (to a neighbour) if it does not answer in time.
-        PeerSession* src = block_source(block_hash);
-        pb.last_peer = src ? src->key : std::string{};
+        // The peer request_block() just sent the initial getdata to (announcer
+        // for a tip body, or the round-robin pool peer for a bulk/historical
+        // body). Recorded so the watchdog rotates AWAY from it to a neighbour
+        // if it does not answer in time.
+        pb.last_peer = m_last_requested_peer;
         m_pending_bodies.push_back(std::move(pb));
         return sent;
     }
@@ -1755,11 +1777,12 @@ private:
         m_block_announcers.push_back(BlockAnnouncer{hash, key});
     }
 
-    /// The peer to fetch a block from: the one that ANNOUNCED it (it holds it
-    /// by definition and its reply routes back to its own session), falling
-    /// back to the primary when the announcer is unknown or has since churned
-    /// out of the pool. Never returns a stale pointer — resolved live.
-    PeerSession* block_source(const uint256& hash)
+    /// The peer that ANNOUNCED this block (it holds it by definition and its
+    /// reply routes back to its own session), or nullptr when no live
+    /// handshaked announcer is known — the deep-historical / bulk-fold case,
+    /// where the block was buried long before this node connected and was
+    /// never inv'd to us. Never returns a stale pointer — resolved live.
+    PeerSession* announced_source(const uint256& hash)
     {
         for (auto& a : m_block_announcers)
             if (a.hash == hash)
@@ -1768,7 +1791,65 @@ private:
                 if (p && p->handshake.complete()) return p;
                 break;
             }
+        return nullptr;
+    }
+
+    /// The peer to fetch a block from for the ORDERED, non-bulk legs
+    /// (getheaders-before-connect): the announcer, else the primary. Unchanged
+    /// from the pre-rotation behaviour so the header/tip legs keep their stable
+    /// carrier.
+    PeerSession* block_source(const uint256& hash)
+    {
+        if (PeerSession* a = announced_source(hash)) return a;
         return m_primary;
+    }
+
+    /// Round-robin the next handshaked peer for a bulk/historical block-body
+    /// getdata. dashd's FindNextBlocksToDownload assigns each needed block to a
+    /// peer whose tip covers it and keeps MAX_BLOCKS_IN_TRANSIT_PER_PEER in
+    /// flight PER PEER, in parallel across the whole peer set — it never
+    /// funnels a deep IBD window at a single peer. For a buried block every
+    /// handshaked peer's tip covers it, so we spread the window across them: a
+    /// slow / rate-limiting peer then serialises only its 1/N share instead of
+    /// wedging the entire anchor->tip fold behind one primary. Falls back to
+    /// the primary only when the pool holds no handshaked peer at all.
+    PeerSession* next_bulk_peer()
+    {
+        const std::size_t n = m_pool.size();
+        if (n == 0) return m_primary;
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
+            if (p->handshake.complete())
+            {
+                m_bulk_rr = (m_bulk_rr + i + 1) % n;
+                return p;
+            }
+        }
+        return m_primary;
+    }
+
+    /// dashd mapBlocksInFlight bound: MAX_BLOCKS_IN_TRANSIT_PER_PEER across
+    /// every handshaked peer, floored at PENDING_BODY_CAP so a momentarily
+    /// empty pool still keeps the tip-follow slots.
+    std::size_t effective_pending_cap() const
+    {
+        const std::size_t hs = handshaked_peer_count();
+        const std::size_t cap = MAX_BLOCKS_IN_TRANSIT_PER_PEER * (hs ? hs : 1);
+        return cap > PENDING_BODY_CAP ? cap : PENDING_BODY_CAP;
+    }
+
+    /// The peer a plain block-body getdata is sent to: the announcer when one
+    /// is live (tip-follow), else round-robin across the pool (bulk/historical
+    /// IBD). Records the chosen peer (m_last_requested_peer) so
+    /// request_block_tracked() arms the watchdog slot against the peer that was
+    /// ACTUALLY asked.
+    PeerSession* select_block_peer(const uint256& hash)
+    {
+        PeerSession* p = announced_source(hash);
+        if (!p) p = next_bulk_peer();
+        m_last_requested_peer = p ? p->key : std::string{};
+        return p;
     }
 
     bool holds_key(const std::string& key) const

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1176,4 +1176,97 @@ TEST(DashCoinP2PPool, tracked_request_that_died_locally_reports_it_and_recovers_
         << "re-asking an already-tracked hash must not grow the slots";
 }
 
+// ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
+// DASHD-CUT — the anchor->tip mn-checkpoint BULK fold must fan its block-body
+// getdata across the WHOLE handshaked pool and disconnect a stalling peer, the
+// way dashd's FindNextBlocksToDownload / mapBlocksInFlight downloads a deep IBD
+// window in parallel across peers and drops a staller (BLOCK_STALLING_TIMEOUT).
+//
+// The wedge these cover (measured on vm905, wf wt1q31gh2, belt+control both
+// FROZE at cursor=2513065 applied=64): #1250 seeds the mn-ckpt anchor ~9.5k
+// blocks BELOW the header tip, so the ENTIRE fold is the deep-historical
+// (no-announcer) regime. On master every such body was routed to a single
+// m_primary (block_source fallback) and the fixed PENDING_BODY_CAP=8 evicted
+// all but the newest 8 tracked slots — so a slow / churning primary froze the
+// fold at the first 64-block window and only that one peer was ever re-asked.
+//
+// FAILS-ON-MASTER: (1) all getdata funnel at the primary (peers_asked==1),
+// (2) the window is evicted to 8 tracked slots (pending_body_count==8 not 64).
+// ââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
+
+TEST(DashCoinP2PPool, bulk_fold_getdata_fans_out_across_the_whole_pool)
+{
+    PoolRig rig;
+    rig.client.set_max_peers(8);
+    for (int i = 1; i <= 8; ++i) rig.handshake(i, /*height=*/2513000u + i);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 8u);
+
+    // Per-peer outbound baseline (the handshake itself sent our version).
+    std::vector<uint64_t> base(9, 0);
+    for (int i = 1; i <= 8; ++i) base[i] = rig.session(i)->msgs_sent;
+
+    // A full fold window of BURIED blocks — none announced (no inv delivered),
+    // exactly the deep anchor->tip regime.
+    const uint32_t W = 64;
+    for (uint32_t k = 0; k < W; ++k)
+        ASSERT_TRUE(rig.client.request_block_tracked(hash_n(500000u + k)))
+            << "with 8 handshaked peers every bulk body must reach the wire";
+
+    int peers_asked = 0;
+    uint64_t max_on_one = 0, total = 0;
+    for (int i = 1; i <= 8; ++i) {
+        const uint64_t got = rig.session(i)->msgs_sent - base[i];
+        if (got > 0) ++peers_asked;
+        if (got > max_on_one) max_on_one = got;
+        total += got;
+    }
+    EXPECT_EQ(total, static_cast<uint64_t>(W))
+        << "every window body must reach exactly one peer";
+    EXPECT_EQ(peers_asked, 8)
+        << "the fold window must fan out across the WHOLE handshaked pool "
+           "(dashd FindNextBlocksToDownload), not funnel at m_primary";
+    EXPECT_LE(max_on_one, static_cast<uint64_t>(W / 8 + 1))
+        << "no peer may carry more than its round-robin share of the window";
+
+    // ...and the full window stays TRACKED by the lost-body watchdog: the
+    // in-flight bound is dashd's MAX_BLOCKS_IN_TRANSIT_PER_PEER(16) x 8 peers
+    // = 128 >= 64, not the fixed cap of 8 that used to strand the bulk fold.
+    EXPECT_EQ(rig.client.pending_body_count(), static_cast<std::size_t>(W))
+        << "the whole fold window must stay in service_pending_bodies so a "
+           "stalled body is re-requested from another peer, not lost";
+}
+
+TEST(DashCoinP2PPool, a_stalling_bulk_peer_is_disconnected_so_the_fold_advances)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(8);
+    for (int i = 1; i <= 8; ++i) rig.handshake(i, /*height=*/2513000u + i);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 8u);
+
+    // A fold window that NOBODY ever delivers — every assigned peer stalls the
+    // body it was handed. The watchdog must re-request each stalled body from a
+    // DIFFERENT peer and, once a peer has chronically stalled, DISCONNECT it
+    // (dashd disconnect-on-stall + reassign), so the fold keeps advancing
+    // instead of freezing behind one silent peer at the first window.
+    const uint32_t W = 64;
+    for (uint32_t k = 0; k < W; ++k)
+        ASSERT_TRUE(rig.client.request_block_tracked(hash_n(600000u + k)));
+    ASSERT_EQ(rig.client.pending_body_count(), static_cast<std::size_t>(W))
+        << "the full bulk window is tracked (this assert also fails on master, "
+           "where the window is evicted to the fixed cap of 8)";
+
+    const uint64_t rr0 = rig.client.body_rerequests_total();
+    rig.run_seconds(600);   // ten minutes of stall service; no peer answers
+
+    EXPECT_GT(rig.client.body_rerequests_total(), rr0)
+        << "a stalled bulk window must be re-requested by the watchdog, not "
+           "left on one peer forever";
+    EXPECT_GE(rig.client.body_stall_evictions(), 1u)
+        << "a chronically stalling peer must be disconnected so the pool churns "
+           "to a peer that serves the body (dashd disconnect-on-stall)";
+    EXPECT_GT(rig.client.handshaked_peer_count(), 0u)
+        << "graceful degradation: a stall must never drain the pool to zero";
+}
+
 } // namespace


### PR DESCRIPTION
## What

Route the daemonless DASH MN-checkpoint **anchor→tip bulk fold** block-body `getdata` across the whole handshaked coin-P2P pool instead of funnelling it at a single `m_primary`, mirroring dashd's IBD block download (`FindNextBlocksToDownload` + `mapBlocksInFlight`). Reuses the existing `service_pending_bodies()` lost-body watchdog (the #138 tracked path) and extends it to the bulk leg.

**Reward-safety: UNTOUCHED.** Only body *acquisition* routing changes. The served template MN-payee / quorum-root / credit-pool bytes stay dashd-exact, each folded block is still validated and coinbase-cross-checked, and every `publish()` hold (#91 resume, #1048 unseeded-fold, #94/#1128 SML freshness) and the refuse-newer-anchor guard are unchanged.

## Why

On a `--coin-rpc`-removed cut cold start the MN-set anchor (#1250, mainnet `2513000`) sits ~9.5k blocks below the header tip, so the **entire** fold runs in the deep-historical (no-announcer) regime. On master:

- `request_block()` routed every un-announced body to `block_source()`'s `m_primary` fallback — one peer for the whole window.
- the bulk leg was deliberately left **untracked** because a full `kWindow=64` would defeat the fixed `PENDING_BODY_CAP=8`, so the only re-request driver was the lane's own loop, which re-asked the **same** primary forever with no rotation and no disconnect-on-stall.

Measured on vm905 (belt `e5b26503` + control `3e4fddb4`, both cold, `--coin-rpc` removed, `--embedded-null-arm`, dashd absent): the fold **froze** at `cursor=2513065 applied=64` once the archival workhorse peer churned out / rate-limited and the replacement primary would not serve window-2; the other 7 handshaked peers were never asked.

## How (reuses existing seams)

- `next_bulk_peer()` — round-robin the initial `getdata` of an un-announced (buried) body across the handshaked pool. Announced tip bodies still go to their announcer (`block_source` unchanged for the ordered header legs).
- `effective_pending_cap()` = `MAX_BLOCKS_IN_TRANSIT_PER_PEER(16) × handshaked peers` (≥ `PENDING_BODY_CAP`) — dashd's `mapBlocksInFlight` bound, so a full fold window stays tracked instead of being evicted to 8 and stranded on one primary.
- `main_dash` `RequestBlockFn` routes the **whole** anchor→tip fold (bulk + tail) through `request_block_tracked`, so a stalled window is re-requested from a **different** peer and the chronic staller is disconnected (dashd disconnect-on-stall), never re-asked on the single primary.

## Tests (red-on-master, green with fix)

`test/test_dash_coin_p2p_pool.cpp`:
- `DashCoinP2PPool.bulk_fold_getdata_fans_out_across_the_whole_pool` — RED on master: `peers_asked==1`, `max_on_one==64`, window evicted to 8 tracked slots. GREEN: fan-out across all 8, full 64-block window tracked.
- `DashCoinP2PPool.a_stalling_bulk_peer_is_disconnected_so_the_fold_advances` — the full tracked window is re-requested + the chronic staller disconnected, pool never drained to zero.

Full `test_dash_p2p_node` suite **130/130 green**. Build: `c2pool-dash`, **BLS=REAL** (dashbls linked).

## vm905 cold-cut measurement (dashd absent, --coin-rpc removed, --embedded-null-arm)

The single-peer funnel is **fixed and proven live**: block bodies now fan out across **all 8** handshaked peers (histogram e.g. `199.85.8.191:407  85.209.241.13:343  83.149.100.186:144  95.85.12.33:112  8.222.146.67:72  89.35.131.149:61  188.40.163.12:60  45.58.56.82:59` — vs belt's single-peer `8.222.146.67:1495` = ~99%), with `body_rerequests` climbing into the thousands, active `body_stall_evictions`, and **no hard wedge** (`have_tip` reaches 1; cursor advances instead of the belt's `frozen_for=1066s`).

**Honest limitation — the cold fold does NOT reach `populated=1`/tip in this environment, and this PR alone does not close that gate.** After the funnel is removed the contiguous frontier body still arrives at only ~0.02 blk/s from the reachable peer set, **with or without** the co-running `--embedded-utxo` bootstrap lane. That residual is genuine **open-network deep-historical body scarcity** (most mainnet peers prune ~9.6k-deep blocks; the few archival ones rate-limit) — the classification's `archival_peer_unblocks: PARTIALLY / UNRELIABLY`. Closing the cold-cut-to-tip gate additionally needs an operator **archival peer** (`--coin-p2p-connect`/`addnode` a known non-pruned dashd), and would benefit from two follow-ups: (a) **prefer** a proven-archival peer for the serial fold frontier rather than blind round-robin (a contiguous fold serializes on the frontier block); (b) **deconflict** the `--embedded-utxo` bootstrap lane while the MN-checkpoint fold is bridging (analogous to the replay-bulk deconfliction seam).

DRAFT — author frstrtr, integrator review. Not merged.
