### PR TITLE
dash(replay): bulk-fetch CanServeBlocks + BLOCK_STALLING_TIMEOUT demote + event-refill (throughput port, reward-safe) [DRAFT]

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7547,13 +7547,31 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // Priority invariant 1: the PRIMARY carries every stateful
             // request/response leg — bulk loads it only when it is the sole
             // handshaked peer.
+            // Priority invariant 1 + dashd CanServeBlocks (#1254): the bulk
+            // lane's peer universe is the handshaked pool FILTERED to archival
+            // deliverers (advertises full-block service, not stall-demoted),
+            // primary excluded unless it is the sole survivor. A non-serving
+            // peer silently drops deep-history getdata (the full run measured
+            // notfound=0, timeout=45%); this is the proactive half of dashd's
+            // block-download peer policy, the scheduler's reactive stall-demote
+            // is the other half. Liveness fallback lives inside the helper.
             seams.eligible_peers = [cp = coin_p2p.get()] {
-                auto keys = cp->handshaked_peer_keys();
-                const auto prim = cp->primary_peer_key();
-                if (keys.size() > 1 && !prim.empty())
-                    keys.erase(std::remove(keys.begin(), keys.end(), prim),
-                               keys.end());
-                return keys;
+                return cp->eligible_bulk_peer_keys();
+            };
+            // dashd FindNextBlocksToDownload per-(peer,height) coverage: a
+            // contiguous range is assigned to a peer only if it can serve
+            // blocks AND its announced start_height covers the height.
+            seams.peer_can_serve = [cp = coin_p2p.get()](
+                const std::string& peer, uint32_t height) {
+                return cp->bulk_peer_can_serve(peer, height);
+            };
+            // Monotonic clock for the event-driven refill (same steady_clock
+            // seconds the 1 s tick uses — keeps the stall-demote timebase
+            // consistent across tick and body-triggered pumps).
+            seams.now_sec = [] {
+                return std::chrono::duration_cast<std::chrono::seconds>(
+                           std::chrono::steady_clock::now().time_since_epoch())
+                    .count();
             };
             seams.send_getdata = [cp = coin_p2p.get()](
                 const std::string& peer, const std::vector<uint256>& hashes) {

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1326,6 +1326,53 @@ public:
         return m_primary ? m_primary->key : std::string{};
     }
 
+    /// The bulk lane's peer universe FILTERED through dashd CanServeBlocks
+    /// (#1254 bulk_eligible: handshaked + advertises full-block service + not
+    /// demoted). The replay BulkFetchLane wires this as its eligible_peers seam
+    /// so a deep-history getdata is only ever handed to an archival deliverer —
+    /// the reactive stall-demote + this proactive service-bit filter are dashd
+    /// net_processing's two halves of the block-download peer policy. Liveness
+    /// fallback: if the CanServeBlocks filter empties the set (a transient
+    /// all-pruned/all-demoted pool), fall back to the raw handshaked set so the
+    /// lane never freezes — the same Pass-0/Pass-1 shape as next_bulk_peer().
+    /// Primary excluded unless it is the only survivor (priority invariant 1).
+    std::vector<std::string> eligible_bulk_peer_keys() const
+    {
+        std::vector<std::string> serving, handshaked;
+        for (const auto& up : m_pool)
+        {
+            const PeerSession* p = up.get();
+            if (!p->handshake.complete()) continue;
+            handshaked.push_back(p->key);
+            if (bulk_eligible(p)) serving.push_back(p->key);
+        }
+        std::vector<std::string> keys =
+            serving.empty() ? std::move(handshaked) : std::move(serving);
+        const std::string prim = primary_peer_key();
+        if (keys.size() > 1 && !prim.empty())
+            keys.erase(std::remove(keys.begin(), keys.end(), prim), keys.end());
+        return keys;
+    }
+
+    /// dashd FindNextBlocksToDownload per-(peer,height) coverage for the replay
+    /// bulk lane's pump() assignment: the named peer serves blocks at all
+    /// (CanServeBlocks), is not demoted, and its announced start_height covers
+    /// `height` (peer_covers_height — the lever for a lagging peer that joined
+    /// below the wanted band). Unknown/incomplete peer ⇒ false.
+    bool bulk_peer_can_serve(const std::string& key, uint32_t height) const
+    {
+        for (const auto& up : m_pool)
+        {
+            const PeerSession* p = up.get();
+            if (p->key != key) continue;
+            return p->handshake.complete()
+                   && can_serve_blocks(p)
+                   && !bulk_demoted(key)
+                   && peer_covers_height(p, height);
+        }
+        return false;
+    }
+
     /// getheaders to a NAMED peer (bulk header backfill: the walker rotates
     /// its own peer cursor and must not disturb the primary-bound tip legs).
     /// Returns false when the peer is unknown/not handshaked.

