### PR TITLE
dash(replay): progress-condition the bulk-lane defer so a frozen MN-ckpt bridge cannot wedge the self-derive at 0 blk/s

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7596,7 +7596,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // false and the bulk lane resumes at full rate. Reward-safe: this
             // only reorders WHO fetches WHEN, never what either derives.
             seams.defer_to_higher_priority = [mnl = mn_ckpt_lane.get()] {
-                return mnl && mnl->bridging_active();
+                // PROGRESS-CONDITIONED (dashd BLOCK_STALLING_TIMEOUT parity):
+                // yield the shared link to the bridge only while its apply
+                // cursor is actually advancing. A bridge frozen on a pending
+                // getmnlistd reply is idle-waiting, not using the link -- so it
+                // must NOT starve the genesis->anchor backfill + body pump. See
+                // MnCheckpointLane::bulk_should_yield().
+                return mnl && mnl->bulk_should_yield();
             };
 
             rp::BulkFetchLane::Config rcfg;

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -1417,6 +1417,53 @@ public:
     /// bulk path (a plain cut cold node, the KATs) nothing reads it, and it is
     /// pure telemetry-shaped state — reading it changes nothing.
     bool     bridging_active() const { return m_state == State::Bridging; }
+
+    /// Silence (no cursor advance) after which the bulk-lane defer treats the
+    /// bridge as FROZEN and stops yielding the shared coin-P2P link to it.
+    /// dashd BLOCK_STALLING_TIMEOUT is 2s and adapts up to 64s; the bridge
+    /// legitimately pauses a few seconds per on-demand getmnlistd fold, so this
+    /// sits well above a healthy fold pause (seconds) and well below a real
+    /// freeze (minutes) -- 20s cleanly separates the two, matching the
+    /// 2026-08-18 measurement's 15-30s parity band.
+    static constexpr int64_t kBulkDeferStallMs = 20000;
+
+    /// dashd BLOCK_STALLING_TIMEOUT parity, applied to the shared-demux defer.
+    ///
+    /// bridging_active() is TRUE for the WHOLE Bridging state, including the
+    /// multi-minute freezes the LANE-WATCHDOG measured when the cold bridge
+    /// parks on a single-outstanding getmnlistd reply (217s / 337s / 98s,
+    /// mainnet 2026-08-18). Wiring the bulk-lane defer straight to it turns one
+    /// frozen fold into a TOTAL priority inversion: while the bridge sits
+    /// Bridging-but-idle the genesis->anchor header backfill AND the body pump
+    /// issue NOTHING, so the whole self-derive holds 0 blk/s -- measured 48+ min
+    /// across a restart. dashd has no such coupling: block download
+    /// (FindNextBlocksToDownload) never waits on masternode-state sync;
+    /// CMasternodeSync waits for blocks, never the reverse.
+    ///
+    /// This predicate is what the defer should read instead. It yields the link
+    /// to the bridge ONLY while the bridge is actually progressing -- its apply
+    /// cursor advanced within kBulkDeferStallMs. Once the cursor stands still
+    /// past that window the bridge is, by construction, NOT using the shared
+    /// link (it is idle-waiting on a reply), so the contention the defer guards
+    /// against does not exist and the bulk lane runs. The instant a reply lands
+    /// and the cursor advances, progress() re-stamps the watchdog and this
+    /// returns true again -- priority snaps straight back to the bridge. It
+    /// reorders only WHO fetches WHEN on an idle link, never WHAT either lane
+    /// folds: the bridge's forward-contiguous cursor, its per-block
+    /// merkleRootMNList/merkleRootQuorums self-check and its poison fail-closed
+    /// are all untouched -- reward-safe by exactly the argument #1257 made for
+    /// the reorder buffer.
+    ///
+    /// m_watchdog is armed at the Waiting->Bridging edge and progress()-stamped
+    /// on every cursor advance, so elapsed_ms is precisely "time since the
+    /// bridge last moved". A not-yet-armed or just-armed lane reads elapsed 0
+    /// and holds priority -- correct, a bridge that just started cannot have
+    /// stalled yet.
+    bool bulk_should_yield() const
+    {
+        if (m_state != State::Bridging) return false;
+        return m_watchdog.elapsed_ms(m_now()) < kBulkDeferStallMs;
+    }
     /// How many times the event-driven body re-request (service_tick) has
     /// re-asked a starved window from the cursor. Telemetry / KAT witness only.
     uint64_t service_rerequests() const { return m_service_rerequests; }

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -797,6 +797,83 @@ TEST(DashMnCheckpointBridge, ServiceTickReRequestsAStarvedWindowOffPump)
     EXPECT_FALSE(h.lane.bridging_active());
 }
 
