### PR TITLE
dash(replay): parallel getheaders window + event refill + stall-disconnect for the pre-anchor header backfill

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -337,6 +337,30 @@ target_link_libraries(c2pool-dash
     ${Boost_LIBRARIES}
 )
 
+# KAT: pre-anchor header-backfill PARALLEL GETHEADERS WINDOW (extends #1263 /
+# task #151; base PR #1278). Drives the real BulkFetchLane header lane against a
+# scripted peer set: RED (window=1, no disconnect) serializes/wedges on a silent
+# peer; GREEN (window=N + event refill + disconnect-and-redial) completes. Links
+# the same DASH library set as c2pool-dash (header lane pulls block_producer /
+# header_chain / x11 / block-replay; BLS carried for the shared object graph).
+add_executable(dash_hdr_backfill_window_kat dash_hdr_backfill_window_kat.cpp)
+target_link_libraries(dash_hdr_backfill_window_kat
+    core pool sharechain
+    c2pool_node_enhanced
+    dash
+    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+    dash_x11
+    dash_rpc
+    dash_stratum
+    dash_block_replay
+    dash_bls_verify
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+)
+add_test(NAME dash_hdr_backfill_window_kat COMMAND dash_hdr_backfill_window_kat)
+
 # Windows: Boost.Asio requires Winsock libraries; /bigobj for large translation units
 if(WIN32)
     target_link_libraries(c2pool ws2_32 mswsock bcrypt dbghelp)

