### PR TITLE
dash(daemonless): stateful getmnlistd acquisition + archival selection, and make EXPANSION see a getmnlistd stall (stacked on #1285)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5098,7 +5098,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // maintainer's SmlResyncWatchdog; this closure only forwards.
         maintainer->set_on_sml_rerequest(
             [cp = coin_p2p.get()](const uint256& base, const uint256& target) {
-                if (cp) cp->send_getmnlistd(base, target);
+                // TIMEOUT re-ask (SmlResyncWatchdog): rotate to a DIFFERENT
+                // archival carrier and strike the stalled one as a non-server,
+                // so a slow/limited primary can neither wedge the tip SML nor
+                // stay invisible to the outbound-acquisition pump. dashd
+                // rotate-on-stall + prefer-CanServeBlocks for the getmnlistd
+                // leg. Reward-safe: peer selection + dial count only.
+                if (cp) cp->send_getmnlistd_reask(base, target);
             });
 
         // ChainLock verifier: BLS-verify a relayed clsig against the quorum
@@ -6123,6 +6129,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         // eligible pool so a slow/non-serving primary cannot
                         // wedge the anchor->tip fold (dashd rotate-on-stall).
                         cp->send_getmnlistd_rotating(uint256::ZERO, block_hash);
+                    });
+                // TIMEOUT RE-ASK of that same fold snapshot: besides rotating,
+                // strike the stalled carrier as a demonstrated non-server so
+                // the acquisition pump expands the outbound set
+                // (GetExtraFullOutboundCount) toward a peer that actually
+                // serves the deep base->anchor snapshot, instead of re-asking
+                // one slow peer forever. Reward-safe: peer selection + dial
+                // count only.
+                mn_ckpt_lane->set_reask_snapshot_fn(
+                    [cp](const uint256& block_hash) {
+                        cp->send_getmnlistd_reask(uint256::ZERO, block_hash);
                     });
                 // DEMUX (reward-critical): the reply comes back on the SAME
                 // mnlistdiff message the tip sync uses. Routed here it is

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -399,6 +399,16 @@ public:
     {
         m_request_snapshot = std::move(fn);
     }
+    /// Optional TIMEOUT RE-ASK seam. When set, tick_pending_fold() re-asks the
+    /// unanswered fold snapshot through THIS callback instead of the first-ask
+    /// one, so the re-ask can rotate to a fresh archival carrier AND strike the
+    /// stalled one as a non-server (feeding the outbound-acquisition pump). It
+    /// is a pure connection-management upgrade: unwired, the lane re-asks the
+    /// same way it always did.
+    void set_reask_snapshot_fn(RequestSnapshotFn fn)
+    {
+        m_reask_snapshot = std::move(fn);
+    }
     void set_merkle_root_at_fn(MerkleRootAtFn fn)
     {
         m_merkle_root_at = std::move(fn);
@@ -2897,7 +2907,10 @@ public:
                         << " drives — re-asking (same block, so still ONE"
                            " outstanding request: a reply to either ask is"
                            " indistinguishable and both are ours)";
-            m_request_snapshot(m_snapshot_hash);
+            // Route the re-ask through the rotate+demote seam when wired, so a
+            // stalled carrier is struck and a fresh archival peer is tried;
+            // falls back to the plain first-ask send when it is not.
+            (m_reask_snapshot ? m_reask_snapshot : m_request_snapshot)(m_snapshot_hash);
             return false;
         }
         if (m_snapshot_waits < kFoldGiveUpPumps) return false;
@@ -4067,6 +4080,7 @@ public:
     bool      m_revive_probe_cap_forced{false};
     bool      m_revive_probe_cap_hit{false};
     RequestSnapshotFn m_request_snapshot;
+    RequestSnapshotFn m_reask_snapshot;   // optional rotate+demote re-ask seam
     MerkleRootAtFn    m_merkle_root_at;
     size_t   m_sml_recovery_cap{0}; // budget handed to the machine, mirrored
     size_t   m_registered{0};       // ADDS observed across the replay

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1761,6 +1761,48 @@ public:
         p->write(msg);
     }
 
