### PR TITLE
dash: cold-arm pre-anchor header backfill so getqrinfo snapshots authenticate (stacked on #1263)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6445,6 +6445,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         uint32_t last_send_h{0};
                         uint256  cycle_base_hash;
                         std::vector<std::pair<uint32_t, dash::coin::BlockType>> hold;
+                        // Pre-anchor header backfill (cold fast-start): leg (b)
+                        // of the getqrinfo snapshot auth needs the FULL headers
+                        // of the three rotated work blocks, all BELOW the anchor
+                        // and absent from the lone-anchor cold chain. One-shot
+                        // backward getheaders installs the span DOWN from the
+                        // trusted anchor before the seed can authenticate.
+                        bool     backfill_sent{false};
+                        uint256  anchor_hash;      // trusted downward-link root
+                        uint32_t anchor_height{0};
                     };
                     auto sseed = std::make_shared<StoreStraddleSeed>();
                     {
@@ -6464,6 +6473,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             // correct for both and costs at most a few dozen buffered
                             // blocks in the rare case the reply is slow.
                             sseed->first_need_h = sseed->cycle_base;
+                            sseed->anchor_hash  = ckpt.blockhash;
+                            sseed->anchor_height= anchor_h;
                             sseed->armed        = true;
                             break;   // one rotated type on mainnet (type 5)
                         }
@@ -6478,6 +6489,42 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                      << " (its H-C/2C/3C predecessors are all below"
                                         " the anchor; the store engine cannot"
                                         " self-derive them).";
+                    }
+
+                    // ── PRE-ANCHOR HEADER BACKFILL INSTALLER ─────────────────
+                    // The one-shot backward getheaders issued by the qrinfo
+                    // consumer below (when the work-block headers leg (b) needs
+                    // are absent at cold fast-start) returns a `headers` batch
+                    // spanning [h-4C .. anchor]. It arrives on the new_headers
+                    // event, where the forward add_headers path orphan-rejects
+                    // every pre-anchor header (parent not held). This installer
+                    // instead links them DOWN from the trusted anchor via
+                    // HeaderChain::install_preanchor_span (X11 prev-hash chain +
+                    // PoW, reward-safe), then re-drives getqrinfo so leg (b)
+                    // authenticates promptly. Self-guarding: it no-ops unless the
+                    // backfill was issued and not yet landed, and a batch that
+                    // does not reach the anchor installs nothing.
+                    if (sseed->armed) {
+                        coin_feed_subs.push_back(
+                            coin_state.new_headers.subscribe(
+                                [sseed, hc = header_chain.get(),
+                                 cp = coin_p2p.get()](
+                                    const std::vector<dash::coin::BlockHeaderType>&
+                                        batch) {
+                                    if (!sseed->armed || sseed->landed) return;
+                                    if (!sseed->backfill_sent) return;
+                                    if (batch.empty()) return;
+                                    const size_t n = hc->install_preanchor_span(
+                                        sseed->anchor_hash, batch);
+                                    if (n == 0) return;
+                                    // Re-drive getqrinfo now that the pre-anchor
+                                    // work-block headers are held → leg (b)
+                                    // authenticates on the next reply.
+                                    if (cp && !sseed->cycle_base_hash.IsNull())
+                                        cp->send_getqrinfo(
+                                            {}, sseed->cycle_base_hash,
+                                            /*extra=*/true);
+                                }));
                     }
 
                     // The shared per-block fold drive. Both the live feed and the
@@ -6520,6 +6567,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             [sseed, feed,
                              qbr = mn_bridge_quorum_bridge.get(),
                              hc  = header_chain.get(),
+                             cp  = coin_p2p.get(),
                              anchor_h = ckpt.height, net = net_name](
                                 const dash::coin::vendor::CQuorumRotationInfo& info) {
                                 if (!sseed->armed || sseed->landed) return;
@@ -6533,6 +6581,69 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                     || hcb.nHeight < 0) return;
                                 if (static_cast<uint32_t>(hcb.nHeight)
                                     != sseed->cycle_base - 8u) return;   // not ours