--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -794,6 +794,19 @@ public:
         uint32_t per_peer_inflight{32};   // outstanding bodies per peer (keeps reply queues short — priority inv. 4)
         uint32_t batch{16};               // invs per getdata message
         int64_t  request_timeout_sec{30}; // unanswered this long ⇒ re-request elsewhere
+        // dashd net_processing BLOCK_STALLING_TIMEOUT parity (reactive half of
+        // the block-download peer policy). A peer that leaves `demote_after`
+        // consecutive getdata unanswered — its deep-history bodies never arrive,
+        // and the whole full-history run measured notfound=0, so a non-archival
+        // peer SILENTLY DROPS the request rather than declining it — is held OFF
+        // FRESH contiguous-range assignment for `demote_cooldown_sec`, so the
+        // in-order delivery cursor stops being handed work-ahead behind a peer
+        // that never answers. Purely fetch-side WHO/WHEN: no height is ever
+        // skipped (timed-out heights requeue exactly as before, and retries are
+        // never gated by demotion), and a single delivered body clears it.
+        // demote_after=0 restores byte-identical pre-port behaviour.
+        uint32_t demote_after{3};
+        int64_t  demote_cooldown_sec{60};
     };
 
     struct PeerTally
@@ -801,6 +814,9 @@ public:
         uint64_t blocks{0};
         uint64_t bytes{0};
         uint32_t inflight{0};
+        uint32_t timeouts{0};        // cumulative unanswered-getdata timeouts (telemetry)
+        uint32_t timeout_streak{0};  // consecutive timeouts since this peer last delivered a body
+        int64_t  demoted_until{0};   // held off FRESH range assignment until this wall-second (0 = eligible)
     };
 
     struct Assignment
@@ -881,9 +897,23 @@ public:
         auto& t = m_tallies[it->second.peer];
         ++t.blocks;
         t.bytes += raw_size;
+        // A delivered body proves the peer is serving: clear its stall streak
+        // and any demotion so it is immediately re-eligible for fresh ranges.
+        t.timeout_streak = 0;
+        t.demoted_until = 0;
         if (t.inflight > 0) --t.inflight;
         m_inflight.erase(it);
         return height;
+    }
+
+    /// Peers currently held off fresh-range assignment (stall-demoted). Purely
+    /// observational — for telemetry / the live [BULK] line.
+    std::size_t demoted_count(int64_t now) const
+    {
+        std::size_t n = 0;
+        for (const auto& [key, t] : m_tallies)
+            if (t.demoted_until > now) ++n;
+        return n;
     }
 
     /// The asked peer answered notfound (pruned/archival gap): requeue at the
@@ -922,8 +952,21 @@ public:
             const bool timed_out =
                 (now - it->second.at) >= m_cfg.request_timeout_sec;
             if (!peer_gone && !timed_out) { ++it; continue; }
-            if (timed_out) ++m_timeouts;
             auto& t = m_tallies[it->second.peer];
+            if (timed_out)
+            {
+                ++m_timeouts;
+                ++t.timeouts;
+                ++t.timeout_streak;
+                // dashd BLOCK_STALLING_TIMEOUT parity: after `demote_after`
+                // consecutive unanswered getdata (no delivery in between), hold
+                // this peer off fresh-range assignment for the cooldown. A
+                // departed peer (peer_gone) is a topology event, not a serve
+                // failure — it does not accrue the stall streak.
+                if (m_cfg.demote_after > 0 &&
+                    t.timeout_streak >= m_cfg.demote_after)
+                    t.demoted_until = now + m_cfg.demote_cooldown_sec;
+            }
             if (t.inflight > 0) --t.inflight;
             m_retry.emplace_front(it->second.height, it->second.peer);
             it = m_inflight.erase(it);
@@ -940,7 +983,17 @@ public:
         int64_t now,
         const std::vector<std::string>& peers,
         const std::function<std::optional<uint256>(uint32_t)>& hash_at,
