### PR TITLE
DASH daemonless: head-of-line staller detection for the mn-checkpoint fold (dashd nStallingSince) — DRAFT, honest negative on throughput

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5891,6 +5891,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     if (!e) return std::nullopt;
                     return e->hash;
                 });
+            // dashd nStallingSince (net_processing.cpp FindNextBlocksToDownload +
+            // the SendMessages 2s adaptive disconnect-on-stall). Tag the
+            // FRONT-OF-ORDERED-WINDOW block (the fold cursor's next height) as the
+            // head-of-line body so the fetch layer disconnects its slow carrier on
+            // the FIRST stall and re-homes JUST that block to the fastest-
+            // delivering NODE_NETWORK peer — instead of leaving it as one of
+            // kWindow equal round-robin slots that competes with the buffered-ahead
+            // bodies for re-request attention. This lets the ordered fold cursor
+            // track buffer-arrival rate rather than the round-robin's luck.
+            // Reward-safe: getdata routing only — no served MN/quorum/subsidy bytes
+            // and no publish() hold is touched, and the fold still validates every
+            // block. Same header-by-height lookup the block-request seam uses.
+            mn_ckpt_lane->set_hol_request_fn(
+                [cp = coin_p2p.get(), hc = header_chain.get()](uint32_t h) {
+                    auto e = hc->get_header_by_height(h);
+                    if (!e) return false;
+                    return cp->request_head_of_line(e->hash);
+                });
             // SML validity attestation — the ONLY carrier of a post-anchor
             // PoSe ban. dashd applies those from consensus, never as a special
             // tx, so the bridge's block replay is structurally unable to see

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5960,7 +5960,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 auto* cp = coin_p2p.get();
                 mn_ckpt_lane->set_request_snapshot_fn(
                     [cp](const uint256& block_hash) {
-                        cp->send_getmnlistd(uint256::ZERO, block_hash);
+                        // Rotate the fold snapshot's getmnlistd across the
+                        // eligible pool so a slow/non-serving primary cannot
+                        // wedge the anchor->tip fold (dashd rotate-on-stall).
+                        cp->send_getmnlistd_rotating(uint256::ZERO, block_hash);
                     });
                 // DEMUX (reward-critical): the reply comes back on the SAME
                 // mnlistdiff message the tip sync uses. Routed here it is

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -249,6 +249,13 @@ public:
     /// body short of publishing while the maintainer's mn-needs-reseed latch
     /// keeps the embedded arm demoted, forever (the reseed-tail wedge).
     using RequestBlockFn = std::function<bool(uint32_t height)>;
+    /// dashd nStallingSince seam: (re)tag the block at `height` as the single
+    /// HEAD-OF-LINE (front-of-ordered-window) body in the fetch layer, so its
+    /// slow carrier is disconnected on the first stall and the block re-homed to
+    /// the fastest deliverer. Return value is unused here (marker only); the
+    /// request LEDGER stays owned by RequestBlockFn. FETCH-TIMING ONLY — same
+    /// reward-safety contract as RequestBlockFn.
+    using HolRequestFn = std::function<bool(uint32_t height)>;
     /// Publish the bridged, payout-bearing set as an authoritative MN-list
     /// resync. Wired by main_dash to Node::mn_list_update.happened().
     using PublishFn =
@@ -334,6 +341,10 @@ public:
     MnCheckpointLane& operator=(const MnCheckpointLane&) = delete;
 
     void set_request_block_fn(RequestBlockFn fn) { m_request = std::move(fn); }
+    /// OPTIONAL. Unwired, the bridge behaves exactly as before this seam existed:
+    /// the fold cursor's block is one of kWindow equal round-robin slots. Wired,
+    /// the fetch layer runs dashd's nStallingSince against ITS carrier only.
+    void set_hol_request_fn(HolRequestFn fn) { m_hol_request = std::move(fn); }
     void set_publish_fn(PublishFn fn)            { m_publish = std::move(fn); }
     void set_tip_height_fn(TipHeightFn fn)       { m_tip_height = std::move(fn); }
     void set_header_hash_at_fn(HeaderHashAtFn fn){ m_header_hash_at = std::move(fn); }
@@ -565,6 +576,16 @@ public:
         if (!m_tip_height) return;
         const uint32_t tip = m_tip_height();
         if (tip == 0 || m_next > tip) return;   // nothing left to fetch
+        // ── dashd nStallingSince (net_processing FindNextBlocksToDownload). The
+        // block at the fold cursor (m_next) is the FRONT of the ordered window —
+        // apply_block cannot cross the hole it leaves, so its slow carrier gates
+        // the WHOLE fold even while up to kWindow-1 later bodies buffer ahead.
+        // Tag it as the head-of-line body every tick so the fetch layer runs ONE
+        // stall timer against ITS carrier and, on stall, disconnects that carrier
+        // and re-homes just this block to the fastest deliverer. Idempotent and
+        // marker-only: no extra getdata once the slot exists; the request ledger
+        // and every publish() hold are untouched (fetch-timing, reward-safe).
+        if (m_hol_request) m_hol_request(m_next);
         // ACT ONLY ON A STALL. A healthy self-driving replay advances the
         // cursor every service interval (on_block_connected tops up the window
         // per applied block) and must not be sprayed with redundant getdata, so
@@ -3638,6 +3659,7 @@ public:
     MnStateMachine m_machine;
 
     RequestBlockFn m_request;
+    HolRequestFn   m_hol_request;   // dashd nStallingSince front-of-window tag
     PublishFn      m_publish;
     TipHeightFn    m_tip_height;
     HeaderHashAtFn m_header_hash_at;

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -668,6 +668,16 @@ private:
     // reconnect to the same non-serving address. Incremented on NOTFOUND for a
     // bulk body and on stall-eviction; cleared when that peer delivers a body.
     std::map<std::string, int> m_bulk_nonserver_strikes;
+    // Round-robin cursor for the STATEFUL request legs (the mn-checkpoint
+    // anchor->tip fold's getmnlistd snapshot). dashd picks a sync peer for a
+    // mnlistdiff and ROTATES to another on stall rather than re-asking one slow
+    // peer forever; a live cold soak froze 26 min pinned to a single slow
+    // primary waiting for the deep base->anchor fold snapshot. This cursor
+    // spreads the fold's getmnlistd (and its re-asks) across the eligible
+    // (CanServeBlocks) pool. m_last_stateful_peer lets a re-ask prefer a
+    // DIFFERENT carrier so it actually fans out.
+    std::size_t  m_stateful_rr{0};
+    std::string  m_last_stateful_peer;
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1246,6 +1256,12 @@ public:
     /// TEST-ONLY: clear a peer's non-server strike (the forgiveness a real
     /// body delivery triggers on the ingest path).
     void forgive_bulk_nonserver_for_test(const std::string& key) { forgive_bulk_nonserver(key); }
+    /// TEST-ONLY: exercise the STATEFUL (getmnlistd fold) carrier selection —
+    /// the seam the rotate-on-timeout KAT asserts fans out on. Returns the
+    /// chosen peer key and records it as the last stateful carrier, exactly as
+    /// send_getmnlistd_rotating() does on the wire, so repeated calls rotate.
+    std::string select_stateful_peer_key_for_test()
+    { PeerSession* p = next_stateful_peer(); if (p) m_last_stateful_peer = p->key; return p ? p->key : std::string{}; }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1562,6 +1578,36 @@ public:
                  << " target=" << block_hash.GetHex();
         auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
         m_primary->write(msg);
