### PR TITLE
dash(replay): early-era (pre-V20) non-rotated quorum members — resolve the h=1081595 LLMQ_50_60 fold poison

### DIFF
--- a/src/impl/dash/coin/replay_quorum_bridge.hpp
+++ b/src/impl/dash/coin/replay_quorum_bridge.hpp
@@ -637,6 +637,7 @@ public:
     std::string observe(uint32_t height, const uint256& hash,
                         const BlockType& block)
     {
+        m_observed = std::make_pair(height, hash);
         std::string err;
         auto in = QuorumReplayEngine::input_from_block(block, height, hash,
                                                        &err);
@@ -709,6 +710,7 @@ public:
         if ((height + kWorkDiffDepth) % m_cfg.work_stride == 0)
             retain_list_at(height);
         prune(height);
+        maybe_produce_early_members(height);
     }
 
     /// Exposed for tests and for callers that want the seam without the
@@ -779,6 +781,37 @@ public:
     }
 
 private:
+    /// Early-era (pre-V20) non-rotated member production, wired into the
+    /// POST-fold step. observe_block() refuses below the V20 floor, so the
+    /// forward member lane never produced a set for a REAL early LLMQ_50_60
+    /// commitment and the W1 fold failed closed on its PoSe punishes
+    /// (h=1081595). Once the DML fold of a DKG base block H has completed
+    /// (so the DML is GetListForBlock(H) by construction), derive that base's
+    /// non-rotated member sets from the SAME replayed list and register them
+    /// for members_for(). Above the floor this is a no-op — the engine's
+    /// observe_block() path owns that era.
+    void maybe_produce_early_members(uint32_t height)
+    {
+        if (height >= m_quorum.v20_floor()) return;
+        if (!m_observed || m_observed->first != height) return;
+        bool is_base = false;
+        for (const auto& p : replay_chainparams_llmqs(m_cfg.network)) {
+            if (!p.use_rotation && p.dkg_interval
+                    && height % p.dkg_interval == 0) { is_base = true; break; }
+        }
+        if (!is_base) return;
+        std::vector<QuorumMnEntry> list_at_base;
+        list_at_base.reserve(m_dml.entries().size());
+        for (const auto& [protx, st] : m_dml.entries())
+            list_at_base.push_back(to_quorum_entry(protx, st));
+        auto r = m_quorum.produce_early_nonrotated_members(
+            height, m_observed->second, list_at_base);
+        m_stats.member_cycles_derived += r.cycles_produced;
+        m_stats.member_cycles_skipped += r.cycles_skipped;
+        if (!r.skip_reasons.empty())
+            m_stats.last_skip_reason = r.skip_reasons.back();
+    }
+
     void retain_list_at(uint32_t height)
     {
         std::vector<QuorumMnEntry> list;
@@ -808,6 +841,9 @@ private:
     QuorumReplayEngine& m_quorum;
     QuorumBridgeConfig  m_cfg;
     std::map<uint32_t, std::vector<QuorumMnEntry>> m_lists;
+    /// The (height, hash) of the block currently being folded, cached by
+    /// observe() so the post-fold early-member producer has the base hash.
+    std::optional<std::pair<uint32_t, uint256>> m_observed;
     std::vector<uint32_t> m_seeded_work_heights;
     Stats  m_stats;
     size_t m_seeded_snapshots{0};

--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -1000,6 +1000,106 @@ public:
         return it->second;
     }
 