-        std::size_t buffered)
+        std::size_t buffered,
+        // dashd FindNextBlocksToDownload/CanServeBlocks per-(peer,height)
+        // coverage: returns true iff the named peer advertises block service
+        // (NODE_NETWORK / NODE_NETWORK_LIMITED) AND its announced start_height
+        // covers `height`. Null ⇒ every peer serves every height (KATs / any
+        // embedding without the coin-P2P service map) — byte-identical to before
+        // this parameter existed. When non-null it only steers WHO is asked;
+        // a height for which NO eligible peer qualifies still goes out (liveness
+        // bypass below) so no block is ever skipped.
+        const std::function<bool(const std::string&, uint32_t)>& peer_can_serve
+            = {})
     {
         std::vector<Assignment> out;
         if (peers.empty()) return out;
@@ -954,11 +1007,46 @@ public:
         const uint64_t budget_total =
             static_cast<uint64_t>(m_delivered) + m_cfg.window;
 
+        // CanServeBlocks helpers. `serves` is the per-(peer,height) gate;
+        // `any_serves` answers "does SOME eligible peer cover this height?" so
+        // the filter degrades to a preference (never a freeze) when the pool
+        // holds no peer that can serve a given height.
+        auto serves = [&](const std::string& p, uint32_t h) -> bool {
+            return !peer_can_serve || peer_can_serve(p, h);
+        };
+        auto any_serves = [&](uint32_t h) -> bool {
+            if (!peer_can_serve) return true;
+            for (const auto& p : peers)
+                if (peer_can_serve(p, h)) return true;
+            return false;
+        };
+
+        // dashd BLOCK_STALLING_TIMEOUT parity (fresh-range side): is ANY peer
+        // currently un-demoted? If every peer is stalled we must still hand out
+        // fresh ranges (liveness — never freeze the fetch), so the demotion gate
+        // is bypassed in that degenerate case. Retries are never gated by
+        // demotion here: the oldest missing height must be able to land on
+        // whichever peer's slot is free.
+        bool any_fresh_eligible = false;
+        for (const auto& p : peers)
+        {
+            auto ti = m_tallies.find(p);
+            if (ti == m_tallies.end() || ti->second.demoted_until <= now)
+            {
+                any_fresh_eligible = true;
+                break;
+            }
+        }
+
         for (std::size_t pi = 0; pi < peers.size(); ++pi)
         {
             const std::string& peer = peers[(m_rr + pi) % peers.size()];
             auto& tally = m_tallies[peer];
             if (tally.inflight >= m_cfg.per_peer_inflight) continue;
+            // A demoted peer still takes retries below, but is skipped for fresh
+            // contiguous ranges while any healthy peer remains.
+            const bool fresh_ok =
+                !any_fresh_eligible || tally.demoted_until <= now;
             uint32_t capacity = std::min<uint32_t>(
                 m_cfg.batch, m_cfg.per_peer_inflight - tally.inflight);
 
@@ -971,6 +1059,13 @@ public:
                 auto [height, avoid] = m_retry.front();
                 if (avoid == peer && peers.size() > 1)
                     break;   // let another peer's slot take this one
+                // CanServeBlocks: if some eligible peer covers this height,
+                // don't hand it to one that cannot (steer it to an archival
+                // deliverer); if NONE can, fall through so the head-of-line
+                // height never freezes (liveness — same intent as the demote
+                // bypass and the historical-body-scarcity fallback in #1254).
+                if (!serves(peer, height) && any_serves(height))
+                    break;
                 m_retry.pop_front();
                 auto h = hash_at(height);
                 if (!h) continue;   // index shrank (should not happen) — drop
@@ -981,12 +1076,19 @@ public:
                 --capacity;
             }
 
-            // Then a fresh CONTIGUOUS range for this peer.
-            while (capacity > 0 && m_next <= m_target_end &&
+            // Then a fresh CONTIGUOUS range for this peer (unless it is demoted
+            // and healthy peers remain — dashd BLOCK_STALLING_TIMEOUT parity).
+            // The range starts at m_next; a peer whose announced history does
+            // not cover m_next takes no fresh work (its slot stays free for a
+            // range it can serve, or for retries), and the contiguous run stops
+            // at the first height the peer cannot serve.
+            while (fresh_ok && capacity > 0 && m_next <= m_target_end &&
                    static_cast<uint64_t>(m_next) <= budget_total &&
                    (static_cast<uint64_t>(m_inflight.size()) + buffered) <
                        m_cfg.window)
             {
+                if (!serves(peer, m_next) && any_serves(m_next))
+                    break;   // this peer lacks m_next's history — leave it
                 auto h = hash_at(m_next);
                 if (!h) break;   // header index ends here for now
                 m_inflight[*h] = Req{m_next, peer, now, 0};
@@ -1040,6 +1142,19 @@ public:
         // derivation). Null (KATs, any embedding without the fold) ⇒ this lane
         // behaves BYTE-IDENTICALLY to before this seam existed.
         std::function<bool()> defer_to_higher_priority;
+        // OPTIONAL. dashd FindNextBlocksToDownload/CanServeBlocks per-(peer,
+        // height) coverage — main_dash wires it to the coin-P2P service map
+        // (CanServeBlocks + start_height covers the height). Forwarded straight
+        // into BulkBlockScheduler::pump so a deep-history range is assigned only
+        // to a peer that advertises it holds that history. Null (KATs / any
+        // embedding without the map) ⇒ every peer serves every height, exactly
+        // as before this seam existed.
+        std::function<bool(const std::string&, uint32_t)> peer_can_serve;
+        // OPTIONAL. Monotonic wall-second clock. Present ⇒ a delivered body
+        // event-drives an immediate refill pump (removing the ~1/s core::Timer
+        // pump ceiling that capped healthy bands); null ⇒ pumping stays on the
+        // tick() cadence only (byte-identical to before this seam existed).
+        std::function<int64_t()> now_sec;
     };
 
     struct Config
@@ -1165,7 +1280,8 @@ private:
             peers << " " << key << "=" << t.blocks << "blk/"
                   << (t.bytes / (1024 * 1024)) << "MB"
                   << (t.inflight ? ("(+" + std::to_string(t.inflight) + ")")
-                                 : "");
+                                 : "")
+                  << (t.demoted_until > now ? "!D" : "");
         }
         LOG_INFO << "[BULK] delivered=" << m_delivered << "/"
                  << m_sched.target_end()