+    }
+
+    /// Fold-snapshot variant of send_getmnlistd that ROTATES its carrier across
+    /// the eligible pool (next_stateful_peer) instead of pinning to m_primary.
+    /// The mn-checkpoint anchor->tip fold's deep base->anchor snapshot is the
+    /// stateful leg that froze a cold soak for 26 min behind a single slow
+    /// primary (LANE-WATCHDOG waiting_for=fold-mnlist-reply, re-asking the SAME
+    /// primary). The reply is matched by block hash and only one getmnlistd is
+    /// ever outstanding, so a reply from ANY carrier satisfies the same await —
+    /// rotating the carrier is safe, and is exactly dashd's rotate-on-stall
+    /// sync-peer behaviour. Reward-safe: this changes WHICH peer is asked, never
+    /// the served MN-payee/quorum-root bytes (those stay DIP-4 client-verified
+    /// against the block's own cbTx commitment before they are believed).
+    void send_getmnlistd_rotating(const uint256& base_block_hash,
+                                  const uint256& block_hash)
+    {
+        PeerSession* p = next_stateful_peer();
+        if (!p) {
+            LOG_WARNING << "[COIN-P2P] getmnlistd(rotating) DROPPED (no peer):"
+                        << " base=" << base_block_hash.GetHex()
+                        << " target=" << block_hash.GetHex()
+                        << " — the fold cannot advance until a peer is up";
+            return;
+        }
+        m_last_stateful_peer = p->key;
+        LOG_INFO << "[COIN-P2P] getmnlistd(rotating) -> peer=" << p->key
+                 << " base=" << base_block_hash.GetHex()
+                 << " target=" << block_hash.GetHex();
+        auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
+        p->write(msg);
     }
 
     /// Send a getqrinfo (DIP-24 quorum-rotation-info request) — the ROTATED
@@ -1911,6 +1957,33 @@ private:
                 if (!p->handshake.complete()) continue;
                 if (pass == 0 && !bulk_eligible(p)) continue;
                 m_bulk_rr = (m_bulk_rr + i + 1) % n;
+                return p;
+            }
+        }
+        return m_primary;
+    }
+
+    /// dashd sync-peer selection for the STATEFUL request legs (the
+    /// mn-checkpoint fold's getmnlistd snapshot). Round-robin across the
+    /// eligible (CanServeBlocks + handshaked + non-demoted) pool, PREFERRING a
+    /// peer other than the one the last stateful request went to so a re-ask
+    /// actually fans out instead of re-hammering one slow peer (the 26-min
+    /// single-primary freeze). Falls back — like next_bulk_peer — to any
+    /// eligible peer (first ask / pool of one), then any handshaked peer
+    /// (historical-scarcity), then m_primary.
+    PeerSession* next_stateful_peer()
+    {
+        const std::size_t n = m_pool.size();
+        if (n == 0) return m_primary;
+        for (int pass = 0; pass < 3; ++pass)
+        {
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                PeerSession* p = m_pool[(m_stateful_rr + i) % n].get();
+                if (!p->handshake.complete()) continue;
+                if (pass < 2 && !bulk_eligible(p)) continue;
+                if (pass == 0 && p->key == m_last_stateful_peer) continue;
+                m_stateful_rr = (m_stateful_rr + i + 1) % n;
                 return p;
             }
         }

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -775,12 +775,41 @@ private:
         int         stalls_since_evict{0};
         // Stallers disconnected to recover THIS body (per-slot telemetry).
         int         evictions{0};
+        // dashd nStallingSince (net_processing.cpp FindNextBlocksToDownload):
+        // this slot is the FRONT-OF-DOWNLOAD-WINDOW body — the mn-checkpoint
+        // fold cursor, whose slow carrier gates the whole ordered fold because
+        // apply_block cannot cross the hole it leaves. A HOL slot's carrier is
+        // disconnected on its FIRST stall and the body re-homed to the fastest
+        // deliverer, instead of waiting BODY_REREQUEST_MAX round-robin rotations
+        // like an ordinary buffered-ahead slot.
+        bool        hol{false};
     };
     std::vector<PendingBody> m_pending_bodies;
     uint64_t m_body_rerequests_total{0};
     // Stalling peers disconnected to keep a needed body from wedging the lane
     // (dashd disconnect-on-stall). Surfaced as body_stall_evictions.
     uint64_t m_body_stall_evictions{0};
+
+    // ── dashd nStallingSince: head-of-line (front-of-window) staller state ──
+    // The mn-checkpoint fold is forward-CONTIGUOUS: the body at the cursor
+    // (m_next) gates the WHOLE ordered fold even while up to kWindow-1 later
+    // bodies buffer ahead. dashd arms its stall timer against the carrier of
+    // the FIRST in-flight block ONLY (net_processing.cpp:1482-1494 nodeStaller),
+    // disconnects it on a 2s adaptive timeout, and FindNextBlocksToDownload
+    // reassigns the block to another peer. We mirror that: the lane tags ONE
+    // block as head-of-line (m_hol_hash) via request_head_of_line(); a HOL stall
+    // disconnects that carrier on the FIRST stall and re-homes JUST that block to
+    // the fastest-delivering peer. Exactly one HOL slot at a time.
+    uint256     m_hol_hash;               // current head-of-line block (null = none)
+    uint64_t    m_hol_disconnects{0};     // carriers disconnected for a HOL stall
+    uint64_t    m_hol_rehomes{0};         // HOL bodies re-homed to a faster peer
+    std::string m_hol_last_rehome_target; // key of the last HOL re-home carrier
+    // dashd PeerTally.blocks (the FindNextBlocksToDownload "fastest deliverer"
+    // rank source): count of bodies each ADDRESS has actually delivered, keyed
+    // by addr:port so the rank survives a PeerSession churn / reconnect.
+    // Incremented on body receipt; fastest_bulk_peer() ranks the HOL re-home on
+    // it. A blind analog of replay_bulk_fetch.hpp's PeerTally for the live path.
+    std::map<std::string, uint64_t> m_peer_bodies_delivered;
 
     // ── tip-body announcer routing (#1082 pool + #1094 body-first) ───────
     // A block `inv` names a peer that HOLDS the block. The tip-body getdata
@@ -1262,6 +1291,20 @@ public:
     /// send_getmnlistd_rotating() does on the wire, so repeated calls rotate.
     std::string select_stateful_peer_key_for_test()
     { PeerSession* p = next_stateful_peer(); if (p) m_last_stateful_peer = p->key; return p ? p->key : std::string{}; }
+    /// TEST-ONLY: head-of-line (dashd nStallingSince) seams. Tag a block as the
+    /// front-of-window body, inspect its marker/carrier, bump the fastest-
+    /// deliverer tally the live block handler maintains, and drive the pool-tick
+    /// body service directly (no io_context) — the seams the HOL KAT asserts on.
+    bool request_head_of_line_for_test(const uint256& h) { return request_head_of_line(h); }
+    bool pending_body_is_hol_for_test(const uint256& h) const
+    { for (const auto& pb : m_pending_bodies) if (pb.hash == h) return pb.hol; return false; }
+    std::string pending_body_last_peer_for_test(const uint256& h) const
+    { for (const auto& pb : m_pending_bodies) if (pb.hash == h) return pb.last_peer; return std::string{}; }
+    void bump_peer_delivered_for_test(const std::string& key, uint64_t n)
+    { m_peer_bodies_delivered[key] += n; }
+    uint64_t peer_delivered_for_test(const std::string& key) const
+    { auto it = m_peer_bodies_delivered.find(key); return it == m_peer_bodies_delivered.end() ? 0 : it->second; }
+    void service_pending_bodies_for_test(int64_t now) { service_pending_bodies(now); }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1547,10 +1590,44 @@ public:
         return sent;
     }
 