+    /// The DEPLOYMENT_V20 activation height this engine gates its modifier /
+    /// merkleRootQuorums era on (diagnostics + the early-era producer below,
+    /// which runs STRICTLY below this line).
+    uint32_t v20_floor() const { return m_cfg.v20_floor; }
+
+    /// Outcome of an early-era non-rotated member production pass.
+    struct EarlyMemberProdResult {
+        uint32_t                 base_height{0};
+        uint32_t                 cycles_produced{0};
+        uint32_t                 cycles_skipped{0};
+        std::vector<std::string> skip_reasons;
+    };
+
+    /// EARLY-ERA (pre-V20) NON-ROTATED member PRODUCER.
+    ///
+    /// dashd llmq/utils.cpp verbatim for a non-rotated quorum whose work block
+    /// is PRE-V20 (DeploymentActiveAfter(pWorkBlockIndex, ..., DEPLOYMENT_V20)
+    /// is FALSE):
+    ///   * member list = GetListForBlock(pQuorumBaseBlockIndex) — the list AS
+    ///     OF the DKG base block itself, NO -8 work-block offset. The offset
+    ///     lives ONLY in GetHashModifier's ChainLock lookup;
+    ///     ComputeQuorumMembers feeds the BASE-block list (verified against
+    ///     dashpay/dash develop). `list_at_base` is exactly that: the W1
+    ///     fold's just-proven DML at this base (post_fold), which IS
+    ///     GetListForBlock(base) by construction.
+    ///   * modifier    = ::SerializeHash(std::make_pair(llmqType, baseHash)) —
+    ///     GetHashModifier's pre-V20 branch (no ChainLock term). That is
+    ///     compute_quorum_modifier's CL-absent branch fed the BASE hash.
+    ///   * selection   = CalculateQuorum(size, modifier) over confirmed+valid
+    ///     MNs — compute_nonrotated_members (eligible() drops PoSe-banned and
+    ///     null-confirmedHash exactly as CalculateScores does).
+    ///
+    /// This is the piece observe_block() cannot supply below the V20 floor:
+    /// it refuses every such block (the rotated / CL-modifier eras and the
+    /// merkleRootQuorums self-check are Phase-2), so a REAL early LLMQ_50_60
+    /// commitment — mainnet's first mined DKG era, May 2019 — had NO member
+    /// set and the W1 fold failed closed on its PoSe punishes (the h=1081595
+    /// poison). merkleRootQuorums does not exist pre-DIP8; ONLY member
+    /// production is enabled here. Above the floor this is a no-op —
+    /// observe_block owns that era and must never be shadowed.
+    ///
+    /// Iterates the CHAINPARAMS llmq list (which still carries LLMQ_50_60,
+    /// mined in this era), not the runtime-enabled set (which correctly drops
+    /// it on modern mainnet). Keyed by (llmqType, baseHash) via the same
+    /// m_height_by_hash the forward path uses, so members_for(type,
+    /// quorumHash) resolves a commitment whose quorumHash == its DKG base
+    /// block hash. commitment_is_null() is unchanged (already dashd-IsNull-
+    /// faithful): a genuinely null early commitment still skips before any
+    /// member set is consulted.
+    EarlyMemberProdResult produce_early_nonrotated_members(
+        uint32_t base_height, const uint256& base_hash,
+        const std::vector<QuorumMnEntry>& list_at_base)
+    {
+        EarlyMemberProdResult out;
+        out.base_height = base_height;
+        if (!m_cfg.enabled) return out;
+        // STRICTLY below the V20 floor. At/above it observe_block() is the
+        // authoritative producer (work-block list + CL modifier + rotation).
+        if (base_height >= m_cfg.v20_floor) return out;
+
+        // Register the base block in the height/hash window so members_for()
+        // maps a commitment's quorumHash (== base block hash) back to the base
+        // height. Below the floor observe_block() refuses before it would.
+        m_hash_by_height[base_height] = base_hash;
+        m_height_by_hash[base_hash]   = base_height;
+
+        for (const auto& p : replay_chainparams_llmqs(m_cfg.network)) {
+            if (p.use_rotation) continue;              // rotated => Phase-2
+            if (p.dkg_interval == 0) continue;
+            if (base_height % p.dkg_interval != 0) continue;
+
+            const uint256 modifier = vendor::compute_quorum_modifier(
+                p.type, base_height, /*best_cl_sig=*/std::nullopt, base_hash);
+            const bool evo_only =
+                (m_cfg.network == LlmqNetwork::Mainnet
+                     ? p.type == vendor::kLlmqTypePlatformMainnet
+                     : p.type == vendor::kLlmqTypePlatformTestnet);
+            std::string err;
+            auto members = compute_nonrotated_members(
+                p, evo_only, list_at_base, modifier, &err);
+            if (!members) {
+                ++out.cycles_skipped;
+                out.skip_reasons.push_back(
+                    "early non-rotated type " + std::to_string(int(p.type))
+                    + " base h=" + std::to_string(base_height) + ": " + err);
+                continue;
+            }
+            m_modifiers[{p.type, base_height}] = modifier;
+            m_members[{p.type, base_height}]   = std::move(*members);
+            ++out.cycles_produced;
+        }
+
+        // Bound memory across a genesis-length early era. A base's member set
+        // is consumed only inside its own mining window (base+mining_window),
+        // so keep_depth (>> that window) can never evict a set a later
+        // commitment still needs.
+        prune(base_height);
+        return out;
+    }
+
     // ── observe_block — the per-block quorum fold + THE self-check ───────
     QuorumObserveResult observe_block(const QuorumBlockInput& in)
     {

--- a/test/test_dash_replay_quorum_seam.cpp
+++ b/test/test_dash_replay_quorum_seam.cpp
@@ -776,3 +776,159 @@ TEST(DashReplayQuorumSeam, BridgeNeverArmsTheRootSelfCheckByItself)
     EXPECT_TRUE(bridge.self_check_armed())
         << "arm_self_check() is the ONLY door, and it must still work";
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT-E — EARLY-ERA (pre-V20) NON-ROTATED member production (the h=1081595
+//         poison)
+//
+//   A REAL LLMQ_50_60 (type 1) final commitment — mainnet's FIRST mined DKG
+//   era, May 2019 — marks members invalid, so the W1 fold needs its ORDERED
+//   member set to attribute dashd's HandleQuorumCommitment PoSe punishes by
+//   bitset index. But the W4 QuorumReplayEngine refuses every block below the
+//   V20 floor (1'987'776), so members_for() answered nullopt and the fold
+//   FAILED CLOSED: "quorum-member resolver has no member set for llmqType=1
+//   ... failing closed". That is the live-proven poison (DIVERGED_AT=1081595).
+//
+//   commitment_is_null() was NEVER the bug — it is already dashd
+//   CFinalCommitment::IsNull-faithful and the 1081595 commitment is non-null
+//   (41/50 signers, real pubkey/sigs). The fix PRODUCES the early non-rotated
+//   member set, dashd llmq/utils.cpp ComputeQuorumMembers verbatim for a
+//   pre-V20 work block: member list = GetListForBlock(base) (NO -8 offset),
+//   modifier = ::SerializeHash(make_pair(type, baseHash)) (no ChainLock term
+//   — GetHashModifier's pre-V20 branch, verified against dashpay/dash develop).
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// Deterministic distinct 32-byte value (display-hex from two 64-bit words).
+uint256 u256_from(uint64_t hi, uint64_t lo)
+{
+    static const char* H = "0123456789abcdef";
+    std::string s(64, '0');
+    const uint64_t v[2] = {lo, hi};
+    for (int k = 0; k < 2; ++k)
+        for (int i = 0; i < 16; ++i)
+            s[63 - k * 16 - i] = H[(v[k] >> (4 * i)) & 0xf];
+    return from_display(s.c_str());
+}
+
+std::vector<QuorumMnEntry> synth_mn_list(size_t n, size_t n_invalid)
+{
+    std::vector<QuorumMnEntry> list;
+    list.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        QuorumMnEntry e;
+        e.proTxHash      = u256_from(0x1000u + i, i * 2654435761ull);
+        e.confirmedHash  = u256_from(0xc0ffeeu, i * 40503ull + 7);  // non-null
+        e.is_valid       = (i >= n_invalid);   // first n_invalid are PoSe-banned
+        e.n_type         = 0;
+        e.has_collateral = true;
+        e.collateral_hash  = u256_from(0xabcdu, i * 7919ull);
+        e.collateral_index = static_cast<uint32_t>(i);
+        list.push_back(e);
+    }
+    return list;
+}
+
+// The real quorumHash the live poison names at h=1081595 (== its DKG base
+// block hash; the fold resolves members_for(type, quorumHash) through it).
+const uint256 kEarlyBaseHash = from_display(
+    "00000000000000019b39d2d042f4da5d2edcb3f5c73b3517d6bdf9ae2568c52c");
+constexpr uint32_t kEarlyBase = 1'081'584;   // % 24 == 0, below the V20 floor
+constexpr uint8_t  kType5060  = 1;
+
+}  // namespace
+
+// RED WITNESS: the era gate that caused the poison. Below the V20 floor the
+// forward observe_block() path refuses, so a fresh engine has NO member set
+// for the early quorum — the fold fails closed exactly as the live run did.
+TEST(DashReplayQuorumSeam, EarlyNonRotatedGateRefusesWithoutTheProducer)
+{
+    QuorumReplayConfig qcfg;
+    qcfg.enabled = true;
+    qcfg.network = LlmqNetwork::Mainnet;      // v20_floor = 1'987'776
+    QuorumReplayEngine eng(qcfg);
+    eng.seed_cursor(kEarlyBase - 24, u256_from(0x1u, 0x105ab0u));
+
+    dash::coin::replay::QuorumBlockInput in;
+    in.height     = kEarlyBase;
+    in.block_hash = kEarlyBaseHash;
+    auto r = eng.observe_block(in);
+    EXPECT_FALSE(r.ok);
+    EXPECT_NE(r.error.find("below the V20 floor"), std::string::npos) << r.error;
+
+    // ... so members_for stays nullopt: the W1 fold would fail closed here.
+    EXPECT_FALSE(eng.members_for(kType5060, kEarlyBaseHash).has_value());
+}
+
+// GREEN: the early producer registers the base's non-rotated member sets and
+// members_for() now resolves the LLMQ_50_60 quorum — byte-identical to dashd's
+// pre-V20 ComputeQuorumMembers.
+TEST(DashReplayQuorumSeam, EarlyNonRotatedProducerResolvesMembersFaithfully)
+{
+    QuorumReplayConfig qcfg;
+    qcfg.enabled = true;
+    qcfg.network = LlmqNetwork::Mainnet;
+    QuorumReplayEngine eng(qcfg);
+    eng.seed_cursor(kEarlyBase - 24, u256_from(0x1u, 0x105ab0u));
+
+    auto list = synth_mn_list(/*n=*/80, /*n_invalid=*/9);
+
+    auto prod = eng.produce_early_nonrotated_members(kEarlyBase, kEarlyBaseHash,
+                                                     list);
+    EXPECT_GE(prod.cycles_produced, 1u)
+        << (prod.skip_reasons.empty() ? std::string{} : prod.skip_reasons.back());
+
+    auto got = eng.members_for(kType5060, kEarlyBaseHash);
+    ASSERT_TRUE(got.has_value())
+        << "members_for must now resolve the early LLMQ_50_60 quorum";
+
+    const auto* p =
+        dash::coin::replay::replay_llmq_params(LlmqNetwork::Mainnet, kType5060);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(got->size(), std::min<size_t>(p->size, 80u));   // top 50 of 80
+
+    // FAITHFULNESS: byte-identical to dashd ComputeQuorumMembers for a pre-V20
+    // work block — base-block list + SerializeHash(pair(type, baseHash)), NO
+    // -8 work-block offset, NO ChainLock term.
+    const uint256 pre_v20_modifier =
+        dash::coin::vendor::compute_quorum_modifier(
+            kType5060, kEarlyBase, /*best_cl_sig=*/std::nullopt, kEarlyBaseHash);
+    auto want = dash::coin::replay::compute_nonrotated_members(
+        *p, /*evo_only=*/false, list, pre_v20_modifier, nullptr);
+    ASSERT_TRUE(want.has_value());
+    EXPECT_EQ(*got, *want);
+
+    // The pre-V20 formula is NOT the post-V20 (work-block hash) one: a modifier
+    // built over a different hash reorders the top-50, so the choice is load-
+    // bearing, not cosmetic.
+    const uint256 wrong_modifier =
+        dash::coin::vendor::compute_quorum_modifier(
+            kType5060, kEarlyBase, std::nullopt, u256_from(0xdead, 0xbeef));
+    auto wrong = dash::coin::replay::compute_nonrotated_members(
+        *p, false, list, wrong_modifier, nullptr);
+    ASSERT_TRUE(wrong.has_value());
+    EXPECT_NE(*got, *wrong);
+
+    // Every PoSe-banned synthetic MN is excluded (eligible() == dashd
+    // CalculateScores onlyValid + confirmedHash skip).
+    for (const auto& m : *got)
+        for (size_t i = 0; i < 9; ++i)
+            EXPECT_NE(m.GetHex(), list[i].proTxHash.GetHex());
+}
+
+// The producer is STRICTLY a below-floor lane: at/above the V20 floor the
+// forward observe_block() path is authoritative and must never be shadowed.
+TEST(DashReplayQuorumSeam, EarlyProducerIsANoOpAtOrAboveTheV20Floor)
+{
+    QuorumReplayConfig qcfg;
+    qcfg.enabled = true;
+    qcfg.network = LlmqNetwork::Mainnet;
+    QuorumReplayEngine eng(qcfg);
+    const uint256 base_hash = u256_from(0x1e5u, 0x0u);
+    auto list = synth_mn_list(80, 9);
+    auto prod = eng.produce_early_nonrotated_members(
+        /*base=*/2'000'000u, base_hash, list);          // >= 1'987'776
+    EXPECT_EQ(prod.cycles_produced, 0u);
+    EXPECT_FALSE(eng.members_for(kType5060, base_hash).has_value());
+}