@@ -1175,6 +1291,7 @@ private:
                  << " inflight=" << m_sched.inflight_count()
                  << " buffer=" << m_buffer.size()
                  << " retry=" << m_sched.retry_count()
+                 << " demoted=" << m_sched.demoted_count(now)
                  << " hdr="
                  << (m_backfill
                          ? (m_backfill->complete()
@@ -1215,6 +1332,32 @@ private:
         LOG_INFO << "[BULK] resume cursor VERIFIED at height "
                  << m_resume->height << " — resuming fetch from "
                  << (m_resume->height + 1);
+    }
+
+    /// Plan and issue bulk getdata under the strict-priority guards. Shared by
+    /// the 1 s tick() and by the event-driven refill in on_block_body(): the
+    /// guards (cursor verified, tip lane idle, no higher-priority consumer) are
+    /// identical in both paths, so a body-triggered refill can never overtake a
+    /// tracked tip body or the MN-checkpoint fold. Assumes the fetch ceiling
+    /// (set_target_end) is current — tick() refreshes it once per second.
+    void issue_bulk_pump(int64_t now)
+    {
+        if (m_failed || !m_cursor_checked) return;
+        if (m_seams.tip_busy && m_seams.tip_busy()) return;
+        if (m_seams.defer_to_higher_priority &&
+            m_seams.defer_to_higher_priority()) return;
+        const auto peers = m_seams.eligible_peers();
+        if (peers.empty()) return;
+        auto assignments = m_sched.pump(
+            now, peers, m_seams.hash_at, m_buffer.size(),
+            m_seams.peer_can_serve);
+        for (const auto& a : assignments)
+        {
+            std::vector<uint256> hashes;
+            hashes.reserve(a.blocks.size());
+            for (const auto& [h, hash] : a.blocks) hashes.push_back(hash);
+            m_seams.send_getdata(a.peer, hashes);
+        }
     }
 
 public:
@@ -1322,6 +1465,15 @@ public:
             return true;   // duplicate (double-answered re-request) — pruned
         m_buffer[*height] = block;
         drain_buffer();
+        // EVENT-DRIVEN REFILL: the serving peer just freed a slot. Hand it (and
+        // any other peer with capacity) fresh work NOW instead of waiting up to
+        // one full core::Timer tick — the ~1/s tick cadence is what capped the
+        // healthy bands (issue rate ≈ batch × peers per second). Guarded on the
+        // clock seam: null ⇒ pumping stays tick-only, byte-identical to before.
+        // issue_bulk_pump re-applies the strict-priority guards, so this can
+        // never overtake a tracked tip body or the MN-checkpoint fold.
+        if (m_seams.now_sec)
+            issue_bulk_pump(m_seams.now_sec());
         return true;
     }
 
@@ -1349,22 +1501,10 @@ public:
                                    ? tip - m_cfg.tip_exclusion : 0);
 
         // STRICT PRIORITY: no new bulk requests while a tracked tip body is
