### PR TITLE
dash(daemonless): rotate the mn-checkpoint fold getmnlistd snapshot across the archival pool (dashd rotate-on-stall)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5960,7 +5960,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 auto* cp = coin_p2p.get();
                 mn_ckpt_lane->set_request_snapshot_fn(
                     [cp](const uint256& block_hash) {
-                        cp->send_getmnlistd(uint256::ZERO, block_hash);
+                        // Rotate the fold snapshot's getmnlistd across the
+                        // eligible pool so a slow/non-serving primary cannot
+                        // wedge the anchor->tip fold (dashd rotate-on-stall).
+                        cp->send_getmnlistd_rotating(uint256::ZERO, block_hash);
                     });
                 // DEMUX (reward-critical): the reply comes back on the SAME
                 // mnlistdiff message the tip sync uses. Routed here it is

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -668,6 +668,16 @@ private:
     // reconnect to the same non-serving address. Incremented on NOTFOUND for a
     // bulk body and on stall-eviction; cleared when that peer delivers a body.
     std::map<std::string, int> m_bulk_nonserver_strikes;
+    // Round-robin cursor for the STATEFUL request legs (the mn-checkpoint
+    // anchor->tip fold's getmnlistd snapshot). dashd picks a sync peer for a
+    // mnlistdiff and ROTATES to another on stall rather than re-asking one slow
+    // peer forever; a live cold soak froze 26 min pinned to a single slow
+    // primary waiting for the deep base->anchor fold snapshot. This cursor
+    // spreads the fold's getmnlistd (and its re-asks) across the eligible
+    // (CanServeBlocks) pool. m_last_stateful_peer lets a re-ask prefer a
+    // DIFFERENT carrier so it actually fans out.
+    std::size_t  m_stateful_rr{0};
+    std::string  m_last_stateful_peer;
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1246,6 +1256,12 @@ public:
     /// TEST-ONLY: clear a peer's non-server strike (the forgiveness a real
     /// body delivery triggers on the ingest path).
     void forgive_bulk_nonserver_for_test(const std::string& key) { forgive_bulk_nonserver(key); }
+    /// TEST-ONLY: exercise the STATEFUL (getmnlistd fold) carrier selection —
+    /// the seam the rotate-on-timeout KAT asserts fans out on. Returns the
+    /// chosen peer key and records it as the last stateful carrier, exactly as
+    /// send_getmnlistd_rotating() does on the wire, so repeated calls rotate.
+    std::string select_stateful_peer_key_for_test()
+    { PeerSession* p = next_stateful_peer(); if (p) m_last_stateful_peer = p->key; return p ? p->key : std::string{}; }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1562,6 +1578,36 @@ public:
                  << " target=" << block_hash.GetHex();
         auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
         m_primary->write(msg);
+    }
+
+    /// Fold-snapshot variant of send_getmnlistd that ROTATES its carrier across
+    /// the eligible pool (next_stateful_peer) instead of pinning to m_primary.
+    /// The mn-checkpoint anchor->tip fold's deep base->anchor snapshot is the
+    /// stateful leg that froze a cold soak for 26 min behind a single slow
+    /// primary (LANE-WATCHDOG waiting_for=fold-mnlist-reply, re-asking the SAME
+    /// primary). The reply is matched by block hash and only one getmnlistd is
+    /// ever outstanding, so a reply from ANY carrier satisfies the same await —
+    /// rotating the carrier is safe, and is exactly dashd's rotate-on-stall
+    /// sync-peer behaviour. Reward-safe: this changes WHICH peer is asked, never
+    /// the served MN-payee/quorum-root bytes (those stay DIP-4 client-verified
+    /// against the block's own cbTx commitment before they are believed).
+    void send_getmnlistd_rotating(const uint256& base_block_hash,
+                                  const uint256& block_hash)
+    {
+        PeerSession* p = next_stateful_peer();
+        if (!p) {
+            LOG_WARNING << "[COIN-P2P] getmnlistd(rotating) DROPPED (no peer):"
+                        << " base=" << base_block_hash.GetHex()
+                        << " target=" << block_hash.GetHex()
+                        << " — the fold cannot advance until a peer is up";
+            return;
+        }
+        m_last_stateful_peer = p->key;
+        LOG_INFO << "[COIN-P2P] getmnlistd(rotating) -> peer=" << p->key
+                 << " base=" << base_block_hash.GetHex()
+                 << " target=" << block_hash.GetHex();
+        auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
+        p->write(msg);
     }
 
     /// Send a getqrinfo (DIP-24 quorum-rotation-info request) — the ROTATED
