### PR TITLE
dash(replay): stall-demote non-serving peers in bulk block-fetch — dashd BLOCK_STALLING_TIMEOUT parity (DRAFT)

### DIFF
--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -794,6 +794,17 @@ public:
         uint32_t per_peer_inflight{32};   // outstanding bodies per peer (keeps reply queues short — priority inv. 4)
         uint32_t batch{16};               // invs per getdata message
         int64_t  request_timeout_sec{30}; // unanswered this long ⇒ re-request elsewhere
+        // dashd net_processing BLOCK_STALLING_TIMEOUT parity. A peer that leaves
+        // `demote_after` consecutive getdata unanswered (its deep-history bodies
+        // never arrive — the whole run measured notfound=0: non-archival peers
+        // silently drop the request rather than decline it) is held OFF fresh
+        // contiguous-range assignment for `demote_cooldown_sec`, so the in-order
+        // delivery cursor stops being handed work-ahead behind a peer that never
+        // answers. Purely fetch-side WHO/WHEN: no height is ever skipped (timed-
+        // out heights are requeued exactly as before), and a single delivered
+        // body clears the demotion. demote_after=0 restores pre-port behaviour.
+        uint32_t demote_after{3};
+        int64_t  demote_cooldown_sec{60};
     };
 
     struct PeerTally
@@ -801,6 +812,9 @@ public:
         uint64_t blocks{0};
         uint64_t bytes{0};
         uint32_t inflight{0};
+        uint32_t timeouts{0};        // cumulative unanswered-getdata timeouts (telemetry)
+        uint32_t timeout_streak{0};  // consecutive timeouts since this peer last delivered a body
+        int64_t  demoted_until{0};   // held off FRESH range assignment until this wall-second (0 = eligible)
     };
 
     struct Assignment
@@ -864,6 +878,16 @@ public:
     uint64_t timeout_count() const { return m_timeouts; }
     const std::map<std::string, PeerTally>& tallies() const { return m_tallies; }
 
