### PR TITLE
dash: distributed won-block re-broadcast (reconstruct + dual-path dispatch)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -59,6 +59,7 @@
 #include <impl/dash/coin/coin_peer_manager.hpp> // dash::coin::DashCoinPeerManager — DASH-ISOLATED scored/diverse peer discovery (--coin-p2p-discover; network-standalone gate)
 #include <impl/dash/coin/chain_seeds.hpp>  // dash::coin::dash_dns_seeds / dash_fixed_seeds — DASH mainnet/testnet seed bootstrap
 #include <impl/dash/coin/won_block_dispatch.hpp> // dash::coin::broadcast_won_block — S8 dual-path won-block dispatcher (embedded P2P primary + submitblock RPC backup)
+#include <impl/dash/coin/reconstruct_won_block.hpp> // dash::coin::reconstruct_won_block — distributed won-block: rebuild full block from a won share for re-broadcast
 #include <impl/dash/coin/zmq_tip_notify.hpp> // dash::coin::TipHashDedup / ZmqHashblockSubscriber — dashd ZMQ hashblock INSTANT tip-notify (opt-in, hardening on the #770 poll)
 #include <impl/dash/coin/coin_p2p_magic.hpp>      // dash::coin::select_coin_p2p_magic — E5 --coin-p2p-magic override (regtest ARM A dial)
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
@@ -1801,46 +1802,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // block hash (on DASH the share hash IS X11(block header)) and the same
         // "DASH" label, and record_found_block dedups on exactly that pair.
         //
-        // Display only: no submit, mint, target or payout path is reachable.
-        {
-            core::WebServer* ws = web_server.get();
-            dash::Node* node = &p2p_node;
-            p2p_node.tracker().m_on_block_found =
-                dash::dashboard::make_on_block_found(
-                    node, testnet,
-                    [&ioc](std::function<void()> work) {
-                        boost::asio::post(ioc, std::move(work));
-                    },
-                    [ws](const dash::dashboard::FoundBlockRow& row) {
-                        auto* mi = ws->get_mining_interface();
-                        LOG_INFO << "[DASH] GOT BLOCK FROM POOL! height=" << row.height
-                                 << " hash=" << row.block_hash.GetHex().substr(0, 16)
-                                 << " miner=" << row.miner;
-                        mi->record_found_block(
-                            row.height, row.block_hash, row.timestamp,
-                            row.chain, row.miner, row.share_hash,
-                            mi->get_network_difficulty(),
-                            row.share_difficulty,
-                            // pool_hashrate_at_find: 0 routes the core to the
-                            // real POOL estimator (m_pool_hashrate_fn); this
-                            // site passed get_local_hashrate(), which is only
-                            // the pool rate when every rig sits on this node.
-                            /*pool_hashrate=*/0.0,
-                            row.subsidy,
-                            // Sharechain peer path: another node built the
-                            // template that won. Our pins and our tx selection
-                            // are not in it, and our address may still be in
-                            // the coinbase as our share of the pool payout.
-                            // row.miner is that peer's own payout address,
-                            // derived from the winning share's pubkey hash.
-                            core::MiningInterface::BlockAuthorship
-                                ::sharechain_peer);
-                        // Arm the post-broadcast confirm/orphan poller so this
-                        // peer-found block flips off "pending" (main_ltc.cpp:6315
-                        // parity). Telemetry only; never gates a broadcast.
-                        mi->schedule_block_verification(row.block_hash.GetHex());
-                    });
-        }
+        // WON-BLOCK RE-BROADCAST (distributed close, p2pool node.py:268-282):
+        // this dashboard row is now the POST-BROADCAST TELEMETRY LEG of the
+        // dash::coin::make_on_block_found dispatcher. The tracker binding moved
+        // DOWN to after the p2p_relay + rpc_submit sinks are constructed (search
+        // "DISTRIBUTED WON-BLOCK RE-BROADCAST (tracker arm)"), so both the stratum
+        // submit fn and this tracker dispatcher share the IDENTICAL two sinks, and
+        // the dashboard record_found_block row is composed there as the
+        // post-broadcast telemetry leg (unchanged display behavior; now preceded
+        // by the actual re-broadcast). Nothing to install here anymore.
 
         // ── REAL node-owner fee (already parsed from argv above) ──────────
         if (node_owner_fee > 0.0 && !node_owner_address.empty())
@@ -2530,6 +2500,89 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         rpc_submit = [&rpc](const std::string& block_hex) -> bool {
             return rpc->submit_block_hex(block_hex, /*ignore_failure=*/false);
         };
+    }
+
+    // ── DISTRIBUTED WON-BLOCK RE-BROADCAST (tracker arm) ──────────────────────
+    // Bind ShareTracker::m_on_block_found to the dash::coin dispatcher so a block
+    // found by ANY pool participant (a gossiped share whose X11 header clears the
+    // coin BLOCK target) is RECONSTRUCTED and RE-BROADCAST to the DASH network,
+    // not merely recorded. This is the p2pool node.py:268-282 fan-out DASH lacked
+    // (it previously bound the DISPLAY-ONLY dashboard handler). It reuses the
+    // IDENTICAL p2p_relay + rpc_submit sinks the stratum finder uses (constructed
+    // just above), so both arms broadcast the same way.
+    //
+    // The reconstruct closure runs SYNCHRONOUSLY inside the hook (on the compute
+    // thread, m_tracker_mutex held) because it reads the on-chain PPLNS window +
+    // walks tracker.chain -- the SAME reads verify_payout_commitment already did
+    // one call earlier under this same lock (no new lock, no inversion). The
+    // actual broadcast is POSTed onto ioc so the submitblock RPC round-trip never
+    // runs under the tracker lock. The dashboard row (captured above) is the
+    // post-broadcast telemetry leg. known_txs is empty for now: the daemonless
+    // norm is coinbase-only (transactions==[]), so a share that references other
+    // txs fails loud (broadcast NOTHING, telemetry still recorded) rather than
+    // emit an incomplete block -- reward-safe, and it fills in with mempool
+    // tx-selection later with no change here.
+    {
+        auto& won_tracker = p2p_node.tracker();
+        const core::CoinParams won_params = mint_params;
+        core::MiningInterface* won_mi =
+            web_server ? web_server->get_mining_interface() : nullptr;
+
+        dash::coin::WonBlockReconstructor won_reconstruct =
+            [&won_tracker, won_params](const uint256& sh)
+                -> std::optional<dash::coin::ReconstructedWonBlock> {
+                if (!won_tracker.chain.contains(sh)) return std::nullopt;
+                std::optional<dash::coin::ReconstructedWonBlock> result;
+                won_tracker.chain.get_share(sh).invoke([&](auto* obj) {
+                    if (!obj) return;
+                    using ShareT = std::decay_t<decltype(*obj)>;
+                    if constexpr (std::is_same_v<ShareT, dash::DashShare>) {
+                        result = dash::coin::reconstruct_won_block(
+                            sh, *obj, won_tracker, won_params, /*known_txs=*/{});
+                    }
+                });
+                return result;
+            };
+
+        dash::coin::AlreadyBroadcastPredicate won_already;
+        dash::coin::MarkBroadcastFn           won_mark;
+        if (won_mi) {
+            won_already = [won_mi](const uint256& h) { return won_mi->already_submitted_block(h); };
+            won_mark    = [won_mi](const uint256& h) { won_mi->mark_block_submitted(h); };
+        }
+
+        // Post-broadcast telemetry leg: the EXISTING dashboard found-block handler
+        // (unchanged display behavior; ANY-participant /recent_blocks feed). Now it
+        // fires AFTER the re-broadcast rather than instead of it -- composed, not
+        // replaced. Reads the share via read_tracker() (reentrancy-aware) and posts
+        // record_found_block onto ioc, exactly as the old dashboard-only binding.
+        core::WebServer* won_ws = web_server.get();
+        dash::Node*      won_node = &p2p_node;
+        std::function<void(const uint256&)> won_telemetry =
+            dash::dashboard::make_on_block_found(
+                won_node, testnet,
+                [&ioc](std::function<void()> work) { boost::asio::post(ioc, std::move(work)); },
+                [won_ws](const dash::dashboard::FoundBlockRow& row) {
+                    auto* mi = won_ws->get_mining_interface();
+                    LOG_INFO << "[DASH] GOT BLOCK FROM POOL! height=" << row.height
+                             << " hash=" << row.block_hash.GetHex().substr(0, 16)
+                             << " miner=" << row.miner;
+                    mi->record_found_block(
+                        row.height, row.block_hash, row.timestamp,
+                        row.chain, row.miner, row.share_hash,
+                        mi->get_network_difficulty(),
+                        row.share_difficulty,
+                        /*pool_hashrate=*/0.0,
+                        row.subsidy,
+                        core::MiningInterface::BlockAuthorship::sharechain_peer);
+                    mi->schedule_block_verification(row.block_hash.GetHex());
+                });
+
+        p2p_node.tracker().m_on_block_found = dash::coin::make_on_block_found(
+            std::move(won_reconstruct), p2p_relay, rpc_submit,
+            [&ioc](std::function<void()> work) { boost::asio::post(ioc, std::move(work)); },
+            std::move(won_already), std::move(won_mark),
+            std::move(won_telemetry));
     }
 
     dash::stratum::DASHWorkSource::SubmitBlockFn stratum_submit_fn =