+    /// TIMEOUT RE-ASK of the STATEFUL getmnlistd leg — the recovery half of
+    /// dashd's rotate-on-stall sync-peer behaviour, fired when the carrier we
+    /// last asked did not answer in time (the tip-follow SmlResyncWatchdog
+    /// re-request, or the mn-checkpoint fold's tick_pending_fold re-ask). Two
+    /// things happen, and the live A/B (wf w8cr3yepg) proved BOTH were missing
+    /// on this leg — it pinned every ask AND every re-ask to one primary:
+    ///
+    ///   (B) ROTATE — send_getmnlistd_rotating() picks a DIFFERENT eligible
+    ///       archival carrier (next_stateful_peer avoids m_last_stateful_peer
+    ///       and prefers CanServeBlocks/NODE_NETWORK), so a slow/limited peer
+    ///       cannot wedge the fold by being re-asked forever.
+    ///
+    ///   (A) DEMOTE — strike the carrier that just stalled us as a demonstrated
+    ///       non-server, in the SAME bulk-demotion tally the block-body lane
+    ///       feeds. This is what makes the acquisition pump SEE a getmnlistd
+    ///       stall: outbound_behind() then reads a demoted slot-holder, the
+    ///       effective dial target expands (GetExtraFullOutboundCount) and
+    ///       refill/rotate pulls in MORE fresh archival peers to reach one that
+    ///       actually serves. Without it "behind" was blind to everything but
+    ///       block bodies, so a getmnlistd-dominated near-tip window kept the
+    ///       pool frozen at its base size even while a slow primary starved the
+    ///       SML — exactly the EXPANSION-never-engaged half of the finding.
+    ///
+    /// Reward-safe: this changes only WHICH peer is asked and HOW MANY we dial.
+    /// Exactly one getmnlistd is outstanding, so a reply from ANY carrier
+    /// satisfies the same await; the served MN-payee/quorum-root bytes are
+    /// still DIP-4 client-verified against the block's own cbTx commitment
+    /// before they are believed; and a peer that later delivers a body clears
+    /// its strike (forgive_bulk_nonserver on the ingest path).
+    void send_getmnlistd_reask(const uint256& base_block_hash,
+                               const uint256& block_hash)
+    {
+        // (A) the carrier we last asked demonstrably did not answer in time —
+        // strike it so the acquisition pump treats it as a slot-holding non-
+        // server and expands/rotates the outbound set toward a real server.
+        if (!m_last_stateful_peer.empty() && holds_key(m_last_stateful_peer))
+            note_bulk_nonserver(m_last_stateful_peer);
+        // (B) rotate to a fresh archival carrier and send (never drops: the
+        // rotating send falls back to any handshaked peer, then m_primary).
+        send_getmnlistd_rotating(base_block_hash, block_hash);
+    }
+
     /// Send a getqrinfo (DIP-24 quorum-rotation-info request) — the ROTATED
     /// counterpart of send_getmnlistd above. An EMPTY baseBlockHashes asks for
     /// FULL (base=ZERO) mnlistdiffs at every cycle height, which is what the

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1504,6 +1504,121 @@ TEST(DashStatefulFold, fold_getmnlistd_never_wedges_when_only_pruned_peers_exist
                            "archival peer exists (fallback to the handshaked pool)";
 }
 
