### PR TITLE
dash: self-derived MN-set checkpoint dump (--dump-mn-checkpoint H FILE)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -98,6 +98,7 @@
 #include <impl/dash/coin/replay_bulk_fetch.hpp>  // W2: full-history replay bulk block-fetch lane (--replay-bulk)
 #include <impl/dash/coin/replay_utxo_fold.hpp>   // W3: full-history replay standalone UTXO fold (--replay-utxo-*)
 #include <impl/dash/coin/replay_prestate.hpp>    // W5: anchor prestate loader (--replay-fold-prestate)
+#include <impl/dash/coin/mn_checkpoint_dump.hpp> // self-derived MN-set checkpoint dump (--dump-mn-checkpoint)
 #include <impl/dash/coin/replay_fold_consumer.hpp> // W5: bulk lane -> W1 DML fold + per-block root check
 #include <impl/dash/coin/replay_quorum_bridge.hpp> // SEAM: W4 quorum lane <-> W1 MembersFn
 #include <impl/dash/coin/historical_sml.hpp> // authenticate_historical_snapshot (DIP-4 R3, straddle-seed)
@@ -261,6 +262,13 @@ bool g_mn_bridge_no_cursor = false;
 bool        g_replay_bulk = false;            // --replay-bulk: arm the lane
 std::string g_replay_bulk_capture_dir;        // --replay-bulk-capture DIR (implies --replay-bulk)
 uint32_t    g_replay_bulk_start = 0;          // --replay-bulk-start H (0 = network default: mainnet DIP3 1028160)
+// ── DASHD-CUT: self-derived MN-set checkpoint dump (--dump-mn-checkpoint H FILE) ─
+// When the --replay-bulk DML fold's cursor reaches H, serialize its REGISTERED
+// masternode set to the checkpoint .inc at FILE — SELF-DERIVED from the fold's
+// own root-checked ReplayMNState, no dashd RPC, no trusted protx snapshot
+// (operator decision 2026-08-17). One-shot; the fold is unaffected otherwise.
+uint32_t    g_dump_mn_checkpoint_height = 0;  // 0 = off
+std::string g_dump_mn_checkpoint_file;
 
 // ── W5 INTEGRATION: drive the W1 DML fold from the W2 bulk lane ───────────
 // --replay-fold-prestate FILE seeds the W1 fold engine from a full-state
@@ -424,6 +432,7 @@ void print_banner(const char* argv0)
         << "           [--replay-fold-prestate FILE] [--replay-fold-quorums]\n"
         << "           [--replay-fold-qsnapshot FILE] [--replay-fold-worklists FILE]\n"
         << "           [--replay-mined-commitment-index]\n"
+        << "           [--dump-mn-checkpoint H FILE]\n"
         << "           [--embedded-no-dashd-mn-seed]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
@@ -579,6 +588,11 @@ void print_banner(const char* argv0)
         << "        caches raw bodies into append-only segment files (fleet re-fold\n"
         << "        cache; implies --replay-bulk). --replay-bulk-start H overrides\n"
         << "        the first fetched height (default: mainnet DIP3 1028160).\n"
+        << "        --dump-mn-checkpoint H FILE serializes the --replay-fold DML\n"
+        << "        set at height H to the checkpoint .inc at FILE, SELF-DERIVED\n"
+        << "        from the fold's own root-checked state (no dashd RPC, no\n"
+        << "        protx snapshot; registered-not-valid; reuses the runtime\n"
+        << "        parser field order + digest, self-verifies before writing).\n"
         << "        --external-ip ADDR (alias --stratum-advertise / --public-host)\n"
         << "        overrides the miner-facing host shown in the dashboard Stratum\n"
         << "        URL -- for NAT / port-mapped nodes whose outbound IP is not the\n"
@@ -7117,6 +7131,52 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // carries a payout script. A fold that diverged, is poisoned,
                 // or is behind the tip can never become the authoritative
                 // snapshot, and the refusal names which condition blocked.
