### PR TITLE
dash(replay): CanServeBlocks + stall-demote for the header-backfill lane (extend #1273)

### DIFF
--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -1162,7 +1162,8 @@ public:
         uint32_t start_height{MAINNET_DIP3_HEIGHT};
         uint32_t tip_exclusion{12};          // live edge belongs to the tip lane
         int64_t  telemetry_interval_sec{30};
-        int64_t  backfill_rekick_sec{15};    // headers stall re-kick
+        int64_t  backfill_rekick_sec{15};    // headers stall re-kick (== dashd BLOCK_STALLING_TIMEOUT window for the header lane)
+        int64_t  backfill_demote_cooldown_sec{60};  // header peer held OFF targeting after a stall (#1273 demote_cooldown parity); 0 ⇒ demote disabled (byte-identical to the pre-port blind lane, like the scheduler's demote_after=0)
         uint32_t cursor_persist_every{512};  // delivered blocks between cursor writes
     };
 
@@ -1193,6 +1194,20 @@ private:
 
     int64_t m_last_backfill_kick{0};
     std::size_t m_backfill_rr{0};
+
+    // dashd net_processing block-download peer policy for the HEADER-backfill
+    // lane — the reactive half of what #1273 (df10298d) ported for the BODY
+    // lane, which the header round-robin at maybe_kick_backfill()/on_headers()
+    // was never covered by. A header peer that RECEIVED a getheaders but did not
+    // advance the walker within the re-kick window is silently dropping it (a
+    // pruned / NODE_NETWORK_LIMITED peer that the eligible_peers liveness
+    // fallback re-admitted, or a full node that lies) — hold it OFF header
+    // targeting until this wall-second (BLOCK_STALLING_TIMEOUT class). Empty ⇒
+    // no header peer demoted, byte-identical to the pre-port blind round-robin.
+    std::map<std::string, int64_t> m_hdr_demoted_until;
+    std::string m_hdr_target_peer;      // peer the last getheaders was sent to
+    uint32_t    m_hdr_target_height{0}; // walker tip when that getheaders left
+    bool        m_hdr_targeted{false};  // a getheaders is outstanding to track
 
     void fail(const std::string& cause)
     {
@@ -1241,6 +1256,93 @@ private:
         }
     }
 
