### PR TITLE
dash(replay-fold): mirror GetBlockTxOuts operator-reward split in the payee cross-check (h=1439234 sub-class)

### DIFF
--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -427,6 +427,13 @@ struct FoldResult
     // still fully derived and self-consistent (nLastPaidHeight accumulates on
     // the projected payee exactly as dashd BuildNewListFromBlock does).
     bool        payee_check_preenforcement_skipped{false};
+    // True when the projected payee carried nOperatorReward==10000 with a
+    // non-empty scriptOperatorPayout, so dashd (payments.cpp GetBlockTxOuts)
+    // zeroed masternodeReward and emitted ONLY the operator output — the
+    // payee cross-check therefore required scriptOperatorPayout, NOT
+    // scriptPayout. Diagnostic: distinguishes a full-operator-reward payment
+    // from the ordinary owner-paid case at h=1439234 and its sub-class.
+    bool        payee_operator_full_reward{false};
 };
 
 class DmlFoldEngine
@@ -641,15 +648,26 @@ public:
         // ── Pass 0: payee, from the PRE-block list ──────────────────────
         r.payee = project_payee(H);
 
-        // ── Pass 0b: capture the payee's PRE-BLOCK payout script ────────
+        // ── Pass 0b: capture the payee's PRE-BLOCK payment tuple ────────
         // dashd built this block's coinbase from the list at H-1, which is
         // exactly the list being held right now. A ProUpRegTx later in this
         // same block may rewrite scriptPayout, and a collateral spend may
-        // remove the masternode outright, so the script is captured HERE and
+        // remove the masternode outright, so the tuple is captured HERE and
         // adjudicated in pass 6 — after the special-tx folds, so that a block
         // with a genuinely broken payload still reports ITS OWN blocking
         // condition rather than this one.
+        //
+        // The full tuple is (scriptPayout, scriptOperatorPayout, bps): dashd
+        // GetBlockTxOuts (masternode/payments.cpp:64-77) does NOT always emit
+        // scriptPayout. When nOperatorReward==10000 and scriptOperatorPayout
+        // is set, the operator reward eats the entire MN share, masternodeReward
+        // becomes exactly 0, and the ONLY MN vout dashd emits is the operator
+        // script. Capturing all three lets pass 6 mirror that branch exactly
+        // instead of unconditionally demanding scriptPayout (which false-poisons
+        // a byte-correct fold at every 100%-operator-reward payment — h=1439234).
         std::vector<unsigned char> payee_script_pre;
+        std::vector<unsigned char> payee_op_script_pre;
+        uint16_t                   payee_bps_pre = 0;
         if (r.payee) {
             const ReplayMNState* pst = find(*r.payee);
             if (pst == nullptr) {
@@ -661,7 +679,9 @@ public:
                 LOG_ERROR << "[DML-FOLD] " << r.error;
                 return r;
             }
-            payee_script_pre = pst->scriptPayout.m_data;
+            payee_script_pre    = pst->scriptPayout.m_data;
+            payee_op_script_pre = pst->scriptOperatorPayout.m_data;
+            payee_bps_pre       = pst->nOperatorReward;
         }
 
         // ── Pass 1: confirmedHash (specialtxman.cpp:205-218) ────────────
@@ -832,26 +852,80 @@ public:
         // derived and self-consistent across the window and is correct the
         // instant enforcement begins. Production (tip ~2.5M) is far above
         // enforcement, so the money-path check is UNCHANGED.
