### PR TITLE
dash(replay): incremental SML merkleRootMNList in the fold self-check

### DIFF
--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -153,6 +153,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <set>
 #include <span>
 #include <string>
 #include <utility>
@@ -479,6 +480,7 @@ public:
         m_network                = std::move(network);
         m_poisoned               = false;
         m_poison_reason.clear();
+        reset_sml_cache();
     }
 
     // ── Accessors ────────────────────────────────────────────────────────
@@ -530,7 +532,53 @@ public:
 
     /// DIP-4 merkleRootMNList of the CURRENT state — the value the
     /// self-check compares against each block's committed cbTx root.
+    ///
+    /// INCREMENTAL (dashd CDeterministicMNListDiff parity). The profiled
+    /// dominant fold cost was rebuilding ALL ~4900 CSimplifiedMNListEntry,
+    /// serializing+SHA256d'ing each leaf, sorting and merkling the whole tree
+    /// EVERY block. dashd instead caches each CDeterministicMN's SML entry
+    /// hash and re-hashes only the entries a diff actually changed. This
+    /// mirrors that:
+    ///   • m_leaf_hash_cache — per-proTxHash CalcHash, invalidated ONLY for
+    ///     entries whose SML-serialized fields changed this block. The
+    ///     mutation sites that touch an SML field call mark_sml_dirty; the
+    ///     ones that do NOT (nLastPaidHeight/nConsecutivePayments in pass 5,
+    ///     the nPoSePenalty decrement in pass 2, a punish that does not cross
+    ///     into a ban) never dirty — those fields are not under CalcHash.
+    ///   • m_sml_tree — a cached merkle tree over the memcmp-sorted leaf
+    ///     hashes. On a FIELD-ONLY block (leaf set unchanged, positions
+    ///     stable) each changed leaf updates the O(log N) nodes on its path.
+    /// A STRUCTURAL block (ProRegTx add, collateral remove) shifts every
+    /// sorted position after the mutation, which reshuffles all pairings in
+    /// the positional duplicate-last-on-odd Bitcoin/Dash merkle — O(log N) is
+    /// UNSAFE there, so the tree is rebuilt from the (still-valid) leaf-hash
+    /// cache. HYBRID: incremental path on field-only blocks, recompute from
+    /// cached leaves on structural blocks. The result is byte-identical to
+    /// compute_sml_root_full() at every block (KAT-proven across add / remove
+    /// / isValid-flip / confirmedHash / operator-key change), so the
+    /// self-check against the committed cbTx root is UNCHANGED and still
+    /// poisons on mismatch.
     uint256 compute_sml_root() const
+    {
+        if (m_entries.empty()) {
+            m_sml_tree.clear();
+            m_sml_sorted_protx.clear();
+            m_sml_tree_valid      = true;
+            m_sml_structure_dirty = false;
+            m_sml_dirty_leaves.clear();
+            return uint256::ZERO;
+        }
+        if (!m_sml_tree_valid || m_sml_structure_dirty)
+            rebuild_sml_tree();
+        else if (!m_sml_dirty_leaves.empty())
+            apply_sml_field_updates();
+        return m_sml_tree.back().front();
+    }
+
+    /// Reference FULL recompute — the pre-incremental path, kept as the KAT
+    /// oracle (the incremental root MUST equal this at every block) and as a
+    /// cache-independent belt any caller can reach.
+    uint256 compute_sml_root_full() const
     {
         std::vector<vendor::CSimplifiedMNListEntry> ents;
         ents.reserve(m_entries.size());
@@ -538,6 +586,26 @@ public:
             ents.push_back(st.to_sml_entry(protx));
         vendor::CSimplifiedMNList sml(std::move(ents));
         return sml.CalcMerkleRoot();
+    }
+
+    /// TEST-ONLY. Simulate a MISSED SML invalidation: a mutation that changed
+    /// an entry's SML-serialized fields but failed to mark its proTxHash
+    /// dirty. Corrupts the cached leaf so the next compute_sml_root() returns
+    /// a STALE root — the fold self-check then mismatches the committed cbTx
+    /// root and poisons. Proves the incremental path cannot silently serve a
+    /// wrong list. Never called in production.
+    void test_only_corrupt_incremental_cache(const uint256& protx)
+    {
+        (void)compute_sml_root();               // materialise the tree
+        uint256 bogus;
+        auto it = m_leaf_hash_cache.find(protx);
+        if (it != m_leaf_hash_cache.end()) bogus = it->second;
+        bogus.data()[0] ^= 0xff;                // cannot equal a real CalcHash
+        m_leaf_hash_cache[protx] = bogus;
+        // Force a rebuild that REUSES the corrupted cached leaf (present, not
+        // dirty) — models a leaf whose recompute was skipped.
+        m_sml_structure_dirty = true;
+        m_sml_dirty_leaves.clear();
     }
 
     /// dashd CDeterministicMNList::GetMNPayee (deterministicmns.cpp:183-215)
