### PR TITLE
dash: lift the MN diff-store + writer onto the cold MN-CKPT bridge arm (DRAFT — cold benefit gated on full-state anchor)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3536,6 +3536,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // queue gap-repair seam. Constructed only alongside the fold engine.
     std::unique_ptr<dash::coin::replay::MnDiffStore>           mn_diff_store;
     std::unique_ptr<dash::coin::replay::MnDiffWriter>          mn_diff_writer;
+    // DASHD-CUT ARM: the PARALLEL DML fold engine that feeds the diff store on
+    // the COLD MN-CKPT bridge path (no --replay-bulk / --replay-fold-prestate).
+    // The cold bridge folds an MnStateMachine (payee projection); this engine
+    // folds the full ReplayMNState alongside it so the store writer has the
+    // root+payee-checked per-block commit it needs. Seeded at the same anchor
+    // the bridge stands on; sinks MnDiffWriter::on_folded off ITS OWN commit.
+    std::unique_ptr<dash::coin::replay::DmlFoldEngine>         mn_bridge_fold_engine;
     // PR-2 FORWARD: dashd's mined-commitment store, fed from the same replayed
     // bodies. shared_ptr because the qc-plan lambda (installed far above, on
     // the serve path) captures it by value and must see it appear later — it
@@ -6250,6 +6257,197 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     mnl->pump();
                 };
             maintainer->set_on_mn_reseed(mn_reseed_fallback);