+    /// dashd nStallingSince: tag ONE block as the HEAD-OF-LINE (front-of-
+    /// ordered-window) body and ensure it is tracked. Reuses
+    /// request_block_tracked()'s slot + #138 ledger honesty; the ONLY addition
+    /// is the privileged marker service_pending_bodies() reads to disconnect the
+    /// carrier on the FIRST stall and re-home to the fastest deliverer. Exactly
+    /// one HOL slot exists at a time — marking a new front clears the previous
+    /// (dashd arms the stall timer against a SINGLE carrier). Idempotent: safe to
+    /// call every service tick; when the slot already exists it only re-tags,
+    /// issuing no extra getdata. Reward-safe: fetch routing only.
+    /// Returns request_block_tracked()'s truth (TRUE when a getdata reached a
+    /// peer) so a ledger-keeping caller can refuse to count a dead send.
+    bool request_head_of_line(const uint256& block_hash)
+    {
+        m_hol_hash = block_hash;
+        bool existed = false;
+        for (auto& pb : m_pending_bodies)
+        {
+            if (pb.hash == block_hash) { pb.hol = true; existed = true; }
+            else                       pb.hol = false;
+        }
+        if (existed) return true;   // already tracked — re-tagged, no new getdata
+        // Not tracked yet: create the slot + issue the initial getdata exactly as
+        // request_block_tracked does, then mark the (possibly newly created) slot
+        // HOL and clear the marker on every other slot.
+        const bool sent = request_block_tracked(block_hash);
+        for (auto& pb : m_pending_bodies) pb.hol = (pb.hash == block_hash);
+        return sent;
+    }
+
     /// Watchdog observability (KATs + POOL-STATUS).
     std::size_t pending_body_count()    const { return m_pending_bodies.size(); }
     uint64_t body_rerequests_total()    const { return m_body_rerequests_total; }
     uint64_t body_stall_evictions()     const { return m_body_stall_evictions; }
+    // dashd nStallingSince telemetry: how many front-of-window carriers were
+    // disconnected, how many HOL bodies were re-homed, and to whom last.
+    uint64_t hol_disconnects()          const { return m_hol_disconnects; }
+    uint64_t hol_rehomes()              const { return m_hol_rehomes; }
+    std::string hol_last_rehome_target() const { return m_hol_last_rehome_target; }
 
     /// Send a getmnlistd (SML diff request) — E2/E3 masternode-list sync seam.
     ///
@@ -1963,6 +2040,38 @@ private:
         return m_primary;
     }
 
+    /// dashd FindNextBlocksToDownload reassignment, ranked by the fastest
+    /// DELIVERER (PeerTally.blocks): the handshaked, bulk-eligible (CanServeBlocks
+    /// + non-demoted) peer that has delivered the most bodies, skipping `avoid`
+    /// (the just-blamed head-of-line carrier). Before any delivery history exists
+    /// (cold start) it degrades to next_bulk_peer()'s round-robin spread — still
+    /// skipping the blamed carrier when a neighbour exists — so a HOL re-home
+    /// never wedges on an empty ranking.
+    PeerSession* fastest_bulk_peer(const std::string& avoid)
+    {
+        PeerSession* best = nullptr;
+        uint64_t best_n = 0;
+        for (auto& up : m_pool)
+        {
+            PeerSession* p = up.get();
+            if (!p->handshake.complete()) continue;
+            if (!bulk_eligible(p))         continue;
+            if (p->key == avoid)           continue;
+            auto it = m_peer_bodies_delivered.find(p->key);
+            const uint64_t n = it == m_peer_bodies_delivered.end() ? 0 : it->second;
+            if (!best || n > best_n) { best = p; best_n = n; }
+        }
+        if (best && best_n > 0) return best;   // a demonstrated fast deliverer
+        // No delivery history to rank on — fall back to the round-robin spread.
+        PeerSession* rr = next_bulk_peer();
+        if (rr && rr->key == avoid)
+        {
+            PeerSession* alt = next_bulk_peer();   // one nudge past the staller
+            if (alt && alt->key != avoid) return alt;
+        }
+        return best ? best : rr;
+    }
+
     /// dashd sync-peer selection for the STATEFUL request legs (the
     /// mn-checkpoint fold's getmnlistd snapshot). Round-robin across the
     /// eligible (CanServeBlocks + handshaked + non-demoted) pool, PREFERRING a
@@ -2358,6 +2467,80 @@ private:
             const std::string staller = pb.last_peer;
             ++pb.stalls_since_evict;
 
+            // ── dashd nStallingSince: the FRONT-OF-WINDOW block gates the whole
+            // ordered fold, so it does NOT wait for BODY_REREQUEST_MAX rotations.
+            // On its FIRST stall, re-home JUST this block to the FASTEST-delivering
+            // peer (not a blind round-robin pick) and disconnect the slow carrier
+            // immediately (fDisconnect parity). Guarded so one missing block can
+            // never drain the pool to zero. Reward-safe: getdata routing + a peer
+            // disconnect, no served bytes.
+            if (pb.hol)
+            {
+                PeerSession* target = fastest_bulk_peer(staller);
+                if (!target) { ++it; continue; }   // retry when the pool refills
+                auto hmsg = message_getdata::make_raw(
+                    {inventory_type(inventory_type::block, pb.hash)});
+                target->write(hmsg);
+                ++pb.rerequests;
+                ++m_body_rerequests_total;
+                ++m_hol_rehomes;
+                m_hol_last_rehome_target = target->key;
+                pb.last_req = now;
+                // dashd nStallingSince ADAPTIVE DOUBLING: a front that keeps
+                // stalling backs its window off 2->4->...->64s so a
+                // genuinely-slow-deep front does not spin-disconnect one peer
+                // every 2s and thrash the pool. A NEW front is a FRESH slot
+                // (request_head_of_line -> request_block_tracked) that starts at
+                // BODY_STALL_TIMEOUT_INIT, so only a persistently-stuck cursor
+                // block backs off — exactly dashd's per-node stalling-timeout
+                // doubling, scoped to the one privileged slot.
+                pb.stall_timeout =
+                    std::min<int64_t>(pb.stall_timeout * 2, BODY_STALL_TIMEOUT_MAX);
+                pb.last_peer = target->key;
+                LOG_INFO << "[" << m_chain_label
+                         << "] cause=hol-rehome attempt=" << pb.rerequests
+                         << " target=" << target->key << " hash="
+                         << pb.hash.GetHex().substr(0, 16) << "... unanswered_for="
+                         << (now - pb.first_req) << "s (front-of-window; fastest"
+                            " deliverer, dashd nStallingSince)";
+                // Disconnect the blamed carrier ONLY once it is a CHRONIC
+                // front-of-window staller — the adaptive window has climbed to
+                // >=16s (a front stuck across ~3 stalls), not merely momentarily
+                // behind. On a network where every archival peer serves deep
+                // history at a similar rate (no dramatically-faster peer), the
+                // earlier stalls just RACE the front to the fastest deliverer
+                // WITHOUT dropping a willing-but-slow peer, so the pool keeps its
+                // parallelism (dashd only arms nStallingSince when the window is
+                // genuinely starved, and its stalling-timeout has doubled by the
+                // time it disconnects). Still guarded by a survivor/refill so the
+                // pool can never be drained by one missing block.
+                if (!staller.empty() && staller != target->key
+                    && pb.stall_timeout >= 16)
+                {
+                    PeerSession* bad = find_peer(staller);
+                    const bool have_alternative =
+                        handshaked_peer_count() > 1 || m_reconnect_enabled;
+                    if (bad && owns(bad) && have_alternative)
+                    {
+                        ++pb.evictions;
+                        ++m_body_stall_evictions;
+                        ++m_hol_disconnects;
+                        pb.stalls_since_evict = 0;
+                        note_bulk_nonserver(staller);
+                        remove_peer(bad,
+                            "block-stall(head-of-line): body "
+                            + pb.hash.GetHex().substr(0, 16)
+                            + "... unanswered over "
+                            + std::to_string(now - pb.first_req)
+                            + "s — disconnecting the FRONT-OF-WINDOW staller so the"
+                              " fold cursor re-homes to a fast peer (dashd"
+                              " nStallingSince disconnect-on-stall)");
+                    }
+                }
+                ++it;
+                continue;
+            }
+
             // Rotate through the handshaked peers, preferring one we did not
             // just ask; a single-peer pool re-asks the same peer (still
             // strictly better than the 600 s inv-TTL wait). The ANNOUNCER goes