@@ -693,6 +761,7 @@ public:
             const int32_t confs = (H - 1) - st.nRegisteredHeight;
             if (confs >= m_cfg.gates.masternode_min_confirmations) {
                 st.UpdateConfirmedHash(protx, prev_hash);
+                mark_sml_dirty(protx);  // confirmedHash is an SML field
                 ++r.confirmed;
             }
         }
@@ -1053,6 +1122,7 @@ public:
             m_total_registered_count = total_registered;
             m_poisoned               = false;
             m_poison_reason.clear();
+            reset_sml_cache();
             return true;
         } catch (const std::exception& ex) {
             error = std::string("snapshot deserialize failed: ") + ex.what();
@@ -1099,6 +1169,149 @@ private:
     bool        m_poisoned{false};
     std::string m_poison_reason;
 
+    // ─────────────────────────────────────────────────────────────────────
+    // Incremental SML merkle-root cache (see compute_sml_root doc). mutable:
+    // compute_sml_root() is const (external callers hold const refs) but
+    // memoizes; single-io-thread discipline like the rest of the engine — no
+    // locks.
+    // ─────────────────────────────────────────────────────────────────────
+    mutable std::map<uint256, uint256>        m_leaf_hash_cache;   // protx→CalcHash
+    mutable std::vector<uint256>              m_sml_sorted_protx;  // memcmp-sorted keys
+    mutable std::vector<std::vector<uint256>> m_sml_tree;          // [0]=leaves … root
+    mutable bool                              m_sml_tree_valid{false};
+    mutable bool                              m_sml_structure_dirty{true};
+    mutable std::set<uint256>                 m_sml_dirty_leaves;  // field-changed protx
+
+    // dashcore sorts SML entries by proRegTxHash.Compare (memcmp of the raw
+    // 32 bytes) — see vendor/simplifiedmns.hpp CSimplifiedMNList::sort. The
+    // incremental tree MUST use the SAME order or the leaves interleave wrong.
+    static bool protx_memcmp_less(const uint256& a, const uint256& b)
+    {
+        return std::memcmp(a.data(), b.data(), 32) < 0;
+    }
+
+    static uint256 sml_merkle_pair(const uint256& a, const uint256& b)
+    {
+        uint256 out;
+        CHash256()
+            .Write(std::span<const unsigned char>(a.data(), 32))
+            .Write(std::span<const unsigned char>(b.data(), 32))
+            .Finalize(std::span<unsigned char>(out.data(), 32));
+        return out;
+    }
+
+    // Called ONLY at mutation sites that touch an SML-serialized field
+    // (nVersion, confirmedHash, netInfo ip/port, pubKeyOperator, keyIDVoting,
+    // isValid via ban/revive, platformHTTPPort/NodeID). Position unchanged.
+    void mark_sml_dirty(const uint256& protx) { m_sml_dirty_leaves.insert(protx); }
+
+    // The leaf SET changed (add/remove): positions shift → rebuild next compute.
+    void mark_sml_structural() { m_sml_structure_dirty = true; }
+
+    // Fresh list (seed / snapshot load): a proTxHash could even carry
+    // different fields than a prior life, so drop the whole cache.
+    void reset_sml_cache() const
+    {
+        m_leaf_hash_cache.clear();
+        m_sml_sorted_protx.clear();
+        m_sml_tree.clear();
+        m_sml_dirty_leaves.clear();
+        m_sml_tree_valid      = false;
+        m_sml_structure_dirty = true;
+    }
+
+    // Leaf hash for protx, memoized. Recomputes when forced (field changed).
+    const uint256& sml_leaf_hash(const uint256& protx, bool force) const
+    {
+        auto it = m_leaf_hash_cache.find(protx);
+        if (!force && it != m_leaf_hash_cache.end()) return it->second;
+        const uint256 h = m_entries.at(protx).to_sml_entry(protx).CalcHash();
+        return m_leaf_hash_cache[protx] = h;
+    }
+
+    // Standard Bitcoin/Dash SHA256d-pairwise levels, duplicate-last-on-odd —
+    // byte-identical to vendor compute_merkle_root_local, but every level is
+    // KEPT so a field-only update can walk the path.
+    void build_sml_levels(std::vector<uint256> leaves) const
+    {
+        m_sml_tree.clear();
+        m_sml_tree.push_back(std::move(leaves));
+        while (m_sml_tree.back().size() > 1) {
+            const std::vector<uint256>& cur = m_sml_tree.back();
+            const size_t sz = cur.size();
+            std::vector<uint256> next;
+            next.reserve((sz + 1) / 2);
+            for (size_t i = 0; i < sz; i += 2) {
+                const uint256& a = cur[i];
+                const uint256& b = (i + 1 < sz) ? cur[i + 1] : cur[i];
+                next.push_back(sml_merkle_pair(a, b));
+            }
+            m_sml_tree.push_back(std::move(next));
+        }
+    }
+
+    // Full rebuild from m_entries: re-sort keys (memcmp), recompute dirty /
+    // absent leaves (reuse the rest from cache), rebuild every tree level.
+    void rebuild_sml_tree() const
+    {
+        m_sml_sorted_protx.clear();
+        m_sml_sorted_protx.reserve(m_entries.size());
+        for (const auto& [protx, st] : m_entries)
+            m_sml_sorted_protx.push_back(protx);
+        std::sort(m_sml_sorted_protx.begin(), m_sml_sorted_protx.end(),
+                  protx_memcmp_less);
+
+        std::vector<uint256> leaves;
+        leaves.reserve(m_sml_sorted_protx.size());
+        for (const uint256& protx : m_sml_sorted_protx) {
+            const bool force = m_sml_dirty_leaves.count(protx) != 0;
+            leaves.push_back(sml_leaf_hash(protx, force));
+        }
+        build_sml_levels(std::move(leaves));
+        m_sml_tree_valid      = true;
+        m_sml_structure_dirty = false;
+        m_sml_dirty_leaves.clear();
+    }
+
+    // Field-only update: same leaf set / positions, some leaf hashes changed.
+    // Recompute each dirty leaf, then propagate ONLY the affected O(log N)
+    // path nodes up the cached tree (dedup shared ancestors). If a dirty
+    // proTxHash is somehow absent (should be impossible on the field-only
+    // path) fall back to a full rebuild — never serve a stale root.
+    void apply_sml_field_updates() const
+    {
+        std::set<size_t> dirty_idx;
+        for (const uint256& protx : m_sml_dirty_leaves) {
+            auto lo = std::lower_bound(m_sml_sorted_protx.begin(),
+                                       m_sml_sorted_protx.end(), protx,
+                                       protx_memcmp_less);
+            if (lo == m_sml_sorted_protx.end() || *lo != protx) {
+                m_sml_structure_dirty = true;
+                rebuild_sml_tree();
+                return;
+            }
+            const size_t idx =
+                static_cast<size_t>(lo - m_sml_sorted_protx.begin());
+            m_sml_tree[0][idx] = sml_leaf_hash(protx, /*force=*/true);
+            dirty_idx.insert(idx);
+        }
+        for (size_t level = 0; level + 1 < m_sml_tree.size(); ++level) {
+            const std::vector<uint256>& cur = m_sml_tree[level];
+            const size_t sz = cur.size();
+            std::set<size_t> next_dirty;
+            for (size_t idx : dirty_idx) {
+                const size_t pidx  = idx / 2;
+                const size_t left  = pidx * 2;
+                const size_t right = (left + 1 < sz) ? left + 1 : left;
+                m_sml_tree[level + 1][pidx] =
+                    sml_merkle_pair(cur[left], cur[right]);
+                next_dirty.insert(pidx);
+            }
+            dirty_idx = std::move(next_dirty);
+        }
+        m_sml_dirty_leaves.clear();
+    }
+
     void poison(const std::string& why)
     {
         m_poisoned      = true;
@@ -1111,6 +1324,9 @@ private:
         if (it == m_entries.end()) return;
         m_collateral_index.erase(it->second.collateralOutpoint);
         m_entries.erase(it);
+        m_leaf_hash_cache.erase(protx);   // proTxHash is never reused
+        m_sml_dirty_leaves.erase(protx);  // leaf no longer exists
+        mark_sml_structural();            // a leaf left the sorted set
     }
 
     /// dashd CompareByLastPaid_GetHeight (deterministicmns.cpp:157-166),
@@ -1214,6 +1430,7 @@ private:
 
         m_collateral_index[st.collateralOutpoint] = proTxHash;
         m_entries[proTxHash] = std::move(st);
+        mark_sml_structural();  // a new leaf enters the sorted set
         ++m_total_registered_count;
         ++r.registered;
         if (m_cfg.debug_logs) {
@@ -1268,6 +1485,7 @@ private:
                 }
             }
         }