-        // outstanding (invariant 2). In-flight bulk completes on its own.
-        if (!peers.empty() && m_cursor_checked &&
-            !(m_seams.tip_busy && m_seams.tip_busy()) &&
-            !(m_seams.defer_to_higher_priority &&
-              m_seams.defer_to_higher_priority()))
-        {
-            auto assignments = m_sched.pump(
-                now, peers, m_seams.hash_at, m_buffer.size());
-            for (const auto& a : assignments)
-            {
-                std::vector<uint256> hashes;
-                hashes.reserve(a.blocks.size());
-                for (const auto& [h, hash] : a.blocks) hashes.push_back(hash);
-                m_seams.send_getdata(a.peer, hashes);
-            }
-        }
+        // outstanding (invariant 2). In-flight bulk completes on its own. The
+        // guards live in issue_bulk_pump so the event-driven refill honours the
+        // exact same priority.
+        issue_bulk_pump(now);
         maybe_log_telemetry(now);
     }
 

--- a/test/test_dash_replay_bulk_fetch.cpp
+++ b/test/test_dash_replay_bulk_fetch.cpp
@@ -856,4 +856,279 @@ TEST(DashReplayBulkLane, CaptureConsumerDecoratesWithoutChangingDelivery)
     std::filesystem::remove_all(dir);
 }
 
