### PR TITLE
dash: assemble+key the store-engine straddle cycle member set on getqrinfo seed

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6740,6 +6740,51 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                             " fold_qfcommit past the anchor resolves its"
                                             " member set and the store extends toward"
                                             " tip.";
+                                // ── ASSEMBLE + KEY the straddle cycle NOW ────
+                                // The seed made the cycle DERIVABLE (snapshots +
+                                // work-lists present); this drives dashd's
+                                // ComputeQuorumMembersByQuarterRotation over them
+                                // (the engine's compute_rotation_cycle, verbatim)
+                                // and registers the ordered member set keyed by
+                                // (llmqType, cycle_base+quorumIndex) — the exact
+                                // key fold_qfcommit's m_members_fn(type,quorumHash)
+                                // resolves a commitment quorumHash to. Done BEFORE
+                                // draining the held blocks so the qfcommit at
+                                // cycle_base+mining_window_start (the height the
+                                // store used to cap at) resolves its member set
+                                // and the fold folds THROUGH toward tip.
+                                {
+                                    auto dr = qbr->derive_members_for_cycle(
+                                        sseed->llmq_type, sseed->cycle_base);
+                                    if (dr.ok)
+                                        LOG_INFO << "[MN-DIFF-DB] straddle cycle"
+                                                    " base h=" << sseed->cycle_base
+                                                 << " (type "
+                                                 << int(sseed->llmq_type)
+                                                 << ") rotated member sets"
+                                                    " ASSEMBLED + KEYED: "
+                                                 << dr.member_sets << "/"
+                                                 << dr.expected_sets
+                                                 << " quorumIndex lists (quorum"
+                                                    " size " << dr.quorum_size
+                                                 << ") — fold_qfcommit resolves"
+                                                    " past the anchor.";
+                                    else
+                                        LOG_WARNING << "[MN-DIFF-DB] straddle cycle"
+                                                       " base h="
+                                                    << sseed->cycle_base
+                                                    << " (type "
+                                                    << int(sseed->llmq_type)
+                                                    << ") member assembly"
+                                                       " INCOMPLETE ("
+                                                    << dr.member_sets << "/"
+                                                    << dr.expected_sets << "): "
+                                                    << dr.skip_reason
+                                                    << " — store will cap at the"
+                                                       " cycle's first punishing"
+                                                       " qfcommit; callers fall"
+                                                       " through (reward-safe).";
+                                }
                                 if (!sseed->hold.empty()) {
                                     for (auto& pr : sseed->hold)
                                         (*feed)(pr.second, pr.first);

--- a/src/impl/dash/coin/replay_quorum_bridge.hpp
+++ b/src/impl/dash/coin/replay_quorum_bridge.hpp
@@ -738,6 +738,25 @@ public:
         return std::nullopt;
     }
 
+    /// Drive the straddle-cycle member assembly the moment the getqrinfo
+    /// seed lands (store-engine bootstrap, main_dash.cpp). Pass-through to the
+    /// engine; folds the outcome into the report counters so a run states
+    /// whether the seeded cycle became derivable. See
+    /// QuorumReplayEngine::derive_members_for_cycle for the reward-safety
+    /// argument (a wrong set fails the writer's root self-check closed).
+    QuorumReplayEngine::DeriveCycleResult
+    derive_members_for_cycle(uint8_t llmq_type, uint32_t cycle_base)
+    {
+        auto r = m_quorum.derive_members_for_cycle(llmq_type, cycle_base);
+        if (r.ok) {
+            ++m_stats.member_cycles_derived;
+        } else {
+            ++m_stats.member_cycles_skipped;
+            if (!r.skip_reason.empty()) m_stats.last_skip_reason = r.skip_reason;
+        }
+        return r;
+    }
+
     size_t retained_lists() const { return m_lists.size(); }
 
     /// dashd CDeterministicMN → the member-computation view. Carries the

--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -900,6 +900,91 @@ public:
         return mit->second;
     }
 
