### PR TITLE
dash: full-state anchor seed for the cold MN diff-store fold engine (DRAFT, stack on #1260)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6287,15 +6287,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // does not re-hash to the block's committed merkleRootMNList
             // (mn_diff_store.hpp:849-857). The trusted-anchor checkpoint carries
             // the DIP-3 PAYEE fields but NOT the SML fields the root commits
-            // (confirmedHash, netInfo) — so the parallel engine cannot reproduce
-            // the anchor+1 root and POISONS at the first fold. A poisoned engine
-            // writes no diffs, the store holds only the anchor, every height
-            // above it REPAIR-REFUSES, and the SOURCE callers fall through to
-            // their unchanged network path: today's behaviour EXACTLY, never a
-            // wrong row, never a bad mint. The wiring is in place so that the
-            // day a FULL-STATE (v3) anchor is pinned, the store serves the cold
-            // bridge with zero further change. Until then it is an accelerator
-            // that is present and inert, precisely as an accelerator should be.
+            // (confirmedHash, netInfo) — which a checkpoint-only seed cannot
+            // supply. So rather than seed from the checkpoint alone (which would
+            // poison at anchor+1), the seed is DEFERRED to the lane's own anchor
+            // fold: it fetches getmnlistd(base=ZERO, target=anchor_hash) and
+            // DIP-4-authenticates the FULL Simplified MN List against the anchor
+            // block's committed merkleRootMNList, and set_on_anchor_snapshot()
+            // merges those root-committing fields onto the checkpoint's forward
+            // facets. The merged seed is SELF-CHECKED against the committed root
+            // before forward folds arm; a seed that fails leaves the engine
+            // UNSEEDED, the store empty, and the SOURCE callers on their unchanged
+            // network path — never a wrong row, never a bad mint. When the seed
+            // matches, the store COVERS heights and the ban-state probe /
+            // on-demand fold source 0-RTT/uncapped from it.
             if (mn_ckpt_lane && header_chain && ckpt.ok
                 && !mn_diff_store) {
                 namespace rp = dash::coin::replay;
@@ -6322,52 +6326,151 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         LOG_INFO << "[MN-DIFF-DB] cold-bridge startup verify: "
                                  << vnote;
 
-                    // PARALLEL engine seeded at the bridge anchor. The checkpoint
-                    // MNState carries the payee facets; the SML-root facets it
-                    // omits are left at their ReplayMNState defaults (the engine
-                    // then self-checks and poisons at anchor+1 unless a genuine
-                    // full-state anchor was supplied — see the safety note above).
+                    // ── FULL-STATE ANCHOR SEED (dashd-parity, option A) ──────
+                    // Stand up the parallel DmlFoldEngine here but DEFER its seed
+                    // to the lane's own anchor fold. The payee-only compiled
+                    // checkpoint omits the two fields the anchor merkleRootMNList
+                    // commits to (confirmedHash, netInfo); a checkpoint-only seed
+                    // therefore cannot reproduce the anchor+1 root and poisons at
+                    // the first fold. set_on_anchor_snapshot() below receives the
+                    // DIP-4-authenticated FULL SML the lane already fetches for its
+                    // anchor fold, MERGES its root-committing fields onto the
+                    // checkpoint's forward-fold facets, seeds, and SELF-CHECKS the
+                    // merged state against the anchor's committed root BEFORE arming
+                    // forward folds. A seed that fails the self-check leaves the
+                    // engine UNSEEDED -> store never populates -> callers fall
+                    // through unchanged (reward-safe: a wrong seed can never mint).
                     dash::coin::replay::FoldConfig fcfg;
                     fcfg.enabled = true;
                     mn_bridge_fold_engine =
                         std::make_unique<rp::DmlFoldEngine>(fcfg);
-                    std::vector<std::pair<uint256, rp::ReplayMNState>> seed;
-                    seed.reserve(ckpt.entries.size());
-                    uint64_t trc = 0;
-                    for (const auto& [protx, mn] : ckpt.entries) {
-                        rp::ReplayMNState st;
-                        st.nType             = mn.nType;
-                        st.internalId        = trc++;   // ordering only; not root
-                        st.collateralOutpoint = mn.collateralOutpoint;
-                        st.nOperatorReward   = mn.nOperatorReward;
-                        st.nVersion          = mn.nVersion;
-                        st.nRegisteredHeight  = static_cast<int32_t>(mn.nRegisteredHeight);
-                        st.nLastPaidHeight    = static_cast<int32_t>(mn.nLastPaidHeight);
-                        st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
-                        st.nPoSeRevivedHeight = mn.nPoSeRevivedHeight == 0
-                            ? rp::ReplayMNState::NEVER
-                            : static_cast<int32_t>(mn.nPoSeRevivedHeight);
-                        st.nPoSeBanHeight     = mn.nPoSeBanHeight == 0
-                            ? rp::ReplayMNState::NEVER
-                            : static_cast<int32_t>(mn.nPoSeBanHeight);
-                        st.nRevocationReason = mn.nRevocationReason;
-                        st.keyIDOwner        = mn.keyIDOwner;
-                        st.pubKeyOperator    = mn.pubKeyOperator;
-                        st.keyIDVoting       = mn.keyIDVoting;
-                        st.netInfo           = mn.netInfo;
-                        st.scriptPayout      = mn.scriptPayout;
-                        st.scriptOperatorPayout = mn.scriptOperatorPayout;
-                        st.platformNodeID    = mn.platformNodeID;
-                        st.platformP2PPort   = mn.platformP2PPort;
-                        st.platformHTTPPort  = mn.platformHTTPPort;
-                        seed.emplace_back(protx, std::move(st));
-                    }
-                    mn_bridge_fold_engine->seed(std::move(seed), trc,
-                                                ckpt.height, ckpt.blockhash,
-                                                net_name);
                     mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
                         *mn_diff_store, *mn_bridge_fold_engine);
-                    mn_diff_writer->arm();
+                    mn_ckpt_lane->set_on_anchor_snapshot(
+                        [eng = mn_bridge_fold_engine.get(),
+                         w   = mn_diff_writer.get(),
+                         anchor = ckpt, net = net_name](
+                            const dash::coin::vendor::CSimplifiedMNList& asml,
+                            uint32_t /*anchor_h*/) {
+                            if (eng->size() != 0) return;   // already seeded
+                            // The DIP-4-authenticated anchor SML is the AUTHORITATIVE
+                            // source for EVERY field the committed merkleRootMNList
+                            // commits to (nVersion, confirmedHash, netInfo,
+                            // pubKeyOperator, keyIDVoting, isValid, nType, platform
+                            // HTTP port + node id). The payee-only checkpoint diverges
+                            // from the committed list in MORE than confirmedHash+
+                            // netInfo (proven live: a confirmedHash+netInfo-only merge
+                            // still missed the anchor root), so iterate the SML and
+                            // take those root fields from it -- the seeded set then IS
+                            // the anchor set and the root reproduces BY CONSTRUCTION.
+                            // The FORWARD-FOLD facets the SML does not carry
+                            // (collateralOutpoint, nRegisteredHeight, nLastPaidHeight,
+                            // nConsecutivePayments, nPoSeRevivedHeight, nOperatorReward,
+                            // keyIDOwner, scriptPayout/scriptOperatorPayout,
+                            // platformP2PPort, the ban HEIGHT magnitude) come from the
+                            // compiled checkpoint when it holds the MN.
+                            std::map<uint256, const dash::coin::MNState*> cp;
+                            for (const auto& [protx, mn] : anchor.entries)
+                                cp[protx] = &mn;
+                            std::vector<std::pair<uint256, rp::ReplayMNState>> seed;
+                            seed.reserve(asml.mnList.size());
+                            uint64_t trc = 0;
+                            size_t with_facets = 0, without_facets = 0;
+                            for (const auto& e : asml.mnList) {
+                                rp::ReplayMNState st;
+                                // ROOT-COMMITTING fields -- SML authoritative.
+                                st.nVersion         = e.nVersion;
+                                st.nType            = e.nType;
+                                st.pubKeyOperator   = e.pubKeyOperator;
+                                st.keyIDVoting      = e.keyIDVoting;
+                                st.netInfo.ip       = e.netAddress;
+                                st.netInfo.port_be  = e.netPort;
+                                st.platformHTTPPort = e.platformHTTPPort;
+                                st.platformNodeID   = e.platformNodeID;
+                                if (!e.confirmedHash.IsNull())
+                                    st.UpdateConfirmedHash(e.proRegTxHash,
+                                                           e.confirmedHash);
+                                st.internalId       = trc++;   // ordering only; not root
+                                // FORWARD-FOLD facets -- checkpoint when present.
+                                auto cit = cp.find(e.proRegTxHash);
+                                if (cit != cp.end()) {
+                                    const auto& mn = *cit->second;
+                                    st.collateralOutpoint   = mn.collateralOutpoint;
+                                    st.nOperatorReward      = mn.nOperatorReward;
+                                    st.nRegisteredHeight    = static_cast<int32_t>(mn.nRegisteredHeight);
+                                    st.nLastPaidHeight      = static_cast<int32_t>(mn.nLastPaidHeight);
+                                    st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
+                                    st.nPoSeRevivedHeight   = mn.nPoSeRevivedHeight == 0
+                                        ? rp::ReplayMNState::NEVER
+                                        : static_cast<int32_t>(mn.nPoSeRevivedHeight);
+                                    st.nRevocationReason    = mn.nRevocationReason;
+                                    st.keyIDOwner           = mn.keyIDOwner;
+                                    st.scriptPayout         = mn.scriptPayout;
+                                    st.scriptOperatorPayout = mn.scriptOperatorPayout;
+                                    st.platformP2PPort      = mn.platformP2PPort;
+                                    ++with_facets;
+                                } else {
+                                    ++without_facets;
+                                }
+                                // BAN STATE: the SML isValid boolean is the root truth
+                                // (isValid == !IsBanned()); reconcile the ban HEIGHT so
+                                // IsBanned() matches it -- the checkpoint height when it
+                                // agrees, else a sentinel at the anchor.
+                                if (e.isValid) {
+                                    st.nPoSeBanHeight = rp::ReplayMNState::NEVER;
+                                } else {
+                                    int32_t cpban = rp::ReplayMNState::NEVER;
+                                    if (cit != cp.end() && cit->second->nPoSeBanHeight != 0)
+                                        cpban = static_cast<int32_t>(cit->second->nPoSeBanHeight);
+                                    st.nPoSeBanHeight = (cpban != rp::ReplayMNState::NEVER)
+                                        ? cpban
+                                        : static_cast<int32_t>(anchor.height);
+                                }
+                                seed.emplace_back(e.proRegTxHash, std::move(st));
+                            }
+                            eng->seed(std::move(seed), trc, anchor.height,
+                                      anchor.blockhash, net);
+                            // SEED SELF-CHECK: the merged state MUST reproduce the
+                            // anchor's own committed merkleRootMNList (== the DIP-4
+                            // authenticated SML's root). If not, UNSEED so the store
+                            // never populates and every caller falls through.
+                            const uint256 got  = eng->compute_sml_root();
+                            const uint256 want = asml.CalcMerkleRoot();
+                            if (got != want) {
+                                LOG_ERROR
+                                    << "[MN-DIFF-DB] FULL-STATE anchor seed SELF-CHECK"
+                                       " FAILED at h=" << anchor.height
+                                    << " (with_facets=" << with_facets
+                                    << " without_facets=" << without_facets
+                                    << "): computed root "
+                                    << got.GetHex().substr(0, 16) << " != committed "
+                                    << want.GetHex().substr(0, 16)
+                                    << " -- engine left UNSEEDED, store stays empty,"
+                                       " callers fall through to the network path"
+                                       " unchanged (reward-safe).";
+                                eng->seed({}, 0, 0, uint256::ZERO, net);   // UNSEED
+                                return;
+                            }
+                            if (!w->arm()) {
+                                LOG_WARNING
+                                    << "[MN-DIFF-DB] writer arm FAILED after a"
+                                       " root-matched full-state seed -- store"
+                                       " inert, callers unchanged.";
+                                return;
+                            }
+                            LOG_INFO
+                                << "[MN-DIFF-DB] FULL-STATE anchor seed OK: "
+                                << with_facets << " MNs seeded root-fields from the"
+                                   " DIP-4 anchor SML (" << without_facets
+                                << " without a checkpoint facet); reproduces the"
+                                   " anchor's committed"
+                                   " merkleRootMNList "
+                                << want.GetHex().substr(0, 16)
+                                << " -- the parallel DML engine now folds forward"
+                                   " WITHOUT poisoning at anchor+1; the store will"
+                                   " COVER heights and the ban-state probe /"
+                                   " on-demand fold source 0-RTT/uncapped from it.";
+                        });
 
                     // THE WRITE FEED: every block the bridge folds CLEANLY is
                     // handed to the parallel engine; only its OWN root-checked
@@ -6379,6 +6482,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          logged = std::make_shared<bool>(false)](
                             const dash::coin::BlockType& blk, uint32_t h) {
                             if (eng->poisoned()) return;
+                            if (eng->size() == 0) return;   // seed deferred to the anchor fold; nothing to fold yet
                             const uint256 bh =
                                 rp::DmlFoldEngine::block_header_hash(blk);
                             const auto fr = eng->fold_block(blk, h);
@@ -6395,11 +6499,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                        " only its anchor row; every height above"
                                        " REPAIR-REFUSES and the probe/on-demand"
                                        " paths fall through to the network"
-                                       " unchanged. This is the expected,"
-                                       " reward-safe state when the anchor is a"
-                                       " payee-only checkpoint (no committed-root"
-                                       " SML fields) rather than a full-state"
-                                       " snapshot.";
+                                       " unchanged (reward-safe). With the"
+                                       " full-state anchor seed this is NOT the"
+                                       " expected cold-bridge state: it means the"
+                                       " parallel fold diverged from a committed"
+                                       " cbTx root at this height.";
                             }
                         });
 

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -362,6 +362,25 @@ public:
         m_on_block_applied = std::move(fn);
     }
 
