### PR TITLE
DASHD-CUT: deep-pipelined block download (out-of-order block staging port) [DRAFT]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5960,7 +5960,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 auto* cp = coin_p2p.get();
                 mn_ckpt_lane->set_request_snapshot_fn(
                     [cp](const uint256& block_hash) {
-                        cp->send_getmnlistd(uint256::ZERO, block_hash);
+                        // Rotate the fold snapshot's getmnlistd across the
+                        // eligible pool so a slow/non-serving primary cannot
+                        // wedge the anchor->tip fold (dashd rotate-on-stall).
+                        cp->send_getmnlistd_rotating(uint256::ZERO, block_hash);
                     });
                 // DEMUX (reward-critical): the reply comes back on the SAME
                 // mnlistdiff message the tip sync uses. Routed here it is

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -221,6 +221,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -1169,6 +1170,13 @@ public:
     const std::string& status() const { return m_status; }
     uint32_t anchor_height() const { return m_anchor_height; }
     uint32_t cursor_height() const { return m_next == 0 ? 0 : m_next - 1; }
+    /// The fetch reorder buffer's current occupancy and its high-water mark.
+    /// staged_peak() is the measured effective in-flight depth: on the throttled
+    /// path it stays ~1 (bodies dropped, never retained); with the pipeline fix
+    /// it climbs toward kWindow as concurrently-fetched bodies land ahead of the
+    /// cursor and wait to be drained.
+    size_t   staged_size()   const { return m_stage.size(); }
+    size_t   staged_peak()   const { return m_stage_peak; }
     size_t   set_size()      const { return m_machine.size(); }
     /// Masternodes PERMANENTLY excluded during this bridge on SML-attested
     /// PoSe bans. Non-zero is not a failure — it is the repair working — but
@@ -1677,17 +1685,125 @@ public:
         request_window(tip);
     }
 
-    /// Fold the next bridge block. Wired to the SAME block-connect ingest the
-    /// maintainer uses; blocks that are not the exact next height are ignored
-    /// (a live tip block arriving mid-bridge must not be folded onto a stale
-    /// cursor — that is the E4-soak bad-cb-payee shape).
+    /// Ingest a block body off the coin-P2P feed. Wired to the SAME
+    /// block-connect ingest the maintainer uses.
+    ///
+    /// ── DASHD PIPELINE PARITY (the ~1000x throttle fix) ────────────────────
+    /// Before this seam, a body that arrived AHEAD of the strictly-contiguous
+    /// apply cursor was DROPPED on the floor ("if (height != m_next) return")
+    /// and re-fetched only once the cursor crawled up to it — one serving
+    /// round-trip per block. The kWindow-wide getdata burst therefore collapsed
+    /// to an EFFECTIVE in-flight depth of 1: measured 0.31 blk/s over a
+    /// 99%-idle link while dashd pulls the same peers at 150-350 blk/s.
+    ///
+    /// dash-core keeps every out-of-order block it fetched in its block store
+    /// and connects them CONTIGUOUSLY as ActivateBestChain advances the tip
+    /// (net_processing FindNextBlocksToDownload + MAX_BLOCKS_IN_TRANSIT_PER_PEER
+    /// x peers genuinely in flight, connect decoupled from receipt). This ports
+    /// exactly that: a body ahead of the cursor is RETAINED in a bounded
+    /// height-keyed staging map (m_stage, capped at the request window) instead
+    /// of dropped, and drained contiguously into apply the instant the
+    /// head-of-line block fills the gap. The window then slides forward by the
+    /// whole drained run and request_window() tops it straight back up, so
+    /// ~kWindow bodies stay on the wire continuously. Reward-safety is
+    /// untouched: staging changes only WHEN a body is applied, never WHAT
+    /// apply_block derives — every drained block is still forward-contiguous,
+    /// still merkle-bound (live_feed block_body_binds_to_header), still
+    /// per-block payee-falsified in exactly the same order.
     void on_block_connected(const BlockType& block, uint32_t height)