+
+                                // ── PRE-ANCHOR HEADER BACKFILL GATE ──────────
+                                // leg (b) below needs the FULL headers of the
+                                // three rotated work blocks (h-C/2C/3C), all
+                                // BELOW the fast-start anchor. At cold start the
+                                // header chain holds only the anchor, so the auth
+                                // fails closed 'block header not held'. Fetch the
+                                // pre-anchor span (once) and install it DOWN from
+                                // the trusted anchor BEFORE authenticating.
+                                {
+                                    const uint256 wh_c  =
+                                        info.mnListDiffAtHMinusC.blockHash;
+                                    const uint256 wh_2c =
+                                        info.mnListDiffAtHMinus2C.blockHash;
+                                    const uint256 wh_3c =
+                                        info.mnListDiffAtHMinus3C.blockHash;
+                                    if (!hc->has_header(wh_c)
+                                        || !hc->has_header(wh_2c)
+                                        || !hc->has_header(wh_3c)) {
+                                        // getheaders replies START at locator+1,
+                                        // so to INCLUDE the deepest work block
+                                        // (h-3C) the locator is seeded one rotated
+                                        // cycle DEEPER — the h-4C block from the
+                                        // extraShare leg. That hash is used ONLY
+                                        // as a locator; it is never trusted (a bad
+                                        // one yields no downward linkage from the
+                                        // anchor → zero installs → fail closed).
+                                        if (!sseed->backfill_sent && cp
+                                            && info.extraShare
+                                            && info.mnListDiffAtHMinus4C) {
+                                            const uint256 loc =
+                                                info.mnListDiffAtHMinus4C->blockHash;
+                                            const std::string peer =
+                                                cp->primary_peer_key();
+                                            if (!peer.empty()
+                                                && cp->send_getheaders_to(
+                                                       peer, 70230, {loc},
+                                                       sseed->anchor_hash)) {
+                                                sseed->backfill_sent = true;
+                                                LOG_INFO << "[MN-DIFF-DB] pre-anchor"
+                                                    " header BACKFILL issued:"
+                                                    " getheaders locator=h-4C "
+                                                    << loc.GetHex().substr(0, 16)
+                                                    << " stop=anchor "
+                                                    << sseed->anchor_hash.GetHex()
+                                                           .substr(0, 16)
+                                                    << " — installs the h-C/2C/3C"
+                                                       " work-block headers leg (b)"
+                                                       " needs; getqrinfo retries"
+                                                       " once the span lands.";
+                                            }
+                                        } else if (!info.extraShare
+                                                   || !info.mnListDiffAtHMinus4C) {
+                                            LOG_WARNING << "[MN-DIFF-DB] getqrinfo"
+                                                " reply lacks the h-4C extraShare"
+                                                " leg — cannot seed a locator below"
+                                                " the deepest work block; rotated"
+                                                " bootstrap fails closed"
+                                                " (reward-safe), retry.";
+                                        }
+                                        return;   // headers absent → fail closed
+                                    }
+                                }
                                 dash::coin::MerkleRootOfHashFn mroot =
                                     [hc](const uint256& b)
                                         -> std::optional<uint256> {
@@ -6659,8 +6770,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                 if (auto he = hc->get_header_by_height(
                                         sseed->cycle_base)) {
                                     sseed->cycle_base_hash = he->hash;
+                                    // extra=true: the reply must carry the h-4C
+                                    // leg, whose blockHash seeds a getheaders
+                                    // locator BELOW the deepest work block so the
+                                    // pre-anchor backfill span includes h-3C.
                                     if (cp) cp->send_getqrinfo(
-                                        {}, he->hash, /*extra=*/false);
+                                        {}, he->hash, /*extra=*/true);
                                     sseed->sent        = true;
                                     sseed->last_send_h = h;
                                     LOG_INFO << "[MN-DIFF-DB] getqrinfo issued for"
@@ -6690,7 +6805,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                         if (auto he = hc->get_header_by_height(
                                                 sseed->cycle_base)) {
                                             if (cp) cp->send_getqrinfo(
-                                                {}, he->hash, false);
+                                                {}, he->hash, /*extra=*/true);
                                             sseed->last_send_h = h;
                                         }
                                     }

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -563,6 +563,110 @@ public:
         return accepted;
     }
 