+    /// FULL-STATE ANCHOR SEED seam (dashd-cut MN diff store). The lane's OWN
+    /// first fold is the anchor fold: begin_fold(m_anchor_height) requests
+    /// getmnlistd(base=ZERO, target=anchor_hash) and on_historical_snapshot()
+    /// DIP-4-authenticates the reply against the anchor block's committed
+    /// merkleRootMNList (never a partial acceptance). That authenticated list
+    /// is the FULL Simplified MN List AS OF the anchor -- precisely the
+    /// root-committing fields (confirmedHash, netInfo) the payee-only compiled
+    /// checkpoint OMITS. This callback hands that verified list to the parallel
+    /// DmlFoldEngine seed so it reproduces the anchor's committed root and no
+    /// longer poisons at anchor+1. Fired EXACTLY ONCE, from apply_fold() at
+    /// height == m_anchor_height, BEFORE any forward block is folded. A resumed
+    /// bridge never runs the anchor fold, so it never fires. Optional -- unset
+    /// is a no-op (the checkpoint-only seed stands, which self-checks/poisons).
+    void set_on_anchor_snapshot(
+        std::function<void(const vendor::CSimplifiedMNList&, uint32_t)> fn)
+    {
+        m_on_anchor_snapshot = std::move(fn);
+    }
+
     /// OPTIONAL. Unwired, the bridge behaves exactly as it did before this
     /// seam existed: any payee mismatch during replay is terminal.
     void set_sml_validity_fn(SmlValidityFn fn)