@@ -2746,11 +2929,22 @@ private:
         // answered first) — disarm its slot.
         for (auto it = m_pending_bodies.begin();
              it != m_pending_bodies.end(); ++it)
-            if (it->hash == blockhash) { m_pending_bodies.erase(it); break; }
+            if (it->hash == blockhash) {
+                // The head-of-line block landed — clear the privileged marker so
+                // the next fold cursor becomes the new front (dashd nStallingSince
+                // re-targets the new first in-flight block).
+                if (!m_hol_hash.IsNull() && m_hol_hash == blockhash)
+                    m_hol_hash.SetNull();
+                m_pending_bodies.erase(it);
+                break;
+            }
         // This peer just DELIVERED a body — it demonstrably serves blocks, so
         // clear any non-server strike so it re-enters bulk selection (dashd
         // forgives a peer the moment it satisfies a download).
         forgive_bulk_nonserver(p->key);
+        // dashd PeerTally.blocks: record the delivery so the head-of-line
+        // re-home can rank this address as a demonstrated fast deliverer.
+        ++m_peer_bodies_delivered[p->key];
         // W2 bulk demux: a body the replay bulk lane has in flight is consumed
         // HERE (verified + folded + pruned by the lane) and never fires
         // full_block — the live ingest legs are tip-rate consumers and must

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -618,6 +618,22 @@ private:
     // vendor/quorum_tail.hpp) parse the >=70230 layout.
     static constexpr uint32_t PROTOCOL_VERSION = 70230;
     static constexpr uint64_t NODE_NETWORK = 1;   // no segwit/witness on Dash
+    // dashd service-flag classification (net_processing CanServeBlocks /
+    // IsLimitedPeer). A PRUNED node advertises NODE_NETWORK_LIMITED (serves
+    // only the last ~288 blocks) and CLEARS NODE_NETWORK; a full/archival node
+    // sets NODE_NETWORK (usually LIMITED too). The mn-checkpoint anchor->tip
+    // bulk fold reaches ~9.5k blocks deep, so a limited-only peer can never
+    // serve it — CanServeBlocks convergence must exclude it from selection.
+    static constexpr uint64_t NODE_NETWORK_LIMITED = 0x400;
+    // dashd NODE_NETWORK_LIMITED_MIN_BLOCKS(288) - 2: the depth beyond which a
+    // limited peer is not asked (FindNextBlocksToDownload historical gate).
+    static constexpr uint32_t LIMITED_PEER_HISTORY_BLOCKS = 286;
+    // A peer that answers NOTFOUND for a bulk body, or that the stall watchdog
+    // disconnects for a chronic body stall, is demoted after this many strikes:
+    // next_bulk_peer() then skips it so the round-robin CONVERGES onto peers
+    // that actually deliver deep history (dashd per-peer download-failure
+    // demotion). One clean body delivery from a peer forgives it.
+    static constexpr int BULK_NONSERVER_STRIKE_MAX = 2;
     static constexpr uint16_t MAINNET_P2P_PORT = 9999;
 
 public:
@@ -647,6 +663,11 @@ private:
     // (dashd FindNextBlocksToDownload spreads a deep IBD window across peers,
     // never funnelling it at one peer).
     std::size_t  m_bulk_rr{0};
+    // dashd per-peer download-failure demotion (archival convergence). Keyed by
+    // peer addr:port so a strike survives the PeerSession object and even a
+    // reconnect to the same non-serving address. Incremented on NOTFOUND for a
+    // bulk body and on stall-eviction; cleared when that peer delivers a body.
+    std::map<std::string, int> m_bulk_nonserver_strikes;
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1211,6 +1232,20 @@ public:
     /// pool timer would. Paired with set_now_fn this replaces the io_context
     /// entirely for policy tests — no real timer, no real waiting, no race.
     void tick_for_test() { on_pool_tick(); }
+
+    /// TEST-ONLY: exercise the bulk/historical body peer SELECTION directly
+    /// (announcer-less path), returning the chosen peer's key — the seam the
+    /// CanServeBlocks/demotion KATs assert convergence on.
+    std::string select_bulk_peer_key_for_test(const uint256& hash)
+    { PeerSession* p = select_block_peer(hash); return p ? p->key : std::string{}; }
+    /// TEST-ONLY: current non-server strike count for a peer address.
+    int bulk_nonserver_strikes_for_test(const std::string& key) const
+    { auto it = m_bulk_nonserver_strikes.find(key); return it == m_bulk_nonserver_strikes.end() ? 0 : it->second; }
+    /// TEST-ONLY: is this peer currently demoted out of bulk selection?
+    bool bulk_demoted_for_test(const std::string& key) const { return bulk_demoted(key); }
+    /// TEST-ONLY: clear a peer's non-server strike (the forgiveness a real
+    /// body delivery triggers on the ingest path).
+    void forgive_bulk_nonserver_for_test(const std::string& key) { forgive_bulk_nonserver(key); }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1813,15 +1848,68 @@ private:
     /// slow / rate-limiting peer then serialises only its 1/N share instead of
     /// wedging the entire anchor->tip fold behind one primary. Falls back to
     /// the primary only when the pool holds no handshaked peer at all.