+// (STATEFUL-STALL A) THE EXPANSION HALF, DRIVEN BY A STATEFUL STALL.
+// The live A/B (wf w8cr3yepg) proved the acquisition ROTATION fired but the
+// effective_max_peers EXPANSION never engaged: the near-tip window was
+// dominated by the STATEFUL getmnlistd leg, and "behind" was fed ONLY by the
+// block-body demotion tally — blind to a getmnlistd stall. send_getmnlistd_
+// reask() closes it: a timeout re-ask strikes the stalled carrier through the
+// SAME tally, so outbound_behind() sees the demoted slot-holder, the dial
+// target rises (GetExtraFullOutboundCount) and refill dials fresh archival
+// peers. RED contrast: the pre-port rotating send never strikes, so the
+// identical stall stays invisible and the pool stays frozen at its base size.
+TEST(DashStatefulFold, stateful_getmnlistd_stall_expands_outbound_like_a_body_stall)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(8);
+
+    // Come up full: 8 handshaked peers, exactly ONE archival (peer 1); the
+    // rest pruned, so the stateful leg can only ride peer 1 — the single-
+    // carrier topology the live 26-min freeze happened on.
+    std::vector<NetService> plan;
+    for (int i = 1; i <= 8; ++i) plan.push_back(PoolRig::peer_addr(i));
+    rig.client.connect(plan);
+    rig.handshake_services(1, SVC_FULL);
+    for (int i = 2; i <= 8; ++i) rig.handshake_services(i, SVC_LIMITED_ONLY);
+    ASSERT_EQ(rig.client.connected_peer_count(), 8u);
+
+    // Fresh archival candidates the frozen set never reached.
+    rig.client.update_dial_targets({PoolRig::peer_addr(9), PoolRig::peer_addr(10),
+                                    PoolRig::peer_addr(11), PoolRig::peer_addr(12)});
+
+    // Healthy to begin with: not behind, base target.
+    EXPECT_FALSE(rig.client.outbound_behind_for_test());
+    EXPECT_EQ(rig.client.effective_max_peers_for_test(), 8u);
+
+    // The fold asks peer 1 (records it as the stateful carrier), then two
+    // timeout re-asks go unanswered — each strikes the carrier. Two strikes =
+    // BULK_NONSERVER_STRIKE_MAX => demoted.
+    rig.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(700));   // first ask
+    ASSERT_EQ(rig.client.bulk_nonserver_strikes_for_test(PoolRig::peer_key(1)), 0);
+    rig.client.send_getmnlistd_reask(uint256::ZERO, hash_n(700));      // re-ask #1
+    rig.client.send_getmnlistd_reask(uint256::ZERO, hash_n(700));      // re-ask #2
+    EXPECT_GE(rig.client.bulk_nonserver_strikes_for_test(PoolRig::peer_key(1)), 2);
+    ASSERT_TRUE(rig.client.bulk_demoted_for_test(PoolRig::peer_key(1)))
+        << "a chronically-unanswered stateful carrier must demote, exactly like "
+           "a chronically-unanswered block-body peer";
+
+    // EXPANSION now engages — the half that never fired in the live run.
+    EXPECT_TRUE(rig.client.outbound_behind_for_test());
+    EXPECT_EQ(rig.client.effective_max_peers_for_test(), 10u)
+        << "a stateful-leg stall must raise the dial target, not only a body stall";
+
+    // One pool tick dials the extra fresh archival outbound.
+    rig.run_seconds(1);
+    EXPECT_EQ(rig.client.dialing_count(), 2u)
+        << "behind on the stateful leg, the pool must acquire MORE archival peers";
+    for (const auto& k : rig.client.dialing_keys())
+    {
+        bool fresh = k == PoolRig::peer_key(9)  || k == PoolRig::peer_key(10) ||
+                     k == PoolRig::peer_key(11) || k == PoolRig::peer_key(12);
+        EXPECT_TRUE(fresh) << "extra outbound dialed a non-fresh target: " << k;
+    }
+
+    // RED CONTRAST: the pre-port rotating send (no strike) leaves the identical
+    // stall invisible — no demotion, no expansion, the frozen pool of the run.
+    PoolRig red;
+    red.use_fake_clock();
+    red.client.set_max_peers(8);
+    red.client.connect(plan);
+    red.handshake_services(1, SVC_FULL);
+    for (int i = 2; i <= 8; ++i) red.handshake_services(i, SVC_LIMITED_ONLY);
+    red.client.update_dial_targets({PoolRig::peer_addr(9), PoolRig::peer_addr(10),
+                                    PoolRig::peer_addr(11), PoolRig::peer_addr(12)});
+    red.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(700));
+    red.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(700));
+    red.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(700));
+    red.run_seconds(5);
+    EXPECT_EQ(red.client.bulk_nonserver_strikes_for_test(PoolRig::peer_key(1)), 0)
+        << "the plain rotating send must never strike — that is why EXPANSION "
+           "never engaged in the live A/B";
+    EXPECT_FALSE(red.client.outbound_behind_for_test());
+    EXPECT_EQ(red.client.effective_max_peers_for_test(), 8u);
+    EXPECT_EQ(red.client.dialing_count(), 0u);
+}
+
+// (STATEFUL-STALL B) The re-ask STRIKES the stalled carrier; the plain first-
+// ask rotating send never does. This is the reward-safe demote-on-stall the
+// tip-follow SmlResyncWatchdog re-request now feeds so a slow/limited primary
+// can neither wedge the SML nor stay invisible to the acquisition pump.
+TEST(DashStatefulFold, getmnlistd_reask_strikes_the_stalled_carrier)
+{
+    PoolRig rig;
+    rig.handshake_services(1, SVC_FULL);
+    rig.handshake_services(2, SVC_FULL);
+    rig.handshake_services(3, SVC_FULL);
+
+    const std::string c1 = rig.client.select_stateful_peer_key_for_test();
+    ASSERT_FALSE(c1.empty());
+    ASSERT_EQ(rig.client.bulk_nonserver_strikes_for_test(c1), 0);
+
+    // A timeout re-ask strikes THAT carrier (it did not answer in time).
+    rig.client.send_getmnlistd_reask(uint256::ZERO, hash_n(11));
+    EXPECT_EQ(rig.client.bulk_nonserver_strikes_for_test(c1), 1)
+        << "the stalled stateful carrier must be struck (dashd disconnect-on-stall)";
+
+    // RED: the first-ask rotating send is not a stall signal and never demotes.
+    PoolRig red;
+    red.handshake_services(1, SVC_FULL);
+    red.handshake_services(2, SVC_FULL);
+    const std::string rc = red.client.select_stateful_peer_key_for_test();
+    ASSERT_FALSE(rc.empty());
+    red.client.send_getmnlistd_rotating(uint256::ZERO, hash_n(12));
+    EXPECT_EQ(red.client.bulk_nonserver_strikes_for_test(rc), 0)
+        << "a first-ask rotating send must not demote its carrier";
+}
+
 // ══════════════════════════════════════════════════════════════════════════
 // (H) OUTBOUND ACQUISITION — dashd never stays starved on a full-but-shallow
 //     peer set. While it is behind it opens EXTRA full-relay outbound