+    {
+        if (m_state != State::Bridging) return;
+        // Already applied (a duplicate / redundant re-request answer). Never
+        // stage a height at or behind the cursor.
+        if (height < m_next) return;
+        // Retain the body — DO NOT drop it — if it sits ahead of the cursor,
+        // within the window we actually requested. This is the reorder buffer:
+        // its whole point is to keep the other kWindow-1 concurrently-fetched
+        // bodies instead of re-fetching them one round-trip at a time. Bound it
+        // to the request window so memory is O(kWindow) blocks; a body outside
+        // the window was never requested, so seeing one is a bug elsewhere —
+        // drop it rather than grow unbounded.
+        if (height > m_next) {
+            if (height <= m_next + kWindow - 1) {
+                auto ins = m_stage.emplace(height, block);
+                if (ins.second && m_stage.size() > m_stage_peak)
+                    m_stage_peak = m_stage.size();
+            }
+            return;
+        }
+        // height == m_next: the head-of-line block just arrived. Apply it, then
+        // drain every contiguous body the staging buffer already holds.
+        drain_from_cursor(block);
+    }
+
+    /// Apply the head-of-line block (height == m_next), then keep applying
+    /// staged bodies as long as they are contiguous with the advancing cursor
+    /// and the replay is not PAUSED (a fold / ban-state probe outstanding) or
+    /// finished. This is dashd's contiguous-connect drain: one head fill can
+    /// release a whole run of already-fetched blocks in a single burst.
+    void drain_from_cursor(const BlockType& head)
+    {
+        // Re-entrancy guard: a synchronous test harness (ordered-stream demux)
+        // can answer a getdata INLINE from inside apply_contiguous_body ->
+        // request_window, re-entering on_block_connected before we return. The
+        // outer drain loop already re-reads m_stage/m_next each turn, so let the
+        // outer loop own the draining and make the inner call a no-op.
+        if (m_draining) {
+            // Stash and let the active drain pick it up on its next turn.
+            if (!m_snapshot_pending)
+                m_stage.emplace(m_next, head);
+            return;
+        }
+        m_draining = true;
+        apply_contiguous_body(head, m_next);
+        drain_loop();
+        m_draining = false;
+    }
+
+    /// Drain whatever the staging buffer ALREADY holds contiguously from the
+    /// cursor, with no fresh network arrival. The resume paths call this after a
+    /// fold lands so the bodies fetched WHILE the fold was outstanding apply
+    /// immediately, instead of waiting for the ~2.5-min next-tip re-fetch.
+    void drain_staged_from_cursor()
+    {
+        if (m_draining) return;
+        m_draining = true;
+        drain_loop();
+        m_draining = false;
+    }
+
+    /// The shared contiguous-connect loop. Precondition: m_draining is held so a
+    /// synchronous (inline) getdata answer cannot re-enter it.
+    void drain_loop()
+    {
+        while (m_state == State::Bridging && !m_snapshot_pending) {
+            auto it = m_stage.find(m_next);
+            if (it == m_stage.end()) break;
+            BlockType next = std::move(it->second);
+            const uint32_t h = it->first;
+            m_stage.erase(it);
+            apply_contiguous_body(next, h);
+        }
+        // Once the cursor has moved past a staged height it can never be applied
+        // (apply_block only folds m_next). Trim anything now behind the cursor
+        // so a stale entry cannot pin memory or shadow a fresh body.
+        while (!m_stage.empty() && m_stage.begin()->first < m_next)
+            m_stage.erase(m_stage.begin());
+    }
+
+    /// Fold ONE bridge block at the contiguous cursor. PRECONDITION:
+    /// height == m_next and the lane is Bridging and not snapshot-paused (the
+    /// public entry + drain loop enforce all three). A live tip block arriving
+    /// mid-bridge must never be folded onto a stale cursor — that is the
+    /// E4-soak bad-cb-payee shape — which is exactly why only height == m_next
+    /// reaches here.
+    void apply_contiguous_body(const BlockType& block, uint32_t height)
     {
         if (m_state != State::Bridging) return;
         // PAUSED: a fold request is outstanding for the current cursor. The
         // cursor must not advance past the height the pending list describes,
-        // or the fold would land EARLY. Blocks arriving now are dropped; they
-        // are re-requested when the fold completes.
+        // or the fold would land EARLY. The drain loop already stops on this
+        // flag; this is the belt-and-braces backstop for a direct caller.
         if (m_snapshot_pending) return;
         if (height != m_next) return;
 
@@ -2722,6 +2838,11 @@ public:
             const uint32_t tip = m_tip_height();
             if (m_next > tip) { publish(tip); return true; }
             request_window(tip);
+            // The bodies fetched WHILE this fold was outstanding are still in
+            // the staging buffer — apply them now rather than waiting for the
+            // request_window() re-fetch round-trip (dashd resumes its connect
+            // straight off the block store the moment the gap fills).
+            drain_staged_from_cursor();
         }
         return true;
     }