+    /// Pick the header-backfill getheaders target — dashd net_processing's two
+    /// halves of the block-download peer policy applied to the single-target
+    /// header walk (the BODY-lane analog #1273 ported into pump()):
+    ///   * PROACTIVE (CanServeBlocks): reuse the peer_can_serve seam VERBATIM
+    ///     (main_dash → bulk_peer_can_serve: advertises full-block service AND
+    ///     start_height covers `want_height` AND not bulk-demoted). No
+    ///     CanServeBlocks logic is reimplemented here.
+    ///   * REACTIVE (BLOCK_STALLING_TIMEOUT): skip a peer currently held in
+    ///     m_hdr_demoted_until (set by maybe_kick_backfill's stall check).
+    /// Preference DEGRADES to a liveness bypass so no header span is EVER
+    /// skipped — the exact shape of pump()'s any_serves / any_fresh_eligible
+    /// bypasses:
+    ///   1. serving + un-demoted            (the healthy target)
+    ///   2. serving, demotions CLEARED      (every serving peer was demoted —
+    ///                                        never deadlock on demotions)
+    ///   3. any peer                        (NO peer advertises the span)
+    /// Returns "" only when the eligible pool is itself empty.
+    std::string select_backfill_peer(
+        int64_t now, uint32_t want_height,
+        const std::vector<std::string>& peers)
+    {
+        if (peers.empty()) return {};
+        auto serves = [&](const std::string& p) {
+            return !m_seams.peer_can_serve ||
+                   m_seams.peer_can_serve(p, want_height);
+        };
+        auto demoted = [&](const std::string& p) {
+            auto it = m_hdr_demoted_until.find(p);
+            return it != m_hdr_demoted_until.end() && it->second > now;
+        };
+        // Does SOME eligible peer advertise this height? CanServeBlocks is a
+        // preference, never a freeze (pump()'s any_serves): if none do, every
+        // peer is admitted so the span is still fetched (liveness bypass §3).
+        bool any_serves = false;
+        for (const auto& p : peers)
+            if (serves(p)) { any_serves = true; break; }
+
+        const std::size_t n = peers.size();
+        // Pass 1: serving (when some peer serves) AND un-demoted, round-robin.
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            const std::string& p = peers[(m_backfill_rr + i) % n];
+            if ((!any_serves || serves(p)) && !demoted(p))
+            {
+                m_backfill_rr = (m_backfill_rr + i + 1) % n;
+                return p;
+            }
+        }
+        // Pass 2 (dashd stall-bypass, liveness §3): every serving peer is
+        // demoted — clear demotions and re-home rather than deadlock the walk.
+        m_hdr_demoted_until.clear();
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            const std::string& p = peers[(m_backfill_rr + i) % n];
+            if (!any_serves || serves(p))
+            {
+                m_backfill_rr = (m_backfill_rr + i + 1) % n;
+                return p;
+            }
+        }
+        // Unreachable (!any_serves ⇒ serves() is vacuously true in Pass 2) —
+        // kept as a total function so the walker always has a target.
+        const std::string& p = peers[m_backfill_rr++ % n];
+        return p;
+    }
+
+    /// Issue ONE backfill getheaders to a CanServeBlocks-selected, un-demoted
+    /// peer and RECORD the target (peer + walker tip) so the next kick can tell
+    /// a stall (received-but-did-not-advance) from healthy progress and
+    /// demote+re-home. Height coverage is checked against tip_height()+1 — the
+    /// next header the walk needs — so a limited/pruned peer whose window sits
+    /// above genesis fails CanServeBlocks exactly as it should for a
+    /// from-genesis walk.
+    void issue_backfill_getheaders(
+        int64_t now, const std::vector<std::string>& peers)
+    {
+        const uint32_t want = m_backfill->tip_height() + 1;
+        std::string peer = select_backfill_peer(now, want, peers);
+        if (peer.empty()) return;
+        m_seams.send_getheaders(peer, m_backfill->tip_hash(),
+                                uint256::ZERO /* stop: serve max batches; the
+                                walker itself stops at the anchor */);
+        m_hdr_target_peer   = peer;
+        m_hdr_target_height = m_backfill->tip_height();
+        m_hdr_targeted      = true;
+    }
+
     void maybe_kick_backfill(int64_t now)
     {
         if (!m_backfill || m_backfill->complete() || m_backfill->failed())
@@ -1255,10 +1357,30 @@ private:
         if ((now - m_last_backfill_kick) < m_cfg.backfill_rekick_sec) return;
         auto peers = m_seams.eligible_peers();
         if (peers.empty()) return;
-        const std::string& peer = peers[m_backfill_rr++ % peers.size()];
-        m_seams.send_getheaders(peer, m_backfill->tip_hash(),
-                                uint256::ZERO /* stop: serve max batches; the
-                                walker itself stops at the anchor */);
+        // dashd BLOCK_STALLING_TIMEOUT (reactive half, header lane): this
+        // re-kick backstop only fires because the walker has NOT advanced since
+        // the last kick. If the peer we last targeted still holds the walker at
+        // the height we left it, it received the getheaders and silently
+        // dropped it — DEMOTE it for the cooldown so the re-home below lands on
+        // a different serving peer. Never wedge on one peer. A peer that DID
+        // advance the walker (tip_height moved) is not blamed; on_headers also
+        // clears the demotion the instant a delivery lands.
+        if (m_cfg.backfill_demote_cooldown_sec > 0 &&
+            m_hdr_targeted && !m_hdr_target_peer.empty() &&
+            m_backfill->tip_height() <= m_hdr_target_height)
+        {
+            m_hdr_demoted_until[m_hdr_target_peer] =
+                now + m_cfg.backfill_demote_cooldown_sec;
+            LOG_WARNING << "[BULK] header-backfill peer " << m_hdr_target_peer
+                        << " STALLED at hdr=" << m_backfill->tip_height() << "/"
+                        << m_backfill->anchor_height()
+                        << " (getheaders unanswered ≥"
+                        << m_cfg.backfill_rekick_sec
+                        << "s) — demoted for " << m_cfg.backfill_demote_cooldown_sec
+                        << "s, re-homing the span (dashd BLOCK_STALLING_TIMEOUT "
+                           "parity)";
+        }
+        issue_backfill_getheaders(now, peers);
         m_last_backfill_kick = now;
     }
 