+
+            // ── DASHD-CUT ARM: the MN DIFF/SNAPSHOT STORE on the COLD bridge ──
+            // The store block below (dashd evodb dmn_D4/dmn_S3 port) was DORMANT
+            // on the daemonless cold flags: its only construction site was gated
+            // under --replay-bulk → --replay-fold-prestate. LIFT it onto the
+            // cold MN-CKPT bridge arm so the ban-state probe / on-demand fold can
+            // repair from a 0-RTT root+payee-verified store instead of a capped
+            // network round trip (see begin_revive_probe / the payee-desync
+            // store re-apply in mn_checkpoint_lane.hpp).
+            //
+            // The cold bridge folds an MnStateMachine (payee projection); the
+            // store WRITER is bound to a DmlFoldEngine (full ReplayMNState). So
+            // we stand up a PARALLEL DmlFoldEngine seeded at the SAME anchor the
+            // bridge stands on, feed it every block the bridge folds CLEANLY
+            // (set_on_block_applied), and sink MnDiffWriter::on_folded off THAT
+            // engine's own root-checked commit.
+            //
+            // REWARD-SAFETY IS BY CONSTRUCTION and does NOT depend on the seed
+            // being complete: MnDiffStore::reconstruct() REFUSES any row that
+            // does not re-hash to the block's committed merkleRootMNList
+            // (mn_diff_store.hpp:849-857). The trusted-anchor checkpoint carries
+            // the DIP-3 PAYEE fields but NOT the SML fields the root commits
+            // (confirmedHash, netInfo) — so the parallel engine cannot reproduce
+            // the anchor+1 root and POISONS at the first fold. A poisoned engine
+            // writes no diffs, the store holds only the anchor, every height
+            // above it REPAIR-REFUSES, and the SOURCE callers fall through to
+            // their unchanged network path: today's behaviour EXACTLY, never a
+            // wrong row, never a bad mint. The wiring is in place so that the
+            // day a FULL-STATE (v3) anchor is pinned, the store serves the cold
+            // bridge with zero further change. Until then it is an accelerator
+            // that is present and inert, precisely as an accelerator should be.
+            if (mn_ckpt_lane && header_chain && ckpt.ok
+                && !mn_diff_store) {
+                namespace rp = dash::coin::replay;
+                mn_diff_store = std::make_unique<rp::MnDiffStore>(
+                    (core::filesystem::config_path() / net_subdir
+                        / "dash_mn_diff_db").string());
+                if (!mn_diff_store->open()) {
+                    LOG_WARNING << "[MN-DIFF-DB] cold-bridge open failed — diff"
+                                   " store DISABLED (gap repair unavailable;"
+                                   " probe/fold caps unchanged)";
+                    mn_diff_store.reset();
+                } else {
+                    auto diff_hlookup =
+                        [hc = header_chain.get()](const uint256& h)
+                            -> std::optional<std::pair<uint32_t, uint256>> {
+                        if (!hc) return std::nullopt;
+                        auto e = hc->get_header(h);
+                        if (!e) return std::nullopt;
+                        return std::make_pair(e->height, e->prev_hash);
+                    };
+                    std::string vnote;
+                    mn_diff_store->startup_verify(diff_hlookup, vnote);
+                    if (!vnote.empty())
+                        LOG_INFO << "[MN-DIFF-DB] cold-bridge startup verify: "
+                                 << vnote;
+
+                    // PARALLEL engine seeded at the bridge anchor. The checkpoint
+                    // MNState carries the payee facets; the SML-root facets it
+                    // omits are left at their ReplayMNState defaults (the engine
+                    // then self-checks and poisons at anchor+1 unless a genuine
+                    // full-state anchor was supplied — see the safety note above).
+                    dash::coin::replay::FoldConfig fcfg;
+                    fcfg.enabled = true;
+                    mn_bridge_fold_engine =
+                        std::make_unique<rp::DmlFoldEngine>(fcfg);
+                    std::vector<std::pair<uint256, rp::ReplayMNState>> seed;
+                    seed.reserve(ckpt.entries.size());
+                    uint64_t trc = 0;
+                    for (const auto& [protx, mn] : ckpt.entries) {
+                        rp::ReplayMNState st;
+                        st.nType             = mn.nType;
+                        st.internalId        = trc++;   // ordering only; not root
+                        st.collateralOutpoint = mn.collateralOutpoint;
+                        st.nOperatorReward   = mn.nOperatorReward;
+                        st.nVersion          = mn.nVersion;
+                        st.nRegisteredHeight  = static_cast<int32_t>(mn.nRegisteredHeight);
+                        st.nLastPaidHeight    = static_cast<int32_t>(mn.nLastPaidHeight);
+                        st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
+                        st.nPoSeRevivedHeight = mn.nPoSeRevivedHeight == 0
+                            ? rp::ReplayMNState::NEVER
+                            : static_cast<int32_t>(mn.nPoSeRevivedHeight);
+                        st.nPoSeBanHeight     = mn.nPoSeBanHeight == 0
+                            ? rp::ReplayMNState::NEVER
+                            : static_cast<int32_t>(mn.nPoSeBanHeight);
+                        st.nRevocationReason = mn.nRevocationReason;
+                        st.keyIDOwner        = mn.keyIDOwner;
+                        st.pubKeyOperator    = mn.pubKeyOperator;
+                        st.keyIDVoting       = mn.keyIDVoting;
+                        st.netInfo           = mn.netInfo;
+                        st.scriptPayout      = mn.scriptPayout;
+                        st.scriptOperatorPayout = mn.scriptOperatorPayout;
+                        st.platformNodeID    = mn.platformNodeID;
+                        st.platformP2PPort   = mn.platformP2PPort;
+                        st.platformHTTPPort  = mn.platformHTTPPort;
+                        seed.emplace_back(protx, std::move(st));
+                    }
+                    mn_bridge_fold_engine->seed(std::move(seed), trc,
+                                                ckpt.height, ckpt.blockhash,
+                                                net_name);
+                    mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
+                        *mn_diff_store, *mn_bridge_fold_engine);
+                    mn_diff_writer->arm();
+
+                    // THE WRITE FEED: every block the bridge folds CLEANLY is
+                    // handed to the parallel engine; only its OWN root-checked
+                    // commit sinks the writer. A once-latched poison log names
+                    // the reality when a partial anchor cannot reproduce roots.
+                    mn_ckpt_lane->set_on_block_applied(
+                        [eng = mn_bridge_fold_engine.get(),
+                         w   = mn_diff_writer.get(),
+                         logged = std::make_shared<bool>(false)](
+                            const dash::coin::BlockType& blk, uint32_t h) {
+                            if (eng->poisoned()) return;
+                            const uint256 bh =
+                                rp::DmlFoldEngine::block_header_hash(blk);
+                            const auto fr = eng->fold_block(blk, h);
+                            if (fr.ok) {
+                                w->on_folded(h, bh, blk, fr);
+                                return;
+                            }
+                            if (!*logged) {
+                                *logged = true;
+                                LOG_WARNING
+                                    << "[MN-DIFF-DB] cold-bridge parallel fold"
+                                       " could not extend the store at h=" << h
+                                    << " (" << fr.error << "). The store keeps"
+                                       " only its anchor row; every height above"
+                                       " REPAIR-REFUSES and the probe/on-demand"
+                                       " paths fall through to the network"
+                                       " unchanged. This is the expected,"
+                                       " reward-safe state when the anchor is a"
+                                       " payee-only checkpoint (no committed-root"
+                                       " SML fields) rather than a full-state"
+                                       " snapshot.";
+                            }
+                        });
+
+                    // THE READ SEAM: the 0-RTT gap-repair the SOURCE callers
+                    // use, reconstructed from the store and cross-checked at
+                    // every hop against OUR PoW-validated header chain.
+                    dash::coin::MnGapRepairFn repair_fn =
+                        [store = mn_diff_store.get(),
+                         hc = header_chain.get()](uint32_t want)
+                            -> dash::coin::MnGapRepairResult {
+                        dash::coin::MnGapRepairResult out;
+                        out.as_of = want;
+                        if (store == nullptr || hc == nullptr) {
+                            out.error = "diff store / header chain absent";
+                            return out;
+                        }
+                        auto e = hc->get_header_by_height(want);
+                        if (!e) {
+                            out.error = "h=" + std::to_string(want)
+                                      + " is not on our PoW-validated header"
+                                        " chain";
+                            return out;
+                        }
+                        auto hlookup = [hc](const uint256& h)
+                            -> std::optional<std::pair<uint32_t, uint256>> {
+                            auto ie = hc->get_header(h);
+                            if (!ie) return std::nullopt;
+                            return std::make_pair(ie->height, ie->prev_hash);
+                        };
+                        rp::DmlFoldEngine::Entries list;
+                        uint64_t trc2 = 0;
+                        std::string err;
+                        if (!store->reconstruct(e->hash, hlookup, list, trc2,
+                                                err)) {
+                            out.error = err;
+                            return out;
+                        }
+                        out.entries.reserve(list.size());
+                        for (const auto& [protx, st] : list)
+                            out.entries.emplace_back(protx,
+                                                     rp::to_payee_state(st));
+                        out.ok = true;
+                        return out;
+                    };
+                    mn_ckpt_lane->set_gap_repair(repair_fn);
+
+                    std::cout << "[run] MN DIFF STORE ARMED (cold bridge): the"
+                                 " MN-CKPT bridge's clean folds feed a parallel"
+                                 " root-checked DML engine; the ban-state probe"
+                                 " and on-demand fold repair from it 0-RTT when"
+                                 " it covers the height, else fall through to"
+                                 " the network unchanged (reward-safe: a row"
+                                 " that does not re-hash to the committed"
+                                 " merkleRootMNList is REFUSED)\n";
+                }
+            }
 
             // Kick the lane once now in case the header chain is already past
             // the anchor from a previous run's persisted header DB.

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -343,6 +343,25 @@ public:
     /// level APPLY GAP before fail_closed. Optional — unset keeps the
     /// terminal fail_closed behavior byte-identical.
     void set_gap_repair(MnGapRepairFn fn)        { m_gap_repair = std::move(fn); }