+    // Feature macro: the cold-start pre-anchor header backfill primitive
+    // below exists. Guards the KAT so it still compiles on a pre-fix tree.
+#ifndef C2POOL_PREANCHOR_SPAN_BACKFILL
+#define C2POOL_PREANCHOR_SPAN_BACKFILL 1
+#endif
+    /// Install a PRE-ANCHOR header span that links DOWNWARD from a trusted,
+    /// already-held block (the fast-start anchor). The forward add_header path
+    /// cannot do this: a pre-anchor header's parent is not held, so it
+    /// orphan-rejects (add_header_internal :660-661). At cold fast-start the
+    /// chain holds a LONE anchor and none of the work-block headers BELOW it
+    /// that the DIP-4 historical-snapshot auth (leg (b), historical_sml.hpp)
+    /// must consult — so getqrinfo rotated-quarter snapshots fail closed with
+    /// "block header not held". This walks DOWN from `anchor_hash` (which MUST
+    /// be held) through the supplied getheaders batch, authenticating each
+    /// parent by (1) X11(header) == the prev-hash its already-trusted child
+    /// commits to, and (2) check_pow against pow_limit — exactly the two legs
+    /// dashd requires of any header it stores. Headers that do not chain
+    /// downward from the trusted anchor are IGNORED (fail closed). Does NOT
+    /// move the tip / best-work: pre-anchor headers never compete for the tip,
+    /// and the synthetic-anchor daemon-tip honesty guards stay intact.
+    ///
+    /// REWARD-SAFETY: every installed header is bound to the release-pinned
+    /// anchor by an unbroken X11 prev-hash chain AND is independently
+    /// PoW-verified, so a wrong/forged header can never enter the view leg (b)
+    /// consults. A lying peer that returns garbage produces no linkage → zero
+    /// installs → leg (b) still fails closed.
+    ///
+    /// Returns the number of headers newly installed.
+    size_t install_preanchor_span(const uint256& anchor_hash,
+                                  const std::vector<BlockHeaderType>& batch)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        // The anchor is the trust root of the downward walk; it must be held.
+        auto anchor_it = m_headers.find(anchor_hash);
+        if (anchor_it == m_headers.end()) return 0;
+        const uint32_t anchor_height = anchor_it->second.height;
+
+        // Index the batch by X11 identity so prev-hash pointers can be
+        // followed. A header's presence here means it hashes to a specific
+        // block id; whether that id is TRUSTED is decided only by the walk.
+        std::map<uint256, const BlockHeaderType*> by_hash;
+        for (const auto& h : batch)
+            by_hash[x11_hash(h)] = &h;
+
+        // Bootstrap: the stored anchor entry keeps a SYNTHETIC prev (ZERO) so
+        // it never masquerades as a daemon tip, so read the anchor's REAL
+        // previous-block hash from the batch's own copy of the anchor header
+        // (getheaders with hash_stop=anchor returns it as the terminal entry).
+        // That copy is trusted the instant X11(copy) == the release-pinned
+        // anchor hash — which is exactly its key in by_hash.
+        auto anchor_hdr = by_hash.find(anchor_hash);
+        if (anchor_hdr == by_hash.end()) return 0;   // span never reached the anchor
+
+        uint32_t child_height = anchor_height;
+        uint256  parent_hash  = anchor_hdr->second->m_previous_block;
+
+        size_t installed = 0;
+        while (!parent_hash.IsNull() && child_height > 0) {
+            auto pit = by_hash.find(parent_hash);
+            if (pit == by_hash.end()) break;   // bottom of the supplied span
+            const BlockHeaderType& ph = *pit->second;
+            const uint32_t parent_height = child_height - 1;
+            // (1) X11 identity: pit was keyed by X11==parent_hash, and
+            //     parent_hash is the value the trusted child commits to — the
+            //     link is cryptographic. (2) PoW must be real.
+            if (!check_pow(parent_hash, ph.m_bits, m_params.pow_limit)) {
+                LOG_WARNING << "[EMB-DASH] pre-anchor backfill PoW FAIL at h="
+                            << parent_height << " hash="
+                            << parent_hash.GetHex().substr(0, 24)
+                            << " — stop (fail closed)";
+                break;
+            }
+            if (!m_headers.count(parent_hash)) {
+                IndexEntry e;
+                e.header     = ph;
+                e.hash       = parent_hash;
+                e.height     = parent_height;
+                // Pre-anchor cumulative work is unknown (genesis..anchor not
+                // held) and never consulted: these entries never enter tip
+                // selection. Zero keeps them strictly below m_best_work.
+                e.chain_work = uint256::ZERO;
+                e.prev_hash  = ph.m_previous_block;
+                e.status     = HEADER_VALID_CHAIN;
+                m_headers[parent_hash] = e;
+                // Bonus: back-fill the height index so get_header_by_height
+                // resolves pre-anchor heights too (harmless — forward entries
+                // at >= anchor are untouched; a later reorg rebuild walks from
+                // the synthetic anchor and simply drops these again, which
+                // leg (b)'s by-HASH lookup does not depend on).
+                m_height_index[parent_height] = parent_hash;
+                persist_header(e);
+                ++installed;
+            }
+            child_height = parent_height;
+            parent_hash  = ph.m_previous_block;
+        }
+        if (installed)
+            LOG_INFO << "[EMB-DASH] pre-anchor backfill INSTALLED " << installed
+                     << " header(s) down to h=" << child_height
+                     << " (X11-linked + PoW-verified from trusted anchor h="
+                     << anchor_height << "); DIP-4 leg (b) can now consult them.";
+        return installed;
+    }
+
     std::vector<uint256> get_locator() const {
         std::lock_guard<std::mutex> lock(m_mutex);
         return get_locator_internal();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1225,7 +1225,8 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_mn_checkpoint.cpp
                    test_dash_lane_diag.cpp
                    test_dash_header_checkpoint_coincide.cpp
-                   test_dash_anchor_header_merkle_root.cpp)
+                   test_dash_anchor_header_merkle_root.cpp
+                   test_dash_preanchor_header_backfill.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_preanchor_header_backfill.cpp
+++ b/test/test_dash_preanchor_header_backfill.cpp
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH daemonless COLD-START pre-anchor header backfill KAT (#1263 stack).
+///
+/// THE INCIDENT (2026-08-17, vm905, --coin-rpc removed, dashd ABSENT). The
+/// #1263 getqrinfo straddle seed is FULLY WIRED — the cold node asks for the
+/// rotated-quorum snapshot at the cycle base, the peer answers, the consumer
+/// binds mnListDiffAtHMinusC at exactly B0-C-8 — yet the seed NEVER lands:
+///
+///     [MN-DIFF-DB] getqrinfo cycle diff 0 DIP-4 auth FAILED at work h=2512792
+///     ...historical snapshot AUTH FAILED (block header not held)...
+///
+/// ROOT CAUSE. The three rotated quarter snapshots for cycle 2513088 are at
+/// WORK blocks 2512792 / 2512504 / 2512216 — all BELOW the fast-start anchor
+/// (2513000). At cold fast-start HeaderChain holds a LONE anchor and none of
+/// those pre-anchor headers, so DIP-4 leg (b) — bind the snapshot's cbTx merkle
+/// proof to OUR PoW-verified header's hashMerkleRoot — fails "block header not
+/// held" and the snapshot is consumed-but-never-applied. The store caps below
+/// the straddle, the resolver arms capped, the bridge falls to the network
+/// payee lane → PAYEE DESYNC fail-closed → no embedded template. The forward
+/// add_header path cannot fix this: a pre-anchor header's parent is not held,
+/// so it orphan-rejects.
+///
+/// THE FIX (this PR, dashd-parity). At cold store-arm, once the qrinfo reply is
+/// in hand, one-shot BACKWARD getheaders fetches the pre-anchor span and
+/// HeaderChain::install_preanchor_span installs it by walking DOWN from the
+/// trusted anchor: each parent is bound to its already-trusted child by an
+/// X11 prev-hash link AND independently check_pow-verified — exactly the two
+/// legs dashd requires of any header it stores (LookupBlockIndex over its full
+/// header tree). DIP-4 leg (b) stays STRICT (header must be held); a
+/// wrong/missing header installs nothing → leg (b) still fails closed → no bad
+/// mint. The tip / best-work are never moved (pre-anchor headers never compete
+/// for the tip; the synthetic-anchor daemon-tip honesty guards stay intact).
+///
+/// RED → GREEN is demonstrated WITHIN each test at runtime: BEFORE install,
+/// get_header(work_block) == nullopt and the leg-(b) merkle_root_of_hash
+/// callback returns nullopt ("block header not held"); AFTER install, the same
+/// callback returns the header's real merkleRoot — the exact value
+/// authenticate_historical_snapshot reads for its step-(b) proof. Fail-closed
+/// tests prove a PoW-broken or anchor-detached batch installs nothing.
+///
+/// The whole file is guarded on the fix's feature macro so it still COMPILES
+/// (empty) on a pre-fix tree that lacks install_preanchor_span. #143 note:
+/// FOLDED into the allowlisted test_dash_node_reception_wire target (a
+/// standalone add_executable would silently report "Not Run").
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/header_chain.hpp>   // HeaderChain, params, x11_hash, check_pow
+
+#include <core/uint256.hpp>
+
+#include <cstdio>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#ifdef C2POOL_PREANCHOR_SPAN_BACKFILL
+
+using dash::coin::HeaderChain;
+using dash::coin::DashChainParams;
+using dash::coin::BlockHeaderType;
+using dash::coin::make_dash_chain_params_mainnet;
+using dash::coin::x11_hash;
+
+namespace {
+
+// bits = 0x207fffff decodes to target 0x7fffff·2^(8·29) (~2^255) — the largest
+// compact-representable target. pow_limit is set EQUAL to that target so
+// check_pow's `target > pow_limit` guard passes; roughly half of random X11
+// hashes fall under it, so mine_hdr grinds the nonce a couple of times to make
+// each synthetic header PoW-VALID. X11 identity + prev-hash linkage are
+// exercised exactly as in production; only the difficulty is relaxed so a KAT
+// needs no real proof-of-work.
+constexpr uint32_t kEasyBits = 0x207fffffu;
+
+DashChainParams make_easy_params()
+{
+    DashChainParams p = make_dash_chain_params_mainnet();
+    p.pow_limit.SetHex(
+        "7fffff0000000000000000000000000000000000000000000000000000000000");
+    // Drop the mainnet fast-start pin; each test installs its own synthetic
+    // anchor via set_dynamic_checkpoint so it controls the anchor header.
+    p.fast_start_checkpoint.reset();
+    p.genesis_hash = uint256::ZERO;   // no genesis stub — start empty
+    return p;
+}
+
+// The distinct, non-null merkleRoot for the header at height `tag` — encoded so
+// the leg-(b) assertion can prove the RIGHT header's root is returned.
+uint256 tag_root(uint32_t tag)
+{
+    char buf[9];
+    std::snprintf(buf, sizeof buf, "%08x", tag);
+    std::string hex = "bb";
+    hex += buf;
+    hex.resize(64, '0');
+    uint256 r;
+    r.SetHex(hex);
+    return r;
+}
+
+// A header linking to `prev`, tagged at height `tag`, WITHOUT grinding PoW.
+// Used to plant a deliberately PoW-broken header (bits carry an impossible
+// target).
+BlockHeaderType raw_hdr(const uint256& prev, uint32_t bits, uint32_t tag)
+{
+    BlockHeaderType h;
+    h.m_version        = 0x20000000u;
+    h.m_previous_block = prev;
+    h.m_merkle_root    = tag_root(tag);
+    h.m_timestamp      = 1785000000u + tag;
+    h.m_bits           = bits;
+    h.m_nonce          = tag;
+    return h;
+}
+
+// A PoW-VALID header: grind the nonce until X11(header) <= target(kEasyBits).
+BlockHeaderType mine_hdr(const uint256& prev, const uint256& pow_limit,
+                         uint32_t tag)
+{
+    BlockHeaderType h = raw_hdr(prev, kEasyBits, tag);
+    for (uint32_t n = 0; ; ++n) {
+        h.m_nonce = n;
+        if (dash::coin::check_pow(x11_hash(h), h.m_bits, pow_limit))
+            return h;
+    }
+}
+
+struct SynthChain {
+    DashChainParams params;
+    uint32_t easy_bits{0};
+    uint32_t anchor_height{0};
+    uint256  anchor_hash;
+    BlockHeaderType anchor_hdr;
+    // batch = getheaders reply span [deepest .. anchor], anchor terminal
+    std::vector<BlockHeaderType> batch;
+    // hashes by height for assertions (heights below anchor)
+    std::vector<std::pair<uint32_t, uint256>> below;   // {height, hash}
+    std::vector<uint256> below_roots;                  // parallel merkleRoots
+};
+
+// Build a `count`-deep pre-anchor span below `anchor_height`. Header for the
+// deepest block links to a parent NOT in the batch, so the downward walk stops
+// there (the natural bottom of a bounded getheaders reply).
+SynthChain build_chain(uint32_t anchor_height, int count)
+{
+    SynthChain c;
+    c.params        = make_easy_params();
+    c.easy_bits     = kEasyBits;
+    c.anchor_height = anchor_height;
+
+    const uint32_t bottom_h = anchor_height - static_cast<uint32_t>(count);
+    // parent of the deepest header — intentionally absent from the batch.
+    uint256 prev; prev.SetHex(
+        "deadbeef00000000000000000000000000000000000000000000000000000000");
+
+    std::vector<BlockHeaderType> chain;   // bottom → anchor
+    for (uint32_t h = bottom_h; h <= anchor_height; ++h) {
+        BlockHeaderType hd = mine_hdr(prev, c.params.pow_limit, /*tag=*/h);
+        uint256 id = x11_hash(hd);
+        if (h == anchor_height) {
+            c.anchor_hdr  = hd;
+            c.anchor_hash = id;
+        } else {
+            c.below.emplace_back(h, id);
+            c.below_roots.push_back(hd.m_merkle_root);
+        }
+        chain.push_back(hd);
+        prev = id;   // next header's parent
+    }
+    // getheaders returns ascending; the installer indexes by hash regardless.
+    c.batch = chain;
+    return c;
+}
+
+// Byte-for-byte the leg-(b) callback main_dash.cpp binds as `mroot` (the
+// std::function signature of dash::coin::MerkleRootOfHashFn).
+std::function<std::optional<uint256>(const uint256&)>
+leg_b(const HeaderChain& hc)
+{
+    return [&hc](const uint256& b) -> std::optional<uint256> {
+        if (auto e = hc.get_header(b))
+            return e->header.m_merkle_root;
+        return std::nullopt;
+    };
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. RED → GREEN. Before install the three pre-anchor work-block headers are
+//    absent and leg (b) fails "block header not held"; after
+//    install_preanchor_span walks them down from the trusted anchor, leg (b)
+//    returns each real merkleRoot — the seed authenticates.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, InstallMakesLegBConsultPreanchorHeaders)
+{
+    SynthChain c = build_chain(/*anchor_height=*/2513000, /*count=*/3);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);   // lone anchor
+    ASSERT_EQ(hc.height(), c.anchor_height);
+
+    auto legb = leg_b(hc);
+
+    // RED (in-test): every pre-anchor work-block header is absent → leg (b)
+    // returns nullopt ("block header not held") → snapshot fails closed.
+    for (const auto& [h, id] : c.below) {
+        EXPECT_FALSE(hc.has_header(id))
+            << "pre-anchor header at h=" << h << " must be absent at cold start";
+        EXPECT_FALSE(legb(id).has_value())
+            << "leg (b) must fail closed for the un-held header at h=" << h;
+    }
+
+    // Install the pre-anchor span walking DOWN from the trusted anchor.
+    const size_t n = hc.install_preanchor_span(c.anchor_hash, c.batch);
+    EXPECT_EQ(n, c.below.size())
+        << "every X11-linked + PoW-verified pre-anchor header must install";
+
+    // GREEN (in-test): leg (b) now returns each header's REAL merkleRoot.
+    for (size_t i = 0; i < c.below.size(); ++i) {
+        const auto& [h, id] = c.below[i];
+        ASSERT_TRUE(hc.has_header(id))
+            << "pre-anchor header at h=" << h << " must be held after install";
+        auto root = legb(id);
+        ASSERT_TRUE(root.has_value())
+            << "leg (b) must now find the installed header at h=" << h;
+        EXPECT_EQ(*root, c.below_roots[i])
+            << "leg (b) must return the header's real merkleRoot at h=" << h;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. TIP UNMOVED. Pre-anchor headers never compete for the tip: the install
+//    must leave m_tip / height at the anchor so the synthetic-anchor daemon-
+//    tip honesty guards stay intact.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, InstallDoesNotMoveTheTip)
+{
+    SynthChain c = build_chain(2513000, 5);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);
+
+    const uint32_t tip_before = hc.height();
+    auto           head_before = hc.tip();
+    ASSERT_TRUE(head_before.has_value());
+
+    ASSERT_EQ(hc.install_preanchor_span(c.anchor_hash, c.batch), c.below.size());
+
+    EXPECT_EQ(hc.height(), tip_before) << "the tip height must not move";
+    auto head_after = hc.tip();
+    ASSERT_TRUE(head_after.has_value());
+    EXPECT_EQ(head_after->hash, head_before->hash)
+        << "the tip hash must stay at the anchor";
+    EXPECT_EQ(head_after->hash, c.anchor_hash);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. FAIL-CLOSED: broken PoW. A header in the span whose bits FAIL check_pow
+//    stops the downward walk; nothing at or below it installs, so leg (b)
+//    still fails closed for those heights — never a bad mint.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, PoWBrokenHeaderStopsWalkFailClosed)
+{
+    SynthChain c = build_chain(2513000, 4);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);
+
+    // c.below is {anchor-1, anchor-2, anchor-3, anchor-4} in ascending height.
+    // Break PoW on the SECOND header below the anchor (anchor-2): a compact
+    // bits encoding a near-zero target that no X11 hash can satisfy. Its X11
+    // id changes, so re-key the batch AND the anchor's child links accordingly
+    // by rebuilding from the corrupted header up to the anchor.
+    // Simplest faithful corruption: rebuild the chain, flipping one header's
+    // bits to an impossible target, and re-link everything above it.
+    const uint32_t impossible  = 0x03000001u;   // target ~ 1 → X11 hash > target
+    const uint32_t bottom_h    = c.anchor_height - 4;
+    uint256 prev; prev.SetHex(
+        "deadbeef00000000000000000000000000000000000000000000000000000000");
+    std::vector<BlockHeaderType> batch;
+    uint256 anchor_hash;
+    uint256 broken_id, below_top_id;   // anchor-2 (broken), anchor-1
+    for (uint32_t h = bottom_h; h <= c.anchor_height; ++h) {
+        const bool is_broken = (h == c.anchor_height - 2);
+        // Good headers are PoW-mined; the broken one carries an impossible
+        // target (no nonce can satisfy it) so check_pow rejects it.
+        BlockHeaderType hd = is_broken
+            ? raw_hdr(prev, impossible, /*tag=*/h)
+            : mine_hdr(prev, c.params.pow_limit, /*tag=*/h);
+        uint256 id = x11_hash(hd);
+        if (h == c.anchor_height)      anchor_hash   = id;
+        if (h == c.anchor_height - 2)  broken_id     = id;
+        if (h == c.anchor_height - 1)  below_top_id  = id;
+        batch.push_back(hd);
+        prev = id;
+    }
+    HeaderChain hc2(c.params);
+    ASSERT_TRUE(hc2.init());
+    hc2.set_dynamic_checkpoint(c.anchor_height, anchor_hash);
+
+    const size_t n = hc2.install_preanchor_span(anchor_hash, batch);
+    // Only anchor-1 (directly below the anchor, PoW-good) installs; the walk
+    // hits the impossible-PoW anchor-2 and STOPS.
+    EXPECT_EQ(n, 1u) << "walk must stop at the first PoW-broken header";
+    EXPECT_TRUE(hc2.has_header(below_top_id))
+        << "the PoW-good header directly below the anchor installs";
+    EXPECT_FALSE(hc2.has_header(broken_id))
+        << "a PoW-broken header must NEVER be installed (fail closed)";
+    EXPECT_FALSE(leg_b(hc2)(broken_id).has_value())
+        << "leg (b) must fail closed for the rejected header";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. FAIL-CLOSED: batch never reaches the anchor. A span whose top header is
+//    NOT the trusted anchor (a lying peer, or a wrong stop hash) yields no
+//    downward linkage from the anchor → zero installs → leg (b) unchanged.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, BatchWithoutAnchorInstallsNothing)
+{
+    SynthChain c = build_chain(2513000, 3);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);
+
+    // Drop the terminal (anchor) header from the batch: the walk can find no
+    // trusted root to descend from.
+    std::vector<BlockHeaderType> no_anchor(c.batch.begin(), c.batch.end() - 1);
+    EXPECT_EQ(hc.install_preanchor_span(c.anchor_hash, no_anchor), 0u)
+        << "a batch that never reaches the anchor must install nothing";
+
+    // Entirely unrelated garbage installs nothing either.
+    std::vector<BlockHeaderType> garbage;
+    garbage.push_back(mine_hdr(uint256::ZERO, c.params.pow_limit, /*tag=*/777u));
+    EXPECT_EQ(hc.install_preanchor_span(c.anchor_hash, garbage), 0u)
+        << "a batch with no linkage to the anchor must install nothing";
+
+    for (const auto& [h, id] : c.below) {
+        (void)h;
+        EXPECT_FALSE(leg_b(hc)(id).has_value())
+            << "leg (b) stays fail-closed when the span never authenticated";
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 5. ANCHOR MUST BE HELD. If the claimed anchor is not in the header index,
+//    the install refuses outright (no trust root) — installs nothing.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, UnheldAnchorInstallsNothing)
+{
+    SynthChain c = build_chain(2513000, 3);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    // NOTE: do NOT seed the anchor — it is unheld.
+    EXPECT_FALSE(hc.has_header(c.anchor_hash));
+    EXPECT_EQ(hc.install_preanchor_span(c.anchor_hash, c.batch), 0u)
+        << "install must refuse when the anchor (trust root) is not held";
+}
+
+#endif // C2POOL_PREANCHOR_SPAN_BACKFILL


### PR DESCRIPTION
## Cold-arm pre-anchor header backfill so the getqrinfo straddle seed authenticates

**DRAFT — stacked on #1263** (base branch `dash/mn-diff-store-getqrinfo-straddle-seed`). Do not merge; review only.

### The gap this closes
On a cold fast-start daemonless node the #1263 getqrinfo straddle seed is fully wired but never lands: the three rotated quarter snapshots for the straddle cycle 2513088 sit at WORK blocks **2512792 / 2512504 / 2512216**, all *below* the fast-start anchor (2513000), and the cold header chain holds only the lone anchor. DIP-4 leg (b) of `authenticate_historical_snapshot` binds the snapshot cbTx merkle proof to our PoW-verified header's `hashMerkleRoot`; with those pre-anchor headers absent it fails **"block header not held"** and fails closed, so the store caps below the straddle and the bridge falls to the network payee lane. The forward `add_header` path cannot supply them — a pre-anchor header's parent is not held, so it orphan-rejects.

### The fix (dashd-parity, option b)
Supply the span the way dashd holds it — from its own header tree. At cold store-arm, once the qrinfo reply is in hand, issue **one bounded BACKWARD `getheaders`** (locator = the h-4C work block from the `extraShare` leg, `hash_stop` = the trusted anchor) and install the returned span with a new `HeaderChain::install_preanchor_span` that walks **down** from the anchor: each parent is bound to its already-trusted child by an X11 prev-hash link **AND** independently `check_pow`-verified — exactly the two legs dashd requires of any header it stores. The tip / best-work are never moved (pre-anchor headers never compete for the tip; the synthetic-anchor daemon-tip honesty guards stay intact). `getqrinfo` is re-driven once the span lands so leg (b) authenticates on the next reply.

DIP-4 leg (b) stays **STRICT**: header must be held + merkle root must match. A wrong/forged/missing header produces no downward linkage from the trusted anchor → zero installs → leg (b) still fails closed → callers fall through to the network path → never a bad mint. Backfilled headers are themselves PoW-verified and prev-hash-linked to the release-pinned anchor. Cost is one-shot ~800 headers (~64 KB wire) per cold arm vs `--replay-bulk`'s ~2.5M, so fast-start is preserved. The reply reaches the installer via the `new_headers` event; the replay bulk headers-demux is null off `--replay-bulk`, so the daemonless posture routes it unchanged.

Design's flagged residual (getheaders starts at locator+1, so h-3C's own header would be excluded) is handled by seeding the locator from the **h-4C** `extraShare` leg one rotated cycle deeper.

### What is PROVEN (KAT + provenance-checked vm905 cold daemonless run)
- **KAT** `test_dash_preanchor_header_backfill` (5/5 green, folded into the allowlisted wire target). Demonstrates red→green *within each test*: before install `get_header`/leg (b) return nullopt ("block header not held"); after `install_preanchor_span` walks the span down from the trusted anchor, leg (b) returns each header's real merkleRoot. Fail-closed cases (PoW-broken header stops the walk; a batch that never reaches the anchor; an unheld anchor) install nothing.
- **Build**: DASH `C2POOL_DASH_BLS=ON` (real `libdashbls.a`), BLS backend REAL confirmed at runtime.
- **Provenance**: `/proc/<pid>/exe` md5 `f05c184fce4272b2b722e5c48498aa46` == built binary md5, `--version` = `...-82-g2692fb42` (this HEAD).
- **vm905 cold daemonless run** (fresh state dir, `--embedded-mainnet --embedded-null-arm --embedded-utxo --coin-p2p-discover`, **dashd ABSENT**, no `--coin-rpc`):
  - `getqrinfo issued` for straddle cycle base h=2513088 → `pre-anchor header BACKFILL issued: getheaders locator=h-4C stop=anchor` → `pre-anchor backfill INSTALLED 1071 header(s) down to h=2511929` (covers all three work blocks) → `getqrinfo rotated bootstrap SEEDED: 3 pre-anchor quarter snapshots + 3 work-lists ... cycle 2513088 is now derivable`.
  - **0** occurrences of "block header not held"; **0** "DIP-4 auth FAILED". Seed authenticates.
  - Seed authenticated ~2m18s after cold start.

### Honest status: end-to-end cold serve NOT yet reached — two DOWNSTREAM residuals (out of scope of this PR)
This PR does exactly what it claims (the seed now authenticates), which advances the store-engine frontier from "capped at/below the straddle" to the straddle cycle's own commitment. Two further, independent residuals block serve-ready and are **not** in the header-backfill's domain:

1. **Store-engine parallel fold caps at h=2513130.** The type-5 rotated quorum of cycle 2513088 is committed at 2513088+42 = **2513130** (its DKG mining window). The store-engine W4 resolver's `m_members_fn(5, quorumHash)` returns *no member set* for that quorum even though the seed made cycle 2513088 "derivable" (3 quarter snapshots + work-lists present). The resolver does not assemble/key the rotated quorum's member set for the seeded cycle. **This is the store-engine resolver's domain (#1262 W4 / #1263 seed→derive), one layer below the header backfill.**

2. **Main mn-ckpt bridge FAIL-CLOSED at h=2517703** (PAYEE DESYNC): projected MN `6b17d6e1…` not paid by the coinbase, and the height-exact DIP-4-verified SML attests the projected candidate VALID (counter-evidence, not a missed ban). Root: BAN-STATE PROBE cap exhausted (8/8) — 27 ProUpServTx applied without a pre-block-height MN list → queue-ordering divergence accumulates. **This is the known ban-state-probe / reinstatement-gap class (DEF5/#1043 territory), not caused by this change.**

`reached_tip=false`, `store_covers_past_qfcommit=false`, `first_embedded_serve=false`. The pre-anchor header backfill is proven at its own layer and is reward-safe; the next residual to attack is #1 (store-engine rotated-quorum member-set assembly for the seeded straddle cycle).