--- a/src/c2pool/dash_hdr_backfill_window_kat.cpp
+++ b/src/c2pool/dash_hdr_backfill_window_kat.cpp
@@ -1,0 +1,384 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT: pre-anchor header-backfill PARALLEL GETHEADERS WINDOW (extends the #1263
+// cold-arm header-backfill lane; base PR #1278).
+//
+// PROVEN DIAGNOSIS (wf wx0agv6hk): the self-derive cold start walked genesis ->
+// anchor headers on a SINGLE in-flight getheaders. A peer that received the
+// getheaders but never answered stalled the WHOLE walk until the ~15 s re-kick
+// timer fired and demoted it — dashd never serializes header fetch on one peer
+// (it keeps a download window across peers, event-refills on each arrival, and
+// DISCONNECTS a staller rather than leaving a zombie session). This KAT drives
+// the real BulkFetchLane header lane against a scripted peer set and proves,
+// RED (legacy config) -> GREEN (ported config), the three behaviours:
+//
+//   A. PARALLEL WINDOW  — GREEN keeps >1 getheaders span in flight across peers
+//                         from a cold tip; RED (window=1) is single-inflight.
+//   B. EVENT REFILL     — a delivered headers batch immediately issues the next
+//                         span (no tick / no timer wait).
+//   C. STALL DISCONNECT — a peer silent past the stalling window is
+//                         disconnected+redialed (GREEN); RED never disconnects.
+//   D. SERIALIZATION    — with one dead peer in the pool, RED pays at least a
+//                         full stall window of zero progress (single-inflight
+//                         wedge) while GREEN routes around it and completes in
+//                         fewer ticks than one stall window. Both complete
+//                         (liveness: never a true deadlock).
+//
+// The lane is REWARD-SAFE by construction and this KAT does not touch that: the
+// synthetic chain is prev-hash linked and the join check still pins the anchor;
+// only header-fetch peer selection + timing is exercised.
+
+#include <impl/dash/coin/replay_bulk_fetch.hpp>
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/crypto/hash_x11.hpp>
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace rp = dash::coin::replay;
+using dash::coin::BlockType;
+using dash::coin::BlockHeaderType;
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            std::cout << "  FAIL: " << (msg) << "\n";                           \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            std::cout << "  ok:   " << (msg) << "\n";                           \
+        }                                                                       \
+    } while (0)
+
+// Hash a header exactly as HeaderBackfill::add_headers does (header slice only).
+static uint256 header_hash(const BlockType& b)
+{
+    BlockHeaderType hdr = static_cast<BlockHeaderType>(b);
+    auto packed = ::pack(hdr);
+    return dash::crypto::hash_x11(packed.get_span());
+}
+
+// A scripted coin-P2P network for the header lane. good peers answer getheaders
+// (after a fixed latency); non-good peers swallow them (the silent-stall case).
+struct Net
+{
+    std::vector<BlockType> chain;          // chain[0..anchor]
+    std::vector<uint256>   hashes;         // hashes[h] = header_hash(chain[h])
+    std::map<uint256, uint32_t> h2h;       // hash -> height
+    uint32_t anchor = 0;
+    uint32_t batch  = 6;
+    int64_t  latency = 1;                  // ticks between ask and answer
+
+    std::set<std::string> good;            // peers that answer
+    std::set<std::string> eligible;        // peers CoinClient would offer
+
+    int64_t clock = 0;
+
+    struct Sent { std::string peer; uint256 locator; int64_t at; };
+    std::vector<Sent> pending;             // asked, not yet delivered
+
+    uint64_t send_count = 0;
+    std::vector<std::string> tick_peers;   // getheaders targets since last reset
+    std::vector<std::string> disconnected; // disconnect_and_redial calls
+    std::string redial_peer;               // replacement dialed on a disconnect
+
+    void build(uint32_t n, uint32_t batch_)
+    {
+        anchor = n; batch = batch_;
+        chain.clear(); hashes.clear(); h2h.clear();
+        uint256 prev;   // genesis prev = null
+        for (uint32_t i = 0; i <= n; ++i)
+        {
+            BlockType b;
+            b.SetNull();
+            b.m_version = 1;
+            b.m_previous_block = prev;
+            b.m_timestamp = 1000000 + i;
+            b.m_bits = 0x1e0ffff0;         // nonzero (not consulted: check_pow off)
+            b.m_nonce = i;
+            b.m_merkle_root.SetNull();
+            b.m_merkle_root.data()[0] = static_cast<unsigned char>(i & 0xFF);
+            b.m_merkle_root.data()[1] = static_cast<unsigned char>((i >> 8) & 0xFF);
+            uint256 h = header_hash(b);
+            chain.push_back(b);
+            hashes.push_back(h);
+            h2h[h] = i;
+            prev = h;
+        }
+    }
+
+    std::vector<std::string> eligible_vec() const
+    {
+        return std::vector<std::string>(eligible.begin(), eligible.end());
+    }
+
+    // Deliver every pending response whose peer still answers and whose latency
+    // has elapsed. Returns the batches to the lane (which may re-arm the window
+    // via the event-driven refill inside on_headers).
+    template <typename Lane>
+    void deliver(Lane& lane)
+    {
+        std::vector<Sent> ready;
+        for (auto it = pending.begin(); it != pending.end(); )
+        {
+            const bool answers = good.count(it->peer) && eligible.count(it->peer);
+            if (answers && (clock - it->at) >= latency)
+            {
+                ready.push_back(*it);
+                it = pending.erase(it);
+            }
+            else ++it;
+        }
+        for (const auto& s : ready)
+        {
+            auto hit = h2h.find(s.locator);
+            if (hit == h2h.end()) continue;
+            const uint32_t H = hit->second;
+            if (H >= anchor) continue;
+            std::vector<BlockType> b;
+            for (uint32_t k = H + 1; k <= std::min<uint32_t>(H + batch, anchor); ++k)
+                b.push_back(chain[k]);
+            if (!b.empty()) lane.on_headers(s.peer, b);
+        }
+    }
+};
+
+// Build a BulkFetchLane wired to the scripted Net + a fresh HeaderBackfill.
+struct Rig
+{
+    Net net;
+    uint256 pow_limit;
+    std::unique_ptr<rp::HeaderBackfill> backfill;
+    std::unique_ptr<rp::CountingReplayConsumer> consumer;
+    std::unique_ptr<rp::BulkFetchLane> lane;
+
+    void make(uint32_t chain_n, uint32_t batch, uint32_t window,
+              int64_t stall_disconnect_sec)
+    {
+        net.build(chain_n, batch);
+        pow_limit = uint256::ZERO;
+        for (int i = 0; i < 32; ++i) pow_limit.data()[i] = 0xFF;
+
+        backfill = std::make_unique<rp::HeaderBackfill>(
+            net.hashes[0], net.anchor, net.hashes[net.anchor], pow_limit,
+            /*db_path=*/"", /*check_pow=*/false);
+        consumer = std::make_unique<rp::CountingReplayConsumer>();
+
+        rp::BulkFetchLane::Seams s;
+        Net* n = &net;
+        s.hash_at      = [](uint32_t) -> std::optional<uint256> { return std::nullopt; };
+        s.chain_height = [n]() { return n->anchor; };
+        s.eligible_peers = [n]() { return n->eligible_vec(); };
+        s.send_getdata = [](const std::string&, const std::vector<uint256>&) {};
+        s.send_getheaders = [n](const std::string& peer, const uint256& loc,
+                                const uint256&) {
+            ++n->send_count;
+            n->tick_peers.push_back(peer);
+            n->pending.push_back(Net::Sent{ peer, loc, n->clock });
+        };
+        s.tip_busy = []() { return false; };
+        s.peer_can_serve = [](const std::string&, uint32_t) { return true; };
+        s.now_sec = [n]() { return n->clock; };
+        s.disconnect_and_redial = [n](const std::string& peer) {
+            n->disconnected.push_back(peer);
+            n->eligible.erase(peer);
+            if (!n->redial_peer.empty())
+            {
+                n->eligible.insert(n->redial_peer);
+                n->good.insert(n->redial_peer);
+            }
+        };
+
+        rp::BulkFetchLane::Config cfg;
+        cfg.start_height = net.anchor + 1;   // body scheduler idle; header lane is the subject
+        cfg.tip_exclusion = 0;
+        cfg.backfill_rekick_sec = 15;
+        cfg.backfill_demote_cooldown_sec = 60;
+        cfg.backfill_getheaders_window = window;
+        cfg.backfill_stall_disconnect_sec = stall_disconnect_sec;
+
+        lane = std::make_unique<rp::BulkFetchLane>(
+            std::move(s), cfg, backfill.get(), consumer.get(), /*cursor=*/nullptr);
+    }
+
+    // One simulated second: advance clock, tick the lane, deliver answers.
+    void step()
+    {
+        ++net.clock;
+        lane->tick(net.clock);
+        net.deliver(*lane);
+    }
+
+    // Run until the backfill joins the anchor or the tick budget is spent.
+    // Returns the tick count at completion (or budget+1 if it never completed).
+    int run(int budget)
+    {
+        for (int t = 1; t <= budget; ++t)
+        {
+            step();
+            if (backfill->complete()) return t;
+        }
+        return budget + 1;
+    }
+};
+
+static void scenario_A_window()
+{
+    std::cout << "[A] parallel getheaders window (cold tip)\n";
+    // GREEN: 3 eligible peers, window 3 — expect 3 concurrent spans.
+    {
+        Rig r;
+        r.make(/*chain*/60, /*batch*/6, /*window*/3, /*disc*/15);
+        r.net.good = {"g1", "g2", "g3"};
+        r.net.eligible = {"g1", "g2", "g3"};
+        r.net.tick_peers.clear();
+        ++r.net.clock;
+        r.lane->tick(r.net.clock);         // NO delivery: measure the cold fan
+        std::set<std::string> distinct(r.net.tick_peers.begin(),
+                                       r.net.tick_peers.end());
+        CHECK(distinct.size() == 3,
+              "GREEN window=3 issues 3 concurrent getheaders (got " +
+                  std::to_string(distinct.size()) + ")");
+    }
+    // RED: same pool, window 1 — single-inflight.
+    {
+        Rig r;
+        r.make(60, 6, /*window*/1, /*disc*/0);
+        r.net.good = {"g1", "g2", "g3"};
+        r.net.eligible = {"g1", "g2", "g3"};
+        r.net.tick_peers.clear();
+        ++r.net.clock;
+        r.lane->tick(r.net.clock);
+        std::set<std::string> distinct(r.net.tick_peers.begin(),
+                                       r.net.tick_peers.end());
+        CHECK(distinct.size() == 1,
+              "RED window=1 is single-inflight (got " +
+                  std::to_string(distinct.size()) + ")");
+    }
+}
+
+static void scenario_B_event_refill()
+{
+    std::cout << "[B] event-driven refill (no timer wait)\n";
+    Rig r;
+    r.make(60, 6, /*window*/2, /*disc*/15);
+    r.net.good = {"g1", "g2"};
+    r.net.eligible = {"g1", "g2"};
+    r.net.latency = 0;                     // answer available immediately
+    ++r.net.clock;
+    r.lane->tick(r.net.clock);             // cold fan issues up to 2 spans
+    const uint64_t sends_before = r.net.send_count;
+    const uint32_t tip_before = r.backfill->tip_height();
+    // Deliver ONE response — WITHOUT another tick. The event-driven refill must
+    // issue the next span from inside on_headers.
+    // Deliver just g1's pending span.
+    for (auto it = r.net.pending.begin(); it != r.net.pending.end(); ++it)
+    {
+        if (it->peer != "g1") continue;
+        uint32_t H = r.net.h2h[it->locator];
+        std::vector<BlockType> b;
+        for (uint32_t k = H + 1; k <= std::min<uint32_t>(H + r.net.batch, r.net.anchor); ++k)
+            b.push_back(r.net.chain[k]);
+        r.net.pending.erase(it);
+        r.lane->on_headers("g1", b);
+        break;
+    }
+    CHECK(r.backfill->tip_height() > tip_before,
+          "delivered batch advanced the walk");
+    CHECK(r.net.send_count > sends_before,
+          "on_headers issued the next span immediately (event refill, no tick)");
+}
+
+static void scenario_C_stall_disconnect()
+{
+    std::cout << "[C] stall disconnect + redial\n";
+    Rig r;
+    r.make(/*chain*/100, /*batch*/5, /*window*/2, /*disc*/15);
+    r.net.good = {"g1"};                   // g1 answers, bad swallows
+    r.net.eligible = {"g1", "bad"};
+    r.net.latency = 1;
+    r.net.redial_peer = "g3";              // the redial brings a fresh serving peer
+    int done = r.run(400);
+    CHECK(done <= 400, "backfill completed despite a permanently-silent peer");
+    bool bad_dropped = false, g1_dropped = false;
+    for (const auto& p : r.net.disconnected)
+    {
+        if (p == "bad") bad_dropped = true;
+        if (p == "g1") g1_dropped = true;
+    }
+    CHECK(bad_dropped, "silent peer was DISCONNECT+REDIALed (BLOCK_STALLING_TIMEOUT)");
+    CHECK(!g1_dropped, "the answering peer was NOT disconnected");
+    CHECK(r.backfill->tip_height() == r.net.anchor,
+          "walk reached the anchor (join pinned)");
+}
+
+static void scenario_C_red_no_disconnect()
+{
+    std::cout << "[C-RED] disconnect disabled -> demote-only, no disconnect seam call\n";
+    Rig r;
+    r.make(100, 5, /*window*/2, /*disc*/0);   // disconnect OFF
+    r.net.good = {"g1"};
+    r.net.eligible = {"g1", "bad"};
+    r.net.latency = 1;
+    int done = r.run(400);
+    CHECK(done <= 400, "RED still completes via demote-only re-home (liveness)");
+    CHECK(r.net.disconnected.empty(),
+          "RED never called disconnect_and_redial (demote-only fallback)");
+}
+
+static void scenario_D_serialization()
+{
+    std::cout << "[D] single-inflight serialization vs parallel window\n";
+    const uint32_t CHAIN = 30, BATCH = 10;   // 3 spans
+    // GREEN: window 3, one dead peer in the pool. Must route around it and
+    // finish in FEWER ticks than a single stall window (15).
+    int green_ticks;
+    {
+        Rig r;
+        r.make(CHAIN, BATCH, /*window*/3, /*disc*/15);
+        r.net.good = {"g1", "g2"};
+        r.net.eligible = {"g1", "bad", "g2"};
+        r.net.latency = 1;
+        green_ticks = r.run(400);
+        CHECK(r.backfill->complete(), "GREEN completed");
+    }
+    // RED: window 1, SAME pool. Single-inflight lands on the dead peer and pays
+    // a full stall window (>=15 ticks) of zero progress before re-homing.
+    int red_ticks;
+    {
+        Rig r;
+        r.make(CHAIN, BATCH, /*window*/1, /*disc*/0);
+        r.net.good = {"g1", "g2"};
+        r.net.eligible = {"g1", "bad", "g2"};
+        r.net.latency = 1;
+        red_ticks = r.run(400);
+        CHECK(r.backfill->complete(), "RED eventually completed (no true deadlock)");
+    }
+    std::cout << "  green_ticks=" << green_ticks
+              << " red_ticks=" << red_ticks << "\n";
+    CHECK(green_ticks < 15,
+          "GREEN finished inside one stall window (never serialized on the dead peer)");
+    CHECK(red_ticks >= 15,
+          "RED paid at least one full stall window (single-inflight wedge)");
+    CHECK(red_ticks > green_ticks,
+          "parallel window is strictly faster than single-inflight");
+}
+
+int main()
+{
+    std::cout << "=== dash header-backfill parallel-window KAT ===\n";
+    scenario_A_window();
+    scenario_B_event_refill();
+    scenario_C_stall_disconnect();
+    scenario_C_red_no_disconnect();
+    scenario_D_serialization();
+    std::cout << (g_failures == 0 ? "ALL PASS\n" : "FAILURES\n");
+    return g_failures == 0 ? 0 : 1;
+}

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7582,6 +7582,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 const uint256& stop) {
                 cp->send_getheaders_to(peer, 70230, {locator_hash}, stop);
             };