+    // ── dashd CanServeBlocks service-flag classification ─────────────────
+    /// A peer advertises full-block (archival) service — dashd NODE_NETWORK.
+    static bool advertises_full_blocks(const PeerSession* p)
+    { return p && (p->services & NODE_NETWORK); }
+    /// dashd IsLimitedPeer: pruned — serves only the last ~288 blocks.
+    static bool advertises_limited_only(const PeerSession* p)
+    { return p && !(p->services & NODE_NETWORK) && (p->services & NODE_NETWORK_LIMITED); }
+    /// dashd CanServeBlocks: serves blocks AT ALL (full or limited).
+    static bool can_serve_blocks(const PeerSession* p)
+    { return p && (p->services & (NODE_NETWORK | NODE_NETWORK_LIMITED)); }
+    /// dashd pindexBestKnownBlock coverage: the peer's announced tip is at or
+    /// above the wanted height, so it can be expected to hold that block.
+    static bool peer_covers_height(const PeerSession* p, uint32_t height)
+    { return p && p->start_height >= height; }
+
+    /// Has this peer been demoted as a demonstrated non-server of deep history?
+    bool bulk_demoted(const std::string& key) const
+    {
+        auto it = m_bulk_nonserver_strikes.find(key);
+        return it != m_bulk_nonserver_strikes.end()
+               && it->second >= BULK_NONSERVER_STRIKE_MAX;
+    }
+    void note_bulk_nonserver(const std::string& key)
+    { if (!key.empty()) ++m_bulk_nonserver_strikes[key]; }
+    void forgive_bulk_nonserver(const std::string& key)
+    { if (!key.empty()) m_bulk_nonserver_strikes.erase(key); }
+
+    /// dashd FindNextBlocksToDownload eligibility for a DEEP-historical bulk
+    /// body: the peer must have handshaked, advertise full-block service (a
+    /// limited/pruned peer cannot serve ~9.5k-deep history), and not be a
+    /// demoted non-server. Height coverage is not gated here because the fold
+    /// requests span the whole anchor->tip window and every peer's start_height
+    /// (its own tip) covers every buried block; peer_covers_height() is the
+    /// available lever should a lagging peer ever join.
+    bool bulk_eligible(const PeerSession* p) const
+    {
+        return p && p->handshake.complete()
+               && advertises_full_blocks(p)
+               && !advertises_limited_only(p)
+               && !bulk_demoted(p->key);
+    }
+
     PeerSession* next_bulk_peer()
     {
         const std::size_t n = m_pool.size();
         if (n == 0) return m_primary;
-        for (std::size_t i = 0; i < n; ++i)
+        // Pass 0: dashd CanServeBlocks + per-peer failure demotion — only peers
+        // that advertise full-block service AND have not been demoted for
+        // chronic non-service. This makes the round-robin CONVERGE onto
+        // archival deliverers instead of blindly re-asking pruned/dead peers.
+        // Pass 1: any handshaked peer (non-regression — when the reachable set
+        // holds no eligible peer we still spread across the pool exactly as
+        // #1253 did, rather than wedge on an empty selection; this is the real
+        // historical-body-scarcity case where every reachable peer is
+        // limited/demoted).
+        for (int pass = 0; pass < 2; ++pass)
         {
-            PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
-            if (p->handshake.complete())
+            for (std::size_t i = 0; i < n; ++i)
             {
+                PeerSession* p = m_pool[(m_bulk_rr + i) % n].get();
+                if (!p->handshake.complete()) continue;
+                if (pass == 0 && !bulk_eligible(p)) continue;
                 m_bulk_rr = (m_bulk_rr + i + 1) % n;
                 return p;
             }
@@ -2254,6 +2342,10 @@ private:
                     ++pb.evictions;
                     ++m_body_stall_evictions;
                     pb.stalls_since_evict = 0;
+                    // The disconnected staller demonstrably did not serve this
+                    // deep body: demote its address so a refill/reconnect to it
+                    // is skipped by next_bulk_peer() (dashd failure demotion).
+                    note_bulk_nonserver(staller);
                     pb.stall_timeout = BODY_STALL_TIMEOUT_INIT;
                     remove_peer(bad,
                         "block-stall: body " + pb.hash.GetHex().substr(0, 16)
@@ -2582,6 +2674,10 @@ private:
         for (auto it = m_pending_bodies.begin();
              it != m_pending_bodies.end(); ++it)
             if (it->hash == blockhash) { m_pending_bodies.erase(it); break; }
+        // This peer just DELIVERED a body — it demonstrably serves blocks, so
+        // clear any non-server strike so it re-enters bulk selection (dashd
+        // forgives a peer the moment it satisfies a download).
+        forgive_bulk_nonserver(p->key);
         // W2 bulk demux: a body the replay bulk lane has in flight is consumed
         // HERE (verified + folded + pruned by the lane) and never fires
         // full_block — the live ingest legs are tip-rate consumers and must
@@ -3001,6 +3097,11 @@ private:
                 // on a DIFFERENT peer immediately instead of waiting out the
                 // scheduler timeout. No-op unless --replay-bulk registered it.
                 if (m_on_block_notfound) m_on_block_notfound(inv.m_hash);
+                // dashd per-peer download-failure demotion: this peer just
+                // declared it does NOT hold a block we asked for. Strike it so
+                // next_bulk_peer() converges away from non-servers of deep
+                // history onto archival peers that actually deliver.
+                note_bulk_nonserver(p->key);
             }
         }
     }

--- a/test/test_dash_coin_p2p_client.cpp
+++ b/test/test_dash_coin_p2p_client.cpp
@@ -61,6 +61,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <algorithm>
 #include <vector>
 
 using dash::coin::p2p::CoinClient;
@@ -734,6 +735,144 @@ TEST(DashCoinP2PClient, pool_tick_timer_is_actually_armed_on_the_io_context)
     EXPECT_GE(rig.client.pings_sent(), 1u)
         << "the pool tick timer was never armed on the io_context — every "
            "clock-driven test above would still pass with the tick deleted";
