### PR TITLE
dash: getqrinfo rotated-quorum bootstrap across the anchor for the MN diff-store engine (stacked on #1262)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -101,6 +101,8 @@
 #include <impl/dash/coin/replay_fold_consumer.hpp> // W5: bulk lane -> W1 DML fold + per-block root check
 #include <impl/dash/coin/replay_quorum_bridge.hpp> // SEAM: W4 quorum lane <-> W1 MembersFn
 #include <impl/dash/coin/replay_payee_publish.hpp> // SEAM: W1 fold -> the PAYEE queue that gates serving
+#include <impl/dash/coin/mn_diff_store.hpp>      // dashd evodb dmn_D4/dmn_S3 port: per-block MN list diffs + snapshots
+#include <impl/dash/coin/mn_gap_repair.hpp>      // payee-queue gap-repair seam (maintainer + checkpoint bridge)
 #include <impl/dash/node.hpp>          // dash::Node — sharechain pool-node (NodeBridge<NodeImpl,Legacy,Actual>)
 #include <impl/dash/config.hpp>        // dash::Config (PoolConfig/CoinConfig)
 #include <impl/dash/config_pool.hpp>   // dash::SharechainConfig — P2P_PORT / PREFIX / min-proto SSOT
@@ -3465,6 +3467,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // Constructed only alongside the fold engine.
     std::unique_ptr<dash::coin::replay::FoldLiveTail>          replay_live_tail;
     std::unique_ptr<dash::coin::replay::ReplayPayeePublisher>  replay_payee_pub;
+    // MN DIFF/SNAPSHOT STORE (dashd evodb dmn_D4/dmn_S3 port,
+    // evo/deterministicmns.cpp:689-694): per-block list diffs + 576-cadence
+    // snapshots written by the fold's per-block commit, read by the payee-
+    // queue gap-repair seam. Constructed only alongside the fold engine.
+    std::unique_ptr<dash::coin::replay::MnDiffStore>           mn_diff_store;
+    std::unique_ptr<dash::coin::replay::MnDiffWriter>          mn_diff_writer;
     // PR-2 FORWARD: dashd's mined-commitment store, fed from the same replayed
     // bodies. shared_ptr because the qc-plan lambda (installed far above, on
     // the serve path) captures it by value and must see it appear later — it
@@ -6398,6 +6406,119 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                 if (pp && pp->republish_for_reseed()) return;
                                 if (fb) fb();
                             });
+                    }
+                }
+
+                // ── MN DIFF/SNAPSHOT STORE (dashd evodb dmn_D4/dmn_S3 port,
+                // evo/deterministicmns.cpp:689-694) ──────────────────────────
+                // Written by the fold's per-block commit (post root-match, via
+                // the consumer's diff sink); read ONLY by the gap-repair seam.
+                // Opened next to dash_replay_headers. On open/verify failure
+                // the store is simply absent and both repair callers keep
+                // their historical wipe/demote fail-closed behavior — the
+                // store is an accelerator, never consensus-required.
+                if (replay_fold_consumer) {
+                    mn_diff_store = std::make_unique<rp::MnDiffStore>(
+                        (core::filesystem::config_path() / net_subdir
+                            / "dash_mn_diff_db").string());
+                    if (!mn_diff_store->open()) {
+                        LOG_WARNING << "[MN-DIFF-DB] open failed — diff store"
+                                       " DISABLED (gap repair unavailable;"
+                                       " wipe/demote floor unchanged)";
+                        mn_diff_store.reset();
+                    } else {
+                        // hash -> (height, prev_hash) off OUR PoW-validated
+                        // header chain — the walk's cross-check at every hop.
+                        auto diff_hlookup =
+                            [hc = header_chain.get()](const uint256& h)
+                                -> std::optional<std::pair<uint32_t, uint256>> {
+                            if (!hc) return std::nullopt;
+                            auto e = hc->get_header(h);
+                            if (!e) return std::nullopt;
+                            return std::make_pair(e->height, e->prev_hash);
+                        };
+                        // Startup: 'B' sentinel cross-check + newest snapshot
+                        // pair verify (dashd VerifyBestBlock /
+                        // VerifySnapshotPair posture, scope-reduced). A
+                        // failure wipes THIS store alone; the live fold
+                        // repopulates it.
+                        std::string vnote;
+                        mn_diff_store->startup_verify(diff_hlookup, vnote);
+                        if (!vnote.empty())
+                            LOG_INFO << "[MN-DIFF-DB] startup verify: "
+                                     << vnote;
+                        mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
+                            *mn_diff_store, *replay_fold_engine);
+                        // Seed/anchor snapshot: the explicit grounding row
+                        // every backward walk must reach (the fail-closed
+                        // inversion of dashd's initial-empty-list default).
+                        mn_diff_writer->arm();
+                        replay_fold_consumer->set_diff_sink(
+                            [w = mn_diff_writer.get()](
+                                uint32_t h, const uint256& bh,
+                                const dash::coin::BlockType& blk,
+                                const rp::FoldResult& fr) {
+                                w->on_folded(h, bh, blk, fr);
+                            });
+                        // DELIBERATELY NOT added to set_on_sml_clear's reorg
+                        // wipe cascade: dashd's UndoBlock keeps disk rows too
+                        // (deterministicmns.cpp:736-769) — hash-keyed rows
+                        // for orphaned blocks are harmless residue, and
+                        // wiping diff history on reorg would destroy exactly
+                        // what repair depends on.
+
+                        // ── The GAP-REPAIR seam, wired at BOTH callers ─────
+                        // want_height -> reconstruct(hash(want)) -> MNState
+                        // projection through the same to_payee_state boundary
+                        // every other lane uses.
+                        dash::coin::MnGapRepairFn repair_fn =
+                            [store = mn_diff_store.get(),
+                             hc = header_chain.get()](uint32_t want)
+                                -> dash::coin::MnGapRepairResult {
+                            dash::coin::MnGapRepairResult out;
+                            out.as_of = want;
+                            if (store == nullptr || hc == nullptr) {
+                                out.error = "diff store / header chain absent";
+                                return out;
+                            }
+                            auto e = hc->get_header_by_height(want);
+                            if (!e) {
+                                out.error = "h=" + std::to_string(want)
+                                          + " is not on our PoW-validated"
+                                            " header chain";
+                                return out;
+                            }
+                            auto hlookup = [hc](const uint256& h)
+                                -> std::optional<std::pair<uint32_t, uint256>> {
+                                auto ie = hc->get_header(h);
+                                if (!ie) return std::nullopt;
+                                return std::make_pair(ie->height,
+                                                      ie->prev_hash);
+                            };
+                            rp::DmlFoldEngine::Entries list;
+                            uint64_t trc = 0;
+                            std::string err;
+                            if (!store->reconstruct(e->hash, hlookup, list,
+                                                    trc, err)) {
+                                out.error = err;
+                                return out;
+                            }
+                            out.entries.reserve(list.size());
+                            for (const auto& [protx, st] : list)
+                                out.entries.emplace_back(
+                                    protx, rp::to_payee_state(st));
+                            out.ok = true;
+                            return out;
+                        };
+                        if (maintainer)
+                            maintainer->set_mn_gap_repair(repair_fn);
+                        if (mn_ckpt_lane)
+                            mn_ckpt_lane->set_gap_repair(repair_fn);
+                        std::cout << "[run] MN DIFF STORE ARMED: per-block"
+                                     " list diffs + 576-cadence snapshots"
+                                     " (dashd dmn_D4/dmn_S3 mechanism);"
+                                     " payee-queue gap repair wired at the"
+                                     " maintainer and the checkpoint bridge\n";
                     }
                 }
             }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6143,15 +6143,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // does not re-hash to the block's committed merkleRootMNList
             // (mn_diff_store.hpp:849-857). The trusted-anchor checkpoint carries
             // the DIP-3 PAYEE fields but NOT the SML fields the root commits
-            // (confirmedHash, netInfo) — so the parallel engine cannot reproduce
-            // the anchor+1 root and POISONS at the first fold. A poisoned engine
-            // writes no diffs, the store holds only the anchor, every height
-            // above it REPAIR-REFUSES, and the SOURCE callers fall through to
-            // their unchanged network path: today's behaviour EXACTLY, never a
-            // wrong row, never a bad mint. The wiring is in place so that the
-            // day a FULL-STATE (v3) anchor is pinned, the store serves the cold
-            // bridge with zero further change. Until then it is an accelerator
-            // that is present and inert, precisely as an accelerator should be.
+            // (confirmedHash, netInfo) — which a checkpoint-only seed cannot
+            // supply. So rather than seed from the checkpoint alone (which would
+            // poison at anchor+1), the seed is DEFERRED to the lane's own anchor
+            // fold: it fetches getmnlistd(base=ZERO, target=anchor_hash) and
+            // DIP-4-authenticates the FULL Simplified MN List against the anchor
+            // block's committed merkleRootMNList, and set_on_anchor_snapshot()
+            // merges those root-committing fields onto the checkpoint's forward
+            // facets. The merged seed is SELF-CHECKED against the committed root
+            // before forward folds arm; a seed that fails leaves the engine
+            // UNSEEDED, the store empty, and the SOURCE callers on their unchanged
+            // network path — never a wrong row, never a bad mint. When the seed
+            // matches, the store COVERS heights and the ban-state probe /
+            // on-demand fold source 0-RTT/uncapped from it.
             if (mn_ckpt_lane && header_chain && ckpt.ok
                 && !mn_diff_store) {
                 namespace rp = dash::coin::replay;
@@ -6178,52 +6182,151 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         LOG_INFO << "[MN-DIFF-DB] cold-bridge startup verify: "
                                  << vnote;
 
-                    // PARALLEL engine seeded at the bridge anchor. The checkpoint
-                    // MNState carries the payee facets; the SML-root facets it
-                    // omits are left at their ReplayMNState defaults (the engine
-                    // then self-checks and poisons at anchor+1 unless a genuine
-                    // full-state anchor was supplied — see the safety note above).
+                    // ── FULL-STATE ANCHOR SEED (dashd-parity, option A) ──────
+                    // Stand up the parallel DmlFoldEngine here but DEFER its seed
+                    // to the lane's own anchor fold. The payee-only compiled
+                    // checkpoint omits the two fields the anchor merkleRootMNList
+                    // commits to (confirmedHash, netInfo); a checkpoint-only seed
+                    // therefore cannot reproduce the anchor+1 root and poisons at
+                    // the first fold. set_on_anchor_snapshot() below receives the
+                    // DIP-4-authenticated FULL SML the lane already fetches for its
+                    // anchor fold, MERGES its root-committing fields onto the
+                    // checkpoint's forward-fold facets, seeds, and SELF-CHECKS the
+                    // merged state against the anchor's committed root BEFORE arming
+                    // forward folds. A seed that fails the self-check leaves the
+                    // engine UNSEEDED -> store never populates -> callers fall
+                    // through unchanged (reward-safe: a wrong seed can never mint).
                     dash::coin::replay::FoldConfig fcfg;
                     fcfg.enabled = true;
                     mn_bridge_fold_engine =
                         std::make_unique<rp::DmlFoldEngine>(fcfg);
-                    std::vector<std::pair<uint256, rp::ReplayMNState>> seed;
-                    seed.reserve(ckpt.entries.size());
-                    uint64_t trc = 0;
-                    for (const auto& [protx, mn] : ckpt.entries) {
-                        rp::ReplayMNState st;
-                        st.nType             = mn.nType;
-                        st.internalId        = trc++;   // ordering only; not root
-                        st.collateralOutpoint = mn.collateralOutpoint;
-                        st.nOperatorReward   = mn.nOperatorReward;
-                        st.nVersion          = mn.nVersion;
-                        st.nRegisteredHeight  = static_cast<int32_t>(mn.nRegisteredHeight);
-                        st.nLastPaidHeight    = static_cast<int32_t>(mn.nLastPaidHeight);
-                        st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
-                        st.nPoSeRevivedHeight = mn.nPoSeRevivedHeight == 0
-                            ? rp::ReplayMNState::NEVER
-                            : static_cast<int32_t>(mn.nPoSeRevivedHeight);
-                        st.nPoSeBanHeight     = mn.nPoSeBanHeight == 0
-                            ? rp::ReplayMNState::NEVER
-                            : static_cast<int32_t>(mn.nPoSeBanHeight);
-                        st.nRevocationReason = mn.nRevocationReason;
-                        st.keyIDOwner        = mn.keyIDOwner;
-                        st.pubKeyOperator    = mn.pubKeyOperator;
-                        st.keyIDVoting       = mn.keyIDVoting;
-                        st.netInfo           = mn.netInfo;
-                        st.scriptPayout      = mn.scriptPayout;
-                        st.scriptOperatorPayout = mn.scriptOperatorPayout;
-                        st.platformNodeID    = mn.platformNodeID;
-                        st.platformP2PPort   = mn.platformP2PPort;
-                        st.platformHTTPPort  = mn.platformHTTPPort;
-                        seed.emplace_back(protx, std::move(st));
-                    }
-                    mn_bridge_fold_engine->seed(std::move(seed), trc,
-                                                ckpt.height, ckpt.blockhash,
-                                                net_name);
                     mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
                         *mn_diff_store, *mn_bridge_fold_engine);
-                    mn_diff_writer->arm();
+                    mn_ckpt_lane->set_on_anchor_snapshot(
+                        [eng = mn_bridge_fold_engine.get(),
+                         w   = mn_diff_writer.get(),
+                         anchor = ckpt, net = net_name](
+                            const dash::coin::vendor::CSimplifiedMNList& asml,
+                            uint32_t /*anchor_h*/) {
+                            if (eng->size() != 0) return;   // already seeded
+                            // The DIP-4-authenticated anchor SML is the AUTHORITATIVE
+                            // source for EVERY field the committed merkleRootMNList
+                            // commits to (nVersion, confirmedHash, netInfo,
+                            // pubKeyOperator, keyIDVoting, isValid, nType, platform
+                            // HTTP port + node id). The payee-only checkpoint diverges
+                            // from the committed list in MORE than confirmedHash+
+                            // netInfo (proven live: a confirmedHash+netInfo-only merge
+                            // still missed the anchor root), so iterate the SML and
+                            // take those root fields from it -- the seeded set then IS
+                            // the anchor set and the root reproduces BY CONSTRUCTION.
+                            // The FORWARD-FOLD facets the SML does not carry
+                            // (collateralOutpoint, nRegisteredHeight, nLastPaidHeight,
+                            // nConsecutivePayments, nPoSeRevivedHeight, nOperatorReward,
+                            // keyIDOwner, scriptPayout/scriptOperatorPayout,
+                            // platformP2PPort, the ban HEIGHT magnitude) come from the
+                            // compiled checkpoint when it holds the MN.
+                            std::map<uint256, const dash::coin::MNState*> cp;
+                            for (const auto& [protx, mn] : anchor.entries)
+                                cp[protx] = &mn;
+                            std::vector<std::pair<uint256, rp::ReplayMNState>> seed;
+                            seed.reserve(asml.mnList.size());
+                            uint64_t trc = 0;
+                            size_t with_facets = 0, without_facets = 0;
+                            for (const auto& e : asml.mnList) {
+                                rp::ReplayMNState st;
+                                // ROOT-COMMITTING fields -- SML authoritative.
+                                st.nVersion         = e.nVersion;
+                                st.nType            = e.nType;
+                                st.pubKeyOperator   = e.pubKeyOperator;
+                                st.keyIDVoting      = e.keyIDVoting;
+                                st.netInfo.ip       = e.netAddress;
+                                st.netInfo.port_be  = e.netPort;
+                                st.platformHTTPPort = e.platformHTTPPort;
+                                st.platformNodeID   = e.platformNodeID;
+                                if (!e.confirmedHash.IsNull())
+                                    st.UpdateConfirmedHash(e.proRegTxHash,
+                                                           e.confirmedHash);
+                                st.internalId       = trc++;   // ordering only; not root
+                                // FORWARD-FOLD facets -- checkpoint when present.
+                                auto cit = cp.find(e.proRegTxHash);
+                                if (cit != cp.end()) {
+                                    const auto& mn = *cit->second;
+                                    st.collateralOutpoint   = mn.collateralOutpoint;
+                                    st.nOperatorReward      = mn.nOperatorReward;
+                                    st.nRegisteredHeight    = static_cast<int32_t>(mn.nRegisteredHeight);
+                                    st.nLastPaidHeight      = static_cast<int32_t>(mn.nLastPaidHeight);
+                                    st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
+                                    st.nPoSeRevivedHeight   = mn.nPoSeRevivedHeight == 0
+                                        ? rp::ReplayMNState::NEVER
+                                        : static_cast<int32_t>(mn.nPoSeRevivedHeight);
+                                    st.nRevocationReason    = mn.nRevocationReason;
+                                    st.keyIDOwner           = mn.keyIDOwner;
+                                    st.scriptPayout         = mn.scriptPayout;
+                                    st.scriptOperatorPayout = mn.scriptOperatorPayout;
+                                    st.platformP2PPort      = mn.platformP2PPort;
+                                    ++with_facets;
+                                } else {
+                                    ++without_facets;
+                                }
+                                // BAN STATE: the SML isValid boolean is the root truth
+                                // (isValid == !IsBanned()); reconcile the ban HEIGHT so
+                                // IsBanned() matches it -- the checkpoint height when it
+                                // agrees, else a sentinel at the anchor.
+                                if (e.isValid) {
+                                    st.nPoSeBanHeight = rp::ReplayMNState::NEVER;
+                                } else {
+                                    int32_t cpban = rp::ReplayMNState::NEVER;
+                                    if (cit != cp.end() && cit->second->nPoSeBanHeight != 0)
+                                        cpban = static_cast<int32_t>(cit->second->nPoSeBanHeight);
+                                    st.nPoSeBanHeight = (cpban != rp::ReplayMNState::NEVER)
+                                        ? cpban
+                                        : static_cast<int32_t>(anchor.height);
+                                }
+                                seed.emplace_back(e.proRegTxHash, std::move(st));
+                            }
+                            eng->seed(std::move(seed), trc, anchor.height,
+                                      anchor.blockhash, net);
+                            // SEED SELF-CHECK: the merged state MUST reproduce the
+                            // anchor's own committed merkleRootMNList (== the DIP-4
+                            // authenticated SML's root). If not, UNSEED so the store
+                            // never populates and every caller falls through.
+                            const uint256 got  = eng->compute_sml_root();
+                            const uint256 want = asml.CalcMerkleRoot();
+                            if (got != want) {
+                                LOG_ERROR
+                                    << "[MN-DIFF-DB] FULL-STATE anchor seed SELF-CHECK"
+                                       " FAILED at h=" << anchor.height
+                                    << " (with_facets=" << with_facets
+                                    << " without_facets=" << without_facets
+                                    << "): computed root "
+                                    << got.GetHex().substr(0, 16) << " != committed "
+                                    << want.GetHex().substr(0, 16)
+                                    << " -- engine left UNSEEDED, store stays empty,"
+                                       " callers fall through to the network path"
+                                       " unchanged (reward-safe).";
+                                eng->seed({}, 0, 0, uint256::ZERO, net);   // UNSEED
+                                return;
+                            }
+                            if (!w->arm()) {
+                                LOG_WARNING
+                                    << "[MN-DIFF-DB] writer arm FAILED after a"
+                                       " root-matched full-state seed -- store"
+                                       " inert, callers unchanged.";
+                                return;
+                            }
+                            LOG_INFO
+                                << "[MN-DIFF-DB] FULL-STATE anchor seed OK: "
+                                << with_facets << " MNs seeded root-fields from the"
+                                   " DIP-4 anchor SML (" << without_facets
+                                << " without a checkpoint facet); reproduces the"
+                                   " anchor's committed"
+                                   " merkleRootMNList "
+                                << want.GetHex().substr(0, 16)
+                                << " -- the parallel DML engine now folds forward"
+                                   " WITHOUT poisoning at anchor+1; the store will"
+                                   " COVER heights and the ban-state probe /"
+                                   " on-demand fold source 0-RTT/uncapped from it.";
+                        });
 
                     // THE WRITE FEED: every block the bridge folds CLEANLY is
                     // handed to the parallel engine; only its OWN root-checked
@@ -6235,6 +6338,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          logged = std::make_shared<bool>(false)](
                             const dash::coin::BlockType& blk, uint32_t h) {
                             if (eng->poisoned()) return;
+                            if (eng->size() == 0) return;   // seed deferred to the anchor fold; nothing to fold yet
                             const uint256 bh =
                                 rp::DmlFoldEngine::block_header_hash(blk);
                             const auto fr = eng->fold_block(blk, h);
@@ -6251,11 +6355,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                        " only its anchor row; every height above"
                                        " REPAIR-REFUSES and the probe/on-demand"
                                        " paths fall through to the network"
-                                       " unchanged. This is the expected,"
-                                       " reward-safe state when the anchor is a"
-                                       " payee-only checkpoint (no committed-root"
-                                       " SML fields) rather than a full-state"
-                                       " snapshot.";
+                                       " unchanged (reward-safe). With the"
+                                       " full-state anchor seed this is NOT the"
+                                       " expected cold-bridge state: it means the"
+                                       " parallel fold diverged from a committed"
+                                       " cbTx root at this height.";
                             }
                         });
 

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -100,6 +100,7 @@
 #include <impl/dash/coin/replay_prestate.hpp>    // W5: anchor prestate loader (--replay-fold-prestate)
 #include <impl/dash/coin/replay_fold_consumer.hpp> // W5: bulk lane -> W1 DML fold + per-block root check
 #include <impl/dash/coin/replay_quorum_bridge.hpp> // SEAM: W4 quorum lane <-> W1 MembersFn
+#include <impl/dash/coin/historical_sml.hpp> // authenticate_historical_snapshot (DIP-4 R3, straddle-seed)
 #include <impl/dash/coin/replay_payee_publish.hpp> // SEAM: W1 fold -> the PAYEE queue that gates serving
 #include <impl/dash/coin/mn_diff_store.hpp>      // dashd evodb dmn_D4/dmn_S3 port: per-block MN list diffs + snapshots
 #include <impl/dash/coin/mn_gap_repair.hpp>      // payee-queue gap-repair seam (maintainer + checkpoint bridge)
@@ -6410,47 +6411,302 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                    " on-demand fold source 0-RTT/uncapped from it.";
                         });
 