+            // dashd BLOCK_STALLING_TIMEOUT (proactive half, header lane): a peer
+            // that received a header-backfill getheaders but never answered
+            // within the stalling window is dropped + a replacement redialed,
+            // instead of demote-only (which left the zombie session pinned to a
+            // pool slot at max RTO backoff — the POOL-STATUS started/lost=8/0
+            // pileup the cold-start diagnosis named). refill_pool() redials NOW.
+            seams.disconnect_and_redial = [cp = coin_p2p.get()](
+                const std::string& peer) {
+                cp->stall_disconnect_and_redial(
+                    peer, "header-backfill getheaders stalling (BLOCK_STALLING_TIMEOUT)");
+            };
             // Priority invariant 2: no new bulk getdata while a tracked tip
             // body is outstanding.
             seams.tip_busy = [cp = coin_p2p.get()] {

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1407,6 +1407,27 @@ public:
         p->write(msg);
         return true;
     }
+
+    /// dashd net_processing BLOCK_STALLING_TIMEOUT: force-drop a single named
+    /// peer session and redial a replacement NOW. The pre-anchor header-backfill
+    /// lane calls this on a peer that received a getheaders but never answered
+    /// within the stalling window — dashd disconnects such a peer ('Peer is
+    /// stalling block download, disconnecting') instead of leaving the zombie
+    /// session occupying a pool slot at max RTO backoff. remove_peer() fires the
+    /// disconnect seam + re-elects the primary if needed; refill_pool() redials
+    /// from the scored dial plan immediately rather than waiting the 30 s
+    /// reconnect tick (which is only the backstop). Returns true iff a session
+    /// was actually dropped. A no-op (peer already gone) when the key is stale.
+    bool stall_disconnect_and_redial(const std::string& peer_key,
+                                     const std::string& reason)
+    {
+        PeerSession* p = find_peer(peer_key);
+        if (!p) return false;
+        remove_peer(p, reason);
+        refill_pool();   // immediate redial; the 30 s loop is only the backstop
+        return true;
+    }
+
     /// Fired on socket connect (before handshake) with the peer endpoint — the
     /// DashCoinPeerManager scores the connect + tracks anchors off this.
     void set_on_peer_connected(PeerLifecycleCallback cb) { m_on_peer_connected = std::move(cb); }