@@ -2837,6 +2958,9 @@ private:
         const uint32_t tip = m_tip_height();
         if (m_next > tip) { publish(tip); return; }
         request_window(tip);
+        // Apply the bodies staged while this on-demand fold was outstanding
+        // instead of waiting for the request_window() re-fetch.
+        drain_staged_from_cursor();
     }
 
     /// Apply an AUTHENTICATED list dated exactly at `height`, with the cursor
@@ -3565,6 +3689,11 @@ public:
         m_last_pump_next        = 0;
         m_requested_through     = 0;
         m_rerequest_from_cursor = false;
+        // The fetch reorder buffer holds bodies for a SPECIFIC bridge's height
+        // range; a re-arm replays the same heights from the anchor, so any body
+        // staged by the previous attempt is stale and must not be inherited.
+        m_stage.clear();
+        m_draining              = false;
         m_last_wait_log         = 0;
         m_last_reqfail_logged   = 0;   // #138: same class as m_last_wait_log —
                                        // a log throttle a fresh bridge must
@@ -3724,6 +3853,17 @@ public:
                                          // asked for (#138: never advanced on
                                          // a locally-dead request)
     bool     m_rerequest_from_cursor{false};
+    // ── DASHD PIPELINE PARITY: the fetch reorder / staging buffer ──────────
+    // Height-keyed store of block bodies that arrived AHEAD of the contiguous
+    // apply cursor (dash-core's block store + mapBlocksInFlight analog). Bounded
+    // to the request window (kWindow entries) by on_block_connected. Bodies are
+    // drained contiguously into apply as the cursor advances; this is what turns
+    // the effective in-flight depth from ~1 back into ~kWindow and closes the
+    // measured ~1000x fold throttle. Retained state only — it changes WHEN a
+    // body is applied, never WHAT apply_block derives.
+    std::map<uint32_t, BlockType> m_stage;
+    bool     m_draining{false};          // re-entrancy guard for the drain loop
+    size_t   m_stage_peak{0};            // telemetry: high-water reorder depth
     uint32_t m_last_wait_log{0};
     uint32_t m_last_reqfail_logged{0};   // #138 refusal-log throttle (per height)
     bool     m_position_verified{false};

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -668,6 +668,16 @@ private:
     // reconnect to the same non-serving address. Incremented on NOTFOUND for a
     // bulk body and on stall-eviction; cleared when that peer delivers a body.
     std::map<std::string, int> m_bulk_nonserver_strikes;
+    // Round-robin cursor for the STATEFUL request legs (the mn-checkpoint
+    // anchor->tip fold's getmnlistd snapshot). dashd picks a sync peer for a
+    // mnlistdiff and ROTATES to another on stall rather than re-asking one slow
+    // peer forever; a live cold soak froze 26 min pinned to a single slow
+    // primary waiting for the deep base->anchor fold snapshot. This cursor
+    // spreads the fold's getmnlistd (and its re-asks) across the eligible
+    // (CanServeBlocks) pool. m_last_stateful_peer lets a re-ask prefer a
+    // DIFFERENT carrier so it actually fans out.
+    std::size_t  m_stateful_rr{0};
+    std::string  m_last_stateful_peer;
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1246,6 +1256,12 @@ public:
     /// TEST-ONLY: clear a peer's non-server strike (the forgiveness a real
     /// body delivery triggers on the ingest path).
     void forgive_bulk_nonserver_for_test(const std::string& key) { forgive_bulk_nonserver(key); }
