### PR TITLE
dash: seed W1 fold from EMPTY set at DIP3 activation (true from-chain self-derive)

### DIFF
--- a/src/impl/dash/coin/replay_prestate.hpp
+++ b/src/impl/dash/coin/replay_prestate.hpp
@@ -31,6 +31,9 @@
 //   * every per-mn hash field is WIRE hex (raw internal bytes, memcpy'd).
 
 #include <impl/dash/coin/replay_fold_engine.hpp>
+#include <impl/dash/coin/replay_bulk_fetch.hpp>   // MAINNET_DIP3_HEIGHT — the
+                                                  // SAME constant --replay-bulk-start
+                                                  // defaults to (do NOT re-literal it)
 
 #include <cstdint>
 #include <cstring>
@@ -322,8 +325,31 @@ inline Prestate parse_prestate_text(const std::string& text)
         return fail("prestate declares count=" + std::to_string(declared)
                     + " but carries " + std::to_string(ps.entries.size())
                     + " mn records");
-    if (ps.entries.empty())
-        return fail("prestate carries no masternodes");
+    // ── SCOPED empty-set relaxation (reward-safe, DIP3-activation ONLY) ──────
+    //
+    // An empty entries set is CHAIN-TRUE at exactly one height: the DIP3
+    // activation height. DASH's deterministic masternode list is empty until
+    // the first ProRegTx at/after DIP3 enforcement, so the W1 fold must be
+    // seedable from an EMPTY set at h=MAINNET_DIP3_HEIGHT to derive the whole
+    // set FROM CHAIN (dashd BuildNewListFromBlock parity) instead of capturing
+    // it from dashd RPC. We reuse the SAME constant --replay-bulk-start
+    // defaults to (rp::MAINNET_DIP3_HEIGHT == 1028160); no fresh literal.
+    //
+    // At EVERY other height an empty set stays a HARD reject: there it can only
+    // mean a half-parsed / records-dropped seed, which would seed a replay that
+    // diverges SILENTLY (the very failure this loader exists to refuse).
+    //
+    // This relaxation is FAIL-CLOSED and can never mint: the empty seed is not
+    // trusted on faith. The fold's per-block merkleRootMNList self-check
+    // (replay_fold_engine.hpp poison() ~:815) HARD-STOPS at the first post-DIP3
+    // ProRegTx block if the empty-at-DIP3 seed (or its anchor hash/height) is
+    // wrong — a wrong seed folds to the wrong root and poisons the engine
+    // instead of serving wrong bytes. DIP-4 / root self-checks stay strict.
+    if (ps.entries.empty() && ps.height != MAINNET_DIP3_HEIGHT)
+        return fail("prestate carries no masternodes (an empty set is chain-true"
+                    " ONLY at the DIP3 activation height "
+                    + std::to_string(MAINNET_DIP3_HEIGHT) + ", not at h="
+                    + std::to_string(ps.height) + ")");
 
     ps.ok = true;
     return ps;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -838,7 +838,8 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_replay_fold.cpp
                    test_dash_replay_run.cpp
                    test_dash_replay_quorum_seam.cpp