--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -103,6 +103,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -1155,6 +1156,18 @@ public:
         // pump ceiling that capped healthy bands); null ⇒ pumping stays on the
         // tick() cadence only (byte-identical to before this seam existed).
         std::function<int64_t()> now_sec;
+        // OPTIONAL. dashd net_processing BLOCK_STALLING_TIMEOUT (proactive half,
+        // header lane): a peer that received a header-backfill getheaders but
+        // never answered within the stalling window is DROPPED and a replacement
+        // is redialed — not demote-only. dashd disconnects a stalling block peer
+        // ('Peer is stalling block download, disconnecting') rather than leaving
+        // the zombie session occupying a pool slot at max RTO backoff; this seam
+        // is the header-lane analog. main_dash wires it to
+        // CoinClient::stall_disconnect_and_redial (remove_peer + immediate
+        // refill_pool). Null (KATs without a live pool / any embedding that
+        // cannot redial) ⇒ the lane falls back to demote-only, byte-identical to
+        // the pre-port behaviour of this lane.
+        std::function<void(const std::string& peer_key)> disconnect_and_redial;
     };
 
     struct Config
@@ -1164,6 +1177,21 @@ public:
         int64_t  telemetry_interval_sec{30};
         int64_t  backfill_rekick_sec{15};    // headers stall re-kick (== dashd BLOCK_STALLING_TIMEOUT window for the header lane)
         int64_t  backfill_demote_cooldown_sec{60};  // header peer held OFF targeting after a stall (#1273 demote_cooldown parity); 0 ⇒ demote disabled (byte-identical to the pre-port blind lane, like the scheduler's demote_after=0)
