### PR TITLE
dash(daemonless): converge bulk-fold body getdata onto archival peers (dashd CanServeBlocks + per-peer failure demotion)

### DIFF
--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -618,6 +618,22 @@ private:
     // vendor/quorum_tail.hpp) parse the >=70230 layout.
     static constexpr uint32_t PROTOCOL_VERSION = 70230;
     static constexpr uint64_t NODE_NETWORK = 1;   // no segwit/witness on Dash
+    // dashd service-flag classification (net_processing CanServeBlocks /
+    // IsLimitedPeer). A PRUNED node advertises NODE_NETWORK_LIMITED (serves
+    // only the last ~288 blocks) and CLEARS NODE_NETWORK; a full/archival node
+    // sets NODE_NETWORK (usually LIMITED too). The mn-checkpoint anchor->tip
+    // bulk fold reaches ~9.5k blocks deep, so a limited-only peer can never
+    // serve it — CanServeBlocks convergence must exclude it from selection.
+    static constexpr uint64_t NODE_NETWORK_LIMITED = 0x400;
+    // dashd NODE_NETWORK_LIMITED_MIN_BLOCKS(288) - 2: the depth beyond which a
+    // limited peer is not asked (FindNextBlocksToDownload historical gate).
+    static constexpr uint32_t LIMITED_PEER_HISTORY_BLOCKS = 286;
+    // A peer that answers NOTFOUND for a bulk body, or that the stall watchdog
+    // disconnects for a chronic body stall, is demoted after this many strikes:
+    // next_bulk_peer() then skips it so the round-robin CONVERGES onto peers
+    // that actually deliver deep history (dashd per-peer download-failure
+    // demotion). One clean body delivery from a peer forgives it.
+    static constexpr int BULK_NONSERVER_STRIKE_MAX = 2;
     static constexpr uint16_t MAINNET_P2P_PORT = 9999;
 
 public:
@@ -647,6 +663,11 @@ private:
     // (dashd FindNextBlocksToDownload spreads a deep IBD window across peers,
     // never funnelling it at one peer).
     std::size_t  m_bulk_rr{0};
+    // dashd per-peer download-failure demotion (archival convergence). Keyed by
+    // peer addr:port so a strike survives the PeerSession object and even a
+    // reconnect to the same non-serving address. Incremented on NOTFOUND for a
+    // bulk body and on stall-eviction; cleared when that peer delivers a body.
+    std::map<std::string, int> m_bulk_nonserver_strikes;
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1211,6 +1232,20 @@ public:
     /// pool timer would. Paired with set_now_fn this replaces the io_context
     /// entirely for policy tests — no real timer, no real waiting, no race.
     void tick_for_test() { on_pool_tick(); }
+
+    /// TEST-ONLY: exercise the bulk/historical body peer SELECTION directly
+    /// (announcer-less path), returning the chosen peer's key — the seam the
+    /// CanServeBlocks/demotion KATs assert convergence on.
+    std::string select_bulk_peer_key_for_test(const uint256& hash)
+    { PeerSession* p = select_block_peer(hash); return p ? p->key : std::string{}; }
+    /// TEST-ONLY: current non-server strike count for a peer address.
+    int bulk_nonserver_strikes_for_test(const std::string& key) const
+    { auto it = m_bulk_nonserver_strikes.find(key); return it == m_bulk_nonserver_strikes.end() ? 0 : it->second; }
+    /// TEST-ONLY: is this peer currently demoted out of bulk selection?
+    bool bulk_demoted_for_test(const std::string& key) const { return bulk_demoted(key); }
+    /// TEST-ONLY: clear a peer's non-server strike (the forgiveness a real
+    /// body delivery triggers on the ingest path).
+    void forgive_bulk_nonserver_for_test(const std::string& key) { forgive_bulk_nonserver(key); }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1813,15 +1848,68 @@ private:
     /// slow / rate-limiting peer then serialises only its 1/N share instead of
     /// wedging the entire anchor->tip fold behind one primary. Falls back to
     /// the primary only when the pool holds no handshaked peer at all.