@@ -1408,23 +1530,23 @@ public:
 
     /// Headers demux filter body (registered on the CoinClient): claim and
     /// fold backfill batches; everything else falls through to new_headers.
-    bool on_headers(const std::string& /*peer_key*/,
+    bool on_headers(const std::string& peer_key,
                     const std::vector<BlockType>& batch)
     {
         if (!m_backfill || !m_backfill->claims(batch)) return false;
         const int accepted = m_backfill->add_headers(batch);
         if (accepted > 0 && !m_backfill->complete() && !m_backfill->failed())
         {
-            // Self-propel: immediately ask for the next span. The stall
-            // re-kick in tick() is only the backstop.
+            // The peer that just delivered headers PROVED it serves this span:
+            // clear any stall-demotion (mirror #1273's on_body clearing
+            // demoted_until on a delivered body). Then self-propel — ask a
+            // CanServeBlocks-selected, un-demoted peer for the next span
+            // immediately. The stall re-kick in tick() is only the backstop.
+            if (!peer_key.empty()) m_hdr_demoted_until.erase(peer_key);
             auto peers = m_seams.eligible_peers();
             if (!peers.empty())
-            {
-                const std::string& peer =
-                    peers[m_backfill_rr++ % peers.size()];
-                m_seams.send_getheaders(peer, m_backfill->tip_hash(),
-                                        uint256::ZERO);
-            }
+                issue_backfill_getheaders(
+                    m_seams.now_sec ? m_seams.now_sec() : 0, peers);
         }
         return true;   // claimed — never reaches the tip-lane header ingest
     }

--- a/test/test_dash_replay_bulk_fetch.cpp
+++ b/test/test_dash_replay_bulk_fetch.cpp
@@ -782,6 +782,196 @@ TEST(DashReplayHeaderBackfill, RestartResumeRejoinsAnchor)
     std::filesystem::remove_all(db_path);
 }
 