-                    // THE WRITE FEED: every block the bridge folds CLEANLY is
-                    // handed to the parallel engine; only its OWN root-checked
-                    // commit sinks the writer. A once-latched poison log names
-                    // the reality when a partial anchor cannot reproduce roots.
+                    // ── DIP-24 ROTATED-QUORUM STRADDLE BOOTSTRAP (getqrinfo) ─────
+                    // The store engine is seeded at the anchor with ZERO
+                    // pre-anchor quarter snapshots (only pre-anchor header
+                    // hashes, above). The FIRST rotated (DIP-24, llmqType=5)
+                    // cycle mined AFTER the anchor has a base B0 whose three
+                    // quarter predecessors (B0-C/2C/3C) all sit BELOW the
+                    // anchor, so the engine's self_contained_from is beyond it
+                    // and it cannot self-derive that cycle's member set from
+                    // the replayed post-anchor stream alone. Its first punishing
+                    // qfcommit then hits fold_qfcommit with "resolver has no
+                    // member set", the parallel fold fails closed only ~a
+                    // window past the anchor, the store caps, and the payee lane
+                    // falls to the capped network probe (the #149-class payee
+                    // desync). FIX (dashd DIP-24 CGetQuorumRotationInfo /
+                    // BuildQuorumSnapshot, the companion to the #1261 full-SML
+                    // seed): fetch getqrinfo(B0) once at cold arm, DIP-4/merkle
+                    // authenticate the returned quarter snapshots + work lists
+                    // against the committed roots, and seed them so cycle B0 is
+                    // derivable. A WRONG snapshot -> wrong members -> folded root
+                    // mismatch -> the writer's own root self-check REFUSES the
+                    // row -> store empty -> callers fall through (reward-safe by
+                    // construction; never a bad mint).
+                    struct StoreStraddleSeed {
+                        bool     armed{false};
+                        bool     sent{false};
+                        bool     landed{false};
+                        bool     exhausted{false};
+                        uint8_t  llmq_type{5};
+                        uint32_t C{0};
+                        uint32_t cycle_base{0};     // B0 = first rotated cycle base > anchor
+                        uint32_t first_need_h{0};   // hold straddle blocks at/after this height
+                        uint32_t last_send_h{0};
+                        uint256  cycle_base_hash;
+                        std::vector<std::pair<uint32_t, dash::coin::BlockType>> hold;
+                    };
+                    auto sseed = std::make_shared<StoreStraddleSeed>();
+                    {
+                        const uint32_t anchor_h = ckpt.height;
+                        for (const auto& pv : dash::coin::enabled_llmqs(
+                                 testnet ? dash::coin::LlmqNetwork::Testnet
+                                         : dash::coin::LlmqNetwork::Mainnet)) {
+                            if (!pv.use_rotation || pv.dkg_interval == 0) continue;
+                            sseed->llmq_type   = pv.type;
+                            sseed->C           = pv.dkg_interval;
+                            sseed->cycle_base  = ((anchor_h / pv.dkg_interval) + 1u)
+                                                 * pv.dkg_interval;
+                            // Hold from the cycle base itself (conservative): the
+                            // engine derives cycle B0's members no later than the
+                            // block that carries B0's first punishing qfcommit, and
+                            // no earlier than observing B0; gating at the base is
+                            // correct for both and costs at most a few dozen buffered
+                            // blocks in the rare case the reply is slow.
+                            sseed->first_need_h = sseed->cycle_base;
+                            sseed->armed        = true;
+                            break;   // one rotated type on mainnet (type 5)
+                        }
+                        if (sseed->armed)
+                            LOG_INFO << "[MN-DIFF-DB] store-engine rotated-quorum"
+                                        " bootstrap ARMED: getqrinfo(cycle_base h="
+                                     << sseed->cycle_base << ", type="
+                                     << int(sseed->llmq_type) << ", C=" << sseed->C
+                                     << ") will seed the pre-anchor quarter"
+                                        " snapshots+work-lists for the cycle that"
+                                        " STRADDLES anchor h=" << anchor_h
+                                     << " (its H-C/2C/3C predecessors are all below"
+                                        " the anchor; the store engine cannot"
+                                        " self-derive them).";
+                    }
+
+                    // The shared per-block fold drive. Both the live feed and the
+                    // held-block drain call THIS, so a block folded from the hold
+                    // buffer takes the exact same observe/fold/after_fold/writer
+                    // path as a live one.
+                    auto feed = std::make_shared<
+                        std::function<void(const dash::coin::BlockType&, uint32_t)>>();
+                    *feed = [eng = mn_bridge_fold_engine.get(),
+                             w   = mn_diff_writer.get(),
+                             qbr = mn_bridge_quorum_bridge.get(),
+                             logged = std::make_shared<bool>(false)](
+                                const dash::coin::BlockType& blk, uint32_t h) {
+                        if (eng->poisoned()) return;
+                        if (eng->size() == 0) return;   // seed deferred to the anchor fold
+                        const uint256 bh = rp::DmlFoldEngine::block_header_hash(blk);
+                        if (qbr) qbr->observe(h, bh, blk);
+                        const auto fr = eng->fold_block(blk, h);
+                        if (qbr) qbr->after_fold(h);
+                        if (fr.ok) { w->on_folded(h, bh, blk, fr); return; }
+                        if (!*logged) {
+                            *logged = true;
+                            LOG_WARNING
+                                << "[MN-DIFF-DB] cold-bridge parallel fold could"
+                                   " not extend the store at h=" << h << " ("
+                                << fr.error << "). The store keeps only heights up"
+                                   " to here; every height above REPAIR-REFUSES and"
+                                   " the probe/on-demand paths fall through to the"
+                                   " network unchanged (reward-safe).";
+                        }
+                    };
+
+                    // The qrinfo reply consumer: authenticate the straddle-cycle
+                    // snapshots + work lists and seed them into the store engine.
+                    // Additive (coexists with the serve-path consumer at
+                    // main_dash.cpp:4446); it filters by the reply's H so only OUR
+                    // getqrinfo(B0) reply is consumed.
+                    if (coin_p2p && sseed->armed) {
+                        coin_p2p->add_qrinfo_consumer(
+                            [sseed, feed,
+                             qbr = mn_bridge_quorum_bridge.get(),
+                             hc  = header_chain.get(),
+                             anchor_h = ckpt.height, net = net_name](
+                                const dash::coin::vendor::CQuorumRotationInfo& info) {
+                                if (!sseed->armed || sseed->landed) return;
+                                namespace v  = dash::coin::vendor;
+                                namespace rq = dash::coin::replay;
+                                // Bind: OUR reply's mnListDiffH sits at B0-8.
+                                v::CCbTx hcb;
+                                if (info.mnListDiffH.cbTx.type != 5
+                                    || !v::parse_cbtx(
+                                           info.mnListDiffH.cbTx.extra_payload, hcb)
+                                    || hcb.nHeight < 0) return;
+                                if (static_cast<uint32_t>(hcb.nHeight)
+                                    != sseed->cycle_base - 8u) return;   // not ours
+                                dash::coin::MerkleRootOfHashFn mroot =
+                                    [hc](const uint256& b)
+                                        -> std::optional<uint256> {
+                                        if (auto e = hc->get_header(b))
+                                            return e->header.m_merkle_root;
+                                        return std::nullopt;
+                                    };
+                                const v::CSimplifiedMNListDiff* diffs[3] = {
+                                    &info.mnListDiffAtHMinusC,
+                                    &info.mnListDiffAtHMinus2C,
+                                    &info.mnListDiffAtHMinus3C };
+                                const v::CQuorumSnapshot* snaps[3] = {
+                                    &info.quorumSnapshotAtHMinusC,
+                                    &info.quorumSnapshotAtHMinus2C,
+                                    &info.quorumSnapshotAtHMinus3C };
+                                rq::QSnapshotSeed qs;  qs.network = net;
+                                rq::WorkListSeed  wl;  wl.network = net;
+                                wl.llmq_type  = sseed->llmq_type;
+                                wl.cycle_base = sseed->cycle_base;
+                                wl.interval   = sseed->C;
+                                for (size_t i = 0; i < 3; ++i) {
+                                    const uint32_t cyc = sseed->cycle_base
+                                        - static_cast<uint32_t>(i + 1) * sseed->C;
+                                    const uint32_t work_h = cyc - 8u;
+                                    // A qrinfo cycle diff is a FULL list (applied
+                                    // onto empty); a delete means it is not.
+                                    if (!diffs[i]->deletedMNs.empty()) {
+                                        LOG_WARNING << "[MN-DIFF-DB] getqrinfo cycle"
+                                                       " diff " << i << " is not a"
+                                                       " full list (deletes) — rotated"
+                                                       " bootstrap fails closed, retry.";
+                                        return;
+                                    }
+                                    v::CCbTx cbtx;
+                                    auto sml = dash::coin::authenticate_historical_snapshot(
+                                        *diffs[i], work_h, mroot, cbtx, "MN-DIFF-DB-QR");
+                                    if (!sml) {
+                                        LOG_WARNING << "[MN-DIFF-DB] getqrinfo cycle"
+                                                       " diff " << i << " DIP-4 auth"
+                                                       " FAILED at work h=" << work_h
+                                                    << " — rotated bootstrap fails"
+                                                       " closed, retry.";
+                                        return;
+                                    }
+                                    rq::QSnapshotSeedEntry se;
+                                    se.llmq_type  = sseed->llmq_type;
+                                    se.cycle_base = cyc;
+                                    se.snapshot   = *snaps[i];
+                                    qs.entries.push_back(std::move(se));
+                                    rq::WorkListSeedEntry we;
+                                    we.work_height = work_h;
+                                    we.cycle_base  = cyc;
+                                    we.block_hash  = diffs[i]->blockHash;
+                                    if (cbtx.nVersion >= v::CCbTx::VERSION_CLSIG_AND_BALANCE
+                                        && cbtx.has_best_cl_signature()) {
+                                        we.has_cl = true;
+                                        std::memcpy(we.cl_sig.data(),
+                                                    cbtx.bestCLSignature.data(),
+                                                    we.cl_sig.size());
+                                    }
+                                    we.entries.reserve(sml->mnList.size());
+                                    for (const auto& e : sml->mnList) {
+                                        rq::QuorumMnEntry qe;
+                                        qe.proTxHash      = e.proRegTxHash;
+                                        qe.confirmedHash  = e.confirmedHash;
+                                        qe.is_valid       = e.isValid;
+                                        qe.n_type         = e.nType;
+                                        qe.has_collateral = false;
+                                        we.entries.push_back(std::move(qe));
+                                    }
+                                    wl.works.push_back(std::move(we));
+                                }
+                                qs.ok = true;  wl.ok = true;
+                                std::string e1, e2;
+                                const bool ok1 = qbr->seed_snapshots(qs, anchor_h, e1);
+                                const bool ok2 = qbr->seed_work_lists(wl, anchor_h, e2);
+                                if (!ok1 || !ok2) {
+                                    LOG_ERROR << "[MN-DIFF-DB] getqrinfo rotated"
+                                                 " bootstrap seed REJECTED (snapshots: "
+                                              << (ok1 ? "ok" : e1) << "; work-lists: "
+                                              << (ok2 ? "ok" : e2) << ") — store engine"
+                                                 " stays without the straddle snapshots;"
+                                                 " callers fall through (reward-safe).";
+                                    return;
+                                }
+                                sseed->landed = true;
+                                LOG_INFO << "[MN-DIFF-DB] getqrinfo rotated bootstrap"
+                                            " SEEDED: " << qs.entries.size()
+                                         << " pre-anchor quarter snapshots + "
+                                         << wl.works.size() << " work-lists for cycle"
+                                            " base h=" << sseed->cycle_base << " (type "
+                                         << int(sseed->llmq_type) << "); cycle "
+                                         << sseed->cycle_base << " is now derivable —"
+                                            " fold_qfcommit past the anchor resolves its"
+                                            " member set and the store extends toward"
+                                            " tip.";
+                                if (!sseed->hold.empty()) {
+                                    for (auto& pr : sseed->hold)
+                                        (*feed)(pr.second, pr.first);
+                                    sseed->hold.clear();
+                                }
+                            });
+                    }
+
+                    // THE WRITE FEED: the SAME shared drive as the hold-buffer
+                    // drain (feed), wrapped by the rotated-quorum ORDERING GATE.
+                    // getqrinfo(B0) is a P2P round-trip that races the parallel
+                    // fold advancing from the anchor; a straddle block folded
+                    // BEFORE its snapshots are seeded fails closed and POISONS
+                    // the engine. So: issue the fetch once a body-serving peer is
+                    // certainly up, HOLD straddle blocks until the seed lands
+                    // (then drain them in order), and — reward-safe fallback — if
+                    // the reply never arrives within a bounded hold, cap the store
+                    // below the straddle and let callers fall through unchanged
+                    // rather than poison.
                     mn_ckpt_lane->set_on_block_applied(
-                        [eng = mn_bridge_fold_engine.get(),
-                         w   = mn_diff_writer.get(),
-                         qbr = mn_bridge_quorum_bridge.get(),
-                         logged = std::make_shared<bool>(false)](
+                        [sseed, feed, cp = coin_p2p.get(),
+                         hc = header_chain.get()](
                             const dash::coin::BlockType& blk, uint32_t h) {
-                            if (eng->poisoned()) return;
-                            if (eng->size() == 0) return;   // seed deferred to the anchor fold; nothing to fold yet
-                            const uint256 bh =
-                                rp::DmlFoldEngine::block_header_hash(blk);
-                            // Feed the parallel quorum lane the SAME block so its
-                            // member derivation stays in lockstep with the fold;
-                            // observe() BEFORE the punish pass consumes
-                            // members_for(), after_fold() AFTER retains work-block
-                            // lists. Mirrors the main path's pre_fold/post_fold.
-                            if (qbr) qbr->observe(h, bh, blk);
-                            const auto fr = eng->fold_block(blk, h);
-                            if (qbr) qbr->after_fold(h);
-                            if (fr.ok) {
-                                w->on_folded(h, bh, blk, fr);
-                                return;
+                            // Lazy one-shot getqrinfo(B0): fire on the first folded
+                            // block, when headers are synced and a body-serving
+                            // peer exists.
+                            if (sseed->armed && !sseed->sent) {
+                                if (auto he = hc->get_header_by_height(
+                                        sseed->cycle_base)) {
+                                    sseed->cycle_base_hash = he->hash;
+                                    if (cp) cp->send_getqrinfo(
+                                        {}, he->hash, /*extra=*/false);
+                                    sseed->sent        = true;
+                                    sseed->last_send_h = h;
+                                    LOG_INFO << "[MN-DIFF-DB] getqrinfo issued for"
+                                                " straddling cycle base h="
+                                             << sseed->cycle_base
+                                             << " — bootstrap the store engine's"
+                                                " rotated member derivation across"
+                                                " the anchor.";
+                                }
                             }
-                            if (!*logged) {
-                                *logged = true;
-                                LOG_WARNING
-                                    << "[MN-DIFF-DB] cold-bridge parallel fold"
-                                       " could not extend the store at h=" << h
-                                    << " (" << fr.error << "). The store keeps"
-                                       " only its anchor row; every height above"
-                                       " REPAIR-REFUSES and the probe/on-demand"
-                                       " paths fall through to the network"
-                                       " unchanged (reward-safe). With the"
-                                       " full-state anchor seed this is NOT the"
-                                       " expected cold-bridge state: it means the"
-                                       " parallel fold diverged from a committed"
-                                       " cbTx root at this height.";
+                            // Seed landed while blocks were held -> drain first.
+                            if (sseed->landed && !sseed->hold.empty()) {
+                                for (auto& pr : sseed->hold)
+                                    (*feed)(pr.second, pr.first);
+                                sseed->hold.clear();
                             }
+                            // Hold blocks that would ask the resolver for the
+                            // straddling cycle before its snapshots are seeded.
+                            if (sseed->armed && !sseed->landed
+                                && h >= sseed->first_need_h) {
+                                if (sseed->exhausted) return;   // gave up: never fold unseeded
+                                constexpr size_t kHoldCap = 2000;
+                                if (sseed->hold.size() < kHoldCap) {
+                                    sseed->hold.emplace_back(h, blk);
+                                    if (sseed->sent
+                                        && h >= sseed->last_send_h + 24u) {
+                                        if (auto he = hc->get_header_by_height(
+                                                sseed->cycle_base)) {
+                                            if (cp) cp->send_getqrinfo(
+                                                {}, he->hash, false);
+                                            sseed->last_send_h = h;
+                                        }
+                                    }
+                                } else {
+                                    sseed->exhausted = true;
+                                    sseed->hold.clear();
+                                    LOG_WARNING
+                                        << "[MN-DIFF-DB] getqrinfo straddle seed did"
+                                           " not arrive before the hold cap at h="
+                                        << h << "; store caps below the straddling"
+                                           " cycle and callers fall through to the"
+                                           " network path (reward-safe, no bad mint).";
+                                }
+                                return;   // do not fold a straddle block unseeded
+                            }
+                            (*feed)(blk, h);
                         });
 
                     // THE READ SEAM: the 0-RTT gap-repair the SOURCE callers

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3480,6 +3480,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // root+payee-checked per-block commit it needs. Seeded at the same anchor
     // the bridge stands on; sinks MnDiffWriter::on_folded off ITS OWN commit.
     std::unique_ptr<dash::coin::replay::DmlFoldEngine>         mn_bridge_fold_engine;
+    // DASHD-CUT ARM (resolver wiring): the parallel store engine, like the
+    // main replay-fold path, needs the W4 quorum-member resolver or its fold
+    // FAILS CLOSED at the first punishing qfcommit (llmqType=5 @ h=2513130,
+    // ~130 past the anchor) and the store caps there. Stand up a SECOND
+    // QuorumReplayEngine + ReplayQuorumBridge whose ctor installs
+    // set_members_fn onto mn_bridge_fold_engine, seeded at the SAME anchor.
+    std::unique_ptr<dash::coin::replay::QuorumReplayEngine>    mn_bridge_quorum_engine;
+    std::unique_ptr<dash::coin::replay::ReplayQuorumBridge>    mn_bridge_quorum_bridge;
     // PR-2 FORWARD: dashd's mined-commitment store, fed from the same replayed
     // bodies. shared_ptr because the qc-plan lambda (installed far above, on
     // the serve path) captures it by value and must see it appear later — it
@@ -6202,9 +6210,78 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         std::make_unique<rp::DmlFoldEngine>(fcfg);
                     mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
                         *mn_diff_store, *mn_bridge_fold_engine);
+
+                    // ── RESOLVER WIRING (the fix) ────────────────────────
+                    // The parallel store engine, like the main replay-fold
+                    // path, needs the W4 quorum-member resolver or its fold
+                    // fails closed at the first punishing qfcommit (llmqType=5
+                    // @ h=2513130, only ~130 past the anchor): "no quorum-
+                    // member resolver is installed -- PoSe punishes cannot be
+                    // folded, failing closed". That cap is why the store
+                    // covered only ~130 heights and the bridge fell back to the
+                    // capped network getmnlistd probe (payee-desync).
+                    //
+                    // Mirror the main-path --replay-fold-quorums seam: a SECOND
+                    // QuorumReplayEngine seeded at the SAME full-state anchor and
+                    // a SECOND ReplayQuorumBridge whose ctor installs
+                    // set_members_fn onto mn_bridge_fold_engine. The engine
+                    // self-DERIVES rotated + non-rotated member sets from the
+                    // SAME replayed blocks the store folds (dashd
+                    // CalcQuorumMembers / GetAllQuorumMembers analog),
+                    // self-checked vs each block's committed merkleRootQuorums --
+                    // no qrinfo/P2P dependency. The fold then applies dashd
+                    // HandleQuorumCommitment PoSe-punishes (already ported in
+                    // replay_fold_engine.hpp) so the folded list re-hashes to the
+                    // committed merkleRootMNList PAST the qfcommit and the store
+                    // COVERS heights to tip. A WRONG member set -> root mismatch
+                    // -> the writer's own root self-check REFUSES the row -> store
+                    // stays empty -> callers fall through to the network path
+                    // (reward-safe by construction).
+                    {
+                        namespace rq = dash::coin::replay;
+                        rq::QuorumReplayConfig qcfg;
+                        qcfg.enabled = true;
+                        qcfg.network = testnet
+                            ? dash::coin::LlmqNetwork::Testnet
+                            : dash::coin::LlmqNetwork::Mainnet;
+                        if (testnet) qcfg.v20_floor = 905'100u;
+                        mn_bridge_quorum_engine =
+                            std::make_unique<rq::QuorumReplayEngine>(qcfg);
+                        mn_bridge_quorum_engine->seed_cursor(
+                            ckpt.height, ckpt.blockhash);
+                        rq::QuorumBridgeConfig bcfg;
+                        bcfg.network = qcfg.network;
+                        mn_bridge_quorum_bridge =
+                            std::make_unique<rq::ReplayQuorumBridge>(
+                                *mn_bridge_fold_engine,
+                                *mn_bridge_quorum_engine, bcfg);
+                        // Pre-anchor height->hash from the PoW-verified header
+                        // chain: a commitment mined just after the anchor whose
+                        // quorum BASE predates it still resolves instead of
+                        // failing the lane on an unknown base (mirrors the main
+                        // path's back = 3*576 + 64 window).
+                        size_t qseeded = 0;
+                        const uint32_t qback = 3u * 576u + 64u;
+                        for (uint32_t hh = (ckpt.height > qback
+                                                ? ckpt.height - qback : 1);
+                             hh < ckpt.height; ++hh) {
+                            auto he = header_chain->get_header_by_height(hh);
+                            if (!he) continue;
+                            mn_bridge_quorum_bridge->seed_block_hash(hh, he->hash);
+                            ++qseeded;
+                        }
+                        LOG_INFO << "[MN-DIFF-DB] store-engine quorum resolver"
+                                    " WIRED: second QuorumReplayEngine seeded at"
+                                    " anchor h=" << ckpt.height
+                                 << " (" << qseeded << " pre-anchor header"
+                                    " hashes); set_members_fn installed on the"
+                                    " parallel DML engine -- prime_at_anchor"
+                                    " deferred to the anchor snapshot seed.";
+                    }
                     mn_ckpt_lane->set_on_anchor_snapshot(
                         [eng = mn_bridge_fold_engine.get(),
                          w   = mn_diff_writer.get(),
+                         qbr = mn_bridge_quorum_bridge.get(),
                          anchor = ckpt, net = net_name](
                             const dash::coin::vendor::CSimplifiedMNList& asml,
                             uint32_t /*anchor_h*/) {
@@ -6314,6 +6391,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                        " inert, callers unchanged.";
                                 return;
                             }
+                            // Resolver lane: retain the anchor MN list in the
+                            // quorum bridge's window now that the fold engine is
+                            // seeded (m_dml.height()==anchor), so rotated member
+                            // derivation has its base list. Mirrors the main path.
+                            if (qbr) qbr->prime_at_anchor();
                             LOG_INFO
                                 << "[MN-DIFF-DB] FULL-STATE anchor seed OK: "
                                 << with_facets << " MNs seeded root-fields from the"
@@ -6335,13 +6417,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     mn_ckpt_lane->set_on_block_applied(
                         [eng = mn_bridge_fold_engine.get(),
                          w   = mn_diff_writer.get(),
+                         qbr = mn_bridge_quorum_bridge.get(),
                          logged = std::make_shared<bool>(false)](
                             const dash::coin::BlockType& blk, uint32_t h) {
                             if (eng->poisoned()) return;
                             if (eng->size() == 0) return;   // seed deferred to the anchor fold; nothing to fold yet
                             const uint256 bh =
                                 rp::DmlFoldEngine::block_header_hash(blk);
+                            // Feed the parallel quorum lane the SAME block so its
+                            // member derivation stays in lockstep with the fold;
+                            // observe() BEFORE the punish pass consumes
+                            // members_for(), after_fold() AFTER retains work-block
+                            // lists. Mirrors the main path's pre_fold/post_fold.
+                            if (qbr) qbr->observe(h, bh, blk);
                             const auto fr = eng->fold_block(blk, h);
+                            if (qbr) qbr->after_fold(h);
                             if (fr.ok) {
                                 w->on_folded(h, bh, blk, fr);
                                 return;

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3473,6 +3473,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // queue gap-repair seam. Constructed only alongside the fold engine.
     std::unique_ptr<dash::coin::replay::MnDiffStore>           mn_diff_store;
     std::unique_ptr<dash::coin::replay::MnDiffWriter>          mn_diff_writer;
+    // DASHD-CUT ARM: the PARALLEL DML fold engine that feeds the diff store on
+    // the COLD MN-CKPT bridge path (no --replay-bulk / --replay-fold-prestate).
+    // The cold bridge folds an MnStateMachine (payee projection); this engine
+    // folds the full ReplayMNState alongside it so the store writer has the
+    // root+payee-checked per-block commit it needs. Seeded at the same anchor
+    // the bridge stands on; sinks MnDiffWriter::on_folded off ITS OWN commit.
+    std::unique_ptr<dash::coin::replay::DmlFoldEngine>         mn_bridge_fold_engine;
     // PR-2 FORWARD: dashd's mined-commitment store, fed from the same replayed
     // bodies. shared_ptr because the qc-plan lambda (installed far above, on
     // the serve path) captures it by value and must see it appear later — it
@@ -6114,6 +6121,197 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     mnl->pump();
                 };
             maintainer->set_on_mn_reseed(mn_reseed_fallback);
+
+            // ── DASHD-CUT ARM: the MN DIFF/SNAPSHOT STORE on the COLD bridge ──
+            // The store block below (dashd evodb dmn_D4/dmn_S3 port) was DORMANT
+            // on the daemonless cold flags: its only construction site was gated
+            // under --replay-bulk → --replay-fold-prestate. LIFT it onto the
+            // cold MN-CKPT bridge arm so the ban-state probe / on-demand fold can
+            // repair from a 0-RTT root+payee-verified store instead of a capped
+            // network round trip (see begin_revive_probe / the payee-desync
+            // store re-apply in mn_checkpoint_lane.hpp).
+            //
+            // The cold bridge folds an MnStateMachine (payee projection); the
+            // store WRITER is bound to a DmlFoldEngine (full ReplayMNState). So
+            // we stand up a PARALLEL DmlFoldEngine seeded at the SAME anchor the
+            // bridge stands on, feed it every block the bridge folds CLEANLY
+            // (set_on_block_applied), and sink MnDiffWriter::on_folded off THAT
+            // engine's own root-checked commit.
+            //
+            // REWARD-SAFETY IS BY CONSTRUCTION and does NOT depend on the seed
+            // being complete: MnDiffStore::reconstruct() REFUSES any row that
+            // does not re-hash to the block's committed merkleRootMNList
+            // (mn_diff_store.hpp:849-857). The trusted-anchor checkpoint carries
+            // the DIP-3 PAYEE fields but NOT the SML fields the root commits
+            // (confirmedHash, netInfo) — so the parallel engine cannot reproduce
+            // the anchor+1 root and POISONS at the first fold. A poisoned engine
+            // writes no diffs, the store holds only the anchor, every height
+            // above it REPAIR-REFUSES, and the SOURCE callers fall through to
+            // their unchanged network path: today's behaviour EXACTLY, never a
+            // wrong row, never a bad mint. The wiring is in place so that the
+            // day a FULL-STATE (v3) anchor is pinned, the store serves the cold
+            // bridge with zero further change. Until then it is an accelerator
+            // that is present and inert, precisely as an accelerator should be.
+            if (mn_ckpt_lane && header_chain && ckpt.ok
+                && !mn_diff_store) {
+                namespace rp = dash::coin::replay;
+                mn_diff_store = std::make_unique<rp::MnDiffStore>(
+                    (core::filesystem::config_path() / net_subdir
+                        / "dash_mn_diff_db").string());
+                if (!mn_diff_store->open()) {
+                    LOG_WARNING << "[MN-DIFF-DB] cold-bridge open failed — diff"
+                                   " store DISABLED (gap repair unavailable;"
+                                   " probe/fold caps unchanged)";
+                    mn_diff_store.reset();
+                } else {
+                    auto diff_hlookup =
+                        [hc = header_chain.get()](const uint256& h)
+                            -> std::optional<std::pair<uint32_t, uint256>> {
+                        if (!hc) return std::nullopt;
+                        auto e = hc->get_header(h);
+                        if (!e) return std::nullopt;
+                        return std::make_pair(e->height, e->prev_hash);
+                    };
+                    std::string vnote;
+                    mn_diff_store->startup_verify(diff_hlookup, vnote);
+                    if (!vnote.empty())
+                        LOG_INFO << "[MN-DIFF-DB] cold-bridge startup verify: "
+                                 << vnote;
+
+                    // PARALLEL engine seeded at the bridge anchor. The checkpoint
+                    // MNState carries the payee facets; the SML-root facets it
+                    // omits are left at their ReplayMNState defaults (the engine
+                    // then self-checks and poisons at anchor+1 unless a genuine
+                    // full-state anchor was supplied — see the safety note above).
+                    dash::coin::replay::FoldConfig fcfg;
+                    fcfg.enabled = true;
+                    mn_bridge_fold_engine =
+                        std::make_unique<rp::DmlFoldEngine>(fcfg);
+                    std::vector<std::pair<uint256, rp::ReplayMNState>> seed;
+                    seed.reserve(ckpt.entries.size());
+                    uint64_t trc = 0;
+                    for (const auto& [protx, mn] : ckpt.entries) {
+                        rp::ReplayMNState st;
+                        st.nType             = mn.nType;
+                        st.internalId        = trc++;   // ordering only; not root
+                        st.collateralOutpoint = mn.collateralOutpoint;
+                        st.nOperatorReward   = mn.nOperatorReward;
+                        st.nVersion          = mn.nVersion;
+                        st.nRegisteredHeight  = static_cast<int32_t>(mn.nRegisteredHeight);
+                        st.nLastPaidHeight    = static_cast<int32_t>(mn.nLastPaidHeight);
+                        st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
+                        st.nPoSeRevivedHeight = mn.nPoSeRevivedHeight == 0
+                            ? rp::ReplayMNState::NEVER
+                            : static_cast<int32_t>(mn.nPoSeRevivedHeight);
+                        st.nPoSeBanHeight     = mn.nPoSeBanHeight == 0
+                            ? rp::ReplayMNState::NEVER
+                            : static_cast<int32_t>(mn.nPoSeBanHeight);
+                        st.nRevocationReason = mn.nRevocationReason;
+                        st.keyIDOwner        = mn.keyIDOwner;
+                        st.pubKeyOperator    = mn.pubKeyOperator;
+                        st.keyIDVoting       = mn.keyIDVoting;
+                        st.netInfo           = mn.netInfo;
+                        st.scriptPayout      = mn.scriptPayout;
+                        st.scriptOperatorPayout = mn.scriptOperatorPayout;
+                        st.platformNodeID    = mn.platformNodeID;
+                        st.platformP2PPort   = mn.platformP2PPort;
+                        st.platformHTTPPort  = mn.platformHTTPPort;
+                        seed.emplace_back(protx, std::move(st));
+                    }
+                    mn_bridge_fold_engine->seed(std::move(seed), trc,
+                                                ckpt.height, ckpt.blockhash,
+                                                net_name);
+                    mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
+                        *mn_diff_store, *mn_bridge_fold_engine);
+                    mn_diff_writer->arm();
+
+                    // THE WRITE FEED: every block the bridge folds CLEANLY is
+                    // handed to the parallel engine; only its OWN root-checked
+                    // commit sinks the writer. A once-latched poison log names
+                    // the reality when a partial anchor cannot reproduce roots.
+                    mn_ckpt_lane->set_on_block_applied(
+                        [eng = mn_bridge_fold_engine.get(),
+                         w   = mn_diff_writer.get(),
+                         logged = std::make_shared<bool>(false)](
+                            const dash::coin::BlockType& blk, uint32_t h) {
+                            if (eng->poisoned()) return;
+                            const uint256 bh =
+                                rp::DmlFoldEngine::block_header_hash(blk);
+                            const auto fr = eng->fold_block(blk, h);
+                            if (fr.ok) {
+                                w->on_folded(h, bh, blk, fr);
+                                return;
+                            }
+                            if (!*logged) {
+                                *logged = true;
+                                LOG_WARNING
+                                    << "[MN-DIFF-DB] cold-bridge parallel fold"
+                                       " could not extend the store at h=" << h
+                                    << " (" << fr.error << "). The store keeps"
+                                       " only its anchor row; every height above"
+                                       " REPAIR-REFUSES and the probe/on-demand"
+                                       " paths fall through to the network"
+                                       " unchanged. This is the expected,"
+                                       " reward-safe state when the anchor is a"
+                                       " payee-only checkpoint (no committed-root"
+                                       " SML fields) rather than a full-state"
+                                       " snapshot.";
+                            }
+                        });
+
+                    // THE READ SEAM: the 0-RTT gap-repair the SOURCE callers
+                    // use, reconstructed from the store and cross-checked at
+                    // every hop against OUR PoW-validated header chain.
+                    dash::coin::MnGapRepairFn repair_fn =
+                        [store = mn_diff_store.get(),
+                         hc = header_chain.get()](uint32_t want)
+                            -> dash::coin::MnGapRepairResult {
+                        dash::coin::MnGapRepairResult out;
+                        out.as_of = want;
+                        if (store == nullptr || hc == nullptr) {
+                            out.error = "diff store / header chain absent";
+                            return out;
+                        }
+                        auto e = hc->get_header_by_height(want);
+                        if (!e) {
+                            out.error = "h=" + std::to_string(want)
+                                      + " is not on our PoW-validated header"
+                                        " chain";
+                            return out;
+                        }
+                        auto hlookup = [hc](const uint256& h)
+                            -> std::optional<std::pair<uint32_t, uint256>> {
+                            auto ie = hc->get_header(h);
+                            if (!ie) return std::nullopt;
+                            return std::make_pair(ie->height, ie->prev_hash);
+                        };
+                        rp::DmlFoldEngine::Entries list;
+                        uint64_t trc2 = 0;
+                        std::string err;
+                        if (!store->reconstruct(e->hash, hlookup, list, trc2,
+                                                err)) {
+                            out.error = err;
+                            return out;
+                        }
+                        out.entries.reserve(list.size());
+                        for (const auto& [protx, st] : list)
+                            out.entries.emplace_back(protx,
+                                                     rp::to_payee_state(st));
+                        out.ok = true;
+                        return out;
+                    };
+                    mn_ckpt_lane->set_gap_repair(repair_fn);
+
+                    std::cout << "[run] MN DIFF STORE ARMED (cold bridge): the"
+                                 " MN-CKPT bridge's clean folds feed a parallel"
+                                 " root-checked DML engine; the ban-state probe"
+                                 " and on-demand fold repair from it 0-RTT when"
+                                 " it covers the height, else fall through to"
+                                 " the network unchanged (reward-safe: a row"
+                                 " that does not re-hash to the committed"
+                                 " merkleRootMNList is REFUSED)\n";
+                }
+            }
 
             // Kick the lane once now in case the header chain is already past
             // the anchor from a previous run's persisted header DB.

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -34,6 +34,7 @@
 #include <impl/dash/coin/governance_object.hpp>  // parse_superblock_trigger, govvote_signature_hash
 #include <impl/dash/coin/superblock.hpp>         // get_superblock_payments (R6 cross-check + provider)
 #include <impl/dash/coin/mn_state_machine.hpp>   // MNState
+#include <impl/dash/coin/mn_gap_repair.hpp>      // MnGapRepairFn (diff-store gap repair seam)
 #include <impl/dash/coin/lane_diag.hpp>          // diag::MnSource (population attribution)
 #include <impl/dash/coin/block.hpp>            // BlockType
 #include <impl/dash/coin/transaction.hpp>        // MutableTransaction
@@ -388,6 +389,55 @@ public:
         // fetch and the first live full-block ingest were the soak's
         // 2-slot cursor lag -> bad-cb-payee at the address-group boundary).
         m_state.mnstates().load(std::move(mnstates), as_of_height);
+        // ── CONSUMER CURRENCY GATE (the G7 split, consumer half) ─────────
+        // This consumer holds BOTH operands — the seed's as_of_height and
+        // serve_tip_height() — and historically compared neither: currency
+        // was enforced only publisher-side (replay_payee_publish.hpp G7).
+        // With the publisher's exact-tip demand relaxed by kPublishEpsilon,
+        // the enforcement moves HERE: accept and STORE a below-tip seed, but
+        // arm m_have_mn for SERVING only when the queue cursor is current.
+        // If the seed is behind the serve tip, immediately attempt the
+        // diff-store catch-up for (as_of .. tip]; arming happens only at
+        // cursor == tip. A catch-up refusal costs nothing (mirror of G7's
+        // publisher-side economics): the seed stays stored, serving stays
+        // un-armed, and the incumbent lane keeps its job. This gate does NOT
+        // replace publisher G7 — the ε bound keeps the cheap refusal there;
+        // this is the zero-cost currency check that guarantees no serve ever
+        // projects a below-tip queue front.
+        {
+            const uint32_t serve_tip = serve_tip_height();
+            if (m_have_mn && as_of_height != 0 && serve_tip != 0
+                && as_of_height < serve_tip) {
+                bool caught_up = false;
+                if (m_mn_gap_repair) {
+                    auto rep = m_mn_gap_repair(serve_tip);
+                    if (rep.ok && !rep.entries.empty()
+                        && rep.as_of == serve_tip) {
+                        LOG_INFO << "[PAYEE-QUEUE] below-tip seed as_of_h="
+                                 << as_of_height << " CAUGHT UP to serve tip"
+                                    " h=" << serve_tip
+                                 << " from the diff store ("
+                                 << rep.entries.size() << " MNs)";
+                        m_state.mnstates().load(std::move(rep.entries),
+                                                rep.as_of);
+                        m_mn_snapshot_height = rep.as_of;
+                        as_of_height         = rep.as_of;
+                        caught_up            = true;
+                    }
+                }
+                if (!caught_up) {
+                    LOG_WARNING
+                        << "[PAYEE-QUEUE] seed as_of_h=" << as_of_height
+                        << " is BEHIND serve tip h=" << serve_tip
+                        << " and the diff-store catch-up "
+                        << (m_mn_gap_repair ? "refused" : "is not wired")
+                        << " — seed STORED but serving NOT armed (a queue"
+                           " front below the tip must never back a"
+                           " template); the incumbent lane keeps its job";
+                    m_have_mn = false;
+                }
+            }
+        }
         // Startup / reseed join (2026-07-30): the PAYEE axis was just (re)seeded
         // -- reconcile it against an already-present SML so a warm-loaded or
         // live-advanced SML's authoritative isValid lands on the fresh queue
@@ -1401,6 +1451,44 @@ private:
             return r;
         }
         auto r    = m_state.mnstates().apply_block(block, height);
+        // ── DIFF-STORE GAP REPAIR (dashd GetListForBlockInternal analogue,
+        // evo/deterministicmns.cpp:778-870, as a cold repair path). An APPLY
+        // GAP means blocks between the cursor and this one were never folded
+        // into the payee queue. dashd never wipes on that — it reconstructs
+        // the list for ANY block from its per-block diff store. When the
+        // ported store (mn_diff_store.hpp) is wired and can reconstruct the
+        // list AT height-1 — every row present, digest-good, root_matched
+        // AND payee_verified, SML root equal to the chain's committed root —
+        // reseed through the EXISTING single sink (on_mn_list_update: the
+        // reseed latch clears on a non-empty height-stamped set, the anti-
+        // mint invariant below is respected, not bypassed) and re-apply the
+        // block the caller still holds. ANY refusal falls through to the
+        // unchanged wipe chain below; repair only ADDS a lane in front of
+        // it, it removes nothing. payee_desync is NOT repairable this way
+        // (the queue disagreed with the chain at a contiguous height — that
+        // is a divergence, not a gap) and takes the wipe path as always.
+        if (r.gap_detected && !r.payee_desync && m_mn_gap_repair) {
+            auto rep = m_mn_gap_repair(height - 1);
+            if (rep.ok && !rep.entries.empty() && rep.as_of == height - 1) {
+                LOG_INFO << "[EMB-DASH] MN payee APPLY GAP at h=" << height
+                         << " REPAIRED from the diff store: queue reseeded"
+                            " as-of h=" << rep.as_of << " ("
+                         << rep.entries.size() << " MNs, source="
+                         << kPayeeSourceMnDiffRepair
+                         << "); re-applying the held block";
+                on_mn_list_update(std::move(rep.entries), rep.as_of,
+                                  kPayeeSourceMnDiffRepair);
+                // Pass-3's coinbase cross-check inside this re-apply is the
+                // final tripwire: a payee_desync here falls through to the
+                // wipe chain below exactly as an unrepaired gap would.
+                r = m_state.mnstates().apply_block(block, height);
+            } else {
+                LOG_WARNING << "[EMB-DASH] MN payee APPLY GAP at h=" << height
+                            << " NOT repairable from the diff store ("
+                            << (rep.error.empty() ? "refused" : rep.error)
+                            << ") — falling through to the wipe/demote path";
+            }
+        }
         // PAYEE DESYNC (soak-found 2026-07-22, bad-cb-payee class): the
         // connected block's coinbase does not pay the MN our queue projects.
         // The payee set can no longer back a template — serving from it
@@ -1652,6 +1740,22 @@ public:
     /// which is the safe terminal state (never serve a guessed payee).
     void set_on_mn_reseed(std::function<void()> fn) {
         m_on_mn_reseed = std::move(fn);
+    }
+
+    /// Wire the MN diff-store gap-repair seam (mn_gap_repair.hpp; main_dash
+    /// points this at MnDiffStore::reconstruct over the PoW-validated header
+    /// chain — the c2pool port of dashd's snapshot+diff walk,
+    /// evo/deterministicmns.cpp:778-870). Consulted in exactly two places:
+    ///   * on_block_connected's APPLY-GAP branch, BEFORE the wipe chain —
+    ///     a gap that CAN be repaired from stored, root+payee-verified diffs
+    ///     re-seeds through on_mn_list_update and re-applies the held block;
+    ///   * on_mn_list_update's consumer currency gate (the G7 split) —
+    ///     a below-tip seed is caught up to the serve tip before it may arm
+    ///     serving.
+    /// Optional: unset leaves BOTH paths byte-identical to their historical
+    /// fail-closed behavior (wipe/demote/re-seed; exact-currency arming).
+    void set_mn_gap_repair(MnGapRepairFn fn) {
+        m_mn_gap_repair = std::move(fn);
     }
 
     /// Wire a "force a full mnlistdiff re-sync from ZERO" sink (main_dash resets
@@ -2318,6 +2422,7 @@ private:
     std::function<int64_t(uint32_t)> m_sb_budget_fn;  // superblock budget cap (duffs)
     std::function<void()> m_on_state_dirty;  // SML/bestCL/reorg -> re-issue work
     std::function<void()> m_on_mn_reseed;    // payee desync -> authoritative protx re-seed
+    MnGapRepairFn m_mn_gap_repair;           // diff-store gap repair (mn_gap_repair.hpp); unset = historical fail-closed
     std::function<void()> m_on_full_resync;  // H-1 heal -> reset sml_base + full re-sync
     std::function<void(const uint256&, const uint256&)> m_on_sml_rerequest;  // SML-behind-tip -> bounded getmnlistd(base,target)
     // #1153 policy: bounds the getmnlistd re-request to at most a few attempts

--- a/src/impl/dash/coin/lane_diag.hpp
+++ b/src/impl/dash/coin/lane_diag.hpp
@@ -377,21 +377,24 @@ private:
 /// payee queue" is never again an inference.
 enum class MnSource
 {
-    None,        ///< nothing has populated the queue
-    DashdSeed,   ///< dashd RPC `protx list registered` startup seed (mn_seed)
-    MnCkpt,      ///< the release-pinned checkpoint + forward-replay bridge
-    ReplayFold,  ///< a masternode-list fold produced by the block replay lane
-    Unknown      ///< populated by a path that did not name itself: a BUG
+    None,         ///< nothing has populated the queue
+    DashdSeed,    ///< dashd RPC `protx list registered` startup seed (mn_seed)
+    MnCkpt,       ///< the release-pinned checkpoint + forward-replay bridge
+    ReplayFold,   ///< a masternode-list fold produced by the block replay lane
+    MnDiffRepair, ///< gap repair: list reconstructed from the MN diff store's
+                  ///< stored root+payee-verified fold outputs (mn_diff_store)
+    Unknown       ///< populated by a path that did not name itself: a BUG
 };
 
 inline const char* mn_source_name(MnSource s)
 {
     switch (s) {
-        case MnSource::None:       return "none";
-        case MnSource::DashdSeed:  return "dashd-seed";
-        case MnSource::MnCkpt:     return "mn-ckpt";
-        case MnSource::ReplayFold: return "replay-fold";
-        case MnSource::Unknown:    return "unknown";
+        case MnSource::None:         return "none";
+        case MnSource::DashdSeed:    return "dashd-seed";
+        case MnSource::MnCkpt:       return "mn-ckpt";
+        case MnSource::ReplayFold:   return "replay-fold";
+        case MnSource::MnDiffRepair: return "mn-diff-repair";
+        case MnSource::Unknown:      return "unknown";
     }
     return "unknown";
 }
@@ -399,19 +402,23 @@ inline const char* mn_source_name(MnSource s)
 /// Parse back, so a test (or a scraper) can round-trip the token.
 inline MnSource mn_source_from_name(const std::string& n)
 {
-    if (n == "dashd-seed")  return MnSource::DashdSeed;
-    if (n == "mn-ckpt")     return MnSource::MnCkpt;
-    if (n == "replay-fold") return MnSource::ReplayFold;
-    if (n == "none")        return MnSource::None;
+    if (n == "dashd-seed")     return MnSource::DashdSeed;
+    if (n == "mn-ckpt")        return MnSource::MnCkpt;
+    if (n == "replay-fold")    return MnSource::ReplayFold;
+    if (n == "mn-diff-repair") return MnSource::MnDiffRepair;
+    if (n == "none")           return MnSource::None;
     return MnSource::Unknown;
 }
 
 /// Whether a source is daemon-independent. The A/B that exposed the misreading
 /// is exactly this predicate, and encoding it here means the log can state the
 /// conclusion instead of leaving it to the reader.
+/// MnDiffRepair qualifies: the store's rows are fold OUTPUTS, written only
+/// after the engine's own root+payee self-checks — no daemon involved.
 inline bool mn_source_is_daemonless(MnSource s)
 {
-    return s == MnSource::MnCkpt || s == MnSource::ReplayFold;
+    return s == MnSource::MnCkpt || s == MnSource::ReplayFold
+        || s == MnSource::MnDiffRepair;
 }
 
 } // namespace diag

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -362,6 +362,25 @@ public:
         m_on_block_applied = std::move(fn);
     }
 
+    /// FULL-STATE ANCHOR SEED seam (dashd-cut MN diff store). The lane's OWN
+    /// first fold is the anchor fold: begin_fold(m_anchor_height) requests
+    /// getmnlistd(base=ZERO, target=anchor_hash) and on_historical_snapshot()
+    /// DIP-4-authenticates the reply against the anchor block's committed
+    /// merkleRootMNList (never a partial acceptance). That authenticated list
+    /// is the FULL Simplified MN List AS OF the anchor -- precisely the
+    /// root-committing fields (confirmedHash, netInfo) the payee-only compiled
+    /// checkpoint OMITS. This callback hands that verified list to the parallel
+    /// DmlFoldEngine seed so it reproduces the anchor's committed root and no
+    /// longer poisons at anchor+1. Fired EXACTLY ONCE, from apply_fold() at
+    /// height == m_anchor_height, BEFORE any forward block is folded. A resumed
+    /// bridge never runs the anchor fold, so it never fires. Optional -- unset
+    /// is a no-op (the checkpoint-only seed stands, which self-checks/poisons).
+    void set_on_anchor_snapshot(
+        std::function<void(const vendor::CSimplifiedMNList&, uint32_t)> fn)
+    {
+        m_on_anchor_snapshot = std::move(fn);
+    }
+
     /// OPTIONAL. Unwired, the bridge behaves exactly as it did before this
     /// seam existed: any payee mismatch during replay is terminal.
     void set_sml_validity_fn(SmlValidityFn fn)
@@ -3139,6 +3158,16 @@ private:
     /// at `height`. Every caller must have established that equality.
     void apply_fold(const vendor::CSimplifiedMNList& sml, uint32_t height)
     {
+        // FULL-STATE ANCHOR SEED HOOK. The lane's own anchor fold has just
+        // DIP-4-authenticated the FULL SML as of the anchor -- deliver it once,
+        // before any forward block is folded, so the parallel MN diff-store
+        // engine seeds full-state instead of poisoning at anchor+1 on the
+        // payee-only checkpoint. height == m_anchor_height is reached only by
+        // the anchor fold (fold points and on-demand folds are all > cursor,
+        // and a resumed bridge never runs the anchor fold).
+        if (height == m_anchor_height && m_on_anchor_snapshot)
+            m_on_anchor_snapshot(sml, height);
+
         const size_t before = m_machine.eligible_size();
 
         // F5 SANITY BOUND, now defence-in-depth. The list is DIP-4 verified
@@ -3959,6 +3988,12 @@ public:
     // MnDiffWriter). Unset is a no-op, so a bridge with no store wired behaves
     // exactly as before.
     std::function<void(const BlockType&, uint32_t)> m_on_block_applied;
+    // FULL-STATE ANCHOR SEED seam (dashd-cut): fired once from apply_fold at
+    // the anchor height with the DIP-4-authenticated full SML, so main_dash
+    // can seed the parallel DmlFoldEngine with the root-committing fields the
+    // payee-only checkpoint omits. Unset = no-op.
+    std::function<void(const vendor::CSimplifiedMNList&, uint32_t)>
+        m_on_anchor_snapshot;
     // dashd-cut SOURCE observability: pre-block ban state resolved from the
     // diff store (0-RTT) instead of a capped network probe/fold. These are the
     // counts that prove the store SERVED — a green run has probe/fold caps

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -343,6 +343,25 @@ public:
     /// level APPLY GAP before fail_closed. Optional — unset keeps the
     /// terminal fail_closed behavior byte-identical.
     void set_gap_repair(MnGapRepairFn fn)        { m_gap_repair = std::move(fn); }
+
+    /// ── THE MN-DIFF-STORE WRITE FEED (dashd-cut ARM) ──────────────────────
+    /// Called with (block, height) the instant AFTER m_machine.apply_block()
+    /// has folded a bridge block CLEANLY at the contiguous cursor — no gap, no
+    /// surviving payee desync, non-empty set. main_dash wires this to a
+    /// PARALLEL DmlFoldEngine (seeded at the same bridge anchor) so the store
+    /// writer's root+payee-checked per-block diffs are produced off the very
+    /// blocks this lane replays. The parallel engine self-checks each fold
+    /// against the block's committed merkleRootMNList and only its OWN commit
+    /// sinks MnDiffWriter::on_folded, so a seed the engine cannot reproduce
+    /// (e.g. an SML-incomplete anchor) simply poisons the engine and the store
+    /// never populates — never a wrong row. Forward-contiguous by construction:
+    /// this fires once per height, in ascending order, exactly as the engine's
+    /// own forward-only cursor demands. Optional — unset is a no-op.
+    void set_on_block_applied(std::function<void(const BlockType&, uint32_t)> fn)
+    {
+        m_on_block_applied = std::move(fn);
+    }
+
     /// OPTIONAL. Unwired, the bridge behaves exactly as it did before this
     /// seam existed: any payee mismatch during replay is terminal.
     void set_sml_validity_fn(SmlValidityFn fn)
@@ -1337,6 +1356,17 @@ public:
     /// "never evaluated", NOT "evaluated and zero", and the reports say n/a.
     size_t   ondemand_folds()     const { return m_ondemand_folds; }
     size_t   ondemand_excluded()  const { return m_ondemand_excluded; }
+    /// Masternodes whose queue ORDERING (nPoSeRevivedHeight) an on-demand fold
+    /// repaired — a ProUpServTx-revive this bridge applied with the ban
+    /// UNMEASURED, healed forward instead of fail-closing. 0 on a bridge that
+    /// never guessed a revive. See repair_unmeasured_revive_ordering().
+    size_t   ordering_repaired()  const { return m_ordering_repaired; }
+    /// dashd-cut SOURCE: pre-block ban states resolved 0-RTT from the diff
+    /// store instead of a capped network round trip. > 0 means the ARM's store
+    /// SERVED the bridge; a probe/fold cap was not reached because it did not
+    /// need to be. See begin_revive_probe() / the payee-desync store re-apply.
+    size_t   revive_measured_from_store()   const { return m_revive_measured_from_store; }
+    size_t   ondemand_resolved_from_store() const { return m_ondemand_resolved_from_store; }
     size_t   ondemand_cap()       const { return m_ondemand_cap; }
     bool     ondemand_cap_hit()   const { return m_ondemand_cap_hit; }
     bool     ondemand_evaluated() const { return m_ondemand_evaluated; }
@@ -1863,6 +1893,45 @@ public:
         // ask for an RPC re-seed — daemonless has nothing to re-seed from, and
         // guessing is exactly what must never happen).
         if (r.payee_desync && !r.gap_detected) {
+            // ── STORE-FIRST (0-RTT), the on-demand analogue of the ban-state
+            // probe's store-first path in begin_revive_probe(). Before spending
+            // a CAPPED network on-demand fold, ask the diff store for the
+            // AUTHORITATIVE pre-block list AS OF height-1 and RE-APPLY this
+            // block off it — the exact load+re-apply idiom the apply-gap repair
+            // above (r.gap_detected) already uses. The store reconstruct()
+            // returns only a list that re-hashes to the block's committed
+            // merkleRootMNList AND carries payee_verified on every constituent
+            // diff (mn_diff_store.hpp:788,849-857), so re-projecting block
+            // `height`'s payee off it derives EXACTLY the payee dashd's own
+            // list at height-1 projects — the h=2516072 unmeasured-revive
+            // ordering desync heals because the store already recorded
+            // nPoSeRevivedHeight. mark_ban_state_measured(height-1) so the
+            // re-apply's revive gate is decided, not guessed. A refusal (store
+            // absent / row missing / unverified) leaves r untouched and the
+            // network on-demand fold below runs byte-for-byte as before — the
+            // cap is NOT widened, it is simply not reached for the store-covered
+            // case.
+            if (m_gap_repair && height >= 1) {
+                auto rep = m_gap_repair(height - 1);
+                if (rep.ok && !rep.entries.empty() && rep.as_of == height - 1) {
+                    m_machine.load(std::move(rep.entries), height - 1);
+                    m_machine.mark_ban_state_measured(height - 1);
+                    ++m_ondemand_resolved_from_store;
+                    LOG_INFO
+                        << "[MN-CKPT] PAYEE DESYNC at h=" << height
+                        << " RESOLVED FROM STORE (source="
+                        << kPayeeSourceMnDiffRepair << "): re-applied the block "
+                           "off the diff store's authoritative pre-block list AS "
+                           "OF h=" << (height - 1)
+                        << " (0-RTT, root+payee verified) — NO on-demand network "
+                           "fold spent, the "
+                        << m_ondemand_folds << "/" << m_ondemand_cap
+                        << " on-demand budget is untouched.";
+                    r = m_machine.apply_block(block, height);
+                }
+            }
+        }
+        if (r.payee_desync && !r.gap_detected) {
             // ── ON-DEMAND FOLD. The mismatch IS the trigger: ask for the
             // masternode list dated exactly at this height and re-adjudicate.
             // Returns true when the request was issued (the replay is now
@@ -1887,6 +1956,11 @@ public:
         m_next = height + 1;
         ++m_applied;
         note_replay_advance(block);
+        // ── MN-DIFF-STORE WRITE FEED (dashd-cut ARM). The block folded
+        // CLEANLY at the contiguous cursor; hand it to the parallel fold
+        // engine so the store writer emits this height's root+payee-checked
+        // diff. Forward-contiguous, once per height, in order.
+        if (m_on_block_applied) m_on_block_applied(block, height);
         // #91: DELIVERED, and only now. Every guard above had to pass — no
         // gap, no payee desync, a non-empty set — before this height is a
         // height a restart may resume from.
@@ -2555,6 +2629,41 @@ public:
         const auto cands = m_machine.unmeasured_revive_candidates(block, height);
         if (cands.empty()) return false;
 
+        // ── STORE-FIRST (0-RTT, dashd GetListForBlockInternal). Before
+        // spending a CAPPED network probe, ask the diff store for the list AS
+        // OF height-1 — the exact pre-block list dashcore consults to decide
+        // whether a ProUpServTx revives (specialtxman.cpp:361-370). The store
+        // reconstruct() REFUSES any list that does not re-hash to the block's
+        // committed merkleRootMNList (mn_diff_store.hpp:849-857) and the SML
+        // entry commits isValid, so a list it returns AT height-1 carries
+        // dashd's own ban state there — every bit as authoritative as the
+        // fetched height-exact snapshot, at zero round trips. load() it and
+        // mark the ban state measured, which makes ban_state_measured_for(
+        // height) true, so unmeasured_revive_candidates(height) is now empty
+        // and apply_block decides the revive gate correctly WITHOUT a probe.
+        // Only fall through to the network probe when the store is absent or
+        // refuses (a missing/unverified row) — the cap is NEVER widened, it is
+        // simply not reached for the store-covered case.
+        if (m_gap_repair && height >= 1) {
+            auto rep = m_gap_repair(height - 1);
+            if (rep.ok && !rep.entries.empty() && rep.as_of == height - 1) {
+                m_machine.load(std::move(rep.entries), height - 1);
+                m_machine.mark_ban_state_measured(height - 1);
+                ++m_revive_measured_from_store;
+                LOG_INFO
+                    << "[MN-CKPT] BAN-STATE MEASURED FROM STORE at h=" << height
+                    << " (source=" << kPayeeSourceMnDiffRepair << "): the "
+                    << cands.size() << " ProUpServTx here had their pre-block "
+                       "ban state resolved from the diff store's height-exact "
+                       "list AS OF h=" << (height - 1)
+                    << " (0-RTT, root+payee verified) — NO network probe spent, "
+                       "the "
+                    << m_revive_probes << "/" << m_revive_probe_cap
+                    << " probe budget is untouched.";
+                return false;   // measured; apply proceeds, replay NOT paused
+            }
+        }
+
         if (m_revive_probes >= m_revive_probe_cap) {
             m_revive_probe_cap_hit = true;
             LOG_WARNING
@@ -2947,6 +3056,30 @@ private:
         apply_fold(sml, height);
         if (m_state != State::Bridging) return;   // F5 refused; already closed
 
+        // ── ORDERING REPAIR, before the exclusion walk. A masternode revived
+        // by a ProUpServTx we applied with the ban UNMEASURED keeps
+        // nPoSeRevivedHeight=0 and stays the projected head even though this
+        // height-exact list attests it VALID — the h=2516072 wedge, where the
+        // exclusion-only re-adjudication cannot demote a candidate the list
+        // (correctly) calls valid. This writes the nPoSeRevivedHeight dashd
+        // wrote and re-sorts the pending queue, so the walk below adjudicates
+        // against the queue dashd holds. No-op when there is no unmeasured
+        // revive to repair — the ordinary exclusion path is unchanged.
+        const size_t reordered =
+            m_machine.repair_unmeasured_revive_ordering(sml);
+        if (reordered) {
+            m_ordering_repaired += reordered;
+            LOG_WARNING
+                << "[MN-CKPT] ON-DEMAND ORDERING REPAIR at h=" << height << ": "
+                << reordered << " masternode(s) revived by a ProUpServTx applied"
+                   " with the ban UNMEASURED had their nPoSeRevivedHeight"
+                   " restored to dashd's value from the height-exact list, and"
+                   " the payee queue re-sorted. This repairs a queue-ORDERING"
+                   " desync the exclusion-only re-adjudication cannot — the"
+                   " projected candidate was attested VALID, so it was the"
+                   " ORDER that diverged, not the ban state.";
+        }
+
         const auto rr =
             m_machine.readjudicate_payee(m_ondemand_block, height, sml);
         if (!rr.recovered) {
@@ -2978,6 +3111,11 @@ private:
         // after this line. Recording progress here is what gives the watchdog a
         // truthful last-progress timestamp to measure that freeze from.
         note_replay_advance(m_ondemand_block);
+        // MN-DIFF-STORE WRITE FEED (dashd-cut ARM): the on-demand fold resolved
+        // the mismatch and the block is now applied at the contiguous cursor —
+        // feed it to the parallel engine exactly as the ordinary post-apply
+        // path does, so the store's per-height diff chain has no hole here.
+        if (m_on_block_applied) m_on_block_applied(m_ondemand_block, height);
         m_sml_recovered += m_ondemand_r.sml_recovered;
         m_registered    += m_ondemand_r.registered;
         m_spent         += m_ondemand_r.spent;
@@ -3134,6 +3272,14 @@ public:
             + "), " + std::to_string(m_ondemand_excluded)
             + " queue-head exclusion(s) licensed by a list dated EXACTLY at the"
               " height it judged.";
+        if (m_ordering_repaired != 0) {
+            s += " " + std::to_string(m_ordering_repaired)
+                 + " queue-ORDERING repair(s): a ProUpServTx-revive applied with"
+                   " the ban UNMEASURED had nPoSeRevivedHeight restored to"
+                   " dashd's value from the height-exact list and the payee queue"
+                   " re-sorted, healing the mismatch forward instead of failing"
+                   " closed.";
+        }
         if (m_ondemand_cap_hit) {
             s += " THE CAP IS EXHAUSTED: " + std::to_string(m_ondemand_folds)
                  + " of " + std::to_string(m_ondemand_cap)
@@ -3686,6 +3832,9 @@ public:
         m_ondemand_cap_hit   = false;
         m_ondemand_evaluated = false;
         m_ondemand_abandoned = 0;
+        m_ordering_repaired  = 0;
+        m_revive_measured_from_store   = 0;
+        m_ondemand_resolved_from_store = 0;
         m_ondemand_block     = BlockType{};
         m_ondemand_r         = MnStateMachine::ApplyResult{};
         // The SIZED cap, which #1033's arm() did not reset. pump() recomputes
@@ -3806,6 +3955,16 @@ public:
     HeaderHashAtFn m_header_hash_at;
     SmlSnapshotFn  m_sml_snapshot;
     MnGapRepairFn  m_gap_repair;     // diff-store gap repair; unset = terminal fail_closed as before
+    // dashd-cut ARM: parallel-fold write feed (main_dash → DmlFoldEngine +
+    // MnDiffWriter). Unset is a no-op, so a bridge with no store wired behaves
+    // exactly as before.
+    std::function<void(const BlockType&, uint32_t)> m_on_block_applied;
+    // dashd-cut SOURCE observability: pre-block ban state resolved from the
+    // diff store (0-RTT) instead of a capped network probe/fold. These are the
+    // counts that prove the store SERVED — a green run has probe/fold caps
+    // untouched and these > 0.
+    size_t m_revive_measured_from_store{0};   // begin_revive_probe store hits
+    size_t m_ondemand_resolved_from_store{0}; // payee-desync store re-applies
 
     State       m_state{State::Unarmed};
     std::string m_status{"unarmed"};
@@ -3858,6 +4017,7 @@ public:
     bool      m_ondemand_cap_hit{false};
     bool      m_ondemand_evaluated{false};     // a mismatch ever reached it
     size_t    m_ondemand_abandoned{0};         // on-demand asks never answered
+    size_t    m_ordering_repaired{0};          // nPoSeRevivedHeight healed forward
     // ── BAN-STATE PROBE state. Rides the SAME m_snapshot_pending pause and
     // the SAME reply route as a scheduled fold — it IS a scheduled fold, just
     // scheduled by a ProUpServTx instead of by a counter. m_revive_probe_at is

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -208,6 +208,7 @@
 #include <impl/dash/coin/block.hpp>
 #include <impl/dash/coin/mn_bridge_cursor.hpp>   // #91: the resumable replay cursor
 #include <impl/dash/coin/mn_checkpoint.hpp>
+#include <impl/dash/coin/mn_gap_repair.hpp>    // MnGapRepairFn (diff-store gap repair seam)
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/historical_sml.hpp>   // authenticate_historical_snapshot
 #include <impl/dash/coin/lane_diag.hpp>        // ProgressReporter / StallWatchdog / MnSource
@@ -338,6 +339,10 @@ public:
     void set_publish_fn(PublishFn fn)            { m_publish = std::move(fn); }
     void set_tip_height_fn(TipHeightFn fn)       { m_tip_height = std::move(fn); }
     void set_header_hash_at_fn(HeaderHashAtFn fn){ m_header_hash_at = std::move(fn); }
+    /// Diff-store gap repair (mn_gap_repair.hpp): consulted on a machine-
+    /// level APPLY GAP before fail_closed. Optional — unset keeps the
+    /// terminal fail_closed behavior byte-identical.
+    void set_gap_repair(MnGapRepairFn fn)        { m_gap_repair = std::move(fn); }
     /// OPTIONAL. Unwired, the bridge behaves exactly as it did before this
     /// seam existed: any payee mismatch during replay is terminal.
     void set_sml_validity_fn(SmlValidityFn fn)
@@ -1806,6 +1811,9 @@ public:
         // flag; this is the belt-and-braces backstop for a direct caller.
         if (m_snapshot_pending) return;
         if (height != m_next) return;
+        // (The diff-store gap-repair seam below fires only on a machine-level
+        // APPLY GAP — a bridge whose own cursor discipline slipped; the
+        // height!=m_next drop above remains the ordinary filter.)
 
         // Publish the SML's own height into the machine BEFORE it adjudicates
         // anything, so the reactive demotion walk's attestations are gated on
@@ -1822,7 +1830,33 @@ public:
         // resumes it and re-delivers this very block).
         if (begin_revive_probe(block, height)) return;
 
-        const auto r = m_machine.apply_block(block, height);
+        auto r = m_machine.apply_block(block, height);
+
+        // ── DIFF-STORE GAP REPAIR (dashd GetListForBlockInternal analogue,
+        // evo/deterministicmns.cpp:778-870). A machine-level APPLY GAP was
+        // TERMINAL on this lane (fail_closed below — daemonless has no RPC
+        // to re-seed from). When the ported diff store (mn_diff_store.hpp)
+        // can reconstruct the verified list AT height-1, load it and retry
+        // the same block; any refusal leaves `r` as it was and the
+        // pre-existing fail_closed path below runs byte-for-byte unchanged.
+        if (r.gap_detected && m_gap_repair) {
+            auto rep = m_gap_repair(height - 1);
+            if (rep.ok && !rep.entries.empty() && rep.as_of == height - 1) {
+                LOG_INFO << "[MN-CKPT] bridge APPLY GAP at h=" << height
+                         << " REPAIRED from the diff store (source="
+                         << kPayeeSourceMnDiffRepair << ", "
+                         << rep.entries.size()
+                         << " MNs as-of h=" << rep.as_of
+                         << ") — retrying the held block";
+                m_machine.load(std::move(rep.entries), rep.as_of);
+                r = m_machine.apply_block(block, height);
+            } else {
+                LOG_WARNING << "[MN-CKPT] bridge APPLY GAP at h=" << height
+                            << " NOT repairable from the diff store ("
+                            << (rep.error.empty() ? "refused" : rep.error)
+                            << ") — fail_closed path unchanged";
+            }
+        }
 
         // The anchor's own falsification test. apply_block already logs the
         // detail; here it is TERMINAL (unlike the maintainer's path, which can
@@ -3771,6 +3805,7 @@ public:
     TipHeightFn    m_tip_height;
     HeaderHashAtFn m_header_hash_at;
     SmlSnapshotFn  m_sml_snapshot;
+    MnGapRepairFn  m_gap_repair;     // diff-store gap repair; unset = terminal fail_closed as before
 
     State       m_state{State::Unarmed};
     std::string m_status{"unarmed"};

--- a/src/impl/dash/coin/mn_diff_store.hpp
+++ b/src/impl/dash/coin/mn_diff_store.hpp
@@ -1,0 +1,1126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// ── MN DIFF/SNAPSHOT STORE — the dashd evodb list-diff mechanism, ported ──
+///
+/// dashd persists, for EVERY connected block, the per-block delta of the
+/// deterministic masternode list ("dmn_D4" keyed by blockHash,
+/// evo/deterministicmns.cpp:33,:689) plus a full list snapshot every
+/// DISK_SNAPSHOT_PERIOD=576 blocks ("dmn_S3", cpp:690), and reconstructs the
+/// list for ANY block by walking backward hash-by-hash to the nearest
+/// snapshot and replaying the stored diffs forward
+/// (GetListForBlockInternal, cpp:778-870). That store is why dashd never
+/// has a "payee-queue gap": any list at any height is reconstructable.
+///
+/// This file is that mechanism over OUR fold state (ReplayMNState,
+/// replay_fold_engine.hpp:184), written by the replay fold's per-block
+/// commit and read by the gap-repair path (mn_gap_repair.hpp).
+///
+/// Construct map (dashd → here):
+///   * DB_LIST_DIFF "dmn_D4" + blockHash      → 'D' + block_hash(32)
+///   * DB_LIST_SNAPSHOT "dmn_S3" + blockHash  → 'S' + block_hash(32)
+///     (value = the engine's snapshot-v3 payload, reused unchanged)
+///   * EVODB_BEST_BLOCK (evo/evodb.h, validation.cpp:2322/:2707)
+///     → 'B' sentinel written in the SAME batch as every 'D'
+///   * dmn_D3→D4 migration (cpp:958)          → 'F' format key,
+///     wipe-WHOLE-STORE on mismatch (never per-entry migration — the
+///     MnStateDb v1→v2 silently-skipped-rows defect is the counterexample,
+///     mn_state_db.hpp:200-207)
+///   * CDeterministicMNListDiff (deterministicmns.h:580) → MnListDiff
+///   * CDeterministicMNStateDiff bitmask, nVersion-first (dmnstate.h:155-260)
+///     → MnStateDiff
+///   * BuildDiff (cpp:361-395)                → MnListDiff::build
+///   * ApplyDiff throws on base-state mismatch (cpp:396-418)
+///     → MnListDiff::apply returns a fail-closed REFUSAL (a throw is never
+///       a skip; the contract is identical, only the vehicle differs)
+///   * diff.nHeight is memory-only, re-stamped from the walk on every read
+///     (cpp:697,:822) → NO height is stored in a 'D' record, ever. A trusted
+///     stored height silently diverges on reorged hashes.
+///
+/// Deliberate divergences from the mirror, each forced by our trust model:
+///   1. dashd defines "no snapshot AND no diff" as the initial EMPTY list
+///      (cpp:813-819) — sound only because its write is consensus-atomic
+///      with connect. Our store is populated by a P2P fold and CAN
+///      transiently miss rows, so a missing row is REPAIR-REFUSED, never an
+///      empty list. This is the single most important inversion and it is
+///      what keeps the wipe/demote fail-closed floor intact.
+///   2. Each 'D' record carries proof flags (root_matched, payee_verified),
+///      the block's committed merkleRootMNList, prev_hash (we have no
+///      CBlockIndex to walk) and a sha256d trailer. dashd trusts its rows
+///      because write==connect; ours must carry the license that produced
+///      them, checkable at repair time.
+///   3. UndoBlock evicts caches but keeps disk rows (cpp:736-769); we keep
+///      rows on reorg too — hash-keyed rows for orphaned blocks are
+///      harmless residue, and wiping diff history on reorg would destroy
+///      exactly what repair depends on. The reorg wipe cascade
+///      (set_on_sml_clear) is deliberately NOT wired to this store.
+///   4. mini-snapshots (cpp:832-847) and the mnListsCache/tip retention +
+///      cleanup machinery (cpp:850-956) are NOT ported: they are read-path
+///      cache economics for a hot GetListForBlock; our reconstruct runs
+///      rarely (gap repair), bounded ≤576 diff applies by the cadence.
+///   5. DB_LIST_REPAIRED (cpp:1239) is NOT ported: our startup verify is
+///      O(576) and the failure remedy (wipe + repopulate from the live
+///      fold) is idempotent and cheap — the store is an accelerator, never
+///      consensus-required; its absence degrades to today's wipe/demote.
+///
+/// Every record is written for EVERY root-matched folded block, EVEN WHEN
+/// THE DIFF IS EMPTY: the empty record is proof-of-processing. Skipping
+/// empties would make "no change at h" indistinguishable from "h was never
+/// folded" — the dashd gotcha, kept verbatim.
+
+#include <impl/dash/coin/replay_fold_engine.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/hash.hpp>
+#include <core/leveldb_store.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace replay {
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnStateDiff — mirror of dashd CDeterministicMNStateDiff (evo/dmnstate.h:155)
+// ═══════════════════════════════════════════════════════════════════════════
+/// Field bitmask over the STATE-level members of ReplayMNState — the same 19
+/// bits, same values, same member order as dashd's boost::hana member tuple
+/// (dmnstate.h:158-213). The DMN-level members (nType, internalId,
+/// collateralOutpoint, nOperatorReward) are immutable after registration in
+/// dashd (they live on CDeterministicMN, not CDeterministicMNState) and are
+/// therefore NOT diffable here either — they travel only in `added` entries.
+///
+/// Wire rule kept structurally even though our codec is not byte-compatible
+/// with evodb (persistence is internal-only, mn_state_db.hpp:35-38): fields
+/// whose wire format depends on the version serialize AFTER the version bit,
+/// and a diff that sets pubKeyOperator or netInfo without nVersion is
+/// invalid data (dmnstate.h:225-236 and the SERIALIZE_METHODS guard).
+struct MnStateDiff
+{
+    enum Field : uint32_t {
+        Field_nVersion                      = 0x0001,
+        Field_nRegisteredHeight             = 0x0002,
+        Field_nLastPaidHeight               = 0x0004,
+        Field_nPoSePenalty                  = 0x0008,
+        Field_nPoSeRevivedHeight            = 0x0010,
+        Field_nPoSeBanHeight                = 0x0020,
+        Field_nRevocationReason             = 0x0040,
+        Field_confirmedHash                 = 0x0080,
+        Field_confirmedHashWithProRegTxHash = 0x0100,
+        Field_keyIDOwner                    = 0x0200,
+        Field_pubKeyOperator                = 0x0400,
+        Field_keyIDVoting                   = 0x0800,
+        Field_netInfo                       = 0x1000,
+        Field_scriptPayout                  = 0x2000,
+        Field_scriptOperatorPayout          = 0x4000,
+        Field_nConsecutivePayments          = 0x8000,
+        Field_platformNodeID                = 0x10000,
+        Field_platformP2PPort               = 0x20000,
+        Field_platformHTTPPort              = 0x40000,
+    };
+    static constexpr uint32_t kAllFields = 0x7FFFF;
+
+    uint32_t      fields{0};
+    /// Only the members named by `fields` are valid — dashd reuses the state
+    /// class the same way (dmnstate.h:216-218).
+    ReplayMNState state;
+
+    MnStateDiff() = default;
+
+    /// dashd CDeterministicMNStateDiff(a, b) (dmnstate.h:221-241): record
+    /// every state member where b differs from a; pubKeyOperator/netInfo
+    /// changing forces the nVersion bit.
+    MnStateDiff(const ReplayMNState& a, const ReplayMNState& b)
+    {
+        auto take = [&](uint32_t mask, auto member) {
+            if (member(a) != member(b)) {
+                fields |= mask;
+            }
+        };
+        take(Field_nVersion,          [](const ReplayMNState& s) { return s.nVersion; });
+        take(Field_nRegisteredHeight, [](const ReplayMNState& s) { return s.nRegisteredHeight; });
+        take(Field_nLastPaidHeight,   [](const ReplayMNState& s) { return s.nLastPaidHeight; });
+        take(Field_nPoSePenalty,      [](const ReplayMNState& s) { return s.nPoSePenalty; });
+        take(Field_nPoSeRevivedHeight,[](const ReplayMNState& s) { return s.nPoSeRevivedHeight; });
+        take(Field_nPoSeBanHeight,    [](const ReplayMNState& s) { return s.nPoSeBanHeight; });
+        take(Field_nRevocationReason, [](const ReplayMNState& s) { return s.nRevocationReason; });
+        take(Field_confirmedHash,     [](const ReplayMNState& s) { return s.confirmedHash; });
+        take(Field_confirmedHashWithProRegTxHash,
+                                      [](const ReplayMNState& s) { return s.confirmedHashWithProRegTxHash; });
+        take(Field_keyIDOwner,        [](const ReplayMNState& s) { return s.keyIDOwner; });
+        take(Field_pubKeyOperator,    [](const ReplayMNState& s) { return s.pubKeyOperator; });
+        take(Field_keyIDVoting,       [](const ReplayMNState& s) { return s.keyIDVoting; });
+        if (a.netInfo.ip != b.netInfo.ip || a.netInfo.port_be != b.netInfo.port_be)
+            fields |= Field_netInfo;
+        if (a.scriptPayout.m_data != b.scriptPayout.m_data)
+            fields |= Field_scriptPayout;
+        if (a.scriptOperatorPayout.m_data != b.scriptOperatorPayout.m_data)
+            fields |= Field_scriptOperatorPayout;
+        take(Field_nConsecutivePayments,
+                                      [](const ReplayMNState& s) { return s.nConsecutivePayments; });
+        take(Field_platformNodeID,    [](const ReplayMNState& s) { return s.platformNodeID; });
+        take(Field_platformP2PPort,   [](const ReplayMNState& s) { return s.platformP2PPort; });
+        take(Field_platformHTTPPort,  [](const ReplayMNState& s) { return s.platformHTTPPort; });
+
+        if (fields != 0) state = b;   // masked members read from b's copy
+        // pubKeyOperator and netInfo need nVersion (dmnstate.h:237-241).
+        if ((fields & Field_pubKeyOperator) || (fields & Field_netInfo)) {
+            state.nVersion = b.nVersion;
+            fields |= Field_nVersion;
+        }
+    }
+
+    /// dashd CDeterministicMNState::ApplyDiff via UpdateMN: copy exactly the
+    /// masked members onto the target state; everything else keeps.
+    void apply_to(ReplayMNState& t) const
+    {
+        if (fields & Field_nVersion)                      t.nVersion = state.nVersion;
+        if (fields & Field_nRegisteredHeight)             t.nRegisteredHeight = state.nRegisteredHeight;
+        if (fields & Field_nLastPaidHeight)               t.nLastPaidHeight = state.nLastPaidHeight;
+        if (fields & Field_nPoSePenalty)                  t.nPoSePenalty = state.nPoSePenalty;
+        if (fields & Field_nPoSeRevivedHeight)            t.nPoSeRevivedHeight = state.nPoSeRevivedHeight;
+        if (fields & Field_nPoSeBanHeight)                t.nPoSeBanHeight = state.nPoSeBanHeight;
+        if (fields & Field_nRevocationReason)             t.nRevocationReason = state.nRevocationReason;
+        if (fields & Field_confirmedHash)                 t.confirmedHash = state.confirmedHash;
+        if (fields & Field_confirmedHashWithProRegTxHash) t.confirmedHashWithProRegTxHash = state.confirmedHashWithProRegTxHash;
+        if (fields & Field_keyIDOwner)                    t.keyIDOwner = state.keyIDOwner;
+        if (fields & Field_pubKeyOperator)                t.pubKeyOperator = state.pubKeyOperator;
+        if (fields & Field_keyIDVoting)                   t.keyIDVoting = state.keyIDVoting;
+        if (fields & Field_netInfo)                       t.netInfo = state.netInfo;
+        if (fields & Field_scriptPayout)                  t.scriptPayout = state.scriptPayout;
+        if (fields & Field_scriptOperatorPayout)          t.scriptOperatorPayout = state.scriptOperatorPayout;
+        if (fields & Field_nConsecutivePayments)          t.nConsecutivePayments = state.nConsecutivePayments;
+        if (fields & Field_platformNodeID)                t.platformNodeID = state.platformNodeID;
+        if (fields & Field_platformP2PPort)               t.platformP2PPort = state.platformP2PPort;
+        if (fields & Field_platformHTTPPort)              t.platformHTTPPort = state.platformHTTPPort;
+    }
+
+    /// Masked serialization, member order = dashd's tuple order, nVersion
+    /// FIRST (dmnstate.h "Bumped for nVersion-first format" — the very
+    /// reason dmn_D3 became dmn_D4).
+    void write_to(::PackStream& s) const
+    {
+        WriteCompactSize(s, fields);
+        if (fields & Field_nVersion)                      s << state.nVersion;
+        if (fields & Field_nRegisteredHeight)             s << state.nRegisteredHeight;
+        if (fields & Field_nLastPaidHeight)               s << state.nLastPaidHeight;
+        if (fields & Field_nPoSePenalty)                  s << state.nPoSePenalty;
+        if (fields & Field_nPoSeRevivedHeight)            s << state.nPoSeRevivedHeight;
+        if (fields & Field_nPoSeBanHeight)                s << state.nPoSeBanHeight;
+        if (fields & Field_nRevocationReason)             s << state.nRevocationReason;
+        if (fields & Field_confirmedHash)                 s << state.confirmedHash;
+        if (fields & Field_confirmedHashWithProRegTxHash) s << state.confirmedHashWithProRegTxHash;
+        if (fields & Field_keyIDOwner)                    s << state.keyIDOwner;
+        if (fields & Field_pubKeyOperator)
+            s.write(std::as_bytes(std::span{state.pubKeyOperator}));
+        if (fields & Field_keyIDVoting)                   s << state.keyIDVoting;
+        if (fields & Field_netInfo)                       s << state.netInfo;
+        if (fields & Field_scriptPayout)                  s << state.scriptPayout;
+        if (fields & Field_scriptOperatorPayout)          s << state.scriptOperatorPayout;
+        if (fields & Field_nConsecutivePayments)          s << state.nConsecutivePayments;
+        if (fields & Field_platformNodeID)                s << state.platformNodeID;
+        if (fields & Field_platformP2PPort)               s << state.platformP2PPort;
+        if (fields & Field_platformHTTPPort)              s << state.platformHTTPPort;
+    }
+
+    /// Throws std::ios_base::failure on malformed data (unknown bits, the
+    /// nVersion rule) — the caller converts to a whole-record refusal.
+    void read_from(::PackStream& s)
+    {
+        fields = static_cast<uint32_t>(ReadCompactSize(s));
+        if (fields & ~kAllFields)
+            throw std::ios_base::failure("MnStateDiff: unknown field bits");
+        // dashd SERIALIZE_METHODS guard (dmnstate.h:249-252), verbatim rule.
+        if (((fields & Field_pubKeyOperator) || (fields & Field_netInfo))
+            && !(fields & Field_nVersion))
+            throw std::ios_base::failure(
+                "Invalid data, nVersion unset when pubKeyOperator or netInfo set");
+        if (fields & Field_nVersion)                      s >> state.nVersion;
+        if (fields & Field_nRegisteredHeight)             s >> state.nRegisteredHeight;
+        if (fields & Field_nLastPaidHeight)               s >> state.nLastPaidHeight;
+        if (fields & Field_nPoSePenalty)                  s >> state.nPoSePenalty;
+        if (fields & Field_nPoSeRevivedHeight)            s >> state.nPoSeRevivedHeight;
+        if (fields & Field_nPoSeBanHeight)                s >> state.nPoSeBanHeight;
+        if (fields & Field_nRevocationReason)             s >> state.nRevocationReason;
+        if (fields & Field_confirmedHash)                 s >> state.confirmedHash;
+        if (fields & Field_confirmedHashWithProRegTxHash) s >> state.confirmedHashWithProRegTxHash;
+        if (fields & Field_keyIDOwner)                    s >> state.keyIDOwner;
+        if (fields & Field_pubKeyOperator)
+            s.read(std::as_writable_bytes(std::span{state.pubKeyOperator}));
+        if (fields & Field_keyIDVoting)                   s >> state.keyIDVoting;
+        if (fields & Field_netInfo)                       s >> state.netInfo;
+        if (fields & Field_scriptPayout)                  s >> state.scriptPayout;
+        if (fields & Field_scriptOperatorPayout)          s >> state.scriptOperatorPayout;
+        if (fields & Field_nConsecutivePayments)          s >> state.nConsecutivePayments;
+        if (fields & Field_platformNodeID)                s >> state.platformNodeID;
+        if (fields & Field_platformP2PPort)               s >> state.platformP2PPort;
+        if (fields & Field_platformHTTPPort)              s >> state.platformHTTPPort;
+    }
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnListDiff — mirror of dashd CDeterministicMNListDiff (deterministicmns.h)
+// ═══════════════════════════════════════════════════════════════════════════
+struct MnListDiff
+{
+    using Entries = DmlFoldEngine::Entries;
+
+    /// Sorted ASCENDING by internalId (BuildDiff, deterministicmns.cpp:383-386:
+    /// "added MNs need to be sorted by internalId so that these are added in
+    /// correct order when the diff is applied later; otherwise internalIds
+    /// will not match with the original list").
+    std::vector<std::pair<uint256, ReplayMNState>> added;
+    /// Keyed by internalId, exactly as dashd's updatedMNs map.
+    std::map<uint64_t, MnStateDiff>                updated;
+    /// internalIds, exactly as dashd's removedMns set.
+    std::set<uint64_t>                             removed;
+
+    bool empty() const
+    {
+        return added.empty() && updated.empty() && removed.empty();
+    }
+
+    /// dashd CDeterministicMNList::BuildDiff (deterministicmns.cpp:361-395),
+    /// including the removal-scan early-out arithmetic.
+    static MnListDiff build(const Entries& from, const Entries& to)
+    {
+        MnListDiff d;
+        for (const auto& [protx, to_st] : to) {
+            auto it = from.find(protx);
+            if (it == from.end()) {
+                d.added.emplace_back(protx, to_st);
+            } else {
+                MnStateDiff sd(it->second, to_st);
+                if (sd.fields) d.updated.emplace(to_st.internalId, std::move(sd));
+            }
+        }
+        if (from.size() + d.added.size() != to.size()) {
+            for (const auto& [protx, from_st] : from) {
+                if (to.find(protx) == to.end()) {
+                    d.removed.insert(from_st.internalId);
+                    if (from.size() + d.added.size() - d.removed.size()
+                            == to.size())
+                        break;
+                }
+            }
+        }
+        std::sort(d.added.begin(), d.added.end(),
+                  [](const auto& a, const auto& b) {
+                      return a.second.internalId < b.second.internalId;
+                  });
+        return d;
+    }
+
+    /// dashd CDeterministicMNList::ApplyDiff (deterministicmns.cpp:396-418)
+    /// with exception→refusal: any internalId miss, duplicate proTxHash /
+    /// internalId / collateralOutpoint refuses the WHOLE apply and the list
+    /// is left in an unspecified partial state the caller must DISCARD. The
+    /// contract is identical to dashd's throw — a refusal is never a skip;
+    /// it is the tripwire for "diff applied to a list that is not its true
+    /// parent".
+    bool apply(Entries& list, std::string& err) const
+    {
+        err.clear();
+        std::map<uint64_t, uint256> by_id;
+        std::set<std::pair<uint256, uint32_t>> collaterals;
+        for (const auto& [protx, st] : list) {
+            by_id[st.internalId] = protx;
+            collaterals.emplace(st.collateralOutpoint.hash,
+                                st.collateralOutpoint.index);
+        }
+        // Order mirrors ApplyDiff: removed, added, updated.
+        for (uint64_t id : removed) {
+            auto it = by_id.find(id);
+            if (it == by_id.end()) {
+                err = "can't find a removed masternode, id=" + std::to_string(id);
+                return false;
+            }
+            auto lit = list.find(it->second);
+            collaterals.erase({lit->second.collateralOutpoint.hash,
+                               lit->second.collateralOutpoint.index});
+            list.erase(lit);
+            by_id.erase(it);
+        }
+        for (const auto& [protx, st] : added) {
+            // dashd AddMN's uniqueness proofs (deterministicmns.cpp:420-447):
+            // duplicate proTxHash, duplicate internalId, duplicate
+            // collateralOutpoint each throw there and refuse here. The other
+            // unique properties (netInfo entries, keys) are covered
+            // transitively by the caller's final SML-root check.
+            if (list.find(protx) != list.end()) {
+                err = "can't add a masternode with a duplicate proTxHash="
+                    + protx.GetHex().substr(0, 16);
+                return false;
+            }
+            if (by_id.find(st.internalId) != by_id.end()) {
+                err = "can't add a masternode with a duplicate internalId="
+                    + std::to_string(st.internalId);
+                return false;
+            }
+            if (!collaterals.emplace(st.collateralOutpoint.hash,
+                                     st.collateralOutpoint.index).second) {
+                err = "can't add a masternode with a duplicate "
+                      "collateralOutpoint (proTxHash="
+                    + protx.GetHex().substr(0, 16) + ")";
+                return false;
+            }
+            by_id[st.internalId] = protx;
+            list.emplace(protx, st);
+        }
+        for (const auto& [id, sd] : updated) {
+            auto it = by_id.find(id);
+            if (it == by_id.end()) {
+                err = "can't find an updated masternode, id=" + std::to_string(id);
+                return false;
+            }
+            sd.apply_to(list.at(it->second));
+        }
+        return true;
+    }
+
+    void write_to(::PackStream& s) const
+    {
+        WriteCompactSize(s, added.size());
+        for (const auto& [protx, st] : added) {
+            s << protx;
+            s << st;
+        }
+        WriteCompactSize(s, updated.size());
+        for (const auto& [id, sd] : updated) {
+            WriteCompactSize(s, id);
+            sd.write_to(s);
+        }
+        WriteCompactSize(s, removed.size());
+        for (uint64_t id : removed) WriteCompactSize(s, id);
+    }
+
+    void read_from(::PackStream& s)
+    {
+        added.clear(); updated.clear(); removed.clear();
+        const uint64_t na = ReadCompactSize(s);
+        for (uint64_t i = 0; i < na; ++i) {
+            uint256 protx;
+            ReplayMNState st;
+            s >> protx >> st;
+            added.emplace_back(protx, std::move(st));
+        }
+        const uint64_t nu = ReadCompactSize(s);
+        for (uint64_t i = 0; i < nu; ++i) {
+            const uint64_t id = ReadCompactSize(s);
+            MnStateDiff sd;
+            sd.read_from(s);
+            if (!updated.emplace(id, std::move(sd)).second)
+                throw std::ios_base::failure("MnListDiff: duplicate updated id");
+        }
+        const uint64_t nr = ReadCompactSize(s);
+        for (uint64_t i = 0; i < nr; ++i) {
+            if (!removed.insert(ReadCompactSize(s)).second)
+                throw std::ios_base::failure("MnListDiff: duplicate removed id");
+        }
+    }
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnDiffRecord — the 'D' row value
+// ═══════════════════════════════════════════════════════════════════════════
+/// One per folded block, keyed by that block's hash. Carries what dashd's row
+/// does NOT need to carry (see the header's divergence list): prev_hash for
+/// a CBlockIndex-free walk, the block's own committed merkleRootMNList, the
+/// proof flags of the fold that produced it, and a sha256d trailer
+/// (MnBridgeCursorStore digest posture — refuse-whole-record on mismatch).
+/// NO height field — the walker stamps height from the header-chain walk
+/// (dashd cpp:697,:822 rule, kept verbatim).
+struct MnDiffRecord
+{
+    static constexpr uint8_t kVersion           = 1;
+    static constexpr uint8_t kFlagRootMatched   = 0x01;
+    static constexpr uint8_t kFlagPayeeVerified = 0x02;
+
+    uint8_t    record_version{kVersion};
+    uint256    prev_hash;
+    uint256    merkle_root_mn_list;   // committed root from THIS block's CbTx
+    uint8_t    flags{0};
+    /// POST-block totalRegisteredCount — makes internalId assignment
+    /// restart-reproducible across a repair reseed. u64 mirroring the
+    /// engine's counter (the plan sketched u32; truncating a monotonic id
+    /// source is exactly the kind of silent wrap this store must not have).
+    uint64_t   total_registered_count{0};
+    MnListDiff diff;
+
+    bool root_matched() const   { return (flags & kFlagRootMatched) != 0; }
+    bool payee_verified() const { return (flags & kFlagPayeeVerified) != 0; }
+
+    std::vector<uint8_t> encode() const
+    {
+        ::PackStream s;
+        s << record_version;
+        s << prev_hash;
+        s << merkle_root_mn_list;
+        s << flags;
+        s << total_registered_count;
+        diff.write_to(s);
+        auto sp = s.get_span();
+        uint256 digest;
+        CHash256()
+            .Write(std::span<const unsigned char>(
+                reinterpret_cast<const unsigned char*>(sp.data()), sp.size()))
+            .Finalize(std::span<unsigned char>(digest.data(), 32));
+        s << digest;
+        auto full = s.get_span();
+        return std::vector<uint8_t>(
+            reinterpret_cast<const uint8_t*>(full.data()),
+            reinterpret_cast<const uint8_t*>(full.data()) + full.size());
+    }
+
+    /// Fail-closed decode: digest first, then version, then payload; any
+    /// trailing bytes refuse. On false the out-param is unspecified.
+    static bool decode(const std::vector<uint8_t>& bytes, MnDiffRecord& out,
+                       std::string& err)
+    {
+        err.clear();
+        if (bytes.size() < 1 + 32 + 32 + 1 + 8 + 3 + 32) {
+            err = "diff record too short (" + std::to_string(bytes.size())
+                + " bytes)";
+            return false;
+        }
+        const size_t payload_len = bytes.size() - 32;
+        uint256 want, got;
+        std::memcpy(want.data(), bytes.data() + payload_len, 32);
+        CHash256()
+            .Write(std::span<const unsigned char>(bytes.data(), payload_len))
+            .Finalize(std::span<unsigned char>(got.data(), 32));
+        if (want != got) {
+            err = "diff record digest mismatch — corrupted or truncated";
+            return false;
+        }
+        try {
+            std::vector<uint8_t> payload(bytes.begin(),
+                                         bytes.begin() + payload_len);
+            ::PackStream s(payload);
+            s >> out.record_version;
+            if (out.record_version != kVersion) {
+                err = "diff record version " + std::to_string(out.record_version)
+                    + " != supported " + std::to_string(kVersion);
+                return false;
+            }
+            s >> out.prev_hash;
+            s >> out.merkle_root_mn_list;
+            s >> out.flags;
+            s >> out.total_registered_count;
+            out.diff.read_from(s);
+            if (!s.empty()) {
+                err = "diff record carries trailing bytes — format drift";
+                return false;
+            }
+            return true;
+        } catch (const std::exception& ex) {
+            err = std::string("diff record deserialize failed: ") + ex.what();
+            return false;
+        }
+    }
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnDiffStore — the LevelDB store + the reconstruct walk
+// ═══════════════════════════════════════════════════════════════════════════
+class MnDiffStore
+{
+public:
+    /// dashd DISK_SNAPSHOT_PERIOD (evo/deterministicmns.cpp:690), verbatim.
+    static constexpr uint32_t kSnapshotPeriod = 576;
+    /// Store format version ('F'). Mismatch clears the WHOLE store — the
+    /// MnStateDb open() idiom (mn_state_db.hpp:207-230), never per-entry
+    /// migration.
+    static constexpr uint32_t kFormatVersion = 1;
+
+    /// PoW-validated header-chain lookup: hash -> (height, prev_hash).
+    /// nullopt = the hash is not on OUR chain; the walk refuses. The record's
+    /// own prev_hash is cross-checked against this at EVERY hop — the record
+    /// is self-spanning but never trusted alone.
+    using HeaderLookupFn = std::function<
+        std::optional<std::pair<uint32_t, uint256>>(const uint256& hash)>;
+
+    explicit MnDiffStore(const std::string& db_path,
+                         const ::core::LevelDBOptions& opts = {})
+        : m_store(db_path, opts) {}
+
+    bool open()
+    {
+        if (!m_store.open()) return false;
+        const uint32_t stored = load_u32(make_format_key());
+        if (stored != kFormatVersion) {
+            if (stored != 0 || !m_store.list_keys("D", /*limit=*/1).empty()
+                || !m_store.list_keys("S", /*limit=*/1).empty()) {
+                LOG_INFO << "[MN-DIFF-DB] format v" << stored << " -> v"
+                         << kFormatVersion
+                         << ": clearing WHOLE store (dmn_D3->D4 idiom — "
+                            "never per-entry migration); the live fold "
+                            "repopulates it";
+                if (!clear()) return false;
+            }
+            store_u32(make_format_key(), kFormatVersion);
+        }
+        load_best();
+        LOG_INFO << "[MN-DIFF-DB] opened best_height=" << m_best_height
+                 << " best_hash=" << m_best_hash.GetHex().substr(0, 16);
+        return true;
+    }
+
+    void close()        { m_store.close(); }
+    bool is_open() const { return m_store.is_open(); }
+
+    uint256  best_hash() const   { return m_best_hash; }
+    uint32_t best_height() const { return m_best_height; }
+
+    /// One folded block = one atomic batch: 'D' (+ optionally 'S') + 'B',
+    /// force-synced — money-path rows must survive a host blackout
+    /// (LevelDBOptions.sync_writes defaults false; HeaderBackfill precedent).
+    /// Mirrors dashd writing DB_LIST_DIFF and DB_LIST_SNAPSHOT inside the
+    /// same connect (deterministicmns.cpp:689-694) with EVODB_BEST_BLOCK
+    /// discipline (validation.cpp:2322).
+    bool put_block(const uint256& block_hash, uint32_t height,
+                   const MnDiffRecord& rec,
+                   const std::vector<uint8_t>* snapshot_bytes)
+    {
+        if (!m_store.is_open()) return false;
+        auto batch = m_store.create_batch();
+        batch.put(make_key('D', block_hash), rec.encode());
+        if (snapshot_bytes)
+            batch.put(make_key('S', block_hash), *snapshot_bytes);
+        batch.put(make_best_key(), encode_best(block_hash, height));
+        if (!batch.commit_sync()) {
+            LOG_WARNING << "[MN-DIFF-DB] put_block batch commit failed at h="
+                        << height;
+            return false;
+        }
+        m_best_hash   = block_hash;
+        m_best_height = height;
+        return true;
+    }
+
+    /// Standalone snapshot write (the SEED/anchor snapshot — dashd's "extra
+    /// snapshot after the initial-snapshot block", cpp:690-691 second
+    /// disjunct). The seed snapshot is what grounds every backward walk: our
+    /// inversion demands an explicit stored snapshot, never "row absent".
+    bool put_snapshot(const uint256& block_hash,
+                      const std::vector<uint8_t>& snapshot_bytes)
+    {
+        if (!m_store.is_open()) return false;
+        auto batch = m_store.create_batch();
+        batch.put(make_key('S', block_hash), snapshot_bytes);
+        return batch.commit_sync();
+    }
+
+    bool get_diff(const uint256& block_hash, MnDiffRecord& out,
+                  std::string& err)
+    {
+        std::vector<uint8_t> bytes;
+        if (!m_store.get(make_key('D', block_hash), bytes)) {
+            err = "no diff record for block "
+                + block_hash.GetHex().substr(0, 16);
+            return false;
+        }
+        return MnDiffRecord::decode(bytes, out, err);
+    }
+
+    bool has_diff(const uint256& block_hash)
+    {
+        return m_store.exists(make_key('D', block_hash));
+    }
+
+    bool has_snapshot(const uint256& block_hash)
+    {
+        return m_store.exists(make_key('S', block_hash));
+    }
+
+    bool get_snapshot(const uint256& block_hash, std::vector<uint8_t>& out)
+    {
+        return m_store.get(make_key('S', block_hash), out);
+    }
+
+    /// Every stored snapshot hash. Streaming (for_each_prefix) — list_keys
+    /// is capped at its limit param and a 576/day store blows past any cap
+    /// silently. A false return is fail-closed at the caller.
+    bool for_each_snapshot_hash(const std::function<bool(const uint256&)>& fn)
+    {
+        return m_store.for_each_prefix("S",
+            [&](const std::string& key, const std::vector<uint8_t>&) {
+                if (key.size() != 33) return true;   // not ours; skip
+                uint256 h;
+                std::memcpy(h.data(), key.data() + 1, 32);
+                return fn(h);
+            });
+    }
+
+    bool clear()
+    {
+        // Streaming enumerate + batched remove; list_keys' cap would leave
+        // rows behind silently on a store this write rate fills.
+        std::vector<std::string> keys;
+        if (!m_store.for_each_prefix("",
+                [&](const std::string& k, const std::vector<uint8_t>&) {
+                    keys.push_back(k);
+                    return true;
+                }))
+            return false;
+        auto batch = m_store.create_batch();
+        for (const auto& k : keys) batch.remove(k);
+        if (!batch.commit_sync()) return false;
+        m_best_hash   = uint256{};
+        m_best_height = 0;
+        LOG_INFO << "[MN-DIFF-DB] cleared (" << keys.size() << " rows)";
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // reconstruct — dashd GetListForBlockInternal (deterministicmns.cpp:
+    // 778-870) as a COLD repair path: backward hash-walk to the nearest
+    // snapshot, forward replay of the stored diffs, then verify.
+    // ─────────────────────────────────────────────────────────────────────
+    /// On success `out`/`out_total_registered` are the list AT `target_hash`
+    /// and the DIP-4 root of `out` equals the merkleRootMNList that block's
+    /// own cbTx committed. Refusals (false + err) are TOTAL — never a
+    /// partial list, never an empty-list default:
+    ///   * target not on our header chain
+    ///   * any missing 'D' or 'S' row on the path      (THE inversion:
+    ///     dashd's "initial empty list" default, cpp:813-819, is unsound
+    ///     for a P2P-fed store)
+    ///   * record digest / version mismatch
+    ///   * record prev_hash != the header chain's prev at that hop
+    ///   * walk depth > kSnapshotPeriod
+    ///   * any record on the path missing root_matched OR payee_verified —
+    ///     merkleRootMNList does not commit nLastPaidHeight (G9 semantics),
+    ///     so an unverified diff's queue-order claim is unprovable and
+    ///     poisons the whole range
+    ///   * any apply refusal (internalId miss, duplicate unique property)
+    ///   * final recomputed SML root != the committed root at target
+    ///
+    /// `skip_snapshot_at_target`: the startup pair-verify grounds the walk
+    /// one snapshot EARLIER so the newest snapshot is re-derived instead of
+    /// read (RecalculateAndRepairDiffs' VerifySnapshotPair analogue,
+    /// cpp:1130-1419, reduced to the newest pair).
+    bool reconstruct(const uint256& target_hash,
+                     const HeaderLookupFn& header_lookup,
+                     DmlFoldEngine::Entries& out,
+                     uint64_t& out_total_registered,
+                     std::string& err,
+                     bool skip_snapshot_at_target = false)
+    {
+        err.clear();
+        out.clear();
+        out_total_registered = 0;
+        if (!m_store.is_open()) { err = "diff store is not open"; return false; }
+        if (!header_lookup)     { err = "no header-chain lookup wired"; return false; }
+
+        // ── Backward walk (cpp:790-829, hash-keyed, CBlockIndex-free) ────
+        std::vector<std::pair<uint256, MnDiffRecord>> path; // newest→oldest
+        DmlFoldEngine base{FoldConfig{}};   // snapshot codec host, folds nothing
+        uint256 cur = target_hash;
+        for (;;) {
+            const auto hdr = header_lookup(cur);
+            if (!hdr) {
+                err = "block " + cur.GetHex().substr(0, 16)
+                    + " is not on our PoW-validated header chain — REFUSED";
+                return false;
+            }
+            const bool skip_snap =
+                skip_snapshot_at_target && cur == target_hash;
+            if (!skip_snap && has_snapshot(cur)) {
+                std::vector<uint8_t> bytes;
+                if (!get_snapshot(cur, bytes)) {
+                    err = "snapshot row for " + cur.GetHex().substr(0, 16)
+                        + " vanished between exists() and get() — REFUSED";
+                    return false;
+                }
+                std::string serr;
+                if (!base.load_snapshot(bytes, serr)) {
+                    err = "stored snapshot at " + cur.GetHex().substr(0, 16)
+                        + " failed to load: " + serr;
+                    return false;
+                }
+                if (base.block_hash() != cur) {
+                    err = "stored snapshot at " + cur.GetHex().substr(0, 16)
+                        + " claims block " + base.block_hash().GetHex().substr(0, 16)
+                        + " — key/payload divergence, REFUSED";
+                    return false;
+                }
+                break;
+            }
+            // ── THE FAIL-CLOSED INVERSION. dashd (cpp:813-819) treats "no
+            // snapshot AND no diff" as the initial EMPTY list — sound only
+            // when the write is consensus-atomic with connect. Ours is fed
+            // by a P2P fold that CAN transiently miss rows: a missing row
+            // is a GAP WE CANNOT REPAIR, never an empty list.
+            MnDiffRecord rec;
+            std::string derr;
+            if (!get_diff(cur, rec, derr)) {
+                err = "walk broken at " + cur.GetHex().substr(0, 16) + ": "
+                    + derr + " — a missing row is REPAIR-REFUSED, never an "
+                      "empty list (fail-closed inversion of dashd's initial-"
+                      "snapshot default)";
+                return false;
+            }
+            // Self-spanning but never trusted alone: the record's prev must
+            // BE the header chain's prev at this hop.
+            if (rec.prev_hash != hdr->second) {
+                err = "record prev_hash "
+                    + rec.prev_hash.GetHex().substr(0, 16)
+                    + " != header-chain prev "
+                    + hdr->second.GetHex().substr(0, 16) + " at "
+                    + cur.GetHex().substr(0, 16) + " — REFUSED";
+                return false;
+            }
+            // Whole-range proof-flag requirement (G9 semantics): a block
+            // whose payee the engine could not verify poisons the range.
+            if (!rec.root_matched() || !rec.payee_verified()) {
+                err = "record at " + cur.GetHex().substr(0, 16)
+                    + " lacks proof flags (root_matched="
+                    + std::to_string(rec.root_matched())
+                    + " payee_verified=" + std::to_string(rec.payee_verified())
+                    + ") — merkleRootMNList does not commit nLastPaidHeight, "
+                      "so an unverified diff cannot back a payment queue; "
+                      "REFUSED";
+                return false;
+            }
+            path.emplace_back(cur, std::move(rec));
+            if (path.size() > kSnapshotPeriod) {
+                err = "walk exceeded " + std::to_string(kSnapshotPeriod)
+                    + " diffs without hitting a snapshot — REFUSED";
+                return false;
+            }
+            cur = path.back().second.prev_hash;
+        }
+
+        // ── Forward replay, oldest-first (cpp:846-848) ───────────────────
+        out                  = base.entries();
+        out_total_registered = base.total_registered_count();
+        for (auto it = path.rbegin(); it != path.rend(); ++it) {
+            std::string aerr;
+            if (!it->second.diff.apply(out, aerr)) {
+                out.clear();
+                err = "diff apply REFUSED at " + it->first.GetHex().substr(0, 16)
+                    + ": " + aerr + " — diff applied to a list that is not "
+                      "its true parent";
+                return false;
+            }
+            out_total_registered = it->second.total_registered_count;
+        }
+
+        // ── Verify before trusting: DIP-4 SML root vs the committed root
+        // at target. This proves the SET; the ORDER (nLastPaidHeight) is
+        // licensed transitively by payee_verified on every constituent diff
+        // (checked above). Note the SML entry commits isValid, so consensus
+        // PoSe bans/revives inside the range ARE under this root.
+        uint256 committed;
+        if (!path.empty()) {
+            committed = path.front().second.merkle_root_mn_list;
+        } else {
+            // target IS the grounding snapshot. Prefer its own 'D' record's
+            // committed root when present; a seed-anchor snapshot without a
+            // 'D' row is digest-pinned and was written only after the
+            // engine's own root match — accepted on that license.
+            MnDiffRecord rec;
+            std::string derr;
+            if (get_diff(target_hash, rec, derr)) {
+                committed = rec.merkle_root_mn_list;
+            } else {
+                return true;
+            }
+        }
+        std::vector<vendor::CSimplifiedMNListEntry> ents;
+        ents.reserve(out.size());
+        for (const auto& [protx, st] : out)
+            ents.push_back(st.to_sml_entry(protx));
+        vendor::CSimplifiedMNList sml(std::move(ents));
+        const uint256 got = sml.CalcMerkleRoot();
+        if (got != committed) {
+            out.clear();
+            err = "reconstructed list re-hashes to " + got.GetHex()
+                + " but block " + target_hash.GetHex().substr(0, 16)
+                + " committed " + committed.GetHex()
+                + " — REFUSED (verify-then-trust)";
+            return false;
+        }
+        return true;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Startup verify — dashd VerifyBestBlock + VerifySnapshotPair, reduced
+    // ─────────────────────────────────────────────────────────────────────
+    /// Two checks, wipe-ALONE-and-repopulate on failure (our "reindex" is
+    /// cheap: the store is an accelerator, not consensus-required — its
+    /// absence degrades to today's wipe/demote floor):
+    ///   1. 'B' sentinel cross-check (validation.cpp:2322/:2707 posture):
+    ///      the last-written 'D' row must exist and decode.
+    ///   2. Newest-pair verify (RecalculateAndRepairDiffs /
+    ///      VerifySnapshotPair, cpp:1130-1419, scope-reduced to the NEWEST
+    ///      pair): re-derive the newest snapshot from the previous one via
+    ///      the stored diffs and require the reconstruction to succeed —
+    ///      which includes the SML-root equality at the newest snapshot's
+    ///      block. Verify-then-wipe, never verify-then-patch (dashd
+    ///      rebuilds diffs from raw blocks; we store no raw blocks).
+    /// Returns true when the store is usable (possibly after a wipe, which
+    /// is reported through `note`).
+    bool startup_verify(const HeaderLookupFn& header_lookup, std::string& note)
+    {
+        note.clear();
+        if (!m_store.is_open()) { note = "store not open"; return false; }
+
+        // (1) 'B' sentinel vs the rows it promises.
+        if (!m_best_hash.IsNull()) {
+            MnDiffRecord rec;
+            std::string derr;
+            if (!get_diff(m_best_hash, rec, derr)) {
+                note = "best-block sentinel names "
+                     + m_best_hash.GetHex().substr(0, 16)
+                     + " but its diff row is unusable (" + derr
+                     + ") — wiping store, live fold repopulates";
+                clear();
+                store_u32(make_format_key(), kFormatVersion);
+                return true;
+            }
+        }
+
+        // (2) newest snapshot pair, dated via the header chain (orphaned
+        // snapshots simply do not date and are skipped — hash-keyed rows
+        // for dead branches are harmless residue, cpp:736-769 posture).
+        if (!header_lookup) return true;
+        uint32_t best_h = 0, second_h = 0;
+        uint256  best, second;
+        bool have_best = false, have_second = false;
+        const bool scan_ok = for_each_snapshot_hash([&](const uint256& h) {
+            const auto e = header_lookup(h);
+            if (!e) return true;
+            if (!have_best || e->first > best_h) {
+                second_h = best_h; second = best; have_second = have_best;
+                best_h = e->first; best = h; have_best = true;
+            } else if (!have_second || e->first > second_h) {
+                second_h = e->first; second = h; have_second = true;
+            }
+            return true;
+        });
+        if (!scan_ok) {
+            note = "snapshot enumeration failed (store/iterator error) — "
+                   "wiping store, live fold repopulates";
+            clear();
+            store_u32(make_format_key(), kFormatVersion);
+            return true;
+        }
+        if (!have_best || !have_second) return true;   // <2 dated: nothing to pair-verify
+
+        DmlFoldEngine::Entries reconstructed;
+        uint64_t trc = 0;
+        std::string rerr;
+        if (!reconstruct(best, header_lookup, reconstructed, trc, rerr,
+                         /*skip_snapshot_at_target=*/true)) {
+            note = "newest snapshot pair FAILED verify (h="
+                 + std::to_string(second_h) + "->" + std::to_string(best_h)
+                 + "): " + rerr + " — wiping store, live fold repopulates";
+            clear();
+            store_u32(make_format_key(), kFormatVersion);
+            return true;
+        }
+        // Reconstruction reaching the ROOT equality at `best` already proves
+        // the pair agrees on every SML-committed field; compare the stored
+        // snapshot's full entries too (stricter than dashd's IsEqual — our
+        // diffs carry internalId explicitly, so full equality must hold).
+        std::vector<uint8_t> bytes;
+        DmlFoldEngine snap{FoldConfig{}};
+        std::string serr;
+        if (!get_snapshot(best, bytes) || !snap.load_snapshot(bytes, serr)) {
+            note = "newest snapshot unreadable after pair walk (" + serr
+                 + ") — wiping store, live fold repopulates";
+            clear();
+            store_u32(make_format_key(), kFormatVersion);
+            return true;
+        }
+        if (!(snap.entries() == reconstructed)
+            || snap.total_registered_count() != trc) {
+            note = "newest snapshot pair DISAGREES beyond the root (entry or "
+                   "counter drift) — wiping store, live fold repopulates";
+            clear();
+            store_u32(make_format_key(), kFormatVersion);
+            return true;
+        }
+        note = "newest snapshot pair verified (h=" + std::to_string(second_h)
+             + "->" + std::to_string(best_h) + ", "
+             + std::to_string(reconstructed.size()) + " MNs)";
+        return true;
+    }
+
+private:
+    ::core::LevelDBStore m_store;
+    uint256              m_best_hash;
+    uint32_t             m_best_height{0};
+
+    static std::string make_key(char prefix, const uint256& hash)
+    {
+        std::string k;
+        k.reserve(33);
+        k.push_back(prefix);
+        k.append(reinterpret_cast<const char*>(hash.data()), 32);
+        return k;
+    }
+    static std::string make_best_key()   { return std::string(1, 'B'); }
+    static std::string make_format_key() { return std::string(1, 'F'); }
+
+    uint32_t load_u32(const std::string& key)
+    {
+        std::vector<uint8_t> d;
+        if (!m_store.get(key, d) || d.size() < 4) return 0;
+        return uint32_t(d[0]) | (uint32_t(d[1]) << 8)
+             | (uint32_t(d[2]) << 16) | (uint32_t(d[3]) << 24);
+    }
+
+    void store_u32(const std::string& key, uint32_t v)
+    {
+        std::vector<uint8_t> d(4);
+        d[0] = uint8_t(v); d[1] = uint8_t(v >> 8);
+        d[2] = uint8_t(v >> 16); d[3] = uint8_t(v >> 24);
+        m_store.put(key, d);
+    }
+
+    static std::vector<uint8_t> encode_best(const uint256& hash, uint32_t h)
+    {
+        std::vector<uint8_t> d(36);
+        std::memcpy(d.data(), hash.data(), 32);
+        d[32] = uint8_t(h); d[33] = uint8_t(h >> 8);
+        d[34] = uint8_t(h >> 16); d[35] = uint8_t(h >> 24);
+        return d;
+    }
+
+    void load_best()
+    {
+        std::vector<uint8_t> d;
+        if (!m_store.get(make_best_key(), d) || d.size() < 36) return;
+        std::memcpy(m_best_hash.data(), d.data(), 32);
+        m_best_height = uint32_t(d[32]) | (uint32_t(d[33]) << 8)
+                      | (uint32_t(d[34]) << 16) | (uint32_t(d[35]) << 24);
+    }
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnDiffWriter — the write side (dashd ProcessBlock's store write, cpp:689)
+// ═══════════════════════════════════════════════════════════════════════════
+/// Hooks the fold consumer's per-block commit AFTER the root match succeeded
+/// (the only path that calls on_folded). Only the ENGINE produces records —
+/// the maintainer's live MnStateMachine path writes nothing (it holds
+/// neither ReplayMNState nor the roots).
+///
+/// Keeps a copy of the previous block's entries so BuildDiff has its
+/// oldList; dashd gets that for free from its COW lists
+/// (GetListForBlockInternal(pindex->pprev), cpp:689).
+class MnDiffWriter
+{
+public:
+    MnDiffWriter(MnDiffStore& store, const DmlFoldEngine& engine)
+        : m_store(store), m_engine(engine) {}
+
+    /// Arm at the engine's CURRENT (seeded) cursor: writes the seed/anchor
+    /// snapshot — dashd's extra snapshot at the initial-snapshot block
+    /// (cpp:690-691). Our backward walk must ground on an explicit stored
+    /// snapshot, never on "row absent", so this is what makes the very
+    /// first repair possible.
+    bool arm()
+    {
+        if (m_engine.block_hash().IsNull() || m_engine.size() == 0) {
+            LOG_WARNING << "[MN-DIFF-DB] writer NOT armed: engine has no "
+                           "seeded state";
+            return false;
+        }
+        const auto bytes = m_engine.save_snapshot();
+        if (!m_store.put_snapshot(m_engine.block_hash(), bytes)) {
+            LOG_WARNING << "[MN-DIFF-DB] writer NOT armed: seed snapshot "
+                           "write failed";
+            return false;
+        }
+        m_prev     = m_engine.entries();
+        m_prev_trc = m_engine.total_registered_count();
+        m_armed    = true;
+        LOG_INFO << "[MN-DIFF-DB] writer ARMED: seed snapshot at h="
+                 << m_engine.height() << " block "
+                 << m_engine.block_hash().GetHex().substr(0, 16)
+                 << " mns=" << m_engine.size();
+        return true;
+    }
+
+    bool armed() const { return m_armed; }
+
+    /// Called by the fold consumer for every block whose fold COMPLETED
+    /// (root self-check passed — fold_block only returns ok on equality).
+    /// Written UNCONDITIONALLY, even when the diff is empty: the empty
+    /// record is proof-of-processing (dashd gotcha, kept verbatim).
+    void on_folded(uint32_t height, const uint256& block_hash,
+                   const dash::coin::BlockType& block, const FoldResult& r)
+    {
+        if (!m_armed) return;
+        // The engine's cursor must BE the height just folded — a mismatch
+        // means this writer's oldList is not the true parent, and a wrong
+        // parent produces a wrong diff. Disarm; a disarmed writer leaves a
+        // missing row, which every reader REFUSES on (fail-closed).
+        if (m_engine.height() != height) {
+            LOG_WARNING << "[MN-DIFF-DB] writer DISARMED at h=" << height
+                        << ": engine cursor h=" << m_engine.height()
+                        << " is not the folded height — refusing to write a "
+                           "diff off a wrong parent";
+            m_armed = false;
+            return;
+        }
+        MnDiffRecord rec;
+        rec.prev_hash           = block.m_previous_block;
+        rec.merkle_root_mn_list = r.committed_root;
+        rec.flags               = MnDiffRecord::kFlagRootMatched;
+        if (r.payee_paid_verified)
+            rec.flags |= MnDiffRecord::kFlagPayeeVerified;
+        rec.total_registered_count = m_engine.total_registered_count();
+        rec.diff = MnListDiff::build(m_prev, m_engine.entries());
+
+        // Snapshot cadence: height % 576 == 0 (DISK_SNAPSHOT_PERIOD,
+        // cpp:690). The seed snapshot was written by arm().
+        std::vector<uint8_t> snap;
+        const bool want_snap = (height % MnDiffStore::kSnapshotPeriod) == 0;
+        if (want_snap) snap = m_engine.save_snapshot();
+
+        if (!m_store.put_block(block_hash, height, rec,
+                               want_snap ? &snap : nullptr)) {
+            LOG_WARNING << "[MN-DIFF-DB] write failed at h=" << height
+                        << " — writer DISARMED (a hole in the store refuses "
+                           "at read time; it never fakes continuity)";
+            m_armed = false;
+            return;
+        }
+        ++m_written;
+        if (want_snap) ++m_snapshots;
+        m_prev     = m_engine.entries();
+        m_prev_trc = m_engine.total_registered_count();
+    }
+
+    uint64_t written()   const { return m_written; }
+    uint64_t snapshots() const { return m_snapshots; }
+
+private:
+    MnDiffStore&           m_store;
+    const DmlFoldEngine&   m_engine;
+    DmlFoldEngine::Entries m_prev;
+    uint64_t               m_prev_trc{0};
+    bool                   m_armed{false};
+    uint64_t               m_written{0};
+    uint64_t               m_snapshots{0};
+};
+
+} // namespace replay
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_gap_repair.hpp
+++ b/src/impl/dash/coin/mn_gap_repair.hpp
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// The GAP-REPAIR seam shared by the two payee-queue gap handlers
+/// (CoinStateMaintainer::on_block_connected and
+/// MnCheckpointLane::on_block_connected).
+///
+/// dashd never needs this seam because its diff store is written
+/// consensus-atomically with block connect (evo/deterministicmns.cpp:689
+/// writes DB_LIST_DIFF inside ProcessBlock) and any list for any block is
+/// reconstructable on demand via GetListForBlockInternal
+/// (evo/deterministicmns.cpp:778-870). Our payee queue is fed by a P2P fold,
+/// so a gap (blocks mined while the machine was not folding) historically
+/// had exactly one remedy: wipe + demote + authoritative re-seed. This seam
+/// lets the caller ASK for the list at a specific height, reconstructed from
+/// the MnDiffStore (mn_diff_store.hpp) — the ported analogue of dashd's
+/// snapshot+diff walk — before paying the wipe.
+///
+/// The function is injected (main_dash wires it to
+/// MnDiffStore::reconstruct + the PoW-validated header chain); when absent
+/// or refusing, callers execute their pre-existing fail-closed path
+/// UNCHANGED. Repair only ever ADDS a lane in front of the wipe.
+
+#include <impl/dash/coin/mn_state_db.hpp>   // dash::coin::MNState
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// The `source` token a diff-store gap repair publishes under. The source is
+/// the classification of PROVENANCE (the queue was reconstructed from stored
+/// root-checked fold outputs), never inferred from flags — same rule as the
+/// kPayeeSource* tokens in replay_payee_publish.hpp.
+inline constexpr const char* kPayeeSourceMnDiffRepair = "mn-diff-repair";
+
+/// Result of a gap-repair ask. `ok` is true ONLY when `entries` is the
+/// reconstructed, root-verified masternode list AS OF `as_of` (the height the
+/// caller asked for). Any refusal carries the blocking condition in `error`
+/// and the caller falls through to its unchanged wipe/fail_closed path.
+struct MnGapRepairResult
+{
+    bool        ok{false};
+    uint32_t    as_of{0};
+    std::vector<std::pair<uint256, MNState>> entries;
+    std::string error;
+};
+
+/// want_height -> the list AT want_height (i.e. after folding block
+/// want_height), or a refusal. Callers ask for H-1 when a gap fires at
+/// incoming block H.
+using MnGapRepairFn = std::function<MnGapRepairResult(uint32_t want_height)>;
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -446,6 +446,10 @@ public:
         // set is reloaded. Leaving it would let a re-armed lane re-adjudicate
         // an old height against a new set.
         m_pending = PendingPayeeAdjudication{};
+        // The unmeasured-revive ordering ledger describes THESE entries; a
+        // reload retires it for the same reason the ban-state measurement is
+        // retired above.
+        m_unmeasured_revive_at.clear();
         for (auto& [h, st] : entries) {
             m_collateral_index[st.collateralOutpoint] = h;
             m_entries.emplace(h, std::move(st));
@@ -471,6 +475,25 @@ public:
     {
         return m_ban_state_measured_at != 0
             && m_ban_state_measured_at + 1 == height;
+    }
+
+    /// Declare the PoSe ban state of THIS set measured as-of `height` — the
+    /// same fact sync_validity_from_sml() records, but for a set loaded from
+    /// the diff store instead of folded from a fetched SML.
+    ///
+    /// The diff store's reconstruct() only ever returns a list that RE-HASHES
+    /// to the block's committed merkleRootMNList (mn_diff_store.hpp:849-857),
+    /// and the SML entry commits isValid — so a store-reconstructed list AT
+    /// `height` carries dashd's own pre-block ban state at `height`, exactly
+    /// what a fetched height-exact snapshot would. load() clears
+    /// m_ban_state_measured_at (the measurement described the OLD entries), so
+    /// a store-sourced load must re-assert it or ban_state_measured_for()
+    /// stays false and the caller wastes a network probe on a set it already
+    /// measured. Reward-safe by construction: a wrong store row cannot reach
+    /// here — it is REFUSED at reconstruct() before load() is ever called.
+    void mark_ban_state_measured(uint32_t height)
+    {
+        m_ban_state_measured_at = height;
     }
 
     /// The proTxHashes in `block` whose revive outcome this machine cannot
@@ -1034,6 +1057,42 @@ public:
             return false;
         };
 
+        // ── ORDERING-REPAIR fast path. The exclusion walk only ever
+        // attributes to a RUNNER-UP, after demoting a banned head — it cannot
+        // accept a head that is itself the correct paid payee. But when the
+        // mismatch was a queue-ORDERING artifact (a ProUpServTx-revive applied
+        // with the ban unmeasured, since repaired and re-sorted by
+        // repair_unmeasured_revive_ordering()), the projected head is now the
+        // masternode dashd actually paid — there is nothing to exclude. If the
+        // (re-sorted) head's scriptPayout IS paid by this coinbase and the
+        // height-exact list does not attest it INVALID, attribute the payment
+        // to it directly, exactly as a clean apply_block pass-3 would. On a
+        // genuine PoSe-ban desync the head is NOT paid (that is why it
+        // mismatched), so this is skipped and the exclusion walk runs
+        // unchanged.
+        if (!m_pending.ranked.empty()) {
+            auto hit = m_entries.find(m_pending.ranked.front());
+            if (hit != m_entries.end()
+                && paid_in_cb(hit->second.scriptPayout.m_data)) {
+                const std::optional<bool> ha = attest(m_pending.ranked.front());
+                if (!ha.has_value() || *ha) {
+                    mark_paid_entry(hit, height);
+                    out.recovered = true;
+                    out.accepted  = m_pending.ranked.front();
+                    LOG_WARNING
+                        << "[MNS-SM] ON-DEMAND RE-ADJUDICATION h=" << height
+                        << ": the projected payee "
+                        << out.accepted->GetHex().substr(0, 16)
+                        << " is itself paid by this coinbase after the"
+                           " revive-height ORDERING repair re-sorted the queue"
+                           " — the mismatch was a queue-position artifact, not a"
+                           " ban. Payment attributed to it; no exclusion needed.";
+                    m_pending = PendingPayeeAdjudication{};
+                    return out;
+                }
+            }
+        }
+
         const WalkOutcome w =
             walk_to_paid_candidate(m_pending.ranked, attest, paid_in_cb);
         if (!w.accepted) {
@@ -1067,6 +1126,101 @@ public:
                        " height.";
         m_pending = PendingPayeeAdjudication{};
         return out;
+    }
+
+    /// ─────────────────────────────────────────────────────────────────────
+    /// repair_unmeasured_revive_ordering — the ORDERING arm of the on-demand
+    /// PoSe repair (mainnet h=2516072, proTx f513574b70a029ef)
+    /// ─────────────────────────────────────────────────────────────────────
+    ///
+    /// readjudicate_payee re-decides EXCLUSION (ban/valid) and NEVER ORDERING.
+    /// A masternode revived by a ProUpServTx this machine applied while the
+    /// pre-block ban state was UNMEASURED keeps nPoSeRevivedHeight=0, so
+    /// payee_score() sorts it by its stale nLastPaidHeight — ~one queue length
+    /// too early — and it stays the projected head even after the height-exact
+    /// masternode list (correctly) attests it VALID. That is the fail-closed
+    /// WEDGE the exclusion-only re-adjudication cannot repair: the projected
+    /// candidate is attested valid, so nothing is demoted, and the mismatch
+    /// SURVIVES the fold.
+    ///
+    /// dashd's BuildNewListFromBlock applies CDeterministicMNState::Revive(h)
+    /// on a ProUpServTx whenever the masternode IsBanned() pre-block
+    /// (specialtxman.cpp:361-370), setting nPoSeRevivedHeight = the ProUpServTx
+    /// height. The masternode list dated EXACTLY at the mismatch height (the
+    /// one begin_ondemand_fold fetched and DIP-4 client-verified) IS dashd's
+    /// own answer to "was it banned when the revive landed": if it attests the
+    /// masternode VALID here, the revive DID happen, so we write the SAME
+    /// nPoSeRevivedHeight dashd wrote — the height we OBSERVED the ProUpServTx
+    /// at — and re-sort the pending queue. Nothing is guessed: the height is
+    /// recorded from the block, and it is applied only under height-exact
+    /// confirmation. A list that attests INVALID or is silent licenses nothing
+    /// (the exclusion walk owns that case). Returns the number of masternodes
+    /// whose ordering was repaired.
+    ///
+    /// Call BETWEEN apply_fold() and readjudicate_payee() on the on-demand
+    /// path: the fold reconciles ban/valid, this repairs the queue position,
+    /// and the walk then adjudicates against the queue dashd actually holds.
+    size_t repair_unmeasured_revive_ordering(
+        const vendor::CSimplifiedMNList& sml)
+    {
+        if (m_unmeasured_revive_at.empty()) return 0;
+        std::map<uint256, bool> attested;
+        for (const auto& e : sml.mnList) attested[e.proRegTxHash] = e.isValid;
+
+        size_t repaired = 0;
+        for (auto pit = m_unmeasured_revive_at.begin();
+             pit != m_unmeasured_revive_at.end(); ) {
+            const uint256& protx    = pit->first;
+            const uint32_t revive_h = pit->second;
+            auto ait = attested.find(protx);
+            auto eit = m_entries.find(protx);
+            // Repair ONLY when the height-exact list ATTESTS VALID (the revive
+            // really happened) AND we still hold the entry. Absent, invalid, or
+            // spent: leave the ledger entry and let the exclusion walk decide.
+            if (ait == attested.end() || !ait->second
+                || eit == m_entries.end()) { ++pit; continue; }
+            if (revive_h > eit->second.nPoSeRevivedHeight) {
+                eit->second.nPoSeRevivedHeight = revive_h;
+                eit->second.nPoSeBanHeight     = 0;
+                eit->second.isValid            = true;
+                ++repaired;
+                LOG_WARNING
+                    << "[MNS-SM] ORDERING REPAIR: proTx "
+                    << protx.GetHex().substr(0, 16)
+                    << " revived by a ProUpServTx at h=" << revive_h
+                    << " that this set applied with the ban UNMEASURED"
+                       " (nPoSeRevivedHeight stayed 0). The masternode list"
+                       " dated EXACTLY at the mismatch height attests it VALID,"
+                       " so the revive is confirmed: writing"
+                       " nPoSeRevivedHeight=" << revive_h
+                    << " (dashd's own value) and re-sorting the payee queue.";
+            }
+            pit = m_unmeasured_revive_at.erase(pit);
+        }
+
+        // Re-sort the PENDING queue by the corrected scores so the on-demand
+        // re-adjudication walks the queue dashd holds, not the mis-ordered one
+        // captured before the repair. The revived masternode drops to its true
+        // slot; the candidate dashd actually pays rises to the head.
+        if (repaired && m_pending.present) {
+            std::stable_sort(
+                m_pending.ranked.begin(), m_pending.ranked.end(),
+                [this](const uint256& a, const uint256& b) {
+                    auto ia = m_entries.find(a);
+                    auto ib = m_entries.find(b);
+                    const int sa = (ia == m_entries.end())
+                        ? std::numeric_limits<int>::max()
+                        : payee_score(ia->second);
+                    const int sb = (ib == m_entries.end())
+                        ? std::numeric_limits<int>::max()
+                        : payee_score(ib->second);
+                    return payee_order_before(sa, a, sb, b);
+                });
+            m_pending.projected = m_pending.ranked.empty()
+                ? std::optional<uint256>{}
+                : std::optional<uint256>{m_pending.ranked.front()};
+        }
+        return repaired;
     }
 
     // Process a single block. Mutates state per dashcore's
@@ -1284,6 +1438,16 @@ public:
                     // missed one, and both have been measured on mainnet.
                     ++r.revive_unmeasured;
                     r.revive_unmeasured_protx.push_back(ptx.proTxHash);
+                    // Remember WHERE dashd would have written nPoSeRevivedHeight
+                    // so the on-demand fold can reproduce it forward. dashd's
+                    // BuildNewListFromBlock sets it to THIS ProUpServTx height
+                    // (specialtxman.cpp:361-370); we cannot decide the gate now
+                    // (ban state unmeasured), but if a height-exact list later
+                    // attests this masternode VALID the revive DID happen, and
+                    // this is the height it happened at. This is the single
+                    // dashd write the unmeasured path drops — recorded, not
+                    // guessed, and applied only under height-exact confirmation.
+                    m_unmeasured_revive_at[ptx.proTxHash] = height;
                     LOG_WARNING
                         << "[MNS-SM] ProUpServTx h=" << height << " for proTx "
                         << ptx.proTxHash.GetHex().substr(0, 16)
@@ -1851,6 +2015,16 @@ private:
     // 0 = the ban state in this set has NEVER been measured against a dated
     // list; it is whatever the seed carried plus whatever transactions moved.
     uint32_t m_ban_state_measured_at{0};
+
+    // proTxHash -> ProUpServTx height for every revive this machine applied
+    // with the pre-block ban state UNMEASURED (apply_block case-2 else branch).
+    // dashd wrote nPoSeRevivedHeight = that height; we could not decide the
+    // gate, so nPoSeRevivedHeight stayed 0 and the projection drifted ~one
+    // queue length ahead. repair_unmeasured_revive_ordering() consumes this
+    // under height-exact confirmation. Transient (never persisted): a resume
+    // re-measures via the fold ladder, and a stale ledger must not license a
+    // revive-height write. Cleared by load().
+    std::map<uint256, uint32_t> m_unmeasured_revive_at;
 
     /// Walk every ProUpServTx in a block, in tx order, handing the caller the
     /// proTxHash it names. The pre-scan and the apply BOTH go through here so

--- a/src/impl/dash/coin/replay_fold_consumer.hpp
+++ b/src/impl/dash/coin/replay_fold_consumer.hpp
@@ -153,6 +153,18 @@ public:
         m_post_fold = std::move(h);
     }
 
+    /// ── The diff-store seam (mn_diff_store.hpp) ──────────────────────────
+    /// Invoked for every block whose fold COMPLETED — i.e. after the root
+    /// self-check passed and the counters above were credited. This is the
+    /// c2pool analogue of dashd writing DB_LIST_DIFF inside ProcessBlock
+    /// (evo/deterministicmns.cpp:689): the write rides the same per-block
+    /// commit that proved the state, so a record can never exist for a block
+    /// the fold did not verify. A refused/diverged fold never reaches this
+    /// sink (the divergence latch above returns first).
+    using DiffSink = std::function<void(uint32_t, const uint256&,
+                                        const BlockType&, const FoldResult&)>;
+    void set_diff_sink(DiffSink s) { m_diff_sink = std::move(s); }
+
     bool on_replay_block(uint32_t height, const uint256& hash,
                          const BlockType& block) override
     {
@@ -236,6 +248,7 @@ public:
         m_stats.collateral_spent += r.collateral_spent;
 
         if (m_post_fold) m_post_fold(height);
+        if (m_diff_sink) m_diff_sink(height, hash, block, r);
 
         if (m_utxo_sink && !m_utxo_sink(height, hash, block)) {
             // Tier-B is a DECORATION: its failure is reported but must never
@@ -311,6 +324,7 @@ private:
     UtxoSink          m_utxo_sink;
     BlockHook         m_pre_fold;
     std::function<void(uint32_t)> m_post_fold;
+    DiffSink          m_diff_sink;
     uint32_t          m_progress_every;
     FoldConsumerStats m_stats;
     std::chrono::steady_clock::time_point m_started;

--- a/src/impl/dash/coin/replay_payee_publish.hpp
+++ b/src/impl/dash/coin/replay_payee_publish.hpp
@@ -101,6 +101,25 @@ inline constexpr const char* kPayeeSourceReplayFold = "replay-fold";
 inline constexpr const char* kPayeeSourceDashdSeed  = "dashd-seed";
 inline constexpr const char* kPayeeSourceMnCkpt     = "mn-ckpt";
 
+/// ── THE G7 SPLIT (publisher half) ─────────────────────────────────────────
+/// G7 used to demand fold cursor == header tip EXACTLY. With the MN diff
+/// store (mn_diff_store.hpp) the consumer (CoinStateMaintainer::
+/// on_mn_list_update) now holds its own currency gate: it accepts a seed
+/// with as_of below the serve tip but arms SERVING only after catching the
+/// queue up to the tip from stored diffs — so the publisher may release a
+/// proven list within a small ε of the tip without a serve ever projecting
+/// a below-tip queue front. ε is deliberately tiny: the engine's live tail
+/// lags by seconds against a 2.5-minute block interval, and every block in
+/// the ε window must still be root+payee-verified in the diff store before
+/// the consumer arms. The consumer-side gate does NOT replace this guard —
+/// the cheap refusal stays here (the pre-existing consumer-side backstop,
+/// gap_detected, fires one block late at the cost of a serve window + wipe
+/// + one of 3 re-arms).
+/// NOT measured from soak data: 2 is a design bound (engine-tail-lag vs
+/// block interval); re-derive from the live tail-lag distribution before
+/// widening it.
+inline constexpr uint32_t kPublishEpsilon = 2;
+
 /// ReplayMNState (fold state, dashd's CDeterministicMNState field-for-field,
 /// -1 == NEVER) -> MNState (payee state, 0 == never, isValid derived).
 ///
@@ -251,17 +270,23 @@ inline ReplayPayeeGuard evaluate_payee_guard(const DmlFoldEngine&     engine,
     }
     // G7 — CURRENCY. A proven-correct list AS OF a height below the tip has
     // not seen the registrations, bans and payments in between; its queue
-    // front is stale and the coinbase it projects is wrong.
+    // front is stale and the coinbase it projects is wrong. The exact-tip
+    // demand is relaxed by kPublishEpsilon (see the constant's comment): the
+    // consumer's own currency gate holds serving until the queue cursor
+    // reaches the tip, so within ε the publish carries a correct-as-of
+    // snapshot the consumer completes from the diff store. The blocker keeps
+    // the "G7" 2-char prefix — the withheld-log dedup keys on it.
     if (tip_height == 0) {
         g.blocker = "G7 header-chain tip height unknown (0)";
         return g;
     }
-    if (g.fold_height < tip_height) {
-        g.blocker = "G7 fold is BEHIND the tip: fold h="
+    if (g.fold_height + kPublishEpsilon < tip_height) {
+        g.blocker = "G7 fold is BEHIND the tip beyond epsilon: fold h="
                   + std::to_string(g.fold_height) + ", tip h="
                   + std::to_string(tip_height) + " ("
                   + std::to_string(tip_height - g.fold_height)
-                  + " blocks to go)";
+                  + " blocks to go, epsilon="
+                  + std::to_string(kPublishEpsilon) + ")";
         return g;
     }
     // G8 — usability. An empty set is a set-gap (the maintainer demotes on it

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -826,7 +826,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # ReplayMNState->MNState dialect change, and the fail-closed guard — a
     # diverged, poisoned, unchecked or behind-the-tip fold must NOT publish.
     # Same allowlisted target, same #143 NOT_BUILT reason.
+    # Sixth TU (dashd evodb port): test_dash_mn_diff_store.cpp — the MN
+    # diff/snapshot store (coin/mn_diff_store.hpp): the dmn_D4/dmn_S3
+    # mechanism over ReplayMNState — CDeterministicMNStateDiff bitmask
+    # semantics, BuildDiff/ApplyDiff refusals, the GetListForBlockInternal
+    # backward-walk with the fail-closed missing-row inversion, 'F'
+    # wipe-on-mismatch and the startup newest-pair verify. Same allowlisted
+    # target, same #143 NOT_BUILT reason. Links leveldb (via core).
     add_executable(test_dash_mn_state test_dash_mn_state.cpp
+                   test_dash_mn_diff_store.cpp
                    test_dash_replay_fold.cpp
                    test_dash_replay_run.cpp
                    test_dash_replay_quorum_seam.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1132,7 +1132,14 @@ if (BUILD_TESTING AND GTest_FOUND)
     # CoinStateMaintainer: drives NodeCoinState off async tip/MN/mempool update
     # events (readiness gate: MN+tip required before publish). Same link set as
     # test_dash_node_coin_state -- header-only over the work_source selector set.
-    add_executable(test_dash_coin_state_maintainer test_dash_coin_state_maintainer.cpp)
+    # Second TU: test_dash_mn_gap_repair.cpp — the diff-store gap-repair seam
+    # (mn_gap_repair.hpp) at its money-path caller: an APPLY GAP against a
+    # MOVING tip repaired from real MnDiffStore rows byte-identical to a
+    # contiguous fold; the unrepairable-gap fail-closed floor (wipe + demote +
+    # re-seed ask) unchanged; and the consumer half of the G7 split (below-tip
+    # seed catch-up / refusal-to-arm). Links leveldb via core.
+    add_executable(test_dash_coin_state_maintainer test_dash_coin_state_maintainer.cpp
+                   test_dash_mn_gap_repair.cpp)
     target_link_libraries(test_dash_coin_state_maintainer PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -901,11 +901,37 @@ TEST(DashMnCheckpointE2e, NegativeControlAntiMintLatchBlocksUnseededArming)
     EXPECT_FALSE(state.populated())
         << "an unheighted masternode set must never arm the embedded arm";
 
-    // Positive control on the same object: the SAME set WITH its height arms it.
-    maint.on_mn_list_update(cp.entries, kAnchorHeight);
+    // Positive control on the same object: the SAME set WITH a height stamp
+    // arms it. Stamped AT the serve tip: the consumer currency gate (the G7
+    // split, coin_state_maintainer.hpp on_mn_list_update) refuses to arm
+    // SERVING off a seed whose as_of is below an already-known serve tip
+    // unless the diff-store catch-up (not wired in this rig) brings the
+    // cursor to the tip — a below-tip queue front must never back a template.
+    maint.on_mn_list_update(cp.entries, /*as_of_height=*/1519546);
     fire_tip();
     EXPECT_TRUE(state.populated())
-        << "a height-stamped authoritative snapshot must still arm normally";
+        << "a height-stamped authoritative snapshot at the serve tip must"
+           " still arm normally";
+
+    // The currency gate's own negative control: with the serve tip already
+    // known, a stale (below-tip) stamp must NOT arm serving — but the seed
+    // itself is STORED (refusal to arm is not a wipe, no reseed latch).
+    {
+        dash::coin::NodeCoinState st2;
+        dash::coin::CoinStateMaintainer m2{st2};
+        m2.set_require_seeded_mn_set(true);
+        m2.on_new_tip(/*prev_height=*/1519546, uint256S(kAnchorHash),
+                      /*bits_for_next=*/0x1d00ffff,
+                      /*mtp_at_tip=*/1751000000,
+                      TESTNET_PUBKEY_VER, TESTNET_P2SH_VER);
+        m2.on_mn_list_update(cp.entries, kAnchorHeight);   // 3 below the tip
+        EXPECT_FALSE(st2.populated())
+            << "a below-tip seed with no diff-store catch-up must not arm"
+               " serving";
+        EXPECT_EQ(st2.mnstates().size(), cp.entries.size())
+            << "the seed itself is STORED — refusal to arm is not a wipe";
+        EXPECT_FALSE(m2.mn_needs_reseed_latched());
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/test/test_dash_mn_diff_store.cpp
+++ b/test/test_dash_mn_diff_store.cpp
@@ -1,0 +1,632 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KATs for the MN diff/snapshot store (mn_diff_store.hpp) — the dashd evodb
+// dmn_D4/dmn_S3 mechanism (evo/deterministicmns.cpp:689-870) ported over
+// ReplayMNState. Coverage:
+//   * MnStateDiff bitmask semantics (dmnstate.h:155-260): masking, the
+//     nVersion-first rule, round-trip
+//   * MnListDiff build/apply (deterministicmns.cpp:361-418): added sorted by
+//     internalId, removal arithmetic, every ApplyDiff throw as a REFUSAL
+//   * MnDiffRecord codec: sha256d trailer, digest-corrupt refuse, empty diff
+//     is a real record (proof-of-processing)
+//   * MnDiffStore reconstruct (GetListForBlockInternal analogue): the
+//     snapshot+diff walk, the fail-closed inversion (missing row REFUSES,
+//     never an empty list), flag holes, orphaned-sibling disambiguation,
+//     depth bound, internalId reproduction via total_registered_count
+//   * 'F' wipe-on-mismatch (the dmn_D3->D4 idiom) and the startup verify
+//     ('B' sentinel cross-check + newest snapshot pair)
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mn_diff_store.hpp>
+#include <impl/dash/coin/replay_fold_engine.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/leveldb_store.hpp>
+#include <core/uint256.hpp>
+
+#include <cstring>
+#include <filesystem>
+#include <iterator>
+#include <map>
+#include <unistd.h>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace dash::coin::replay;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+
+namespace {
+
+uint256 h256(uint64_t v)
+{
+    uint256 h;
+    std::memset(h.data(), 0, 32);
+    std::memcpy(h.data(), &v, sizeof(v));
+    return h;
+}
+
+ReplayMNState make_state(uint64_t i)
+{
+    ReplayMNState st;
+    st.internalId              = i;
+    st.collateralOutpoint.hash = h256(0x10000 + i);
+    st.collateralOutpoint.index = 1;
+    st.nRegisteredHeight       = static_cast<int32_t>(1000 + i);
+    st.nLastPaidHeight         = static_cast<int32_t>(2000 + i);
+    st.keyIDOwner              = uint160{};
+    st.pubKeyOperator[0]       = static_cast<uint8_t>(0x40 + i);
+    st.netInfo.ip[15]          = static_cast<uint8_t>(i + 1);
+    st.netInfo.port_be         = 9999;
+    st.scriptPayout.m_data     = {0x76, 0xa9, 0x14, static_cast<uint8_t>(i),
+                                  0x88, 0xac};
+    return st;
+}
+
+DmlFoldEngine::Entries make_list(size_t n)
+{
+    DmlFoldEngine::Entries e;
+    for (size_t i = 0; i < n; ++i) e.emplace(h256(i + 1), make_state(i));
+    return e;
+}
+
+uint256 sml_root_of(const DmlFoldEngine::Entries& list)
+{
+    std::vector<CSimplifiedMNListEntry> ents;
+    ents.reserve(list.size());
+    for (const auto& [protx, st] : list) ents.push_back(st.to_sml_entry(protx));
+    CSimplifiedMNList sml(std::move(ents));
+    return sml.CalcMerkleRoot();
+}
+
+std::string fresh_db_dir(const char* name)
+{
+    const auto dir = std::filesystem::temp_directory_path()
+                   / ("c2pool_mn_diff_store_kat_" + std::string(name) + "_"
+                      + std::to_string(::getpid()));
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    return (dir / "db").string();
+}
+
+std::vector<uint8_t> record_bytes(const MnListDiff& d, const uint256& prev,
+                                  const uint256& root, uint8_t flags,
+                                  uint64_t trc)
+{
+    MnDiffRecord rec;
+    rec.prev_hash              = prev;
+    rec.merkle_root_mn_list    = root;
+    rec.flags                  = flags;
+    rec.total_registered_count = trc;
+    rec.diff                   = d;
+    return rec.encode();
+}
+
+/// Synthetic hash-linked chain: hash(h) = h256(0xA00000 + h).
+uint256 chain_hash(uint32_t h) { return h256(0xA00000ull + h); }
+
+MnDiffStore::HeaderLookupFn synth_headers(uint32_t max_h)
+{
+    return [max_h](const uint256& hash)
+        -> std::optional<std::pair<uint32_t, uint256>> {
+        for (uint32_t h = 0; h <= max_h; ++h) {
+            if (chain_hash(h) == hash) {
+                return std::make_pair(
+                    h, h == 0 ? uint256{} : chain_hash(h - 1));
+            }
+        }
+        return std::nullopt;
+    };
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnStateDiff — the dashd bitmask semantics
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnDiffStore, StateDiffMasksExactlyTheChangedField)
+{
+    ReplayMNState a = make_state(1);
+    ReplayMNState b = a;
+    b.nLastPaidHeight = 777;
+    MnStateDiff d(a, b);
+    EXPECT_EQ(d.fields, MnStateDiff::Field_nLastPaidHeight);
+
+    // apply reproduces b from a
+    ReplayMNState t = a;
+    d.apply_to(t);
+    EXPECT_TRUE(t == b);
+
+    // codec round-trip
+    ::PackStream s;
+    d.write_to(s);
+    auto sp = s.get_span();
+    std::vector<uint8_t> bytes(
+        reinterpret_cast<const uint8_t*>(sp.data()),
+        reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+    ::PackStream in(bytes);
+    MnStateDiff d2;
+    d2.read_from(in);
+    EXPECT_EQ(d2.fields, d.fields);
+    ReplayMNState t2 = a;
+    d2.apply_to(t2);
+    EXPECT_TRUE(t2 == b);
+}
+
+TEST(DashMnDiffStore, StateDiffNetInfoAndOperatorKeyForceVersionBit)
+{
+    // dashd dmnstate.h:237-241: pubKeyOperator/netInfo need nVersion.
+    {
+        ReplayMNState a = make_state(1), b = a;
+        b.netInfo.port_be = 12345;
+        MnStateDiff d(a, b);
+        EXPECT_TRUE(d.fields & MnStateDiff::Field_netInfo);
+        EXPECT_TRUE(d.fields & MnStateDiff::Field_nVersion);
+    }
+    {
+        ReplayMNState a = make_state(1), b = a;
+        b.pubKeyOperator[5] = 0xEE;
+        MnStateDiff d(a, b);
+        EXPECT_TRUE(d.fields & MnStateDiff::Field_pubKeyOperator);
+        EXPECT_TRUE(d.fields & MnStateDiff::Field_nVersion);
+    }
+    // The deser guard refuses the invalid combination (dashd throws the same).
+    {
+        ::PackStream s;
+        WriteCompactSize(s, MnStateDiff::Field_netInfo);   // no nVersion bit
+        auto sp = s.get_span();
+        std::vector<uint8_t> bytes(
+            reinterpret_cast<const uint8_t*>(sp.data()),
+            reinterpret_cast<const uint8_t*>(sp.data()) + sp.size());
+        ::PackStream in(bytes);
+        MnStateDiff d;
+        EXPECT_THROW(d.read_from(in), std::ios_base::failure);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// MnListDiff — BuildDiff/ApplyDiff (deterministicmns.cpp:361-418)
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnDiffStore, ListDiffBuildApplyRoundTrip)
+{
+    auto from = make_list(3);                       // internalIds 0,1,2
+    auto to   = from;
+    to.erase(h256(3));                              // remove internalId 2
+    to.at(h256(2)).nLastPaidHeight = 555;           // update internalId 1
+    ReplayMNState add_b = make_state(9);            // internalId 9
+    ReplayMNState add_a = make_state(8);            // internalId 8
+    to.emplace(h256(20), add_b);
+    to.emplace(h256(21), add_a);
+
+    auto d = MnListDiff::build(from, to);
+    ASSERT_EQ(d.added.size(), 2u);
+    // sorted ASCENDING by internalId (deterministicmns.cpp:383-386)
+    EXPECT_EQ(d.added[0].second.internalId, 8u);
+    EXPECT_EQ(d.added[1].second.internalId, 9u);
+    ASSERT_EQ(d.updated.size(), 1u);
+    EXPECT_EQ(d.updated.begin()->first, 1u);
+    ASSERT_EQ(d.removed.size(), 1u);
+    EXPECT_EQ(*d.removed.begin(), 2u);
+
+    // encode through the record codec and back
+    auto bytes = record_bytes(d, chain_hash(0), sml_root_of(to),
+                              MnDiffRecord::kFlagRootMatched
+                                  | MnDiffRecord::kFlagPayeeVerified,
+                              10);
+    MnDiffRecord rec;
+    std::string err;
+    ASSERT_TRUE(MnDiffRecord::decode(bytes, rec, err)) << err;
+
+    auto applied = from;
+    ASSERT_TRUE(rec.diff.apply(applied, err)) << err;
+    EXPECT_TRUE(applied == to);
+}
+
+TEST(DashMnDiffStore, EmptyDiffIsARealRecord)
+{
+    // The empty record is proof-of-processing: skipping empties turns "no
+    // change at h" into an indistinguishable gap (the dashd gotcha).
+    auto list = make_list(2);
+    auto d = MnListDiff::build(list, list);
+    EXPECT_TRUE(d.empty());
+    auto bytes = record_bytes(d, chain_hash(0), sml_root_of(list),
+                              MnDiffRecord::kFlagRootMatched
+                                  | MnDiffRecord::kFlagPayeeVerified,
+                              2);
+    MnDiffRecord rec;
+    std::string err;
+    ASSERT_TRUE(MnDiffRecord::decode(bytes, rec, err)) << err;
+    EXPECT_TRUE(rec.diff.empty());
+    auto applied = list;
+    ASSERT_TRUE(rec.diff.apply(applied, err)) << err;
+    EXPECT_TRUE(applied == list);
+}
+
+TEST(DashMnDiffStore, RecordDigestCorruptionRefuses)
+{
+    auto list = make_list(2);
+    auto d = MnListDiff::build(make_list(1), list);
+    auto bytes = record_bytes(d, chain_hash(0), sml_root_of(list), 3, 2);
+    bytes[bytes.size() / 2] ^= 0xFF;
+    MnDiffRecord rec;
+    std::string err;
+    EXPECT_FALSE(MnDiffRecord::decode(bytes, rec, err));
+    EXPECT_NE(err.find("digest"), std::string::npos) << err;
+}
+
+TEST(DashMnDiffStore, ApplyRefusesEveryBaseStateMismatch)
+{
+    // dashd ApplyDiff THROWS on each of these (deterministicmns.cpp:396-447);
+    // ours refuses — a throw is never a skip.
+    auto base = make_list(2);   // internalIds 0,1
+    std::string err;
+
+    { // removed id not present
+        MnListDiff d;
+        d.removed.insert(77);
+        auto l = base;
+        EXPECT_FALSE(d.apply(l, err));
+        EXPECT_NE(err.find("removed"), std::string::npos) << err;
+    }
+    { // updated id not present
+        MnListDiff d;
+        d.updated.emplace(77, MnStateDiff{});
+        auto l = base;
+        EXPECT_FALSE(d.apply(l, err));
+        EXPECT_NE(err.find("updated"), std::string::npos) << err;
+    }
+    { // duplicate proTxHash
+        MnListDiff d;
+        d.added.emplace_back(h256(1), make_state(9));
+        auto l = base;
+        EXPECT_FALSE(d.apply(l, err));
+        EXPECT_NE(err.find("proTxHash"), std::string::npos) << err;
+    }
+    { // duplicate internalId
+        MnListDiff d;
+        d.added.emplace_back(h256(50), make_state(1));   // internalId 1 taken
+        auto l = base;
+        EXPECT_FALSE(d.apply(l, err));
+        EXPECT_NE(err.find("internalId"), std::string::npos) << err;
+    }
+    { // duplicate collateralOutpoint (unique-property violation)
+        MnListDiff d;
+        ReplayMNState st  = make_state(9);
+        st.collateralOutpoint = base.at(h256(1)).collateralOutpoint;
+        d.added.emplace_back(h256(50), st);
+        auto l = base;
+        EXPECT_FALSE(d.apply(l, err));
+        EXPECT_NE(err.find("collateralOutpoint"), std::string::npos) << err;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The store: format wipe, walk, refusals
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Writes a snapshot at h0 and diff records for h1..hN over a synthetic
+/// hash-linked chain, mutating the list once per block. Returns the final
+/// list per height.
+struct SynthChain
+{
+    std::vector<DmlFoldEngine::Entries> lists;   // index = height
+    uint64_t trc{0};
+
+    static SynthChain build(MnDiffStore& store, uint32_t n_blocks,
+                            uint8_t flags = MnDiffRecord::kFlagRootMatched
+                                          | MnDiffRecord::kFlagPayeeVerified,
+                            uint32_t skip_height = 0)
+    {
+        SynthChain c;
+        c.lists.push_back(make_list(3));
+        c.trc = 3;
+
+        // grounding snapshot at h0 (the seed/anchor row)
+        DmlFoldEngine eng{FoldConfig{}};
+        std::vector<std::pair<uint256, ReplayMNState>> seed;
+        for (const auto& [k, v] : c.lists[0]) seed.emplace_back(k, v);
+        eng.seed(std::move(seed), c.trc, 0, chain_hash(0));
+        EXPECT_TRUE(store.put_snapshot(chain_hash(0), eng.save_snapshot()));
+
+        for (uint32_t h = 1; h <= n_blocks; ++h) {
+            auto next = c.lists.back();
+            // one mutation per block, cycling add/update/remove
+            if (h % 3 == 1) {
+                ReplayMNState st = make_state(c.trc);
+                next.emplace(h256(0x900 + h), st);
+                ++c.trc;
+            } else if (h % 3 == 2) {
+                next.begin()->second.nLastPaidHeight =
+                    static_cast<int32_t>(3000 + h);
+            } else if (next.size() > 1) {
+                next.erase(std::prev(next.end()));
+            }
+            auto d = MnListDiff::build(c.lists.back(), next);
+            MnDiffRecord rec;
+            rec.prev_hash              = chain_hash(h - 1);
+            rec.merkle_root_mn_list    = sml_root_of(next);
+            rec.flags                  = flags;
+            rec.total_registered_count = c.trc;
+            rec.diff                   = d;
+            if (h != skip_height)
+                EXPECT_TRUE(store.put_block(chain_hash(h), h, rec, nullptr));
+            c.lists.push_back(std::move(next));
+        }
+        return c;
+    }
+};
+
+TEST(DashMnDiffStore, ReconstructWalksSnapshotPlusDiffs)
+{
+    MnDiffStore store(fresh_db_dir("walk"));
+    ASSERT_TRUE(store.open());
+    auto c = SynthChain::build(store, 5);
+
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    ASSERT_TRUE(store.reconstruct(chain_hash(5), synth_headers(5), out, trc,
+                                  err)) << err;
+    EXPECT_TRUE(out == c.lists[5]);
+    // internalId assignment restart-reproducible via the stored counter
+    EXPECT_EQ(trc, c.trc);
+
+    // ... and an interior height reconstructs to ITS list, not the tip's.
+    ASSERT_TRUE(store.reconstruct(chain_hash(3), synth_headers(5), out, trc,
+                                  err)) << err;
+    EXPECT_TRUE(out == c.lists[3]);
+}
+
+TEST(DashMnDiffStore, MissingMiddleRowRefusesNeverEmptyList)
+{
+    // THE fail-closed inversion: dashd's "no snapshot AND no diff => initial
+    // empty list" (deterministicmns.cpp:813-819) would silently ground the
+    // walk here; ours refuses.
+    MnDiffStore store(fresh_db_dir("hole"));
+    ASSERT_TRUE(store.open());
+    SynthChain::build(store, 5, MnDiffRecord::kFlagRootMatched
+                                    | MnDiffRecord::kFlagPayeeVerified,
+                      /*skip_height=*/3);
+
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    EXPECT_FALSE(store.reconstruct(chain_hash(5), synth_headers(5), out, trc,
+                                   err));
+    EXPECT_NE(err.find("REPAIR-REFUSED"), std::string::npos) << err;
+    EXPECT_TRUE(out.empty());
+}
+
+TEST(DashMnDiffStore, ProofFlagHoleRefusesWholeRange)
+{
+    // A single payee-unverified record poisons the range: merkleRootMNList
+    // does not commit nLastPaidHeight (G9 semantics).
+    MnDiffStore store(fresh_db_dir("flags"));
+    ASSERT_TRUE(store.open());
+    SynthChain::build(store, 4, MnDiffRecord::kFlagRootMatched); // no payee bit
+
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    EXPECT_FALSE(store.reconstruct(chain_hash(4), synth_headers(4), out, trc,
+                                   err));
+    EXPECT_NE(err.find("payee_verified"), std::string::npos) << err;
+}
+
+TEST(DashMnDiffStore, OrphanedSiblingRowDoesNotConfuseTheWalk)
+{
+    // Hash keying disambiguates same-height siblings (a reorged branch's
+    // rows are harmless residue — dashd UndoBlock keeps disk rows too).
+    MnDiffStore store(fresh_db_dir("sibling"));
+    ASSERT_TRUE(store.open());
+    auto c = SynthChain::build(store, 4);
+
+    // A sibling record at height 3 on a dead branch, keyed by a different
+    // hash, with garbage prev linkage.
+    MnDiffRecord orphan;
+    orphan.prev_hash           = h256(0xDEAD);
+    orphan.merkle_root_mn_list = h256(0xBEEF);
+    orphan.flags = MnDiffRecord::kFlagRootMatched
+                 | MnDiffRecord::kFlagPayeeVerified;
+    ASSERT_TRUE(store.put_block(h256(0xFACE), 3, orphan, nullptr));
+
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    ASSERT_TRUE(store.reconstruct(chain_hash(4), synth_headers(4), out, trc,
+                                  err)) << err;
+    EXPECT_TRUE(out == c.lists[4]);
+}
+
+TEST(DashMnDiffStore, RecordPrevHashMustMatchHeaderChain)
+{
+    // The record is self-spanning but never trusted alone: a record whose
+    // prev_hash disagrees with the PoW-validated header chain refuses.
+    MnDiffStore store(fresh_db_dir("prevmismatch"));
+    ASSERT_TRUE(store.open());
+    auto c = SynthChain::build(store, 2);
+
+    MnDiffRecord bad;
+    bad.prev_hash           = h256(0x666);      // NOT chain_hash(2)
+    bad.merkle_root_mn_list = sml_root_of(c.lists[2]);
+    bad.flags = MnDiffRecord::kFlagRootMatched
+              | MnDiffRecord::kFlagPayeeVerified;
+    bad.total_registered_count = c.trc;
+    ASSERT_TRUE(store.put_block(chain_hash(3), 3, bad, nullptr));
+
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    EXPECT_FALSE(store.reconstruct(chain_hash(3), synth_headers(3), out, trc,
+                                   err));
+    EXPECT_NE(err.find("header-chain prev"), std::string::npos) << err;
+}
+
+TEST(DashMnDiffStore, FinalRootMismatchRefuses)
+{
+    // verify-then-trust: the reconstructed list must re-hash to the root the
+    // target block committed.
+    MnDiffStore store(fresh_db_dir("rootbad"));
+    ASSERT_TRUE(store.open());
+    auto c = SynthChain::build(store, 2);
+
+    // h3's record claims a WRONG committed root.
+    auto next = c.lists[2];
+    next.begin()->second.nLastPaidHeight = 4444;
+    auto d = MnListDiff::build(c.lists[2], next);
+    MnDiffRecord rec;
+    rec.prev_hash              = chain_hash(2);
+    rec.merkle_root_mn_list    = h256(0x777);   // not sml_root_of(next)
+    rec.flags = MnDiffRecord::kFlagRootMatched
+              | MnDiffRecord::kFlagPayeeVerified;
+    rec.total_registered_count = c.trc;
+    rec.diff                   = d;
+    ASSERT_TRUE(store.put_block(chain_hash(3), 3, rec, nullptr));
+
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    EXPECT_FALSE(store.reconstruct(chain_hash(3), synth_headers(3), out, trc,
+                                   err));
+    EXPECT_NE(err.find("re-hashes"), std::string::npos) << err;
+}
+
+TEST(DashMnDiffStore, FormatMismatchWipesWholeStore)
+{
+    // The dmn_D3->D4 idiom: wipe-on-mismatch, never per-entry migration
+    // (the MnStateDb v1->v2 silently-skipped-rows counterexample).
+    const std::string dir = fresh_db_dir("format");
+    {
+        MnDiffStore store(dir);
+        ASSERT_TRUE(store.open());
+        SynthChain::build(store, 2);
+        ASSERT_TRUE(store.has_diff(chain_hash(1)));
+    }
+    {   // corrupt the 'F' key out-of-band
+        ::core::LevelDBStore raw(dir, {});
+        ASSERT_TRUE(raw.open());
+        raw.put("F", {0x63, 0x00, 0x00, 0x00});   // v99
+        raw.close();
+    }
+    {
+        MnDiffStore store(dir);
+        ASSERT_TRUE(store.open());
+        EXPECT_FALSE(store.has_diff(chain_hash(1)))
+            << "format mismatch must clear the WHOLE store";
+        EXPECT_FALSE(store.has_snapshot(chain_hash(0)));
+    }
+}
+
+TEST(DashMnDiffStore, StartupVerifySentinelCrossCheckWipes)
+{
+    // dashd EVODB_BEST_BLOCK posture (validation.cpp:2322/:2707): a sentinel
+    // naming a row that does not decode wipes the store (ALONE).
+    const std::string dir = fresh_db_dir("sentinel");
+    {
+        MnDiffStore store(dir);
+        ASSERT_TRUE(store.open());
+        SynthChain::build(store, 2);
+    }
+    {   // corrupt the newest 'D' row out-of-band
+        ::core::LevelDBStore raw(dir, {});
+        ASSERT_TRUE(raw.open());
+        std::string key(1, 'D');
+        key.append(reinterpret_cast<const char*>(chain_hash(2).data()), 32);
+        raw.put(key, {0x01, 0x02, 0x03});
+        raw.close();
+    }
+    {
+        MnDiffStore store(dir);
+        ASSERT_TRUE(store.open());
+        std::string note;
+        ASSERT_TRUE(store.startup_verify(synth_headers(2), note));
+        EXPECT_NE(note.find("wiping store"), std::string::npos) << note;
+        EXPECT_FALSE(store.has_diff(chain_hash(1)));
+    }
+}
+
+TEST(DashMnDiffStore, StartupVerifyNewestPairPassesAndFailsClosed)
+{
+    // VerifySnapshotPair analogue, scope-reduced to the newest pair:
+    // re-derive the newest snapshot from the previous one via stored diffs.
+    const std::string dir = fresh_db_dir("pair");
+    {
+        MnDiffStore store(dir);
+        ASSERT_TRUE(store.open());
+        auto c = SynthChain::build(store, 4);
+        // write a second snapshot at h4 (the test's "cadence" row)
+        DmlFoldEngine eng{FoldConfig{}};
+        std::vector<std::pair<uint256, ReplayMNState>> seed;
+        for (const auto& [k, v] : c.lists[4]) seed.emplace_back(k, v);
+        eng.seed(std::move(seed), c.trc, 4, chain_hash(4));
+        ASSERT_TRUE(store.put_snapshot(chain_hash(4), eng.save_snapshot()));
+
+        std::string note;
+        ASSERT_TRUE(store.startup_verify(synth_headers(4), note));
+        EXPECT_NE(note.find("verified"), std::string::npos) << note;
+        EXPECT_TRUE(store.has_diff(chain_hash(1)))
+            << "a passing verify must not wipe anything";
+    }
+    // Now a pair whose connecting diffs have a hole: wipe.
+    const std::string dir2 = fresh_db_dir("pairhole");
+    {
+        MnDiffStore store(dir2);
+        ASSERT_TRUE(store.open());
+        auto c = SynthChain::build(store, 4,
+                                   MnDiffRecord::kFlagRootMatched
+                                       | MnDiffRecord::kFlagPayeeVerified,
+                                   /*skip_height=*/2);
+        DmlFoldEngine eng{FoldConfig{}};
+        std::vector<std::pair<uint256, ReplayMNState>> seed;
+        for (const auto& [k, v] : c.lists[4]) seed.emplace_back(k, v);
+        eng.seed(std::move(seed), c.trc, 4, chain_hash(4));
+        ASSERT_TRUE(store.put_snapshot(chain_hash(4), eng.save_snapshot()));
+
+        std::string note;
+        ASSERT_TRUE(store.startup_verify(synth_headers(4), note));
+        EXPECT_NE(note.find("wiping store"), std::string::npos) << note;
+        EXPECT_FALSE(store.has_snapshot(chain_hash(4)));
+    }
+}
+
+TEST(DashMnDiffStore, WalkDepthBoundRefuses)
+{
+    // >576 diffs without a snapshot refuses (the cadence guarantees a
+    // grounding row within 576 on a healthy store).
+    MnDiffStore store(fresh_db_dir("depth"));
+    ASSERT_TRUE(store.open());
+    const uint32_t n = MnDiffStore::kSnapshotPeriod + 2;   // 578 blocks
+    auto list = make_list(2);
+    const auto root = sml_root_of(list);
+    // NO grounding snapshot at h0 — every row is an (empty) diff.
+    for (uint32_t h = 1; h <= n; ++h) {
+        MnDiffRecord rec;
+        rec.prev_hash              = chain_hash(h - 1);
+        rec.merkle_root_mn_list    = root;
+        rec.flags = MnDiffRecord::kFlagRootMatched
+                  | MnDiffRecord::kFlagPayeeVerified;
+        rec.total_registered_count = 2;
+        ASSERT_TRUE(store.put_block(chain_hash(h), h, rec, nullptr));
+    }
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    EXPECT_FALSE(store.reconstruct(chain_hash(n), synth_headers(n), out, trc,
+                                   err));
+    EXPECT_NE(err.find("exceeded"), std::string::npos) << err;
+}
+
+TEST(DashMnDiffStore, TargetOffOurHeaderChainRefuses)
+{
+    MnDiffStore store(fresh_db_dir("offchain"));
+    ASSERT_TRUE(store.open());
+    SynthChain::build(store, 2);
+    DmlFoldEngine::Entries out;
+    uint64_t trc = 0;
+    std::string err;
+    EXPECT_FALSE(store.reconstruct(h256(0x123456), synth_headers(2), out, trc,
+                                   err));
+    EXPECT_NE(err.find("header chain"), std::string::npos) << err;
+}

--- a/test/test_dash_mn_gap_repair.cpp
+++ b/test/test_dash_mn_gap_repair.cpp
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// ── THE GAP-REPAIR SEAM AT ITS MONEY-PATH CALLER ───────────────────────────
+//
+// CoinStateMaintainer::on_block_connected historically had exactly one remedy
+// for a payee-queue APPLY GAP: wipe + demote + authoritative re-seed (the E4
+// fail-closed fix). dashd never pays that price — it reconstructs the list
+// for ANY block from its per-block diff store (GetListForBlockInternal,
+// evo/deterministicmns.cpp:778-870). mn_diff_store.hpp is that mechanism
+// ported over ReplayMNState, and mn_gap_repair.hpp is the seam that lets the
+// maintainer ask it for the list at height-1 BEFORE paying the wipe.
+//
+// THE CRITICAL SHAPE, pinned in every gap test here: THE TIP MOVES. A gap is
+// blocks mined while the queue folded nothing — on a static tip the scenario
+// cannot even be expressed (the vm905 death: tip ran ~20 ahead of the bridge,
+// the wipe fired at the APPLY GAP, and the re-arm never caught the running
+// target again). Every test below advances the serve tip across heights the
+// queue never folded, then proves either the repair (queue byte-identical to
+// a contiguous fold — dashd's own equivalence) or the UNCHANGED fail-closed
+// floor (wipe + demote + re-seed ask) when the store cannot answer.
+//
+// End-to-end through the REAL store: records written with MnListDiff::build,
+// reconstructed by MnDiffStore::reconstruct over a header-chain lookup, and
+// projected through the same to_payee_state boundary main_dash wires — not a
+// stubbed repair function.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/coin_state_maintainer.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <impl/dash/coin/mn_diff_store.hpp>
+#include <impl/dash/coin/mn_gap_repair.hpp>
+#include <impl/dash/coin/replay_fold_engine.hpp>
+#include <impl/dash/coin/replay_payee_publish.hpp>   // to_payee_state
+#include <impl/dash/coin/mn_state_machine.hpp>
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/block_producer.hpp>         // compute_merkle_root
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+using dash::coin::CoinStateMaintainer;
+using dash::coin::MNState;
+using dash::coin::MnGapRepairFn;
+using dash::coin::MnGapRepairResult;
+using dash::coin::MutableTransaction;
+using dash::coin::NodeCoinState;
+using dash::coin::WorkSelection;
+using dash::coin::WorkSource;
+using dash::coin::BlockType;
+using dash::coin::DashWorkData;
+using dash::coin::replay::DmlFoldEngine;
+using dash::coin::replay::FoldConfig;
+using dash::coin::replay::MnDiffRecord;
+using dash::coin::replay::MnDiffStore;
+using dash::coin::replay::MnListDiff;
+using dash::coin::replay::ReplayMNState;
+using dash::coin::replay::to_payee_state;
+using dash::coin::vendor::CSimplifiedMNList;
+using dash::coin::vendor::CSimplifiedMNListEntry;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+namespace {
+
+constexpr uint8_t  DASH_PUBKEY_VER = 76;
+constexpr uint8_t  DASH_P2SH_VER   = 16;
+constexpr uint32_t H       = 2'400'000;    // the block that finds the gap
+constexpr uint32_t SEED_H  = H - 3;        // queue seeded as-of here
+constexpr uint32_t BITS    = 0x1b104be3u;
+constexpr uint32_t MTP     = 1'700'000'000u;
+
+uint256 h256(uint64_t v)
+{
+    uint256 h;
+    std::memset(h.data(), 0, 32);
+    std::memcpy(h.data(), &v, sizeof(v));
+    return h;
+}
+
+/// Synthetic hash-linked chain: hash(h) = h256(0xB00000 + h).
+uint256 chain_hash(uint32_t h) { return h256(0xB00000ull + h); }
+
+std::vector<unsigned char> p2pkh_script(uint8_t hashseed)
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i)
+        s.push_back(static_cast<unsigned char>(hashseed + i));
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
+MutableTransaction make_spend(const uint256& prev, uint32_t idx,
+                              int64_t out_value, uint32_t salt)
+{
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = salt;
+    TxIn in; in.prevout.hash = prev; in.prevout.index = idx;
+    in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut o; o.value = out_value;
+    tx.vout.push_back(o);
+    return tx;
+}
+
+void bind_block(BlockType& b)
+{
+    std::vector<uint256> ids;
+    for (const auto& tx : b.m_txs) ids.push_back(dash::coin::dash_txid(tx));
+    b.m_merkle_root = dash::coin::compute_merkle_root(ids);
+}
+
+/// A block whose coinbase pays `payee` (the projected MN's script), bound to
+/// its header — the readiness-preserving "normal" block shape the pre-existing
+/// maintainer KATs use.
+BlockType paying_block(const std::vector<unsigned char>& payee, uint32_t salt)
+{
+    BlockType blk;
+    blk.m_txs.push_back(make_spend(h256(0x9000 + salt), 0, 500000000, salt));
+    blk.m_txs[0].vout[0].scriptPubKey.m_data = payee;
+    bind_block(blk);
+    return blk;
+}
+
+ReplayMNState make_replay_mn(uint64_t i,
+                             const std::vector<unsigned char>& payout,
+                             int32_t last_paid)
+{
+    ReplayMNState st;
+    st.internalId               = i;
+    st.collateralOutpoint.hash  = h256(0x5000 + i);
+    st.collateralOutpoint.index = static_cast<uint32_t>(i);
+    st.nRegisteredHeight        = static_cast<int32_t>(2'300'000 + i);
+    st.nLastPaidHeight          = last_paid;
+    st.pubKeyOperator[0]        = static_cast<uint8_t>(0x40 + i);
+    st.netInfo.ip[15]           = static_cast<uint8_t>(i + 1);
+    st.netInfo.port_be          = 9999;
+    st.scriptPayout.m_data.assign(payout.begin(), payout.end());
+    return st;
+}
+
+uint256 sml_root_of(const DmlFoldEngine::Entries& list)
+{
+    std::vector<CSimplifiedMNListEntry> ents;
+    ents.reserve(list.size());
+    for (const auto& [protx, st] : list) ents.push_back(st.to_sml_entry(protx));
+    CSimplifiedMNList sml(std::move(ents));
+    return sml.CalcMerkleRoot();
+}
+
+std::vector<std::pair<uint256, MNState>>
+to_payee_list(const DmlFoldEngine::Entries& list)
+{
+    std::vector<std::pair<uint256, MNState>> out;
+    out.reserve(list.size());
+    for (const auto& [protx, st] : list)
+        out.emplace_back(protx, to_payee_state(st));
+    return out;
+}
+
+std::string fresh_db_dir(const char* name)
+{
+    const auto dir = std::filesystem::temp_directory_path()
+                   / ("c2pool_mn_gap_repair_kat_" + std::string(name) + "_"
+                      + std::to_string(::getpid()));
+    std::filesystem::remove_all(dir);
+    std::filesystem::create_directories(dir);
+    return (dir / "db").string();
+}
+
+// ── The fixture chain ──────────────────────────────────────────────────────
+// Two masternodes with DISTINCT payout scripts, so payment ORDER is what the
+// repair must reproduce — with shared addresses a wrong queue front is
+// invisible to the coinbase cross-check (the whole E4 incident class).
+//
+//   L0 (as-of SEED_H = H-3): MN1 lastPaid H-10, MN2 lastPaid H-9
+//   block H-2 pays MN1 (the older slot)  -> L1: MN1 lastPaid = H-2
+//   block H-1 pays MN2                   -> L2: MN2 lastPaid = H-1
+//   block H   pays MN1 again
+struct Fixture
+{
+    std::vector<unsigned char> script1 = p2pkh_script(0x30);
+    std::vector<unsigned char> script2 = p2pkh_script(0x60);
+    DmlFoldEngine::Entries L0, L1, L2;
+
+    Fixture()
+    {
+        L0.emplace(h256(1), make_replay_mn(0, script1,
+                                           static_cast<int32_t>(H - 10)));
+        L0.emplace(h256(2), make_replay_mn(1, script2,
+                                           static_cast<int32_t>(H - 9)));
+        L1 = L0;
+        L1.at(h256(1)).nLastPaidHeight = static_cast<int32_t>(H - 2);
+        L2 = L1;
+        L2.at(h256(2)).nLastPaidHeight = static_cast<int32_t>(H - 1);
+    }
+
+    /// Write the grounding snapshot at SEED_H and diff rows for H-2, H-1
+    /// (both root_matched AND payee_verified — the store refuses anything
+    /// less). `skip_height` punches the unrepairable hole.
+    void populate_store(MnDiffStore& store, uint32_t skip_height = 0) const
+    {
+        DmlFoldEngine eng{FoldConfig{}};
+        std::vector<std::pair<uint256, ReplayMNState>> seed;
+        for (const auto& [k, v] : L0) seed.emplace_back(k, v);
+        eng.seed(std::move(seed), L0.size(), SEED_H, chain_hash(SEED_H));
+        ASSERT_TRUE(store.put_snapshot(chain_hash(SEED_H),
+                                       eng.save_snapshot()));
+
+        const DmlFoldEngine::Entries* prev = &L0;
+        const DmlFoldEngine::Entries* rows[] = {&L1, &L2};
+        for (uint32_t i = 0; i < 2; ++i) {
+            const uint32_t h = H - 2 + i;
+            MnDiffRecord rec;
+            rec.prev_hash              = chain_hash(h - 1);
+            rec.merkle_root_mn_list    = sml_root_of(*rows[i]);
+            rec.flags                  = MnDiffRecord::kFlagRootMatched
+                                       | MnDiffRecord::kFlagPayeeVerified;
+            rec.total_registered_count = 2;
+            rec.diff                   = MnListDiff::build(*prev, *rows[i]);
+            if (h != skip_height)
+                ASSERT_TRUE(store.put_block(chain_hash(h), h, rec, nullptr));
+            prev = rows[i];
+        }
+    }
+};
+
+/// hash -> (height, prev_hash) over the synthetic chain — the walk's
+/// cross-check at every hop, exactly what main_dash wires off HeaderChain.
+MnDiffStore::HeaderLookupFn synth_headers()
+{
+    return [](const uint256& hash)
+        -> std::optional<std::pair<uint32_t, uint256>> {
+        for (uint32_t h = H - 6; h <= H + 1; ++h) {
+            if (chain_hash(h) == hash)
+                return std::make_pair(h, chain_hash(h - 1));
+        }
+        return std::nullopt;
+    };
+}
+
+/// The seam wired exactly as main_dash wires it: want_height -> hash off the
+/// header chain -> MnDiffStore::reconstruct -> to_payee_state projection.
+MnGapRepairFn make_repair_fn(MnDiffStore* store)
+{
+    return [store](uint32_t want) -> MnGapRepairResult {
+        MnGapRepairResult out;
+        out.as_of = want;
+        if (store == nullptr) { out.error = "diff store absent"; return out; }
+        DmlFoldEngine::Entries list;
+        uint64_t trc = 0;
+        std::string err;
+        if (!store->reconstruct(chain_hash(want), synth_headers(), list, trc,
+                                err)) {
+            out.error = err;
+            return out;
+        }
+        out.entries = to_payee_list(list);
+        out.ok = true;
+        return out;
+    };
+}
+
+void expect_queue_byte_identical(NodeCoinState& a, NodeCoinState& b,
+                                 const char* what)
+{
+    ASSERT_EQ(a.mnstates().size(), b.mnstates().size()) << what;
+    auto ib = b.mnstates().entries().begin();
+    for (const auto& [protx, mn] : a.mnstates().entries()) {
+        EXPECT_EQ(protx, ib->first) << what;
+        EXPECT_TRUE(mn == ib->second)
+            << what << ": entry " << protx.GetHex().substr(0, 16)
+            << " differs between the contiguous fold and the repaired queue";
+        ++ib;
+    }
+    EXPECT_EQ(a.mnstates().last_applied_height(),
+              b.mnstates().last_applied_height()) << what;
+}
+
+void expect_queue_equals(NodeCoinState& st, const DmlFoldEngine::Entries& want,
+                         const char* what)
+{
+    ASSERT_EQ(st.mnstates().size(), want.size()) << what;
+    for (const auto& [protx, rst] : want) {
+        const MNState expect = to_payee_state(rst);
+        auto it = st.mnstates().entries().find(protx);
+        ASSERT_NE(it, st.mnstates().entries().end()) << what;
+        EXPECT_TRUE(it->second == expect)
+            << what << ": entry " << protx.GetHex().substr(0, 16);
+    }
+}
+
+void tip(CoinStateMaintainer& m, uint32_t prev_height)
+{
+    m.on_new_tip(prev_height, chain_hash(prev_height), BITS, MTP,
+                 DASH_PUBKEY_VER, DASH_P2SH_VER);
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CASE 1 — an APPLY GAP of 2 blocks, AGAINST A MOVING TIP, repaired from the
+// stored diffs; the repaired queue is BYTE-IDENTICAL to the queue a
+// contiguous fold of the same blocks produces (dashd's own equivalence:
+// GetListForBlockInternal(h) == the incrementally-built list at h).
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnGapRepair, ApplyGapAgainstMovingTipRepairedByteIdenticalToContiguousFold)
+{
+    Fixture fx;
+    MnDiffStore store(fresh_db_dir("repair"));
+    ASSERT_TRUE(store.open());
+    fx.populate_store(store);
+
+    // ── A: the reference — every block folded contiguously ───────────────
+    NodeCoinState stA;
+    CoinStateMaintainer A(stA);
+    bool reseedA = false;
+    A.set_on_mn_reseed([&]() { reseedA = true; });
+    tip(A, SEED_H);
+    A.on_mn_list_update(to_payee_list(fx.L0), SEED_H);
+    ASSERT_TRUE(A.live());
+    {
+        auto r = A.on_block_connected(paying_block(fx.script1, 1), H - 2);
+        ASSERT_FALSE(r.gap_detected);
+        ASSERT_FALSE(r.payee_desync);
+        ASSERT_EQ(r.paid, 1u);
+    }
+    tip(A, H - 2);
+    {
+        auto r = A.on_block_connected(paying_block(fx.script2, 2), H - 1);
+        ASSERT_FALSE(r.gap_detected);
+        ASSERT_EQ(r.paid, 1u);
+    }
+    tip(A, H - 1);
+    // The stored-diff fixture really does describe the contiguous fold: A's
+    // queue at H-1 is exactly to_payee_state(L2). This is the assertion that
+    // makes the byte-identity below MEAN something.
+    expect_queue_equals(stA, fx.L2, "contiguous fold at H-1 vs L2");
+
+    // ── B: the gap — the TIP MOVES across two blocks the queue never saw ──
+    NodeCoinState stB;
+    CoinStateMaintainer B(stB);
+    bool reseedB = false;
+    B.set_on_mn_reseed([&]() { reseedB = true; });
+    B.set_mn_gap_repair(make_repair_fn(&store));
+    tip(B, SEED_H);
+    B.on_mn_list_update(to_payee_list(fx.L0), SEED_H);
+    ASSERT_TRUE(B.live());
+    // Blocks H-2 and H-1 are mined while the queue folds nothing (the E4 /
+    // vm905 shape: header lane keeps up, body ingest does not). The serve
+    // tip RUNS — this is the movement without which the defect class cannot
+    // be expressed at all.
+    tip(B, H - 2);
+    tip(B, H - 1);
+    ASSERT_EQ(stB.mnstates().last_applied_height(), SEED_H)
+        << "precondition: the queue cursor must be 2 behind the moved tip";
+
+    // Block H connects. First apply reports the gap; the seam reconstructs
+    // the list at H-1 from the stored diffs, reseeds through the single sink,
+    // and re-applies THIS block. No wipe, no demotion, no re-seed ask.
+    auto rB = B.on_block_connected(paying_block(fx.script1, 3), H);
+    EXPECT_FALSE(rB.gap_detected)
+        << "the returned result is the post-repair re-apply";
+    EXPECT_FALSE(rB.payee_desync);
+    EXPECT_EQ(rB.paid, 1u);
+    EXPECT_FALSE(reseedB) << "a repaired gap must not fire the re-seed ask";
+    EXPECT_TRUE(B.live()) << "a repaired gap must not demote the bundle";
+    EXPECT_EQ(B.mn_snapshot_height(), H - 1)
+        << "the repair reseeds as-of the reconstructed height";
+    EXPECT_FALSE(B.mn_needs_reseed_latched());
+
+    // ── the required equivalence ──────────────────────────────────────────
+    {
+        auto r = A.on_block_connected(paying_block(fx.script1, 3), H);
+        ASSERT_EQ(r.paid, 1u);
+    }
+    expect_queue_byte_identical(stA, stB, "after block H");
+
+    // And the repaired cursor is a REAL cursor: the next live block folds
+    // contiguously on both, and the queues stay identical.
+    tip(A, H);
+    tip(B, H);
+    {
+        auto ra = A.on_block_connected(paying_block(fx.script2, 4), H + 1);
+        auto rb = B.on_block_connected(paying_block(fx.script2, 4), H + 1);
+        EXPECT_FALSE(ra.gap_detected);
+        EXPECT_FALSE(rb.gap_detected);
+        EXPECT_EQ(ra.paid, 1u);
+        EXPECT_EQ(rb.paid, 1u);
+    }
+    expect_queue_byte_identical(stA, stB, "after block H+1");
+
+    // The repaired arm still serves embedded work.
+    bool fb = false;
+    WorkSelection sel = stB.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_FALSE(fb);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CASE 2 — an APPLY GAP the store CANNOT repair (a diff row is absent): the
+// pre-existing fail-closed path runs byte-for-byte unchanged — wipe, demote,
+// authoritative re-seed ask. The repair seam only ever ADDS a lane in front
+// of the wipe; this pins that the wipe was not lost behind it.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnGapRepair, ApplyGapNotRepairableStillWipesDemotesAndReseeds)
+{
+    Fixture fx;
+    MnDiffStore store(fresh_db_dir("hole"));
+    ASSERT_TRUE(store.open());
+    fx.populate_store(store, /*skip_height=*/H - 2);   // the hole
+
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    bool reseed_fired = false;
+    m.set_on_mn_reseed([&]() { reseed_fired = true; });
+    m.set_mn_gap_repair(make_repair_fn(&store));
+    tip(m, SEED_H);
+    m.on_mn_list_update(to_payee_list(fx.L0), SEED_H);
+    ASSERT_TRUE(m.live());
+    tip(m, H - 2);       // the tip moves; the queue folds nothing
+    tip(m, H - 1);
+
+    // The repair fn is WIRED and is consulted — and the store refuses (the
+    // walk hits the missing H-2 row; missing row = REFUSED, never an empty
+    // list). Everything the E4 fail-closed fix demanded must still happen.
+    auto r = m.on_block_connected(paying_block(fx.script1, 3), H);
+    EXPECT_TRUE(r.gap_detected);
+    EXPECT_EQ(r.paid, 0u) << "a gapped fold must not attribute the payment";
+    EXPECT_EQ(st.mnstates().size(), 0u) << "stale-cursor queue must be wiped";
+    EXPECT_FALSE(m.live()) << "an unrepairable gap must demote to fallback";
+    EXPECT_TRUE(reseed_fired)
+        << "an unrepairable gap must request an authoritative re-seed";
+    EXPECT_TRUE(m.mn_needs_reseed_latched());
+    EXPECT_EQ(m.mn_snapshot_height(), 0u);
+
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CASE 3a — THE CONSUMER HALF OF THE G7 SPLIT, success arm: a seed stamped
+// BELOW an already-moving tip is caught up to the tip from the stored diffs
+// BEFORE serving arms. The publisher may now release within epsilon precisely
+// because this gate exists.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnGapRepair, BelowTipSeedCatchesUpFromStoreAndArmsAtTheTip)
+{
+    Fixture fx;
+    MnDiffStore store(fresh_db_dir("catchup"));
+    ASSERT_TRUE(store.open());
+    fx.populate_store(store);
+
+    NodeCoinState st;
+    st.set_require_fresh_mn_payee(true);   // serve only a tip-current queue
+    CoinStateMaintainer m(st);
+    m.set_mn_gap_repair(make_repair_fn(&store));
+
+    // The tip has ALREADY moved past the seed's as-of when the seed lands —
+    // the publisher-side epsilon window made this ordering routine.
+    tip(m, H - 1);
+    m.on_mn_list_update(to_payee_list(fx.L0), SEED_H);   // 2 below the tip
+
+    EXPECT_TRUE(m.live())
+        << "the catch-up succeeded, so serving must be armed";
+    EXPECT_EQ(m.mn_snapshot_height(), H - 1)
+        << "the queue cursor must be AT the tip, not at the seed stamp";
+    expect_queue_equals(st, fx.L2, "caught-up queue vs L2");
+
+    // The freshness gate agrees: the queue is current AT the tip and the
+    // embedded arm serves.
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::Embedded);
+    EXPECT_FALSE(fb);
+
+    // And the caught-up cursor folds the next live block contiguously.
+    auto r = m.on_block_connected(paying_block(fx.script1, 3), H);
+    EXPECT_FALSE(r.gap_detected);
+    EXPECT_EQ(r.paid, 1u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CASE 3b — refusal arm, WITH the store wired: the catch-up walk refuses (a
+// hole again) and the stamp is too old to serve — the seed is STORED but
+// serving is NOT armed. Refusal-to-arm is not a wipe: no reseed latch, the
+// entries stay, and the incumbent lane keeps its job.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnGapRepair, BelowTipSeedRefusedCatchUpStoredButNotArmed)
+{
+    Fixture fx;
+    MnDiffStore store(fresh_db_dir("catchuphole"));
+    ASSERT_TRUE(store.open());
+    fx.populate_store(store, /*skip_height=*/H - 1);   // hole at the tip row
+
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    m.set_mn_gap_repair(make_repair_fn(&store));
+    tip(m, H - 1);
+    m.on_mn_list_update(to_payee_list(fx.L0), SEED_H);
+
+    EXPECT_FALSE(m.live())
+        << "a below-tip queue front must never back a template";
+    EXPECT_EQ(st.mnstates().size(), fx.L0.size())
+        << "the seed itself is STORED — refusal to arm is not a wipe";
+    EXPECT_EQ(m.mn_snapshot_height(), SEED_H);
+    EXPECT_FALSE(m.mn_needs_reseed_latched());
+
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CASE 3c — the consumer refuses a stamp that is too old when NO catch-up is
+// wired at all. This is the bare currency gate — the exact behavioral change
+// of the G7 split, and the RED-ON-BASE witness: before the split this seed
+// armed serving with a queue front 2 blocks behind the tip.
+// (Deliberately uses ONLY the pre-existing maintainer API so it compiles on
+// the base commit; it FAILS there — live() came back true.)
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMnGapRepair, BelowTipSeedWithoutCatchUpMustNotArmServing)
+{
+    Fixture fx;
+    NodeCoinState st;
+    CoinStateMaintainer m(st);
+    tip(m, H - 1);                                        // the tip moved first
+    m.on_mn_list_update(to_payee_list(fx.L0), SEED_H);    // stale stamp
+
+    EXPECT_FALSE(m.live())
+        << "a below-tip seed with no diff-store catch-up must not arm serving";
+    EXPECT_EQ(st.mnstates().size(), fx.L0.size())
+        << "the seed is stored — refusal to arm is not a wipe";
+    EXPECT_FALSE(m.mn_needs_reseed_latched());
+
+    bool fb = false;
+    WorkSelection sel = st.select_work([&]() { fb = true; return DashWorkData{}; });
+    EXPECT_EQ(sel.source, WorkSource::DashdFallback);
+    EXPECT_TRUE(fb);
+}

--- a/test/test_dash_replay_payee_publish.cpp
+++ b/test/test_dash_replay_payee_publish.cpp
@@ -409,6 +409,55 @@ TEST(DashReplayPayeePublish, AtTipStillPublishes)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// KAT 3c — THE G7 SPLIT AGAINST A MOVING TIP (the vm905 death shape)
+//
+// The defect the epsilon exists for cannot be expressed on a static tip: with
+// the tip parked, fold==tip eventually holds and the old exact-tip G7 passes
+// trivially. The fault is that the TARGET RUNS — blocks land on the header
+// chain faster than the fold fetches bodies, so `fold == tip` is never true
+// at any evaluation instant, the publisher withholds forever, and a node
+// whose fold is provably one block behind a 2.5-minute chain pushes ZERO
+// mining.notify (vm905: bridge stuck ~20 behind live tip, ARMED but never
+// PUBLISHES, latch eternal). So here the tip MOVES between every evaluation
+// and never once equals the fold cursor.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayPayeePublish, PublishesWithinEpsilonAgainstAMovingTip)
+{
+    auto rig = make_clean_rig();
+    ASSERT_TRUE(rig.fold_through(kFirstBody + 2));   // fold cursor 2516758
+    rig.tip = kFirstBody + 3;                        // tip ALREADY ahead
+    auto pub = rig.make_publisher();
+
+    // One behind, and the tip is about to move again: within epsilon, the
+    // guard passes NOW (on the old exact-tip G7 this evaluation refuses, and
+    // with the tip running it refuses at every later instant too).
+    const auto g1 = pub.evaluate();
+    EXPECT_TRUE(g1.ok) << g1.blocker;
+
+    // The tip moves BEFORE the publish fires — the fold is now two behind,
+    // the epsilon bound exactly. Still allowed.
+    rig.tip = kFirstBody + 4;
+    const auto g2 = pub.evaluate();
+    EXPECT_TRUE(g2.ok) << g2.blocker;
+    EXPECT_TRUE(pub.maybe_publish());
+    ASSERT_EQ(rig.sink.calls.size(), 1u);
+
+    // The stamp is the FOLD height — the honest as-of — never the tip: the
+    // consumer's currency gate needs the true as-of to know what to catch up
+    // from the diff store before it may arm serving.
+    EXPECT_EQ(rig.sink.calls.back().as_of, kFirstBody + 2);
+    EXPECT_LT(rig.sink.calls.back().as_of, rig.tip)
+        << "this publish happened while the tip was AHEAD — that is the point";
+
+    // The tip keeps running: three behind is beyond epsilon and the guard
+    // closes again. The relaxation is a 2-block window, not a repeal.
+    rig.tip = kFirstBody + 5;
+    const auto g3 = pub.evaluate();
+    EXPECT_FALSE(g3.ok);
+    EXPECT_EQ(g3.blocker.substr(0, 2), "G7") << g3.blocker;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // KAT 4 — THE FAIL-CLOSED GUARD: a DIVERGED / POISONED fold must never publish
 //
 // Built the only honest way: tamper with the anchor (drop one masternode) so
@@ -562,6 +611,121 @@ TEST(DashReplayPayeePublish, EveryGuardConditionNamesItself)
         EXPECT_EQ(g.blocker.substr(0, 2), "G8") << g.blocker;
         EXPECT_NE(g.blocker.find("EMPTY scriptPayout"), std::string::npos)
             << g.blocker;
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT 5b — REGRESSION FENCE: the epsilon relaxed G7 and ONLY G7
+//
+// Every other guard is a money-path correctness proof and must refuse at the
+// WIDEST distance the epsilon now admits (tip = fold + kPublishEpsilon) —
+// i.e. the new window must not have reordered guard precedence or opened a
+// publish for a fold that is diverged/unchecked/mutated/scriptless within it.
+// Each block below synthesises exactly one failure and pins the guard CODE.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayPayeePublish, EpsilonRelaxedOnlyG7EveryOtherGuardStillRefuses)
+{
+    auto rig = make_clean_rig();
+    ASSERT_TRUE(rig.fold_through(kLastBody - 1));   // fold cursor 2516759
+    const uint32_t eps = dash::coin::replay::kPublishEpsilon;
+    const uint32_t tip = (kLastBody - 1) + eps;     // the widest admitted gap
+    const FoldConsumerStats good = rig.consumer.stats();
+    ASSERT_TRUE(evaluate_payee_guard(rig.engine, good, tip).ok)
+        << "precondition: the healthy fold passes at the epsilon bound";
+
+    // G1 — a POISONED engine refuses inside the window too.
+    {
+        auto fx = pp_parse_prestate(kDashReplayPrestate2516755);
+        ASSERT_GT(fx.entries.size(), 10u);
+        fx.entries.erase(fx.entries.begin() + 7);       // tamper the anchor
+        uint256 anchor;
+        anchor.SetHex(fx.blockhash_display);
+        Rig bad(fx.entries, fx.height, anchor);
+        EXPECT_FALSE(bad.fold_through(kFirstBody));
+        ASSERT_TRUE(bad.engine.poisoned());
+        const auto g = evaluate_payee_guard(bad.engine, bad.consumer.stats(),
+                                            bad.engine.height() + eps);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G1") << g.blocker;
+    }
+    // G2 — a recorded divergence.
+    {
+        FoldConsumerStats s = good;
+        s.diverged          = true;
+        s.divergence_height = kLastBody - 1;
+        const auto g = evaluate_payee_guard(rig.engine, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G2") << g.blocker;
+    }
+    // G3 — nothing folded.
+    {
+        FoldConsumerStats s;
+        const auto g = evaluate_payee_guard(rig.engine, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G3") << g.blocker;
+    }
+    // G4 — a folded-but-unchecked block.
+    {
+        FoldConsumerStats s = good;
+        s.roots_matched -= 1;
+        const auto g = evaluate_payee_guard(rig.engine, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G4") << g.blocker;
+    }
+    // G5 — a cursor that is not the height that passed.
+    {
+        FoldConsumerStats s = good;
+        s.last_height -= 1;
+        const auto g = evaluate_payee_guard(rig.engine, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G5") << g.blocker;
+    }
+    // G6 — a list that no longer re-hashes to the matched root.
+    {
+        FoldConsumerStats s = good;
+        s.last_matched_root.data()[0] ^= 0xff;
+        const auto g = evaluate_payee_guard(rig.engine, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G6") << g.blocker;
+    }
+    // G7 — an UNKNOWN tip still refuses outright (epsilon needs an operand).
+    {
+        const auto g = evaluate_payee_guard(rig.engine, good, 0);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G7") << g.blocker;
+    }
+    // G7 — one past the epsilon refuses (the boundary itself, both sides).
+    {
+        const auto g = evaluate_payee_guard(rig.engine, good, tip + 1);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G7") << g.blocker;
+    }
+    // G8 — a payout-scriptless entry, root-clean and inside the window.
+    {
+        ReplayMNState st;
+        st.nRegisteredHeight = 2500000;
+        st.nPoSeBanHeight    = ReplayMNState::NEVER;
+        st.collateralOutpoint.hash.data()[0] = 0x11;
+        std::vector<std::pair<uint256, ReplayMNState>> one;
+        uint256 protx;
+        protx.data()[0] = 0x22;
+        one.emplace_back(protx, st);
+        DmlFoldEngine scriptless(Rig::make_cfg());
+        scriptless.seed(std::move(one), 1, kLastBody - 1, uint256{}, "mainnet");
+        FoldConsumerStats s = good;
+        s.last_matched_root = scriptless.compute_sml_root();
+        ASSERT_FALSE(s.last_matched_root.IsNull());
+        const auto g = evaluate_payee_guard(scriptless, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G8") << g.blocker;
+    }
+    // G9 — a block whose payee was not proven paid.
+    {
+        FoldConsumerStats s = good;
+        s.payees_verified -= 1;
+        const auto g = evaluate_payee_guard(rig.engine, s, tip);
+        EXPECT_FALSE(g.ok);
+        EXPECT_EQ(g.blocker.substr(0, 2), "G9") << g.blocker;
     }
 }
 

--- a/test/test_dash_replay_payee_publish.cpp
+++ b/test/test_dash_replay_payee_publish.cpp
@@ -356,13 +356,17 @@ TEST(DashReplayPayeePublish, OneShotThenOnlyReseedRepublishes)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// KAT 3 — THE FAIL-CLOSED GUARD: a fold BEHIND THE TIP must never publish
+// KAT 3 — THE FAIL-CLOSED GUARD: a fold BEHIND THE TIP beyond epsilon must
+// never publish; within epsilon it may (the G7 split: the CONSUMER's currency
+// gate — CoinStateMaintainer::on_mn_list_update — holds serving until the
+// queue cursor is caught up to the tip from the diff store, so a publish
+// within epsilon never lets a below-tip queue front reach a template)
 // ═══════════════════════════════════════════════════════════════════════════
-TEST(DashReplayPayeePublish, BehindTheTipMustNotPublish)
+TEST(DashReplayPayeePublish, BehindTheTipBeyondEpsilonMustNotPublish)
 {
     auto rig = make_clean_rig();
     ASSERT_TRUE(rig.fold_through(kLastBody - 1));   // 4 of the 5 bodies
-    rig.tip = kLastBody;                            // one block behind
+    rig.tip = kLastBody - 1 + dash::coin::replay::kPublishEpsilon + 1;  // one past the epsilon
 
     auto pub = rig.make_publisher();
     const auto g = pub.evaluate();
@@ -378,11 +382,30 @@ TEST(DashReplayPayeePublish, BehindTheTipMustNotPublish)
     EXPECT_FALSE(pub.republish_for_reseed());
     EXPECT_TRUE(rig.sink.calls.empty());
 
-    // ... and the very next block closes it.
-    ASSERT_TRUE(rig.fold_through(kLastBody));
+    // ... and AT the epsilon boundary (tip - fold == kPublishEpsilon) the
+    // publisher releases, stamped as_of the FOLD height — the consumer's
+    // currency gate takes over from there.
+    rig.tip = kLastBody - 1 + dash::coin::replay::kPublishEpsilon;
     EXPECT_TRUE(pub.evaluate().ok);
     EXPECT_TRUE(pub.maybe_publish());
-    EXPECT_EQ(rig.sink.calls.size(), 1u);
+    ASSERT_EQ(rig.sink.calls.size(), 1u);
+    EXPECT_EQ(rig.sink.calls.back().as_of, kLastBody - 1);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT 3b — the exact-tip publish (epsilon = 0 distance) is unchanged
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayPayeePublish, AtTipStillPublishes)
+{
+    auto rig = make_clean_rig();
+    ASSERT_TRUE(rig.fold_through(kLastBody));
+    rig.tip = kLastBody;
+
+    auto pub = rig.make_publisher();
+    EXPECT_TRUE(pub.evaluate().ok);
+    EXPECT_TRUE(pub.maybe_publish());
+    ASSERT_EQ(rig.sink.calls.size(), 1u);
+    EXPECT_EQ(rig.sink.calls.back().as_of, kLastBody);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

At cold MN diff-store arm, bootstrap the store-engine's second `QuorumReplayEngine`
across the anchor by fetching `getqrinfo(B0)` — where `B0` is the first rotated
(DIP-24, llmqType=5) cycle base after the anchor — DIP-4/merkle-authenticating the
returned quarter snapshots + work-block MN lists, and seeding them through the
existing bridge `seed_snapshots` / `seed_work_lists` guards so the cycle that
straddles the anchor becomes derivable.

Stacked on #1262 (`dash/mn-diff-store-quorum-resolver`). One file: `src/c2pool/main_dash.cpp`
(+1 include). Reuses the operator's store/engines verbatim; adds only the seed transport.

## Why (ROOT)

The store-engine's second `QuorumReplayEngine` is seeded at the anchor h=2513000 with
**0 pre-anchor quarter snapshots** (only pre-anchor header hashes). The first punishing
qfcommit at h=2513130 is a ROTATED llmqType=5 quorum whose cycle base is **2513088**,
whose quarter work blocks (2512792 / 2512504 / 2512216) are **all below the anchor**.
`self_contained_from(5, 2513000) = 2513952`, so the engine cannot self-derive cycle 2513088
from the post-anchor stream → `fold_qfcommit` gets `resolver has no member set` → the parallel
fold fails closed a window past the anchor → the store caps (~130 heights) → the MN-CKPT payee
lane falls to the capped network probe → the payee-desync fail-closed wedge (task #149 class).

`getqrinfo(2513088)` returns exactly the pre-anchor data the engine needs: the three
`quorumSnapshotAtHMinusC/2C/3C` (cycle bases 2512800/2512512/2512224) and the `mnListDiffAtHMinusC/2C/3C`
(work heights 2512792/2512504/2512216) — all below the anchor, which is precisely what the
bridge's `producible_from = anchor + 3C = 2513952` guard **accepts** and what the replay
must itself produce it **refuses**. One fetch bootstraps the whole straddle; 2513376/2513664
self-produce forward.

## Reward-safety by construction

Fetched snapshots are DIP-4/merkle-authenticated (`authenticate_historical_snapshot`, the shared
R3: applied-onto-empty SML root == cbTx.merkleRootMNList + blockHash tied to a PoW-verified header),
and every folded list is re-checked vs `merkleRootMNList` before the writer commits. A wrong/partial
snapshot → wrong members → folded root mismatch → writer refuses the row → store empty → callers use
the network path → **never a bad mint**.

## Ordering gate

`getqrinfo` is a P2P round-trip that races the fold advancing from the anchor. The block-applied
callback (which this PR owns) **holds** straddle blocks (≥ B0) until the seed lands, then **drains**
them in order; re-issues the fetch while holding; and — if the reply never arrives within a bounded
hold — caps the store below the straddle and lets callers fall through **rather than poison**. No
engine change.

## Verification

- **Build**: `c2pool-dash`, BLS=REAL (`C2POOL_DASH_BLS=ON`, dashbls static). Clean. Runtime banner
  `DASH BLS backend: REAL`.
- **Provenance**: `/proc/<pid>/exe` md5 `9ef2f5b8…` == built binary; `--version` =
  `archive/dash/tipfreeze-stale-tip-alarm-81-g7ac9d631` (this HEAD).
- **KAT** (`DashReplayQuorumSeam`, 13/13 PASS) encodes the red→green→reward-safe for the seed
  mechanism this PR feeds: `Height2513130FailsClosedWithoutAResolver` (RED),
  `Height2513130FoldsThroughDerivedMembership` (GREEN), `DerivesCycle2513088MembersMatchingDashd`
  (byte-parity vs dashd), `BridgeNeverArmsTheRootSelfCheckByItself` (reward-safe poison).

## Live cold daemonless measurement (vm905, dashd ABSENT, `--embedded-null-arm --embedded-utxo
`--coin-p2p-discover`, no `--coin-rpc`) — HONEST PARTIAL

Proven end-to-end **up to the DIP-4 gate**:
- Bootstrap ARMED with the exactly-correct `B0=2513088` (`getqrinfo(cycle_base h=2513088, type=5, C=288)`).
- `getqrinfo(2513088)` issued and re-issued; the reply is **received and correctly bound** by the new
  consumer (it authenticates the `AtHMinusC` diff at exactly `h=2512792 = B0−C−8`).
- Ordering gate holds the straddle blocks; **0 poison, 0 `resolver has no member set`, 0 rejects, 0 bad mint** — reward-safety fully preserved.

**Parked, reward-safe.** The seed does **not** land: the cold node's header chain starts at the
anchor and does **not** hold the PRE-ANCHOR work-block headers (2512792/2512504/2512216, all below
h=2513000), so `authenticate_historical_snapshot` fails DIP-4 leg (b) `block header not held` and
**fails closed** (3× observed). Store still caps below the straddle; `populated=0`; no embedded serve.

**Next residual** (names the real prerequisite, not a band-aid): the cold node must hold the ≥3-cycle
pre-anchor header span (≈2512216..2513000, ~784 headers) so the DIP-4 leg-(b) merkle trust anchor
resolves — e.g. a one-shot backward `getheaders` at cold store-arm before authenticating, or a
checkpoint-supplied pre-anchor header set. Relaxing leg (b) would rely only on the downstream fold
self-check and is deliberately **not** done (the HARD RULE requires the DIP-4 verify; dashd itself
authenticates qrinfo against its own full header chain).

DRAFT — do not merge.