@@ -3139,6 +3158,16 @@ private:
     /// at `height`. Every caller must have established that equality.
     void apply_fold(const vendor::CSimplifiedMNList& sml, uint32_t height)
     {
+        // FULL-STATE ANCHOR SEED HOOK. The lane's own anchor fold has just
+        // DIP-4-authenticated the FULL SML as of the anchor -- deliver it once,
+        // before any forward block is folded, so the parallel MN diff-store
+        // engine seeds full-state instead of poisoning at anchor+1 on the
+        // payee-only checkpoint. height == m_anchor_height is reached only by
+        // the anchor fold (fold points and on-demand folds are all > cursor,
+        // and a resumed bridge never runs the anchor fold).
+        if (height == m_anchor_height && m_on_anchor_snapshot)
+            m_on_anchor_snapshot(sml, height);
+
         const size_t before = m_machine.eligible_size();
 
         // F5 SANITY BOUND, now defence-in-depth. The list is DIP-4 verified
@@ -3959,6 +3988,12 @@ public:
     // MnDiffWriter). Unset is a no-op, so a bridge with no store wired behaves
     // exactly as before.
     std::function<void(const BlockType&, uint32_t)> m_on_block_applied;
+    // FULL-STATE ANCHOR SEED seam (dashd-cut): fired once from apply_fold at
+    // the anchor height with the DIP-4-authenticated full SML, so main_dash
+    // can seed the parallel DmlFoldEngine with the root-committing fields the
+    // payee-only checkpoint omits. Unset = no-op.
+    std::function<void(const vendor::CSimplifiedMNList&, uint32_t)>
+        m_on_anchor_snapshot;
     // dashd-cut SOURCE observability: pre-block ban state resolved from the
     // diff store (0-RTT) instead of a capped network probe/fold. These are the
     // counts that prove the store SERVED — a green run has probe/fold caps


### PR DESCRIPTION
## Full-state anchor seed for the cold MN diff-store fold engine

Stacked on #1260 (`dash/mn-diff-store-arm`). DRAFT — review only, do not merge.

### Problem
The parallel `DmlFoldEngine` on the cold MN-CKPT bridge was seeded from the
compiled **payee-only** checkpoint, which omits fields the anchor block's
committed `merkleRootMNList` commits to. It therefore could not reproduce the
anchor+1 root and **poisoned at the first fold** → the MN diff-store covered
**0 heights** → the accelerator was inert on the daemonless cold path.

### Fix
Seed the engine from the **full Simplified MN List** the lane already fetches
for its own anchor fold. The lane issues `getmnlistd(base=ZERO, target=anchor)`
and DIP-4-authenticates the reply against the anchor block's committed
`merkleRootMNList` (`historical_sml.hpp::authenticate_historical_snapshot` —
no partial acceptance). A new `set_on_anchor_snapshot()` seam hands that
verified list to `main_dash`, which:

1. seeds **every root-committing field** (`nVersion`, `confirmedHash`,
   `netInfo`, `pubKeyOperator`, `keyIDVoting`, `isValid`/ban, `nType`, platform
   HTTP port + node id) from the authenticated SML — so the seeded set **is**
   the anchor set and the root reproduces by construction;
2. takes the **forward-fold-only facets** the SML does not carry
   (`collateralOutpoint`, `nRegisteredHeight`, `nLastPaidHeight`,
   `nConsecutivePayments`, `nPoSeRevivedHeight`, `nOperatorReward`,
   `keyIDOwner`, `scriptPayout`, ban-height magnitude, …) from the checkpoint;
3. **self-checks** the merged state reproduces the anchor's committed root
   before arming forward folds.

Note: a `confirmedHash`+`netInfo`-only merge was tried first and **still missed
the anchor root** (proven live), so the seed takes *all* root fields from the
SML, not just the two the checkpoint obviously omits.

### Reward-safety (by construction)
A seed that fails the self-check leaves the engine **UNSEEDED** → the store
never populates → every SOURCE caller falls through to the unchanged network
path. `MnDiffStore::reconstruct` additionally refuses any row that does not
re-hash to the committed root. A wrong/partial seed can never mint.

### Reuse
No new primitive, no cap widening: reuses `send_getmnlistd_rotating(ZERO,anchor)`,
the historical demux, `authenticate_historical_snapshot`, and
`DmlFoldEngine::seed` verbatim.

### Live measurement (vm905, cold daemonless, dashd ABSENT)
Flags `--embedded-mainnet --embedded-null-arm --embedded-utxo --coin-p2p-discover`;
binary provenance verified (`/proc/<pid>/exe` md5 == built); BLS=REAL.

- **Anchor+1 poison ELIMINATED**: `FULL-STATE anchor seed OK: 2974 MNs …
  reproduces the anchor's committed merkleRootMNList 2315e6df…`; writer ARMED at
  h=2513000.
- **Store now COVERS heights** (was 0): folds forward contiguously from
  anchor+1.

### Known remaining gap (separate, NOT this seed fix)
The store stops extending at the **first quorum finality commitment**
(h=2513130): the parallel `DmlFoldEngine` has no quorum-member resolver
(`set_members_fn`), so it fail-closes (reward-safely) on qfcommit PoSe-punish
blocks. The available `QuorumMemberSource::lookup` returns operator *keys*, not
the member proTxHashes the fold needs, so it is not a drop-in — full store
tip-coverage requires standing up the W4 quorum-replay lane on the cold path
(a separate port). The bridge itself still advances to the tip via the lane's
own network fold path; the store is an accelerator whose coverage this fix
extends from 0 heights to a contiguous run from the anchor.