+// ═══ (G.2) header-backfill peer selection: CanServeBlocks + stall-demote ════
+//
+// THE INCIDENT (2026-08-17, vm905, --coin-rpc removed, dashd ABSENT). The
+// genesis→anchor header backfill WEDGED at hdr=0/2513000. The getheaders
+// round-robin at maybe_kick_backfill()/on_headers() picked its target BLINDLY
+// over eligible_peers(), whose liveness fallback re-admits a pruned /
+// NODE_NETWORK_LIMITED peer when the CanServeBlocks-filtered serving set is
+// transiently empty (cold start with one limited peer up). That peer SILENTLY
+// DROPS the from-genesis getheaders, m_backfill->tip_height() never leaves 0,
+// BulkBlockScheduler stays gated on m_backfill->complete(), bodies=0, the fold
+// never starts. PR #1273 (df10298d) fixed exactly this class for the BODY
+// scheduler (peer_can_serve + BLOCK_STALLING_TIMEOUT demote); the header lane
+// was simply not covered.
+//
+// THE PORT (this PR). The header round-robin now (1) reuses the peer_can_serve
+// seam VERBATIM (main_dash → bulk_peer_can_serve: CanServeBlocks + start_height
+// coverage + not-demoted) so a non-serving peer is never targeted for a span it
+// cannot serve, and (2) stall-demotes a peer that RECEIVED getheaders but did
+// not advance the walker within the re-kick window, re-homing the span — with a
+// liveness bypass so no header span is ever skipped.
+//
+// A getheaders-driven rig stands the lane up with no sockets: a "live" server
+// answers a getheaders with the next real header batch (driving the walk); a
+// non-live peer records the target and DROPS it. `serving` models CanServeBlocks
+// (what a peer ADVERTISES); `live` models whether it actually answers — a LIAR
+// advertises service but is not live, the case peer_can_serve alone cannot catch
+// and only the stall-demote re-homes.
+struct HdrLaneRig
+{
+    BackfillChain bc;
+    rp::HeaderBackfill bf;
+    rp::CountingReplayConsumer counter;
+    std::unique_ptr<rp::BulkFetchLane> lane;
+
+    std::vector<std::string> peers;
+    std::set<std::string> serving;      // CanServeBlocks: advertises + covers span
+    std::set<std::string> live;         // actually answers getheaders
+    bool     wire_can_serve;            // false ⇒ peer_can_serve null (blind lane)
+    uint32_t batch_headers;
+    int64_t  now{1000};                 // start past backfill_rekick_sec so the first tick kicks
+
+    std::vector<std::string> getheaders_targets;   // every peer a getheaders went to
+
+    HdrLaneRig(uint32_t anchor, std::vector<std::string> peers_,
+               std::set<std::string> serving_, std::set<std::string> live_,
+               bool can_serve, uint32_t batch, const uint256& pow_limit,
+               int64_t demote_cooldown_sec)
+        : bc(anchor)
+        , bf(bc.genesis, anchor, bc.hashes[anchor], pow_limit,
+             /*db_path=*/"", /*check_pow=*/false)
+        , peers(std::move(peers_)), serving(std::move(serving_))
+        , live(std::move(live_)), wire_can_serve(can_serve), batch_headers(batch)
+    {
+        rp::BulkFetchLane::Config cfg;
+        cfg.start_height = anchor + 1;
+        cfg.backfill_rekick_sec = 15;
+        cfg.backfill_demote_cooldown_sec = demote_cooldown_sec;
+
+        rp::BulkFetchLane::Seams s;
+        s.hash_at = [](uint32_t) -> std::optional<uint256> { return std::nullopt; };
+        s.chain_height = [anchor] { return anchor + 1; };
+        s.eligible_peers = [this] { return peers; };
+        s.send_getdata = [](const std::string&, const std::vector<uint256>&) {};
+        s.now_sec = [this] { return now; };
+        if (can_serve)
+            s.peer_can_serve = [this](const std::string& p, uint32_t) {
+                return serving.count(p) != 0;
+            };
+        s.send_getheaders = [this](const std::string& peer, const uint256&,
+                                   const uint256&) {
+            getheaders_targets.push_back(peer);
+            // A live server answers with the next real header batch (driving the
+            // walk, and — via on_headers — self-propelling). A non-live peer
+            // (pruned/limited or a liar) drops it: only the target is recorded.
+            if (live.count(peer))
+            {
+                auto b = bc.batch(bf.tip_height() + 1, batch_headers);
+                if (!b.empty()) lane->on_headers(peer, b);
+            }
+        };
+        lane = std::make_unique<rp::BulkFetchLane>(
+            std::move(s), cfg, &bf,
+            static_cast<rp::IReplayBlockConsumer*>(&counter), nullptr);
+    }
+
+    // One tick per re-kick window (each tick advances `now` past the re-kick
+    // gate so the backstop fires), until complete/failed or max_kicks.
+    void drive(int max_kicks)
+    {
+        for (int k = 0; k < max_kicks && !bf.complete() && !bf.failed(); ++k)
+        {
+            lane->tick(now);
+            now += 16;
+        }
+    }
+
+    bool targeted(const std::string& p) const
+    {
+        return std::find(getheaders_targets.begin(), getheaders_targets.end(), p)
+               != getheaders_targets.end();
+    }
+};
+
+// (G.2 RED) The PRE-PORT blind lane (peer_can_serve null AND demote disabled,
+// backfill_demote_cooldown_sec=0 — the byte-identical pre-#1273 behaviour)
+// round-robins onto the non-serving peer every other kick and WEDGES: within a
+// tight kick budget it never reaches the anchor, and it DID target the dead
+// peer (the wedge cause).
+TEST(DashReplayHeaderBackfillPeerSelect, RedBlindRoundRobinWedgesOnNonServer)
+{
+    uint256 pow_limit;
+    pow_limit.SetHex("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    const uint32_t ANCHOR = 40;   // 8 batches of 5 headers to reach the anchor
+    HdrLaneRig rig(ANCHOR, {"limited:1", "full:1"},
+                   /*serving=*/{"full:1"}, /*live=*/{"full:1"},
+                   /*can_serve=*/false, /*batch=*/5, pow_limit,
+                   /*demote_cooldown_sec=*/0);
+    rig.drive(/*max_kicks=*/4);
+    EXPECT_FALSE(rig.bf.complete())
+        << "blind round-robin wastes every other kick on the non-serving peer";
+    EXPECT_LT(rig.bf.tip_height(), ANCHOR) << "walker stalls short of the anchor";
+    EXPECT_TRUE(rig.targeted("limited:1"))
+        << "the blind lane DID target the dead peer — the wedge cause";
+}
+
+// (G.2 GREEN, proactive) With peer_can_serve wired the CanServeBlocks filter
+// NEVER targets the non-serving peer; the walk self-propels off the one serving
+// peer and JOINS the anchor in a single kick.
+TEST(DashReplayHeaderBackfillPeerSelect, GreenCanServeFilterCompletesInOneKick)
+{
+    uint256 pow_limit;
+    pow_limit.SetHex("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    const uint32_t ANCHOR = 40;
+    HdrLaneRig rig(ANCHOR, {"limited:1", "full:1"},
+                   /*serving=*/{"full:1"}, /*live=*/{"full:1"},
+                   /*can_serve=*/true, /*batch=*/5, pow_limit,
+                   /*demote_cooldown_sec=*/60);
+    rig.drive(/*max_kicks=*/1);
+    EXPECT_TRUE(rig.bf.complete()) << "filtered lane joins the anchor at once";
+    EXPECT_EQ(rig.bf.tip_height(), ANCHOR);
+    EXPECT_FALSE(rig.targeted("limited:1"))
+        << "CanServeBlocks never targets the non-serving peer";
+}
+
+// (G.2 GREEN, reactive) A LIAR advertises full-block service (passes
+// CanServeBlocks) but silently drops every getheaders — the case peer_can_serve
+// alone cannot catch. The BLOCK_STALLING_TIMEOUT demote must fire: the liar is
+// tried once, stalls, is demoted, and the span RE-HOMES to the live server,
+// completing. No span is skipped.
+TEST(DashReplayHeaderBackfillPeerSelect, GreenStallDemoteReHomesOffLyingPeer)
+{
+    uint256 pow_limit;
+    pow_limit.SetHex("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    const uint32_t ANCHOR = 40;
+    HdrLaneRig rig(ANCHOR, {"liar:1", "full:1"},
+                   /*serving=*/{"liar:1", "full:1"},   // BOTH advertise service
+                   /*live=*/{"full:1"},                // only full actually answers
+                   /*can_serve=*/true, /*batch=*/5, pow_limit,
+                   /*demote_cooldown_sec=*/60);
+    rig.drive(/*max_kicks=*/4);
+    EXPECT_TRUE(rig.bf.complete())
+        << "stall-demote re-homes the span off the lying peer and completes";
+    EXPECT_EQ(rig.bf.tip_height(), ANCHOR);
+    EXPECT_TRUE(rig.targeted("liar:1"))
+        << "the liar WAS tried once (it advertised service) — then demoted";
+}
+
+// (G.2 liveness bypass) BOTH peers advertise service but NEITHER answers. The
+// lane must keep re-homing — Pass 2 clears demotions rather than deadlock — so
+// it never freezes and never permanently skips a span: both peers keep getting
+// retried. It cannot complete (no live server) but it MUST NOT fail/crash.
+TEST(DashReplayHeaderBackfillPeerSelect, LivenessBypassNeverDeadlocks)
+{
+    uint256 pow_limit;
+    pow_limit.SetHex("00000fffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    const uint32_t ANCHOR = 40;
+    HdrLaneRig rig(ANCHOR, {"a:1", "b:1"},
+                   /*serving=*/{"a:1", "b:1"}, /*live=*/{},   // nobody answers
+                   /*can_serve=*/true, /*batch=*/5, pow_limit,
+                   /*demote_cooldown_sec=*/60);
+    rig.drive(/*max_kicks=*/10);
+    EXPECT_FALSE(rig.bf.complete());   // no live server ⇒ cannot join
+    EXPECT_FALSE(rig.bf.failed());     // but never fails/crashes/deadlocks
+    EXPECT_TRUE(rig.targeted("a:1"));
+    EXPECT_TRUE(rig.targeted("b:1"))
+        << "liveness bypass re-homes to BOTH — no span permanently skipped";
+    EXPECT_GE(rig.getheaders_targets.size(), 5u)
+        << "the lane keeps trying every kick — never wedges silently";
+}
+
 // ═══ (H) capture cache ════════════════════════════════════════════════════
 
 TEST(DashReplayBulkCapture, SegmentRoundTripAndTornTail)


### PR DESCRIPTION
## Extend #1273's CanServeBlocks + BLOCK_STALLING_TIMEOUT to the header-backfill lane

**Stacked on #1275** (`integrator/dashd-cut-bulk-and-payee`). DRAFT — review only, do not merge.

### The wedge (vm905, cold start, `--coin-rpc` removed, dashd absent)
The genesis→anchor header backfill selected its `getheaders` target by **blind round-robin** over `eligible_peers()` at `replay_bulk_fetch.hpp` `maybe_kick_backfill()` / `on_headers()`. That pool (`eligible_bulk_peer_keys`) has a liveness fallback that re-admits a pruned / `NODE_NETWORK_LIMITED` peer whenever the CanServeBlocks-filtered serving set is transiently empty — the exact cold-start case (one limited peer up). The limited peer **silently drops** the from-genesis `getheaders`, `m_backfill->tip_height()` never leaves 0, `BulkBlockScheduler` stays gated on `m_backfill->complete()`, **bodies=0, the fold never starts** (`hdr=0/2513000`).

This is the same class PR #1273 (`df10298d`) fixed for the **body** scheduler; the **header** lane was simply not covered.

### The port (faithful dashd `net_processing` parity)
The two halves of dashd's block-download peer policy, applied to the single-target header walk:

- **Proactive (CanServeBlocks):** reuse the `peer_can_serve` seam **verbatim** (main_dash → `bulk_peer_can_serve`: advertises full-block service AND `start_height` covers the span AND not bulk-demoted). CanServeBlocks is **not** reimplemented. The round-robin now only targets a peer that can serve `tip_height()+1`.
- **Reactive (BLOCK_STALLING_TIMEOUT):** a header peer that received `getheaders` but did not advance the walker within the re-kick window is **demoted** (`m_hdr_demoted_until`, cooldown parity with the scheduler's `demote_cooldown`) and the span **re-homes** to a different serving peer. This catches a peer that *advertises* service but lies/drops — the case CanServeBlocks alone cannot see. `on_headers` clears the demotion the instant a peer delivers (mirror of `on_body` clearing `demoted_until`).

**Liveness bypass (never skip a span):** if no peer advertises the height the filter degrades to a preference; if every serving peer is demoted the demotions are cleared and the walk re-homes — it never deadlocks. `backfill_demote_cooldown_sec = 0` restores byte-identical pre-port blind behaviour (like the scheduler's `demote_after=0`).

### Reward-safety
Header-fetch peer **selection only**. PoW + prev-hash header linkage stays strict (`HeaderBackfill::add_headers` unchanged); the anchor JOIN CHECK, the per-block `merkleRootMNList` / `merkleRootQuorums` fold self-check and poison fail-closed are untouched; **no header or block is ever skipped** — a demote re-homes the span, it does not drop it.

### Proof
KAT `DashReplayHeaderBackfillPeerSelect` in `test_dash_replay_bulk_fetch.cpp`, red→green:
- **red** — blind round-robin (peer_can_serve null, demote disabled) wedges on the non-serving peer, walker stalls short of the anchor, dead peer WAS targeted.
- **green** — CanServeBlocks filter joins the anchor without ever targeting the non-server; stall-demote re-homes off a lying full-node peer and completes; liveness bypass never deadlocks with all peers non-answering.

Built DASH `C2POOL_DASH_BLS=ON` (BLS=REAL). Full `test_dash_p2p_node`: 147/147 pass.