--- a/src/impl/dash/coin/gentx_coinbase.hpp
+++ b/src/impl/dash/coin/gentx_coinbase.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ---------------------------------------------------------------------------
+// dash::coin::GentxCoinbase -- the regenerated DASH coinbase (gentx) as both
+// its non-witness serialization AND its txid, mirroring dgb::coin::GentxCoinbase
+// (src/impl/dgb/coin/gentx_coinbase.hpp).
+//
+// It is the SSOT hand-off between the accept-path coinbase recompute
+// (share_check.hpp generate_share_transaction, which already builds the exact
+// DIP3/DIP4 CbTx bytes the share committed to) and the won-block reconstructor
+// (reconstruct_won_block.hpp): generate_share_transaction fills this out-param
+// with the coinbase BYTES + its txid, so the reconstructor never re-implements
+// the coinbase assembly -- it reuses the one, KAT-proven, byte path.
+//
+// Reward/consensus-NEUTRAL: a plain data record. No PoW hash, share format,
+// coinbase commitment, or PPLNS math lives here. Per-coin isolation:
+// src/impl/dash/ only.
+// ---------------------------------------------------------------------------
+
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace dash
+{
+namespace coin
+{
+
+// The regenerated coinbase transaction:
+//   bytes : non-witness serialization (block tx 0)
+//   txid  : SHA256d(bytes) == the gentx_hash the share's hash_link committed to
+struct GentxCoinbase
+{
+    std::vector<unsigned char> bytes;
+    uint256                    txid;
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/reconstruct_won_block.hpp
+++ b/src/impl/dash/coin/reconstruct_won_block.hpp
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ---------------------------------------------------------------------------
+// dash::coin::reconstruct_won_block -- turn a VERIFIED won share into the full
+// serialized DASH parent block, ready for broadcast_won_block's dual path.
+//
+// This is the DASH analogue of dgb::coin::reconstruct_won_block
+// (src/impl/dgb/coin/reconstruct_won_block.hpp) and the C++ of p2pool-dash
+// data.py Share.as_block(tracker, known_txs):
+//
+//     gentx     = self.check(tracker, known_txs)                 # coinbase tx
+//     other_txs = [known_txs[h]
+//                  for h in self.get_other_tx_hashes(tracker)]   # ref-walk
+//     return dict(header=self.header, txs=[gentx]+other_txs)
+//
+// THE DASH-SPECIFIC BIT -- the coinbase is a DIP3/DIP4 special CbTx (version|type
+// = 3|(5<<16), extra_payload appended). We do NOT re-implement that assembly:
+// generate_share_transaction (share_check.hpp) ALREADY regenerates the exact
+// coinbase the share committed to (it is the accept-path payout-commitment
+// keystone, KAT-proven by test_dash_payout_commitment / test_dash_share_producer),
+// and now exposes the coinbase BYTES + txid via its out_gentx param. We reuse
+// that ONE byte path. So the reconstructed coinbase is, by construction, the
+// very coinbase whose txid equals the gentx_hash the share's hash_link committed
+// to -- the same value share_init_verify folded into the block's merkle_root.
+//
+// FAIL-LOUD (reward-safety, mirrors p2pool "GOT INCOMPLETE BLOCK" + dgb "NOT
+// broadcast"): every unrecoverable condition returns std::nullopt so the caller
+// broadcasts NOTHING -- never a partial/malformed block:
+//   * the winning share's parent is not yet in-chain (no PPLNS window to rebuild
+//     the coinbase from) -> nullopt;
+//   * generate_share_transaction throws / yields empty coinbase bytes -> nullopt;
+//   * the share references other (non-coinbase) txs whose bodies are not in the
+//     known-tx set -> nullopt (an incomplete block would hash to the committed
+//     merkle_root's tree but omit a body -> daemon-rejected; never emit it).
+// A partial/wrong reconstruction hashes to the wrong merkle_root and is rejected
+// by every peer/daemon, so failing loudly here is strictly safer than emitting.
+//
+// COINBASE-ONLY is the DAEMONLESS NORM (transactions==[]): the share carries no
+// transaction_hash_refs, other_tx_hashes is empty, the block is [gentx] alone,
+// and merkle_root == gentx_txid (an empty merkle_link is identity). That is the
+// path this reconstructor takes today; the ref-walk + known-tx bodies fill in
+// automatically as embedded mempool tx-selection lands, with no change here.
+//
+// Reward/consensus-NEUTRAL: it READS already-validated share_info + the on-chain
+// PPLNS window (the SAME reads the accept path already did under the same tracker
+// lock) and already-relayed tx bodies; it WRITES no consensus, PPLNS, payout, or
+// target state. Per-coin isolation: src/impl/dash/ only.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <core/hash.hpp>
+#include <core/log.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+#include <btclibs/util/strencodings.h>   // HexStr
+
+#include "gentx_coinbase.hpp"
+#include "won_block_dispatch.hpp"       // dash::coin::ReconstructedWonBlock
+#include "../share.hpp"
+#include "../share_check.hpp"            // generate_share_transaction, check_merkle_link
+
+namespace dash
+{
+namespace coin
+{
+
+// Look up a known non-coinbase tx BODY (non-witness bytes) by txid, or nullptr
+// if absent. The run-loop binds this to the node's remember_tx / m_known_txs
+// cache; an empty function means "no known-tx source" -> any share that
+// references other txs fails loud (coinbase-only still reconstructs).
+using KnownTxLookup =
+    std::function<const std::vector<unsigned char>*(const uint256&)>;
+
+// ── resolve_other_tx_hashes (DASH) ──────────────────────────────────────────
+// Resolve a share's transaction_hash_refs to the ordered other_tx hash list,
+// the DASH port of dgb::coin::resolve_other_tx_hashes. DASH stores refs FLAT as
+// [share_count, tx_count] pairs (share.hpp: std::vector<uint64_t>), so we walk
+// them two-at-a-time. Throws std::out_of_range on a ref that walks off the known
+// sharechain or indexes past an ancestor's new_transaction_hashes -- both are
+// malformed-share conditions the caller turns into a fail-loud nullopt.
+//
+//   nth_parent_fn    : (start, n) -> hash of the n-th parent (n==0 -> start),
+//                      IsNull() when the walk runs off the known sharechain
+//   new_tx_hashes_fn : share_hash -> that share's new_transaction_hashes (copy)
+inline std::vector<uint256>
+resolve_other_tx_hashes(
+    const uint256& won_share_hash,
+    const std::vector<uint64_t>& refs,
+    const std::function<uint256(const uint256&, uint64_t)>& nth_parent_fn,
+    const std::function<std::vector<uint256>(const uint256&)>& new_tx_hashes_fn)
+{
+    std::vector<uint256> out;
+    out.reserve(refs.size() / 2);
+
+    for (std::size_t i = 0; i + 1 < refs.size(); i += 2)
+    {
+        const uint64_t share_count = refs[i];
+        const uint64_t tx_count    = refs[i + 1];
+
+        const uint256 ancestor = nth_parent_fn(won_share_hash, share_count);
+        if (ancestor.IsNull())
+            throw std::out_of_range(
+                "dash resolve_other_tx_hashes: transaction_hash_ref share_count "
+                "walks past the known sharechain");
+
+        const std::vector<uint256> nths = new_tx_hashes_fn(ancestor);
+        if (tx_count >= nths.size())
+            throw std::out_of_range(
+                "dash resolve_other_tx_hashes: transaction_hash_ref tx_count "
+                "out of range for ancestor new_transaction_hashes");
+
+        out.push_back(nths[tx_count]);
+    }
+
+    return out;
+}
+
+// ── frame_won_block (pure) ──────────────────────────────────────────────────
+// Frame the final block bytes from its parts. Pure + injectable (no tracker):
+//   header = version|prev|merkle_root|time|bits|nonce   (80 bytes, DASH block)
+//   merkle_root = check_merkle_link(gentx.txid, merkle_link)   (== gentx.txid
+//                 for an empty coinbase-only link)
+//   body   = varint(1 + other.size()) ++ gentx.bytes ++ other_tx_bodies...
+// The header build MIRRORS share_check.hpp share_init_verify byte-for-byte, so
+// X11(header) of the reconstructed block equals the share hash the tracker fired
+// on -- i.e. the reconstructed block IS the block the winning share solved.
+inline ReconstructedWonBlock
+frame_won_block(const bitcoin_family::coin::SmallBlockHeaderType& min_header,
+                const MerkleLink& merkle_link,
+                const GentxCoinbase& gentx,
+                const std::vector<std::vector<unsigned char>>& other_tx_bodies)
+{
+    const uint256 merkle_root = check_merkle_link(gentx.txid, merkle_link);
+
+    // 80-byte block header (identical field order to share_init_verify).
+    PackStream header;
+    {
+        uint32_t hdr_version = static_cast<uint32_t>(min_header.m_version);
+        header << hdr_version;
+    }
+    header << min_header.m_previous_block;
+    header << merkle_root;
+    header << min_header.m_timestamp;
+    header << min_header.m_bits;
+    header << min_header.m_nonce;
+
+    std::vector<unsigned char> block(
+        reinterpret_cast<const unsigned char*>(header.data()),
+        reinterpret_cast<const unsigned char*>(header.data()) + header.size());
+
+    // tx count (CompactSize) then [gentx] ++ other bodies.
+    const std::size_t n_txs = 1 + other_tx_bodies.size();
+    if (n_txs < 253) {
+        block.push_back(static_cast<unsigned char>(n_txs));
+    } else {
+        block.push_back(0xfd);
+        block.push_back(static_cast<unsigned char>(n_txs & 0xff));
+        block.push_back(static_cast<unsigned char>((n_txs >> 8) & 0xff));
+    }
+
+    block.insert(block.end(), gentx.bytes.begin(), gentx.bytes.end());
+    for (const auto& body : other_tx_bodies)
+        block.insert(block.end(), body.begin(), body.end());
+
+    ReconstructedWonBlock out;
+    out.hex = HexStr(block);
+    out.bytes = std::move(block);
+    return out;
+}
+
+// ── reconstruct_won_block (tracker-bound) ───────────────────────────────────
+// Full reconstruction for the run-loop. MUST be called on the compute thread
+// with the tracker lock held (the m_on_block_found contract): it reads the
+// on-chain PPLNS window via generate_share_transaction and walks the sharechain
+// via tracker.chain -- exactly the reads the accept path already performed under
+// this same lock. Returns std::nullopt (never throws) on any unrecoverable
+// condition so the caller broadcasts NOTHING.
+template <typename TrackerT>
+inline std::optional<ReconstructedWonBlock>
+reconstruct_won_block(const uint256& share_hash,
+                      const DashShare& share,
+                      TrackerT& tracker,
+                      const core::CoinParams& params,
+                      const KnownTxLookup& known_txs = {})
+{
+    // Guard: the coinbase recompute needs the parent's PPLNS window in-chain.
+    if (share.m_prev_hash.IsNull() || !tracker.chain.contains(share.m_prev_hash)) {
+        LOG_WARNING << "[EMB-DASH] won-block " << share_hash.GetHex().substr(0, 16)
+                    << " parent not in-chain -- cannot rebuild coinbase; NOT broadcast.";
+        return std::nullopt;
+    }
+
+    // 1. Regenerate the DIP3/DIP4 coinbase (bytes + txid) via the SSOT accept
+    //    path. Any throw -> fail loud.
+    GentxCoinbase gentx;
+    try {
+        (void)generate_share_transaction(share, tracker, params, &gentx);
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[EMB-DASH] won-block " << share_hash.GetHex().substr(0, 16)
+                    << " coinbase regen threw (" << e.what() << ") -- NOT broadcast.";
+        return std::nullopt;
+    }
+    if (gentx.bytes.empty()) {
+        LOG_WARNING << "[EMB-DASH] won-block " << share_hash.GetHex().substr(0, 16)
+                    << " coinbase regen empty -- NOT broadcast.";
+        return std::nullopt;
+    }
+
+    // 2. Resolve any other (non-coinbase) tx bodies. Empty for the coinbase-only
+    //    daemonless norm. Missing body / malformed ref -> fail loud.
+    std::vector<std::vector<unsigned char>> other_bodies;
+    try {
+        const std::vector<uint256> other_hashes = resolve_other_tx_hashes(
+            share_hash, share.m_transaction_hash_refs,
+            [&tracker](const uint256& h, uint64_t n) {
+                return tracker.chain.get_nth_parent_via_skip(h, n);
+            },
+            [&tracker](const uint256& h) {
+                std::vector<uint256> nths;
+                tracker.chain.get_share(h).invoke([&](auto* obj) {
+                    if (obj) nths = obj->m_new_transaction_hashes;
+                });
+                return nths;
+            });
+
+        other_bodies.reserve(other_hashes.size());
+        for (const auto& h : other_hashes) {
+            const std::vector<unsigned char>* body = known_txs ? known_txs(h) : nullptr;
+            if (!body) {
+                LOG_WARNING << "[EMB-DASH] won-block " << share_hash.GetHex().substr(0, 16)
+                            << " references unknown tx " << h.GetHex().substr(0, 16)
+                            << " -- INCOMPLETE, NOT broadcast.";
+                return std::nullopt;
+            }
+            other_bodies.push_back(*body);
+        }
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[EMB-DASH] won-block " << share_hash.GetHex().substr(0, 16)
+                    << " other-tx resolve threw (" << e.what() << ") -- NOT broadcast.";
+        return std::nullopt;
+    }
+
+    // 3. Frame [gentx] ++ other bodies under the share's committed header.
+    return frame_won_block(share.m_min_header, share.m_merkle_link, gentx, other_bodies);
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/won_block_dispatch.hpp
+++ b/src/impl/dash/coin/won_block_dispatch.hpp
@@ -53,10 +53,13 @@
 
 #include <exception>
 #include <functional>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <core/log.hpp>
+#include <core/uint256.hpp>
 
 namespace dash
 {
@@ -86,6 +89,19 @@ using P2pRelaySink = std::function<bool(const std::vector<unsigned char>&)>;
 // NodeRPC::submit_block_hex. Returns true iff dashd accepted (or duplicate).
 // EMPTY == no dashd RPC arm armed (the daemonless deployment).
 using RpcSubmitSink = std::function<bool(const std::string&)>;
+
+// The reconstructed parent block, ready for BOTH broadcast arms:
+//   bytes : the blob the embedded P2P relay sends (submit_block_p2p_raw)
+//   hex   : the same block hex for the submitblock RPC backup
+// (Defined here, the light won-block header, so the tracker-dispatch handler
+// below can name it WITHOUT this header pulling in the heavy share_check.hpp
+// reconstruct machinery -- reconstruct_won_block.hpp includes this header and
+// fills this struct.)
+struct ReconstructedWonBlock
+{
+    std::vector<unsigned char> bytes;
+    std::string                hex;
+};
 
 // Outcome of a won-block broadcast across both arms. ARM A is primary; the
 // submitblock RPC backup fires whenever it is configured. landed_first records
@@ -259,6 +275,140 @@ inline BlockBroadcast broadcast_won_block(const P2pRelaySink& p2p_relay,
                  << " rpc=" << (r.rpc_ok ? "ok" : (rpc_submit ? "no-ack" : "unarmed"))
                  << " landed_first=" << r.landed_first << ".";
     return r;
+}
+
+// ---------------------------------------------------------------------------
+// dash::coin::make_on_block_found -- the won-block DISPATCH handler the run-loop
+// installs as dash::ShareTracker::m_on_block_found, so a block found by ANY pool
+// participant (a gossiped share whose X11 header also clears the coin BLOCK
+// target) is RE-BROADCAST to the DASH network, not merely recorded. This is the
+// DASH port of the fan-out every node does in p2pool-dash node.py:268-282
+// (tracker.verified.added -> if pow<=target: block=share.as_block(); submit) and
+// of dgb::coin::make_on_block_found. Before it, DASH bound m_on_block_found to
+// the DISPLAY-ONLY dashboard handler (dashboard_found_block.hpp), so a peer-found
+// block was paid/recorded but NEVER re-submitted -- only the LOCAL finder's
+// stratum path broadcast.
+//
+// It composes, it does not replace: reconstruct -> broadcast (the SAME dual-path
+// broadcast_won_block the stratum finder uses, sharing the IDENTICAL two sinks)
+// -> THEN the existing dashboard telemetry leg, POST-broadcast and non-gating.
+//
+// THREADING / LOCK CONTRACT (identical to the dashboard handler it composes):
+// the hook fires on the compute thread with m_tracker_mutex held EXCLUSIVELY
+// (attempt_verify, share_tracker.hpp). So:
+//   * `reconstruct` runs SYNCHRONOUSLY here -- it MUST, because it reads the
+//     on-chain PPLNS window + walks tracker.chain, exactly the reads the accept
+//     path (verify_payout_commitment -> generate_share_transaction) already did
+//     one call earlier under this same held lock. No new lock is taken; there is
+//     no lock-order inversion (it is the identical, proven access pattern).
+//   * the ACTUAL broadcast (submit_block_p2p_raw io::post + the synchronous
+//     submitblock RPC round-trip) is handed to `post` so the network I/O runs on
+//     the io_context with NO tracker lock held -- never stalling sharechain
+//     progress behind a submitblock. broadcast_won_block's own p2p arm also
+//     posts internally; the RPC arm is what `post` moves off the lock.
+//   * `already`/`mark` (recent-won-block dedup FIFO, MiningInterface) take only
+//     their own leaf mutex; nothing acquires the tracker lock while holding it,
+//     so no inversion.
+//   * `telemetry` (the dashboard handler) is reentrancy-aware (read_tracker()
+//     takes no lock on the compute thread) and posts its own write onto the io
+//     context -- calling it here is exactly what master already did.
+//
+// FAIL-LOUD: reconstruct -> nullopt => log + broadcast NOTHING (never a partial
+// block), but STILL fire the dashboard telemetry so a peer-found block we cannot
+// yet reassemble is not LOST from the dashboard (no display regression vs the
+// old dashboard-only binding). reconstruct -> block => dedup-guard, then post
+// the dual-path broadcast, then telemetry.
+
+// Reconstruct a won share into a full serialized block, or nullopt if it is
+// unknown / cannot be assembled. Runs synchronously under the tracker lock.
+using WonBlockReconstructor =
+    std::function<std::optional<ReconstructedWonBlock>(const uint256&)>;
+
+// Recent-won-block dedup (block hash == share hash on DASH). `already` is the
+// bounded FIFO predicate (MiningInterface::already_submitted_block); `mark`
+// records a block this node has broadcast (mark_block_submitted). Both optional;
+// empty == no dedup (broadcast_won_block is itself duplicate-tolerant).
+using AlreadyBroadcastPredicate = std::function<bool(const uint256&)>;
+using MarkBroadcastFn           = std::function<void(const uint256&)>;
+
+// Hand work to the io_context (boost::asio::post(ioc, ...)) so the broadcast's
+// network I/O never runs under the tracker lock.
+using WonBlockPostFn = std::function<void(std::function<void()>)>;
+
+// Post-broadcast telemetry leg -- the existing dashboard found-block handler
+// (dash::dashboard::make_on_block_found). Fired AFTER the broadcast dispatch;
+// never gates or delays it. Empty when the dashboard is off.
+using FoundBlockTelemetryFn = std::function<void(const uint256&)>;
+
+inline std::function<void(const uint256&)>
+make_on_block_found(WonBlockReconstructor reconstruct,
+                    P2pRelaySink p2p_relay,
+                    RpcSubmitSink rpc_submit,
+                    WonBlockPostFn post,
+                    AlreadyBroadcastPredicate already = {},
+                    MarkBroadcastFn mark = {},
+                    FoundBlockTelemetryFn telemetry = {})
+{
+    return [reconstruct = std::move(reconstruct),
+            p2p_relay = std::move(p2p_relay),
+            rpc_submit = std::move(rpc_submit),
+            post = std::move(post),
+            already = std::move(already),
+            mark = std::move(mark),
+            telemetry = std::move(telemetry)](const uint256& share_hash)
+    {
+        const std::string tag = share_hash.GetHex().substr(0, 16);
+
+        // Dedup: a local win already broadcast by the stratum path is re-fired
+        // here once #888 mints the winning share. Skip the re-broadcast (still
+        // fire telemetry -- record_found_block dedups on (hash, chain)).
+        if (already && already(share_hash)) {
+            LOG_INFO << "[EMB-DASH] won-block " << tag
+                     << " already broadcast this node -- skipping re-submit (dedup).";
+            if (telemetry) telemetry(share_hash);
+            return;
+        }
+
+        std::optional<ReconstructedWonBlock> blk;
+        if (reconstruct) {
+            blk = reconstruct(share_hash);   // SYNC, under the tracker lock
+        } else {
+            LOG_ERROR << "[EMB-DASH] won-block " << tag
+                      << " -- no reconstructor wired; cannot broadcast.";
+        }
+
+        if (!blk) {
+            // Fail-loud: broadcast NOTHING (reconstruct already logged the cause),
+            // but keep the dashboard row so the found block is not lost from view.
+            if (telemetry) telemetry(share_hash);
+            return;
+        }
+
+        // Committed to broadcasting: mark BEFORE the (posted) broadcast so a
+        // second fire for the same block dedups even if the io post is still
+        // queued. broadcast_won_block is duplicate-tolerant regardless.
+        if (mark) mark(share_hash);
+
+        LOG_INFO << "[EMB-DASH] GOT BLOCK FROM POOL! " << tag
+                 << " reconstructed " << blk->bytes.size()
+                 << " bytes -- dispatching dual-path (embedded P2P + submitblock RPC).";
+
+        // Move the actual broadcast (esp. the synchronous submitblock RPC) OFF
+        // the tracker lock onto the io_context.
+        auto do_broadcast =
+            [p2p_relay, rpc_submit, bytes = blk->bytes, hex = blk->hex, tag]() {
+                const auto bcast = broadcast_won_block(p2p_relay, rpc_submit, bytes, hex);
+                if (!bcast.any())
+                    LOG_ERROR << "[EMB-DASH] won-block " << tag
+                              << " reached NEITHER sink (no embedded P2P peer AND no dashd "
+                                 "RPC creds) -- NOT broadcast.";
+            };
+        if (post) post(std::move(do_broadcast));
+        else      do_broadcast();
+
+        // Post-broadcast telemetry (dashboard found-block row). Non-gating.
+        if (telemetry) telemetry(share_hash);
+    };
 }
 
 } // namespace coin

--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -22,6 +22,7 @@
 #include "share.hpp"
 #include "share_types.hpp"
 #include "version_negotiation.hpp"   // dash::version_negotiation:: accept-path version gate
+#include "coin/gentx_coinbase.hpp"   // dash::coin::GentxCoinbase (won-block reconstruct SSOT hand-off)
 
 #include <core/coin_params.hpp>
 #include <core/donation.hpp>          // cross-coin COMBINED_DONATION_SCRIPT SSOT (Bucket-2)
@@ -520,9 +521,19 @@ inline std::vector<unsigned char> get_share_script(const auto* obj)
 //
 // Reference: ref/p2pool-dash/p2pool/data.py generate_transaction() lines 131-269
 // ─────────────────────────────────────────────────────────────────────────────
+//
+// out_gentx (optional, default null): when non-null it is filled with the
+// regenerated coinbase's non-witness BYTES + its txid (== the returned hash),
+// so the won-block reconstructor (reconstruct_won_block.hpp) reuses this ONE
+// KAT-proven coinbase byte path instead of re-implementing the DIP3/DIP4 CbTx
+// assembly. PURELY ADDITIVE: every existing caller passes nothing (nullptr),
+// the coinbase bytes are already built here regardless, and the returned txid
+// is byte-identical with or without the out-param -- no accept-path behavior,
+// PPLNS math, or committed-txid comparison changes. Mirrors dgb's out_gentx.
 template <typename TrackerT>
 uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
-                                   const core::CoinParams& params)
+                                   const core::CoinParams& params,
+                                   dash::coin::GentxCoinbase* out_gentx = nullptr)
 {
     const uint64_t subsidy = share.m_subsidy;
 
@@ -793,7 +804,16 @@ uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
     // ── 6. Compute txid ──
     auto tx_span = std::span<const unsigned char>(
         reinterpret_cast<const unsigned char*>(tx.data()), tx.size());
-    return Hash(tx_span);
+    uint256 gentx_txid = Hash(tx_span);
+
+    // Additive: expose the coinbase BYTES + txid for the won-block reconstructor.
+    // Existing callers pass nullptr and are byte-for-byte unaffected.
+    if (out_gentx) {
+        out_gentx->bytes.assign(tx_span.begin(), tx_span.end());
+        out_gentx->txid = gentx_txid;
+    }
+
+    return gentx_txid;
 }
 
 // === verify_payout_commitment (Dash accept-path step 3: trustless PPLNS payout) ===

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1456,7 +1456,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # build.yml --target allowlist never built -> NOT_BUILT/CTest "Could not find
     # executable" red). Separate TU, own anon namespace + distinct
     # DashWonBlockDualPath suite, gtest_main-provided main() -> no symbol clash.
-    add_executable(test_dash_broadcaster_full test_dash_broadcaster_full.cpp test_dash_won_block_dualpath.cpp)
+    add_executable(test_dash_broadcaster_full test_dash_broadcaster_full.cpp test_dash_won_block_dualpath.cpp test_dash_won_block_dispatch.cpp)
     target_link_libraries(test_dash_broadcaster_full PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -28,6 +28,9 @@
 #include <impl/dash/params.hpp>
 #include <impl/dash/coinbase_builder.hpp>   // coinbase::merkle_branches_raw (drift fence)
 #include <impl/dash/stratum/work_target.hpp> // stratum::cap_pool_share (1.67% pool-share cap)
+#include <impl/dash/coin/reconstruct_won_block.hpp> // dash::coin::reconstruct_won_block / frame_won_block (distributed won-block)
+
+#include <optional>
 
 #include <core/coin_params.hpp>
 #include <core/hash.hpp>
@@ -1049,4 +1052,133 @@ TEST(DashPayoutCommitment, FinderTamperRejected) {
     // tampered share's recomputed coinbase no longer matches -> REJECTED.
     EXPECT_THROW(dash::verify_payout_commitment(
         tampered, tv, params, built.gentx_hash), std::invalid_argument);
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// DISTRIBUTED WON-BLOCK RECONSTRUCT (dash::coin::reconstruct_won_block /
+// frame_won_block) -- byte-correctness of rebuilding the full parent block from
+// a won share so ANY node can re-broadcast it (p2pool node.py:268-282 fan-out).
+// ═════════════════════════════════════════════════════════════════════════════
+namespace {
+
+// mint_scene's coinbase-ONLY sibling: same g<-s1<-s2<-C(win) window, but NO
+// masternode payments and NO GBT txs -> empty transaction_hash_refs + empty
+// merkle_link. This is the DAEMONLESS norm (transactions==[]): the reconstructed
+// block is [gentx] alone and merkle_root == gentx_txid.
+static dash::producer::BuiltShare mint_scene_coinbase_only(
+    SyntheticChain& sc, const core::CoinParams& params) {
+    const uint160 A = h160_uniform(0xaa), B = h160_uniform(0xbb), C = h160_uniform(0xcc);
+    uint256 g  = sc.add(0x01, uint256(), BITS_DIFF1, BITS_DIFF1, 1699999900, A, 0,
+                        1, u128_hex(ATA_DIFF1_HEX));
+    uint256 s1 = sc.add(0x02, g,  BITS_DIFF1, BITS_DIFF1, 1699999920, B, 0,
+                        2, u128_hex(ATA_DIFF1_HEX) * 2u);
+    uint256 s2 = sc.add(0x03, s1, BITS_DIFF1, BITS_DIFF1, 1699999940, C, 0,
+                        3, u128_hex(ATA_DIFF1_HEX) * 3u);
+    ProducerJobInputs in;
+    in.prev_share_hash = s2; in.coinbase_scriptSig = {0x03,0x01,0x02,0x03};
+    in.share_nonce = 7; in.pubkey_hash = C; in.subsidy = 500000000;
+    in.donation = 0; in.desired_version = 16; in.desired_timestamp = 1700000000;
+    in.desired_target = params.max_target;
+    in.packed_payments = {}; in.payment_amount = 0;    // coinbase-only
+    in.desired_tx_hashes = {};                          // transactions == []
+    auto info = dash::producer::generate_prospective_share_info(sc.chain, params, in);
+    return dash::producer::build_share(
+        sc.chain, params, info, fixture_min_header(), F1_NONCE64, /*check_pow=*/false);
+}
+
+} // namespace
+
+// GREEN: a coinbase-only won share reconstructs to the EXACT block it solved --
+// header(80) + varint(1) + gentx, whose X11(header) == the share hash (on DASH
+// the share hash IS the block hash). This is the block any node re-broadcasts.
+TEST(DashWonBlockReconstruct, CoinbaseOnlyShareRebuildsToWonBlock) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    auto built = mint_scene_coinbase_only(sc, params);
+    PayoutTrackerView tv{sc.chain};
+
+    // The out_gentx param exposes the SAME coinbase bytes/txid the accept path
+    // commits to (additive; the returned txid is unchanged).
+    dash::coin::GentxCoinbase gc;
+    uint256 txid = dash::generate_share_transaction(built.share, tv, params, &gc);
+    EXPECT_EQ(hex_of(txid), hex_of(built.gentx_hash));
+    EXPECT_EQ(hex_of(gc.txid), hex_of(built.gentx_hash));
+    EXPECT_FALSE(gc.bytes.empty());
+
+    auto blk = dash::coin::reconstruct_won_block(
+        built.share.m_hash, built.share, tv, params, /*known_txs=*/{});
+    ASSERT_TRUE(blk.has_value());
+
+    // 80-byte header + CompactSize(1) + the gentx bytes, nothing else.
+    ASSERT_GT(blk->bytes.size(), 81u);
+    EXPECT_EQ(blk->bytes[80], 0x01);   // exactly one tx (the coinbase)
+    std::vector<unsigned char> body(blk->bytes.begin() + 81, blk->bytes.end());
+    EXPECT_EQ(body, gc.bytes);
+
+    // X11(header) of the reconstructed block == the share hash the tracker fired
+    // on: the reconstructed block IS the block the winning share solved.
+    std::span<const unsigned char> hdr(blk->bytes.data(), 80);
+    EXPECT_EQ(hex_of(params.pow_func(hdr)), hex_of(built.share.m_hash));
+
+    // hex mirror is exactly HexStr(bytes) for the RPC submitblock arm.
+    EXPECT_EQ(blk->hex, HexStr(blk->bytes));
+}
+
+// FAIL-LOUD: a share that references other (non-coinbase) txs whose bodies are
+// not in the known-tx set reconstructs to NOTHING (nullopt) -- never a partial
+// block. mint_scene carries non-empty transaction_hash_refs; with an empty
+// known-tx lookup the referenced bodies are unavailable.
+TEST(DashWonBlockReconstruct, ShareReferencingUnknownTxFailsLoud) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    auto built = mint_scene(sc, params);            // has transaction_hash_refs
+    PayoutTrackerView tv{sc.chain};
+
+    ASSERT_FALSE(built.share.m_transaction_hash_refs.empty());
+    auto blk = dash::coin::reconstruct_won_block(
+        built.share.m_hash, built.share, tv, params, /*known_txs=*/{});
+    EXPECT_FALSE(blk.has_value());                  // INCOMPLETE -> broadcast NOTHING
+}
+
+// FAIL-LOUD: a share whose parent is not in-chain has no PPLNS window to rebuild
+// the coinbase from -> nullopt.
+TEST(DashWonBlockReconstruct, ParentNotInChainFailsLoud) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;                              // empty chain
+    PayoutTrackerView tv{sc.chain};
+
+    dash::DashShare orphan;
+    orphan.m_hash = h256_tag(0x55);
+    orphan.m_prev_hash = h256_tag(0x54);            // not added to the chain
+    auto blk = dash::coin::reconstruct_won_block(
+        orphan.m_hash, orphan, tv, params, /*known_txs=*/{});
+    EXPECT_FALSE(blk.has_value());
+}
+
+// resolve_other_tx_hashes: ordered ref-walk + loud out-of-range failure (pure).
+TEST(DashWonBlockReconstruct, ResolveOtherTxHashesOrdersAndFailsLoud) {
+    const uint256 won = h256_tag(0x90);
+    const uint256 anc = h256_tag(0x80);
+    const uint256 t0 = h256_tag(0x01), t1 = h256_tag(0x02);
+
+    auto nth_parent = [&](const uint256& s, uint64_t n) -> uint256 {
+        if (s == won && n == 1) return anc;         // parent
+        return uint256();                            // off-chain
+    };
+    auto new_txs = [&](const uint256& s) -> std::vector<uint256> {
+        if (s == anc) return {t0, t1};
+        return {};
+    };
+
+    // refs = [share_count=1, tx_count=1] -> ancestor's new_tx_hashes[1] == t1.
+    auto hashes = dash::coin::resolve_other_tx_hashes(won, {1, 1}, nth_parent, new_txs);
+    ASSERT_EQ(hashes.size(), 1u);
+    EXPECT_EQ(hex_of(hashes[0]), hex_of(t1));
+
+    // tx_count out of range -> throws (turned into fail-loud nullopt by caller).
+    EXPECT_THROW(dash::coin::resolve_other_tx_hashes(won, {1, 9}, nth_parent, new_txs),
+                 std::out_of_range);
+    // share_count walks off-chain -> throws.
+    EXPECT_THROW(dash::coin::resolve_other_tx_hashes(won, {5, 0}, nth_parent, new_txs),
+                 std::out_of_range);
 }

--- a/test/test_dash_won_block_dispatch.cpp
+++ b/test/test_dash_won_block_dispatch.cpp
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// test_dash_won_block_dispatch -- KATs for dash::coin::make_on_block_found, the
+// DISTRIBUTED won-block re-broadcast dispatcher (p2pool-dash node.py:268-282
+// fan-out). This is the behavioral proof of the feature that DASH previously
+// LACKED: before it, ShareTracker::m_on_block_found was bound to the DISPLAY-ONLY
+// dashboard handler, so a block found by a PEER (a gossiped share whose X11
+// header also clears the coin BLOCK target) was recorded but NEVER re-broadcast.
+//
+// RED->GREEN: the symbol dash::coin::make_on_block_found does not exist on
+// master (only the low-level broadcast_won_block does), so this TU does not even
+// compile against master -- the feature is absent. With the dispatcher wired it
+// compiles and these behaviors hold.
+//
+// The dispatcher is driven with an INJECTED reconstruct fn + RECORDING sinks, so
+// no live ShareTracker / coin-P2P peer / dashd is needed. reconstruct_won_block's
+// own byte correctness is proven separately in test_dash_won_block_reconstruct.
+//
+// FOLDED into the already-allowlisted test_dash_broadcaster_full executable (same
+// fold rationale as test_dash_won_block_dualpath): distinct suite name + anon
+// namespace, gtest_main-provided main() -> no symbol clash.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <impl/dash/coin/won_block_dispatch.hpp>
+
+namespace {
+
+using dash::coin::ReconstructedWonBlock;
+using dash::coin::make_on_block_found;
+
+uint256 hash_from_byte(unsigned char b) {
+    uint256 h;
+    std::vector<unsigned char> v(32, 0);
+    v[0] = b;
+    h = uint256(v);
+    return h;
+}
+
+ReconstructedWonBlock sample_block() {
+    ReconstructedWonBlock blk;
+    blk.bytes = {0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04};
+    blk.hex   = "deadbeef01020304";
+    return blk;
+}
+
+// A recorder for the two broadcast arms + the telemetry/dedup legs.
+struct Sinks {
+    int p2p_calls = 0, rpc_calls = 0, telemetry_calls = 0, mark_calls = 0;
+    std::vector<unsigned char> last_p2p_bytes;
+    std::string last_rpc_hex;
+    uint256 last_marked;
+
+    dash::coin::P2pRelaySink p2p() {
+        return [this](const std::vector<unsigned char>& b) -> bool {
+            ++p2p_calls; last_p2p_bytes = b; return true;
+        };
+    }
+    dash::coin::RpcSubmitSink rpc() {
+        return [this](const std::string& hex) -> bool {
+            ++rpc_calls; last_rpc_hex = hex; return true;
+        };
+    }
+    dash::coin::FoundBlockTelemetryFn telemetry() {
+        return [this](const uint256&) { ++telemetry_calls; };
+    }
+    dash::coin::MarkBroadcastFn mark() {
+        return [this](const uint256& h) { ++mark_calls; last_marked = h; };
+    }
+};
+
+// Post inline so the broadcast is observable synchronously in the test.
+dash::coin::WonBlockPostFn inline_post() {
+    return [](std::function<void()> w) { w(); };
+}
+
+} // namespace
+
+// GREEN: a reconstructable PEER won-share is re-broadcast down BOTH arms and the
+// dashboard telemetry fires AFTER the broadcast. This is the fan-out the feature
+// adds -- on master this path did nothing but record a dashboard row.
+TEST(DashWonBlockDispatch, ReconstructablePeerShareBroadcastsBothArms) {
+    Sinks s;
+    const uint256 sh = hash_from_byte(0xa1);
+
+    auto handler = make_on_block_found(
+        /*reconstruct=*/[](const uint256&) { return std::optional<ReconstructedWonBlock>(sample_block()); },
+        s.p2p(), s.rpc(), inline_post(),
+        /*already=*/{}, s.mark(), s.telemetry());
+
+    handler(sh);
+
+    EXPECT_EQ(s.p2p_calls, 1);
+    EXPECT_EQ(s.rpc_calls, 1);
+    EXPECT_EQ(s.last_p2p_bytes, sample_block().bytes);
+    EXPECT_EQ(s.last_rpc_hex, sample_block().hex);
+    EXPECT_EQ(s.mark_calls, 1);
+    EXPECT_EQ(s.last_marked, sh);
+    EXPECT_EQ(s.telemetry_calls, 1);   // post-broadcast telemetry still fires
+}
+
+// FAIL-LOUD: a share that cannot be reconstructed (nullopt) broadcasts NOTHING
+// down either arm (never a partial/malformed block) -- mirroring p2pool "GOT
+// INCOMPLETE BLOCK" + dgb "NOT broadcast". The dashboard row is still recorded
+// so the found block is not lost from view (no display regression).
+TEST(DashWonBlockDispatch, IncompleteShareBroadcastsNothing) {
+    Sinks s;
+    auto handler = make_on_block_found(
+        /*reconstruct=*/[](const uint256&) { return std::optional<ReconstructedWonBlock>(std::nullopt); },
+        s.p2p(), s.rpc(), inline_post(),
+        /*already=*/{}, s.mark(), s.telemetry());
+
+    handler(hash_from_byte(0xb2));
+
+    EXPECT_EQ(s.p2p_calls, 0);       // NOTHING broadcast
+    EXPECT_EQ(s.rpc_calls, 0);
+    EXPECT_EQ(s.mark_calls, 0);      // not marked (nothing went out)
+    EXPECT_EQ(s.telemetry_calls, 1); // but the found-block row is still recorded
+}
+
+// A missing reconstructor is also fail-loud: broadcast NOTHING (telemetry still
+// records the found block).
+TEST(DashWonBlockDispatch, NoReconstructorBroadcastsNothing) {
+    Sinks s;
+    auto handler = make_on_block_found(
+        /*reconstruct=*/{}, s.p2p(), s.rpc(), inline_post(),
+        /*already=*/{}, s.mark(), s.telemetry());
+
+    handler(hash_from_byte(0xc3));
+
+    EXPECT_EQ(s.p2p_calls, 0);
+    EXPECT_EQ(s.rpc_calls, 0);
+    EXPECT_EQ(s.mark_calls, 0);
+    EXPECT_EQ(s.telemetry_calls, 1);
+}
+
+// DEDUP: a block already broadcast by this node (the recent-won-block FIFO says
+// so) is NOT re-submitted -- the reconstruct + broadcast are skipped -- but the
+// dashboard row is still (idempotently) recorded.
+TEST(DashWonBlockDispatch, AlreadyBroadcastSkipsReBroadcast) {
+    Sinks s;
+    int reconstruct_calls = 0;
+    auto handler = make_on_block_found(
+        /*reconstruct=*/[&](const uint256&) {
+            ++reconstruct_calls;
+            return std::optional<ReconstructedWonBlock>(sample_block());
+        },
+        s.p2p(), s.rpc(), inline_post(),
+        /*already=*/[](const uint256&) { return true; }, s.mark(), s.telemetry());
+
+    handler(hash_from_byte(0xd4));
+
+    EXPECT_EQ(reconstruct_calls, 0); // short-circuited before reconstruct
+    EXPECT_EQ(s.p2p_calls, 0);
+    EXPECT_EQ(s.rpc_calls, 0);
+    EXPECT_EQ(s.mark_calls, 0);
+    EXPECT_EQ(s.telemetry_calls, 1);
+}
+
+// Daemonless (P2P-only) deployment: a reconstructable share still reaches the
+// network on the embedded relay alone (RPC arm empty).
+TEST(DashWonBlockDispatch, DaemonlessP2pOnlyStillBroadcasts) {
+    Sinks s;
+    auto handler = make_on_block_found(
+        /*reconstruct=*/[](const uint256&) { return std::optional<ReconstructedWonBlock>(sample_block()); },
+        s.p2p(), /*rpc=*/{}, inline_post(),
+        /*already=*/{}, s.mark(), s.telemetry());
+
+    handler(hash_from_byte(0xe5));
+
+    EXPECT_EQ(s.p2p_calls, 1);
+    EXPECT_EQ(s.rpc_calls, 0);
+    EXPECT_EQ(s.mark_calls, 1);
+    EXPECT_EQ(s.telemetry_calls, 1);
+}


### PR DESCRIPTION
## DASH: distributed won-block re-broadcast (reconstruct + dual-path dispatch)

Ports the P2Pool-faithful multi-node won-block fan-out to the **DASH** lane so a block found by **any** pool participant is re-broadcast to the DASH network — not merely recorded — closing a gap DGB/NMC already close.

### The gap (code-cited)
DASH bound `ShareTracker::m_on_block_found` (fires for local **and** remote shares at `share_tracker.hpp:582`, from `attempt_verify`) to the **display-only** `dash::dashboard::make_on_block_found` (`dashboard_found_block.hpp` — *"Display only. No block submission … reachable"*). So a gossiped share whose X11 header also cleared the coin **block** target was paid/recorded but **never re-submitted**. Only the local finder broadcast, via `dash::coin::broadcast_won_block` from the stratum win path. Every DASH node that verified the block-share should re-submit it (fan-out).

### References
- **P2Pool**: `p2pool-dash/p2pool/node.py:268-282` — `tracker.verified.added.watch` → if `share.pow_hash <= target`: `block = share.as_block(...)`; `None` → *"GOT INCOMPLETE BLOCK"* skip; else `helper.submit_block`.
- **In-tree DGB** (already unit-tested): `src/impl/dgb/coin/reconstruct_won_block.hpp` + `won_block_dispatch.hpp` (`make_on_block_found`), wired at `main_dgb.cpp`.

### The port
1. **`src/impl/dash/coin/gentx_coinbase.hpp`** (new) — `GentxCoinbase{bytes,txid}` hand-off (mirror of dgb).
2. **`share_check.hpp`** — `generate_share_transaction` gains an **additive** `out_gentx` param exposing the DIP3/DIP4 CbTx coinbase **bytes** it already builds. This is the reuse the task calls for: the reconstructor does **not** re-implement coinbase/gentx assembly — it reuses the one accept-path byte builder (the payout-commitment keystone), so the reconstructed coinbase is by construction the one whose txid equals the committed `gentx_hash`. Existing callers pass `nullptr`; the returned txid is byte-identical.
3. **`src/impl/dash/coin/reconstruct_won_block.hpp`** (new) — rebuild the full block from a won share: regen coinbase → `merkle_root = check_merkle_link(gentx.txid, merkle_link)` → header `version|prev|merkle_root|time|bits|nonce` + `[gentx] ++ other_tx_bodies`. Coinbase-only (`transactions==[]`) is the daemonless norm; the ref-walk (`resolve_other_tx_hashes`, DASH flat `[share_count,tx_count]` pairs) + a `known_txs` lookup fill in non-coinbase bodies.
4. **`won_block_dispatch.hpp`** — `make_on_block_found` dispatcher: reconstruct → **same** dual-path `broadcast_won_block` the stratum finder uses (embedded coin-P2P relay + `submitblock` RPC) → dashboard telemetry (**composed, not replaced**; still fires on fail-loud so no display regression).
5. **`main_dash.cpp`** — bind `m_on_block_found` to the dispatcher **after** the `p2p_relay` + `rpc_submit` sinks are constructed, so both the stratum submit fn and the tracker dispatcher share the **identical two sinks**. Reuses the recent-won-block FIFO (`MiningInterface::already_submitted_block`/`mark_block_submitted`) for dedup.

### Reward-safety verification
- **Submitting a VALID block is always safe.** Reconstruction **fails loud** — `std::nullopt` → broadcast **NOTHING** (never a partial/malformed block), mirroring p2pool *"INCOMPLETE BLOCK"* + DGB *"NOT broadcast"* — on: parent-not-in-chain (no PPLNS window), coinbase regen throw, or an unknown referenced tx. A wrong reconstruction hashes to the wrong merkle root and is rejected by every peer/daemon, so local fail-loud is strictly safer than emitting.
- **No consensus/PPLNS/payout/target STATE is read or written by the new path.** It *reads* already-validated `share_info` + the on-chain PPLNS window (via `generate_share_transaction`) and already-relayed tx bodies; it writes none of it. The `out_gentx` refactor is purely additive (returned txid unchanged).
- **`broadcast_won_block` is duplicate-tolerant**: `submitblock` duplicate = success; p2p duplicate = non-event. Dedup FIFO is an added optimization on top.

### Caller-side lock trace
`m_on_block_found` fires on the **compute thread** with `m_tracker_mutex` held **exclusively** (`attempt_verify`, one call after `verify_payout_commitment`). In the dispatcher:
- **`reconstruct` runs synchronously under that held lock** — it must, because it reads the on-chain PPLNS window + walks `tracker.chain`; these are the **identical reads `verify_payout_commitment → generate_share_transaction` already performed under this same lock** one call earlier. No new lock is acquired for reconstruction; there is **no lock-order inversion** (same proven access pattern). `m_known_txs` is not touched under the tracker lock in this PR (the wired `known_txs` is empty; coinbase-only norm).
- **The actual broadcast is POSTed onto `ioc`** — the synchronous `submitblock` RPC round-trip and the `submit_block_p2p_raw` relay run on the io_context with **no tracker lock held**, so sharechain progress never stalls behind a submitblock. (`broadcast_won_block`'s p2p arm also posts internally.)
- **Dedup** (`already_submitted_block`/`mark_block_submitted`) takes only its own leaf `m_recent_submit_mutex`; nothing acquires the tracker lock while holding it → no inversion.
- **Telemetry** is the existing dashboard handler (`read_tracker()` reentrancy-aware — no lock on the compute thread — and posts its `record_found_block` write onto `ioc`), exactly as the prior dashboard-only binding.

### Build + tests
- **DASH built `BLS=REAL`** on the daemonless build host (`-DC2POOL_DASH_BLS=ON`, dashbls linked): `--version` → `…-g07336ac5-dirty`, *"DASH BLS backend: REAL"*.
- **KAT red→green**: `test_dash_won_block_dispatch.cpp` references `dash::coin::make_on_block_found` / `ReconstructedWonBlock`, which **do not exist on master** → the TU **fails to compile against master** (feature absent = RED). With the dispatcher wired it is GREEN:
  - reconstructable peer share → **both arms broadcast** (+ dedup mark + telemetry);
  - incomplete / no-reconstructor share → **broadcasts NOTHING** (telemetry still records — no display regression);
  - already-broadcast → skips re-submit (dedup);
  - daemonless P2P-only → still reaches the network.
- **Reconstruct byte-correctness** (folded into `test_dash_share_producer`): a coinbase-only won share rebuilds to `header(80) + varint(1) + gentx`, and **`X11(rebuilt header) == the share hash`** (on DASH the share hash *is* the block hash) — i.e. the reconstructed block **is** the block the winning share solved; plus fail-loud on unknown-tx / parent-not-in-chain, and the ref-walk ordering/out-of-range KATs.
- Existing suites stay green: `test_dash_broadcaster_full` **30/30**, `test_dash_share_hash_link` (producer + payout-commitment + hash-link) **74/74**.

**DRAFT** — not for merge. Author `frstrtr`; zero AI attribution.