+    /// TEST-ONLY: exercise the STATEFUL (getmnlistd fold) carrier selection —
+    /// the seam the rotate-on-timeout KAT asserts fans out on. Returns the
+    /// chosen peer key and records it as the last stateful carrier, exactly as
+    /// send_getmnlistd_rotating() does on the wire, so repeated calls rotate.
+    std::string select_stateful_peer_key_for_test()
+    { PeerSession* p = next_stateful_peer(); if (p) m_last_stateful_peer = p->key; return p ? p->key : std::string{}; }
 
     /// TEST-ONLY: stand a peer session up with a synthetic endpoint and NO
     /// socket, the way Factory does on a live connect. A null socket is legal
@@ -1562,6 +1578,36 @@ public:
                  << " target=" << block_hash.GetHex();
         auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
         m_primary->write(msg);
+    }
+
+    /// Fold-snapshot variant of send_getmnlistd that ROTATES its carrier across
+    /// the eligible pool (next_stateful_peer) instead of pinning to m_primary.
+    /// The mn-checkpoint anchor->tip fold's deep base->anchor snapshot is the
+    /// stateful leg that froze a cold soak for 26 min behind a single slow
+    /// primary (LANE-WATCHDOG waiting_for=fold-mnlist-reply, re-asking the SAME
+    /// primary). The reply is matched by block hash and only one getmnlistd is
+    /// ever outstanding, so a reply from ANY carrier satisfies the same await —
+    /// rotating the carrier is safe, and is exactly dashd's rotate-on-stall
+    /// sync-peer behaviour. Reward-safe: this changes WHICH peer is asked, never
+    /// the served MN-payee/quorum-root bytes (those stay DIP-4 client-verified
+    /// against the block's own cbTx commitment before they are believed).
+    void send_getmnlistd_rotating(const uint256& base_block_hash,
+                                  const uint256& block_hash)
+    {
+        PeerSession* p = next_stateful_peer();
+        if (!p) {
+            LOG_WARNING << "[COIN-P2P] getmnlistd(rotating) DROPPED (no peer):"
+                        << " base=" << base_block_hash.GetHex()
+                        << " target=" << block_hash.GetHex()
+                        << " — the fold cannot advance until a peer is up";
+            return;
+        }
+        m_last_stateful_peer = p->key;
+        LOG_INFO << "[COIN-P2P] getmnlistd(rotating) -> peer=" << p->key
+                 << " base=" << base_block_hash.GetHex()
+                 << " target=" << block_hash.GetHex();
+        auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
+        p->write(msg);
     }
 
     /// Send a getqrinfo (DIP-24 quorum-rotation-info request) — the ROTATED
@@ -1911,6 +1957,33 @@ private:
                 if (!p->handshake.complete()) continue;
                 if (pass == 0 && !bulk_eligible(p)) continue;
                 m_bulk_rr = (m_bulk_rr + i + 1) % n;