@@ -1911,6 +1957,33 @@ private:
                 if (!p->handshake.complete()) continue;
                 if (pass == 0 && !bulk_eligible(p)) continue;
                 m_bulk_rr = (m_bulk_rr + i + 1) % n;
+                return p;
+            }
+        }
+        return m_primary;
+    }
+
+    /// dashd sync-peer selection for the STATEFUL request legs (the
+    /// mn-checkpoint fold's getmnlistd snapshot). Round-robin across the
+    /// eligible (CanServeBlocks + handshaked + non-demoted) pool, PREFERRING a
+    /// peer other than the one the last stateful request went to so a re-ask
+    /// actually fans out instead of re-hammering one slow peer (the 26-min
+    /// single-primary freeze). Falls back — like next_bulk_peer — to any
+    /// eligible peer (first ask / pool of one), then any handshaked peer
+    /// (historical-scarcity), then m_primary.
+    PeerSession* next_stateful_peer()
+    {
+        const std::size_t n = m_pool.size();
+        if (n == 0) return m_primary;
+        for (int pass = 0; pass < 3; ++pass)
+        {
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                PeerSession* p = m_pool[(m_stateful_rr + i) % n].get();
+                if (!p->handshake.complete()) continue;
+                if (pass < 2 && !bulk_eligible(p)) continue;
+                if (pass == 0 && p->key == m_last_stateful_peer) continue;
+                m_stateful_rr = (m_stateful_rr + i + 1) % n;
                 return p;
             }
         }

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -618,6 +618,22 @@ private:
     // vendor/quorum_tail.hpp) parse the >=70230 layout.
     static constexpr uint32_t PROTOCOL_VERSION = 70230;
     static constexpr uint64_t NODE_NETWORK = 1;   // no segwit/witness on Dash
+    // dashd service-flag classification (net_processing CanServeBlocks /
+    // IsLimitedPeer). A PRUNED node advertises NODE_NETWORK_LIMITED (serves
+    // only the last ~288 blocks) and CLEARS NODE_NETWORK; a full/archival node
+    // sets NODE_NETWORK (usually LIMITED too). The mn-checkpoint anchor->tip
+    // bulk fold reaches ~9.5k blocks deep, so a limited-only peer can never
+    // serve it — CanServeBlocks convergence must exclude it from selection.
+    static constexpr uint64_t NODE_NETWORK_LIMITED = 0x400;
+    // dashd NODE_NETWORK_LIMITED_MIN_BLOCKS(288) - 2: the depth beyond which a
+    // limited peer is not asked (FindNextBlocksToDownload historical gate).
+    static constexpr uint32_t LIMITED_PEER_HISTORY_BLOCKS = 286;
+    // A peer that answers NOTFOUND for a bulk body, or that the stall watchdog
+    // disconnects for a chronic body stall, is demoted after this many strikes:
+    // next_bulk_peer() then skips it so the round-robin CONVERGES onto peers
+    // that actually deliver deep history (dashd per-peer download-failure
+    // demotion). One clean body delivery from a peer forgives it.
+    static constexpr int BULK_NONSERVER_STRIKE_MAX = 2;
     static constexpr uint16_t MAINNET_P2P_PORT = 9999;
 
 public:
@@ -647,6 +663,11 @@ private:
     // (dashd FindNextBlocksToDownload spreads a deep IBD window across peers,
     // never funnelling it at one peer).
     std::size_t  m_bulk_rr{0};