+    /// Result of an out-of-band single-cycle member derivation.
+    struct DeriveCycleResult {
+        bool        ok{false};
+        uint8_t     llmq_type{0};
+        uint32_t    cycle_base{0};
+        size_t      member_sets{0};   // # of quorumIndex lists now registered
+        size_t      quorum_size{0};   // members per set (for the log)
+        size_t      expected_sets{0}; // signingActiveQuorumCount
+        std::string skip_reason;      // engine's own named miss on !ok
+    };
+
+    /// Out-of-band derivation of ONE rotated cycle's member sets from the
+    /// already-seeded quarter snapshots + work-lists (the getqrinfo straddle
+    /// bootstrap). It drives the SAME compute_rotation_cycle path
+    /// derive_cycles_at() runs at forward-observe — no new consensus code —
+    /// but at the moment the seed LANDS, so the straddle cycle's ordered
+    /// member sets are registered under m_members[{type, cycle_base+index}]
+    /// (exactly the key fold_qfcommit's m_members_fn(type, quorumHash) lookup
+    /// resolves a commitment quorumHash to, via m_height_by_hash) BEFORE any
+    /// held block drains into the fold. Without this the member set is only
+    /// ever attempted lazily during the forward drain, and on the seeded
+    /// straddle cycle that attempt does not populate a result the qfcommit at
+    /// cycle_base+mining_window_start can consume, so the store caps there.
+    ///
+    /// Idempotent (re-storing identical members is a no-op) and reward-safe by
+    /// construction: a WRONG member set later re-hashes to the wrong
+    /// merkleRootMNList and the writer's per-row root self-check refuses the
+    /// row, so callers fall through to the network path — never a bad mint.
+    DeriveCycleResult derive_members_for_cycle(uint8_t llmq_type,
+                                               uint32_t cycle_base)
+    {
+        DeriveCycleResult out;
+        out.llmq_type  = llmq_type;
+        out.cycle_base = cycle_base;
+        const LlmqParamsView* p = replay_llmq_params(m_cfg.network, llmq_type);
+        if (p == nullptr) {
+            out.skip_reason = "llmqType " + std::to_string(int(llmq_type))
+                            + " not in this network's chainparams llmq list";
+            return out;
+        }
+        if (!p->use_rotation) {
+            out.skip_reason = "llmqType " + std::to_string(int(llmq_type))
+                            + " is not a rotated LLMQ — no quarter-rotation "
+                              "member set to assemble";
+            return out;
+        }
+        out.quorum_size   = p->size;
+        out.expected_sets = p->signing_active_quorum_count;
+
+        // Run the engine's own per-cycle derivation verbatim at the cycle
+        // base. derive_cycles_at only acts on types whose dkgInterval divides
+        // the height, so this touches exactly the cycle(s) rooted here.
+        QuorumObserveResult r;
+        r.height = cycle_base;
+        derive_cycles_at(cycle_base, r);
+
+        // Success == the ordered member set for THIS type/cycle is now
+        // registered for every signingActiveQuorumCount index.
+        size_t have = 0;
+        for (uint32_t i = 0; i < p->signing_active_quorum_count; ++i) {
+            if (m_members.count({llmq_type, cycle_base + i})) ++have;
+        }
+        out.member_sets = have;
+        out.ok = (p->signing_active_quorum_count > 0
+                  && have == p->signing_active_quorum_count);
+        if (!out.ok) {
+            const std::string needle =
+                "type " + std::to_string(int(llmq_type)) + " ";
+            for (const auto& s : r.member_skip_reasons) {
+                if (s.find(needle) != std::string::npos) {
+                    out.skip_reason = s;
+                    break;
+                }
+            }
+            if (out.skip_reason.empty())
+                out.skip_reason = "derive produced " + std::to_string(have)
+                    + "/" + std::to_string(p->signing_active_quorum_count)
+                    + " member sets for type " + std::to_string(int(llmq_type))
+                    + " cycle base h=" + std::to_string(cycle_base)
+                    + " with no named skip (inputs present but assembly "
+                      "incomplete)";
+        }
+        return out;
+    }
+
     /// The produced (or seeded) per-cycle snapshot — the qrinfo replacement.
     std::optional<vendor::CQuorumSnapshot> snapshot_for(uint8_t type,
                                                         uint32_t cycle_base) const