+
+    /// ── THE MN-DIFF-STORE WRITE FEED (dashd-cut ARM) ──────────────────────
+    /// Called with (block, height) the instant AFTER m_machine.apply_block()
+    /// has folded a bridge block CLEANLY at the contiguous cursor — no gap, no
+    /// surviving payee desync, non-empty set. main_dash wires this to a
+    /// PARALLEL DmlFoldEngine (seeded at the same bridge anchor) so the store
+    /// writer's root+payee-checked per-block diffs are produced off the very
+    /// blocks this lane replays. The parallel engine self-checks each fold
+    /// against the block's committed merkleRootMNList and only its OWN commit
+    /// sinks MnDiffWriter::on_folded, so a seed the engine cannot reproduce
+    /// (e.g. an SML-incomplete anchor) simply poisons the engine and the store
+    /// never populates — never a wrong row. Forward-contiguous by construction:
+    /// this fires once per height, in ascending order, exactly as the engine's
+    /// own forward-only cursor demands. Optional — unset is a no-op.
+    void set_on_block_applied(std::function<void(const BlockType&, uint32_t)> fn)
+    {
+        m_on_block_applied = std::move(fn);
+    }
+
     /// OPTIONAL. Unwired, the bridge behaves exactly as it did before this
     /// seam existed: any payee mismatch during replay is terminal.
     void set_sml_validity_fn(SmlValidityFn fn)
@@ -1337,6 +1356,17 @@ public:
     /// "never evaluated", NOT "evaluated and zero", and the reports say n/a.
     size_t   ondemand_folds()     const { return m_ondemand_folds; }
     size_t   ondemand_excluded()  const { return m_ondemand_excluded; }
+    /// Masternodes whose queue ORDERING (nPoSeRevivedHeight) an on-demand fold
+    /// repaired — a ProUpServTx-revive this bridge applied with the ban
+    /// UNMEASURED, healed forward instead of fail-closing. 0 on a bridge that
+    /// never guessed a revive. See repair_unmeasured_revive_ordering().
+    size_t   ordering_repaired()  const { return m_ordering_repaired; }
+    /// dashd-cut SOURCE: pre-block ban states resolved 0-RTT from the diff
+    /// store instead of a capped network round trip. > 0 means the ARM's store
+    /// SERVED the bridge; a probe/fold cap was not reached because it did not
+    /// need to be. See begin_revive_probe() / the payee-desync store re-apply.
+    size_t   revive_measured_from_store()   const { return m_revive_measured_from_store; }
+    size_t   ondemand_resolved_from_store() const { return m_ondemand_resolved_from_store; }
     size_t   ondemand_cap()       const { return m_ondemand_cap; }
     bool     ondemand_cap_hit()   const { return m_ondemand_cap_hit; }
     bool     ondemand_evaluated() const { return m_ondemand_evaluated; }