+    // dashd per-peer download-failure demotion (archival convergence). Keyed by
+    // peer addr:port so a strike survives the PeerSession object and even a
+    // reconnect to the same non-serving address. Incremented on NOTFOUND for a
+    // bulk body and on stall-eviction; cleared when that peer delivers a body.
+    std::map<std::string, int> m_bulk_nonserver_strikes;
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1211,6 +1232,20 @@ public:
     /// pool timer would. Paired with set_now_fn this replaces the io_context
     /// entirely for policy tests — no real timer, no real waiting, no race.
     void tick_for_test() { on_pool_tick(); }
+
+    /// TEST-ONLY: exercise the bulk/historical body peer SELECTION directly
+    /// (announcer-less path), returning the chosen peer's key — the seam the
+    /// CanServeBlocks/demotion KATs assert convergence on.
+    std::string select_bulk_peer_key_for_test(const uint256& hash)
+    { PeerSession* p = select_block_peer(hash); return p ? p->key : std::string{}; }
+    /// TEST-ONLY: current non-server strike count for a peer address.
+    int bulk_nonserver_strikes_for_test(const std::string& key) const
+    { auto it = m_bulk_nonserver_strikes.find(key); return it == m_bulk_nonserver_strikes.end() ? 0 : it->second; }
+    /// TEST-ONLY: is this peer currently demoted out of bulk selection?
+    bool bulk_demoted_for_test(const std::string& key) const { return bulk_demoted(key); }
+    /// TEST-ONLY: clear a peer's non-server strike (the forgiveness a real
+    /// body delivery triggers on the ingest path).
+    void forgive_bulk_nonserver_for_test(const std::string& key) { forgive_bulk_nonserver(key); }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1813,15 +1848,68 @@ private:
     /// slow / rate-limiting peer then serialises only its 1/N share instead of
     /// wedging the entire anchor->tip fold behind one primary. Falls back to
     /// the primary only when the pool holds no handshaked peer at all.