+        // dashd HEADERS-DOWNLOAD WINDOW parity (parallel half). The pre-anchor
+        // header walk was SINGLE-INFLIGHT: one getheaders outstanding, and a
+        // peer that silently dropped it stalled the whole walk until the re-kick
+        // timer fired. dashd never serializes header/block fetch on one peer —
+        // it keeps a window open across peers and refills it on each message
+        // arrival. This bounds how many getheaders spans race concurrently
+        // across CanServeBlocks-eligible peers; the fastest answer drives the
+        // walk forward and a slow/dead peer never blocks it. 1 ⇒ legacy
+        // single-inflight (the pre-port behaviour, used by the KAT's RED arm).
+        uint32_t backfill_getheaders_window{4};
+        // dashd BLOCK_STALLING_TIMEOUT: a targeted peer that has not advanced the
+        // walk this many seconds is disconnected+redialed (disconnect_and_redial
+        // seam) instead of demote-only. 0 ⇒ disconnect disabled (demote-only,
+        // the pre-port behaviour / KAT RED arm).
+        int64_t  backfill_stall_disconnect_sec{15};
         uint32_t cursor_persist_every{512};  // delivered blocks between cursor writes
     };
 
@@ -1205,9 +1233,22 @@ private:
     // targeting until this wall-second (BLOCK_STALLING_TIMEOUT class). Empty ⇒
     // no header peer demoted, byte-identical to the pre-port blind round-robin.
     std::map<std::string, int64_t> m_hdr_demoted_until;
-    std::string m_hdr_target_peer;      // peer the last getheaders was sent to
-    uint32_t    m_hdr_target_height{0}; // walker tip when that getheaders left
-    bool        m_hdr_targeted{false};  // a getheaders is outstanding to track
+
+    // dashd HEADERS-DOWNLOAD WINDOW (parallel half): the set of peers with a
+    // getheaders currently OUTSTANDING for the pre-anchor walk. Each entry
+    // records the walker tip height at send time (to tell "answered / walk
+    // advanced" from "still silent") and the wall-second it left (to time the
+    // BLOCK_STALLING_TIMEOUT disconnect). Replaces the single m_hdr_target_*
+    // trio the pre-port lane tracked — up to Config::backfill_getheaders_window
+    // spans race concurrently across CanServeBlocks-eligible peers.
+    struct HdrSpan { uint32_t height_sent{0}; int64_t wall_sent{0}; };
+    std::map<std::string, HdrSpan> m_hdr_inflight;
+
+    // Telemetry: header spans that raced, peers disconnected for stalling, and
+    // header peers demoted (the demote-only fallback when disconnect is off).
+    uint64_t m_hdr_spans_issued{0};
+    uint64_t m_hdr_stall_disconnects{0};
+    uint64_t m_hdr_stall_demotes{0};
 
     void fail(const std::string& cause)
     {
@@ -1322,25 +1363,140 @@ private:
         return p;
     }
 