+// ═══ (I) dashd CanServeBlocks / BLOCK_STALLING_TIMEOUT throughput port ══════
+//
+// The full-history --replay-bulk run measured timeout=753956 / 1.68M delivered
+// (45% re-request) with notfound=0: non-archival peers SILENTLY DROP deep-
+// history getdata, and nothing demoted a near-dead peer that kept its 32 slots
+// the whole run, so the in-order delivery cursor head-of-line-blocked behind
+// each hole for the flat 30 s timeout. This ports dashd net_processing's two
+// halves — the proactive CanServeBlocks service-bit/coverage filter (WHO may
+// be handed a range) and the reactive BLOCK_STALLING_TIMEOUT demote (WHEN a
+// non-server is re-eligible) — plus the event-driven refill that lifts the
+// ~1/s tick pump ceiling. All THROUGHPUT-ONLY: no height is ever skipped.
+
+// (I.1) CanServeBlocks: a fresh contiguous range is handed ONLY to a peer that
+// advertises it can serve the height; a height no eligible peer covers still
+// goes out (liveness — never freeze the head-of-line block).
+TEST(DashReplayBulkScheduler, CanServeBlocksSteersRangesToArchivalPeers)
+{
+    SyntheticChain chain(200);
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.window = 1000; cfg.per_peer_inflight = 32; cfg.batch = 8;
+
+    rp::BulkBlockScheduler s;
+    s.configure(cfg); s.reset(10); s.set_target_end(199);
+    const std::vector<std::string> peers{"full", "pruned"};
+    // "pruned" advertises no history for this deep band; "full" covers all.
+    auto only_full = [](const std::string& p, uint32_t) { return p == "full"; };
+    auto plan = s.pump(1000, peers,
+                       [&](uint32_t h) { return chain.hash_at(h); }, 0,
+                       only_full);
+    ASSERT_EQ(plan.size(), 1u);                 // pruned got nothing
+    EXPECT_EQ(plan[0].peer, "full");
+    EXPECT_EQ(plan[0].blocks.size(), cfg.batch);
+    for (const auto& [h, hash] : plan[0].blocks) EXPECT_EQ(hash, chain.hashes[h]);
+
+    // Liveness: when NO peer can serve a height, the filter degrades to a
+    // preference and the assignment still issues (no block is ever orphaned).
+    rp::BulkBlockScheduler s2;
+    s2.configure(cfg); s2.reset(10); s2.set_target_end(199);
+    auto none = [](const std::string&, uint32_t) { return false; };
+    auto plan2 = s2.pump(1000, peers,
+                         [&](uint32_t h) { return chain.hash_at(h); }, 0, none);
+    std::size_t total = 0;
+    for (const auto& a : plan2) total += a.blocks.size();
+    EXPECT_GT(total, 0u) << "bypass: a height no peer covers must still go out";
+}
+
+// (I.2a) Stall-demote: `demote_after` consecutive timeouts hold a dead peer OFF
+// fresh ranges while a healthy peer remains; its retries steer to the healthy
+// peer. (I.2b) A delivered body clears the streak and the demotion at once.
+TEST(DashReplayBulkScheduler, StallDemoteHoldsDeadPeerOffFreshRanges)
+{
+    SyntheticChain chain(500);
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.window = 1000; cfg.per_peer_inflight = 8; cfg.batch = 8;
+    cfg.request_timeout_sec = 30; cfg.demote_after = 3; cfg.demote_cooldown_sec = 60;
+
+    rp::BulkBlockScheduler s;
+    s.configure(cfg); s.reset(0); s.set_target_end(499);
+    auto hs = [&](uint32_t h) { return chain.hash_at(h); };
+    const std::vector<std::string> peers{"good", "dead"};
+
+    // rr order: good←[0..7], dead←[8..15].
+    s.pump(1000, peers, hs, 0);
+    for (uint32_t h = 0; h < 8; ++h) s.on_body(chain.hashes[h], 100);  // good serves
+
+    EXPECT_EQ(s.demoted_count(1040), 0u);
+    s.service(1040, peers);              // dead's 8..15 time out (streak 8 ≥ 3)
+    EXPECT_GE(s.demoted_count(1040), 1u) << "dead demoted after the stall wave";
+
+    auto plan = s.pump(1041, peers, hs, 0);
+    for (const auto& a : plan)
+        EXPECT_NE(a.peer, "dead")
+            << "a demoted peer gets neither fresh ranges nor its own retries";
+
+    // (I.2b) sole-peer bypass keeps the fetch live AND a delivered body clears
+    // the demotion the instant the peer proves it is serving again.
+    rp::BulkBlockScheduler s2;
+    s2.configure(cfg); s2.reset(0); s2.set_target_end(99);
+    const std::vector<std::string> solo{"dead"};
+    s2.pump(1000, solo, hs, 0);          // dead←[0..7]
+    s2.service(1040, solo);              // all 8 time out → demoted
+    EXPECT_EQ(s2.demoted_count(1040), 1u);
+    s2.pump(1041, solo, hs, 0);          // liveness bypass re-feeds sole peer
+    s2.on_body(chain.hashes[0], 100);    // a body arrives at last
+    EXPECT_EQ(s2.demoted_count(1041), 0u) << "delivered body clears the demotion";
+}
+
+// ── stall-band throughput sim ──────────────────────────────────────────────
+// One archival "good" peer answers instantly; one "dead" peer silently drops
+// every getdata (the measured notfound=0 condition). The lane runs on a 1 s
+// tick; run() returns the virtual seconds to deliver the whole span in order.
+struct StallSim
+{
+    SyntheticChain chain;
+    rp::CountingReplayConsumer counter;
+    std::unique_ptr<rp::BulkFetchLane> lane;
+    std::vector<std::string> peers{"good:1", "dead:1"};
+    struct Out { std::string peer; uint256 hash; int64_t at; };
+    std::vector<Out> outstanding;
+    int64_t timeout;
+    int64_t now{0};
+
+    StallSim(uint32_t heights, uint32_t demote_after, int64_t req_timeout)
+        : chain(heights), timeout(req_timeout)
+    {
+        rp::BulkFetchLane::Config cfg;
+        cfg.start_height = 0; cfg.tip_exclusion = 0;
+        rp::BulkFetchLane::Seams s;
+        s.hash_at = [this](uint32_t h) { return chain.hash_at(h); };
+        s.chain_height = [this] {
+            return static_cast<uint32_t>(chain.hashes.size() - 1);
+        };
+        s.eligible_peers = [this] { return peers; };
+        s.send_getdata = [this](const std::string& p,
+                                const std::vector<uint256>& hh) {
+            for (const auto& h : hh) outstanding.push_back({p, h, now});
+        };
+        s.send_getheaders = [](const std::string&, const uint256&,
+                               const uint256&) {};
+        s.tip_busy = [] { return false; };
+        s.defer_to_higher_priority = [] { return false; };
+        lane = std::make_unique<rp::BulkFetchLane>(
+            std::move(s), cfg, nullptr, &counter, nullptr);
+        rp::BulkBlockScheduler::Config sc;
+        sc.window = 512; sc.per_peer_inflight = 32; sc.batch = 8;
+        sc.request_timeout_sec = req_timeout;
+        sc.demote_after = demote_after; sc.demote_cooldown_sec = 60;
+        lane->scheduler().configure(sc);
+    }
+
+    const BlockType* body_for(const uint256& h)
+    {
+        auto it = std::find(chain.hashes.begin(), chain.hashes.end(), h);
+        return it == chain.hashes.end()
+                   ? nullptr
+                   : &chain.blocks[std::distance(chain.hashes.begin(), it)];
+    }
+
+    // Deliver in order; return {seconds, timeouts}. seconds=-1 ⇒ never finished.
+    std::pair<int64_t, uint64_t> run(uint32_t target)
+    {
+        const int64_t cap = 200000;
+        for (now = 1; now <= cap; ++now)
+        {
+            lane->tick(now);
+            auto batch = outstanding; outstanding.clear();
+            for (auto& e : batch)
+            {
+                if (e.peer == "good:1")
+                {
+                    if (const BlockType* b = body_for(e.hash))
+                        lane->on_block_body(e.hash, *b);   // instant serve
+                }
+                else if (now - e.at >= timeout)
+                {
+                    /* dead request timed out — scheduler already requeued it */
+                }
+                else outstanding.push_back(e);             // still waiting
+            }
+            if (lane->delivered() >= target)
+                return {now, lane->scheduler().timeout_count()};
+        }
+        return {-1, lane->scheduler().timeout_count()};
+    }
+};
+
+// (I.3) THE THROUGHPUT PROOF. Same dead-peer topology, in-order full span:
+// demote_after=0 (pre-port) vs demote_after=3 (ported). The port must deliver
+// every block in order in BOTH cases (never skips a height) while cutting the
+// timeout wall — the stall-band rate rises.
+TEST(DashReplayBulkScheduler, StallBandThroughputRisesWithDemotePort)
+{
+    const uint32_t H = 600;
+    StallSim baseline(H, /*demote_after=*/0, /*timeout=*/30);   // pre-port
+    StallSim ported  (H, /*demote_after=*/3, /*timeout=*/30);   // dashd parity
+
+    auto [b_secs, b_to] = baseline.run(H - 1);
+    auto [p_secs, p_to] = ported.run(H - 1);
+
+    // Correctness FIRST: both deliver the whole span, strictly in order.
+    EXPECT_EQ(baseline.lane->delivered(), H - 1);
+    EXPECT_EQ(ported.lane->delivered(),   H - 1);
+    EXPECT_FALSE(baseline.counter.order_violated());
+    EXPECT_FALSE(ported.counter.order_violated());
+    ASSERT_GT(b_secs, 0);
+    ASSERT_GT(p_secs, 0);
+
+    const double b_rate = double(H) / double(b_secs);
+    const double p_rate = double(H) / double(p_secs);
+    std::printf("[STALL-BAND] pre-port: %lld s, %llu timeouts, %.2f blk/s | "
+                "ported: %lld s, %llu timeouts, %.2f blk/s | rate x%.2f\n",
+                (long long)b_secs, (unsigned long long)b_to, b_rate,
+                (long long)p_secs, (unsigned long long)p_to, p_rate,
+                p_rate / b_rate);
+
+    // The port cuts re-requests and raises the delivered-in-order rate.
+    EXPECT_LT(p_to, b_to)   << "ported issues strictly fewer re-requests";
+    EXPECT_LT(p_secs, b_secs) << "ported clears the span sooner (rate rises)";
+}
+
+// (I.4) Event-driven refill: with the clock seam armed, a delivered body hands
+// its freed slot fresh work IMMEDIATELY (no wait for the next tick); without
+// it, the lane issues nothing new until the tick — the ~1/s pump ceiling.
+struct RefillRig
+{
+    SyntheticChain chain;
+    rp::CountingReplayConsumer counter;
+    std::vector<std::pair<std::string, std::vector<uint256>>> sent;
+    std::unique_ptr<rp::BulkFetchLane> lane;
+    int64_t clock{1000};
+
+    RefillRig(uint32_t heights, bool arm_event) : chain(heights)
+    {
+        rp::BulkFetchLane::Config cfg;
+        cfg.start_height = 0; cfg.tip_exclusion = 0;
+        rp::BulkFetchLane::Seams s;
+        s.hash_at = [this](uint32_t h) { return chain.hash_at(h); };
+        s.chain_height = [this] {
+            return static_cast<uint32_t>(chain.hashes.size() - 1);
+        };
+        s.eligible_peers = [] { return std::vector<std::string>{"p:1"}; };
+        s.send_getdata = [this](const std::string& p,
+                                const std::vector<uint256>& h) {
+            sent.emplace_back(p, h);
+        };
+        s.send_getheaders = [](const std::string&, const uint256&,
+                               const uint256&) {};
+        s.tip_busy = [] { return false; };
+        s.defer_to_higher_priority = [] { return false; };
+        if (arm_event) s.now_sec = [this] { return clock; };
+        lane = std::make_unique<rp::BulkFetchLane>(
+            std::move(s), cfg, nullptr, &counter, nullptr);
+        rp::BulkBlockScheduler::Config sc;
+        sc.window = 1000; sc.per_peer_inflight = 32; sc.batch = 8;
+        sc.request_timeout_sec = 30;
+        lane->scheduler().configure(sc);
+    }
+
+    void deliver_sent()
+    {
+        auto batch = sent; sent.clear();
+        for (auto& [p, hs] : batch)
+            for (auto& h : hs)
+            {
+                auto it = std::find(chain.hashes.begin(), chain.hashes.end(), h);
+                if (it != chain.hashes.end())
+                    lane->on_block_body(
+                        h, chain.blocks[std::distance(chain.hashes.begin(), it)]);
+            }
+    }
+};
+
+TEST(DashReplayBulkLane, EventDrivenRefillLiftsPerTickCeiling)
+{
+    RefillRig armed(500, /*arm_event=*/true);
+    RefillRig tickonly(500, /*arm_event=*/false);
+
+    armed.lane->tick(1000);
+    tickonly.lane->tick(1000);
+    const std::size_t primed = armed.sent.size();
+    ASSERT_GT(primed, 0u);
+    ASSERT_EQ(primed, tickonly.sent.size());   // identical priming
+
+    // Answer the primed bodies WITHOUT a second tick.
+    armed.deliver_sent();
+    tickonly.deliver_sent();
+
+    EXPECT_GT(armed.sent.size(), 0u)
+        << "armed lane refills on each delivered body (no tick needed)";
+    EXPECT_EQ(tickonly.sent.size(), 0u)
+        << "tick-only lane issues nothing until the next tick (the ceiling)";
+    // Both still deliver in order — throughput-only, nothing skipped.
+    EXPECT_FALSE(armed.counter.order_violated());
+}
+
 } // namespace