+    // ── dashd CanServeBlocks service-flag classification ─────────────────
+    /// A peer advertises full-block (archival) service — dashd NODE_NETWORK.
+    static bool advertises_full_blocks(const PeerSession* p)
+    { return p && (p->services & NODE_NETWORK); }
+    /// dashd IsLimitedPeer: pruned — serves only the last ~288 blocks.
+    static bool advertises_limited_only(const PeerSession* p)
+    { return p && !(p->services & NODE_NETWORK) && (p->services & NODE_NETWORK_LIMITED); }
+    /// dashd CanServeBlocks: serves blocks AT ALL (full or limited).
+    static bool can_serve_blocks(const PeerSession* p)
+    { return p && (p->services & (NODE_NETWORK | NODE_NETWORK_LIMITED)); }
+    /// dashd pindexBestKnownBlock coverage: the peer's announced tip is at or
+    /// above the wanted height, so it can be expected to hold that block.
+    static bool peer_covers_height(const PeerSession* p, uint32_t height)
+    { return p && p->start_height >= height; }
+
+    /// Has this peer been demoted as a demonstrated non-server of deep history?
+    bool bulk_demoted(const std::string& key) const
+    {
+        auto it = m_bulk_nonserver_strikes.find(key);
+        return it != m_bulk_nonserver_strikes.end()
+               && it->second >= BULK_NONSERVER_STRIKE_MAX;
+    }
+    void note_bulk_nonserver(const std::string& key)
+    { if (!key.empty()) ++m_bulk_nonserver_strikes[key]; }
+    void forgive_bulk_nonserver(const std::string& key)
+    { if (!key.empty()) m_bulk_nonserver_strikes.erase(key); }
+
+    /// dashd FindNextBlocksToDownload eligibility for a DEEP-historical bulk
+    /// body: the peer must have handshaked, advertise full-block service (a
+    /// limited/pruned peer cannot serve ~9.5k-deep history), and not be a
+    /// demoted non-server. Height coverage is not gated here because the fold
+    /// requests span the whole anchor->tip window and every peer's start_height
+    /// (its own tip) covers every buried block; peer_covers_height() is the
+    /// available lever should a lagging peer ever join.
+    bool bulk_eligible(const PeerSession* p) const
+    {
+        return p && p->handshake.complete()
+               && advertises_full_blocks(p)
+               && !advertises_limited_only(p)
+               && !bulk_demoted(p->key);
+    }
+
     PeerSession* next_bulk_peer()
     {
         const std::size_t n = m_pool.size();
         if (n == 0) return m_primary;
-        for (std::size_t i = 0; i < n; ++i)
+        // Pass 0: dashd CanServeBlocks + per-peer failure demotion — only peers
+        // that advertise full-block service AND have not been demoted for
+        // chronic non-service. This makes the round-robin CONVERGE onto
+        // archival deliverers instead of blindly re-asking pruned/dead peers.
+        // Pass 1: any handshaked peer (non-regression — when the reachable set
+        // holds no eligible peer we still spread across the pool exactly as
+        // #1253 did, rather than wedge on an empty selection; this is the real
+        // historical-body-scarcity case where every reachable peer is
+        // limited/demoted).
+        for (int pass = 0; pass < 2; ++pass)
         {
-            PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
-            if (p->handshake.complete())
+            for (std::size_t i = 0; i < n; ++i)
             {
+                PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
+                if (!p->handshake.complete()) continue;
+                if (pass == 0 && !bulk_eligible(p)) continue;
                 m_bulk_rr = (m_bulk_rr + i + 1) % n;
                 return p;
             }
@@ -2254,6 +2342,10 @@ private:
                     ++pb.evictions;
                     ++m_body_stall_evictions;
                     pb.stalls_since_evict = 0;
+                    // The disconnected staller demonstrably did not serve this
+                    // deep body: demote its address so a refill/reconnect to it
+                    // is skipped by next_bulk_peer() (dashd failure demotion).
+                    note_bulk_nonserver(staller);
                     pb.stall_timeout = BODY_STALL_TIMEOUT_INIT;
                     remove_peer(bad,
                         "block-stall: body " + pb.hash.GetHex().substr(0, 16)
@@ -2582,6 +2674,10 @@ private:
         for (auto it = m_pending_bodies.begin();
              it != m_pending_bodies.end(); ++it)
             if (it->hash == blockhash) { m_pending_bodies.erase(it); break; }
+        // This peer just DELIVERED a body — it demonstrably serves blocks, so
+        // clear any non-server strike so it re-enters bulk selection (dashd
+        // forgives a peer the moment it satisfies a download).
+        forgive_bulk_nonserver(p->key);
         // W2 bulk demux: a body the replay bulk lane has in flight is consumed
         // HERE (verified + folded + pruned by the lane) and never fires
         // full_block — the live ingest legs are tip-rate consumers and must
@@ -3001,6 +3097,11 @@ private:
                 // on a DIFFERENT peer immediately instead of waiting out the
                 // scheduler timeout. No-op unless --replay-bulk registered it.
                 if (m_on_block_notfound) m_on_block_notfound(inv.m_hash);
+                // dashd per-peer download-failure demotion: this peer just
+                // declared it does NOT hold a block we asked for. Strike it so
+                // next_bulk_peer() converges away from non-servers of deep
+                // history onto archival peers that actually deliver.
+                note_bulk_nonserver(p->key);
             }
         }
     }

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -132,12 +132,13 @@ struct PoolRig
     }
 
     std::unique_ptr<RawMessage> version_msg(uint32_t height,
-                                            const std::string& subver = "/Dash Core:21.1.0/")
+                                            const std::string& subver = "/Dash Core:21.1.0/",
+                                            uint64_t services = 1)
     {
         return p2p::message_version::make_raw(
-            70230, /*services=*/1, /*timestamp=*/1234567890ull,
-            addr_t{1, NetService{"127.0.0.1", 19999}},
-            addr_t{1, NetService{"127.0.0.1", 19999}},
+            70230, services, /*timestamp=*/1234567890ull,
+            addr_t{services, NetService{"127.0.0.1", 19999}},
+            addr_t{services, NetService{"127.0.0.1", 19999}},
             /*nonce=*/0x1122334455667788ull, subver, height);
     }
 