+// ── THE DOMINANT-THROTTLE PORT (2026-08-18 self-derive measurement) ─────────
+// The bulk genesis->anchor lane defers to the MN-checkpoint bridge on the
+// shared coin-P2P link. Before this port that defer read bridging_active(),
+// which is TRUE for the entire Bridging state -- including the multi-minute
+// freezes when the cold bridge parks on a single-outstanding getmnlistd reply.
+// One frozen fold therefore inverted priority TOTALLY: the header backfill and
+// the body pump issued NOTHING and the whole self-derive held 0 blk/s for 48+
+// min across a restart. dashd never gates block download on masternode-sync
+// state (CMasternodeSync waits for blocks, never the reverse).
+//
+// The port makes the defer PROGRESS-CONDITIONED (dashd BLOCK_STALLING_TIMEOUT
+// parity): bulk_should_yield() holds priority only while the bridge's apply
+// cursor is advancing, and releases it the moment the cursor has stood still
+// past kBulkDeferStallMs -- i.e. while the bridge is idle-waiting on a reply
+// and NOT using the link. It reclaims priority instantly on the next advance.
+// FETCH TIMING only: nothing folds, publishes, or moves an anchor here.
+//
+// RED on the pre-port logic (bulk_should_yield()==bridging_active(), true for
+// the whole freeze); GREEN once it is progress-conditioned.
+TEST(DashMnCheckpointBridge, BulkDeferReleasesWhenBridgeFreezesAndReclaimsOnProgress)
+{
+    BridgeHarness h;
+    int64_t clk = 100000;                       // injected wall clock (ms)
+    h.lane.set_clock_fn([&clk] { return clk; });
+    h.auto_deliver = false;                     // WE drive body arrival + the clock
+    h.headers[kAnchorHeight] = uint256S(kAnchorHash);
+    h.blocks[1519544] = block_from_hex(kBlockHex1519544);
+    h.blocks[1519545] = block_from_hex(kBlockHex1519545);
+    h.blocks[1519546] = block_from_hex(kBlockHex1519546);
+    h.tip = 1519546;
+
+    h.lane.arm(good_checkpoint());
+    h.lane.pump();                              // Waiting -> Bridging; watchdog armed @100000
+    ASSERT_EQ(h.lane.state(), MnCheckpointLane::State::Bridging);
+
+    // t0: bridge just armed -> it owns the shared link (bulk yields).
+    EXPECT_TRUE(h.lane.bulk_should_yield())
+        << "a just-armed / actively-progressing bridge keeps link priority";
+
+    // Deliver one body: the cursor advances -> progress() re-stamps the watchdog.
+    h.lane.on_block_connected(h.blocks[1519544], 1519544);
+    ASSERT_EQ(h.lane.cursor_height(), 1519544u);
+    EXPECT_TRUE(h.lane.bulk_should_yield())
+        << "immediately after a cursor advance the bridge still owns the link";
+
+    // Now the bridge FREEZES on the wire (a single-outstanding getmnlistd reply
+    // that never comes). Wall clock crosses the stall window with NO cursor
+    // advance: the bridge is not using the link, so the bulk lane must run.
+    clk += MnCheckpointLane::kBulkDeferStallMs + 1;
+    EXPECT_FALSE(h.lane.bulk_should_yield())
+        << "a bridge frozen past kBulkDeferStallMs must NOT starve the bulk lane"
+           " -- dashd never gates block download on an idle masternode-sync lane";
+
+    // Just below the window the defer would still hold (proves it is the elapsed
+    // time, not merely 'ever advanced', that flips it).
+    clk -= 2;                                    // now exactly kBulkDeferStallMs - 1 since last advance
+    EXPECT_TRUE(h.lane.bulk_should_yield())
+        << "inside the stall window the bridge retains priority";
+    clk += 2;                                    // back past the window
+    EXPECT_FALSE(h.lane.bulk_should_yield());
+
+    // A reply finally lands: the cursor advances, progress() resets the timer,
+    // and the bridge reclaims priority in the same instant.
+    h.lane.on_block_connected(h.blocks[1519545], 1519545);
+    ASSERT_EQ(h.lane.cursor_height(), 1519545u);
+    EXPECT_TRUE(h.lane.bulk_should_yield())
+        << "the instant the bridge advances again it reclaims the shared link";
+
+    // Terminal: once the bridge publishes, the defer is off entirely -- the bulk
+    // lane runs unconditionally (bridging_active() and bulk_should_yield() agree
+    // here: both false when not Bridging).
+    h.lane.on_block_connected(h.blocks[1519546], 1519546);
+    EXPECT_EQ(h.lane.state(), MnCheckpointLane::State::Published);
+    EXPECT_FALSE(h.lane.bulk_should_yield());
+    EXPECT_FALSE(h.lane.bridging_active());
+}
+
 // service_tick() is inert off the bridging state: a Waiting lane (headers not
 // yet at the anchor) and a Published lane must never emit a re-request. Proves
 // the tick cannot disturb a lane that is not mid-replay.