+    /// Peers currently held off fresh-range assignment (stall-demoted). Purely
+    /// observational — for telemetry / the live [BULK] line.
+    std::size_t demoted_count(int64_t now) const
+    {
+        std::size_t n = 0;
+        for (const auto& [key, t] : m_tallies)
+            if (t.demoted_until > now) ++n;
+        return n;
+    }
+
     bool is_inflight(const uint256& hash) const
     {
         return m_inflight.find(hash) != m_inflight.end();
@@ -881,6 +905,10 @@ public:
         auto& t = m_tallies[it->second.peer];
         ++t.blocks;
         t.bytes += raw_size;
+        // A delivered body proves the peer is serving: clear its stall streak
+        // and any demotion so it is immediately re-eligible for fresh ranges.
+        t.timeout_streak = 0;
+        t.demoted_until = 0;
         if (t.inflight > 0) --t.inflight;
         m_inflight.erase(it);
         return height;
@@ -922,8 +950,21 @@ public:
             const bool timed_out =
                 (now - it->second.at) >= m_cfg.request_timeout_sec;
             if (!peer_gone && !timed_out) { ++it; continue; }
-            if (timed_out) ++m_timeouts;
             auto& t = m_tallies[it->second.peer];
+            if (timed_out)
+            {
+                ++m_timeouts;
+                ++t.timeouts;
+                ++t.timeout_streak;
+                // dashd BLOCK_STALLING_TIMEOUT parity: after `demote_after`
+                // consecutive unanswered getdata (no delivery in between), hold
+                // this peer off fresh-range assignment for the cooldown. A
+                // departed peer (peer_gone) is a topology event, not a serve
+                // failure — it does not accrue the stall streak.
+                if (m_cfg.demote_after > 0 &&
+                    t.timeout_streak >= m_cfg.demote_after)
+                    t.demoted_until = now + m_cfg.demote_cooldown_sec;
+            }
             if (t.inflight > 0) --t.inflight;
             m_retry.emplace_front(it->second.height, it->second.peer);
             it = m_inflight.erase(it);
@@ -954,11 +995,32 @@ public:
         const uint64_t budget_total =
             static_cast<uint64_t>(m_delivered) + m_cfg.window;
 
+        // dashd BLOCK_STALLING_TIMEOUT parity (fresh-range side): is ANY peer
+        // currently un-demoted? If every peer is stalled we must still hand out
+        // fresh ranges (liveness — never freeze the fetch), so the demotion gate
+        // is bypassed in that degenerate case. Retries are never gated here: the
+        // oldest missing height must be able to land on whichever peer's slot is
+        // free (the per-height avoid-peer already steers it off the last failer).
+        bool any_fresh_eligible = false;
+        for (const auto& p : peers)
+        {
+            auto ti = m_tallies.find(p);
+            if (ti == m_tallies.end() || ti->second.demoted_until <= now)
+            {
+                any_fresh_eligible = true;
+                break;
+            }
+        }
+
         for (std::size_t pi = 0; pi < peers.size(); ++pi)
         {
             const std::string& peer = peers[(m_rr + pi) % peers.size()];
             auto& tally = m_tallies[peer];
             if (tally.inflight >= m_cfg.per_peer_inflight) continue;
+            // A demoted peer still takes retries below, but is skipped for fresh
+            // contiguous ranges while any healthy peer remains.
+            const bool fresh_ok =
+                !any_fresh_eligible || tally.demoted_until <= now;
             uint32_t capacity = std::min<uint32_t>(
                 m_cfg.batch, m_cfg.per_peer_inflight - tally.inflight);
 
@@ -981,8 +1043,9 @@ public:
                 --capacity;
             }
 
-            // Then a fresh CONTIGUOUS range for this peer.
-            while (capacity > 0 && m_next <= m_target_end &&
+            // Then a fresh CONTIGUOUS range for this peer (unless it is demoted
+            // and healthy peers remain — dashd BLOCK_STALLING_TIMEOUT parity).
+            while (fresh_ok && capacity > 0 && m_next <= m_target_end &&
                    static_cast<uint64_t>(m_next) <= budget_total &&
                    (static_cast<uint64_t>(m_inflight.size()) + buffered) <
                        m_cfg.window)
@@ -1165,7 +1228,8 @@ private:
             peers << " " << key << "=" << t.blocks << "blk/"
                   << (t.bytes / (1024 * 1024)) << "MB"
                   << (t.inflight ? ("(+" + std::to_string(t.inflight) + ")")
-                                 : "");
+                                 : "")
+                  << (t.demoted_until > now ? "!D" : "");
         }
         LOG_INFO << "[BULK] delivered=" << m_delivered << "/"
                  << m_sched.target_end()
@@ -1175,6 +1239,7 @@ private:
                  << " inflight=" << m_sched.inflight_count()
                  << " buffer=" << m_buffer.size()
                  << " retry=" << m_sched.retry_count()
