### PR TITLE
dash: exclusion-discipline tx-selector via fee_fold_proven (flag default-OFF)

### DIFF
--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -95,6 +95,19 @@ struct MempoolEntry {
     // 0 everywhere else = byte-identical ordering (modified == base).
     uint64_t fee_delta{0};
     bool     fee_known{false};
+    // EXCLUSION-DISCIPLINE selection predicate (tx-serving reward-safety).
+    // fee_known is TWO things: "priceable via the W5 UTXO fold" OR "a DSTX
+    // whose fee was FORCED to 0 because the fold could not price it"
+    // (add_tx_locked is_dstx branch). The forced case sets fee_known=true on
+    // inputs the fold could NOT vouch for, so fee_known ⇏ inputs-proven-present
+    // — unsafe to SELECT a template member on. fee_fold_proven is set ONLY by
+    // compute_fee_locked success (every vin priced from our own UTXO view /
+    // in-pool parent, in_sum >= out_sum, or an input-free type-9 with a
+    // well-formed explicit-fee payload). It is the ONE bit that proves BOTH
+    // invariant-1 "inputs available in our UTXO view" AND invariant-2 "fee is
+    // fold-exact, never overstated". The template selector gates on THIS, never
+    // on fee_known; fee_known stays the RELAY/index/stats predicate unchanged.
+    bool     fee_fold_proven{false};
     time_t   time_added{0};
 
     uint64_t modified_fee() const { return fee + fee_delta; }
@@ -505,9 +518,19 @@ private:
         // W5-B: a BLS-verified DSTX whose inputs the view cannot price is
         // admitted at fee=0 (see add_dstx — understate-only, reward-safe);
         // a priceable one keeps its computed base fee.
+        //
+        // EXCLUSION-DISCIPLINE: this FORCES fee_known=true so the DSTX rides
+        // the relay pool / feerate index, but it does NOT set fee_fold_proven
+        // — the fold could not vouch for these inputs (or priced in_sum <
+        // out_sum). So the template selector, which gates on fee_fold_proven,
+        // EXCLUDES this entry: an unpriceable DSTX collects no fee and never
+        // risks a lost block, while a fold-priceable DSTX (fee_known already
+        // true above) keeps fee_fold_proven=true and rides at its true base
+        // fee. This is the ONE in-tree hole the discipline closes.
         if (is_dstx && !entry.fee_known) {
             entry.fee = 0;
             entry.fee_known = true;
+            // entry.fee_fold_proven deliberately stays false → template-excluded.
         }
 
         // LRU eviction if over size cap.
@@ -964,7 +987,13 @@ public:
         const AncState anc = build_anc_state_locked();
         std::set<FeeKey> anc_index;
         for (const auto& [txid, e] : m_pool) {
-            if (!e.fee_known) continue;
+            // EXCLUSION-DISCIPLINE: candidate ONLY if the fold proved the fee
+            // (inputs present in our view, in_sum >= out_sum). fee_known alone
+            // admits a DSTX force-priced at 0 on inputs the fold could not
+            // vouch for — a template MUST NOT select on that. delta==0 for
+            // every fee_fold_proven non-DSTX entry, so with no forced entries
+            // in the pool this loop is byte-identical to the fee_known form.
+            if (!e.fee_fold_proven) continue;
             if (anc.over_limit.count(txid)) continue;
             // W5-B: SCORE on the MODIFIED fee (dashd sorts on
             // GetModFeesWithAncestors); delta==0 ⇒ byte-identical to base.
@@ -1143,7 +1172,11 @@ public:
             uint64_t pkg_fees   = 0;
             uint32_t pkg_sigops = 0;
             for (const auto* e : package) {
-                if (!e->fee_known) { ok = false; break; }
+                // EXCLUSION-DISCIPLINE: a member is includable ONLY if its fee
+                // was fold-proven (inputs present + in_sum >= out_sum). A
+                // force-priced DSTX (fee_known, fee_fold_proven==false) drops
+                // its WHOLE package here — never packed, never a lost block.
+                if (!e->fee_fold_proven) { ok = false; break; }
                 if (exclude_special && e->tx.type != 0) { ok = false; break; }
 
                 // ── dashd TestPackageTransactions (node/miner.cpp:374-391),
@@ -1557,12 +1590,12 @@ private:
                 if (memo != anc.end()) return memo->second;
                 std::set<uint256> acc;
                 auto it = m_pool.find(txid);
-                if (it != m_pool.end() && it->second.fee_known) {
+                if (it != m_pool.end() && it->second.fee_fold_proven) {
                     for (const auto& vin : it->second.tx.vin) {
                         const uint256& p = vin.prevout.hash;
                         auto pit = m_pool.find(p);
-                        if (pit == m_pool.end() || !pit->second.fee_known)
-                            continue;   // edge leaves the fee_known pool
+                        if (pit == m_pool.end() || !pit->second.fee_fold_proven)
+                            continue;   // edge leaves the fold-proven pool
                         acc.insert(p);
                         const auto& panc = closure(p);
                         acc.insert(panc.begin(), panc.end());
@@ -1572,7 +1605,11 @@ private:
             };
 
         for (const auto& [txid, e] : m_pool) {
-            if (!e.fee_known) continue;
+            // EXCLUSION-DISCIPLINE: ancestor aggregates + over_limit are built
+            // over fold-proven entries only, so a force-priced DSTX is invisible
+            // to scoring/ordering exactly as it is to selection. With no forced
+            // entries this is byte-identical to the fee_known form.
+            if (!e.fee_fold_proven) continue;
             const auto& a = closure(txid);
             uint32_t cnt = static_cast<uint32_t>(a.size()) + 1;
             uint64_t szf = e.base_size;
@@ -1680,15 +1717,20 @@ private:
                                                   payload)) {
                 entry.fee = payload.fee;
                 entry.fee_known = true;
+                // Explicit, exact miner fee from the DIP-0027 payload (no UTXO
+                // fold needed, never overstated) → fold-proven for selection.
+                entry.fee_fold_proven = true;
                 return true;
             }
             entry.fee_known = false;
+            entry.fee_fold_proven = false;
             entry.fee = 0;
             return false;
         }
 
         if (!utxo) {
             entry.fee_known = false;
+            entry.fee_fold_proven = false;
             return false;
         }
         uint64_t in_sum = 0, out_sum = 0;
@@ -1708,6 +1750,7 @@ private:
                 continue;
             }
             entry.fee_known = false;
+            entry.fee_fold_proven = false;
             entry.fee = 0;
             return false;
         }
@@ -1715,14 +1758,21 @@ private:
             out_sum += static_cast<uint64_t>(vout.value);
         }
         if (in_sum < out_sum) {
-            // Negative fee — invalid tx; mark unknown so we don't
-            // poison block templates with garbage values.
+            // Negative fee — invalid tx (spends more than its inputs hold);
+            // mark unknown so we don't poison block templates with garbage
+            // values. fee_fold_proven stays false → template-excluded even if
+            // a DSTX force later flips fee_known (the money-creating hole).
             entry.fee_known = false;
+            entry.fee_fold_proven = false;
             entry.fee = 0;
             return false;
         }
         entry.fee = in_sum - out_sum;
         entry.fee_known = true;