--- a/test/test_dash_replay_quorum_engine.cpp
+++ b/test/test_dash_replay_quorum_engine.cpp
@@ -596,6 +596,162 @@ TEST(DashReplayQuorumEngine, KatC_OwnSnapshotFeedsTheNextCycleIdentically)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// KAT-D — the STORE-ENGINE straddle bootstrap: derive_members_for_cycle()
+// ASSEMBLES the rotated cycle's 32 ordered member sets from the SEEDED
+// quarters (getqrinfo straddle seed) and KEYS them by (llmqType,
+// cycle_base+quorumIndex), so fold_qfcommit's m_members_fn(type, quorumHash)
+// lookup resolves — the fix for the store capping at cycle_base +
+// mining_window_start. KAT-B proved compute_rotation_cycle's math is
+// dashd-exact; this proves the ENGINE WRAPPER that drives it from the seed
+// and the members_for KEYING the fold consumes.
+//
+//  RED (drop a seeded quarter, or revert the wiring): derive returns ok=false
+//      with a NAMED skip, members_for() is nullopt, the fold fails closed.
+//  GREEN: 32/32 sets registered, each == dashd's golden order (KAT-B
+//      goldens), resolvable through members_for by the per-index quorum base
+//      hash exactly as fold_qfcommit resolves a commitment quorumHash.
+//  REWARD-SAFE: a TAMPERED quarter still runs the math but the assembled set
+//      DIFFERS from dashd's — the divergence the writer's per-row
+//      merkleRootMNList self-check catches, so the store fails closed and
+//      callers fall through to the network path (never a bad mint).
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayQuorumEngine, KatD_DeriveMembersForCycleAssemblesAndKeysStraddleCycle)
+{
+    QrinfoCycles q;
+    ASSERT_TRUE(q.load()) << "mainnet qrinfo must decode + authenticate";
+    auto kat = load_member_kat();
+    ASSERT_EQ(kat.size(), 32u);
+
+    // The cycle-H work block's own hash + CL — chain data the store OBSERVES
+    // forward before the hold; derive recomputes the H modifier from these
+    // (it does NOT read a seeded H modifier), so it must reproduce
+    // q.modifiers[0] for the members to match the goldens.
+    const uint32_t workH = kCycleBase - kWorkDiffDepth;
+    const uint256  workH_hash = q.info.mnListDiffH.blockHash;
+    std::optional<std::array<uint8_t, CFinalCommitment::BLS_SIG_SIZE>> workH_cl;
+    {
+        dash::coin::vendor::CCbTx cb;
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(
+            q.info.mnListDiffH.cbTx.extra_payload, cb));
+        if (cb.nVersion >= dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE
+            && cb.has_best_cl_signature())
+            workH_cl = cb.bestCLSignature;
+    }
+
+    // Seed an engine to the same state the store-engine bridge holds when the
+    // getqrinfo straddle seed lands: the three previous-quarter snapshots +
+    // modifiers + work-lists, and the cycle-H work block chain fields.
+    auto seed_engine = [&](QuorumReplayEngine& eng, bool seed_hminusC) {
+        std::map<uint32_t, std::vector<QuorumMnEntry>> lists_by_h;
+        lists_by_h[kCycleBase - kWorkDiffDepth]              = q.lists[0];
+        lists_by_h[kCycleBase - 1u * kC - kWorkDiffDepth]    = q.lists[1];
+        lists_by_h[kCycleBase - 2u * kC - kWorkDiffDepth]    = q.lists[2];
+        lists_by_h[kCycleBase - 3u * kC - kWorkDiffDepth]    = q.lists[3];
+        eng.set_mn_list_at_fn(
+            [lists_by_h](uint32_t h)
+                -> std::optional<std::vector<QuorumMnEntry>> {
+                auto it = lists_by_h.find(h);
+                if (it == lists_by_h.end()) return std::nullopt;
+                return it->second;
+            });
+        eng.seed_block_hash(workH, workH_hash);
+        eng.seed_work_block_cl(workH, workH_cl);
+        for (size_t i = 1; i <= 3; ++i) {
+            if (i == 1 && !seed_hminusC) continue;   // RED: drop the H-C quarter
+            const uint32_t base = kCycleBase - static_cast<uint32_t>(i) * kC;
+            eng.seed_snapshot(kType6075, base, *q.snaps[i - 1]);
+            eng.seed_modifier(kType6075, base, q.modifiers[i]);
+        }
+    };
+
+    // Per-index quorum base hashes, so members_for() resolves the way
+    // fold_qfcommit does: quorumHash -> height (cycle_base+index) -> members.
+    auto seed_index_hashes = [&](QuorumReplayEngine& eng, char tag,
+                                 std::array<uint256, 32>& qhash) {
+        for (uint32_t idx = 0; idx < 32; ++idx) {
+            std::string h(64, '0');
+            h[0]  = tag;
+            h[58] = "0123456789abcdef"[(idx >> 8) & 0xf];
+            h[59] = "0123456789abcdef"[(idx >> 4) & 0xf];
+            h[60] = "0123456789abcdef"[idx & 0xf];
+            qhash[idx].SetHex(h);
+            eng.seed_block_hash(kCycleBase + idx, qhash[idx]);
+        }
+    };
+
+    // ── GREEN: assembled + keyed, dashd-exact, resolvable ─────────────────
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_engine(eng, /*seed_hminusC=*/true);
+        std::array<uint256, 32> qhash;
+        seed_index_hashes(eng, 'e', qhash);
+
+        auto dr = eng.derive_members_for_cycle(kType6075, kCycleBase);
+        ASSERT_TRUE(dr.ok) << dr.skip_reason;
+        EXPECT_EQ(dr.member_sets, 32u);
+        EXPECT_EQ(dr.expected_sets, 32u);
+        EXPECT_EQ(dr.quorum_size, 60u);
+
+        for (const auto& row : kat) {
+            ASSERT_LT(row.index, 32u);
+            auto m = eng.members_for(kType6075, qhash[row.index]);
+            ASSERT_TRUE(m.has_value())
+                << "quorumIndex " << row.index << " must resolve after derive";
+            auto got = protx_hex(*m);
+            ASSERT_EQ(got.size(), row.protx.size())
+                << "quorumIndex " << row.index;
+            for (size_t i = 0; i < got.size(); ++i)
+                EXPECT_EQ(got[i], row.protx[i])
+                    << "quorumIndex " << row.index << " member INDEX " << i
+                    << " diverges from dashd (this is the validMembers slot — "
+                       "consensus)";
+        }
+    }
+
+    // ── RED: a missing quarter → named skip, no member set, fail-closed ────
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_engine(eng, /*seed_hminusC=*/false);
+        uint256 qh0;
+        qh0.SetHex(
+            "0000000000000000000000000000000000000000000000000000000000000e00");
+        eng.seed_block_hash(kCycleBase, qh0);
+
+        auto dr = eng.derive_members_for_cycle(kType6075, kCycleBase);
+        EXPECT_FALSE(dr.ok);
+        EXPECT_LT(dr.member_sets, 32u);
+        EXPECT_FALSE(dr.skip_reason.empty()) << "the miss must be NAMED";
+        EXPECT_FALSE(eng.members_for(kType6075, qh0).has_value())
+            << "a missing quarter must leave the fold with NO member set "
+               "(fail-closed), never a guessed one";
+    }
+
+    // ── REWARD-SAFE: a tampered quarter assembles a DETECTABLY WRONG set ───
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_engine(eng, /*seed_hminusC=*/true);
+        CQuorumSnapshot bad = *q.snaps[0];   // H-C quarter
+        ASSERT_FALSE(bad.activeQuorumMembers.empty());
+        bad.activeQuorumMembers[0] = !bad.activeQuorumMembers[0];
+        eng.seed_snapshot(kType6075, kCycleBase - kC, bad);
+        std::array<uint256, 32> qhash;
+        seed_index_hashes(eng, 'f', qhash);
+
+        (void)eng.derive_members_for_cycle(kType6075, kCycleBase);
+        bool any_diff = false;
+        for (const auto& row : kat) {
+            auto m = eng.members_for(kType6075, qhash[row.index]);
+            if (!m) { any_diff = true; break; }
+            if (protx_hex(*m) != row.protx) { any_diff = true; break; }
+        }
+        EXPECT_TRUE(any_diff)
+            << "a tampered quarter must NOT reproduce dashd's members — that "
+               "divergence is exactly what the writer's per-row "
+               "merkleRootMNList self-check catches (reward-safe fail-closed)";
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Engine discipline (synthetic)
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## What