+}
+
+// ── (f) HEAD-OF-LINE STALLER — dashd nStallingSince port ───────────────────
+//
+// The mn-checkpoint anchor->tip fold is forward-CONTIGUOUS: apply_block cannot
+// cross a hole, so the single body at the fold cursor (the front of the ordered
+// window) gates the WHOLE fold even while up to kWindow-1 later bodies have
+// already arrived and buffered ahead. Before this port that front body was one
+// of ~64 EQUAL tracked slots: its getdata rode a blind round-robin carrier and
+// its slow carrier was disconnected only after BODY_REREQUEST_MAX(4) rotations.
+//
+// dashd (net_processing.cpp) arms nStallingSince against the carrier of the
+// FIRST in-flight block ONLY, and disconnects it after an ADAPTIVE (doubling,
+// 2->64s) timeout once the window is starved. This port mirrors that: the lane
+// tags the cursor block head-of-line; on stall the front RE-HOMES to the
+// fastest-delivering peer (dashd reassignment), and its carrier is disconnected
+// only once it is a CHRONIC staller (the adaptive window has climbed to >=16s),
+// so a willing-but-slow peer is not dropped on the first stall.
+//
+// These KATs are the red/green pair, expressed as untagged-vs-tagged on the
+// SAME service pass with an identical peer set.
+
+// Stand up one handshaked, bulk-eligible (NODE_NETWORK) peer at a synthetic
+// address on the REAL client — attach + version + verack, all above the socket.
+inline void hol_add_handshaked_peer(ClientRig& rig, const std::string& ip,
+                                    uint16_t port, uint64_t services, uint32_t height)
+{
+    NetService addr{ip, port};
+    rig.client.attach_peer_for_test(addr);
+    rig.client.handle(
+        dash::coin::p2p::message_version::make_raw(
+            70230, services, /*timestamp=*/1234567890ull,
+            addr_t{services, addr},
+            addr_t{services, NetService{"0.0.0.0", port}},
+            /*nonce=*/0x1122334455667788ull, "/Dash Core:21.1.0/", height),
+        addr);
+    rig.client.handle(dash::coin::p2p::message_verack::make_raw(), addr);
+}
+
+// GREEN core: a tagged head-of-line front RE-HOMES to the fastest deliverer on
+// its FIRST stall (not a blind round-robin pick) WITHOUT dropping the slow
+// carrier — the pool keeps its parallelism.
+TEST(DashCoinP2PHeadOfLine, tagged_front_rehomes_to_fastest_on_first_stall_pool_intact)
+{
+    ClientRig rig;
+    rig.use_fake_clock();
+
+    // Four archival peers. Attach order fixes the round-robin: A is the initial
+    // carrier; B is the demonstrated FAST deliverer; C, D are spares.
+    hol_add_handshaked_peer(rig, "10.0.0.1", 9999, /*NODE_NETWORK*/1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.2", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.3", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.4", 9999, 1, 3000000);
+    const std::string A = "10.0.0.1:9999", B = "10.0.0.2:9999";
+    ASSERT_EQ(rig.client.handshaked_peer_keys().size(), 4u);
+
+    // dashd PeerTally.blocks: B is the fastest deliverer.
+    rig.client.bump_peer_delivered_for_test(B, 100);
+
+    const uint256 front = uint256(0xF00Dull);
+    ASSERT_TRUE(rig.client.request_head_of_line_for_test(front));
+    EXPECT_TRUE(rig.client.pending_body_is_hol_for_test(front));
+    ASSERT_EQ(rig.client.pending_body_last_peer_for_test(front), A)
+        << "initial HOL getdata should ride the first round-robin carrier";
+
+    rig.fake_now += 3;   // > BODY_STALL_TIMEOUT_INIT (2s): first stall
+    rig.client.service_pending_bodies_for_test(rig.fake_now);
+
+    // The front block re-homes to the FASTEST deliverer (B), not round-robin.
+    EXPECT_EQ(rig.client.hol_rehomes(), 1u);
+    EXPECT_EQ(rig.client.hol_last_rehome_target(), B)
+        << "HOL re-home must pick the highest PeerTally.blocks peer";
+    EXPECT_EQ(rig.client.pending_body_last_peer_for_test(front), B);
+    // A willing-but-slow carrier is NOT dropped on the first stall — the pool
+    // keeps its parallelism (dashd disconnects only a genuinely-starved window).
+    EXPECT_EQ(rig.client.hol_disconnects(), 0u);
+    EXPECT_EQ(rig.client.handshaked_peer_keys().size(), 4u);
+}
+
+// GREEN chronic: a front that stays stuck across the ADAPTIVE (doubling) window
+// eventually has its chronic carrier disconnected (dashd fDisconnect), so the
+// cursor cannot wedge forever on one dead-but-connected peer.
+TEST(DashCoinP2PHeadOfLine, chronic_front_disconnects_its_carrier_after_adaptive_backoff)
+{
+    ClientRig rig;
+    rig.use_fake_clock();
+    hol_add_handshaked_peer(rig, "10.0.0.1", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.2", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.3", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.4", 9999, 1, 3000000);
+    ASSERT_EQ(rig.client.handshaked_peer_keys().size(), 4u);
+
+    const uint256 front = uint256(0xF00Dull);
+    ASSERT_TRUE(rig.client.request_head_of_line_for_test(front));
+
+    // Nobody ever answers. Drive the adaptive window 2->4->8->16 across stalls.
+    // The disconnect fires only once the window reaches the chronic threshold,
+    // so early stalls re-home (race) but keep the pool intact.
+    for (int i = 0; i < 4; ++i) {
+        rig.fake_now += 70;   // always past the (doubling) stall window
+        rig.client.service_pending_bodies_for_test(rig.fake_now);
+    }
+
+    EXPECT_GE(rig.client.hol_rehomes(), 1u) << "the front must have re-homed";
+    EXPECT_GE(rig.client.hol_disconnects(), 1u)
+        << "a chronic front-of-window staller must eventually be disconnected";
+    EXPECT_LT(rig.client.handshaked_peer_keys().size(), 4u)
+        << "the chronic carrier was dropped";
+}
+
+// RED reference: an UNTAGGED front (plain tracked slot) under the identical peer
+// set keeps the pre-port behaviour — blind round-robin re-request, no
+// fastest-peer targeting, and NO HOL disconnect. This is the trickle the tag
+// removes.
+TEST(DashCoinP2PHeadOfLine, untagged_front_keeps_roundrobin_and_no_hol_machinery)
+{
+    ClientRig rig;
+    rig.use_fake_clock();
+    hol_add_handshaked_peer(rig, "10.0.0.1", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.2", 9999, 1, 3000000);
+    hol_add_handshaked_peer(rig, "10.0.0.3", 9999, 1, 3000000);
+    const std::string B = "10.0.0.2:9999";
+    ASSERT_EQ(rig.client.handshaked_peer_keys().size(), 3u);
+    rig.client.bump_peer_delivered_for_test(B, 100);   // fastest — but untagged path ignores rank
+
+    const uint256 front = uint256(0xBEEFull);
+    ASSERT_TRUE(rig.client.request_block_tracked(front));
+    EXPECT_FALSE(rig.client.pending_body_is_hol_for_test(front));
+
+    rig.fake_now += 3;
+    rig.client.service_pending_bodies_for_test(rig.fake_now);
+
+    // No HOL machinery fired: no fastest-peer re-home and no HOL disconnect.
+    EXPECT_EQ(rig.client.hol_disconnects(), 0u);
+    EXPECT_EQ(rig.client.hol_rehomes(), 0u);
+    // It WAS re-requested (round-robin rotation), proving the difference is the
+    // targeting policy — not whether a re-request occurs at all.
+    EXPECT_GE(rig.client.body_rerequests_total(), 1u);
 }
 
 } // namespace

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -132,12 +132,13 @@ struct PoolRig
     }
 
     std::unique_ptr<RawMessage> version_msg(uint32_t height,
-                                            const std::string& subver = "/Dash Core:21.1.0/")
+                                            const std::string& subver = "/Dash Core:21.1.0/",
+                                            uint64_t services = 1)
     {
         return p2p::message_version::make_raw(
-            70230, /*services=*/1, /*timestamp=*/1234567890ull,
-            addr_t{1, NetService{"127.0.0.1", 19999}},
-            addr_t{1, NetService{"127.0.0.1", 19999}},
+            70230, services, /*timestamp=*/1234567890ull,
+            addr_t{services, NetService{"127.0.0.1", 19999}},
+            addr_t{services, NetService{"127.0.0.1", 19999}},
             /*nonce=*/0x1122334455667788ull, subver, height);
     }
 
@@ -147,6 +148,22 @@ struct PoolRig
         attach(n);
         deliver(n, version_msg(height));
         deliver(n, p2p::message_verack::make_raw());
+    }
+
+    /// Full attach + version/verack for peer n advertising a SPECIFIC service
+    /// bitfield — the CanServeBlocks convergence KATs stand up mixed
+    /// archival(NODE_NETWORK) / pruned(NODE_NETWORK_LIMITED) pools this way.
+    void handshake_services(int n, uint64_t services, uint32_t height = 1000)
+    {
+        attach(n);
+        deliver(n, version_msg(height, "/Dash Core:21.1.0/", services));
+        deliver(n, p2p::message_verack::make_raw());
+    }
+
+    static std::unique_ptr<RawMessage> block_notfound(const uint256& h)
+    {
+        return p2p::message_notfound::make_raw(std::vector<p2p::inventory_type>{
+            p2p::inventory_type(p2p::inventory_type::block, h)});
     }
 
     const PeerSession* session(int n) const
@@ -1270,3 +1287,114 @@ TEST(DashCoinP2PPool, a_stalling_bulk_peer_is_disconnected_so_the_fold_advances)
 }
 
 } // namespace