+        // Every vin priced from our own UTXO view / in-pool parent and
+        // in_sum >= out_sum → the fee is fold-exact and inputs are proven
+        // present. This is the ONE bit the template selector trusts.
+        entry.fee_fold_proven = true;
         return true;
     }
 };

--- a/test/test_dash_dstx.cpp
+++ b/test/test_dash_dstx.cpp
@@ -520,3 +520,185 @@ TEST(DashDstxFailClosed, BadBlsSignatureIsRejected)
     EXPECT_EQ(st.mempool().size(), 0u)
         << "an unverifiable DSTX must never reach add_dstx";
 }
+
+// ═══ 7. EXCLUSION DISCIPLINE (tx-serving reward-safety, flag default-OFF) ═════
+//
+// The template selector now gates every included member on fee_fold_proven —
+// the bit set ONLY by a genuine W5 UTXO fold (inputs present in our view AND
+// in_sum >= out_sum) — never on fee_known, which a forced-fee DSTX admission
+// (add_tx_locked is_dstx branch) can flip true on inputs the fold could not
+// vouch for. These KATs pin the include/exclude matrix the design requires:
+//   INCLUDE  — a fee-proven valid tx rides at its EXACT base fee; coinbase
+//              total_fees == sum of included proven base fees (never more).
+//   EXCLUDE  — a forced-fee tx whose fold FAILED (unpriceable input, or
+//              in_sum < out_sum money-creation) is admitted to the RELAY pool
+//              (fee_known) but is NEVER a template member (fee_fold_proven
+//              stays false). On master (pre-fix) the money-creating tx clears
+//              the vin-present guard and is PACKED at fee 0 — a lost block.
+//   CONFIRMED— an already-confirmed tx is rejected at admission (#125) and
+//              conflict/confirm-evicted at connect (remove_for_block); the
+//              selector's fold-belt is the third, independent layer.
+
+namespace {
+
+// A minimal fee-lane fixture: connect a coinbase whose outputs seed the view,
+// so the mempool fold can price (or fail to price) spends of those outputs.
+struct FeeLane {
+    NodeCoinState st;
+    UtxoLane      lane;
+    Mempool&      mp;
+    uint256       cb_txid;
+
+    FeeLane() : mp(st.mempool())
+    {
+        EXPECT_TRUE(lane.open(""));
+        lane.attach(mp);
+    }
+    // Seed a coinbase at height 1 with the given (value, tag) outputs.
+    void seed(std::vector<std::pair<int64_t, uint8_t>> outs)
+    {
+        auto cb = make_coinbase(std::move(outs), /*salt=*/11);
+        lane.on_block_connected(make_block({cb}, /*salt=*/11), /*height=*/1);
+        cb_txid = dash_txid(cb);
+    }
+};
+
+} // namespace
+
+// INCLUDE: a normal tx spending a seeded output at a real positive fee is
+// fold-proven, selected, and its EXACT base fee flows into total_fees.
+TEST(DashExclusionDiscipline, FeeProvenValidTxIncludedWithExactFee)
+{
+    FeeLane f;
+    f.seed({{200'000, 0x04}});
+
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 3;
+    tx.vin.push_back(make_input(f.cb_txid, 0));
+    tx.vout.push_back(make_output(150'000, p2pkh_script(0x50)));  // fee 50'000
+    const uint256 txid = dash_txid(tx);
+    ASSERT_TRUE(f.mp.add_tx(tx));
+
+    auto e = f.mp.get_entry(txid);
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->fee_known);
+    EXPECT_TRUE(e->fee_fold_proven);          // the selection predicate
+    EXPECT_EQ(e->fee, 50'000u);
+
+    auto [sel, fees] = f.mp.get_sorted_txs_with_fees(1u << 20);
+    ASSERT_EQ(sel.size(), 1u) << "a fold-proven positive-fee tx must be included";
+    EXPECT_EQ(dash_txid(sel[0].tx), txid);
+    EXPECT_EQ(sel[0].fee, 50'000u);
+    EXPECT_EQ(fees, 50'000u)                   // coinbase fee-sum is EXACT
+        << "total_fees must equal the sum of included proven base fees";
+}
+
+// EXCLUDE (the red/green core): a MONEY-CREATING tx (inputs present in the
+// view but out_sum > in_sum) force-admitted like a DSTX gets fee_known=true /
+// fee=0, so it rides the relay pool — but fee_fold_proven stays FALSE, so it is
+// NEVER a template member. On master the vin-present guard passes and it is
+// packed at fee 0, invalidating the block (bad-txns-in-belowout). This is the
+// hole the exclusion discipline closes.
+TEST(DashExclusionDiscipline, MoneyCreatingForcedFeeTxExcluded)
+{
+    FeeLane f;
+    f.seed({{100'000, 0x04}});   // the only input value available
+
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 4;
+    tx.vin.push_back(make_input(f.cb_txid, 0));           // 100'000 in
+    tx.vout.push_back(make_output(200'000, p2pkh_script(0x51)));  // 200'000 out
+    const uint256 txid = dash_txid(tx);
+
+    // Force-admit exactly as the DSTX intake does when the fold can't vouch.
+    ASSERT_TRUE(f.mp.add_dstx(tx));
+
+    auto e = f.mp.get_entry(txid);
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->fee_known)  << "forced admission keeps it in the relay pool";
+    EXPECT_EQ(e->fee, 0u)      << "understate-only: forced fee is 0";
+    EXPECT_FALSE(e->fee_fold_proven)
+        << "the fold FAILED (in_sum < out_sum) — must never be fold-proven";
+
+    auto [sel, fees] = f.mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_EQ(sel.size(), 0u)
+        << "a money-creating forced-fee tx must NEVER be a template member";
+    EXPECT_EQ(fees, 0u);
+    // Belt: it is also absent from the selected txids.
+    for (const auto& s : sel) EXPECT_NE(dash_txid(s.tx), txid);
+}
+
+// EXCLUDE: a forced-fee DSTX whose inputs the view cannot price at all
+// (unknown prevouts) is admitted (fee_known) yet excluded (fee_fold_proven
+// false). Distinct from the money-creating case: here the fold fails on
+// missing-input, not on negative balance.
+TEST(DashExclusionDiscipline, UnpriceableForcedFeeTxExcluded)
+{
+    FeeLane f;   // nothing seeded → the DSTX prevouts are unknown
+
+    auto dstx_tx = make_dstx_tx(raw256(0x77), /*salt=*/9);
+    const uint256 txid = dash_txid(dstx_tx);
+    ASSERT_TRUE(f.mp.add_dstx(dstx_tx));
+
+    auto e = f.mp.get_entry(txid);
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->fee_known);
+    EXPECT_FALSE(e->fee_fold_proven);
+
+    auto [sel, fees] = f.mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_EQ(sel.size(), 0u)
+        << "an unpriceable forced-fee tx must never be a template member";
+    EXPECT_EQ(fees, 0u);
+}
+
+// EXCLUDE: a fold-PRICEABLE DSTX (inputs present, balanced) rides at its true
+// base fee — the discipline excludes only what the fold could not prove, not
+// every DSTX. (Companion to VerifiedDstxRanksFirstAndFeesStayBase, asserting
+// the new bit directly.)
+TEST(DashExclusionDiscipline, PriceableDstxKeepsFoldProvenAndRides)
+{
+    FeeLane f;
+    // Three denomination coins the balanced 3-in/3-out DSTX spends.
+    f.seed({{kDenom, 0x01}, {kDenom, 0x02}, {kDenom, 0x03}});
+    auto dstx_tx = make_dstx_tx(f.cb_txid, /*salt=*/7);
+    const uint256 txid = dash_txid(dstx_tx);
+    ASSERT_TRUE(f.mp.add_dstx(dstx_tx));
+
+    auto e = f.mp.get_entry(txid);
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->fee_known);
+    EXPECT_TRUE(e->fee_fold_proven)
+        << "a balanced, priceable DSTX is fold-proven and template-eligible";
+    EXPECT_EQ(e->fee, 0u);   // in_sum == out_sum → base fee 0
+}
+
+// CONFIRMED (#125 + selector belt): an already-confirmed tx is refused at
+// re-admission (its inputs are now spent, its own outputs are coins) and is
+// never in the pool, so it can never be a template member.
+TEST(DashExclusionDiscipline, AlreadyConfirmedTxRejectedAndUnselectable)
+{
+    FeeLane f;
+    f.seed({{200'000, 0x04}});
+
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 5;
+    tx.vin.push_back(make_input(f.cb_txid, 0));
+    tx.vout.push_back(make_output(150'000, p2pkh_script(0x52)));
+    const uint256 txid = dash_txid(tx);
+
+    // Confirm tx in a block (a coinbase MUST lead so `tx` is treated as a
+    // regular tx whose input is actually spent): input spent, own output
+    // becomes a coin, pool evicts it via remove_for_block.
+    auto cb2 = make_coinbase({{500'000, 0x09}}, /*salt=*/13);
+    f.lane.on_block_connected(make_block({cb2, tx}, /*salt=*/12), /*height=*/2);
+    EXPECT_FALSE(f.mp.contains(txid));
+
+    // #125: re-relaying the confirmed tx is rejected at admission.
+    EXPECT_FALSE(f.mp.add_tx(tx))
+        << "an already-confirmed tx must be refused (txn-already-known)";
+    EXPECT_FALSE(f.mp.contains(txid));
+
+    auto [sel, fees] = f.mp.get_sorted_txs_with_fees(1u << 20);
+    for (const auto& s : sel) EXPECT_NE(dash_txid(s.tx), txid);
+    EXPECT_EQ(fees, 0u);
+}


### PR DESCRIPTION
## Exclusion-discipline tx-selector (flag default-OFF, dormant)

Turns the embedded DASH template selector into an **exclusion-discipline** selector so that, when `--embedded-serve-mempool-txs` is armed, a mined block includes only the pool's own **valid, fee-proven** mempool subset — **valid WITHOUT dashd selection byte-parity**. Ships **dormant** (flag default OFF, `node_coin_state.hpp` `m_serve_mempool_txs{false}`); soak-gated before any money node. **DASH lane only.**

### The one in-tree hole this closes
`fee_known` on a `MempoolEntry` means two different things: *"priceable via the W5 UTXO fold"* **or** *"a DSTX whose fee was FORCED to 0 because the fold could not price it"* (`add_tx_locked` `is_dstx` branch, W5-B). The forced case sets `fee_known=true` on inputs the fold could **not** vouch for — including a tx whose **present** inputs sum to **less** than its outputs (money-creating). The selector gated on `fee_known`, so such an entry clears the vin-present guard and is **packed at fee 0 → invalid block (lost block)**.

### The fix
A new bit, **`fee_fold_proven`**, set **only** by a genuine fold success in `compute_fee_locked` (every vin priced from our own UTXO view / in-pool parent **AND** `in_sum >= out_sum`, or an input-free type-9 with a well-formed explicit-fee payload). The template selector — candidate index, package-member validation, and the ancestor-score closure — now selects on `fee_fold_proven`, never on `fee_known`. `fee_known` stays the relay/index/stats predicate, unchanged. With no forced-fee entry in the pool the selection is **byte-identical** to the previous `fee_known` form (`delta==0`).

### Exclusion rules (any doubt → EXCLUDE)
- `fee_fold_proven==false` — fee unknown / orphan / missing or unpriceable input / `in_sum < out_sum`. One bit covers invariant-1 *inputs-present* and invariant-2 *fee-never-overstated*.
- A **forced-fee DSTX** the fold could not price — excluded from templates, kept in the relay pool; a fold-priceable BLS-verified DSTX rides at its true base fee.
- **Already-confirmed** tx — rejected at admission (#125), conflict/confirm-evicted at connect (`remove_for_block`); the fold is the third belt (spent inputs are unpriceable → excluded). Exemption set **not** widened.
- Non-final member (reorg edge), IS/CL-hold young vin-bearing tx, MN-collateral spend, over byte/sigop/ancestor budget, below `blockMinFeeRate`, special-type under `exclude_special` — all unchanged (G1–G4, #1230/#1232/#1083).

### Coinbase fee-exactness
`build_embedded_workdata` is unchanged: `total_fees = Σ` selected **base** fees, and every included fee is fold-exact (never overstated), so `block_value = subsidy + Σ(actually-included proven fees)` and **bad-cb-amount is structurally impossible**. Excluded fees are simply forgone.

### Reward-safety argument (one-sided by construction)
1. Every **include** is individually proven: inputs present in our replay-fed UTXO view + exact fold fee, not-confirmed (three independent layers), G1 topology, G2 limits, G3 maturity/finality, G4 islock-hold, not a collateral spend.
2. Every **exclude** is consensus-legal: no rule requires any mempool tx in a block, so exclusion only forgoes fee revenue (~0.02–0.07% of reward), never invalidates.
3. Coinbase commits exactly `subsidy + Σ` included proven base fees; proven fees are never overstated.
4. Uncertainty defaults to **EXCLUDE** at every branch.
5. A wrong exclude = bounded fee loss; a wrong include = a lost block. The predicate is therefore one-sided in the safe direction.

### Byte-parity is NOT required (diagnostic only)
The shadow non-coinbase tx-merkle xcheck (`work_source.cpp`) stays a **`--coin-rpc`-only DIAGNOSTIC**; on a cut / no-rpc node it is absent and un-needed because the exclusion discipline itself is the safety. dashd may be used only as a shadow **oracle** during soak to confirm validity — never a required serve gate.

### KAT (test_dash_dstx, `DashExclusionDiscipline`) — red→green
- **INCLUDE** a fee-proven valid tx with its **exact** fee in the coinbase sum (`total_fees` exact).
- **EXCLUDE** a money-creating forced-fee tx, an unpriceable forced-fee tx, and an already-confirmed tx — never packed.
- A fold-priceable DSTX keeps `fee_fold_proven` and rides at base fee.
- **RED proven** by reverting the selection reads to `fee_known`: the money-creating tx becomes a template member (fails); with `fee_fold_proven` it is excluded (passes).

### Verification (vm905, non-money, BLS=REAL)
- Full build clean, `c2pool` + `c2pool-dash` linked against real `libdashbls.a` (BLS verify ENABLED).
- `test_dash_dstx` 13/13, `test_dash_mempool` 63/63 (incl. W5 fold + 5 new KATs), `test_dash_embedded_gbt` 281/281, `test_dash_block_producer` 9/9, `test_dash_g3_assembled` 9/9.

### Residual money-risks (named, none closable by this selector alone)
Script-validity (relay-trust, not proof — sole-ingestion-path invariant), islock dark-feed window (self-disarming hold), reorg snapshot race (bounded by rebuild cadence). The DSTX forced-fee hole is **closed in-design** by `fee_fold_proven`. Arming criterion for any money node = the `mempool_validity_gate` readiness verdict (zero-INVALID over 576 distinct heights via dashd `testmempoolaccept` as shadow oracle), NOT this merge.

**Base:** `master`. Do not merge — review-mine, soak-gated.