+                // ── DASHD-CUT: self-derived MN-set checkpoint DUMP ────────
+                // One-shot: when the fold cursor reaches H, serialize the
+                // registered set to FILE (mn_checkpoint_dump.hpp). SELF-DERIVED
+                // — every field comes from the fold's own root-checked
+                // ReplayMNState (scriptPayout verbatim from the ProRegTx it
+                // replayed; nLastPaidHeight from the payee bookkeeping it
+                // keeps), never a dashd protx snapshot. Serve-inert: it only
+                // reads the engine and writes one file. The write self-verifies
+                // through parse_mn_checkpoint() so it can never emit a file the
+                // runtime cold-start would refuse.
+                if (g_dump_mn_checkpoint_height != 0 && replay_fold_consumer) {
+                    const uint32_t dump_h = g_dump_mn_checkpoint_height;
+                    const std::string dump_file = g_dump_mn_checkpoint_file;
+                    replay_fold_consumer->set_dump_hook(
+                        dump_h,
+                        [dump_file, dump_h](const rp::DmlFoldEngine& eng,
+                                            uint32_t reached) {
+                            const std::string source =
+                                "self-derived from chain via c2pool"
+                                " --replay-bulk at H=" + std::to_string(reached)
+                                + " (blockhash " + eng.block_hash().GetHex()
+                                + ")";
+                            const std::string generated =
+                                dash::coin::mn_dump_detail::iso8601_utc_now();
+                            std::string err;
+                            if (dash::coin::write_mn_checkpoint_inc(
+                                    eng, dump_file, source, generated, err)) {
+                                std::cout << "[run] --dump-mn-checkpoint: WROTE "
+                                          << eng.size() << " registered"
+                                             " masternodes at h=" << reached
+                                          << " to " << dump_file
+                                          << " (self-derived, no dashd) —"
+                                             " verified through"
+                                             " parse_mn_checkpoint()\n";
+                            } else {
+                                std::cerr << "[run] --dump-mn-checkpoint FAILED"
+                                             " at h=" << reached << ": " << err
+                                          << "\n";
+                            }
+                        });
+                    std::cout << "[run] --dump-mn-checkpoint ARMED: the fold will"
+                                 " serialize its registered MN set at h="
+                              << dump_h << " to " << dump_file
+                              << " (self-derived from chain; no dashd RPC)\n";
+                }
+
                 if (replay_fold_consumer) {
                     replay_payee_pub =
                         std::make_unique<rp::ReplayPayeePublisher>(
@@ -9027,6 +9087,13 @@ int main(int argc, char** argv)
         else if (std::strcmp(argv[i], "--replay-bulk-start") == 0 && i + 1 < argc)
             g_replay_bulk_start = static_cast<uint32_t>(
                 std::strtoul(argv[++i], nullptr, 10));
+        // DASHD-CUT: dump the fold's registered MN set at H to a checkpoint
+        // .inc (self-derived; no dashd). Takes two args: H and FILE.
+        else if (std::strcmp(argv[i], "--dump-mn-checkpoint") == 0 && i + 2 < argc) {
+            g_dump_mn_checkpoint_height = static_cast<uint32_t>(
+                std::strtoul(argv[++i], nullptr, 10));
+            g_dump_mn_checkpoint_file = argv[++i];
+        }
         // W5: anchor-seeded DML fold driven by the bulk lane.
         else if (std::strcmp(argv[i], "--replay-fold-prestate") == 0 && i + 1 < argc) {
             g_replay_fold_prestate = argv[++i];

--- a/src/impl/dash/coin/mn_checkpoint_dump.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_dump.hpp
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// SELF-DERIVED masternode-set checkpoint DUMP (dashd-cut, operator decision
+/// 2026-08-17).
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHAT THIS IS, AND WHY IT IS NOT gen_mn_checkpoint.py
+/// ─────────────────────────────────────────────────────────────────────────
+/// tools/dash/gen_mn_checkpoint.py mints the checkpoint .inc from a dashd
+/// `protx list registered true <height>` SNAPSHOT — a set dashd itself never
+/// consumes, obtained over RPC. The two payout-bearing fields the DIP-4 wire
+/// does NOT carry and merkleRootMNList does NOT commit — `scriptPayout` and
+/// `nLastPaidHeight` — are therefore TRUSTED from that snapshot.
+///
+/// This emitter produces the SAME checkpoint .inc payload (byte-identical in
+/// the digest domain, so the runtime parser in mn_checkpoint.hpp accepts it
+/// identically), but sourced entirely from the FOLD's own state: a
+/// DmlFoldEngine that replayed every block body from DIP-3 activation forward,
+/// self-checking each block's computed merkleRootMNList against that block's
+/// own committed cbTx root (replay_fold_consumer.hpp). `scriptPayout` is taken
+/// VERBATIM from the ProRegTx/ProUpRegTx body the fold replayed
+/// (chain-authentic); `nLastPaidHeight` is the payee bookkeeping the fold
+/// already keeps (dashd BuildNewListFromBlock parity). No dashd, no RPC, no
+/// trusted snapshot.
+///
+/// REWARD-SAFETY comes from REUSE, not from new code:
+///   * the 17-field order + conversions are the SAME the runtime parser reads
+///     (mn_checkpoint.hpp:66-83, 417-505) and gen_mn_checkpoint.py writes
+///     (build_mn_record), so a dumped set == the parser's expectation by
+///     construction;
+///   * the digest is the SAME function the parser and the generator agree on
+///     (mn_checkpoint_digest, mn_checkpoint.hpp:280);
+///   * write_mn_checkpoint_inc() PARSES its own output through
+///     parse_mn_checkpoint() before writing — it never emits a file the
+///     runtime would refuse;
+///   * REGISTERED, not valid-filtered: every entry the fold still holds is
+///     emitted, PoSe-banned ones included (they carry poseBanHeight>0, from
+///     which the parser re-derives isValid == false). This is the load-bearing
+///     property mn_checkpoint.hpp:88-104 spells out.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// THE ONE LOAD-BEARING BYTE-ORDER SUBTLETY
+/// ─────────────────────────────────────────────────────────────────────────
+/// proTxHash / collateralHash are uint256 HASHES the parser reads via
+/// uint256S (SetHex → byte-reversed into internal storage). Their .inc column
+/// is DISPLAY hex, so we emit them with GetHex() (which reverses back).
+///
+/// keyIDOwner / keyIDVoting are uint160 CKeyIDs whose .inc column is the RAW
+/// hash160 bytes (mn_checkpoint.hpp:201-210 hex_to_uint160 stores the payload
+/// bytes DIRECTLY, NOT reversed). We therefore emit them FORWARD (m_data
+/// order), NOT GetHex(). GetHex() here would silently byte-reverse the CKeyID
+/// and the round trip would fail. Same for pubKeyOperator (a raw 48-byte BLS
+/// blob) and the scriptPayout/scriptOperatorPayout byte vectors.
+///
+/// And the SORT: gen_mn_checkpoint.py sorts records by proTxHash DISPLAY hex
+/// ascending. std::map<uint256,...> iterates in INTERNAL (memcmp-LE) order,
+/// which is NOT the display order, so we re-sort the formatted lines by the
+/// display-hex proTxHash string — never trust the map iteration order for the
+/// .inc line order.
+///
+/// STRICTLY single-coin (src/impl/dash/coin/ only). Header-only, filesystem
+/// touch confined to write_mn_checkpoint_inc(). KAT-pinned
+/// (test/test_dash_mn_checkpoint.cpp::DashMnCheckpointDump).
+
+#include <impl/dash/coin/replay_fold_engine.hpp>   // DmlFoldEngine, ReplayMNState
+#include <impl/dash/coin/mn_checkpoint.hpp>         // mn_checkpoint_digest, kMnCheckpointMagic, parse_mn_checkpoint
+#include <impl/dash/coin/vendor/providertx.hpp>     // MnType
+
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+namespace mn_dump_detail {
+
+inline std::string hex_lower(const unsigned char* p, size_t n)
+{
+    static const char* kHex = "0123456789abcdef";
+    std::string s;
+    s.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i) {
+        s.push_back(kHex[p[i] >> 4]);
+        s.push_back(kHex[p[i] & 0x0f]);
+    }
+    return s;
+}
+
+// FORWARD (little-endian limb) hex of a base_uint — the raw CKeyID bytes the
+// checkpoint columns carry. mn_checkpoint.hpp::hex_to_uint160 builds the
+// uint160 with `pn[x] = ReadLE32(bytes + x*4)` (core/uint256.cpp vch ctor), so
+// the original bytes are recovered with the matching WriteLE32 per limb. NOT
+// GetHex(), which emits BE / display order. See the header comment "THE ONE
+// LOAD-BEARING BYTE-ORDER SUBTLETY".
+template <unsigned int BITS>
+inline std::string hex_forward(const ::base_uint<BITS>& b)
+{
+    unsigned char bytes[::base_uint<BITS>::BYTES];
+    for (int x = 0; x < ::base_uint<BITS>::WIDTH; ++x) {
+        const uint32_t v = b.pn[x];
+        bytes[x * 4 + 0] = static_cast<unsigned char>(v & 0xff);
+        bytes[x * 4 + 1] = static_cast<unsigned char>((v >> 8) & 0xff);
+        bytes[x * 4 + 2] = static_cast<unsigned char>((v >> 16) & 0xff);
+        bytes[x * 4 + 3] = static_cast<unsigned char>((v >> 24) & 0xff);
+    }
+    return hex_lower(bytes, static_cast<size_t>(::base_uint<BITS>::BYTES));
+}
+
+template <unsigned int BITS>
+inline bool base_uint_is_null(const ::base_uint<BITS>& b)
+{
+    for (int x = 0; x < ::base_uint<BITS>::WIDTH; ++x)
+        if (b.pn[x]) return false;
+    return true;
+}
+
+inline bool blob_is_null(const unsigned char* p, size_t n)
+{
+    for (size_t i = 0; i < n; ++i)
+        if (p[i]) return false;
+    return true;
+}
+
+// dashd's -1 "never" sentinel (and any negative) clamps to 0, byte-exact with
+// gen_mn_checkpoint.py::_clamp_height. ReplayMNState carries these as int32_t
+// with NEVER == -1 (replay_fold_engine.hpp:186), so a non-banned MN's
+// nPoSeBanHeight == -1 emits as 0 and the parser derives isValid == true.
+inline int32_t clamp_height(int32_t v) { return v > 0 ? v : 0; }
+
+// ISO-8601 UTC, matching gen_mn_checkpoint.py::_iso_now ("%Y-%m-%dT%H:%M:%SZ").
+inline std::string iso8601_utc_now()
+{
+    std::time_t t = std::time(nullptr);
+    std::tm tmv{};
+#if defined(_WIN32)
+    gmtime_s(&tmv, &t);
+#else
+    gmtime_r(&t, &tmv);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tmv);
+    return std::string(buf);
+}
+
+// The .inc C-string-literal wrapper for one payload line, byte-exact with
+// gen_mn_checkpoint.py::_c_literal: escape backslash and quote, append \n.
+inline std::string c_literal(const std::string& line)
+{
+    std::string s;
+    s.reserve(line.size() + 6);
+    s.push_back('"');
+    for (char c : line) {
+        if (c == '\\') s += "\\\\";
+        else if (c == '"') s += "\\\"";
+        else s.push_back(c);
+    }
+    s += "\\n\"";
+    return s;
+}
+
+// The generated-file banner. The payload it wraps is byte-identical to the
+// generator's; this comment is NOT — it names the self-derived provenance.
+// It is stripped from the digest domain (mn_checkpoint.hpp in_digest_domain)
+// AND by gen_mn_checkpoint.py::unwrap_inc (both drop `//` / comment lines), so
+// it is not load-bearing and cannot change the loaded set or the digest.
+inline constexpr const char* kSelfDerivedIncHeader =
+    "// SPDX-License-Identifier: AGPL-3.0-or-later\n"
+    "//\n"
+    "// GENERATED FILE -- DO NOT EDIT BY HAND.\n"
+    "// Self-derived from chain by c2pool --replay-bulk (dashd BuildNewListFromBlock\n"
+    "// parity), NOT captured from a dashd `protx list` snapshot. The trailing\n"
+    "// `digest` line commits every other line, so a hand edit is rejected at load\n"
+    "// time.\n"
+    "//\n"
+    "// THIS IS A TRUST ANCHOR. See src/impl/dash/coin/checkpoints/README.md and\n"
+    "// the \"DASH daemonless masternode-set checkpoint\" section of README.md.\n"
+    "//\n";
+
+} // namespace mn_dump_detail
+
+/// One `mn` .inc line for a registered masternode, in the authoritative
+/// 17-field order (mn_checkpoint.hpp:66-83). REUSED by the dumper and the KAT.
+inline std::string emit_mn_record_line(const uint256& protx,
+                                       const replay::ReplayMNState& st)
+{
+    using namespace mn_dump_detail;
+    std::ostringstream o;
+    o << "mn "
+      << protx.GetHex() << ' '                                  //  1 proTxHash (display)
+      << st.collateralOutpoint.hash.GetHex() << ' '            //  2 collateralHash (display)
+      << st.collateralOutpoint.index << ' '                    //  3 collateralIndex
+      << ((st.nType == vendor::MnType::EVO) ? 1 : 0) << ' '    //  4 type
+      << st.nVersion << ' '                                    //  5 version
+      << clamp_height(st.nRegisteredHeight) << ' '             //  6 registeredHeight
+      << clamp_height(st.nLastPaidHeight) << ' '               //  7 lastPaidHeight
+      << clamp_height(st.nPoSeRevivedHeight) << ' '            //  8 poseRevivedHeight
+      << clamp_height(st.nPoSeBanHeight) << ' '                //  9 poseBanHeight
+      << clamp_height(st.nConsecutivePayments) << ' '          // 10 consecutivePayments
+      << st.nRevocationReason << ' '                           // 11 revocationReason
+      << st.nOperatorReward << ' '                             // 12 operatorReward (bps)
+      // 13 scriptPayout — REQUIRED, verbatim ProRegTx bytes (chain-authentic).
+      << hex_lower(st.scriptPayout.m_data.data(), st.scriptPayout.m_data.size()) << ' ';
+    // 14 scriptOperatorPayout — `-` when unset.
+    if (st.scriptOperatorPayout.m_data.empty())
+        o << "- ";
+    else
+        o << hex_lower(st.scriptOperatorPayout.m_data.data(),
+                       st.scriptOperatorPayout.m_data.size()) << ' ';
+    // 15 keyIDOwner — FORWARD hash160 bytes, `-` when null.
+    if (base_uint_is_null(st.keyIDOwner))
+        o << "- ";
+    else
+        o << hex_forward(st.keyIDOwner) << ' ';
+    // 16 keyIDVoting — FORWARD hash160 bytes, `-` when null.
+    if (base_uint_is_null(st.keyIDVoting))
+        o << "- ";
+    else
+        o << hex_forward(st.keyIDVoting) << ' ';
+    // 17 pubKeyOperator — FORWARD 48-byte BLS blob, `-` when null.
+    if (blob_is_null(st.pubKeyOperator.data(), st.pubKeyOperator.size()))
+        o << "-";
+    else
+        o << hex_lower(st.pubKeyOperator.data(), st.pubKeyOperator.size());
+    return o.str();
+}
+
+struct MnCheckpointDump {
+    bool        ok{false};
+    std::string error;      // populated iff !ok
+    std::string payload;    // the raw checkpoint payload (what parse_mn_checkpoint reads)
+    std::string inc;        // the .inc file (C-string-literal wrapped payload)
+    std::string digest;     // the SHA-256 the payload commits to
+    uint32_t    height{0};
+    uint64_t    count{0};
+};
+
+/// Serialize a fold engine's REGISTERED masternode set at its current cursor
+/// height to the checkpoint payload + .inc. `source` becomes the `source`
+/// line (the operator decision requires it to name the self-derived
+/// provenance, e.g. "self-derived from chain via c2pool --replay-bulk at H");
+/// `generated` is the ISO-8601 timestamp (mn_dump_detail::iso8601_utc_now()).
+inline MnCheckpointDump emit_mn_checkpoint_dump(const replay::DmlFoldEngine& engine,
+                                                const std::string& source,
+                                                const std::string& generated)
+{
+    using namespace mn_dump_detail;
+    MnCheckpointDump r;
+    r.height = engine.height();
+
+    if (engine.poisoned()) {
+        r.error = "fold engine is POISONED (" + engine.poison_reason()
+                + ") — refusing to dump a diverged set";
+        return r;
+    }
+    if (engine.size() == 0) {
+        r.error = "fold holds 0 registered masternodes — refusing to write an"
+                  " empty anchor (fail-closed)";
+        return r;
+    }
+
+    // Format every registered MN; refuse a payee-less one exactly as the
+    // runtime parser would (mn_checkpoint.hpp:470-480).
+    std::vector<std::pair<std::string, std::string>> rows;  // (protx display hex, line)
+    rows.reserve(engine.size());
+    for (const auto& [protx, st] : engine.entries()) {
+        if (st.scriptPayout.m_data.empty()) {
+            r.error = "registered MN " + protx.GetHex().substr(0, 16)
+                    + " carries an empty scriptPayout — a payee-less MN would"
+                      " project a wrong payee (fail-closed)";
+            return r;
+        }
+        rows.emplace_back(protx.GetHex(), emit_mn_record_line(protx, st));
+    }
+    // Sort by proTxHash DISPLAY hex ascending — byte-parity with
+    // gen_mn_checkpoint.py `records.sort(key=lambda r: r[0])`. Map order is
+    // internal-byte order and would NOT match.
+    std::sort(rows.begin(), rows.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    std::vector<std::string> mn_lines;
+    mn_lines.reserve(rows.size());
+    for (auto& kv : rows) mn_lines.push_back(std::move(kv.second));
+
+    // 7-line header, exact order/formatting of gen_mn_checkpoint.py.
+    std::vector<std::string> header = {
+        std::string(kMnCheckpointMagic),
+        "network " + engine.network(),
+        "height " + std::to_string(engine.height()),
+        "blockhash " + engine.block_hash().GetHex(),
+        "source " + source,
+        "generated " + generated,
+        "count " + std::to_string(mn_lines.size()),
+    };
+
+    // Digest over header + mn lines (the digest line itself is never in the
+    // domain — mn_checkpoint_digest enforces that anyway).
+    std::string domain;
+    for (const auto& l : header)   { domain += l; domain += '\n'; }
+    for (const auto& l : mn_lines) { domain += l; domain += '\n'; }
+    r.digest = mn_checkpoint_digest(domain);
+
+    // Raw payload = header + digest line + mn lines + a trailing blank line
+    // (the trailing `"\n"` gen_mn_checkpoint.py::write_inc appends).
+    std::string payload;
+    for (const auto& l : header)   { payload += l; payload += '\n'; }
+    payload += "digest " + r.digest + '\n';
+    for (const auto& l : mn_lines) { payload += l; payload += '\n'; }
+    payload += '\n';
+    r.payload = std::move(payload);
+
+    // .inc = banner + blank + C-string-literal per payload line + trailing
+    // `"\n"`, byte-identical to gen_mn_checkpoint.py::write_inc EXCEPT the
+    // leading // banner (not in the digest domain; see kSelfDerivedIncHeader).
+    std::string inc = kSelfDerivedIncHeader;
+    inc += "\n";
+    for (const auto& l : header)   { inc += c_literal(l);                 inc += '\n'; }
+    inc += c_literal("digest " + r.digest); inc += '\n';
+    for (const auto& l : mn_lines) { inc += c_literal(l);                 inc += '\n'; }
+    inc += "\"\\n\"\n";
+    r.inc = std::move(inc);
+
+    r.count = mn_lines.size();
+    r.ok = true;
+    return r;
+}
+
+/// Dump + SELF-VERIFY + write the .inc. Never writes a file the runtime parser
+/// would refuse: the payload is round-tripped through parse_mn_checkpoint()
+/// (with the engine's own network) before the file is opened. Returns true on
+/// success; on failure `error` names the blocking condition and no file is
+/// written (or a partial write is reported).
+inline bool write_mn_checkpoint_inc(const replay::DmlFoldEngine& engine,
+                                    const std::string& path,
+                                    const std::string& source,
+                                    const std::string& generated,
+                                    std::string& error)
+{
+    MnCheckpointDump d = emit_mn_checkpoint_dump(engine, source, generated);
+    if (!d.ok) { error = d.error; return false; }
+
+    // The reward-safety gate: our own output must parse clean under the very
+    // parser the runtime cold-start uses, or we do not ship it.
+    MnCheckpoint cp = parse_mn_checkpoint(d.payload, engine.network());
+    if (!cp.ok) {
+        error = "self-check FAILED — the dumped payload was rejected by"
+                " parse_mn_checkpoint(): " + cp.error;
+        return false;
+    }
+    if (cp.entries.size() != d.count) {
+        error = "self-check FAILED — parsed " + std::to_string(cp.entries.size())
+              + " entries, dumped " + std::to_string(d.count);
+        return false;
+    }
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f) { error = "cannot open '" + path + "' for writing"; return false; }
+    f << d.inc;
+    f.flush();
+    if (!f.good()) { error = "write to '" + path + "' failed"; return false; }
+    return true;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/replay_fold_consumer.hpp
+++ b/src/impl/dash/coin/replay_fold_consumer.hpp
@@ -153,6 +153,24 @@ public:
         m_post_fold = std::move(h);
     }
 
+    /// ── The self-derived checkpoint DUMP seam (mn_checkpoint_dump.hpp) ────
+    /// A ONE-SHOT hook that fires exactly once, right after the successful
+    /// fold whose cursor first REACHES `target_height`. Deliberately SEPARATE
+    /// from set_post_fold so it never contends with the W4 quorum seam (which
+    /// owns post_fold): a --dump-mn-checkpoint run also needs --replay-fold-
+    /// quorums, so both must coexist. The hook receives the engine at H so it
+    /// can serialize the registered set it just proved (each block up to and
+    /// including H self-checked against its own committed merkleRootMNList).
+    /// The fold is strictly forward-contiguous (+1/block), so height == H
+    /// happens at most once; the m_dumped latch guarantees at-most-once even
+    /// if a later re-offer of H arrives.
+    void set_dump_hook(uint32_t target_height,
+                       std::function<void(const DmlFoldEngine&, uint32_t)> h)
+    {
+        m_dump_target = target_height;
+        m_dump_hook   = std::move(h);
+    }
+
     /// ── The diff-store seam (mn_diff_store.hpp) ──────────────────────────
     /// Invoked for every block whose fold COMPLETED — i.e. after the root
     /// self-check passed and the counters above were credited. This is the
@@ -250,6 +268,15 @@ public:
         if (m_post_fold) m_post_fold(height);
         if (m_diff_sink) m_diff_sink(height, hash, block, r);
 
+        // One-shot self-derived checkpoint dump AT the target height. Runs
+        // after post_fold/diff_sink so the diff store has recorded H too. Only
+        // ever fires on a fold that reached H through the byte-exact root
+        // chain above — a diverged/poisoned fold returns before this point.
+        if (m_dump_hook && !m_dumped && height == m_dump_target) {
+            m_dumped = true;
+            m_dump_hook(m_engine, height);
+        }
+
         if (m_utxo_sink && !m_utxo_sink(height, hash, block)) {
             // Tier-B is a DECORATION: its failure is reported but must never
             // invalidate the Tier-A root chain that already passed here.
@@ -325,6 +352,9 @@ private:
     BlockHook         m_pre_fold;
     std::function<void(uint32_t)> m_post_fold;
     DiffSink          m_diff_sink;
+    uint32_t          m_dump_target{0};
+    bool              m_dumped{false};
+    std::function<void(const DmlFoldEngine&, uint32_t)> m_dump_hook;
     uint32_t          m_progress_every;
     FoldConsumerStats m_stats;
     std::chrono::steady_clock::time_point m_started;

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -39,6 +39,8 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/mn_checkpoint.hpp>       // parse_mn_checkpoint (DUT)
+#include <impl/dash/coin/mn_checkpoint_dump.hpp>  // emit_mn_checkpoint_dump / write_mn_checkpoint_inc (DUT)
+#include <impl/dash/coin/replay_fold_engine.hpp>  // DmlFoldEngine / ReplayMNState (dump source)
 #include <impl/dash/coin/mn_checkpoint_lane.hpp>  // MnCheckpointLane (DUT)
 #include <impl/dash/coin/mn_bridge_cursor.hpp>    // MnBridgeCursorStore (DUT, #91)
 #include <impl/dash/coin/vendor/providertx.hpp>   // CProUpServTx (revival leg)
@@ -58,6 +60,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -343,6 +346,232 @@ TEST(DashMnCheckpoint, CheckpointSetIsFieldIdenticalToRpcSeed)
         EXPECT_EQ(ck.collateralOutpoint.hash, rpc_mn.collateralOutpoint.hash);
         EXPECT_EQ(ck.collateralOutpoint.index, rpc_mn.collateralOutpoint.index);
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2b. THE SELF-DERIVED DUMP round trip (dashd-cut, operator decision
+//     2026-08-17). A DmlFoldEngine's registered set is serialized by
+//     mn_checkpoint_dump.hpp to the checkpoint payload, and that payload
+//     parses back through parse_mn_checkpoint() FIELD-IDENTICAL to the
+//     ReplayMNState it came from — the replay-dumped analog of
+//     CheckpointSetIsFieldIdenticalToRpcSeed. No dashd, no RPC, no snapshot:
+//     the source is the fold's own state.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+using dash::coin::replay::DmlFoldEngine;
+using dash::coin::replay::ReplayMNState;
+using dash::coin::replay::FoldConfig;
+
+uint160 u160_of(uint8_t b)
+{
+    std::vector<unsigned char> v(20, b);
+    return uint160(v);
+}
+
+// A P2PKH scriptPubKey over a 20-byte hash160 filled with `b`.
+std::vector<unsigned char> p2pkh(uint8_t b)
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    s.insert(s.end(), 20, b);
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
+ReplayMNState make_replay_mn(uint8_t seed, uint8_t type, int32_t reg,
+                             int32_t last_paid, int32_t revived, int32_t ban,
+                             uint16_t opreward, bool op_payout)
+{
+    ReplayMNState st;
+    st.nType   = type;
+    st.nVersion = (type == dash::coin::vendor::MnType::EVO) ? 2 : 1;
+    // Unique collateral outpoint per MN (the parser's dup-guard).
+    const char* hx = "0123456789abcdef";
+    std::string chash(62, '0');
+    chash.push_back(hx[(seed >> 4) & 0xf]);
+    chash.push_back(hx[seed & 0xf]);
+    st.collateralOutpoint.hash  = uint256S(chash);
+    st.collateralOutpoint.index = seed;
+    st.nOperatorReward   = opreward;
+    st.nRegisteredHeight = reg;
+    st.nLastPaidHeight   = last_paid;
+    st.nPoSeRevivedHeight = revived;
+    st.nPoSeBanHeight    = ban;
+    st.nConsecutivePayments = 0;
+    st.keyIDOwner  = u160_of(static_cast<uint8_t>(0x10 + seed));
+    st.keyIDVoting = u160_of(static_cast<uint8_t>(0x20 + seed));
+    st.pubKeyOperator.fill(static_cast<uint8_t>(0x30 + seed));
+    st.scriptPayout.m_data = p2pkh(static_cast<uint8_t>(0x40 + seed));
+    if (op_payout)
+        st.scriptOperatorPayout.m_data = p2pkh(static_cast<uint8_t>(0x50 + seed));
+    return st;
+}
+
+int32_t clamp0(int32_t v) { return v > 0 ? v : 0; }
+
+} // namespace
+
+TEST(DashMnCheckpointDump, ReplayDumpedSetRoundTripsFieldIdenticalToParser)
+{
+    // Three masternodes whose proTxHash DISPLAY order differs from the
+    // std::map<uint256> INTERNAL (memcmp-LE) order, so the emitter's re-sort
+    // by display hex is actually exercised (not a no-op on map order).
+    const uint256 pA = uint256S(std::string(64, '1'));            // display 11..11
+    const uint256 pB = uint256S(std::string(64, '2'));            // display 22..22
+    const uint256 pC = uint256S(std::string(62, '0') + "ff");     // display 00..ff
+    // display ascending:  pC < pA < pB
+    // internal ascending: pA < pB < pC  (reversed bytes) — different.
+
+    std::vector<std::pair<uint256, ReplayMNState>> entries;
+    // Regular, never banned (NEVER sentinel), no operator payout, reward 0.
+    entries.emplace_back(pA, make_replay_mn(
+        1, dash::coin::vendor::MnType::REGULAR, 1028500, 2500001,
+        ReplayMNState::NEVER, ReplayMNState::NEVER, 0, /*op_payout=*/false));
+    // Evo, PoSe-banned, operator reward + operator payout, revived earlier.
+    entries.emplace_back(pB, make_replay_mn(
+        2, dash::coin::vendor::MnType::EVO, 1500000, 2400000,
+        2450000, 2490000, 500, /*op_payout=*/true));
+    // Regular, never paid (nLastPaidHeight 0), never banned.
+    entries.emplace_back(pC, make_replay_mn(
+        3, dash::coin::vendor::MnType::REGULAR, 2000000, 0,
+        ReplayMNState::NEVER, ReplayMNState::NEVER, 0, /*op_payout=*/false));
+
+    FoldConfig fcfg;
+    fcfg.enabled = true;
+    DmlFoldEngine engine(fcfg);
+    const uint32_t H = 2522504;
+    const uint256 Hhash = uint256S(std::string(62, '0') + "aa");
+    // seed() is the same API the anchor prestate loader uses; it takes a COPY.
+    auto seed_copy = entries;
+    engine.seed(std::move(seed_copy), entries.size(), H, Hhash, "mainnet");
+
+    // ── DUMP ────────────────────────────────────────────────────────────
+    auto dump = dash::coin::emit_mn_checkpoint_dump(
+        engine, "self-derived from chain via c2pool --replay-bulk at H=2522504",
+        "2026-08-17T00:00:00Z");
+    ASSERT_TRUE(dump.ok) << dump.error;
+    EXPECT_EQ(dump.count, 3u);
+    EXPECT_EQ(dump.height, H);
+
+    // The .inc line order is proTxHash DISPLAY hex ascending (pC, pA, pB),
+    // NOT the engine's internal map order (pA, pB, pC).
+    const size_t iC = dump.payload.find("mn " + pC.GetHex());
+    const size_t iA = dump.payload.find("mn " + pA.GetHex());
+    const size_t iB = dump.payload.find("mn " + pB.GetHex());
+    ASSERT_NE(iC, std::string::npos);
+    ASSERT_NE(iA, std::string::npos);
+    ASSERT_NE(iB, std::string::npos);
+    EXPECT_LT(iC, iA) << "dump must sort by DISPLAY hex, not map order";
+    EXPECT_LT(iA, iB);
+
+    // The digest the payload declares is the one the shared function recomputes.
+    EXPECT_EQ(dash::coin::mn_checkpoint_digest(dump.payload), dump.digest);
+    EXPECT_NE(dump.payload.find("digest " + dump.digest), std::string::npos);
+    EXPECT_NE(dump.payload.find(
+        "source self-derived from chain via c2pool --replay-bulk at H=2522504"),
+        std::string::npos);
+
+    // Determinism: dumping the same engine again is byte-identical.
+    auto dump2 = dash::coin::emit_mn_checkpoint_dump(
+        engine, "self-derived from chain via c2pool --replay-bulk at H=2522504",
+        "2026-08-17T00:00:00Z");
+    ASSERT_TRUE(dump2.ok) << dump2.error;
+    EXPECT_EQ(dump.payload, dump2.payload);
+    EXPECT_EQ(dump.inc, dump2.inc);
+
+    // ── PARSE the dump back through the RUNTIME parser ──────────────────
+    MnCheckpoint cp = parse_mn_checkpoint(dump.payload, "mainnet");
+    ASSERT_TRUE(cp.ok) << cp.error;
+    EXPECT_FALSE(cp.unpinned);
+    EXPECT_EQ(cp.height, H);
+    EXPECT_EQ(cp.blockhash, Hhash);
+    ASSERT_EQ(cp.entries.size(), 3u);
+
+    // ── FIELD-IDENTICAL to the source ReplayMNState ─────────────────────
+    std::map<uint256, MNState> parsed(cp.entries.begin(), cp.entries.end());
+    for (const auto& [protx, src] : entries) {
+        auto it = parsed.find(protx);
+        ASSERT_NE(it, parsed.end()) << "dump lost MN " << protx.GetHex();
+        const MNState& got = it->second;
+
+        // THE payee keystone — verbatim ProRegTx bytes survive the round trip.
+        EXPECT_EQ(got.scriptPayout.m_data, src.scriptPayout.m_data)
+            << "PAYEE MISMATCH for " << protx.GetHex();
+        EXPECT_EQ(got.scriptOperatorPayout.m_data, src.scriptOperatorPayout.m_data);
+
+        // Heights: dashd -1/NEVER and negatives clamp to 0, else verbatim.
+        EXPECT_EQ(got.nRegisteredHeight,  (uint32_t)clamp0(src.nRegisteredHeight));
+        EXPECT_EQ(got.nLastPaidHeight,    (uint32_t)clamp0(src.nLastPaidHeight));
+        EXPECT_EQ(got.nPoSeRevivedHeight, (uint32_t)clamp0(src.nPoSeRevivedHeight));
+        EXPECT_EQ(got.nPoSeBanHeight,     (uint32_t)clamp0(src.nPoSeBanHeight));
+
+        EXPECT_EQ((uint16_t)got.nType, src.nType);
+        EXPECT_EQ(got.nVersion, src.nVersion);
+        EXPECT_EQ(got.nOperatorReward, src.nOperatorReward);
+        EXPECT_EQ(got.nRevocationReason, src.nRevocationReason);
+
+        // CKeyIDs / BLS pubkey — forward-byte columns, not GetHex()-reversed.
+        EXPECT_EQ(got.keyIDOwner, src.keyIDOwner)
+            << "keyIDOwner byte-order regression for " << protx.GetHex();
+        EXPECT_EQ(got.keyIDVoting, src.keyIDVoting);
+        EXPECT_EQ(got.pubKeyOperator, src.pubKeyOperator);
+
+        EXPECT_EQ(got.collateralOutpoint.hash, src.collateralOutpoint.hash);
+        EXPECT_EQ(got.collateralOutpoint.index, src.collateralOutpoint.index);
+
+        // isValid is DERIVED as (poseBanHeight == 0) — banned MNs come back
+        // present-but-INELIGIBLE (registered-not-valid).
+        EXPECT_EQ(got.isValid, !src.IsBanned())
+            << "registered-not-valid projection wrong for " << protx.GetHex();
+    }
+
+    // The banned Evo MN is PRESENT (registered set), not filtered out.
+    EXPECT_EQ(parsed.at(pB).isValid, false);
+    EXPECT_GT(parsed.at(pB).nPoSeBanHeight, 0u);
+
+    // ── write_mn_checkpoint_inc self-verifies + writes a real .inc file ──
+    const std::string path = "/tmp/c2pool_dump_kat_"
+        + std::to_string(getpid()) + ".inc";
+    std::string werr;
+    ASSERT_TRUE(dash::coin::write_mn_checkpoint_inc(
+        engine, path, "self-derived from chain via c2pool --replay-bulk at H=2522504",
+        "2026-08-17T00:00:00Z", werr)) << werr;
+    std::ifstream in(path);
+    std::string incfile((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(incfile, dump.inc);
+    EXPECT_NE(incfile.find("Self-derived from chain by c2pool --replay-bulk"),
+              std::string::npos);
+    std::remove(path.c_str());
+}
+
+TEST(DashMnCheckpointDump, EmptyEngineAndPayeelessRefuse)
+{
+    FoldConfig fcfg;
+    fcfg.enabled = true;
+
+    // Empty fold — refuse rather than write an empty anchor.
+    DmlFoldEngine empty(fcfg);
+    empty.seed({}, 0, 2522504, uint256S(std::string(62, '0') + "aa"), "mainnet");
+    auto d0 = dash::coin::emit_mn_checkpoint_dump(empty, "src", "gen");
+    EXPECT_FALSE(d0.ok);
+    EXPECT_NE(d0.error.find("0 registered"), std::string::npos);
+
+    // A registered MN with an empty scriptPayout — fail closed, never emit a
+    // payee-less line the runtime parser would reject anyway.
+    DmlFoldEngine e(fcfg);
+    ReplayMNState bad = make_replay_mn(
+        7, dash::coin::vendor::MnType::REGULAR, 2000000, 2500000,
+        ReplayMNState::NEVER, ReplayMNState::NEVER, 0, false);
+    bad.scriptPayout.m_data.clear();
+    std::vector<std::pair<uint256, ReplayMNState>> one;
+    one.emplace_back(uint256S(std::string(64, '3')), bad);
+    e.seed(std::move(one), 1, 2522504,
+           uint256S(std::string(62, '0') + "aa"), "mainnet");
+    auto d1 = dash::coin::emit_mn_checkpoint_dump(e, "src", "gen");
+    EXPECT_FALSE(d1.ok);
+    EXPECT_NE(d1.error.find("scriptPayout"), std::string::npos);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Self-derived MN-set checkpoint DUMP (`--dump-mn-checkpoint H FILE`)

**DRAFT — do not merge.** Stacked on #1267 (`dash/mn-diff-store-straddle-memberset-assemble`). DASHD-CUT, operator decision 2026-08-17.

### What this adds
A capability to **serialize the `--replay-bulk` DML fold's REGISTERED masternode set at a target height H** to the checkpoint `.inc` payload format (`mn_checkpoint.hpp`), **self-derived from the fold's own root-checked state** — no dashd RPC, no trusted `protx list` snapshot. `scriptPayout` is taken verbatim from the ProRegTx/ProUpRegTx the fold replayed; `nLastPaidHeight` from the payee bookkeeping the fold already keeps (dashd `BuildNewListFromBlock` parity). This is the emitter the operator's decision requires: the two fields not on the DIP-4 wire and not committed in `merkleRootMNList` come from the chain-replayed fold, not from a snapshot dashd never consumes.

### Reward-safety is by REUSE, not new code
- 17-field order + conversions are the **same** the runtime parser reads (`mn_checkpoint.hpp`) and `gen_mn_checkpoint.py` writes.
- Digest is the **shared** `mn_checkpoint_digest()`.
- `write_mn_checkpoint_inc()` **re-parses its own output through `parse_mn_checkpoint()`** (with the engine's network) before writing — it can never emit a file the runtime cold-start would refuse.
- **REGISTERED, not valid-filtered**: PoSe-banned MNs are emitted carrying `poseBanHeight`; `isValid` is re-derived as `poseBanHeight==0`.
- Load-bearing **byte-order split** preserved: `proTxHash`/`collateralHash` via `GetHex` (display), `keyIDOwner`/`keyIDVoting` via forward LE-limb bytes (matching `hex_to_uint160`), and lines **sorted by proTxHash display hex** (matching the generator, NOT `std::map` internal order).
- Serve-inert: only reads the engine and writes one file; fires exactly once, after the successful fold whose cursor first reaches H (the fold's own per-block `merkleRootMNList` self-check is the safety net — a diverged/poisoned fold never reaches the dump).

### Files
- **new** `src/impl/dash/coin/mn_checkpoint_dump.hpp` — `emit_mn_checkpoint_dump` / `emit_mn_record_line` / `write_mn_checkpoint_inc`
- `src/impl/dash/coin/replay_fold_consumer.hpp` — one-shot `set_dump_hook(H, fn)`, separate from the W4 `post_fold` seam so both coexist
- `src/c2pool/main_dash.cpp` — `--dump-mn-checkpoint H FILE` arms the hook on the `--replay-fold` consumer path; the `source` line names the self-derived provenance
- `test/test_dash_mn_checkpoint.cpp` — `DashMnCheckpointDump` round-trip KAT: a replayed set dumps and parses back **field-identical** through `parse_mn_checkpoint()` (the replay-dumped analog of `CheckpointSetIsFieldIdenticalToRpcSeed`), plus sort-order, determinism, digest, `.inc` file, and fail-closed (empty / payee-less) cases

### Verification (vm905, C2POOL_DASH_BLS=REAL, dashd ABSENT)
- KATs green: `DashMnCheckpointDump.ReplayDumpedSetRoundTripsFieldIdenticalToParser`, `DashMnCheckpointDump.EmptyEngineAndPayeelessRefuse`.
- Full checkpoint test target `test_dash_node_reception_wire`: **173/173 passed**.
- `c2pool-dash` binary builds; runtime banner `DASH BLS backend: REAL`; `--dump-mn-checkpoint H FILE` present in usage.

### How the integrator runs the long detached self-derive
The dump fires at H for any `--replay-fold` run that reaches H. The full DIP3→H replay (~1.49M blocks) is **not** run in-agent. See the workflow report for the exact background command, resume/capture dir, and the one remaining enabling note (a from-empty-DIP3 cold seed is separate arming infrastructure the prestate loader does not yet supply).