+
+// ══════════════════════════════════════════════════════════════════════════
+// (H) CanServeBlocks CONVERGENCE — dashd net_processing service-flag gate +
+//     per-peer download-failure demotion, ported onto the #1253 bulk-fold
+//     round-robin. The mn-checkpoint anchor->tip fold must target ONLY peers
+//     that advertise they can serve the block (NODE_NETWORK, not pruned-only)
+//     and must CONVERGE away from peers that fail to serve (NOTFOUND / stall
+//     eviction) so a deep IBD window re-homes onto archival deliverers.
+//
+//     RED on #1253 (blind round-robin, service-flag-/demotion-blind): a
+//     limited-only peer is selected for a deep body it cannot serve, and a
+//     peer that keeps answering NOTFOUND keeps being re-asked.
+//     GREEN with the port: the pruned peer is never selected, the failing peer
+//     is demoted out, and selection converges onto the full-block peers.
+// ══════════════════════════════════════════════════════════════════════════
+
+// NODE_NETWORK=0x1, NODE_NETWORK_LIMITED=0x400 (dashd protocol.h).
+static constexpr uint64_t SVC_NETWORK        = 0x1;
+static constexpr uint64_t SVC_LIMITED        = 0x400;
+static constexpr uint64_t SVC_FULL           = 0x1 | 0x400;   // archival: both
+static constexpr uint64_t SVC_LIMITED_ONLY   = 0x400;         // pruned
+
+TEST(DashBulkCanServe, limited_only_peer_is_never_selected_for_a_deep_bulk_body)
+{
+    PoolRig rig;
+    // Two archival (full-block) peers and one pruned (limited-only) peer.
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 3u);
+
+    // Announcer-less (deep-historical) body selection, many rounds so a blind
+    // round-robin would land on peer 3 repeatedly.
+    std::map<std::string, int> hits;
+    for (uint32_t k = 0; k < 60; ++k)
+        hits[rig.client.select_bulk_peer_key_for_test(hash_n(1000 + k))]++;
+
+    // GREEN: the pruned peer is EXCLUDED entirely; both archival peers serve.
+    EXPECT_EQ(hits[PoolRig::peer_key(3)], 0)
+        << "a limited-only (pruned) peer must never be asked for ~9.5k-deep "
+           "history — dashd IsLimitedPeer gate";
+    EXPECT_GT(hits[PoolRig::peer_key(1)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(2)], 0);
+    EXPECT_EQ(hits[PoolRig::peer_key(1)] + hits[PoolRig::peer_key(2)], 60);
+}
+
+TEST(DashBulkCanServe, notfound_demotes_a_nonserver_and_selection_converges)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 3u);
+
+    // Peer 2 keeps answering NOTFOUND for deep bodies (advertises NODE_NETWORK
+    // but does not actually serve buried history — the live-network symptom).
+    for (int i = 0; i < 2; ++i)   // BULK_NONSERVER_STRIKE_MAX
+        rig.deliver(2, PoolRig::block_notfound(hash_n(7000 + i)));
+
+    EXPECT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)))
+        << "a peer that repeatedly answers NOTFOUND must be demoted "
+           "(dashd per-peer download-failure demotion)";
+
+    // GREEN: selection now CONVERGES onto the two delivering peers; the demoted
+    // non-server is never chosen again.
+    std::map<std::string, int> hits;
+    for (uint32_t k = 0; k < 60; ++k)
+        hits[rig.client.select_bulk_peer_key_for_test(hash_n(8000 + k))]++;
+    EXPECT_EQ(hits[PoolRig::peer_key(2)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(1)], 0);
+    EXPECT_GT(hits[PoolRig::peer_key(3)], 0);
+}
+
+TEST(DashBulkCanServe, delivering_a_body_forgives_a_demoted_peer)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    for (int i = 0; i < 2; ++i)
+        rig.deliver(2, PoolRig::block_notfound(hash_n(100 + i)));
+    ASSERT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)));
+
+    // A single clean body delivery from peer 2 clears the strike — it
+    // demonstrably serves blocks now (dashd forgives on a satisfied download).
+    rig.client.forgive_bulk_nonserver_for_test(PoolRig::peer_key(2));
+    EXPECT_FALSE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(2)));
+    EXPECT_EQ(rig.client.bulk_nonserver_strikes_for_test(PoolRig::peer_key(2)), 0);
+}
+
+TEST(DashBulkCanServe, no_eligible_peer_falls_back_never_wedges_the_selection)
+{
+    PoolRig rig;
+    // Pathological scarcity: EVERY reachable peer is pruned (limited-only).
+    // The port must NOT wedge on an empty selection — it falls back to the
+    // handshaked pool exactly as #1253 did (non-regression: never worse than
+    // the blind rotation on a peer set with no archival deliverer).
+    rig.handshake_services(1, SVC_LIMITED_ONLY);
+    rig.handshake_services(2, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    std::set<std::string> chosen;
+    for (uint32_t k = 0; k < 20; ++k)
+    {
+        std::string key = rig.client.select_bulk_peer_key_for_test(hash_n(200 + k));
+        EXPECT_FALSE(key.empty()) << "selection must never return no peer";
+        chosen.insert(key);
+    }
+    // Both limited peers still get used (fallback pass spreads across the pool).
+    EXPECT_EQ(chosen.size(), 2u);
+}
+

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1398,3 +1398,108 @@ TEST(DashBulkCanServe, no_eligible_peer_falls_back_never_wedges_the_selection)
     EXPECT_EQ(chosen.size(), 2u);
 }
 
+
+// ══════════════════════════════════════════════════════════════════════════
+// (I) STATEFUL FOLD LEG — getmnlistd rotate-on-stall (dashd sync-peer parity)
+//
+//     The mn-checkpoint anchor->tip fold requests its per-height masternode
+//     snapshot with getmnlistd(ZERO, hash_at(H)). On master (#1253/#1254) that
+//     request is pinned to m_primary and, on no reply, tick_pending_fold()
+//     RE-ASKS THE SAME PRIMARY. A live cold soak froze 26 min behind ONE slow
+//     primary waiting for the deep base->anchor snapshot while 7 other archival
+//     peers sat idle (LANE-WATCHDOG waiting_for=fold-mnlist-reply, warn 1..9).
+//
+//     dashd picks a sync peer for a mnlistdiff and ROTATES to another on stall.
+//     send_getmnlistd_rotating() ports that: the fold's snapshot request (and
+//     every re-ask) fans out across the eligible CanServeBlocks pool, preferring
+//     a carrier OTHER than the last one, so a slow-but-alive primary can no
+//     longer wedge the fold. Reply is matched by block hash and only one
+//     getmnlistd is ever outstanding, so any carrier's reply satisfies the await.
+//
+//     RED (pinned path, still used by the LIVE tip follower): send_getmnlistd
+//     lands every ask on the primary — asserted below as the contrast.
+//     GREEN (fold path): send_getmnlistd_rotating spreads consecutive asks
+//     across the archival peers and skips the pruned one.
+// ══════════════════════════════════════════════════════════════════════════
+
+TEST(DashStatefulFold, fold_getmnlistd_rotates_across_archival_peers_and_skips_pruned)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);          // primary (first handshaked)
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+    rig.handshake_services(4, SVC_LIMITED_ONLY);  // pruned — cannot serve deep
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 4u);
+
+    // CONTRAST (the RED behaviour the fix replaces): the PINNED leg — the one
+    // the live tip follower still uses — puts every ask on the primary.
+    const uint64_t p1_before_pinned = rig.session(1)->msgs_sent;
+    for (int i = 0; i < 3; ++i)
+        rig.client.send_getmnlistd(uint256::ZERO, hash_n(500 + i));
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before_pinned + 3u)
+        << "the pinned getmnlistd leg must still land on the primary";
+
+    // GREEN: the ROTATING fold leg fans out. Three consecutive asks over three
+    // eligible archival peers hit three DISTINCT carriers (preferring a peer
+    // other than the last), and the pruned peer is never asked.
+    std::vector<uint64_t> before;
+    for (int i = 1; i <= 4; ++i) before.push_back(rig.session(i)->msgs_sent);
+    for (int i = 0; i < 3; ++i)
+        rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(9000 + i));
+
+    const uint64_t d1 = rig.session(1)->msgs_sent - before[0];
+    const uint64_t d2 = rig.session(2)->msgs_sent - before[1];
+    const uint64_t d3 = rig.session(3)->msgs_sent - before[2];
+    const uint64_t d4 = rig.session(4)->msgs_sent - before[3];
+
+    EXPECT_EQ(d1 + d2 + d3, 3u) << "all three asks must reach an archival peer";
+    EXPECT_EQ(d4, 0u)
+        << "a pruned (limited-only) peer must never carry the deep fold "
+           "snapshot — it cannot serve ~9.5k-deep history";
+    // True fan-out: no single archival peer absorbed all three (the 26-min
+    // single-primary freeze the fix exists to prevent). With three eligible
+    // peers and last-carrier avoidance, each gets exactly one.
+    EXPECT_EQ(d1, 1u);
+    EXPECT_EQ(d2, 1u);
+    EXPECT_EQ(d3, 1u);
+}
+
+TEST(DashStatefulFold, fold_getmnlistd_reask_leaves_the_slow_primary_for_a_neighbour)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);   // primary
+    rig.handshake_services(2, SVC_FULL);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    // First ask (fold snapshot) — allowed to pick the primary.
+    const std::string first = rig.client.select_stateful_peer_key_for_test();
+    EXPECT_FALSE(first.empty());
+    // The RE-ask (tick_pending_fold on no reply) must move OFF that carrier so
+    // a slow-but-alive primary cannot wedge the fold. On master the re-ask hit
+    // the same primary every time; here it rotates to the neighbour.
+    const std::string second = rig.client.select_stateful_peer_key_for_test();
+    EXPECT_FALSE(second.empty());
+    EXPECT_NE(second, first)
+        << "the fold re-ask must rotate to a DIFFERENT eligible peer, not "
+           "re-hammer the slow primary (dashd rotate-on-stall)";
+}
+
+TEST(DashStatefulFold, fold_getmnlistd_never_wedges_when_only_pruned_peers_exist)
+{
+    PoolRig rig;
+    // Pathological: every reachable peer is pruned. The rotating leg must still
+    // send (fallback pass), never drop the fold silently — non-regression vs
+    // the pinned path, which would also have used the (pruned) primary.
+    rig.handshake_services(1, SVC_LIMITED_ONLY);
+    rig.handshake_services(2, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    std::vector<uint64_t> before{rig.session(1)->msgs_sent,
+                                 rig.session(2)->msgs_sent};
+    for (int i = 0; i < 4; ++i)
+        rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(300 + i));
+    const uint64_t sent = (rig.session(1)->msgs_sent - before[0])
+                        + (rig.session(2)->msgs_sent - before[1]);
+    EXPECT_EQ(sent, 4u) << "the fold request must never be dropped even when no "
+                           "archival peer exists (fallback to the handshaked pool)";
+}


