### PR TITLE
dash: fix cold-bridge/replay-fold MnDiffWriter UAF (store-arm mutual exclusion)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6180,7 +6180,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // matches, the store COVERS heights and the ban-state probe /
             // on-demand fold source 0-RTT/uncapped from it.
             if (mn_ckpt_lane && header_chain && ckpt.ok
-                && !mn_diff_store) {
+                && !mn_diff_store
+                // UAF FIX (yield to the deep replay-fold): the cold MN-CKPT
+                // store-bridge and the W5 replay-fold arm (main_dash.cpp ~7288)
+                // both drive the SINGLE mn_diff_store/mn_diff_writer, but they
+                // are MUTUALLY EXCLUSIVE by design -- this block's own header
+                // comment names it "the COLD MN-CKPT bridge path (no
+                // --replay-bulk / --replay-fold-prestate)". The guard never
+                // actually enforced that: this arm runs FIRST (cold bridge),
+                // creates store/writer A and installs set_on_anchor_snapshot()
+                // whose lambda captures raw w=mn_diff_writer.get(); the later W5
+                // make_unique then FREES writer A behind that lambda's back, and
+                // the historical-snapshot callback dereferences the freed writer
+                // -> MnDiffWriter::arm()->save_snapshot() UAF (SIGSEGV/SIGBUS).
+                // When --replay-fold-prestate is set the deep replay owns the
+                // store; the cold bridge YIELDS. Normal cold start (no prestate)
+                // is UNCHANGED -- this predicate is true there.
+                && g_replay_fold_prestate.empty()) {
                 namespace rp = dash::coin::replay;
                 mn_diff_store = std::make_unique<rp::MnDiffStore>(
                     (core::filesystem::config_path() / net_subdir
@@ -7285,7 +7301,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // the store is simply absent and both repair callers keep
                 // their historical wipe/demote fail-closed behavior — the
                 // store is an accelerator, never consensus-required.
-                if (replay_fold_consumer) {
+                if (replay_fold_consumer && mn_diff_store) {
+                    // DEFENSIVE (named fail-closed, not a clobber): the cold
+                    // MN-CKPT store-bridge (main_dash.cpp ~6182) must have YIELDED
+                    // when a prestate is configured. If it did not, a make_unique
+                    // here would FREE the cold bridge's live MnDiffWriter while
+                    // its set_on_anchor_snapshot lambda still holds it raw -> UAF.
+                    // Refuse instead. The deep replay then folds WITHOUT the
+                    // accelerator store (reward-safe: the store is never
+                    // consensus-required, only a gap-repair accelerator).
+                    LOG_ERROR << "[MN-DIFF-DB] INVARIANT VIOLATED: cold-bridge"
+                                 " store present while arming the W5 deep-replay"
+                                 " store -- refusing to clobber a live writer"
+                                 " (would UAF the cold-bridge anchor lambda);"
+                                 " W5 accelerator store DISABLED (reward-safe).";
+                }
+                if (replay_fold_consumer && !mn_diff_store) {
                     mn_diff_store = std::make_unique<rp::MnDiffStore>(
                         (core::filesystem::config_path() / net_subdir
                             / "dash_mn_diff_db").string());


### PR DESCRIPTION
## Problem

The DIP3-empty self-derive replay (`--replay-bulk` + `--replay-fold-prestate` + a compiled fast-start checkpoint) SIGSEGV/SIGBUS'd on the first historical `mnlistdiff`, in `DmlFoldEngine::save_snapshot()` <- `MnDiffWriter::arm()` <- the cold MN-CKPT bridge `set_on_anchor_snapshot` lambda (`main_dash.cpp:6297`). Reproduced twice under gdb on a non-money node.

## Root cause — use-after-free (store-arm aliasing)

The cold MN-CKPT store-bridge (`main_dash.cpp` ~6182) and the W5 replay-fold store-arm (~7288) both drive the **single** `mn_diff_store` / `mn_diff_writer` `unique_ptr`s. They are mutually exclusive **by design** — the cold bridge is documented as "the COLD MN-CKPT bridge path (no `--replay-bulk` / `--replay-fold-prestate`)" — but the guard (`&& !mn_diff_store`) never actually enforced that ordering:

1. The cold bridge arms **first**, creates store/writer **A**, and installs an on-anchor-snapshot lambda that captures a **raw** `w = mn_diff_writer.get()`.
2. The later W5 `make_unique` reassigns `mn_diff_writer` (and `mn_diff_store`) with no guard, **freeing writer A** behind the lambda's back.
3. When the first historical snapshot arrives, the lambda fires `w->arm()` on the freed writer -> `save_snapshot()` serializes an OPScript facet through a dangling engine reference -> UAF.

The seed self-check (`compute_sml_root`) passes microseconds earlier because it serializes via `to_sml_entry()`, which excludes `scriptPayout`/`scriptOperatorPayout` — so only `save_snapshot` touches the corrupt facet, proving the state read is freed, not a bad seed. Sibling replay jobs on the same binary that lack `--replay-fold-prestate` never crash (writer A stays valid): the reported config is the only one that satisfies **both** arms.

This is **not** the fast-start-checkpoint header-floor: the replay already builds a genesis→anchor `HeaderBackfill` (`main_dash.cpp:6955`), so headers below the checkpoint are available, and no header lookup below the floor is dereferenced before the UAF fires.

## Fix

- Gate the cold-bridge arm on `g_replay_fold_prestate.empty()` so a deep replay-fold owns the single store cleanly and the cold bridge **yields** (dashd-parity: dashd builds evoDB from genesis with no such checkpoint bridge).
- Defensive **named fail-closed** at the W5 arm: if the store is somehow already present, refuse to clobber the live writer (named `LOG_ERROR`, never a segfault) and fold without the accelerator store.

The MnDiffStore is a gap-repair accelerator, **never consensus-required** — refusing it is always reward-safe.

## Invariant guard (proof)

Normal cold start (no prestate) is **UNCHANGED** — the gate predicate is true there and the cold bridge arms exactly as before. The defensive branch is the runtime guarded assertion that the two arms never co-own the store: if the mutual-exclusion invariant is ever violated again, it fails closed with a named error instead of a UAF.

## Verification
- Build: DASH, **BLS=REAL** (`dashbls` linked, `bls::PrivateKey`/RELIC symbols present).
- Live re-kick of the exact self-derive replay: no segfault; fold seeds empty at the DIP3 anchor (h=1028160); replay cursor advances.

DRAFT — stacked on #1269. Do not merge.
