### PR TITLE
dash(replay-fold): gate payee cross-check on DIP3 ENFORCEMENT (fix h=1028163 self-derive divergence) [DRAFT]

### DIFF
--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -352,6 +352,12 @@ struct ReplayMNState
 struct FoldGates
 {
     int32_t dip0003_height{1028160};   // fold start — no DML below this
+    // DIP3 has TWO distinct heights (dashd deploymentstatus.h:52 comment:
+    // "'active' and 'enforced' are different statuses for DIP0003"). The
+    // deterministic MN list is BUILT from activation (dip0003_height); the
+    // coinbase paying GetMNPayee(list) is only ENFORCED from here on. dashd
+    // mainnet chainparams.cpp:186 DIP0003EnforcementHeight = 1047200.
+    int32_t dip0003_enforcement_height{1047200};
     int32_t v19_height{1899072};       // basic BLS (per-entry nVersion wrapper)
     int32_t mn_rr_height{2128896};     // MN reward reallocation (Evo 4-in-a-row OFF)
     int32_t masternode_min_confirmations{15};
@@ -362,6 +368,13 @@ struct FoldGates
 
     bool v19_active(int32_t h) const   { return h >= v19_height; }
     bool mn_rr_active(int32_t h) const { return h >= mn_rr_height; }
+    // dashd deploymentstatus.h:53 DeploymentDIP0003Enforced(h) == h >= EnfHeight.
+    // Gates the coinbase payee cross-check: below this dashd's own consensus
+    // rule (CMNPaymentsProcessor::IsTransactionValid, payments.cpp:114) returns
+    // valid WITHOUT checking the det payee, so the coinbase pays the legacy
+    // masternode winner, not GetMNPayee(list) — a cross-check here would be
+    // stricter than dashd and false-poison a correct fold.
+    bool dip0003_enforced(int32_t h) const { return h >= dip0003_enforcement_height; }
 };
 
 /// Feature flag for the whole engine. `enabled` MUST be set explicitly —
@@ -407,6 +420,13 @@ struct FoldResult
     // a projection that is NOT paid fails the fold closed, it never leaves
     // this flag quietly clear.
     bool        payee_paid_verified{false};
+    // True when the payee cross-check was SKIPPED because this height is below
+    // DIP3 enforcement (dashd does not commit the det payee to the coinbase
+    // there either). The SET self-check (merkleRootMNList) still ran; only the
+    // payee AXIS is not coinbase-committed yet. Diagnostic only — the fold is
+    // still fully derived and self-consistent (nLastPaidHeight accumulates on
+    // the projected payee exactly as dashd BuildNewListFromBlock does).
+    bool        payee_check_preenforcement_skipped{false};
 };
 
 class DmlFoldEngine
@@ -794,7 +814,30 @@ public:
         // members WITHIN a group. A within-group swap is invisible to the
         // coinbase and therefore invisible to any consumer of it, including
         // dashd's own validation of our block.