+                 << " demoted=" << m_sched.demoted_count(now)
                  << " hdr="
                  << (m_backfill
                          ? (m_backfill->complete()

--- a/test/test_dash_replay_bulk_fetch.cpp
+++ b/test/test_dash_replay_bulk_fetch.cpp
@@ -351,6 +351,194 @@ TEST(DashReplayBulkScheduler, DepartedPeerRequestsRequeueImmediately)
     EXPECT_EQ(s.inflight_count(), 4u);   // b's requests untouched
 }
 
+// ═══ (B2) stall-demotion — dashd BLOCK_STALLING_TIMEOUT parity ═════════════
+//
+// The live full-history replay measured timeout=753956 against total=1681142
+// delivered (a 45% re-request rate) with notfound=0: non-archival peers do not
+// DECLINE deep-history getdata, they silently drop it, and one near-dead peer
+// (553 blk of 2.52M) kept its slot the whole run because nothing ever demoted
+// it. dashd disconnects a peer that stalls the download window; the reward-safe
+// analogue here holds a peer that leaves `demote_after` consecutive getdata
+// unanswered off FRESH contiguous-range assignment for a cooldown — never
+// dropping a height (timed-out heights requeue exactly as before), and clearing
+// the moment the peer delivers again.
+
+TEST(DashReplayBulkScheduler, StallDemotionHoldsDeadPeerOffFreshRanges)
+{
+    SyntheticChain chain(500);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.window = 400;
+    cfg.per_peer_inflight = 8;
+    cfg.batch = 8;
+    cfg.request_timeout_sec = 30;
+    cfg.demote_after = 3;
+    cfg.demote_cooldown_sec = 60;
+    s.configure(cfg);
+    s.reset(0);
+    s.set_target_end(499);
+    auto hashfn = [&](uint32_t h) { return chain.hash_at(h); };
+
+    // One dead peer, two healthy — so a healthy peer has spare capacity for
+    // fresh work even while the other absorbs the dead peer's requeued heights.
+    const std::vector<std::string> peers{"dead", "live1", "live2"};
+    int64_t now = 1000;
+
+    // Round 1: all three peers get a fresh contiguous batch.
+    auto plan = s.pump(now, peers, hashfn, 0);
+    ASSERT_EQ(plan.size(), 3u);
+    EXPECT_EQ(s.demoted_count(now), 0u);
+    // The live peers answer every body; "dead" answers none.
+    for (const auto& a : plan)
+        if (a.peer != "dead")
+            for (const auto& [h, hash] : a.blocks) s.on_body(hash, 100);
+
+    // 30 s later dead's whole batch times out in one service pass — enough
+    // consecutive unanswered getdata to cross demote_after.
+    now += 30;
+    s.service(now, peers);
+    EXPECT_GE(s.timeout_count(), static_cast<uint64_t>(cfg.demote_after));
+    EXPECT_EQ(s.demoted_count(now), 1u);            // exactly "dead"
+
+    // Next pump: "dead" is handed NOTHING — its timed-out heights requeue with
+    // avoid="dead" (steered onto a live peer) and it is barred from fresh
+    // ranges. All work flows through the live peers, which keep advancing.
+    const uint32_t fresh_floor = s.next_height();
+    auto plan2 = s.pump(now, peers, hashfn, 0);
+    ASSERT_FALSE(plan2.empty());
+    for (const auto& a : plan2)
+        EXPECT_NE(a.peer, "dead") << "demoted peer must receive no assignment";
+    EXPECT_GT(s.next_height(), fresh_floor);        // live kept advancing
+}
+
+TEST(DashReplayBulkScheduler, DeliveredBodyClearsDemotionImmediately)
+{
+    SyntheticChain chain(200);
+    rp::BulkBlockScheduler s;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.per_peer_inflight = 4;
+    cfg.batch = 4;
+    cfg.request_timeout_sec = 30;
+    cfg.demote_after = 3;
+    cfg.demote_cooldown_sec = 600;   // long cooldown — only a delivery can clear
+    s.configure(cfg);
+    s.reset(0);
+    s.set_target_end(199);
+    auto hashfn = [&](uint32_t h) { return chain.hash_at(h); };
+
+    const std::vector<std::string> solo{"x"};
+    int64_t now = 5000;
+    auto plan = s.pump(now, solo, hashfn, 0);        // "x" gets a batch
+    ASSERT_EQ(plan.size(), 1u);
+    const auto batch = plan[0].blocks;
+
+    now += 30;
+    s.service(now, solo);                            // all time out → demoted
+    EXPECT_EQ(s.demoted_count(now), 1u);
+
+    // A single delivered body proves the peer is serving again — clears the
+    // streak and demotion even though the 600 s cooldown has not elapsed.
+    // (Deliver a requeued height by re-pumping first so it is in-flight again;
+    // liveness fallback lets the sole demoted peer take fresh work.)
+    auto plan2 = s.pump(now, solo, hashfn, 0);
+    ASSERT_FALSE(plan2.empty());                     // sole peer ⇒ liveness bypass
+    s.on_body(plan2[0].blocks[0].second, 100);
+    EXPECT_EQ(s.demoted_count(now), 0u);             // demotion cleared
+}
+
+TEST(DashReplayBulkScheduler, StallDemotionCutsTimeoutWallTimeVsBaseline)
+{
+    // Deterministic before/after "measurement" of the exact throttle the live
+    // run measured. One dead peer among four; live peers answer instantly, the
+    // dead peer's requests only clear by 30 s timeout. The lane's in-order
+    // delivery cursor + bounded work-ahead window are modelled faithfully: the
+    // dead peer's contiguous chunk sits at the cursor HEAD, blocks it, the
+    // window fills with buffered work-ahead, and the whole fetch waits out a
+    // 30 s timeout wave before the cursor can advance. The metric is virtual
+    // SECONDS to deliver the entire span in order. Baseline (demote_after=0 ==
+    // pre-port behaviour) re-hands the dead peer a fresh contiguous chunk on
+    // every rotation, so it re-blocks the cursor and pays a 30 s wave again and
+    // again; the port demotes it after one wave and the remainder flows at live
+    // speed. Both MUST deliver every height in order (reward-safety: no skip).
+    auto run = [](uint32_t demote_after) -> std::pair<int64_t, bool> {
+        const uint32_t END = 2999;
+        SyntheticChain chain(END + 1);
+        rp::BulkBlockScheduler s;
+        rp::BulkBlockScheduler::Config cfg;
+        cfg.window = 512;             // bounded work-ahead (the §4.3 buffer)
+        cfg.per_peer_inflight = 16;
+        cfg.batch = 16;
+        cfg.request_timeout_sec = 30;
+        cfg.demote_after = demote_after;
+        cfg.demote_cooldown_sec = 60;
+        s.configure(cfg);
+        s.reset(0);
+        s.set_target_end(END);
+        auto hashfn = [&](uint32_t h) { return chain.hash_at(h); };
+        const std::vector<std::string> peers{"dead", "l1", "l2", "l3"};
+
+        std::set<uint32_t> received;   // bodies in hand, above the cursor
+        int64_t cursor = 0;            // next height the in-order lane needs
+        int64_t now = 0;
+        int guard = 0;
+        while (cursor <= END && guard++ < 2000000)
+        {
+            // Pump to a fixed point at this instant: a delivered body frees
+            // window/inflight, so keep pumping+delivering+draining until the
+            // in-order cursor can no longer advance (blocked behind the dead
+            // peer's held chunk).
+            bool progressed = true;
+            while (progressed)
+            {
+                progressed = false;
+                auto plan = s.pump(now, peers, hashfn, received.size());
+                for (const auto& a : plan)
+                {
+                    if (a.peer == "dead") continue;       // never answers
+                    for (const auto& [h, hash] : a.blocks)
+                    {
+                        auto got = s.on_body(hash, 100);
+                        if (got) received.insert(*got);
+                    }
+                }
+                // Drain in order, advancing the cursor + the scheduler high-water.
+                while (!received.empty() &&
+                       *received.begin() == static_cast<uint32_t>(cursor))
+                {
+                    s.note_delivered(static_cast<uint32_t>(cursor));
+                    received.erase(received.begin());
+                    ++cursor;
+                    progressed = true;
+                }
+            }
+            if (cursor > END) break;
+            // Cursor blocked: advance to the next timeout boundary and service
+            // (times out the dead peer's held chunk + requeues it to a live one).
+            now += cfg.request_timeout_sec;
+            s.service(now, peers);
+        }
+        return {now, cursor == static_cast<int64_t>(END) + 1};
+    };
+
+    auto [baseline_secs, baseline_ok] = run(/*demote_after=*/0);
+    auto [ported_secs,   ported_ok]   = run(/*demote_after=*/3);
+
+    EXPECT_TRUE(baseline_ok) << "baseline must still deliver every block in order";
+    EXPECT_TRUE(ported_ok)   << "port must still deliver every block in order";
+    // The port must slash the timeout wall time.
+    EXPECT_LT(ported_secs, baseline_secs);
+    EXPECT_LT(ported_secs * 3, baseline_secs)
+        << "ported=" << ported_secs << "s baseline=" << baseline_secs << "s";
+    // Surface the numbers in the test log for the before/after record.
+    std::fprintf(stderr,
+        "[stall-demote KAT] in-order full-span fetch virtual wall: "
+        "baseline=%llds ported=%llds (%.1fx less timeout wall)\n",
+        static_cast<long long>(baseline_secs),
+        static_cast<long long>(ported_secs),
+        baseline_secs > 0 && ported_secs > 0
+            ? double(baseline_secs) / double(ported_secs) : 0.0);
+}
+
 // ═══ (C) in-order delivery + prune ════════════════════════════════════════
 
 TEST(DashReplayBulkLane, DeliversInOrderAndPrunes)


### PR DESCRIPTION
## What

Ports **dashd `net_processing` `BLOCK_STALLING_TIMEOUT`** reactive peer-stall handling into the DASH full-history `--replay-bulk` block-fetch scheduler (`BulkBlockScheduler`). Throughput-only, reward-safe, feature-lane-local. **DRAFT — review only, do not merge.**

## Why (measured, not theorized)

The live full-history replay (`pid 424677`, `c2pool-w5`, md5 `266494916daa782de2c4508b0dfe5504`) completed 2.52M blocks in ~51.5 h active wall = **13.6 blk/s average** vs dashd IBD's **~58 blk/s** — a 4.3x run-average gap that is 25–100x inside stall bands.

Cumulative scheduler counters at completion:

```
total=1681142blk/36319MB  timeout=753956  notfound=0  corrupt=0
peers: 178.208.87.226=553blk … 85.209.241.13=257598blk
```

- **`timeout=753956` vs `total=1681142` delivered = a 45% re-request rate.**
- **`notfound=0` for the entire run:** non-archival peers never *decline* deep-history `getdata`, they silently drop it. There is nothing to react to except the timeout.
- The near-dead peer `178.208.87.226` served **553 blocks of 2.52M** yet kept its 32-slot in-flight queue and its round-robin fresh-range assignments the whole run — nothing demoted it.
- The height-ordered delivery cursor head-of-line-blocked behind each such hole for the flat `request_timeout_sec=30`, so ~39 h of the 51.5 h wall was stall bands (2.3 blk/s and below) while healthy bands ran at 75–107 blk/s (already at/above dashd — fetch+fold machinery is not the wall).

## The port

`service()` counts consecutive unanswered `getdata` per peer; after `demote_after` (=3) it stamps `demoted_until = now + demote_cooldown_sec` (=60). `pump()` withholds **fresh contiguous ranges** from a demoted peer while any healthy peer remains. `on_body()` clears the streak + demotion the instant a peer delivers.

Faithful to dashd (reactive, bounded, self-healing), and **distinct from #148** — that is the *proactive* `CanServeBlocks` service-bit filter (advertised `NODE_NETWORK`); this is the *reactive* observed-timeout half. They compose.

## Reward-safety (throughput-only)

- No height is ever skipped: timed-out heights requeue exactly as before; only **who** is asked for fresh work and **when** a stalled peer is re-eligible changes.
- Retries are never gated (liveness); if every peer is demoted the gate is bypassed.
- `block_body_binds_to_header` merkle bind, fold content, `merkleRootMNList` per-block self-check + poison fail-closed — all **UNCHANGED**.
- `demote_after=0` restores the exact pre-port behaviour.

## Proof

`test_dash_p2p_node` — **142/142 green**, real dashbls linked (`DASHBLS_ROOT=/home/ubuntu/dashbls-prefix`, RELIC backend), built + run on vm905 (c2pool-build):

- `StallDemotionHoldsDeadPeerOffFreshRanges` — a dead peer receives no fresh assignment after 3 timeouts; live peers keep advancing.
- `DeliveredBodyClearsDemotionImmediately` — one delivered body clears demotion even mid-cooldown.
- `StallDemotionCutsTimeoutWallTimeVsBaseline` — deterministic in-order full-span before/after with one dead peer among four:

```
[stall-demote KAT] in-order full-span fetch virtual wall:
  baseline=960s ported=30s (32.0x less timeout wall)
```

  both arms deliver every block in order (reward-safety asserted in the test).
- The five pre-existing `BulkBlockScheduler` KATs stay green (no behaviour change to the untouched paths).

Live `[BULK]` telemetry gains `demoted=<n>` and per-peer `!D` markers so the effect is observable in a soak.

## Residual

This closes the reactive-stall half of the bulk-fetch throttle. The proactive archival-peer selection (`CanServeBlocks` service-bit gate) remains **#148**. A live re-measurement of the full DIP3→tip replay with this change is the soak follow-up (the KAT proves the mechanism; the run average will improve in proportion to how much of the 39 h stall time this removes).