@@ -1863,6 +1893,45 @@ public:
         // ask for an RPC re-seed — daemonless has nothing to re-seed from, and
         // guessing is exactly what must never happen).
         if (r.payee_desync && !r.gap_detected) {
+            // ── STORE-FIRST (0-RTT), the on-demand analogue of the ban-state
+            // probe's store-first path in begin_revive_probe(). Before spending
+            // a CAPPED network on-demand fold, ask the diff store for the
+            // AUTHORITATIVE pre-block list AS OF height-1 and RE-APPLY this
+            // block off it — the exact load+re-apply idiom the apply-gap repair
+            // above (r.gap_detected) already uses. The store reconstruct()
+            // returns only a list that re-hashes to the block's committed
+            // merkleRootMNList AND carries payee_verified on every constituent
+            // diff (mn_diff_store.hpp:788,849-857), so re-projecting block
+            // `height`'s payee off it derives EXACTLY the payee dashd's own
+            // list at height-1 projects — the h=2516072 unmeasured-revive
+            // ordering desync heals because the store already recorded
+            // nPoSeRevivedHeight. mark_ban_state_measured(height-1) so the
+            // re-apply's revive gate is decided, not guessed. A refusal (store
+            // absent / row missing / unverified) leaves r untouched and the
+            // network on-demand fold below runs byte-for-byte as before — the
+            // cap is NOT widened, it is simply not reached for the store-covered
+            // case.
+            if (m_gap_repair && height >= 1) {
+                auto rep = m_gap_repair(height - 1);
+                if (rep.ok && !rep.entries.empty() && rep.as_of == height - 1) {
+                    m_machine.load(std::move(rep.entries), height - 1);
+                    m_machine.mark_ban_state_measured(height - 1);
+                    ++m_ondemand_resolved_from_store;
+                    LOG_INFO
+                        << "[MN-CKPT] PAYEE DESYNC at h=" << height
+                        << " RESOLVED FROM STORE (source="
+                        << kPayeeSourceMnDiffRepair << "): re-applied the block "
+                           "off the diff store's authoritative pre-block list AS "
+                           "OF h=" << (height - 1)
+                        << " (0-RTT, root+payee verified) — NO on-demand network "
+                           "fold spent, the "
+                        << m_ondemand_folds << "/" << m_ondemand_cap
+                        << " on-demand budget is untouched.";
+                    r = m_machine.apply_block(block, height);
+                }
+            }
+        }
+        if (r.payee_desync && !r.gap_detected) {
             // ── ON-DEMAND FOLD. The mismatch IS the trigger: ask for the
             // masternode list dated exactly at this height and re-adjudicate.
             // Returns true when the request was issued (the replay is now
@@ -1887,6 +1956,11 @@ public:
         m_next = height + 1;
         ++m_applied;
         note_replay_advance(block);
+        // ── MN-DIFF-STORE WRITE FEED (dashd-cut ARM). The block folded
+        // CLEANLY at the contiguous cursor; hand it to the parallel fold
+        // engine so the store writer emits this height's root+payee-checked
+        // diff. Forward-contiguous, once per height, in order.
+        if (m_on_block_applied) m_on_block_applied(block, height);
         // #91: DELIVERED, and only now. Every guard above had to pass — no
         // gap, no payee desync, a non-empty set — before this height is a
         // height a restart may resume from.
@@ -2555,6 +2629,41 @@ public:
         const auto cands = m_machine.unmeasured_revive_candidates(block, height);
         if (cands.empty()) return false;
 
+        // ── STORE-FIRST (0-RTT, dashd GetListForBlockInternal). Before
+        // spending a CAPPED network probe, ask the diff store for the list AS
+        // OF height-1 — the exact pre-block list dashcore consults to decide
+        // whether a ProUpServTx revives (specialtxman.cpp:361-370). The store
+        // reconstruct() REFUSES any list that does not re-hash to the block's
+        // committed merkleRootMNList (mn_diff_store.hpp:849-857) and the SML
+        // entry commits isValid, so a list it returns AT height-1 carries
+        // dashd's own ban state there — every bit as authoritative as the
+        // fetched height-exact snapshot, at zero round trips. load() it and
+        // mark the ban state measured, which makes ban_state_measured_for(
+        // height) true, so unmeasured_revive_candidates(height) is now empty
+        // and apply_block decides the revive gate correctly WITHOUT a probe.
+        // Only fall through to the network probe when the store is absent or
+        // refuses (a missing/unverified row) — the cap is NEVER widened, it is
+        // simply not reached for the store-covered case.
+        if (m_gap_repair && height >= 1) {
+            auto rep = m_gap_repair(height - 1);
+            if (rep.ok && !rep.entries.empty() && rep.as_of == height - 1) {
+                m_machine.load(std::move(rep.entries), height - 1);
+                m_machine.mark_ban_state_measured(height - 1);
+                ++m_revive_measured_from_store;
+                LOG_INFO
+                    << "[MN-CKPT] BAN-STATE MEASURED FROM STORE at h=" << height
+                    << " (source=" << kPayeeSourceMnDiffRepair << "): the "
+                    << cands.size() << " ProUpServTx here had their pre-block "
+                       "ban state resolved from the diff store's height-exact "
+                       "list AS OF h=" << (height - 1)
+                    << " (0-RTT, root+payee verified) — NO network probe spent, "
+                       "the "
+                    << m_revive_probes << "/" << m_revive_probe_cap
+                    << " probe budget is untouched.";
+                return false;   // measured; apply proceeds, replay NOT paused
+            }
+        }
+
         if (m_revive_probes >= m_revive_probe_cap) {
             m_revive_probe_cap_hit = true;
             LOG_WARNING
@@ -2947,6 +3056,30 @@ private:
         apply_fold(sml, height);
         if (m_state != State::Bridging) return;   // F5 refused; already closed
 
+        // ── ORDERING REPAIR, before the exclusion walk. A masternode revived
+        // by a ProUpServTx we applied with the ban UNMEASURED keeps
+        // nPoSeRevivedHeight=0 and stays the projected head even though this
+        // height-exact list attests it VALID — the h=2516072 wedge, where the
+        // exclusion-only re-adjudication cannot demote a candidate the list
+        // (correctly) calls valid. This writes the nPoSeRevivedHeight dashd
+        // wrote and re-sorts the pending queue, so the walk below adjudicates
+        // against the queue dashd holds. No-op when there is no unmeasured
+        // revive to repair — the ordinary exclusion path is unchanged.
+        const size_t reordered =
+            m_machine.repair_unmeasured_revive_ordering(sml);
+        if (reordered) {
+            m_ordering_repaired += reordered;
+            LOG_WARNING
+                << "[MN-CKPT] ON-DEMAND ORDERING REPAIR at h=" << height << ": "
+                << reordered << " masternode(s) revived by a ProUpServTx applied"
+                   " with the ban UNMEASURED had their nPoSeRevivedHeight"
+                   " restored to dashd's value from the height-exact list, and"
+                   " the payee queue re-sorted. This repairs a queue-ORDERING"
+                   " desync the exclusion-only re-adjudication cannot — the"
+                   " projected candidate was attested VALID, so it was the"
+                   " ORDER that diverged, not the ban state.";
+        }
+
         const auto rr =
             m_machine.readjudicate_payee(m_ondemand_block, height, sml);
         if (!rr.recovered) {
@@ -2978,6 +3111,11 @@ private:
         // after this line. Recording progress here is what gives the watchdog a
         // truthful last-progress timestamp to measure that freeze from.
         note_replay_advance(m_ondemand_block);
+        // MN-DIFF-STORE WRITE FEED (dashd-cut ARM): the on-demand fold resolved
+        // the mismatch and the block is now applied at the contiguous cursor —
+        // feed it to the parallel engine exactly as the ordinary post-apply
+        // path does, so the store's per-height diff chain has no hole here.
+        if (m_on_block_applied) m_on_block_applied(m_ondemand_block, height);
         m_sml_recovered += m_ondemand_r.sml_recovered;
         m_registered    += m_ondemand_r.registered;
         m_spent         += m_ondemand_r.spent;
@@ -3134,6 +3272,14 @@ public:
             + "), " + std::to_string(m_ondemand_excluded)
             + " queue-head exclusion(s) licensed by a list dated EXACTLY at the"
               " height it judged.";
+        if (m_ordering_repaired != 0) {
+            s += " " + std::to_string(m_ordering_repaired)
+                 + " queue-ORDERING repair(s): a ProUpServTx-revive applied with"
+                   " the ban UNMEASURED had nPoSeRevivedHeight restored to"
+                   " dashd's value from the height-exact list and the payee queue"
+                   " re-sorted, healing the mismatch forward instead of failing"
+                   " closed.";
+        }
         if (m_ondemand_cap_hit) {
             s += " THE CAP IS EXHAUSTED: " + std::to_string(m_ondemand_folds)
                  + " of " + std::to_string(m_ondemand_cap)
@@ -3686,6 +3832,9 @@ public:
         m_ondemand_cap_hit   = false;
         m_ondemand_evaluated = false;
         m_ondemand_abandoned = 0;
+        m_ordering_repaired  = 0;
+        m_revive_measured_from_store   = 0;
+        m_ondemand_resolved_from_store = 0;
         m_ondemand_block     = BlockType{};
         m_ondemand_r         = MnStateMachine::ApplyResult{};
         // The SIZED cap, which #1033's arm() did not reset. pump() recomputes
@@ -3806,6 +3955,16 @@ public:
     HeaderHashAtFn m_header_hash_at;
     SmlSnapshotFn  m_sml_snapshot;
     MnGapRepairFn  m_gap_repair;     // diff-store gap repair; unset = terminal fail_closed as before
+    // dashd-cut ARM: parallel-fold write feed (main_dash → DmlFoldEngine +
+    // MnDiffWriter). Unset is a no-op, so a bridge with no store wired behaves
+    // exactly as before.
+    std::function<void(const BlockType&, uint32_t)> m_on_block_applied;
+    // dashd-cut SOURCE observability: pre-block ban state resolved from the
+    // diff store (0-RTT) instead of a capped network probe/fold. These are the
+    // counts that prove the store SERVED — a green run has probe/fold caps
+    // untouched and these > 0.
+    size_t m_revive_measured_from_store{0};   // begin_revive_probe store hits
+    size_t m_ondemand_resolved_from_store{0}; // payee-desync store re-applies
 
     State       m_state{State::Unarmed};
     std::string m_status{"unarmed"};
@@ -3858,6 +4017,7 @@ public:
     bool      m_ondemand_cap_hit{false};
     bool      m_ondemand_evaluated{false};     // a mismatch ever reached it
     size_t    m_ondemand_abandoned{0};         // on-demand asks never answered
+    size_t    m_ordering_repaired{0};          // nPoSeRevivedHeight healed forward
     // ── BAN-STATE PROBE state. Rides the SAME m_snapshot_pending pause and
     // the SAME reply route as a scheduled fold — it IS a scheduled fold, just
     // scheduled by a ProUpServTx instead of by a counter. m_revive_probe_at is

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -446,6 +446,10 @@ public:
         // set is reloaded. Leaving it would let a re-armed lane re-adjudicate
         // an old height against a new set.
         m_pending = PendingPayeeAdjudication{};
+        // The unmeasured-revive ordering ledger describes THESE entries; a
+        // reload retires it for the same reason the ban-state measurement is
+        // retired above.
+        m_unmeasured_revive_at.clear();
         for (auto& [h, st] : entries) {
             m_collateral_index[st.collateralOutpoint] = h;
             m_entries.emplace(h, std::move(st));
@@ -471,6 +475,25 @@ public:
     {
         return m_ban_state_measured_at != 0
             && m_ban_state_measured_at + 1 == height;
+    }
+
+    /// Declare the PoSe ban state of THIS set measured as-of `height` — the
+    /// same fact sync_validity_from_sml() records, but for a set loaded from
+    /// the diff store instead of folded from a fetched SML.
+    ///
+    /// The diff store's reconstruct() only ever returns a list that RE-HASHES
+    /// to the block's committed merkleRootMNList (mn_diff_store.hpp:849-857),
+    /// and the SML entry commits isValid — so a store-reconstructed list AT
+    /// `height` carries dashd's own pre-block ban state at `height`, exactly
+    /// what a fetched height-exact snapshot would. load() clears
+    /// m_ban_state_measured_at (the measurement described the OLD entries), so
+    /// a store-sourced load must re-assert it or ban_state_measured_for()
+    /// stays false and the caller wastes a network probe on a set it already
+    /// measured. Reward-safe by construction: a wrong store row cannot reach
+    /// here — it is REFUSED at reconstruct() before load() is ever called.
+    void mark_ban_state_measured(uint32_t height)
+    {
+        m_ban_state_measured_at = height;
     }
 
     /// The proTxHashes in `block` whose revive outcome this machine cannot
@@ -1034,6 +1057,42 @@ public:
             return false;
         };
 
+        // ── ORDERING-REPAIR fast path. The exclusion walk only ever
+        // attributes to a RUNNER-UP, after demoting a banned head — it cannot
+        // accept a head that is itself the correct paid payee. But when the
+        // mismatch was a queue-ORDERING artifact (a ProUpServTx-revive applied
+        // with the ban unmeasured, since repaired and re-sorted by
+        // repair_unmeasured_revive_ordering()), the projected head is now the
+        // masternode dashd actually paid — there is nothing to exclude. If the
+        // (re-sorted) head's scriptPayout IS paid by this coinbase and the
+        // height-exact list does not attest it INVALID, attribute the payment
+        // to it directly, exactly as a clean apply_block pass-3 would. On a
+        // genuine PoSe-ban desync the head is NOT paid (that is why it
+        // mismatched), so this is skipped and the exclusion walk runs
+        // unchanged.
+        if (!m_pending.ranked.empty()) {
+            auto hit = m_entries.find(m_pending.ranked.front());
+            if (hit != m_entries.end()
+                && paid_in_cb(hit->second.scriptPayout.m_data)) {
+                const std::optional<bool> ha = attest(m_pending.ranked.front());
+                if (!ha.has_value() || *ha) {
+                    mark_paid_entry(hit, height);
+                    out.recovered = true;
+                    out.accepted  = m_pending.ranked.front();
+                    LOG_WARNING
+                        << "[MNS-SM] ON-DEMAND RE-ADJUDICATION h=" << height
+                        << ": the projected payee "
+                        << out.accepted->GetHex().substr(0, 16)
+                        << " is itself paid by this coinbase after the"
+                           " revive-height ORDERING repair re-sorted the queue"
+                           " — the mismatch was a queue-position artifact, not a"
+                           " ban. Payment attributed to it; no exclusion needed.";
+                    m_pending = PendingPayeeAdjudication{};
+                    return out;
+                }
+            }
+        }
+
         const WalkOutcome w =
             walk_to_paid_candidate(m_pending.ranked, attest, paid_in_cb);
         if (!w.accepted) {
@@ -1067,6 +1126,101 @@ public:
                        " height.";
         m_pending = PendingPayeeAdjudication{};
         return out;
+    }
+
+    /// ─────────────────────────────────────────────────────────────────────
+    /// repair_unmeasured_revive_ordering — the ORDERING arm of the on-demand
+    /// PoSe repair (mainnet h=2516072, proTx f513574b70a029ef)
+    /// ─────────────────────────────────────────────────────────────────────
+    ///
+    /// readjudicate_payee re-decides EXCLUSION (ban/valid) and NEVER ORDERING.
+    /// A masternode revived by a ProUpServTx this machine applied while the
+    /// pre-block ban state was UNMEASURED keeps nPoSeRevivedHeight=0, so
+    /// payee_score() sorts it by its stale nLastPaidHeight — ~one queue length
+    /// too early — and it stays the projected head even after the height-exact
+    /// masternode list (correctly) attests it VALID. That is the fail-closed
+    /// WEDGE the exclusion-only re-adjudication cannot repair: the projected
+    /// candidate is attested valid, so nothing is demoted, and the mismatch
+    /// SURVIVES the fold.
+    ///
+    /// dashd's BuildNewListFromBlock applies CDeterministicMNState::Revive(h)
+    /// on a ProUpServTx whenever the masternode IsBanned() pre-block
+    /// (specialtxman.cpp:361-370), setting nPoSeRevivedHeight = the ProUpServTx
+    /// height. The masternode list dated EXACTLY at the mismatch height (the
+    /// one begin_ondemand_fold fetched and DIP-4 client-verified) IS dashd's
+    /// own answer to "was it banned when the revive landed": if it attests the
+    /// masternode VALID here, the revive DID happen, so we write the SAME
+    /// nPoSeRevivedHeight dashd wrote — the height we OBSERVED the ProUpServTx
+    /// at — and re-sort the pending queue. Nothing is guessed: the height is
+    /// recorded from the block, and it is applied only under height-exact
+    /// confirmation. A list that attests INVALID or is silent licenses nothing
+    /// (the exclusion walk owns that case). Returns the number of masternodes
+    /// whose ordering was repaired.
+    ///
+    /// Call BETWEEN apply_fold() and readjudicate_payee() on the on-demand
+    /// path: the fold reconciles ban/valid, this repairs the queue position,
+    /// and the walk then adjudicates against the queue dashd actually holds.
+    size_t repair_unmeasured_revive_ordering(
+        const vendor::CSimplifiedMNList& sml)
+    {
+        if (m_unmeasured_revive_at.empty()) return 0;
+        std::map<uint256, bool> attested;
+        for (const auto& e : sml.mnList) attested[e.proRegTxHash] = e.isValid;
+
+        size_t repaired = 0;
+        for (auto pit = m_unmeasured_revive_at.begin();
+             pit != m_unmeasured_revive_at.end(); ) {
+            const uint256& protx    = pit->first;
+            const uint32_t revive_h = pit->second;
+            auto ait = attested.find(protx);
+            auto eit = m_entries.find(protx);
+            // Repair ONLY when the height-exact list ATTESTS VALID (the revive
+            // really happened) AND we still hold the entry. Absent, invalid, or
+            // spent: leave the ledger entry and let the exclusion walk decide.
+            if (ait == attested.end() || !ait->second
+                || eit == m_entries.end()) { ++pit; continue; }
+            if (revive_h > eit->second.nPoSeRevivedHeight) {
+                eit->second.nPoSeRevivedHeight = revive_h;
+                eit->second.nPoSeBanHeight     = 0;
+                eit->second.isValid            = true;
+                ++repaired;
+                LOG_WARNING
+                    << "[MNS-SM] ORDERING REPAIR: proTx "
+                    << protx.GetHex().substr(0, 16)
+                    << " revived by a ProUpServTx at h=" << revive_h
+                    << " that this set applied with the ban UNMEASURED"
+                       " (nPoSeRevivedHeight stayed 0). The masternode list"
+                       " dated EXACTLY at the mismatch height attests it VALID,"
+                       " so the revive is confirmed: writing"
+                       " nPoSeRevivedHeight=" << revive_h
+                    << " (dashd's own value) and re-sorting the payee queue.";
+            }
+            pit = m_unmeasured_revive_at.erase(pit);
+        }
+
+        // Re-sort the PENDING queue by the corrected scores so the on-demand
+        // re-adjudication walks the queue dashd holds, not the mis-ordered one
+        // captured before the repair. The revived masternode drops to its true
+        // slot; the candidate dashd actually pays rises to the head.
+        if (repaired && m_pending.present) {
+            std::stable_sort(
+                m_pending.ranked.begin(), m_pending.ranked.end(),
+                [this](const uint256& a, const uint256& b) {
+                    auto ia = m_entries.find(a);
+                    auto ib = m_entries.find(b);
+                    const int sa = (ia == m_entries.end())
+                        ? std::numeric_limits<int>::max()
+                        : payee_score(ia->second);
+                    const int sb = (ib == m_entries.end())
+                        ? std::numeric_limits<int>::max()
+                        : payee_score(ib->second);
+                    return payee_order_before(sa, a, sb, b);
+                });
+            m_pending.projected = m_pending.ranked.empty()
+                ? std::optional<uint256>{}
+                : std::optional<uint256>{m_pending.ranked.front()};
+        }
+        return repaired;
     }
 
     // Process a single block. Mutates state per dashcore's
@@ -1284,6 +1438,16 @@ public:
                     // missed one, and both have been measured on mainnet.
                     ++r.revive_unmeasured;
                     r.revive_unmeasured_protx.push_back(ptx.proTxHash);
+                    // Remember WHERE dashd would have written nPoSeRevivedHeight
+                    // so the on-demand fold can reproduce it forward. dashd's
+                    // BuildNewListFromBlock sets it to THIS ProUpServTx height
+                    // (specialtxman.cpp:361-370); we cannot decide the gate now
+                    // (ban state unmeasured), but if a height-exact list later
+                    // attests this masternode VALID the revive DID happen, and
+                    // this is the height it happened at. This is the single
+                    // dashd write the unmeasured path drops — recorded, not
+                    // guessed, and applied only under height-exact confirmation.
+                    m_unmeasured_revive_at[ptx.proTxHash] = height;
                     LOG_WARNING
                         << "[MNS-SM] ProUpServTx h=" << height << " for proTx "
                         << ptx.proTxHash.GetHex().substr(0, 16)
@@ -1851,6 +2015,16 @@ private:
     // 0 = the ban state in this set has NEVER been measured against a dated
     // list; it is whatever the seed carried plus whatever transactions moved.
     uint32_t m_ban_state_measured_at{0};
+
+    // proTxHash -> ProUpServTx height for every revive this machine applied
+    // with the pre-block ban state UNMEASURED (apply_block case-2 else branch).
+    // dashd wrote nPoSeRevivedHeight = that height; we could not decide the
+    // gate, so nPoSeRevivedHeight stayed 0 and the projection drifted ~one
+    // queue length ahead. repair_unmeasured_revive_ordering() consumes this
+    // under height-exact confirmation. Transient (never persisted): a resume
+    // re-measures via the fold ladder, and a stale ledger must not license a
+    // revive-height write. Cleared by load().
+    std::map<uint256, uint32_t> m_unmeasured_revive_at;
 
     /// Walk every ProUpServTx in a block, in tx order, handing the caller the
     /// proTxHash it names. The pre-scan and the apply BOTH go through here so


### PR DESCRIPTION
## What this does

Lifts the MN diff-store + `MnDiffWriter` construction out of the
`--replay-fold-prestate` gate (where it was dormant on the daemonless cold
flags) and onto the cold **MN-CKPT bridge** arm, guarded on
`mn_ckpt_lane != null && header_chain != null`.

Because the writer binds a `DmlFoldEngine` (`ReplayMNState`) while the cold
bridge folds `MnStateMachine` (`MNState`), a **parallel `DmlFoldEngine`** is
stood up, seeded at the bridge anchor, fed each replayed block from
`mn_checkpoint_lane` right after `m_machine.apply_block` succeeds, and
`MnDiffWriter::on_folded` is sunk off *that* engine's root+payee-checked commit.

Source half (`mn_checkpoint_lane.hpp` `begin_revive_probe` /
`begin_ondemand_fold`): before a capped network probe, call
`m_gap_repair(h-1)` / `m_gap_repair(h)` (0-RTT store reconstruct →
`to_payee_state`) and, on ok, load via `m_machine.load(entries, h)` +
`mark_ban_state_measured(h)` so `ban_state_measured_for(h)` is satisfied; only
fall through to `begin_fold` / `m_request_snapshot` when the store is absent or
refuses. #1258 `repair_unmeasured_revive_ordering` folded in as targeted hunks
(belt-and-suspenders) with the `payee_desync` fail-closed as last resort.

`main_dash.cpp +198`, `mn_checkpoint_lane.hpp +160`, `mn_state_machine.hpp +174`.

## Reward-safety (by construction)

`MnDiffStore::reconstruct` REFUSES any row not `root_matched` / `payee_verified`
against the block's committed `merkleRootMNList` (`mn_diff_store.hpp:849-857`). A
wrong arm — or an incomplete seed — never populates the store, so it still
fail-closes and never mints. Each served dated list is DIP-4/merkle-verified.

## KATs (green against the ARM headers)

- `test_dash_coin_state_maintainer` (gap-repair seam): **60/60 PASSED**
- `test_dash_mn_state` (diff-store + replay-payee): **114 PASSED, 1 SKIPPED**
  (`DashReplayRun.AnchorToTipRootChain`, live-data skip)

Includes `WrongPayeeOrderFoldsToTheRightRootAndIsStillRefused` and
`BelowTipSeedRefusedCatchUpStoredButNotArmed`, which exercise the exact
poison/refuse mechanism the cold soak hits.

## Cold daemonless soak (vm905, dashd ABSENT, `--coin-rpc` OMITTED)

Flags: `--embedded-mainnet --embedded-null-arm --embedded-utxo --coin-p2p-discover`.
Provenance verified: `/proc/exe` md5 == built binary
(`4421474c886b493aa8dbc366ab321166`), `--version` = new HEAD (`…-77-g1879b3b2`).

**The store ARMS cold** (no longer dormant): `dash_mn_diff_db` dir appears,
`[MN-DIFF-DB] writer ARMED: seed snapshot at h=2513000 … mns=2974`,
`[run] MN DIFF STORE ARMED (cold bridge) …`.

**Known cold-anchor limitation (documented inline, reward-safe):** the cold
MN-CKPT anchor is a **payee-only checkpoint** (omits `confirmedHash` / `netInfo`),
so the parallel engine cannot reproduce the anchor+1 `merkleRootMNList` and
**poisons at the first fold** (`DML FOLD ROOT MISMATCH at h=2513001 … engine
poisoned, re-seed required`). The store then holds only its anchor row; every
height above REPAIR-REFUSES and the ban-state probe / on-demand fold fall through
to the network **unchanged**. Consequence measured on the soak: the store covers
zero heights → `BAN-STATE MEASURED FROM STORE` never fires, the network probe cap
still bites (`BAN-STATE PROBE REFUSED`, 8/8 exhausted, ≥13×), and the cold bridge
**fail-closed at h=2517703** — `PAYEE DESYNC … SURVIVED the ON-DEMAND PoSe fold …
THE PROBE CAP IS EXHAUSTED (8/8) … Refusing to publish a masternode set that would
mint a rejected coinbase` (27 ProUpServTx left unmeasured for lack of a
pre-block-dated list — exactly what a store-covered 0-RTT probe would have
supplied). The payee-desync at h=2516072 *was* repaired by the #1258 on-demand
ordering repair; 2517703 was not, and the node did not reach a serve. This is the
**baseline** cold outcome — the poisoned store neither helped nor harmed it.
Reward-safety held throughout (refused to mint). The store-accelerated 0-RTT path
becomes effective only when a **full-state (v3) anchor** is pinned.

This is why the PR is a **DRAFT**: the lift, seeding, sink, source-half repair
path, and reward-safety are in and KAT-green, but the cold functional win is
gated on a full-state anchor. Next step is to source a full-state (v3) anchor for
the cold bridge (or seed the parallel engine from the full SML diff at the anchor
height) so the store can cover heights and lift the cap.