+                return p;
+            }
+        }
+        return m_primary;
+    }
+
+    /// dashd sync-peer selection for the STATEFUL request legs (the
+    /// mn-checkpoint fold's getmnlistd snapshot). Round-robin across the
+    /// eligible (CanServeBlocks + handshaked + non-demoted) pool, PREFERRING a
+    /// peer other than the one the last stateful request went to so a re-ask
+    /// actually fans out instead of re-hammering one slow peer (the 26-min
+    /// single-primary freeze). Falls back — like next_bulk_peer — to any
+    /// eligible peer (first ask / pool of one), then any handshaked peer
+    /// (historical-scarcity), then m_primary.
+    PeerSession* next_stateful_peer()
+    {
+        const std::size_t n = m_pool.size();
+        if (n == 0) return m_primary;
+        for (int pass = 0; pass < 3; ++pass)
+        {
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                PeerSession* p = m_pool[(m_stateful_rr + i) % n].get();
+                if (!p->handshake.complete()) continue;
+                if (pass < 2 && !bulk_eligible(p)) continue;
+                if (pass == 0 && p->key == m_last_stateful_peer) continue;
+                m_stateful_rr = (m_stateful_rr + i + 1) % n;
                 return p;
             }
         }

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1398,3 +1398,108 @@ TEST(DashBulkCanServe, no_eligible_peer_falls_back_never_wedges_the_selection)
     EXPECT_EQ(chosen.size(), 2u);
 }
 
+
+// ══════════════════════════════════════════════════════════════════════════
+// (I) STATEFUL FOLD LEG — getmnlistd rotate-on-stall (dashd sync-peer parity)
+//
+//     The mn-checkpoint anchor->tip fold requests its per-height masternode
+//     snapshot with getmnlistd(ZERO, hash_at(H)). On master (#1253/#1254) that
+//     request is pinned to m_primary and, on no reply, tick_pending_fold()
+//     RE-ASKS THE SAME PRIMARY. A live cold soak froze 26 min behind ONE slow
+//     primary waiting for the deep base->anchor snapshot while 7 other archival
+//     peers sat idle (LANE-WATCHDOG waiting_for=fold-mnlist-reply, warn 1..9).
+//
+//     dashd picks a sync peer for a mnlistdiff and ROTATES to another on stall.
+//     send_getmnlistd_rotating() ports that: the fold's snapshot request (and
+//     every re-ask) fans out across the eligible CanServeBlocks pool, preferring
+//     a carrier OTHER than the last one, so a slow-but-alive primary can no
+//     longer wedge the fold. Reply is matched by block hash and only one
+//     getmnlistd is ever outstanding, so any carrier's reply satisfies the await.
+//
+//     RED (pinned path, still used by the LIVE tip follower): send_getmnlistd
+//     lands every ask on the primary — asserted below as the contrast.
+//     GREEN (fold path): send_getmnlistd_rotating spreads consecutive asks
+//     across the archival peers and skips the pruned one.
+// ══════════════════════════════════════════════════════════════════════════
+
+TEST(DashStatefulFold, fold_getmnlistd_rotates_across_archival_peers_and_skips_pruned)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);          // primary (first handshaked)
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+    rig.handshake_services(4, SVC_LIMITED_ONLY);  // pruned — cannot serve deep
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 4u);
+
+    // CONTRAST (the RED behaviour the fix replaces): the PINNED leg — the one
+    // the live tip follower still uses — puts every ask on the primary.
+    const uint64_t p1_before_pinned = rig.session(1)->msgs_sent;
+    for (int i = 0; i < 3; ++i)
+        rig.client.send_getmnlistd(uint256::ZERO, hash_n(500 + i));
+    EXPECT_EQ(rig.session(1)->msgs_sent, p1_before_pinned + 3u)
+        << "the pinned getmnlistd leg must still land on the primary";
+
+    // GREEN: the ROTATING fold leg fans out. Three consecutive asks over three
+    // eligible archival peers hit three DISTINCT carriers (preferring a peer
+    // other than the last), and the pruned peer is never asked.
+    std::vector<uint64_t> before;
+    for (int i = 1; i <= 4; ++i) before.push_back(rig.session(i)->msgs_sent);
+    for (int i = 0; i < 3; ++i)
+        rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(9000 + i));
+
+    const uint64_t d1 = rig.session(1)->msgs_sent - before[0];
+    const uint64_t d2 = rig.session(2)->msgs_sent - before[1];
+    const uint64_t d3 = rig.session(3)->msgs_sent - before[2];
+    const uint64_t d4 = rig.session(4)->msgs_sent - before[3];
+
+    EXPECT_EQ(d1 + d2 + d3, 3u) << "all three asks must reach an archival peer";
+    EXPECT_EQ(d4, 0u)
+        << "a pruned (limited-only) peer must never carry the deep fold "
+           "snapshot — it cannot serve ~9.5k-deep history";
+    // True fan-out: no single archival peer absorbed all three (the 26-min
+    // single-primary freeze the fix exists to prevent). With three eligible
+    // peers and last-carrier avoidance, each gets exactly one.
+    EXPECT_EQ(d1, 1u);
+    EXPECT_EQ(d2, 1u);
+    EXPECT_EQ(d3, 1u);
+}
+
+TEST(DashStatefulFold, fold_getmnlistd_reask_leaves_the_slow_primary_for_a_neighbour)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);   // primary
+    rig.handshake_services(2, SVC_FULL);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    // First ask (fold snapshot) — allowed to pick the primary.
+    const std::string first = rig.client.select_stateful_peer_key_for_test();
+    EXPECT_FALSE(first.empty());
+    // The RE-ask (tick_pending_fold on no reply) must move OFF that carrier so
+    // a slow-but-alive primary cannot wedge the fold. On master the re-ask hit
+    // the same primary every time; here it rotates to the neighbour.
+    const std::string second = rig.client.select_stateful_peer_key_for_test();
+    EXPECT_FALSE(second.empty());
+    EXPECT_NE(second, first)
+        << "the fold re-ask must rotate to a DIFFERENT eligible peer, not "
+           "re-hammer the slow primary (dashd rotate-on-stall)";
+}
+
+TEST(DashStatefulFold, fold_getmnlistd_never_wedges_when_only_pruned_peers_exist)
+{
+    PoolRig rig;
+    // Pathological: every reachable peer is pruned. The rotating leg must still
+    // send (fallback pass), never drop the fold silently — non-regression vs
+    // the pinned path, which would also have used the (pruned) primary.
+    rig.handshake_services(1, SVC_LIMITED_ONLY);
+    rig.handshake_services(2, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.handshaked_peer_count(), 2u);
+
+    std::vector<uint64_t> before{rig.session(1)->msgs_sent,
+                                 rig.session(2)->msgs_sent};
+    for (int i = 0; i < 4; ++i)
+        rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(300 + i));
+    const uint64_t sent = (rig.session(1)->msgs_sent - before[0])
+                        + (rig.session(2)->msgs_sent - before[1]);
+    EXPECT_EQ(sent, 4u) << "the fold request must never be dropped even when no "
+                           "archival peer exists (fallback to the handshaked pool)";
+}

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -617,6 +617,65 @@ TEST(DashMnCheckpointBridge, IgnoresLiveTipBlocksArrivingMidBridge)
     EXPECT_EQ(h.published_as_of, 1519546u);
 }
 