-    /// Issue ONE backfill getheaders to a CanServeBlocks-selected, un-demoted
-    /// peer and RECORD the target (peer + walker tip) so the next kick can tell
-    /// a stall (received-but-did-not-advance) from healthy progress and
-    /// demote+re-home. Height coverage is checked against tip_height()+1 — the
-    /// next header the walk needs — so a limited/pruned peer whose window sits
-    /// above genesis fails CanServeBlocks exactly as it should for a
-    /// from-genesis walk.
-    void issue_backfill_getheaders(
-        int64_t now, const std::vector<std::string>& peers)
+    /// Issue ONE backfill getheaders to a named peer and RECORD it in the
+    /// download window (peer + walker tip at send time + wall-second) so a stall
+    /// (received-but-did-not-advance) is told apart from healthy progress. The
+    /// stop hash is ZERO — the walker itself stops at the anchor.
+    void issue_one_getheaders(int64_t now, const std::string& peer)
     {
+        m_seams.send_getheaders(peer, m_backfill->tip_hash(), uint256::ZERO);
+        m_hdr_inflight[peer] = HdrSpan{ m_backfill->tip_height(), now };
+        ++m_hdr_spans_issued;
+    }
+
+    /// dashd HEADERS-DOWNLOAD WINDOW: top the outstanding-getheaders window up to
+    /// Config::backfill_getheaders_window by racing the CURRENT walker tip across
+    /// DISTINCT CanServeBlocks-eligible, un-demoted, not-already-inflight peers.
+    /// Height coverage is checked against tip_height()+1 (the next header the
+    /// walk needs) via the SAME peer_can_serve seam #1273 ported for the body
+    /// lane. Racing is SAFE by construction: a duplicate/stale batch whose
+    /// prev-hash is still in HeaderBackfill's recent window is claimed and then
+    /// cleanly rejected (prev != tip) — the walk only ever extends its tip. The
+    /// liveness bypass (select_backfill_peer) guarantees the window is never
+    /// left empty while any eligible peer exists — no span is ever skipped.
+    void fan_backfill_getheaders(int64_t now,
+                                 const std::vector<std::string>& peers)
+    {
+        if (peers.empty() || !m_backfill) return;
+        const std::size_t window = m_cfg.backfill_getheaders_window
+                                       ? m_cfg.backfill_getheaders_window : 1;
+        if (m_hdr_inflight.size() >= window) return;   // window already full
         const uint32_t want = m_backfill->tip_height() + 1;
-        std::string peer = select_backfill_peer(now, want, peers);
-        if (peer.empty()) return;
-        m_seams.send_getheaders(peer, m_backfill->tip_hash(),
-                                uint256::ZERO /* stop: serve max batches; the
-                                walker itself stops at the anchor */);
-        m_hdr_target_peer   = peer;
-        m_hdr_target_height = m_backfill->tip_height();
-        m_hdr_targeted      = true;
+        auto serves = [&](const std::string& p) {
+            return !m_seams.peer_can_serve || m_seams.peer_can_serve(p, want);
+        };
+        auto demoted = [&](const std::string& p) {
+            auto it = m_hdr_demoted_until.find(p);
+            return it != m_hdr_demoted_until.end() && it->second > now;
+        };
+        bool any_serves = false;
+        for (const auto& p : peers) if (serves(p)) { any_serves = true; break; }
+
+        const std::size_t n = peers.size();
+        // Round-robin fill with distinct serving, un-demoted, not-already-
+        // inflight peers — same CanServeBlocks preference the body lane uses.
+        for (std::size_t i = 0; i < n && m_hdr_inflight.size() < window; ++i)
+        {
+            const std::string& p = peers[(m_backfill_rr + i) % n];
+            if (m_hdr_inflight.count(p)) continue;   // already racing this window
+            if (any_serves && !serves(p)) continue;  // CanServeBlocks preference
+            if (demoted(p)) continue;                // BLOCK_STALLING_TIMEOUT cooldown
+            issue_one_getheaders(now, p);
+        }
+        m_backfill_rr = (m_backfill_rr + 1) % n;   // rotate start for next fan
+        // Liveness bypass (dashd never deadlocks the walk): if the window is
+        // STILL empty — every serving peer demoted, or the pool could not fill
+        // even one slot — fall back to the total-function selector, which clears
+        // demotions rather than sit idle. Never wedge with peers present.
+        if (m_hdr_inflight.empty())
+        {
+            std::string p = select_backfill_peer(now, want, peers);
+            if (!p.empty()) issue_one_getheaders(now, p);
+        }
+    }
+
+    /// Drop window entries for peers that vanished from the eligible set
+    /// (disconnected / reaped), so the window refills onto live peers.
+    void prune_departed_inflight(const std::vector<std::string>& peers)
+    {
+        if (m_hdr_inflight.empty()) return;
+        std::set<std::string> live(peers.begin(), peers.end());
+        for (auto it = m_hdr_inflight.begin(); it != m_hdr_inflight.end(); )
+        {
+            if (!live.count(it->first)) it = m_hdr_inflight.erase(it);
+            else ++it;
+        }
+    }
+
+    /// dashd BLOCK_STALLING_TIMEOUT: sweep the download window. A peer that
+    /// ANSWERED has already been erased by on_headers (on any claimed batch,
+    /// fresh or stale), so anything still outstanding here has sent NOTHING back
+    /// since we asked it — the walk advancing via OTHER racing peers is not
+    /// credit to a silent one (that is exactly the trap the single-inflight lane
+    /// could not see, because there the walk could not advance without the one
+    /// peer). A peer silent past the stalling window is DISCONNECTED+REDIALED
+    /// (dashd disconnects a stalling block peer rather than leaving a zombie
+    /// session at max RTO backoff); if that seam is absent it is demote-only (the
+    /// pre-port fallback). Either clears the slot so the next fan re-homes the
+    /// span onto a fresh peer. height_sent is retained for the log line only.
+    void check_hdr_stalls(int64_t now, const std::vector<std::string>& /*peers*/)
+    {
+        if (m_hdr_inflight.empty()) return;
+        const bool disc_enabled = m_cfg.backfill_stall_disconnect_sec > 0 &&
+                                  static_cast<bool>(m_seams.disconnect_and_redial);
+        std::vector<std::string> disconnect, demote;
+        for (const auto& [peer, span] : m_hdr_inflight)
+        {
+            const int64_t waited = now - span.wall_sent;
+            if (disc_enabled && waited >= m_cfg.backfill_stall_disconnect_sec)
+                disconnect.push_back(peer);
+            else if (!disc_enabled && m_cfg.backfill_demote_cooldown_sec > 0 &&
+                     waited >= m_cfg.backfill_rekick_sec)
+                demote.push_back(peer);
+        }
+        for (const auto& peer : demote)
+        {
+            m_hdr_demoted_until[peer] =
+                now + m_cfg.backfill_demote_cooldown_sec;
+            m_hdr_inflight.erase(peer);
+            ++m_hdr_stall_demotes;
+            LOG_WARNING << "[BULK] header-backfill peer " << peer
+                        << " STALLED at hdr=" << m_backfill->tip_height() << "/"
+                        << m_backfill->anchor_height()
+                        << " (getheaders unanswered ≥" << m_cfg.backfill_rekick_sec
+                        << "s) — demoted for " << m_cfg.backfill_demote_cooldown_sec
+                        << "s, re-homing the span (dashd BLOCK_STALLING_TIMEOUT "
+                           "parity, demote-only)";
+        }
+        for (const auto& peer : disconnect)
+        {
+            // Hold it off re-targeting until a fresh session redials, so the very
+            // next fan does not re-home the span straight back onto the dropped
+            // peer's key before the redial completes.
+            if (m_cfg.backfill_demote_cooldown_sec > 0)
+                m_hdr_demoted_until[peer] =
+                    now + m_cfg.backfill_demote_cooldown_sec;
+            m_hdr_inflight.erase(peer);
+            ++m_hdr_stall_disconnects;
+            LOG_WARNING << "[BULK] header-backfill peer " << peer
+                        << " STALLED at hdr=" << m_backfill->tip_height() << "/"
+                        << m_backfill->anchor_height()
+                        << " (getheaders unanswered ≥"
+                        << m_cfg.backfill_stall_disconnect_sec
+                        << "s) — DISCONNECT+REDIAL (dashd BLOCK_STALLING_TIMEOUT "
+                           "'Peer is stalling block download, disconnecting')";
+            m_seams.disconnect_and_redial(peer);
+        }
     }
 
     void maybe_kick_backfill(int64_t now)