Makes the **W4 store-engine quorum resolver** compute and register the straddle
cycle's rotated quorum member set from the getqrinfo-seeded quarters, so
`fold_qfcommit`'s `m_members_fn(llmqType, quorumHash)` lookup resolves and the
parallel MN diff-store fold walks **through** the cycle's first punishing
qfcommit instead of capping there.

Stacks on #1266 (`dash/mn-diff-store-preanchor-header-backfill`).

## Why

With #1266, the pre-anchor header span authenticates the getqrinfo snapshots and
the 3 pre-anchor quarter snapshots + work-lists for the straddle cycle
(2513088, type 5, C=288) are **seeded** — the cycle is *derivable*. But the
store engine never drove `ComputeQuorumMembersByQuarterRotation` to a **keyed**
result for it: the member set was only ever attempted lazily at forward-observe,
and on the seeded straddle cycle that attempt did not populate a result the
qfcommit at `cycle_base + mining_window_start` (h=2513130) could consume. So the
fold hit:

```
[MN-DIFF-DB] ... quorum-member resolver has no member set for
llmqType=5 quorumHash=0000000000000025 — failing closed
```

capping the store ~130 heights past the anchor, and the main mn-ckpt bridge fell
to the capped network payee lane (the h=2517703 PAYEE DESYNC class).