-        if (r.payee && !payee_script_pre.empty()
+        //
+        // WHICH SCRIPT dashd requires (masternode/payments.cpp GetBlockTxOuts
+        // :64-77, IsTransactionValid :109-139): the coinbase's REQUIRED MN
+        // output set is NOT unconditionally {scriptPayout}. dashd computes
+        //     if (nOperatorReward != 0 && scriptOperatorPayout != CScript()) {
+        //         operatorReward = (masternodeReward * nOperatorReward) / 10000;
+        //         masternodeReward -= operatorReward;
+        //     }
+        //     if (masternodeReward > 0) emplace(masternodeReward, scriptPayout);
+        //     if (operatorReward  > 0) emplace(operatorReward,  scriptOperatorPayout);
+        // and its validator requires PRECISELY the vouts it emitted — never
+        // scriptPayout when masternodeReward folded to 0.
+        //
+        // At nOperatorReward==10000 with a set scriptOperatorPayout, the
+        // operator reward eats the WHOLE MN share: masternodeReward becomes
+        // exactly 0, so dashd emits NO scriptPayout output and the only
+        // required MN vout is scriptOperatorPayout. A check that demands
+        // scriptPayout there is STRICTER THAN DASHD and false-poisons a
+        // byte-correct fold (observed h=1439234: proTxHash 71ed3bf5…, bps=10000,
+        // owner==operator self-host; roots matched 411073/411073, coinbase paid
+        // the operator script for the full share, no owner remainder).
+        //
+        // For 0 < bps < 10000, masternodeReward = mnShare − floor(mnShare·bps/
+        // 10000) is provably > 0 (floor of a strict-fraction of mnShare is
+        // strictly below mnShare), so scriptPayout IS emitted and required —
+        // today's behaviour. The operator output's exact amount needs the fee
+        // reward, which the fold's fee-unknown (W5) gap cannot price, so we
+        // NEVER poison on the operator axis for a partial split — only the
+        // owner axis, which is always required and always priceable.
+        //
+        // The required script is therefore the SINGLE owner-or-operator script
+        // dashd guarantees to emit; we fail closed on its absence exactly as a
+        // root mismatch, and stay STRICTLY equal to dashd's requirement, never
+        // weaker.
+        const bool full_operator_reward =
+            payee_bps_pre == 10000 && !payee_op_script_pre.empty();
+        const std::vector<unsigned char>& required_script =
+            full_operator_reward ? payee_op_script_pre : payee_script_pre;
+        if (r.payee) r.payee_operator_full_reward = full_operator_reward;
+
+        if (r.payee && !required_script.empty()
             && !m_cfg.gates.dip0003_enforced(H)) {
             r.payee_check_preenforcement_skipped = true;
         }
-        if (r.payee && !payee_script_pre.empty()
+        if (r.payee && !required_script.empty()
             && m_cfg.gates.dip0003_enforced(H)) {
             bool paid = false;
             if (!block.m_txs.empty()) {
                 for (const auto& out : block.m_txs[0].vout) {
-                    if (out.scriptPubKey.m_data == payee_script_pre) {
+                    if (out.scriptPubKey.m_data == required_script) {
                         paid = true;
                         break;
                     }
                 }
             }
             if (!paid) {
+                const auto hx = [](const std::vector<unsigned char>& v) {
+                    static const char* d = "0123456789abcdef";
+                    std::string s; s.reserve(v.size() * 2);
+                    for (unsigned char b : v) { s += d[b >> 4]; s += d[b & 0xf]; }
+                    return s;
+                };
                 r.error = "DML FOLD PAYEE MISMATCH at h=" + std::to_string(height)
                         + ": this block's coinbase does not pay the projected "
                           "masternode " + r.payee->GetHex()
-                        + " — the merkleRootMNList self-check PASSED at this "
+                        + " — required " + (full_operator_reward
+                              ? "scriptOperatorPayout (nOperatorReward=10000, "
+                                "masternodeReward folds to 0 so dashd emits only "
+                                "the operator output)"
+                              : "scriptPayout")
+                        + " {scriptPayout=" + hx(payee_script_pre)
+                        + ", scriptOperatorPayout=" + hx(payee_op_script_pre)
+                        + ", bps=" + std::to_string(payee_bps_pre)
+                        + "} — the merkleRootMNList self-check PASSED at this "
                           "height, which is exactly why this check exists: "
                           "nLastPaidHeight is not committed by any block, so "
                           "a wrong payment order folds to the right root — "

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -1396,7 +1396,7 @@ struct PayeeGateFixture {
 TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeeMismatchFoldsThrough)
 {
     PayeeGateFixture fx(/*enforcement_height=*/103);  // 102 < 103 ⇒ pre-enforcement
-    ASSERT_TRUE(fx.eng.project_payee(102).has_value())
+    ASSERT_TRUE(fx.eng.project_payee(101).has_value())
         << "a payee must be projected (else the test proves nothing)";
     auto pay_blk = make_block(102, raw256(9), fx.payment_root,
                               /*special_txs=*/{}, /*pay_from=*/nullptr);
@@ -1419,7 +1419,7 @@ TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeeMismatchFoldsThrough)
 TEST(DashReplayFoldPreEnforcement, AtEnforcementPayeeMismatchStillPoisons)
 {
     PayeeGateFixture fx(/*enforcement_height=*/102);  // 102 >= 102 ⇒ enforced
-    ASSERT_TRUE(fx.eng.project_payee(102).has_value());
+    ASSERT_TRUE(fx.eng.project_payee(101).has_value());
     auto pay_blk = make_block(102, raw256(9), fx.payment_root,
                               /*special_txs=*/{}, /*pay_from=*/nullptr);
     auto r = fx.eng.fold_block(pay_blk, 102);
@@ -1441,4 +1441,157 @@ TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeePaidIsNotFlaggedSkipped)
     // Below enforcement the check is skipped regardless of whether the coinbase
     // happens to pay the projection; the flag reflects the GATE, not the match.
     EXPECT_TRUE(r.payee_check_preenforcement_skipped);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// OPERATOR-REWARD SPLIT payee cross-check — h=1439234 sub-class
+// ════════════════════════════════════════════════════════════════════════
+//
+// dashd masternode/payments.cpp GetBlockTxOuts:64-77 does NOT unconditionally
+// emit scriptPayout. When nOperatorReward==10000 and scriptOperatorPayout is
+// set, the operator reward eats the WHOLE MN share, masternodeReward folds to
+// exactly 0, and the ONLY MN output dashd emits (and its IsTransactionValid
+// :109-139 requires) is scriptOperatorPayout. A payee cross-check that always
+// demands scriptPayout is STRICTER THAN DASHD there and false-poisons a
+// byte-correct fold — the live self-derive incident at h=1439234 (proTxHash
+// 71ed3bf5…, bps=10000, owner==operator self-host, coinbase paid the operator
+// script for the full 1.51818084 share, no owner remainder; roots matched
+// 411073/411073). These KATs pin the faithful branch.
+//
+// Build the fixture by SEEDING the pre-block state directly (scriptOperatorPayout
+// is set by a ProUpServTx in history; seeding it is the same pre-block tuple
+// dashd built the coinbase from). Confirmations are pushed out so pass 1 never
+// mutates confirmedHash and the SML root stays byte-stable across the payment
+// fold — the SET self-check binds in every arm.
+namespace {
+static FoldConfig op_split_cfg()
+{
+    FoldConfig cfg;
+    cfg.enabled = true;
+    cfg.gates.dip0003_height               = 1;
+    cfg.gates.dip0003_enforcement_height   = 1;   // ENFORCED: payee check ON
+    cfg.gates.v19_height                   = 1;
+    cfg.gates.mn_rr_height                 = 1;
+    cfg.gates.masternode_min_confirmations = 100000000;  // no confirmedHash churn
+    return cfg;
+}
+
+// Seed one non-banned MN carrying (scriptPayout=owner, scriptOperatorPayout=op,
+// nOperatorReward=bps). Returns the engine + the committed SML root of that
+// single-entry list (unchanged by a payment fold).
+struct OpSplitFixture {
+    DmlFoldEngine eng;
+    uint256       committed_root;
+    uint256       mn;
+    std::vector<unsigned char> owner_script;
+    std::vector<unsigned char> op_script;
+    OpSplitFixture(uint16_t bps,
+                   const std::vector<unsigned char>& owner,
+                   const std::vector<unsigned char>& op)
+        : eng(op_split_cfg())
+        , mn(raw256(0xE7))
+        , owner_script(owner)
+        , op_script(op)
+    {
+        ReplayMNState st;
+        st.nVersion   = ProTxVersion::BASIC_BLS;
+        st.nType      = MnType::REGULAR;
+        st.keyIDOwner  = raw160(0x27);
+        st.keyIDVoting = raw160(0x57);
+        st.pubKeyOperator = seq_array<48>(0x37);
+        st.collateralOutpoint.hash  = raw256(0x47);
+        st.collateralOutpoint.index = 1;
+        st.netInfo.ip      = seq_array<16>(0x17);
+        st.netInfo.port_be = 9999;
+        st.nOperatorReward = bps;
+        st.scriptPayout.m_data         = owner;
+        st.scriptOperatorPayout.m_data = op;
+        st.nRegisteredHeight = 50;
+        st.nLastPaidHeight   = 0;            // never paid — first payment here
+        st.confirmedHash     = raw256(0x99); // pre-set: pass 1 leaves it alone
+        eng.seed({{mn, st}}, /*total_registered=*/1, /*height=*/100, raw256(9));
+        committed_root = eng.compute_sml_root();
+    }
+    // A payment block at h whose coinbase pays EXACTLY `scripts` (one vout each).
+    BlockType payment_block(uint32_t h,
+                            std::vector<std::vector<unsigned char>> scripts) const
+    {
+        auto blk = make_block(h, raw256(9), committed_root);  // coinbase, no payee vout
+        for (auto& s : scripts) {
+            TxOut out;
+            out.value = 100000000;
+            out.scriptPubKey.m_data = std::move(s);
+            blk.m_txs[0].vout.push_back(std::move(out));
+        }
+        return blk;
+    }
+};
+} // namespace
+
+// GREEN (RED on master): bps==10000 with a set operator script. dashd zeroes
+// masternodeReward and pays ONLY the operator script — so a coinbase paying the
+// operator script (and NOT scriptPayout) is exactly what dashd produced. The
+// fold must accept it. On master this REDS: the check demands scriptPayout,
+// which is legitimately absent, and false-poisons.
+TEST(DashReplayFoldOperatorSplit, FullOperatorRewardPaysOperatorScriptFoldsThrough)
+{
+    OpSplitFixture fx(/*bps=*/10000, script_bytes(0x6A), script_bytes(0x6B));
+    ASSERT_TRUE(fx.eng.project_payee(101).has_value());
+    // Coinbase pays ONLY the operator script (the h=1439234 shape).
+    auto blk = fx.payment_block(101, {fx.op_script});
+    auto r = fx.eng.fold_block(blk, 101);
+    ASSERT_TRUE(r.ok) << "a full-operator-reward payment (dashd emits ONLY the "
+                         "operator output) must fold through, not poison: "
+                      << r.error;
+    EXPECT_EQ(r.computed_root, r.committed_root);      // SET self-check bound
+    EXPECT_TRUE(r.payee_paid_verified);                // payee AXIS verified
+    EXPECT_TRUE(r.payee_operator_full_reward);         // via the operator branch
+    EXPECT_TRUE(r.payee_marked);                       // nLastPaidHeight bumped
+}
+
+// STRICTNESS / reward-safety: same 100%-operator MN, but the coinbase pays the
+// OWNER scriptPayout instead of the operator script. dashd would REJECT that
+// coinbase (it requires the operator output, masternodeReward==0 so no owner
+// output is valid) — our check must also POISON. The fix makes the requirement
+// EQUAL to dashd's, never weaker: it does not accept "pays either script".
+TEST(DashReplayFoldOperatorSplit, FullOperatorRewardPayingOwnerScriptStillPoisons)
+{
+    OpSplitFixture fx(/*bps=*/10000, script_bytes(0x6A), script_bytes(0x6B));
+    auto blk = fx.payment_block(101, {fx.owner_script});  // pays owner, NOT operator
+    auto r = fx.eng.fold_block(blk, 101);
+    ASSERT_FALSE(r.ok) << "at bps=10000 dashd emits only the operator output; a "
+                          "coinbase paying scriptPayout instead is invalid and "
+                          "MUST poison";
+    EXPECT_NE(r.error.find("PAYEE MISMATCH"), std::string::npos) << r.error;
+    EXPECT_NE(r.error.find("scriptOperatorPayout"), std::string::npos)
+        << "the poison message must name the required operator script: " << r.error;
+    EXPECT_TRUE(fx.eng.poisoned());                    // fail-closed, engine poisoned
+}
+
+// UNCHANGED for partial splits: 0<bps<10000 keeps masternodeReward>0, so dashd
+// still emits scriptPayout and the check still requires it. A coinbase paying
+// the owner script folds through (the operator output is fee-priced, which the
+// fold cannot compute, so it is NEVER poisoned on for absence).
+TEST(DashReplayFoldOperatorSplit, PartialOperatorRewardRequiresOwnerScript)
+{
+    OpSplitFixture fx(/*bps=*/800, script_bytes(0x6A), script_bytes(0x6B));
+    // Pays owner only (operator output amount is fee-unknown; not required).
+    auto blk = fx.payment_block(101, {fx.owner_script});
+    auto r = fx.eng.fold_block(blk, 101);
+    ASSERT_TRUE(r.ok) << "a partial-split payment paying scriptPayout must fold "
+                         "through: " << r.error;
+    EXPECT_TRUE(r.payee_paid_verified);
+    EXPECT_FALSE(r.payee_operator_full_reward);         // partial ⇒ owner-required branch
+}
+
+// STRICTNESS for partial splits: masternodeReward>0 so scriptPayout is required;
+// a coinbase paying ONLY the operator script (no owner output) is invalid and
+// MUST poison — the owner axis is always priceable and always enforced.
+TEST(DashReplayFoldOperatorSplit, PartialOperatorRewardMissingOwnerScriptPoisons)
+{
+    OpSplitFixture fx(/*bps=*/800, script_bytes(0x6A), script_bytes(0x6B));
+    auto blk = fx.payment_block(101, {fx.op_script});  // operator only, no owner
+    auto r = fx.eng.fold_block(blk, 101);
+    ASSERT_FALSE(r.ok) << "partial split with no owner output MUST poison";
+    EXPECT_NE(r.error.find("PAYEE MISMATCH"), std::string::npos) << r.error;
 }


### PR DESCRIPTION
## What

Port dashd's operator-reward split into the DML replay fold's pass-6 payee
cross-check so the projected payee matches dashd at **h=1439234** and for the
whole event sub-class.

## Why (live poison)

The daemonless self-derive hard-stopped:

```
[REPLAY-PAYEE] G1 fold POISONED: DML FOLD PAYEE MISMATCH at h=1439234 --
this block's coinbase does not pay the projected masternode
71ed3bf5...ceb2d006 -- the merkleRootMNList self-check PASSED at this height
```

The projection was **correct** — dashd paid the very MN c2pool projected. The
check was blind to the DIP3 operator-reward split:

- proTxHash `71ed3bf5...ceb2d006`, registered h=1434598, `nOperatorReward=0x2710
  = 10000 bps = 100.00%`, owner==operator self-host.
- dashd `masternode/payments.cpp` `GetBlockTxOuts:64-77`: at bps=10000 the
  operator reward eats the whole MN share, `masternodeReward` folds to exactly
  0, so the ONLY MN output emitted (and required by `IsTransactionValid:109-139`)
  is `scriptOperatorPayout`. `scriptPayout` is legitimately **absent**.
- Block 1439234 paid the operator script for the full `1.51818084` with no owner
  remainder; roots matched `411073/411073`. The fold demanded `scriptPayout` and
  false-poisoned a byte-correct fold.

This recurs for every 100%-operator-reward payment (~one queue length apart
while registered), so a point patch would re-wedge — the general dashd-faithful
branch is required.

## The fix (`replay_fold_engine.hpp`)

- **Pass 0b** now captures the payee's full pre-block tuple
  `(scriptPayout, scriptOperatorPayout, nOperatorReward)` — state already held by
  `fold_proreg`/`fold_proupserv`.
- **Pass 6** mirrors `GetBlockTxOuts` without needing amounts:
  - `bps==10000 && operator-script set` → require `scriptOperatorPayout`, **not**
    `scriptPayout` (dashd emits none);
  - `0<bps<10000` → `masternodeReward = mnShare - floor(mnShare*bps/10000)` is
    provably `>0`, so require `scriptPayout` (unchanged); the operator output's
    exact amount needs the fee reward the fold cannot price (W5 gap), so never
    poison on the operator axis for a partial split;
  - otherwise → require `scriptPayout` (unchanged).
- The poison message now dumps `{scriptPayout, scriptOperatorPayout, bps}` so any
  future instance self-classifies.

Passes 0/5 (projection + `nLastPaidHeight` bookkeeping) are untouched — they were
correct; the projected proTxHash equals the paid MN here.

## Reward-safe by construction

Check-only change on the verification axis. The requirement becomes **exactly**
dashd's required-output set, never weaker: at bps=10000 a coinbase paying
`scriptPayout` instead of the operator output still hard-stops (dashd would
reject it too). The `merkleRootMNList` SET self-check stays unconditional; the
payee projection + `nLastPaidHeight` bookkeeping stay derived. No live-mint
behaviour changes.

## Tests (`DashReplayFoldOperatorSplit`, red→green proven)

- `FullOperatorRewardPaysOperatorScriptFoldsThrough` — the h=1439234 shape; **RED**
  on the old selection (poisons a byte-correct fold), **GREEN** with the faithful
  branch.
- `FullOperatorRewardPayingOwnerScriptStillPoisons` — strictness: a bps=10000
  coinbase paying the owner script is invalid and still poisons.
- `PartialOperatorRewardRequiresOwnerScript` / `...MissingOwnerScriptPoisons` —
  partial splits keep requiring `scriptPayout`, unchanged.

## Build / verification

- `-DC2POOL_DASH_BLS=ON` (real dashbls, relic-backed) — `c2pool-dash` self-reports
  at init: `DASH BLS backend: REAL (dashbls linked; quorum-commitment verify armed)`.
- `test_dash_mn_state`: **130 passed, 1 skipped (data-driven), 0 failed**.

Stacked on `integrator/dashd-cut-early-quorum-memberset` (#1277 branch). **DRAFT
— do not merge.**