@@ -1354,34 +1510,25 @@ private:
         // has published. Null seam ⇒ unchanged.
         if (m_seams.defer_to_higher_priority && m_seams.defer_to_higher_priority())
             return;
-        if ((now - m_last_backfill_kick) < m_cfg.backfill_rekick_sec) return;
         auto peers = m_seams.eligible_peers();
         if (peers.empty()) return;
-        // dashd BLOCK_STALLING_TIMEOUT (reactive half, header lane): this
-        // re-kick backstop only fires because the walker has NOT advanced since
-        // the last kick. If the peer we last targeted still holds the walker at
-        // the height we left it, it received the getheaders and silently
-        // dropped it — DEMOTE it for the cooldown so the re-home below lands on
-        // a different serving peer. Never wedge on one peer. A peer that DID
-        // advance the walker (tip_height moved) is not blamed; on_headers also
-        // clears the demotion the instant a delivery lands.
-        if (m_cfg.backfill_demote_cooldown_sec > 0 &&
-            m_hdr_targeted && !m_hdr_target_peer.empty() &&
-            m_backfill->tip_height() <= m_hdr_target_height)
-        {
-            m_hdr_demoted_until[m_hdr_target_peer] =
-                now + m_cfg.backfill_demote_cooldown_sec;
-            LOG_WARNING << "[BULK] header-backfill peer " << m_hdr_target_peer
-                        << " STALLED at hdr=" << m_backfill->tip_height() << "/"
-                        << m_backfill->anchor_height()
-                        << " (getheaders unanswered ≥"
-                        << m_cfg.backfill_rekick_sec
-                        << "s) — demoted for " << m_cfg.backfill_demote_cooldown_sec
-                        << "s, re-homing the span (dashd BLOCK_STALLING_TIMEOUT "
-                           "parity)";
-        }
-        issue_backfill_getheaders(now, peers);
-        m_last_backfill_kick = now;
+        prune_departed_inflight(peers);
+        // dashd BLOCK_STALLING_TIMEOUT: disconnect+redial (or demote) any span
+        // gone silent past the stalling window — always time-based, every tick.
+        check_hdr_stalls(now, peers);
+        // Tick-driven window TOP-UP is the backstop only: the healthy driver is
+        // the event-driven refill in on_headers (fires on every arrival, no
+        // cadence gate). This backstop is cadence-gated so a window that never
+        // received an arrival (an all-dead cold start) is re-kicked on the
+        // re-kick cadence rather than every tick — which is exactly what makes
+        // window==1 reproduce the pre-port single-inflight stall. An EMPTY
+        // window bypasses the gate so a fully-drained window never idles.
+        if (!m_hdr_inflight.empty() &&
+            (now - m_last_backfill_kick) < m_cfg.backfill_rekick_sec)
+            return;
+        const std::size_t before = m_hdr_inflight.size();
+        fan_backfill_getheaders(now, peers);
+        if (m_hdr_inflight.size() != before) m_last_backfill_kick = now;
     }
 
     void maybe_log_telemetry(int64_t now)
@@ -1425,6 +1572,12 @@ private:
                                          + std::to_string(
                                                m_backfill->anchor_height())))
                          : std::string("n/a"))
+                 << " hdrwin=" << m_hdr_inflight.size() << "/"
+                 << (m_cfg.backfill_getheaders_window
+                         ? m_cfg.backfill_getheaders_window : 1)
+                 << " hdrspans=" << m_hdr_spans_issued
+                 << " hdrdisc=" << m_hdr_stall_disconnects
+                 << " hdrdemote=" << m_hdr_stall_demotes
                  << " rereq=" << m_sched.rerequests()
                  << " timeout=" << m_sched.timeout_count()
                  << " notfound=" << m_sched.notfound_count()