+    // ── dashd CanServeBlocks service-flag classification ─────────────────
+    /// A peer advertises full-block (archival) service — dashd NODE_NETWORK.
+    static bool advertises_full_blocks(const PeerSession* p)
+    { return p && (p->services & NODE_NETWORK); }
+    /// dashd IsLimitedPeer: pruned — serves only the last ~288 blocks.
+    static bool advertises_limited_only(const PeerSession* p)
+    { return p && !(p->services & NODE_NETWORK) && (p->services & NODE_NETWORK_LIMITED); }
+    /// dashd CanServeBlocks: serves blocks AT ALL (full or limited).
+    static bool can_serve_blocks(const PeerSession* p)
+    { return p && (p->services & (NODE_NETWORK | NODE_NETWORK_LIMITED)); }
+    /// dashd pindexBestKnownBlock coverage: the peer's announced tip is at or
+    /// above the wanted height, so it can be expected to hold that block.
+    static bool peer_covers_height(const PeerSession* p, uint32_t height)
+    { return p && p->start_height >= height; }
+
+    /// Has this peer been demoted as a demonstrated non-server of deep history?
+    bool bulk_demoted(const std::string& key) const
+    {
+        auto it = m_bulk_nonserver_strikes.find(key);
+        return it != m_bulk_nonserver_strikes.end()
+               && it->second >= BULK_NONSERVER_STRIKE_MAX;
+    }
+    void note_bulk_nonserver(const std::string& key)
+    { if (!key.empty()) ++m_bulk_nonserver_strikes[key]; }
+    void forgive_bulk_nonserver(const std::string& key)
+    { if (!key.empty()) m_bulk_nonserver_strikes.erase(key); }
+
+    /// dashd FindNextBlocksToDownload eligibility for a DEEP-historical bulk
+    /// body: the peer must have handshaked, advertise full-block service (a
+    /// limited/pruned peer cannot serve ~9.5k-deep history), and not be a
+    /// demoted non-server. Height coverage is not gated here because the fold
+    /// requests span the whole anchor->tip window and every peer's start_height
+    /// (its own tip) covers every buried block; peer_covers_height() is the
+    /// available lever should a lagging peer ever join.
+    bool bulk_eligible(const PeerSession* p) const
+    {
+        return p && p->handshake.complete()
+               && advertises_full_blocks(p)
+               && !advertises_limited_only(p)
+               && !bulk_demoted(p->key);
+    }
+
     PeerSession* next_bulk_peer()
     {
         const std::size_t n = m_pool.size();
         if (n == 0) return m_primary;
-        for (std::size_t i = 0; i < n; ++i)
+        // Pass 0: dashd CanServeBlocks + per-peer failure demotion — only peers
+        // that advertise full-block service AND have not been demoted for
+        // chronic non-service. This makes the round-robin CONVERGE onto
+        // archival deliverers instead of blindly re-asking pruned/dead peers.
+        // Pass 1: any handshaked peer (non-regression — when the reachable set
+        // holds no eligible peer we still spread across the pool exactly as
+        // #1253 did, rather than wedge on an empty selection; this is the real
+        // historical-body-scarcity case where every reachable peer is
+        // limited/demoted).
+        for (int pass = 0; pass < 2; ++pass)
         {
-            PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
-            if (p->handshake.complete())
+            for (std::size_t i = 0; i < n; ++i)
             {
+                PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
+                if (!p->handshake.complete()) continue;
+                if (pass == 0 && !bulk_eligible(p)) continue;
                 m_bulk_rr = (m_bulk_rr + i + 1) % n;
                 return p;
             }
@@ -2254,6 +2342,10 @@ private:
                     ++pb.evictions;
                     ++m_body_stall_evictions;
                     pb.stalls_since_evict = 0;
+                    // The disconnected staller demonstrably did not serve this
+                    // deep body: demote its address so a refill/reconnect to it
+                    // is skipped by next_bulk_peer() (dashd failure demotion).
+                    note_bulk_nonserver(staller);
                     pb.stall_timeout = BODY_STALL_TIMEOUT_INIT;
                     remove_peer(bad,
                         "block-stall: body " + pb.hash.GetHex().substr(0, 16)
@@ -2582,6 +2674,10 @@ private:
         for (auto it = m_pending_bodies.begin();
              it != m_pending_bodies.end(); ++it)
             if (it->hash == blockhash) { m_pending_bodies.erase(it); break; }
+        // This peer just DELIVERED a body — it demonstrably serves blocks, so
+        // clear any non-server strike so it re-enters bulk selection (dashd
+        // forgives a peer the moment it satisfies a download).
+        forgive_bulk_nonserver(p->key);
         // W2 bulk demux: a body the replay bulk lane has in flight is consumed
         // HERE (verified + folded + pruned by the lane) and never fires
         // full_block — the live ingest legs are tip-rate consumers and must
@@ -3001,6 +3097,11 @@ private:
                 // on a DIFFERENT peer immediately instead of waiting out the
                 // scheduler timeout. No-op unless --replay-bulk registered it.
                 if (m_on_block_notfound) m_on_block_notfound(inv.m_hash);
+                // dashd per-peer download-failure demotion: this peer just
+                // declared it does NOT hold a block we asked for. Strike it so
+                // next_bulk_peer() converges away from non-servers of deep
+                // history onto archival peers that actually deliver.
+                note_bulk_nonserver(p->key);
             }
         }
     }

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -132,12 +132,13 @@ struct PoolRig
     }
 
     std::unique_ptr<RawMessage> version_msg(uint32_t height,
-                                            const std::string& subver = "/Dash Core:21.1.0/")
+                                            const std::string& subver = "/Dash Core:21.1.0/",
+                                            uint64_t services = 1)
     {
         return p2p::message_version::make_raw(
-            70230, /*services=*/1, /*timestamp=*/1234567890ull,
-            addr_t{1, NetService{"127.0.0.1", 19999}},
-            addr_t{1, NetService{"127.0.0.1", 19999}},
+            70230, services, /*timestamp=*/1234567890ull,
+            addr_t{services, NetService{"127.0.0.1", 19999}},
+            addr_t{services, NetService{"127.0.0.1", 19999}},
             /*nonce=*/0x1122334455667788ull, subver, height);
     }
 