@@ -147,6 +148,22 @@ struct PoolRig
         attach(n);
         deliver(n, version_msg(height));
         deliver(n, p2p::message_verack::make_raw());
+    }
+
+    /// Full attach + version/verack for peer n advertising a SPECIFIC service
+    /// bitfield — the CanServeBlocks convergence KATs stand up mixed
+    /// archival(NODE_NETWORK) / pruned(NODE_NETWORK_LIMITED) pools this way.
+    void handshake_services(int n, uint64_t services, uint32_t height = 1000)
+    {
+        attach(n);
+        deliver(n, version_msg(height, "/Dash Core:21.1.0/", services));
+        deliver(n, p2p::message_verack::make_raw());
+    }
+
+    static std::unique_ptr<RawMessage> block_notfound(const uint256& h)
+    {
+        return p2p::message_notfound::make_raw(std::vector<p2p::inventory_type>{
+            p2p::inventory_type(p2p::inventory_type::block, h)});
     }
 
     const PeerSession* session(int n) const
@@ -1270,3 +1287,114 @@ TEST(DashCoinP2PPool, a_stalling_bulk_peer_is_disconnected_so_the_fold_advances)
 }
 
 } // namespace
+
+// ══════════════════════════════════════════════════════════════════════════
+// (H) CanServeBlocks CONVERGENCE — dashd net_processing service-flag gate +
+//     per-peer download-failure demotion, ported onto the #1253 bulk-fold
+//     round-robin. The mn-checkpoint anchor->tip fold must target ONLY peers
+//     that advertise they can serve the block (NODE_NETWORK, not pruned-only)
+//     and must CONVERGE away from peers that fail to serve (NOTFOUND / stall
+//     eviction) so a deep IBD window re-homes onto archival deliverers.
+//
+//     RED on #1253 (blind round-robin, service-flag-/demotion-blind): a
+//     limited-only peer is selected for a deep body it cannot serve, and a
+//     peer that keeps answering NOTFOUND keeps being re-asked.
+//     GREEN with the port: the pruned peer is never selected, the failing peer
+//     is demoted out, and selection converges onto the full-block peers.
+// ══════════════════════════════════════════════════════════════════════════
+
+// NODE_NETWORK=0x1, NODE_NETWORK_LIMITED=0x400 (dashd protocol.h).
+static constexpr uint64_t SVC_NETWORK        = 0x1;
+static constexpr uint64_t SVC_LIMITED        = 0x400;
+static constexpr uint64_t SVC_FULL           = 0x1 | 0x400;   // archival: both
+static constexpr uint64_t SVC_LIMITED_ONLY   = 0x400;         // pruned
+
+TEST(DashBulkCanServe, limited_only_peer_is_never_selected_for_a_deep_bulk_body)
+{
+    PoolRig rig;
+    // Two archival (full-block) peers and one pruned (limited-only) peer.
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 3u);
+
+    // Announcer-less (deep-historical) body selection, many rounds so a blind
+    // round-robin would land on peer 3 repeatedly.
+    std::map<std::string, int> hits;
+    for (uint32_t k = 0; k < 60; ++k)
+        hits[rig.client.select_bulk_peer_key_for_test(hash_n(1000 + k))]++;
+
+    // GREEN: the pruned peer is EXCLUDED entirely; both archival peers serve.
+    EXPECT_EQ(hits[PoolRig::peer_key(3)], 0)
+        << "a limited-only (pruned) peer must never be asked for ~9.5k-deep "
+           "history — dashd IsLimitedPeer gate";
+    EXPECT_GT(hits[PoolRig::peer_key(1)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(2)], 0);
+    EXPECT_EQ(hits[PoolRig::peer_key(1)] + hits[PoolRig::peer_key(2)], 60);
+}
+
+TEST(DashBulkCanServe, notfound_demotes_a_nonserver_and_selection_converges)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 3u);
+
+    // Peer 2 keeps answering NOTFOUND for deep bodies (advertises NODE_NETWORK
+    // but does not actually serve buried history — the live-network symptom).
+    for (int i = 0; i < 2; ++i)   // BULK_NONSERVER_STRIKE_MAX
+        rig.deliver(2, PoolRig::block_notfound(hash_n(7000 + i)));
+
+    EXPECT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)))
+        << "a peer that repeatedly answers NOTFOUND must be demoted "
+           "(dashd per-peer download-failure demotion)";
+
+    // GREEN: selection now CONVERGES onto the two delivering peers; the demoted
+    // non-server is never chosen again.
+    std::map<std::string, int> hits;
+    for (uint32_t k = 0; k < 60; ++k)
+        hits[rig.client.select_bulk_peer_key_for_test(hash_n(8000 + k))]++;
+    EXPECT_EQ(hits[PoolRig::peer_key(2)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(1)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(3)], 0);
+}
+
+TEST(DashBulkCanServe, delivering_a_body_forgives_a_demoted_peer)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    for (int i = 0; i < 2; ++i)
+        rig.deliver(2, PoolRig::block_notfound(hash_n(100 + i)));
+    ASSERT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)));
+
+    // A single clean body delivery from peer 2 clears the strike — it
+    // demonstrably serves blocks now (dashd forgives on a satisfied download).
+    rig.client.forgive_bulk_nonserver_for_test(PoolRig::peer_key(2));
+    EXPECT_FALSE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)));
+    EXPECT_EQ(rig.client.bulk_nonserver_strikes_for_test(PoolRig::peer_key(2)), 0);
+}
+
+TEST(DashBulkCanServe, no_eligible_peer_falls_back_never_wedges_the_selection)
+{
+    PoolRig rig;
+    // Pathological scarcity: EVERY reachable peer is pruned (limited-only).
+    // The port must NOT wedge on an empty selection — it falls back to the
+    // handshaked pool exactly as #1253 did (non-regression: never worse than
+    // the blind rotation on a peer set with no archival deliverer).
+    rig.handshake_services(1, SVC_LIMITED_ONLY);
+    rig.handshake_services(2, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    std::set<std::string> chosen;
+    for (uint32_t k = 0; k < 20; ++k)
+    {
+        std::string key = rig.client.select_bulk_peer_key_for_test(hash_n(200 + k));
+        EXPECT_FALSE(key.empty()) << "selection must never return no peer";
+        chosen.insert(key);
+    }
+    // Both limited peers still get used (fallback pass spreads across the pool).
+    EXPECT_EQ(chosen.size(), 2u);
+}
+


### PR DESCRIPTION
Stacked on #1253 (`dash/dashd-cut-bulk-fold-rotation`). Fetch-side only; served MN-payee / quorum-root bytes are dashd-exact (reward-safe).

## Problem
#1253 made `next_bulk_peer()` round-robin the mn-checkpoint anchor→tip bulk-fold body `getdata` across every handshaked peer, but **blindly**: it never reads a peer's advertised service flags and never remembers which peers actually served a deep body. On a cut cold start the rotated re-requests go to peers that cannot or will not serve ~9.5k-deep history, and the fold creeps (~0.01 blk/s) instead of reaching tip.

## dashd port target (checked source first)
`net_processing` `FindNextBlocksToDownload`:
- `CanServeBlocks()` / `IsLimitedPeer()` — a pruned `NODE_NETWORK_LIMITED` peer is **not** asked for history older than ~288 blocks; it prefers peers whose announced best-height covers the block.
- Per-peer download-failure demotion — a `NOTFOUND` / timeout removes the block from that peer and the downloader **re-homes onto full nodes that actually deliver**; chronic stallers are disconnected.

## What this adds (both small, on top of #1253)
**(A) Service-flag gate (`CanServeBlocks`).** `nServices` is already deserialized at `version` (`p->services`). Adds `NODE_NETWORK_LIMITED` + `advertises_full_blocks` / `advertises_limited_only` / `can_serve_blocks` / `peer_covers_height` helpers. `bulk_eligible()` excludes limited-only (pruned) peers from deep-history selection. **No new handshake plumbing.**

**(B) Per-peer download-failure demotion.** A peer that answers `NOTFOUND` for a bulk body, or that the #1253 stall watchdog disconnects for a chronic body stall, takes a strike keyed by `addr:port`; after `BULK_NONSERVER_STRIKE_MAX` it is demoted out of `next_bulk_peer()` so selection converges onto deliverers. A clean body delivery forgives the peer. `next_bulk_peer()` falls back to any handshaked peer when no eligible peer remains — **never wedges harder than #1253.**

## KAT (red→green)
Four `DashBulkCanServe` cases: pruned peer never selected; `NOTFOUND` demotes + selection converges; delivery forgives; all-pruned falls back. **Red** with the gate/demotion defeated (blind #1253 round-robin: 3/4 fail), **green** with the port (4/4). Full `test_dash_p2p_node` pool suite stays green (35/35).

## Honest caveat — does NOT on its own unstick the soak
On the current open-network peer set **all 8 reachable peers advertise `NODE_NETWORK` but none serves ~9.5k-deep bodies**. So:
- The service-flag gate (A) is a **measured no-op** here (0/8 excluded).
- Demotion (B) is the load-bearing lever, but it **cannot manufacture a deliverer** — once every peer is struck it converges to the fallback pass (= #1253) and creeps identically.

Closing the fold needs a **curated archival peer that actually serves deep history AND wins selection** (the demotion score is what makes it win once added). Ship this as robustness + correctness convergence; the archival-peer requirement is orthogonal and tracked separately.

## Reward-safety
Selection/fetch path only. No change to template assembly, MN-payee split, quorum root, or any served bytes.