+// ── DASHD PIPELINE PARITY (the ~1000x throttle fix) ─────────────────────────
+// Bodies fetched concurrently across rotating peers arrive OUT of order. Before
+// the reorder/staging buffer, every body ahead of the strictly-contiguous apply
+// cursor was DROPPED on the floor and re-fetched one serving round-trip at a
+// time — collapsing a kWindow-wide getdata burst to an effective in-flight
+// depth of 1 (the measured 0.31 blk/s over a 99%-idle link). dash-core keeps
+// out-of-order blocks in its store and connects them contiguously as the tip
+// advances; this ports that. The two arms below are RED on the pre-fix
+// (drop-on-out-of-order) code and GREEN on the pipeline fix.
+TEST(DashMnCheckpointBridge, OutOfOrderBodiesAreStagedAndDrainedNotRefetched)
+{
+    BridgeHarness h;
+    h.auto_deliver = false;                       // WE drive the arrival order
+    h.headers[kAnchorHeight] = uint256S(kAnchorHash);
+    h.blocks[1519544] = block_from_hex(kBlockHex1519544);
+    h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+    h.blocks[1519546] = block_from_hex(kBlockHex1519546);
+    h.tip = 1519546;
+
+    h.lane.arm(good_checkpoint());
+    h.lane.pump();                                // issues the window ONCE
+    ASSERT_EQ(h.lane.state(), MnCheckpointLane::State::Bridging);
+    const size_t reqs_after_window = h.requested.size();
+    ASSERT_GE(reqs_after_window, 3u) << "the initial window covers 44/45/46";
+
+    // The two bodies AHEAD of the head-of-line cursor arrive FIRST. They must be
+    // RETAINED (staged), not dropped: the cursor does not move, nothing
+    // publishes, and — the whole point — NO re-request is emitted for them.
+    h.lane.on_block_connected(h.blocks[1519546], 1519546);
+    h.lane.on_block_connected(h.blocks[1519545], 1519545);
+    EXPECT_EQ(h.lane.cursor_height(), kAnchorHeight)
+        << "staged out-of-order bodies must not advance the contiguous cursor";
+    EXPECT_FALSE(h.published);
+    EXPECT_EQ(h.lane.staged_size(), 2u)
+        << "both out-of-order bodies must sit in the reorder buffer";
+    EXPECT_GE(h.lane.staged_peak(), 2u)
+        << "effective in-flight depth reached 2, not the throttled 1";
+    EXPECT_EQ(h.requested.size(), reqs_after_window)
+        << "a staged body must NOT trigger a re-fetch — that IS the throttle";
+
+    // The head-of-line body arrives LAST. It must drain the whole staged run in
+    // ONE burst and publish at the tip — again with no re-fetch of 45/46.
+    h.lane.on_block_connected(h.blocks[1519544], 1519544);
+    EXPECT_TRUE(h.published) << h.lane.status();
+    EXPECT_EQ(h.published_as_of, 1519546u);
+    EXPECT_EQ(h.requested.size(), reqs_after_window)
+        << "the staged bodies drained from the buffer, not from the wire";
+
+    // Every requested height appears exactly once: the pipeline never spent a
+    // round-trip re-fetching a body it had already received. On the pre-fix code
+    // the dropped 45/46 force exactly such re-fetches (or a wedge) — so this and
+    // the publish assertion are the red/green discriminators.
+    std::map<uint32_t, int> counts;
+    for (auto q : h.requested) counts[q]++;
+    for (auto& kv : counts)
+        EXPECT_EQ(kv.second, 1)
+            << "height " << kv.first << " was re-fetched (throttle present)";
+}
+
 TEST(DashMnCheckpointBridge, ChainPositionMismatchFailsClosed)
 {
     // The anchor names a block our PoW-validated header chain does not hold at


### PR DESCRIPTION
## DASHD-CUT: deep-pipelined block download — port dashd's out-of-order block staging into the mn-checkpoint fold

**DRAFT — integrator review, do NOT merge. Stacked on #1256 (`dash/dashd-cut-hol-staller`, 5a26abbd).**

### The throttle
The anchor→tip cold daemonless fold crawled at **~0.31 blk/s** over a **99%-idle** coin-P2P link, while dashd pulls the same peers at **150–350 blk/s** on IBD (~1000x). The prior "uniform ~0.24 bodies/s per peer" reading was an interpretation, never validated against dashd — and it was wrong. The throttle is **c2pool-side**, and deeper than peer selection (all of #1253–#1256 were already merged/stacked and it still crawled).

**Root cause (measured):** the fold had **no fetch reorder buffer**. `on_block_connected` dropped every body that arrived *ahead* of the strictly-contiguous apply cursor (`if (height != m_next) return`). Responses to the kWindow=64 getdata burst come back **out of order across the rotating peer set** (#1253), so 63 of every 64 arrivals landed ahead of the cursor and were **discarded**, then re-fetched one serving round-trip at a time when the cursor finally reached them. The 64-wide window collapsed to an **effective in-flight depth of ~1**: forward progress = one RTT per block on whichever single peer held the head-of-line body, link 99% idle.

### The port
dash-core keeps out-of-order blocks in its block store and connects them **contiguously** as `ActivateBestChain` advances the tip (`net_processing` `FindNextBlocksToDownload` + `MAX_BLOCKS_IN_TRANSIT_PER_PEER` × peers genuinely in flight, connect decoupled from receipt). This ports exactly that into `mn_checkpoint_lane.hpp`:

1. **Retain** every out-of-order body in a bounded height-keyed staging map (`m_stage`, capped at the request window) instead of dropping it.
2. **Drain** the staging map contiguously into apply the instant the head-of-line block fills the gap (`drain_from_cursor` / `drain_loop`), so one head fill releases a whole run in a single burst.
3. **Refill** on apply: the window slides forward by the whole drained run and `request_window()` tops it straight back up, keeping ~kWindow bodies on the wire continuously.
4. Fold / ban-state-probe **resume paths** drain the staged run (`drain_staged_from_cursor`) rather than waiting for the next-tip re-fetch.

### Reward-safety (fetch/connection-side only)
Staging changes only **WHEN** a body is applied, never **WHAT** `apply_block` derives. Every drained block is still forward-contiguous, still merkle-bound (`live_feed` `block_body_binds_to_header`), still per-block payee-falsified in the identical order. Out-of-window live-tip blocks are still ignored — the E4-soak bad-cb-payee guard is preserved by bounding staging to the request window (`height <= m_next + kWindow - 1`). Re-entrancy guarded; `m_stage` cleared on re-arm.

### KAT (red → green)
`OutOfOrderBodiesAreStagedAndDrainedNotRefetched`: delivers the two bodies ahead of the head-of-line cursor first, then the head last.
- **RED** on the pre-fix drop path (temporarily reverted for proof): `staged_peak=0`, never publishes.
- **GREEN** here: `staged_size=2`, drains the whole run on the head fill, publishes at the tip with **zero re-fetch** (each requested height appears exactly once).
- Full suite: **166/166** `test_dash_node_reception_wire` pass.

### vm905 cold daemonless measurement (dashd ABSENT)
Binary `2238d26c` (`/version` = `…-77-g2238d26c`, `/proc/exe` md5 == built `3683255a`), BLS=REAL, flags `--embedded-mainnet --embedded-null-arm --embedded-utxo --coin-p2p-discover`, anchor 2513000.

| metric | before (baseline) | after (this PR) |
|---|---|---|
| fold rate, active-fetch bursts (500-blk milestones) | ~0.31–0.36 blk/s | **~8–12.5 blk/s** (500 blk in 40–63 s) |
| fold rate, overall incl. pauses | ~0.31 blk/s | ~2.7 blk/s |
| on-wire pkt rate | ~25 pkt/s (idle) | **~558 pkt/s** |
| link | 14 KB/s, 99% idle | genuinely busy |
| dashd reference | 150–350 blk/s | — |

The **body-pipeline throttle this PR targets is closed**: rate jumped ~30–40x in active fetch, the link is no longer idle, bodies now stream concurrently from 4+ peers and drain in bursts.

### Honest residual — a SECOND, separate throttle now dominates the average
The fold does **not** yet reach the dashd reference, and it is **not** the body pipeline that stops it. Once fetch is deep, the average is dominated by **per-height / on-demand PoSe fold pauses** — `getmnlistd` round-trips (`fold-mnlist-reply@h=…`, `ondemand-mnlist-reply@h=…`) that pause the **entire** fold for one network RTT at every payee mismatch / fold point. On this span (many `PoSe-removed` events) those pauses are frequent, so overall throughput sits ~2.7 blk/s despite the pipeline running at ~10 blk/s between them. That is the **fold-pause lane** (getmnlistd serialization), a different mechanism from body fetch, and out of scope for this PR. Not-yet-populated at report time (cursor ~2515067, target ~2522936); **0 fail-closed, 0 crash**.

`{reached_full_1000x:false, body_pipeline_throttle:closed, remaining_throttle:"getmnlistd PoSe fold-pause RTTs (fold-mnlist-reply/ondemand-mnlist-reply) stall the whole fold — separate lane"}`