@@ -147,6 +148,22 @@ struct PoolRig
         attach(n);
         deliver(n, version_msg(height));
         deliver(n, p2p::message_verack::make_raw());
+    }
+
+    /// Full attach + version/verack for peer n advertising a SPECIFIC service
+    /// bitfield — the CanServeBlocks convergence KATs stand up mixed
+    /// archival(NODE_NETWORK) / pruned(NODE_NETWORK_LIMITED) pools this way.
+    void handshake_services(int n, uint64_t services, uint32_t height = 1000)
+    {
+        attach(n);
+        deliver(n, version_msg(height, "/Dash Core:21.1.0/", services));
+        deliver(n, p2p::message_verack::make_raw());
+    }
+
+    static std::unique_ptr<RawMessage> block_notfound(const uint256& h)
+    {
+        return p2p::message_notfound::make_raw(std::vector<p2p::inventory_type>{
+            p2p::inventory_type(p2p::inventory_type::block, h)});
     }
 
     const PeerSession* session(int n) const
@@ -1270,3 +1287,114 @@ TEST(DashCoinP2PPool, a_stalling_bulk_peer_is_disconnected_so_the_fold_advances)
 }
 
 } // namespace
+
+// ══════════════════════════════════════════════════════════════════════════
+// (H) CanServeBlocks CONVERGENCE — dashd net_processing service-flag gate +
+//     per-peer download-failure demotion, ported onto the #1253 bulk-fold
+//     round-robin. The mn-checkpoint anchor->tip fold must target ONLY peers
+//     that advertise they can serve the block (NODE_NETWORK, not pruned-only)
+//     and must CONVERGE away from peers that fail to serve (NOTFOUND / stall
+//     eviction) so a deep IBD window re-homes onto archival deliverers.
+//
+//     RED on #1253 (blind round-robin, service-flag-/demotion-blind): a
+//     limited-only peer is selected for a deep body it cannot serve, and a
+//     peer that keeps answering NOTFOUND keeps being re-asked.
+//     GREEN with the port: the pruned peer is never selected, the failing peer
+//     is demoted out, and selection converges onto the full-block peers.
+// ══════════════════════════════════════════════════════════════════════════
+
+// NODE_NETWORK=0x1, NODE_NETWORK_LIMITED=0x400 (dashd protocol.h).
+static constexpr uint64_t SVC_NETWORK        = 0x1;
+static constexpr uint64_t SVC_LIMITED        = 0x400;
+static constexpr uint64_t SVC_FULL           = 0x1 | 0x400;   // archival: both
+static constexpr uint64_t SVC_LIMITED_ONLY   = 0x400;         // pruned
+
+TEST(DashBulkCanServe, limited_only_peer_is_never_selected_for_a_deep_bulk_body)
+{
+    PoolRig rig;
+    // Two archival (full-block) peers and one pruned (limited-only) peer.
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 3u);
+
+    // Announcer-less (deep-historical) body selection, many rounds so a blind
+    // round-robin would land on peer 3 repeatedly.
+    std::map<std::string, int> hits;
+    for (uint32_t k = 0; k < 60; ++k)
+        hits[rig.client.select_bulk_peer_key_for_test(hash_n(1000 + k))]++;
+
+    // GREEN: the pruned peer is EXCLUDED entirely; both archival peers serve.
+    EXPECT_EQ(hits[PoolRig::peer_key(3)], 0)
+        << "a limited-only (pruned) peer must never be asked for ~9.5k-deep "
+           "history — dashd IsLimitedPeer gate";
+    EXPECT_GT(hits[PoolRig::peer_key(1)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(2)], 0);
+    EXPECT_EQ(hits[PoolRig::peer_key(1)] + hits[PoolRig::peer_key(2)], 60);
+}
+
+TEST(DashBulkCanServe, notfound_demotes_a_nonserver_and_selection_converges)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 3u);
+
+    // Peer 2 keeps answering NOTFOUND for deep bodies (advertises NODE_NETWORK
+    // but does not actually serve buried history — the live-network symptom).
+    for (int i = 0; i < 2; ++i)   // BULK_NONSERVER_STRIKE_MAX
+        rig.deliver(2, PoolRig::block_notfound(hash_n(7000 + i)));
+
+    EXPECT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)))
+        << "a peer that repeatedly answers NOTFOUND must be demoted "
+           "(dashd per-peer download-failure demotion)";
+
+    // GREEN: selection now CONVERGES onto the two delivering peers; the demoted
+    // non-server is never chosen again.
+    std::map<std::string, int> hits;
+    for (uint32_t k = 0; k < 60; ++k)
+        hits[rig.client.select_bulk_peer_key_for_test(hash_n(8000 + k))]++;
+    EXPECT_EQ(hits[PoolRig::peer_key(2)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(1)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(3)], 0);
+}
+
+TEST(DashBulkCanServe, delivering_a_body_forgives_a_demoted_peer)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    for (int i = 0; i < 2; ++i)
+        rig.deliver(2, PoolRig::block_notfound(hash_n(100 + i)));
+    ASSERT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)));
+
+    // A single clean body delivery from peer 2 clears the strike — it
+    // demonstrably serves blocks now (dashd forgives on a satisfied download).
+    rig.client.forgive_bulk_nonserver_for_test(PoolRig::peer_key(2));
+    EXPECT_FALSE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)));
+    EXPECT_EQ(rig.client.bulk_nonserver_strikes_for_test(PoolRig::peer_key(2)), 0);
+}
+
+TEST(DashBulkCanServe, no_eligible_peer_falls_back_never_wedges_the_selection)
+{
+    PoolRig rig;
+    // Pathological scarcity: EVERY reachable peer is pruned (limited-only).
+    // The port must NOT wedge on an empty selection — it falls back to the
+    // handshaked pool exactly as #1253 did (non-regression: never worse than
+    // the blind rotation on a peer set with no archival deliverer).
+    rig.handshake_services(1, SVC_LIMITED_ONLY);
+    rig.handshake_services(2, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    std::set<std::string> chosen;
+    for (uint32_t k = 0; k < 20; ++k)
+    {
+        std::string key = rig.client.select_bulk_peer_key_for_test(hash_n(200 + k));
+        EXPECT_FALSE(key.empty()) << "selection must never return no peer";
+        chosen.insert(key);
+    }
+    // Both limited peers still get used (fallback pass spreads across the pool).
+    EXPECT_EQ(chosen.size(), 2u);
+}
+

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1398,3 +1398,108 @@ TEST(DashBulkCanServe, no_eligible_peer_falls_back_never_wedges_the_selection)
     EXPECT_EQ(chosen.size(), 2u);
 }
 