+        mark_sml_dirty(p.proTxHash);  // netInfo/platform, and Revive flips isValid
         ++r.updated;
         return {};
     }
@@ -1307,6 +1525,7 @@ private:
         }
         st.keyIDVoting  = p.keyIDVoting;
         st.scriptPayout = p.scriptPayout;
+        mark_sml_dirty(p.proTxHash);  // keyIDVoting (SML); key-change reset+ban too
         ++r.updated;
         return {};
     }
@@ -1329,6 +1548,7 @@ private:
         st.BanIfNotBanned(H);
         st.nRevocationReason = p.nReason;
         if (!was_banned) ++r.banned;
+        mark_sml_dirty(p.proTxHash);  // operator fields reset + isValid flip
         ++r.revoked;
         return {};
     }
@@ -1439,6 +1659,7 @@ private:
         ++r.punished;
         if (!st.IsBanned() && st.nPoSePenalty >= max_penalty) {
             st.BanIfNotBanned(H);
+            mark_sml_dirty(protx);  // isValid flips false; penalty alone is NOT SML
             ++r.banned;
             if (m_cfg.debug_logs) {
                 LOG_INFO << "[DML-FOLD] h=" << H << " MN "

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -1595,3 +1595,256 @@ TEST(DashReplayFoldOperatorSplit, PartialOperatorRewardMissingOwnerScriptPoisons
     ASSERT_FALSE(r.ok) << "partial split with no owner output MUST poison";
     EXPECT_NE(r.error.find("PAYEE MISMATCH"), std::string::npos) << r.error;
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// INCREMENTAL SML MERKLE-ROOT KATs
+//
+// The incremental root (per-proTxHash CalcHash cache + cached merkle tree,
+// hybrid path/rebuild — replay_fold_engine.hpp compute_sml_root) MUST equal
+// the cache-independent full recompute (compute_sml_root_full) at EVERY
+// block, and the fold self-check MUST still poison when the incremental path
+// is wrong. The whole existing synthetic + real suite above already folds
+// through the incremental path (every self-check passes only if incremental
+// == committed); these add the EXPLICIT incremental == full equality and the
+// missed-invalidation poison property.
+// ════════════════════════════════════════════════════════════════════════
+
+// Root-axis-isolating config: folds enabled from h=1, payee cross-check OFF
+// (enforcement height pushed above every test height) so the UNCONDITIONAL
+// merkleRootMNList self-check is the only thing under test — no coinbase
+// payout scaffolding needed. v19/mn_rr on from h=1 like synth_cfg.
+static FoldConfig inc_cfg()
+{
+    FoldConfig cfg;
+    cfg.enabled = true;
+    cfg.gates.dip0003_height             = 1;
+    cfg.gates.dip0003_enforcement_height = 100000000; // payee axis dormant
+    cfg.gates.v19_height                 = 1;
+    cfg.gates.mn_rr_height               = 1;
+    return cfg;
+}
+
+static MutableTransaction spend_collateral_tx(const TxPrevOut& outpoint)
+{
+    MutableTransaction spend;
+    spend.version = 1;
+    TxIn in;
+    in.prevout  = outpoint;
+    in.sequence = 0xffffffff;
+    spend.vin.push_back(in);
+    return spend;
+}
+
+// A multi-block window that exercises, with the incremental root proven equal
+// to the full recompute AND to an independently hand-built root at each step:
+//   • ProRegTx add (h=101, h=102) — new leaves shift sorted positions
+//   • ProUpRevTx revoke (h=103)   — ResetOperatorFields + ban → isValid false
+//   • ProUpRegTx operator-key change (h=104) — reset + ban + new keys
+//   • collateral spend remove (h=105, h=106) — leaves shift again
+TEST(DashReplayFoldIncremental, WindowIncrementalEqualsFullEqualsHandBuilt)
+{
+    DmlFoldEngine eng(inc_cfg());
+    eng.seed({}, 0, 100, raw256(9));
+    EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+    EXPECT_EQ(eng.compute_sml_root(), uint256::ZERO); // empty list
+
+    // ── h=101: register a, b, c ─────────────────────────────────────────
+    auto pa = make_proreg(1), pb = make_proreg(2), pc = make_proreg(3);
+    auto txa = make_special_tx(1, pa, 1);
+    auto txb = make_special_tx(1, pb, 2);
+    auto txc = make_special_tx(1, pc, 3);
+    const uint256 ha = tx_hash_of(txa), hb = tx_hash_of(txb), hc = tx_hash_of(txc);
+    CSimplifiedMNListEntry ea = expected_entry_of(pa, ha);
+    CSimplifiedMNListEntry eb = expected_entry_of(pb, hb);
+    CSimplifiedMNListEntry ec = expected_entry_of(pc, hc);
+    uint256 root1 = root_of({ea, eb, ec});
+    {
+        auto r = eng.fold_block(make_block(101, raw256(9), root1, {txa, txb, txc}),
+                                101);
+        ASSERT_TRUE(r.ok) << r.error;
+        EXPECT_EQ(r.computed_root, root1);
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+        EXPECT_EQ(eng.compute_sml_root(), root1);
+    }
+
+    // ── h=102: register d, e (positions shift) ──────────────────────────
+    auto pd = make_proreg(4), pe = make_proreg(5);
+    auto txd = make_special_tx(1, pd, 4);
+    auto txe = make_special_tx(1, pe, 5);
+    const uint256 hd = tx_hash_of(txd), he = tx_hash_of(txe);
+    CSimplifiedMNListEntry ed = expected_entry_of(pd, hd);
+    CSimplifiedMNListEntry ee = expected_entry_of(pe, he);
+    uint256 root2 = root_of({ea, eb, ec, ed, ee});
+    {
+        auto r = eng.fold_block(make_block(102, raw256(10), root2, {txd, txe}), 102);
+        ASSERT_TRUE(r.ok) << r.error;
+        EXPECT_EQ(r.computed_root, root2);
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+        EXPECT_EQ(eng.compute_sml_root(), root2);
+    }
+
+    // ── h=103: ProUpRevTx revoke c → reset + ban (isValid flips false) ──
+    CProUpRevTx rev;
+    rev.nVersion  = ProTxVersion::BASIC_BLS;
+    rev.proTxHash = hc;
+    rev.nReason   = CProUpRevTx::REASON_COMPROMISED_KEYS;
+    auto revtx = make_special_tx(4, rev, 6);
+    CSimplifiedMNListEntry ec2;                 // hand-built revoked entry
+    ec2.nVersion     = ProTxVersion::LEGACY_BLS; // ResetOperatorFields floor
+    ec2.proRegTxHash = hc;
+    ec2.keyIDVoting  = pc.keyIDVoting;
+    ec2.isValid      = false;
+    uint256 root3 = root_of({ea, eb, ec2, ed, ee});
+    {
+        auto r = eng.fold_block(make_block(103, raw256(11), root3, {revtx}), 103);
+        ASSERT_TRUE(r.ok) << r.error;
+        EXPECT_EQ(r.revoked, 1u);
+        EXPECT_EQ(r.computed_root, root3);
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+        EXPECT_EQ(eng.compute_sml_root(), root3);
+    }
+
+    // ── h=104: ProUpRegTx operator-key change on a → reset + ban + keys ─
+    CProUpRegTx upr;
+    upr.nVersion       = ProTxVersion::BASIC_BLS;
+    upr.proTxHash      = ha;
+    upr.pubKeyOperator = seq_array<48>(0xB0);
+    upr.keyIDVoting    = raw160(0xB4);
+    upr.scriptPayout.m_data = script_bytes(0xB8);
+    upr.vchSig.assign(8, 0xB);
+    auto uprtx = make_special_tx(3, upr, 7);
+    CSimplifiedMNListEntry ea2;                  // hand-built key-changed entry
+    ea2.nVersion       = ProTxVersion::BASIC_BLS; // never downgraded below basic
+    ea2.proRegTxHash   = ha;
+    ea2.netAddress     = {};                      // reset empties netInfo
+    ea2.netPort        = 0;
+    ea2.pubKeyOperator = upr.pubKeyOperator;
+    ea2.keyIDVoting    = upr.keyIDVoting;
+    ea2.isValid        = false;                   // banned until a ProUpServTx
+    ea2.nType          = MnType::REGULAR;
+    uint256 root4 = root_of({ea2, eb, ec2, ed, ee});
+    {
+        auto r = eng.fold_block(make_block(104, raw256(12), root4, {uprtx}), 104);
+        ASSERT_TRUE(r.ok) << r.error;
+        EXPECT_EQ(r.banned, 1u);
+        EXPECT_EQ(r.computed_root, root4);
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+        EXPECT_EQ(eng.compute_sml_root(), root4);
+    }
+
+    // ── h=105: collateral-spend e (remove; positions shift) ─────────────
+    {
+        auto spend = spend_collateral_tx(pe.collateralOutpoint);
+        uint256 root5 = root_of({ea2, eb, ec2, ed});
+        auto r = eng.fold_block(make_block(105, raw256(13), root5, {spend}), 105);
+        ASSERT_TRUE(r.ok) << r.error;
+        EXPECT_EQ(r.collateral_spent, 1u);
+        EXPECT_EQ(eng.find(he), nullptr);
+        EXPECT_EQ(r.computed_root, root5);
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+        EXPECT_EQ(eng.compute_sml_root(), root5);
+    }
+
+    // ── h=106: collateral-spend a (remove the banned, key-changed leaf) ─
+    {
+        auto spend = spend_collateral_tx(pa.collateralOutpoint);
+        uint256 root6 = root_of({eb, ec2, ed});
+        auto r = eng.fold_block(make_block(106, raw256(14), root6, {spend}), 106);
+        ASSERT_TRUE(r.ok) << r.error;
+        EXPECT_EQ(r.collateral_spent, 1u);
+        EXPECT_EQ(eng.find(ha), nullptr);
+        EXPECT_EQ(r.computed_root, root6);
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+        EXPECT_EQ(eng.compute_sml_root(), root6);
+    }
+}
+
+// Real mainnet, large N (~2972 / ~4900): the incremental root equals the full
+// recompute across the case-D PoSe BAN (isValid flip false) at h=2516412 and
+// the REVIVE (isValid flip true) + confirmedHash + quiet sequence at
+// h=2516756..2516760 — the demanding window the port targets.
+TEST(DashReplayFoldIncremental, RealCaseDBanIncrementalEqualsFull)
+{
+    auto fx  = parse_prestate(kDashReplayPrestate2516411);
+    auto eng = seed_from_fixture(fx);
+    EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+
+    auto qf = parse_quorum(kDashReplayQuorum2516412);
+    const uint256 quorum_hash = from_display(qf.quorum_hash_display.c_str());
+    eng.set_members_fn([&](uint8_t llmq_type, const uint256& qh)
+                           -> std::optional<std::vector<uint256>> {
+        if (llmq_type == qf.llmq_type && qh == quorum_hash) return qf.members;
+        return std::nullopt;
+    });
+
+    auto blk = parse_block(kDashReplayBlock2516412);
+    auto r   = eng.fold_block(blk, 2516412);
+    ASSERT_TRUE(r.ok) << r.error;
+    EXPECT_EQ(r.banned, 1u);
+    EXPECT_EQ(r.computed_root.GetHex(), kRoot2516412);
+    EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+    EXPECT_EQ(eng.compute_sml_root().GetHex(), kRoot2516412);
+}
+
+TEST(DashReplayFoldIncremental, RealReviveAndQuietSequenceIncrementalEqualsFull)
+{
+    auto fx  = parse_prestate(kDashReplayPrestate2516755);
+    auto eng = seed_from_fixture(fx);
+    EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+
+    auto r = eng.fold_block(parse_block(kDashReplayBlock2516756), 2516756);
+    ASSERT_TRUE(r.ok) << r.error;
+    EXPECT_EQ(r.revived, 1u);
+    EXPECT_EQ(r.computed_root.GetHex(), kRoot2516756);
+    EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full());
+
+    const char* seq[] = {kDashReplayBlock2516757, kDashReplayBlock2516758,
+                         kDashReplayBlock2516759, kDashReplayBlock2516760};
+    uint32_t h = 2516757;
+    for (const char* bh : seq) {
+        auto rr = eng.fold_block(parse_block(bh), h);
+        ASSERT_TRUE(rr.ok) << "h=" << h << ": " << rr.error;
+        EXPECT_EQ(eng.compute_sml_root(), eng.compute_sml_root_full()) << "h=" << h;
+        EXPECT_EQ(rr.computed_root.GetHex(), kRoot2516756) << "h=" << h;
+        ++h;
+    }
+}
+
+// POISON: a deliberately-wrong incremental invalidation (a mutation that
+// changed an entry's SML fields but failed to mark its proTxHash dirty) makes
+// compute_sml_root() return a STALE root; the self-check then MISMATCHES the
+// committed cbTx root and HARD-STOPS. Proves the incremental path can never
+// silently serve a wrong list — a missed invalidation is fail-CLOSED.
+TEST(DashReplayFoldIncremental, MissedInvalidationPoisonsAtSelfCheck)
+{
+    auto fx  = parse_prestate(kDashReplayPrestate2516755);
+    auto eng = seed_from_fixture(fx);
+    ASSERT_TRUE(eng.fold_block(parse_block(kDashReplayBlock2516756), 2516756).ok);
+    EXPECT_EQ(eng.compute_sml_root().GetHex(), kRoot2516756);
+
+    // Pick a long-confirmed MN (confirmedHash already set ⇒ pass 1 will not
+    // re-mark it, and the quiet block 2516757 does not otherwise touch it).
+    uint256 victim;
+    for (const auto& [protx, st] : eng.entries()) {
+        if (!st.confirmedHash.IsNull()) { victim = protx; break; }
+    }
+    ASSERT_FALSE(victim.IsNull());
+
+    // Simulate the missed invalidation.
+    eng.test_only_corrupt_incremental_cache(victim);
+
+    // The incremental root now diverges from the truth (full recompute).
+    EXPECT_NE(eng.compute_sml_root(), eng.compute_sml_root_full());
+
+    // Folding the next (correct) block: the stale incremental root != the
+    // block's committed cbTx root ⇒ HARD STOP, engine poisoned.
+    auto r = eng.fold_block(parse_block(kDashReplayBlock2516757), 2516757);
+    EXPECT_FALSE(r.ok);
+    EXPECT_TRUE(eng.poisoned());
+    EXPECT_NE(r.error.find("ROOT MISMATCH"), std::string::npos) << r.error;
+
+    // Sticky: no further fold is accepted after poison.
+    auto r2 = eng.fold_block(parse_block(kDashReplayBlock2516758), 2516758);
+    EXPECT_FALSE(r2.ok);
+    EXPECT_NE(r2.error.find("POISONED"), std::string::npos) << r2.error;
+}


### PR DESCRIPTION
## What

Port dashd's incremental SML `merkleRootMNList` into the daemonless fold self-check.

The profiled dominant cost of the full-history fold was `DmlFoldEngine::compute_sml_root` (`replay_fold_engine.hpp`) rebuilding **all ~4900** `CSimplifiedMNListEntry`, serializing + SHA256d-hashing each leaf, sorting and merkling the whole tree on **every block**, driven from the per-block `on_folded` self-check.

dashd's `CDeterministicMN` caches its SML entry hash and `CDeterministicMNListDiff` re-applies only changed entries. This mirrors that.

## How

Two-level cache on the fold engine's SML view:

- **`m_leaf_hash_cache`** (`proTxHash -> CalcHash`) invalidated **only** at the mutation sites that touch an SML-serialized field:
  - `confirmedHash` (pass 1)
  - `netInfo` / platform fields / `Revive` isValid flip (ProUpServTx)
  - `keyIDVoting` + operator-key reset/ban (ProUpRegTx)
  - operator-field reset + ban (ProUpRevTx)
  - the PoSe punish that **crosses into a ban** (isValid flip)
  - structural add (ProRegTx) / remove (collateral replace + collateral spend) mark the set dirty

  The `DecreaseScores` pass and the `nLastPaidHeight` / `nConsecutivePayments` payee bookkeeping **never** dirty — those fields are not under `CalcHash`.

- **`m_sml_tree`**, a cached merkle tree over the memcmp-sorted leaf hashes. On a field-only block (leaf set unchanged, positions stable) each changed leaf updates the **O(log N)** nodes on its path.

**Merkle: hybrid, not pure O(log N).** A structural block shifts every sorted position after the mutation, which reshuffles all pairings in the positional duplicate-last-on-odd Bitcoin/Dash merkle, so an O(log N) path update is **unsafe** across structural shifts. The tree is therefore **rebuilt from the (still-valid) leaf-hash cache** on structural blocks, and **path-updated** on field-only blocks. The leaf-hash cache — the dominant cost — is reused in both.

## Safety

- The self-check still compares the incrementally-maintained root to the block's committed cbTx `merkleRootMNList` and poisons on mismatch — **unchanged**.
- `compute_sml_root_full()` retains the cache-independent full recompute as the oracle.
- A missed invalidation is **fail-closed**: it can only make the incremental root diverge from the committed root, which hard-stops the fold; it can never serve a wrong list silently.
- BLS-agnostic change (SML `CalcHash` is SHA256d over opaque bytes).

## Tests (`test_dash_replay_fold`, target `test_dash_mn_state`)

- `WindowIncrementalEqualsFullEqualsHandBuilt` — synthetic window exercising ProRegTx add, ProUpRevTx revoke, operator-key change, two collateral spends; incremental root == full recompute == independently hand-built root at every block.
- `RealCaseDBanIncrementalEqualsFull` (h=2516412, ~2972 MNs, isValid flip false) and `RealReviveAndQuietSequenceIncrementalEqualsFull` (h=2516756..2516760, ~4900 MNs, revive isValid flip true + confirmedHash + quiet) — incremental == full on real mainnet bytes.
- `MissedInvalidationPoisonsAtSelfCheck` — a deliberately-stale cache yields `ROOT MISMATCH` and a sticky HARD STOP.

The whole pre-existing synthetic + real fold suite folds through the incremental path unchanged (134 passed / 1 env-gated skip). Regression suites green: `simplifiedmns` (10), `quorum_root` (11), `conformance` (56), `smldiff` (6), `sml_simd_sha256` (1). Built `C2POOL_DASH_BLS=ON`; dashbls link guard PASS.

## Base

Stacked on `integrator/dashd-cut-simd-sha256` (@aa0b3e2d), which sits on the combined `integrator/dashd-cut-combined-fetch-fold` (@8480d28e).

DRAFT — do not merge; review only.