## How

- `QuorumReplayEngine::derive_members_for_cycle(llmqType, cycle_base)` — drives
  the engine's own `compute_rotation_cycle` (the ported
  `ComputeQuorumMembersByQuarterRotation`, **verbatim**, no new consensus code)
  over the just-seeded quarters plus the self-derived new quarter, and registers
  the ordered member set under `m_members[{type, cycle_base + quorumIndex}]` —
  exactly the key the fold's `m_members_fn(type, quorumHash)` resolves a
  commitment quorumHash to (`GetQuorumMembers` derives the cycle base by
  `GetAncestor(nHeight − quorumIndex)`, so the commitment quorumHash's block sits
  at `cycle_base + quorumIndex`). Idempotent; returns a small result the caller
  logs.
- `ReplayQuorumBridge::derive_members_for_cycle` — pass-through that folds the
  outcome into the report counters.
- `main_dash.cpp` — invokes it the moment the getqrinfo straddle seed lands
  (right after `seed_snapshots` + `seed_work_lists` succeed), **before** the held
  blocks drain, so the qfcommit resolves and the fold folds through toward tip.

## Reward-safety (by construction)

Every folded list is re-checked against the block's committed `merkleRootMNList`
before the writer commits the row. A WRONG member set → root mismatch → the
writer refuses the row → the store poisons/empties → callers fall through to the
network path. **Never a bad mint.** The correct member set makes the folded
ban-state dashd-exact.

## Test — KAT-D (`test_dash_replay_quorum_engine`)

Real mainnet qrinfo fixture (`dash_mainnet_qrinfo_2516785.bin`), cycle 2516544,
32 quorumIndex slots, dashd's own `quorum info` member lists as goldens:

- **GREEN**: `derive_members_for_cycle` assembles **32/32** dashd-exact ordered
  member sets, each resolvable through `members_for(type, quorumHash)` by the
  per-index quorum base hash — the exact contract the fold consumes.
- **RED** (a missing quarter): derive returns `ok=false` with a **named** skip,
  and `members_for` is `nullopt` — the fold fails closed, never a guessed set.
- **REWARD-SAFE**: a tampered quarter still runs the math but the assembled set
  **differs** from dashd's — the divergence the writer's per-row
  `merkleRootMNList` self-check catches.

KAT-B (the 32-slot rotation math) and the full 20-test
`DashReplayQuorumEngine` suite stay green.

## Build / provenance

`c2pool-dash` built with **BLS=REAL** (dashbls linked). Draft — do not merge.