+
+// ══════════════════════════════════════════════════════════════════════════
+// (I) STATEFUL FOLD LEG — getmnlistd rotate-on-stall (dashd sync-peer parity)
+//
+//     The mn-checkpoint anchor->tip fold requests its per-height masternode
+//     snapshot with getmnlistd(ZERO, hash_at(H)). On master (#1253/#1254) that
+//     request is pinned to m_primary and, on no reply, tick_pending_fold()
+//     RE-ASKS THE SAME PRIMARY. A live cold soak froze 26 min behind ONE slow
+//     primary waiting for the deep base->anchor snapshot while 7 other archival
+//     peers sat idle (LANE-WATCHDOG waiting_for=fold-mnlist-reply, warn 1..9).
+//
+//     dashd picks a sync peer for a mnlistdiff and ROTATES to another on stall.
+//     send_getmnlistd_rotating() ports that: the fold's snapshot request (and
+//     every re-ask) fans out across the eligible CanServeBlocks pool, preferring
+//     a carrier OTHER than the last one, so a slow-but-alive primary can no
+//     longer wedge the fold. Reply is matched by block hash and only one
+//     getmnlistd is ever outstanding, so any carrier's reply satisfies the await.
+//
+//     RED (pinned path, still used by the LIVE tip follower): send_getmnlistd
+//     lands every ask on the primary — asserted below as the contrast.
+//     GREEN (fold path): send_getmnlistd_rotating spreads consecutive asks
+//     across the archival peers and skips the pruned one.
+// ══════════════════════════════════════════════════════════════════════════
+
+TEST(DashStatefulFold, fold_getmnlistd_rotates_across_archival_peers_and_skips_pruned)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);          // primary (first handshaked)
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+    rig.handshake_services(4, SVC_LIMITED_ONLY);  // pruned — cannot serve deep
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 4u);
+
+    // CONTRAST (the RED behaviour the fix replaces): the PINNED leg — the one
+    // the live tip follower still uses — puts every ask on the primary.
+    const uint64_t p1_before_pinned = rig.session(1)->msgs_sent;
+    for (int i = 0; i < 3; ++i)
+        rig.client.send_getmnlistd(uint256::ZERO, hash_n(500 + i));
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before_pinned + 3u)
+        << "the pinned getmnlistd leg must still land on the primary";
+
+    // GREEN: the ROTATING fold leg fans out. Three consecutive asks over three
+    // eligible archival peers hit three DISTINCT carriers (preferring a peer
+    // other than the last), and the pruned peer is never asked.
+    std::vector<uint64_t> before;
+    for (int i = 1; i <= 4; ++i) before.push_back(rig.session(i)->msgs_sent);
+    for (int i = 0; i < 3; ++i)
+        rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(9000 + i));
+
+    const uint64_t d1 = rig.session(1)->msgs_sent - before[0];
+    const uint64_t d2 = rig.session(2)->msgs_sent - before[1];
+    const uint64_t d3 = rig.session(3)->msgs_sent - before[2];
+    const uint64_t d4 = rig.session(4)->msgs_sent - before[3];
+
+    EXPECT_EQ(d1 + d2 + d3, 3u) << "all three asks must reach an archival peer";
+    EXPECT_EQ(d4, 0u)
+        << "a pruned (limited-only) peer must never carry the deep fold "
+           "snapshot — it cannot serve ~9.5k-deep history";
+    // True fan-out: no single archival peer absorbed all three (the 26-min
+    // single-primary freeze the fix exists to prevent). With three eligible
+    // peers and last-carrier avoidance, each gets exactly one.
+    EXPECT_EQ(d1, 1u);
+    EXPECT_EQ(d2, 1u);
+    EXPECT_EQ(d3, 1u);
+}
+
+TEST(DashStatefulFold, fold_getmnlistd_reask_leaves_the_slow_primary_for_a_neighbour)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);   // primary
+    rig.handshake_services(2, SVC_FULL);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    // First ask (fold snapshot) — allowed to pick the primary.
+    const std::string first = rig.client.select_stateful_peer_key_for_test();
+    EXPECT_FALSE(first.empty());
+    // The RE-ask (tick_pending_fold on no reply) must move OFF that carrier so
+    // a slow-but-alive primary cannot wedge the fold. On master the re-ask hit
+    // the same primary every time; here it rotates to the neighbour.
+    const std::string second = rig.client.select_stateful_peer_key_for_test();
+    EXPECT_FALSE(second.empty());
+    EXPECT_NE(second, first)
+        << "the fold re-ask must rotate to a DIFFERENT eligible peer, not "
+           "re-hammer the slow primary (dashd rotate-on-stall)";
+}
+
+TEST(DashStatefulFold, fold_getmnlistd_never_wedges_when_only_pruned_peers_exist)
+{
+    PoolRig rig;
+    // Pathological: every reachable peer is pruned. The rotating leg must still
+    // send (fallback pass), never drop the fold silently — non-regression vs
+    // the pinned path, which would also have used the (pruned) primary.
+    rig.handshake_services(1, SVC_LIMITED_ONLY);
+    rig.handshake_services(2, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    std::vector<uint64_t> before{rig.session(1)->msgs_sent,
+                                 rig.session(2)->msgs_sent};
+    for (int i = 0; i < 4; ++i)
+        rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(300 + i));
+    const uint64_t sent = (rig.session(1)->msgs_sent - before[0])
+                        + (rig.session(2)->msgs_sent - before[1]);
+    EXPECT_EQ(sent, 4u) << "the fold request must never be dropped even when no "
+                           "archival peer exists (fallback to the handshaked pool)";
+}