### PR DESCRIPTION
**Stacked on #1270** (`dash/uaf-coldbridge-replayfold-store-exclusion`). DRAFT — do not merge.

## What
Ports dashd `net_processing`'s block-download peer policy into the full-history `--replay-bulk` lane (`replay_bulk_fetch.hpp` `BulkBlockScheduler::pump()` / `BulkFetchLane`). **Throughput-only, reward-safe.** This is open task **#148** (CanServeBlocks) plus the reactive stall-demote and event-refill.

## Why
The full-history run measured `timeout=753956 / 1.68M delivered` (45% re-request) with `notfound=0` across the whole 2.52M-block run: non-archival peers **silently drop** deep-history `getdata` rather than declining it, and nothing demoted a near-dead peer that kept its 32 slots the whole run. The in-order delivery cursor head-of-line-blocked behind each hole for the flat 30 s timeout — ~39 h of the 51.5 h wall were stall bands (≤2.3 blk/s) while healthy bands ran 75-107 blk/s.

## Three parts
1. **CanServeBlocks filter** (proactive) — `eligible_peers` seam → `CoinClient::eligible_bulk_peer_keys()` (handshaked ∩ archival ∩ non-demoted, reuses the #1254 helper); `pump()` gains a `peer_can_serve(peer,height)` predicate → `bulk_peer_can_serve()` (`CanServeBlocks` + `peer_covers_height` start_height coverage). Cites dashd `FindNextBlocksToDownload`/`CanServeBlocks`.
2. **Stall-demote** (reactive, `BLOCK_STALLING_TIMEOUT`) — `demote_after=3` consecutive unanswered getdata hold a peer off **fresh** ranges for `demote_cooldown_sec=60`; a delivered body clears it. Retries never gated; all-demoted bypass for liveness. `demote_after=0` = byte-identical pre-port behaviour.
3. **Event-driven refill** — a delivered body event-drives an immediate `issue_bulk_pump()` (same strict-priority guards, gated on the `now_sec` clock seam) instead of waiting up to one 1 s `core::Timer` tick — removes the per-tick issue ceiling.

## Reward-safety
No height is ever skipped — timed-out heights requeue exactly as before and every CanServe/demote gate has a liveness bypass so no block is orphaned; only **WHO** is asked for fresh work and **WHEN** a stalled peer is re-eligible changes. `merkleRootMNList` per-block self-check + poison fail-closed, merkle bind, and fold content are **UNCHANGED**.

## Proof
Built **BLS=REAL** (`libdashbls.a`, CMake: "dashbls found — BLS verify ENABLED"). `test_dash_p2p_node` **143/143 green**. New KATs:
- `CanServeBlocksSteersRangesToArchivalPeers` — ranges only to covering peers, with a no-freeze bypass.
- `StallDemoteHoldsDeadPeerOffFreshRanges` — dead peer off fresh + retries; a body clears it.
- `EventDrivenRefillLiftsPerTickCeiling` — a body issues fresh getdata with no tick; tick-only lane issues nothing.
- `StallBandThroughputRisesWithDemotePort` — deterministic in-order dead-peer full span: **re-requests 96 → 32, delivered rate 6.38 → 8.00 blk/s**, both deliver every block in order.

`[BULK]` telemetry gains `demoted=<n>` and a per-peer `!D` marker.