-                   test_dash_replay_payee_publish.cpp)
+                   test_dash_replay_payee_publish.cpp
+                   test_dash_replay_prestate_empty_dip3.cpp)
     target_link_libraries(test_dash_mn_state PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_replay_prestate_empty_dip3.cpp
+++ b/test/test_dash_replay_prestate_empty_dip3.cpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT: the SCOPED empty-prestate relaxation in replay_prestate.hpp.
+//
+// A TRUE from-DIP3 self-derive seeds the W1 fold from an EMPTY masternode set
+// at the DIP3 activation height (h = MAINNET_DIP3_HEIGHT = 1028160): DASH's
+// deterministic MN list is empty until the first ProRegTx at/after DIP3
+// enforcement, so empty-at-DIP3 is CHAIN-TRUE and lets the whole set be
+// derived from chain (dashd BuildNewListFromBlock parity) instead of captured
+// from dashd RPC.
+//
+// The loader (parse_prestate_text) historically rejected EVERY empty entries
+// set ("a half-parsed masternode set would seed a replay that diverges
+// silently"). This suite pins the reward-safe relaxation:
+//
+//   * empty prestate AT the DIP3 activation height  -> ACCEPTED
+//   * empty prestate at ANY other height            -> HARD REJECT
+//   * an empty DIP3 seed reproduces the empty-list merkleRootMNList
+//     (uint256::ZERO) through the SAME seed_engine_from_prestate root
+//     self-check a live replay trusts.
+//
+// The relaxation is fail-closed: the empty seed is never minted on faith —
+// the fold's per-block merkleRootMNList self-check (replay_fold_engine.hpp
+// poison()) hard-stops at the first post-DIP3 ProRegTx block if the seed is
+// wrong. This suite proves the LOADER gate; the fold self-check is covered by
+// test_dash_replay_fold.cpp (RootMismatchIsAHardStopWithNamedHeight).
+//
+// Folded into the test_dash_mn_state executable (the allowlisted target that
+// already builds the W1/W5 replay TUs) so it is actually built + run in CI —
+// a standalone add_executable would be a #143 NOT_BUILT sentinel.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/replay_prestate.hpp>
+
+#include <string>
+
+namespace {
+
+namespace rp = dash::coin::replay;
+
+// The well-known empty-list merkleRootMNList: dashd returns the null hash for a
+// CSimplifiedMNList with no entries (CalcMerkleRoot: `if (mnList.empty())
+// return uint256();`), which is exactly what DmlFoldEngine::compute_sml_root()
+// returns for an empty engine. 64 zero hex nibbles.
+const std::string kEmptyListRoot =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+// A distinctive 64-hex placeholder for the anchor block hash. parse_prestate_text
+// validates only that blockhash is 64 hex chars; its CHAIN identity is the
+// fold's job (each folded block carries its own hashPrevBlock + committed root),
+// not the loader's — so this unit test of the loader uses a fixture value.
+const std::string kAnchorHashPlaceholder =
+    "00000000000000000abcdef0123456789abcdef0123456789abcdef012345678";
+
+std::string make_empty_prestate(uint32_t height, const std::string& mnroot)
+{
+    std::string t;
+    t += rp::kPrestateMagic;              t += "\n";
+    t += "network mainnet\n";
+    t += "height " + std::to_string(height) + "\n";
+    t += "blockhash " + kAnchorHashPlaceholder + "\n";
+    t += "mnroot " + mnroot + "\n";
+    t += "count 0\n";
+    return t;
+}
+
+} // namespace
+
+// ── The relaxation: empty AT DIP3 activation is ACCEPTED ─────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateAtDip3ActivationAccepted)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT, kEmptyListRoot));
+    ASSERT_TRUE(ps.ok) << "empty prestate at the DIP3 activation height must be "
+                          "accepted (chain-true empty set), got: " << ps.error;
+    EXPECT_TRUE(ps.entries.empty());
+    EXPECT_EQ(ps.height, rp::MAINNET_DIP3_HEIGHT);
+}
+
+// ── The scope: empty ABOVE DIP3 stays a HARD REJECT ──────────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateAboveDip3Rejected)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(2513000, kEmptyListRoot));
+    EXPECT_FALSE(ps.ok) << "an empty set above DIP3 must stay a hard reject";
+    EXPECT_NE(ps.error.find("DIP3 activation height"), std::string::npos)
+        << "the rejection must name why empty is only legal at DIP3: "
+        << ps.error;
+}
+
+// ── The scope: empty BELOW DIP3 stays a HARD REJECT ──────────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateBelowDip3Rejected)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT - 1, kEmptyListRoot));
+    EXPECT_FALSE(ps.ok) << "an empty set below DIP3 must stay a hard reject";
+}
+
+// ── The scope: the relaxation is SPOT-EXACT, not a window ────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateOneAboveDip3Rejected)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT + 1, kEmptyListRoot));
+    EXPECT_FALSE(ps.ok)
+        << "the relaxation is scoped to the EXACT DIP3 height, not h>=DIP3";
+}
+
+// ── Other guards remain intact under the relaxation ──────────────────────────
+// A count/records mismatch must still fail even at the DIP3 height: the empty
+// relaxation only reaches the `entries.empty()` gate AFTER the count-parity
+// gate, so a header that declares count=1 with zero mn records is still caught.
+TEST(DashReplayPrestateEmptyDip3, CountMismatchStillFailsAtDip3)
+{
+    std::string t;
+    t += rp::kPrestateMagic;              t += "\n";
+    t += "network mainnet\n";
+    t += "height " + std::to_string(rp::MAINNET_DIP3_HEIGHT) + "\n";
+    t += "blockhash " + kAnchorHashPlaceholder + "\n";
+    t += "mnroot " + kEmptyListRoot + "\n";
+    t += "count 1\n";   // declares 1, carries 0
+    const auto ps = rp::parse_prestate_text(t);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("count"), std::string::npos) << ps.error;
+}
+
+// ── End to end: the empty DIP3 seed reproduces the committed empty-list root ──
+// This is the check a live replay actually trusts: seed the engine from the
+// empty DIP3 prestate and RE-VERIFY that the seeded (empty) state computes the
+// prestate's committed merkleRootMNList. compute_sml_root() over an empty
+// engine is uint256::ZERO — the well-known empty-list root — so the anchor is
+// self-consistent, and any wrong post-DIP3 fold poisons at its own height.
+TEST(DashReplayPrestateEmptyDip3, EmptyDip3SeedReproducesEmptyListRoot)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT, kEmptyListRoot));
+    ASSERT_TRUE(ps.ok) << ps.error;
+
+    rp::FoldConfig fcfg;
+    fcfg.enabled = true;
+    rp::DmlFoldEngine eng(fcfg);
+
+    const std::string serr = rp::seed_engine_from_prestate(eng, ps);
+    EXPECT_TRUE(serr.empty())
+        << "seeding an empty engine at DIP3 must reproduce the empty-list "
+           "merkleRootMNList (uint256::ZERO): " << serr;
+    EXPECT_EQ(eng.size(), 0u);
+    EXPECT_EQ(eng.compute_sml_root().GetHex(), kEmptyListRoot);
+}