### PR DESCRIPTION
## What

Rotate the mn-checkpoint anchor→tip fold's `getmnlistd` snapshot request across the archival peer pool, instead of pinning it to `m_primary` and re-asking the same peer on stall. This is the **last single-primary funnel** in the daemonless cold fold path.

Stacks on #1254 (block-body `CanServeBlocks` archival convergence) — base branch is `dash/dashd-cut-bulk-fold-canserve`, so the diff here is the single follow-up commit.

## Why (measured)

A live cold soak (vm905, cut binary, **dashd ABSENT**, cold data-dir) reached `State::Bridging`, then **froze ~26 min** behind ONE slow primary waiting for the deep base→anchor mnlistdiff while seven other handshaked archival peers (all `services=0x1c45`, NODE_NETWORK) sat idle:

```
LANE-WATCHDOG state=bridging frozen_for=95s..1056s waiting_for=fold-mnlist-reply@h=2513000 warn=1..9
MN-CKPT no reply to h=2513000 mnlist after 3 drives — re-asking (same block)
```

The block-body legs already fan out (#1253) and converge onto archival deliverers (#1254). The fold's `getmnlistd` snapshot leg was the one that still went to `m_primary` only, with `tick_pending_fold()` re-asking the *same* primary — so a slow-but-alive primary wedges the whole fold.

## dash-core parity

dashd selects a sync peer for a `mnlistdiff` and **rotates to another on stall** rather than re-hammering one peer. Ported as `send_getmnlistd_rotating()` → `next_stateful_peer()`: round-robin across the eligible (`CanServeBlocks` + handshaked + non-demoted) pool, preferring a carrier other than the last. `main_dash` wires the fold's `request_snapshot_fn` through it. Only one `getmnlistd` is ever outstanding and the reply is matched by block hash, so any carrier's reply satisfies the same await — rotating the carrier is safe.

Falls back to any eligible peer → any handshaked peer → `m_primary`, so it never wedges (mirrors `next_bulk_peer`). The live **tip-follower** `getmnlistd` stays pinned (unchanged); only the deep fold snapshot leg rotates.

## Reward safety

Fetch/connection-side only. This changes **which peer is asked**, never the served MN-payee / quorum-root bytes, which stay DIP-4 client-verified against the block's own cbTx commitment before they are believed.

## Tests

`DashStatefulFold.*` (3 new KATs, red/green in-file):
- `fold_getmnlistd_rotates_across_archival_peers_and_skips_pruned` — the pinned leg lands all 3 asks on the primary (RED contrast); the rotating leg fans out 1-1-1 across three archival peers and never touches the pruned (limited-only) peer.
- `fold_getmnlistd_reask_leaves_the_slow_primary_for_a_neighbour` — the re-ask rotates off the current carrier.
- `fold_getmnlistd_never_wedges_when_only_pruned_peers_exist` — fallback still sends, never drops.

Full `test_dash_p2p_node`: **139/139 pass**, no regressions (existing `stateful_request_legs_go_to_the_primary_only` still green — that path is unchanged).

Build: BLS=REAL.

_Draft — integrator review; not for merge until the vm905 cold-fold measurement lands._