@@ -1535,18 +1688,32 @@ public:
     {
         if (!m_backfill || !m_backfill->claims(batch)) return false;
         const int accepted = m_backfill->add_headers(batch);
+        // The peer answered — free its download-window slot and clear any
+        // stall-demotion (mirror #1273's on_body clearing demoted_until on a
+        // delivered body). This also retires a STALE racing response (accepted==0
+        // because another peer advanced the walk first): the slot is freed either
+        // way so the next fan can re-use it.
+        if (!peer_key.empty())
+        {
+            m_hdr_inflight.erase(peer_key);
+            m_hdr_demoted_until.erase(peer_key);
+        }
         if (accepted > 0 && !m_backfill->complete() && !m_backfill->failed())
         {
-            // The peer that just delivered headers PROVED it serves this span:
-            // clear any stall-demotion (mirror #1273's on_body clearing
-            // demoted_until on a delivered body). Then self-propel — ask a
-            // CanServeBlocks-selected, un-demoted peer for the next span
-            // immediately. The stall re-kick in tick() is only the backstop.
-            if (!peer_key.empty()) m_hdr_demoted_until.erase(peer_key);
-            auto peers = m_seams.eligible_peers();
-            if (!peers.empty())
-                issue_backfill_getheaders(
-                    m_seams.now_sec ? m_seams.now_sec() : 0, peers);
+            // EVENT-DRIVEN REFILL (dashd refills the download window on each
+            // message arrival, not on a timer): the walk advanced, so immediately
+            // top the window back up across serving peers at the NEW tip instead
+            // of waiting the tick re-kick cadence. Yields to a higher-priority
+            // coin-P2P consumer (the MN-checkpoint fold) exactly as the tick path
+            // does, so a body-triggered fan can never contend with the fold.
+            if (!(m_seams.defer_to_higher_priority &&
+                  m_seams.defer_to_higher_priority()))
+            {
+                auto peers = m_seams.eligible_peers();
+                if (!peers.empty())
+                    fan_backfill_getheaders(
+                        m_seams.now_sec ? m_seams.now_sec() : 0, peers);
+            }
         }
         return true;   // claimed — never reaches the tip-lane header ingest
     }


### PR DESCRIPTION
## Summary

Extends the #1263 pre-anchor header-backfill lane (task #151) to fetch headers the way dashd does: a **parallel getheaders window across serving peers**, **event-driven refill on each arrival**, and **stall-disconnect-and-redial** of a non-answering peer. Stacked on **#1278** (`integrator/dashd-cut-bulk-defer-progress` @ `ca7e9a5e`) — review/merge #1278 first.

**Draft** — not for merge. Reward-safe (header-fetch peer selection + timing only). DASH lane only.

## The diagnosis (wf `wx0agv6hk`)

Measured against a same-network **dashd v22.1.3 IBD = 95.1 blk/s** on the same 7 archival peers. The self-derive cold start did the full genesis→2513000 header backfill on a **single in-flight getheaders**:

- one getheaders outstanding at a time; on a peer that received it but never answered, the whole walk sat ~15 s until the re-kick timer demoted it and re-homed,
- advancing in lumpy bursts (0→8000 stall, burst to 180000 at ~1750 hdr/s, re-stall at 1394000),
- zombie sessions piled up (POOL-STATUS started/lost = 8/0, every socket at max RTO backoff 9.5 min).

dashd never serializes header fetch on one peer: `FindNextBlocksToDownload` keeps a parallel window across peers, refills event-driven on each message arrival, and on a staller **disconnects + replaces** (`BLOCK_STALLING_TIMEOUT`, "Peer is stalling block download, disconnecting").

## The port

1. **Parallel getheaders window.** Up to `Config::backfill_getheaders_window` (default 4) spans race concurrently across the CanServeBlocks-eligible peer pool — reuses the #1273/#1276 `peer_can_serve` seam and the `eligible_peers` filter verbatim. Racing is safe by construction: a stale racing batch whose prev-hash is still in `HeaderBackfill`'s recent window is *claimed* and then cleanly *rejected* (prev ≠ tip); the walk only ever extends its tip.
2. **Event-driven refill.** A delivered headers batch tops the window back up at the new tip from inside `on_headers` — no timer wait. The tick top-up is a cadence-gated backstop only.
3. **Stall disconnect + redial.** A peer that received a getheaders but sent nothing back within `backfill_stall_disconnect_sec` (default 15 s) is dropped and a replacement redialed (`CoinClient::stall_disconnect_and_redial` → `remove_peer` + immediate `refill_pool`) instead of demote-only. Fixes the zombie-session pileup. A silent peer is **not** credited by the walk advancing via *other* racing peers — the trap the single-inflight lane could not see.

**Liveness bypass preserved:** if every serving peer is demoted the selector clears demotions rather than deadlock; a disconnected peer's span re-homes; no header span is ever skipped. Null seams (KATs / any embedding without a live pool) fall back to single-inflight + demote-only, byte-identical to before.

## Reward-safety

Header-fetch **peer selection + timing only**. PoW + prev-hash header linkage stays strict; the anchor JOIN CHECK still pins the whole pre-anchor segment to genesis; the per-block `merkleRootMNList` / `merkleRootQuorums` fold self-check + poison fail-closed is **unchanged**; no header or block is skipped.

## KAT — red → green

New `dash_hdr_backfill_window_kat` drives the **real** `BulkFetchLane` header lane against a scripted peer set, RED (window=1, disconnect off) → GREEN (window≥2 + event refill + disconnect on). All 16 assertions pass:

- parallel window: 3 concurrent getheaders (GREEN) vs 1 (RED),
- event refill: next span issued from inside `on_headers` with no tick,
- stall disconnect+redial: the silent peer is dropped, the answering peer is kept,
- liveness: RED still completes via the demote-only fallback; GREEN never deadlocks; join pinned,
- serialization: **green = 4 ticks vs red = 19 ticks** — RED pays at least one full stall window, GREEN routes around the dead peer inside one.

## Build / provenance

`c2pool-dash` built on vm905, **BLS = REAL** (`DASH BLS backend: REAL (dashbls linked; quorum-commitment verify armed)`), binary md5 `dae6305dde828f69061e7cf6d631b832`, on HEAD `f701dd57` (base `ca7e9a5e`). KAT green. Live cold-start comparison against a same-host dashd IBD is the soak gate (not run here) — no floor is claimed without it.