### PR DESCRIPTION

**Draft. Do not merge. Stacked on #1276 (`integrator/dashd-cut-header-backfill-canserve`).**

### The poison (live-proven)
The daemonless full-DIP3 self-derive fold (`dash-selfderive-hdrfix.log`) folded **1028161..1081594 byte-clean** (`folded=53434, roots_matched=53434, payees_verified=34395, DIVERGED=none`) — #1274 payee-DIP3 enforcement proven — then **failed CLOSED at h=1081595** on the FIRST non-null early `LLMQ_50_60` (llmqType=1) qfcommit:

```
fold FAILED at h=1081595 tx[1]: quorum-member resolver has no member set
for llmqType=1 quorumHash=0000000000000001... — failing closed
```

`quorum_lane_refusals=53435` (every block).

### Root cause (NOT commitment_is_null)
`commitment_is_null()` is already dashd `CFinalCommitment::IsNull`-faithful and unchanged. The h=1081595 commitment is genuinely **non-null** (41/50 signers, real quorumPublicKey / quorumVvecHash / sigs) — mainnet's first mined `LLMQ_50_60` DKG era (May 2019) with 9 invalid members that dashd's `HandleQuorumCommitment` PoSe-punishes. A member set is **required** for MN-list parity.

The gap is member **production below the V20 floor**. `QuorumReplayEngine::observe_block()` hard-refuses every block under `v20_floor` (mainnet 1'987'776) — the CL-modifier era, DIP-0024 rotation and the `merkleRootQuorums` self-check are all post-V20 / Phase-2 — so the W4 lane produced no member set the whole early-DIP3 run and the W1 fold's punish pass fell to the fail-closed site.