### PR DESCRIPTION
## Summary

Enables a **true from-DIP3 self-derive** so the fresh MN-checkpoint set is derived from chain (dashd `BuildNewListFromBlock` parity), not captured from dashd RPC.

The only missing piece was the anchor seed: the W1 fold must start from an **EMPTY** masternode set at the DIP3 activation height (`h = MAINNET_DIP3_HEIGHT = 1028160`). Empty is chain-true there — DASH's deterministic MN list is empty until the first ProRegTx at/after DIP3 enforcement — but the prestate loader (`replay_prestate.hpp`) rejected **every** empty entries set.

## Change (scoped, reward-safe, fail-closed)

`replay_prestate.hpp` — allow an empty entries set **only** when the prestate height equals the DIP3 activation height, reusing the **same** constant `--replay-bulk-start` defaults to (`rp::MAINNET_DIP3_HEIGHT`, no fresh literal). At any other height an empty set stays a hard reject (there it can only mean a half-parsed / records-dropped seed → silent divergence, the exact failure this loader exists to refuse).

Why this can never mint: the empty seed is not trusted on faith. The fold's per-block `merkleRootMNList` self-check (`replay_fold_engine.hpp` `poison()`) hard-stops at the first post-DIP3 ProRegTx block if the empty-at-DIP3 seed (or its anchor hash/height) is wrong — a wrong seed folds to the wrong root and poisons the engine instead of serving wrong bytes. DIP-4 / root self-checks stay strict; no unscoped relaxation.

## Test (red → green, proven)

`test_dash_replay_prestate_empty_dip3.cpp`, folded into the already-allowlisted `test_dash_mn_state` target so it is built + run in CI:

- empty prestate **at** DIP3 activation → **ACCEPTED**
- empty prestate **below / above / DIP3+1** → **REJECTED** (spot-exact, not a window)
- count/records mismatch still fails at DIP3 (other guards intact)
- the empty DIP3 seed reproduces the empty-list `merkleRootMNList` (`uint256::ZERO`) through the same `seed_engine_from_prestate` root self-check a live replay trusts

Verified on vm905 (BLS=REAL): with the fix all 6 GREEN; reverting only the guard scope to the unconditional pre-fix reject turns the two accept cases RED while the reject/scope cases stay green.

Stacked on #1268 (`dash/mn-checkpoint-dump-self-derived`). Draft — do not merge.