### PR DESCRIPTION
## What

Progress-condition the W2 bulk-lane defer so a **frozen** MN-checkpoint bridge can no longer wedge the daemonless self-derive at **0 blk/s**.

The bulk genesis→anchor lane yields the shared coin-P2P response demux to the MN-checkpoint anchor→tip fold via `BulkFetchLane::Seams::defer_to_higher_priority`. That seam read `bridging_active()`, which is `true` for the **entire** `Bridging` state — including the multi-minute freezes the `LANE-WATCHDOG` measures when the cold bridge parks on a single-outstanding `getmnlistd` reply.

Wired straight to `bridging_active()`, one frozen fold became a **total priority inversion**: while the bridge sat `Bridging`-but-idle, **both** the genesis→anchor header backfill **and** the body pump issued nothing, so the whole self-derive held 0 blk/s.

## Why it is the dominant throttle (measured 2026-08-18, vm905)

Same host, same hour, same 7 archival peers, `-connect`-pinned:

| run | blk/s |
|---|---|
| dashd v22.1.3 IBD (26,514→175,658 in 1,568 s) | **95.1** |
| this-commit-base self-derive (vm905) | **0.0** — one 22-min wedge (hdr frozen 2,020,000) + one 26+-min wedge after a full process restart |

`LANE-WATCHDOG` bridge freezes on the wedged run: `frozen_for=217s / 337s` (`ondemand-mnlist-reply@2513860`), `98s+` (`fold-mnlist-reply@2515864`). `getmnlistd` round-trips on the `--replay-fold-quorums` **fold** path = **0** (0-RTT claim CONFIRMED against the same-commit reference run: 342,382 blocks folded, 299 total `getmnlistd` sends = 0.0009/block). The throttle is **not** a per-block round-trip and **not** raw CPU (3.5–5%) — it is a priority-inversion **freeze**.

dashd has no analogue: block download (`net_processing` `FindNextBlocksToDownload`) never waits on masternode-state sync; `CMasternodeSync` waits for blocks, never the reverse.

## The port (dashd `BLOCK_STALLING_TIMEOUT` parity)

New `MnCheckpointLane::bulk_should_yield()`. The defer yields the link to the bridge **only while the bridge's apply cursor advanced within `kBulkDeferStallMs` (20 s)**. Once the cursor stands still past that window the bridge is, by construction, idle-waiting on a reply and **not using the link** — the contention the defer guards against does not exist, so the bulk lane runs. The instant a reply lands and the cursor advances, `progress()` re-stamps the watchdog and the bridge reclaims priority in the same tick.

- Reuses the existing `BulkBlockScheduler` and the existing `StallWatchdog` (`m_watchdog` is already armed at the `Waiting→Bridging` edge and `progress()`-stamped on every cursor advance, so `elapsed_ms` is exactly "time since the bridge last moved"). **No new state, one predicate, one constant.**
- Seam signature unchanged — the lane owns its own clock via `m_now`.
- No band-aid, no cap, no skipped block.

## Reward-safety

Timing / throughput only. It reorders **who** fetches **when** on an otherwise-idle link, never **what** either lane folds. The bridge's forward-contiguous cursor, its per-block `merkleRootMNList` / `merkleRootQuorums` self-check and its poison fail-closed are **all untouched** — the same argument #1257 made for the reorder buffer.

## Proof

- **KAT red→green** — `DashMnCheckpointBridge.BulkDeferReleasesWhenBridgeFreezesAndReclaimsOnProgress` (folded into the allowlisted `test_dash_node_reception_wire` target). Drives a real 1519544..1519546 bridge with an injected clock: defer **holds** while progressing, **releases** once the cursor freezes past `kBulkDeferStallMs`, **reclaims** on the next advance. RED on the pre-port `bridging_active()` semantics (fails at the freeze assertion, `Actual true / Expected false`); GREEN after.
- **Full TU 174/174** green.
- **Build** — vm905, `C2POOL_DASH_BLS=ON`, BLS backend **REAL** (`dashbls` linked, RELIC), `c2pool-dash` links clean.

## Base / stacking

Stacked on `integrator/dashd-cut-early-quorum-memberset` (@ `d8ba8fba`, the #1277 cold-start fetch+fold stack) — the branch the throttle was measured on. Single commit, 3 files, +131/−1.

## Follow-up (out of scope here, named in the measurement)

The measurement also flags the coin-P2P **session hygiene**: c2pool demotes but never disconnect-cycles a starved coin-P2P session, where dashd disconnects a staller (`BLOCK_STALLING_TIMEOUT` → disconnect + redial) and recovers. That is a separate seam (the coin-P2P session pool, `POOL-STATUS` demote-only) and a separate, smaller PR — this one fixes the dominant 0-blk/s inversion.

---

Draft — do not merge. Review requested.