### PR DESCRIPTION
## Summary

Follow-up to the outbound-acquisition port (#148 / PR #1285), **stacked on its branch** (`integrator/dashd-cut-outbound-acquisition`). The live A/B (wf `w8cr3yepg`) proved that port's acquisition *rotation* half fired (+53% archival peers, one pump eviction) but exposed two gaps this PR closes.

### (A) The EXPANSION half never engaged — pool never rose above 8
Root cause: `outbound_behind()` (the `GetExtraFullOutboundCount` analog that raises `effective_max_peers`) is read from the **bulk-demotion tally**, and that tally was fed **only by block-BODY stalls / NOTFOUND**. The near-tip test window was dominated by the **stateful getmnlistd leg**, so no peer was ever demoted, `outbound_behind` stayed false, and the dial target never rose — even though the node *was* behind (a slow primary was starving the SML). The expansion trigger was blind to everything but block bodies.

### (B) The stateful getmnlistd leg rotated on primary-LOSS, not on TIMEOUT
The tip-follow `SmlResyncWatchdog` re-request (and the mn-checkpoint fold re-ask) pinned every attempt to `m_primary` and did not prefer archival peers, so one slow/limited primary could LANE-WATCHDOG-freeze the whole stateful fold (`applied=4072` stuck in the baseline arm).

## Fix — one primitive, `send_getmnlistd_reask()`, wired at the two TIMEOUT re-ask seams
- `main_dash.cpp` `set_on_sml_rerequest` (tip-follow watchdog)
- `mn_checkpoint_lane` new `set_reask_snapshot_fn` feeding `tick_pending_fold`

It does two things:
- **ROTATE (B):** reuses `send_getmnlistd_rotating -> next_stateful_peer`, which already avoids the last carrier and prefers `CanServeBlocks`/`NODE_NETWORK` archival peers (services parsed at handshake). dashd rotate-on-stall + prefer-full-relay for the getmnlistd leg.
- **DEMOTE (A):** strikes the carrier that just stalled us into the **same** bulk-demotion tally the body lane feeds. A getmnlistd stall now raises `outbound_behind`, so `effective_max_peers` expands (clamped to `POOL_PEERS_HARD_CAP=16`) and refill/rotate dials MORE fresh archival peers — the expansion half now engages on a stateful stall exactly as on a body stall.

## Reward-safe (both halves)
Connection-management + peer-**selection** only. WHICH mnlistdiff is applied, the per-block merkleRoot fold self-check, the payee cross-check, the DIP-4 client verification of every served list against its own cbTx commitment, and poison fail-closed are **unchanged**; no diff/block is ever skipped. Exactly one getmnlistd is outstanding, so a reply from any carrier satisfies the same await; a peer that later delivers a body clears its strike. A healthy pool is byte-identical to before, and the whole behaviour stays behind `m_outbound_rotate_enabled` (default on; off = frozen pre-port pool).

## Tests (red → green)
`test/test_dash_coin_p2p_pool.cpp`, red-proven by disabling the strike and re-running:
- **`stateful_getmnlistd_stall_expands_outbound_like_a_body_stall`** — a chronic getmnlistd stall demotes its carrier, raises `outbound_behind`, expands the dial target 8→10, and dials 2 fresh archival outbound. RED (rotating send, no strike): strikes=0, not behind, target stays 8, 0 dials — the exact live bug.
- **`getmnlistd_reask_strikes_the_stalled_carrier`** — the re-ask strikes the stalled carrier; the plain first-ask rotating send does not.

Full `test_dash_p2p_node` suite: **155/155 green**. Built DASH with `C2POOL_DASH_BLS=ON` (real dashbls; link guard PASS, 111 dashbls symbols).

## Status
DRAFT — do not merge. Base is the #1285 branch, not master.