-        if (r.payee && !payee_script_pre.empty()) {
+        //
+        // DIP3-ENFORCEMENT GATE (dashd parity, DIP3-genesis regime fix):
+        // dashd builds the deterministic list from DIP3 ACTIVATION (1028160)
+        // but only ENFORCES the coinbase paying GetMNPayee(list) from
+        // DIP0003EnforcementHeight (1047200) — CMNPaymentsProcessor::
+        // IsTransactionValid (payments.cpp:114) returns valid WITHOUT checking
+        // the payee when !DeploymentDIP0003Enforced(h). In the [activation,
+        // enforcement) window the historical coinbase pays the LEGACY
+        // masternode winner, not the det projection, so this cross-check —
+        // which is correct at tip — is STRICTER THAN DASHD there and false-
+        // poisons a byte-correct fold (observed: h=1028163, merkleRootMNList
+        // MATCHED, payee projection sound, coinbase simply pays the legacy
+        // winner). Mirror dashd's gate exactly. The SET self-check above stays
+        // UNCONDITIONAL; the payee projection + nLastPaidHeight bookkeeping
+        // (passes 0/5) also run unconditionally, so the payee axis stays fully
+        // derived and self-consistent across the window and is correct the
+        // instant enforcement begins. Production (tip ~2.5M) is far above
+        // enforcement, so the money-path check is UNCHANGED.
+        if (r.payee && !payee_script_pre.empty()
+            && !m_cfg.gates.dip0003_enforced(H)) {
+            r.payee_check_preenforcement_skipped = true;
+        }
+        if (r.payee && !payee_script_pre.empty()
+            && m_cfg.gates.dip0003_enforced(H)) {
             bool paid = false;
             if (!block.m_txs.empty()) {
                 for (const auto& out : block.m_txs[0].vout) {

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -570,6 +570,12 @@ static FoldConfig synth_cfg()
     FoldConfig cfg;
     cfg.enabled = true;
     cfg.gates.dip0003_height = 1;
+    // Synthetic vectors model the ENFORCED regime (their coinbases pay the
+    // projected payee via make_block(&eng)); keep the payee cross-check ON so
+    // the existing payee-axis assertions still bind. The DIP3-genesis window
+    // (activation<h<enforcement) is exercised explicitly by the
+    // PreEnforcementPayeeCheck suite, which lowers dip0003_enforcement_height.
+    cfg.gates.dip0003_enforcement_height = 1;
     cfg.gates.v19_height     = 1;
     cfg.gates.mn_rr_height   = 1;
     return cfg;
@@ -1321,4 +1327,118 @@ TEST(DashReplayFoldSynthetic, SnapshotV3FailLoudPaths)
     // A failed load never clobbers existing state.
     EXPECT_EQ(eng.size(), 1u);
     EXPECT_EQ(eng.height(), 100u);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DIP3-GENESIS payee cross-check gate (dashd DeploymentDIP0003Enforced parity).
+//
+// The deterministic MN list is BUILT from DIP3 ACTIVATION (h=1028160) but the
+// coinbase paying GetMNPayee(list) is only ENFORCED from DIP0003EnforcementHeight
+// (mainnet 1047200). In the [activation, enforcement) window dashd's own
+// consensus rule CMNPaymentsProcessor::IsTransactionValid (masternode/
+// payments.cpp:114) returns valid WITHOUT checking the det payee — the coinbase
+// pays the LEGACY masternode winner, not the det projection. So the fold's payee
+// cross-check must not run there, or it false-poisons a byte-correct fold — the
+// observed h=1028163 divergence: merkleRootMNList MATCHED, projection sound, the
+// coinbase simply pays the legacy winner (which drifts from the det order once
+// more than a couple of MNs are registered).
+//
+// This is the ONE property the payee gate changes: the SAME state + SAME
+// payment-block (coinbase pays nobody) POISONS when the height is at/above
+// enforcement (RED — the check is still strict where dashd enforces it) and
+// FOLDS THROUGH when the height is below enforcement (GREEN — the DIP3-genesis
+// window no longer false-poisons). The merkleRootMNList SET self-check runs in
+// BOTH arms regardless.
+namespace {
+// Two MNs registered at h=101; both configs are identical except the enforcement
+// height, so the only variable is the gate under test.
+struct PayeeGateFixture {
+    DmlFoldEngine eng;
+    uint256       payment_root;   // SML root after the reg block (unchanged by pay)
+    uint256       reg_hash;       // block hash the payment block builds on
+    explicit PayeeGateFixture(int32_t enforcement_height)
+        : eng(make_cfg(enforcement_height))
+    {
+        eng.seed({}, /*total_registered=*/0, /*height=*/100, raw256(9));
+        auto p1  = make_proreg(1);
+        auto p2  = make_proreg(2);
+        auto tx1 = make_special_tx(1, p1, 1);
+        auto tx2 = make_special_tx(1, p2, 2);
+        const uint256 mn1 = tx_hash_of(tx1), mn2 = tx_hash_of(tx2);
+        payment_root = root_of({expected_entry_of(p1, mn1),
+                                expected_entry_of(p2, mn2)});
+        auto reg_blk = make_block(101, raw256(9), payment_root, {tx1, tx2});
+        auto rr = eng.fold_block(reg_blk, 101);
+        EXPECT_TRUE(rr.ok) << "register fold must succeed: " << rr.error;
+        EXPECT_EQ(rr.registered, 2u);
+    }
+    static FoldConfig make_cfg(int32_t enforcement_height)
+    {
+        FoldConfig cfg;
+        cfg.enabled = true;
+        cfg.gates.dip0003_height             = 1;
+        cfg.gates.dip0003_enforcement_height = enforcement_height;
+        // v19/mn_rr far out (classic payee path); confirmations far out so no
+        // confirmedHash mutation at h=102 keeps the SML root stable across the
+        // payment fold.
+        cfg.gates.v19_height                 = 100000000;
+        cfg.gates.mn_rr_height               = 100000000;
+        cfg.gates.masternode_min_confirmations = 100000000;
+        return cfg;
+    }
+};
+} // namespace
+
+// GREEN: h=102 is BELOW enforcement (103). A payment block whose coinbase pays
+// NOBODY folds THROUGH — dashd does not commit the det payee to the coinbase
+// there. The SET self-check still ran (root matched); the payee axis is derived
+// and self-consistent (nLastPaidHeight bumped on the projection).
+TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeeMismatchFoldsThrough)
+{
+    PayeeGateFixture fx(/*enforcement_height=*/103);  // 102 < 103 ⇒ pre-enforcement
+    ASSERT_TRUE(fx.eng.project_payee(102).has_value())
+        << "a payee must be projected (else the test proves nothing)";
+    auto pay_blk = make_block(102, raw256(9), fx.payment_root,
+                              /*special_txs=*/{}, /*pay_from=*/nullptr);
+    auto r = fx.eng.fold_block(pay_blk, 102);
+    ASSERT_TRUE(r.ok) << "pre-enforcement payee mismatch must NOT poison (dashd "
+                         "IsTransactionValid skips the check below enforcement): "
+                      << r.error;
+    EXPECT_TRUE(r.payee.has_value());
+    EXPECT_TRUE(r.payee_check_preenforcement_skipped)
+        << "the skip must be recorded, not silently absent";
+    EXPECT_FALSE(r.payee_paid_verified);
+    EXPECT_EQ(r.computed_root, r.committed_root);   // SET self-check still bound
+    EXPECT_TRUE(r.payee_marked);                    // nLastPaidHeight still bumped
+}
+
+// RED: the SAME state + SAME payment block, but h=102 is AT enforcement (102).
+// The coinbase pays nobody, so the strict payee cross-check fires and POISONS —
+// exactly as it must at tip, where dashd enforces the det payee. This proves the
+// gate is scoped to the genesis window, not a blanket disable of the check.
+TEST(DashReplayFoldPreEnforcement, AtEnforcementPayeeMismatchStillPoisons)
+{
+    PayeeGateFixture fx(/*enforcement_height=*/102);  // 102 >= 102 ⇒ enforced
+    ASSERT_TRUE(fx.eng.project_payee(102).has_value());
+    auto pay_blk = make_block(102, raw256(9), fx.payment_root,
+                              /*special_txs=*/{}, /*pay_from=*/nullptr);
+    auto r = fx.eng.fold_block(pay_blk, 102);
+    ASSERT_FALSE(r.ok) << "at/after enforcement a payee mismatch MUST poison";
+    EXPECT_NE(r.error.find("PAYEE MISMATCH"), std::string::npos) << r.error;
+    EXPECT_FALSE(r.payee_check_preenforcement_skipped);
+}
+
+// Control: when the pre-enforcement block DOES pay the projected payee (the
+// common case, since legacy and det winners coincide while the set is tiny),
+// the fold succeeds and the skip flag is NOT set — the check simply passed.
+TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeePaidIsNotFlaggedSkipped)
+{
+    PayeeGateFixture fx(/*enforcement_height=*/103);
+    auto pay_blk = make_block(102, raw256(9), fx.payment_root,
+                              /*special_txs=*/{}, /*pay_from=*/&fx.eng);
+    auto r = fx.eng.fold_block(pay_blk, 102);
+    ASSERT_TRUE(r.ok) << r.error;
+    // Below enforcement the check is skipped regardless of whether the coinbase
+    // happens to pay the projection; the flag reflects the GATE, not the match.
+    EXPECT_TRUE(r.payee_check_preenforcement_skipped);
 }


### PR DESCRIPTION
## Port (B) — payee-ordering fold-correctness (DIP3-genesis regime)

**Stacked on #1270** (`dash/uaf-coldbridge-replayfold-store-exclusion`). DRAFT, do not merge.

### Root cause (NOT the tie-break)
The full-DIP3 self-derive replay poisoned at **h=1028163** (3rd DIP3 block, 14 fresh MNs) with `DML FOLD PAYEE MISMATCH` even though `merkleRootMNList` **MATCHED** (computed==committed). The MN SET was right; the payee cross-check was wrong to run there.

I audited the tie-break the task fingered and it is **already dashd-exact**:
- `payee_before()` = `memcmp(a.data(), b.data(), 32) < 0` == dashd `uint256 operator<` (`base_blob::Compare`, uint256.h:55/59) — the storage-byte order, **not** the `base_uint` arithmetic order that bit Tier-2 (#1271).
- `compare_by_last_paid_height` / `nRegisteredHeight` / pass-5 bookkeeping all byte-match dashd `CompareByLastPaid_GetHeight` / `RebuildListFromBlock`.
- The SML-root match at the divergence height also proves the `proTxHash` byte layout is dashd-correct (it commits `proRegTxHash`).

The real bug: **DIP3 has two heights.** The deterministic list is *built* from ACTIVATION (1028160) but the coinbase paying `GetMNPayee(list)` is only *ENFORCED* from `DIP0003EnforcementHeight` (mainnet **1047200**). dashd's own consensus rule `CMNPaymentsProcessor::IsTransactionValid` (`masternode/payments.cpp:114`) early-returns valid **without** checking the det payee when `!DeploymentDIP0003Enforced(h)` (`deploymentstatus.h:53`). In `[activation, enforcement)` the historical coinbase pays the **legacy** masternode winner, not the deterministic projection — so the cross-check is stricter than dashd there and false-poisons a byte-correct fold.

### Fix (dashd-faithful, reward-safe)
Gate the payee cross-check on `DeploymentDIP0003Enforced(H)` (`H >= dip0003_enforcement_height`, default 1047200), mirroring dashd exactly.
- The `merkleRootMNList` **SET self-check stays UNCONDITIONAL**.
- The payee projection (pass 0) + `nLastPaidHeight` bookkeeping (pass 5) also stay unconditional — exactly as dashd `BuildNewListFromBlock` runs them from activation — so the payee axis is fully derived and self-consistent across the window and correct the instant enforcement begins.
- Production mines at tip (~2.5M), far above enforcement → **money-path check UNCHANGED**. No block is ever skipped; the fold now folds *through* the DIP3-genesis window instead of hard-stopping.

### KAT (red → green), BLS=REAL
`test_dash_replay_fold.cpp :: DashReplayFoldPreEnforcement` — same state + same payment-block (coinbase pays nobody):
- `AtEnforcementPayeeMismatchStillPoisons` — H≥enforcement → **poison** (strict where dashd enforces).
- `BelowEnforcementPayeeMismatchFoldsThrough` — H<enforcement → **folds through**, SET self-check still binds, `nLastPaidHeight` still bumped.
- `BelowEnforcementPayeePaidIsNotFlaggedSkipped` — control.

Verified **RED** (forcing the old unconditional check poisons at h=102 with the exact `merkleRootMNList self-check PASSED … PAYEE MISMATCH` message — the h=1028163 signature) **→ GREEN** (gated check folds through). Full `test_dash_mn_state` fold+prestate suites: **31/31 pass**, no regressions.