### PR DESCRIPTION
## DRAFT — integrator review, do NOT merge

Stacks on #1255 (`dash/dashd-cut-fold-getmnlistd-fanout`, HEAD 48cdc945). Base of this PR is that branch, not master.

## What this does

Ports dashd's front-of-download-window staller (`net_processing.cpp` `FindNextBlocksToDownload` `nStallingSince` + the `SendMessages` 2s adaptive disconnect-on-stall) into the mn-checkpoint anchor→tip fold's body fetch.

The fold is forward-CONTIGUOUS: `MnStateMachine::apply_block` cannot cross a hole, so the single body at the fold cursor (`m_next`) gates the whole ordered fold even while up to `kWindow-1` (64) later bodies have already arrived and buffered ahead. Before this change that front body was one of ~64 EQUAL tracked slots: its `getdata` rode a blind round-robin carrier and its slow carrier was disconnected only after `BODY_REREQUEST_MAX(4)` rotations.

New behaviour:
1. `MnCheckpointLane::service_tick` tags the block at the fold cursor as the single **head-of-line** body (`set_hol_request_fn` → `CoinP2PClient::request_head_of_line`).
2. In `service_pending_bodies`, a HOL slot on stall **re-homes to the fastest-delivering peer** — ranked by a new per-address delivered-body tally (the live analog of `replay_bulk_fetch.hpp`'s `PeerTally.blocks`), reusing the existing `CanServeBlocks`/`IsLimitedPeer` filter — instead of a blind round-robin pick.
3. Its carrier is disconnected (dashd `fDisconnect`) only once it is a **chronic** staller: the adaptive stall window has doubled to ≥16s (dashd's `nStallingSince` doubling, 2→64s). Early stalls race the front to a faster peer WITHOUT dropping a willing-but-slow peer, so the pool keeps its parallelism.

Reuses the existing `PendingBody` slot, disconnect-on-stall path, `CanServeBlocks`/demotion machinery. The only new state is one privileged-slot marker + the per-address delivered tally + the fastest-peer comparator.

**Reward-safe by construction**: fetch/connection-side only. No served MN-payee / quorum-root / subsidy bytes, no `publish()` hold touched, and the fold still validates every block (`payee_ok` stays in lockstep with `applied`, `diverged=0`).

## Tests

`test/test_dash_coin_p2p_client.cpp` — `DashCoinP2PHeadOfLine`, red/green as untagged-vs-tagged on the same `service_pending_bodies` pass:
- **RED** (untagged front, `request_block_tracked`): blind round-robin re-request, no fastest-peer targeting, no HOL disconnect.
- **GREEN core**: tagged front re-homes to the fastest deliverer on the first stall with the pool intact.
- **GREEN chronic**: a front stuck through the adaptive window has its chronic carrier disconnected.

Full `test_dash_p2p_node` target: **142/142 green** (BLS=REAL).

## HONEST measurement — the speedup premise did NOT hold on the live network

Cold daemonless soak on vm905 (dashd ABSENT; `--embedded-mainnet --embedded-null-arm --embedded-utxo --coin-p2p-discover`). Fold arms correctly: anchor 2513000, eligible=2068 MNs, `applied==payee_ok` in lockstep, `diverged=0`. HOL fires live (re-homes to fastest; chronic-disconnect guard holds).

Same-network, same-wall-window A/B against the running #1255 baseline (no HOL):

| build | Δapplied | Δwall | rate |
|---|---|---|---|
| baseline #1255 (no HOL) | 71 blk | 198 s | **0.359 blk/s** |
| this PR (HOL port) | 67 blk | 203 s | **0.330 blk/s** |

**No material speedup** (difference is inside the block-arrival noise; both fluctuate 0.0–0.7 blk/s instantaneously). Neither reached `populated` in the window (~6–8 h from tip either way).

Why the 10–40× target did not materialise: the investigation's premise was that the front block's carrier is *uniquely* slow while *other peers are fast* (so re-homing wins). On this live network the archival peers serve deep (~10k-deep) history at a **uniform** rate — bodies arrive at ~1.9/s aggregate spread evenly across all 8 peers (~0.24 bodies/s each). There is no dramatically-faster peer to re-home the front to, so re-homing between equally-slow peers gives no gain, and the fold rate stays bounded by the per-peer deep-serve rate (shared, too, with the `--embedded-utxo` bootstrap lane competing for the same body bandwidth).

An earlier revision that disconnected the carrier on the FIRST HOL stall (no adaptive backoff) measured **slower** than baseline (0.23 vs 0.36 blk/s) from pool thrash; the chronic-staller guard in this revision removes that regression and lands at parity.

**Verdict for review**: mechanism is correct, dashd-faithful, reward-safe, non-regressive, and well-tested — but it does NOT deliver the cold-start fold speedup, because the bottleneck on this network is uniform deep-history serving rate + cross-lane body contention, not head-of-line-on-a-uniquely-slow-carrier. Recommend NOT merging on throughput grounds; keep as the honest record and re-evaluate the real gate (per-peer deep-serve rate / prioritising the fold's front over the UTXO bootstrap's bulk window).