### Fix — faithful dashd pre-V20 `ComputeQuorumMembers` (verified vs dashpay/dash `develop`)
For a non-rotated DKG base block **B** (`B % dkgInterval == 0`) below the floor:
- **member list** = `GetListForBlock(B)` — the list AS OF the base block, **NO -8 work-block offset** (the offset lives only in `GetHashModifier`'s ChainLock lookup; `ComputeQuorumMembers` feeds the base-block list). Sourced as the W1 fold's just-proven DML at B (post_fold) = `GetListForBlock(B)` by construction.
- **modifier** = `::SerializeHash(make_pair(llmqType, blockHash(B)))` — `GetHashModifier`'s pre-V20 branch (`DeploymentActiveAfter(pWorkBlockIndex, V20)` is false), no ChainLock term. Byte-exact `compute_quorum_modifier`'s CL-absent branch fed the BASE hash.
- **selection** = `CalculateQuorum(size, modifier)` over confirmed+valid MNs (`compute_nonrotated_members` / `eligible()` == dashd `CalculateScores`).

Keyed by `(llmqType, blockHash(B))` via the same `m_height_by_hash` the forward path uses, so `members_for(type, quorumHash)` resolves a commitment whose quorumHash == its DKG base block hash. Iterates the **chainparams** llmq list (still carries `LLMQ_50_60`, mined in this era), not the runtime-enabled set. **Strictly below the floor** — at/above it `observe_block()` stays authoritative and is never shadowed. Wired into the bridge's post_fold hook (covers both the replay-fold and mn-diff-store drivers).

**Reward-safe by construction:** a wrong member set re-hashes to the wrong `merkleRootMNList` and the fold's per-block committed-cbTx-root self-check refuses forward — never a bad mint.

### Tests (red→green)
`test_dash_replay_quorum_seam`:
- `EarlyNonRotatedGateRefusesWithoutTheProducer` — the poison gate: below the floor `observe_block` refuses and `members_for` is nullopt.
- `EarlyNonRotatedProducerResolvesMembersFaithfully` — GREEN: the producer resolves the `LLMQ_50_60` set, byte-identical to dashd's pre-V20 `ComputeQuorumMembers`, banned MNs excluded, and the pre-V20 modifier is distinct from the post-V20 (work-block-hash) form.
- `EarlyProducerIsANoOpAtOrAboveTheV20Floor` — the below-floor scope.

`test_dash_mn_state` suite: 126 passed, 1 data-driven skip. Build BLS=REAL.

### Live validation
Binary rebuilt; the self-derive run resumed from the existing capture (re-folds DIP3→1081595 from cached bodies). Acceptance: fold PAST h=1081595 with `DIVERGED=none` continuing and members resolving. (Full run to tip is ~days; not awaited here.)
