### PR TITLE
DASH #154: incremental leaf-hash merkle cache for replay-fold self-check (CPU-side dashd-parity port, reward-safe)

### DIFF
--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -135,6 +135,7 @@
 #include <impl/dash/coin/vendor/llmq_commitment.hpp>
 #include <impl/dash/coin/vendor/providertx.hpp>
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/vendor/incremental_sml_merkle.hpp>
 #include <impl/bitcoin_family/coin/base_transaction.hpp>
 
 #include <core/hash.hpp>
@@ -146,6 +147,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cstdint>
 #include <cstring>
 #include <fstream>
@@ -452,6 +454,9 @@ public:
         m_network                = std::move(network);
         m_poisoned               = false;
         m_poison_reason.clear();
+        // The held list was replaced wholesale — the incremental merkle cache's
+        // diff base is gone, so drop it. The next fold rebuilds it in full.
+        m_sml_cache.reset();
     }
 
     // ── Accessors ────────────────────────────────────────────────────────
@@ -503,6 +508,13 @@ public:
 
     /// DIP-4 merkleRootMNList of the CURRENT state — the value the
     /// self-check compares against each block's committed cbTx root.
+    ///
+    /// NAIVE full recompute: rebuilds the whole ~4900-leaf tree from scratch.
+    /// Kept as a PURE function (no cache) for the one-shot re-derivations that
+    /// are NOT the per-block hotspot — the publish-gate G6
+    /// (replay_payee_publish.hpp), the mn_diff_store reconstruct verify, the
+    /// prestate cross-check — and as the correctness oracle the incremental
+    /// path is proven against (KAT + the debug assert below).
     uint256 compute_sml_root() const
     {
         std::vector<vendor::CSimplifiedMNListEntry> ents;
@@ -511,6 +523,37 @@ public:
             ents.push_back(st.to_sml_entry(protx));
         vendor::CSimplifiedMNList sml(std::move(ents));
         return sml.CalcMerkleRoot();
+    }
+
+    /// THE per-block hotspot, incrementalised (task #154). Same value as
+    /// compute_sml_root() — byte-identical by construction — but reusing the
+    /// leaf hashes and internal merkle nodes the block did not disturb, so a
+    /// payment-rotation-only block (the overwhelming majority) hashes NOTHING
+    /// and a block that touches a handful of SML entries re-hashes only those
+    /// leaves plus the O(k·log n) internal nodes on their root-paths. This is
+    /// the routine fold_block's self-check calls; the naive one is the oracle.
+    ///
+    /// The cache maintains its own diff base, so this MUST be driven in strict
+    /// cursor order (which fold_block is) and re-seeded via reset() whenever
+    /// the held list is replaced wholesale (seed()/load_snapshot() do this).
+    uint256 compute_sml_root_incremental()
+    {
+        std::vector<vendor::CSimplifiedMNListEntry> ents;
+        ents.reserve(m_entries.size());
+        for (const auto& [protx, st] : m_entries)
+            ents.push_back(st.to_sml_entry(protx));
+        const uint256 root = m_sml_cache.update(std::move(ents));
+#ifndef NDEBUG
+        // Belt-and-suspenders in debug builds: the incremental root MUST equal
+        // the naive full recompute at every block. (In release the fold's own
+        // committed-root compare is the authority and a divergence fails
+        // closed — poison + re-seed — so this assert is a developer tripwire,
+        // not the production guard.)
+        assert(root == compute_sml_root()
+               && "task#154: incremental merkleRootMNList diverged from the "
+                  "naive full recompute — reward-path hazard");
+#endif
+        return root;
     }
 
     /// dashd CDeterministicMNList::GetMNPayee (deterministicmns.cpp:183-215)
@@ -752,7 +795,7 @@ public:
         // this fold must produce. Equality here is the whole point of
         // replay: a wrong fold rule, wrong body or wrong seed HARD-STOPS at
         // the named height instead of serving wrong bytes.
-        r.computed_root = compute_sml_root();
+        r.computed_root = compute_sml_root_incremental();
         if (r.computed_root != r.committed_root) {
             r.error = "DML FOLD ROOT MISMATCH at h=" + std::to_string(height)
                     + ": folded merkleRootMNList " + r.computed_root.GetHex()
@@ -936,6 +979,10 @@ public:
             m_total_registered_count = total_registered;
             m_poisoned               = false;
             m_poison_reason.clear();
+            // Resumed from a snapshot: the held list is a fresh wholesale load,
+            // so the incremental merkle cache's diff base does not apply. Drop
+            // it; the first post-resume fold rebuilds it in full.
+            m_sml_cache.reset();
             return true;
         } catch (const std::exception& ex) {
             error = std::string("snapshot deserialize failed: ") + ex.what();
@@ -973,6 +1020,11 @@ private:
     MembersFn  m_members_fn;
 
     Entries m_entries;
+    // task #154 — the per-block merkleRootMNList self-check's incremental
+    // leaf-hash + tree cache. Diff base is m_entries; kept in sync by driving
+    // it only through compute_sml_root_incremental() in cursor order, and
+    // reset() on any wholesale state replacement (seed/load_snapshot).
+    vendor::IncrementalSmlMerkle m_sml_cache;
     std::map<bitcoin_family::coin::TxPrevOut, uint256, ReplayOutpointLess>
         m_collateral_index;
     uint64_t    m_total_registered_count{0};

--- a/src/impl/dash/coin/vendor/incremental_sml_merkle.hpp
+++ b/src/impl/dash/coin/vendor/incremental_sml_merkle.hpp
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ─────────────────────────────────────────────────────────────────────────
+// task #154 — incremental merkleRootMNList cache for the DASH replay fold.
+//
+// THE PROBLEM. The daemonless replay fold advances the deterministic
+// masternode list block-by-block and, as a reward-safe self-check, recomputes
+// merkleRootMNList every block and compares it to the block's committed CbTx
+// root (replay_fold_engine.hpp fold_block). The naive recompute
+// (CSimplifiedMNList::CalcMerkleRoot) rebuilds the WHOLE ~4900-leaf tree from
+// scratch on EVERY block:
+//     * ~4900 leaf hashes  — CalcHash() serialize+SHA256d of each MN entry;
+//     * ~4900 internal pair hashes — the SHA256d merkle tree.
+// A DIP3→tip fold is ~1.5M blocks, so that is ~1.5M × ~9800 SHA256d ≈ 1.4e10
+// hashings — the dominant cost that makes the fold take ~2 days versus dashd's
+// <12 h genesis→tip WITH full block validation.
+//
+// WHY dashd IS FAST (the ported insight). dashd does NOT recompute the merkle
+// every block. Its simplified-MN entry (CDeterministicMN::to_sml_entry,
+// deterministicmns.cpp) is built ONLY from consensus-committed fields —
+// proRegTxHash, confirmedHash, netInfo, pubKeyOperator, keyIDVoting, isValid,
+// nType, platform* — and DELIBERATELY EXCLUDES nLastPaidHeight and
+// nPoSePenalty. The per-block payment rotation and PoSe-score decay bump those
+// two excluded fields, so on the overwhelming majority of blocks the SML is
+// byte-for-byte UNCHANGED and dashd returns a cached root having hashed
+// nothing (CalcCbTxMerkleRootMNList's single-slot cache + the DMN list's
+// UpdateMN-only-invalidates-if-to_sml_entry-changed guard,
+// deterministicmns.cpp).
+//
+// WHAT THIS CLASS DOES. It ports that invariance into c2pool and takes it one
+// step further to also make the RARE change-blocks cheap:
+//   (1) LEAF-HASH CACHE. Each cached leaf remembers its CSimplifiedMNListEntry
+//       and its CalcHash(). On the next block we diff the incoming entry set
+//       against the cache; a leaf whose SML entry is byte-identical REUSES its
+//       cached hash and is NEVER re-hashed. Payment-rotation-only blocks touch
+//       zero SML entries → zero leaf hashes.
+//   (2) INCREMENTAL TREE. The full pairwise tree (all levels) is cached. When
+//       a block changes the VALUE of k leaves without changing the leaf set
+//       (confirmedHash crossing, ProUpServ/ProUpReg, PoSe ban↔revive isValid
+//       flip — same proRegTxHash, same sorted positions), only the O(k·log n)
+//       internal nodes on the changed leaves' root-paths are recomputed; the
+//       rest of the tree is reused. When the leaf SET changes (ProReg adds,
+//       collateral spend removes — the rarest ops, which shift sorted
+//       positions) the tree is rebuilt from the cached leaf hashes: still no
+//       leaf re-hashing of the ~4900 unchanged entries, only the cheap pair
+//       hashing.
+//
+// HARD CORRECTNESS INVARIANT (reward-safety). The whole point of the fold
+// self-check is to CATCH divergence from consensus; a fast-but-wrong root
+// would serve a forked list. So update() is REQUIRED to return a value
+// byte-identical to CSimplifiedMNList(entries).CalcMerkleRoot() for EVERY
+// block. This is guaranteed structurally — the leaf hashes come from the exact
+// same CalcHash(), the pairing from the exact same merkle_pair_hash(), and the
+// leaf order from the exact same memcmp(proRegTxHash) sort — and is proven by
+// the KAT (test_dash_replay_fold.cpp, IncrementalMerkleCache suite) which
+// recomputes both across a synthetic mutation sequence and asserts equality at
+// every step, plus a debug-build assert in the fold engine. The self-check's
+// committed-root compare remains the final authority: a caching bug fails
+// CLOSED (poison + re-seed), never mis-folds.
+// ─────────────────────────────────────────────────────────────────────────
+
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace vendor {
+
+class IncrementalSmlMerkle
+{
+public:
+    // A cached leaf: the sort key (proRegTxHash), the SML entry it was built
+    // from (for byte-equality-gated reuse), and the cached CalcHash().
+    struct Leaf
+    {
+        uint256                 key;    // proRegTxHash — the merkle sort key
+        CSimplifiedMNListEntry  entry;  // gates reuse: unchanged ⇒ reuse hash
+        uint256                 hash;   // cached CalcHash()
+    };
+
+    // Recompute merkleRootMNList from `entries` (any order), reusing cached
+    // leaf hashes for entries whose SML bytes are unchanged and reusing cached
+    // internal tree nodes wherever the block did not disturb them.
+    //
+    // Return value is byte-identical to
+    //     CSimplifiedMNList(std::move(copy_of_entries)).CalcMerkleRoot()
+    // for every input — see the header invariant.
+    uint256 update(std::vector<CSimplifiedMNListEntry> entries)
+    {
+        // Same total order the naive path sorts by: dashcore's memcmp over the
+        // raw proRegTxHash bytes (little-endian byte order). proRegTxHash is
+        // unique per MN, so this is a strict total order → deterministic.
+        std::sort(entries.begin(), entries.end(),
+            [](const CSimplifiedMNListEntry& a,
+               const CSimplifiedMNListEntry& b) {
+                return keycmp(a.proRegTxHash, b.proRegTxHash) < 0;
+            });
+
+        // Two-pointer merge of the incoming sorted set against the cached
+        // sorted leaves. Classify each key as reused / value-changed / added /
+        // removed, building the new leaf vector and hashing ONLY new or
+        // value-changed entries.
+        std::vector<Leaf>   merged;
+        std::vector<size_t> value_dirty;   // positions in `merged` re-hashed
+                                           // by a same-key VALUE change
+        merged.reserve(entries.size());
+        bool structural = false;           // leaf SET changed (add/remove)
+
+        size_t i = 0;                      // into sorted `entries`
+        size_t j = 0;                      // into cached `m_leaves`
+        while (i < entries.size() || j < m_leaves.size()) {
+            int c;
+            if (i >= entries.size())      c =  1;   // only cached left ⇒ remove
+            else if (j >= m_leaves.size()) c = -1;  // only incoming left ⇒ add
+            else c = keycmp(entries[i].proRegTxHash, m_leaves[j].key);
+
+            if (c < 0) {
+                // Added MN: no cached leaf for this key — must hash.
+                Leaf lf;
+                lf.key   = entries[i].proRegTxHash;
+                lf.entry = entries[i];
+                lf.hash  = entries[i].CalcHash();
+                merged.push_back(std::move(lf));
+                structural = true;
+                ++i;
+            } else if (c > 0) {
+                // Removed MN: cached leaf has no incoming counterpart — drop.
+                structural = true;
+                ++j;
+            } else {
+                // Surviving key. Reuse the cached hash iff the SML entry is
+                // byte-unchanged (the payment-rotation / PoSe-decay case);
+                // otherwise re-hash exactly this one leaf.
+                Leaf lf;
+                lf.key   = entries[i].proRegTxHash;
+                lf.entry = entries[i];
+                if (entries[i] == m_leaves[j].entry) {
+                    lf.hash = m_leaves[j].hash;         // REUSE — no hashing
+                } else {
+                    lf.hash = entries[i].CalcHash();    // value changed
+                    value_dirty.push_back(merged.size());
+                }
+                merged.push_back(std::move(lf));
+                ++i;
+                ++j;
+            }
+        }
+
+        m_leaves = std::move(merged);
+
+        if (m_leaves.empty()) {
+            // CalcMerkleRoot()'s empty convention.
+            m_levels.clear();
+            m_root  = uint256::ZERO;
+            m_valid = true;
+            return m_root;
+        }
+
+        const bool same_shape =
+            m_valid && !structural
+            && !m_levels.empty()
+            && m_levels[0].size() == m_leaves.size();
+
+        if (same_shape) {
+            if (value_dirty.empty()) {
+                // Nothing SML-relevant moved (pure payment rotation / decay):
+                // the root is definitionally unchanged. Zero hashing.
+                return m_root;
+            }
+            // Patch the changed leaf hashes into level 0, then recompute only
+            // the affected root-paths.
+            for (size_t idx : value_dirty)
+                m_levels[0][idx] = m_leaves[idx].hash;
+            recompute_paths(value_dirty);
+        } else {
+            // First fold, or the leaf SET changed: rebuild the tree from the
+            // cached leaf hashes (unchanged leaves still not re-hashed).
+            rebuild_tree();
+        }
+        m_valid = true;
+        return m_root;
+    }
+
+    const uint256& root() const { return m_root; }
+    size_t         size() const { return m_leaves.size(); }
+    bool           valid() const { return m_valid; }
+
+    // Drop all cached state — forces the next update() to rebuild fully. Used
+    // when the fold re-seeds from a snapshot (the held list is replaced
+    // wholesale, so the incremental diff base is gone).
+    void reset()
+    {
+        m_leaves.clear();
+        m_levels.clear();
+        m_root  = uint256::ZERO;
+        m_valid = false;
+    }
+
+private:
+    // dashcore's leaf order: memcmp over the raw 32 bytes.
+    static int keycmp(const uint256& a, const uint256& b)
+    {
+        return std::memcmp(a.data(), b.data(), 32);
+    }
+
+    // Full pairwise tree from the cached leaf hashes. Byte-identical to
+    // CSimplifiedMNList::compute_merkle_root_local: duplicate-last-on-odd,
+    // level by level, via the shared merkle_pair_hash. Populates m_levels
+    // (level 0 = leaf hashes, last level = {root}).
+    void rebuild_tree()
+    {
+        m_levels.clear();
+        std::vector<uint256> cur;
+        cur.reserve(m_leaves.size());
+        for (const auto& lf : m_leaves) cur.push_back(lf.hash);
+        m_levels.push_back(cur);
+
+        while (cur.size() > 1) {
+            const size_t n = cur.size();
+            std::vector<uint256> next;
+            next.reserve((n + 1) / 2);
+            for (size_t k = 0; k < n; k += 2) {
+                const uint256& a = cur[k];
+                const uint256& b = (k + 1 < n) ? cur[k + 1] : cur[k];
+                next.push_back(CSimplifiedMNList::merkle_pair_hash(a, b));
+            }
+            m_levels.push_back(next);
+            cur = std::move(next);
+        }
+        m_root = m_levels.back()[0];
+    }
+
+    // Recompute ONLY the internal nodes on the root-paths of the given (level
+    // 0) dirty leaf indices, reusing every other cached node. The tree shape
+    // is unchanged (same-shape guarantee), so pairing indices match
+    // rebuild_tree exactly — duplicate-last-on-odd included. O(k·log n).
+    void recompute_paths(const std::vector<size_t>& dirty_leaf_idx)
+    {
+        std::set<size_t> dirty(dirty_leaf_idx.begin(), dirty_leaf_idx.end());
+        for (size_t L = 0; L + 1 < m_levels.size(); ++L) {
+            const size_t n = m_levels[L].size();
+            std::set<size_t> parents;
+            for (size_t idx : dirty) {
+                const size_t p  = idx / 2;
+                const size_t li = 2 * p;
+                const size_t ri = (2 * p + 1 < n) ? 2 * p + 1 : 2 * p; // dup-last
+                m_levels[L + 1][p] =
+                    CSimplifiedMNList::merkle_pair_hash(m_levels[L][li],
+                                                        m_levels[L][ri]);
+                parents.insert(p);
+            }
+            dirty = std::move(parents);
+        }
+        m_root = m_levels.back()[0];
+    }
+
+    std::vector<Leaf>                  m_leaves;   // sorted by keycmp ascending
+    std::vector<std::vector<uint256>>  m_levels;   // [0]=leaves … back()={root}
+    uint256                            m_root{uint256::ZERO};
+    bool                               m_valid{false};
+};
+
+} // namespace vendor
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/vendor/simplifiedmns.hpp
+++ b/src/impl/dash/coin/vendor/simplifiedmns.hpp
@@ -82,6 +82,31 @@ namespace dash {
 namespace coin {
 namespace vendor {
 
+// TEST SEAM (task #154 incremental-merkle cache). Two finer-grained counters
+// that measure the ACTUAL SHA256 work, wherever it happens — the naive full
+// recompute AND the incremental cache (incremental_sml_merkle.hpp) bump these
+// SAME sites, so a fold that re-hashes all ~4900 leaves every block and one
+// that re-hashes only the handful that changed produce directly comparable
+// numbers.
+//   * sml_leaf_hash_count() — one bump per CSimplifiedMNListEntry::CalcHash()
+//     (the expensive ~200-byte serialize + SHA256d of a single MN leaf).
+//   * sml_node_hash_count() — one bump per internal merkle pair-hash (the
+//     64-byte SHA256d of two child node hashes).
+// Declared ahead of the entry struct because CalcHash() (a member) bumps the
+// leaf counter. Same single-io-thread discipline as sml_calc_merkle_root_count
+// (declared below): plain uint64, no atomics.
+inline uint64_t& sml_leaf_hash_count()
+{
+    static uint64_t n = 0;
+    return n;
+}
+
+inline uint64_t& sml_node_hash_count()
+{
+    static uint64_t n = 0;
+    return n;
+}
+
 struct CSimplifiedMNListEntry
 {
     static constexpr uint16_t VER_LEGACY_BLS = 1;
@@ -167,6 +192,7 @@ struct CSimplifiedMNListEntry
     // OMITTED, per-entry nVersion-conditional fields are HONOURED.
     uint256 CalcHash() const
     {
+        ++sml_leaf_hash_count();   // #154 seam — one leaf serialize+SHA256d
         ::PackStream s;
         s << proRegTxHash;
         s << confirmedHash;
@@ -291,14 +317,16 @@ public:
 
     size_t size() const { return mnList.size(); }
 
-private:
-    // Standard Bitcoin/Dash SHA256d-pairwise merkle root with
-    // duplicate-last-on-odd. Inlined from
-    // ltc::coin::compute_merkle_root() to keep this header free of
-    // mweb_builder.hpp's btclibs/serialize.h transitive include —
-    // see preamble re landmine #1.
+    // Standard Bitcoin/Dash SHA256d of two 32-byte child node hashes with
+    // duplicate-last-on-odd pairing. Inlined from ltc::coin::compute_merkle_
+    // root() to keep this header free of mweb_builder.hpp's btclibs/serialize.h
+    // transitive include — see preamble re landmine #1. PUBLIC so the
+    // incremental cache (incremental_sml_merkle.hpp) reuses this EXACT routine
+    // — one pairing implementation, byte-identical between the naive and
+    // incremental paths by construction, and one node-hash counting site.
     static uint256 merkle_pair_hash(const uint256& a, const uint256& b)
     {
+        ++sml_node_hash_count();   // #154 seam — one internal pair SHA256d
         uint256 out;
         CHash256()
             .Write(std::span<const unsigned char>(a.data(), 32))
@@ -307,6 +335,7 @@ private:
         return out;
     }
 
+private:
     static uint256 compute_merkle_root_local(std::vector<uint256> hashes)
     {
         if (hashes.empty()) return uint256::ZERO;

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -41,6 +41,7 @@
 #include <impl/dash/coin/vendor/llmq_commitment.hpp>
 #include <impl/dash/coin/vendor/providertx.hpp>
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/vendor/incremental_sml_merkle.hpp>
 #include <impl/dash/coin/transaction.hpp>
 #include <impl/dash/coin/block.hpp>
 
@@ -49,8 +50,10 @@
 #include <core/hash.hpp>
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <iostream>
 #include <map>
 #include <optional>
 #include <sstream>
@@ -1321,4 +1324,269 @@ TEST(DashReplayFoldSynthetic, SnapshotV3FailLoudPaths)
     // A failed load never clobbers existing state.
     EXPECT_EQ(eng.size(), 1u);
     EXPECT_EQ(eng.height(), 100u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// task #154 — INCREMENTAL merkleRootMNList cache KATs.
+//
+// The DASH replay fold recomputes merkleRootMNList every block as a reward-safe
+// self-check. The naive path (CSimplifiedMNList::CalcMerkleRoot) rebuilds the
+// whole ~4900-leaf tree each block; IncrementalSmlMerkle reuses the leaf hashes
+// and internal nodes the block did not disturb. These KATs prove the two
+// deliverables:
+//   (a) THE HARD INVARIANT — for EVERY mutation the incremental root byte-
+//       matches the naive full recompute (a fast-but-wrong root would serve a
+//       forked list). Proven step-by-step over a synthetic mutation sequence.
+//   (b) THE REDUCED HASH COUNT — measured via the shared sml_leaf_hash_count()
+//       / sml_node_hash_count() seams that BOTH paths bump, so the numbers are
+//       directly comparable. A payment-rotation-only block hashes NOTHING; a
+//       block touching k SML entries re-hashes only those k leaves + O(k·log n)
+//       internal nodes, versus the naive ~n leaves + ~n nodes every block.
+// ═══════════════════════════════════════════════════════════════════════════
+
+using dash::coin::vendor::IncrementalSmlMerkle;
+using dash::coin::vendor::sml_leaf_hash_count;
+using dash::coin::vendor::sml_node_hash_count;
+
+namespace {
+
+// Deterministic, well-spread, unique proRegTxHash for a given seed. Spread
+// across all 32 bytes so the memcmp merkle sort interleaves the MNs (a
+// realistic tree, not a degenerate one).
+uint256 incmerkle_protx_of(uint32_t seed)
+{
+    uint256 h;
+    unsigned char* p = h.data();
+    uint64_t x = 0x9E3779B97F4A7C15ull ^ (static_cast<uint64_t>(seed) * 0xD1B54A32D192ED03ull);
+    for (int b = 0; b < 32; ++b) {
+        x ^= x >> 30; x *= 0xBF58476D1CE4E5B9ull;
+        x ^= x >> 27; x *= 0x94D049BB133111EBull;
+        x ^= x >> 31;
+        p[b] = static_cast<unsigned char>(x & 0xFF);
+    }
+    return h;
+}
+
+CSimplifiedMNListEntry incmerkle_mk_entry(uint32_t seed, bool valid = true)
+{
+    CSimplifiedMNListEntry e;
+    e.nVersion      = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    e.proRegTxHash  = incmerkle_protx_of(seed);
+    e.confirmedHash = uint256::ZERO;
+    e.netPort       = static_cast<uint16_t>(9999u);
+    e.isValid       = valid;
+    e.nType         = CSimplifiedMNListEntry::TYPE_REGULAR;
+    // give the operator key deterministic non-zero content so CalcHash is
+    // hashing a realistic ~200-byte leaf.
+    for (size_t i = 0; i < e.pubKeyOperator.size(); ++i)
+        e.pubKeyOperator[i] = static_cast<uint8_t>((seed * 31u + i) & 0xFF);
+    return e;
+}
+
+} // namespace
+
+// The whole point of the fold self-check is to catch divergence from
+// consensus, so the incremental root MUST equal the naive full recompute at
+// EVERY step. Drives a synthetic sequence of MN-list mutations — the exact
+// shapes the fold produces per block — and asserts byte-identical roots while
+// measuring the hash-count reduction.
+TEST(DashReplayFoldIncrementalMerkle, ByteIdenticalRootsAndReducedHashCount)
+{
+    const uint32_t N = 300;
+    std::map<uint32_t, CSimplifiedMNListEntry> state;   // seed -> current SML entry
+    for (uint32_t i = 0; i < N; ++i) state[i] = incmerkle_mk_entry(i, true);
+
+    IncrementalSmlMerkle cache;
+
+    struct StepCost { uint64_t nl, nn, il, in; std::string root; };
+    uint64_t tot_nl = 0, tot_nn = 0, tot_il = 0, tot_in = 0;
+
+    auto entries_of = [&]() {
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(state.size());
+        for (const auto& [k, e] : state) { (void)k; v.push_back(e); }
+        return v;
+    };
+
+    auto step = [&](const char* label) -> StepCost {
+        const std::vector<CSimplifiedMNListEntry> v = entries_of();
+
+        // NAIVE full recompute (the correctness oracle). Its CalcHash /
+        // merkle_pair_hash bump the shared counters.
+        const uint64_t nl0 = sml_leaf_hash_count(), nn0 = sml_node_hash_count();
+        const uint256 rn =
+            CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>(v)).CalcMerkleRoot();
+        const uint64_t nl = sml_leaf_hash_count() - nl0;
+        const uint64_t nn = sml_node_hash_count() - nn0;
+
+        // INCREMENTAL cache — same shared counters.
+        const uint64_t il0 = sml_leaf_hash_count(), in0 = sml_node_hash_count();
+        const uint256 ri = cache.update(v);
+        const uint64_t il = sml_leaf_hash_count() - il0;
+        const uint64_t in = sml_node_hash_count() - in0;
+
+        // THE HARD INVARIANT.
+        EXPECT_EQ(rn.GetHex(), ri.GetHex())
+            << "incremental root diverged from naive recompute at step: " << label;
+
+        tot_nl += nl; tot_nn += nn; tot_il += il; tot_in += in;
+        std::cout << "  [#154 KAT] " << label
+                  << " | naive leaf=" << nl << " node=" << nn
+                  << " | incr leaf=" << il << " node=" << in
+                  << " | root=" << ri.GetHex().substr(0, 16) << "\n";
+        return { nl, nn, il, in, ri.GetHex() };
+    };
+
+    // ── Step 1: cold build (first fold) — every leaf hashed once. ──────────
+    const StepCost s1 = step("cold-build N=300 (structural)");
+    EXPECT_EQ(s1.il, static_cast<uint64_t>(N)) << "cold build must hash all leaves once";
+    EXPECT_EQ(s1.nl, static_cast<uint64_t>(N));
+
+    // ── Step 2: pure payment rotation — nLastPaidHeight/PoSePenalty are NOT
+    // in the SML entry, so the SML is byte-unchanged. ZERO incremental hashes;
+    // naive re-hashes the whole list regardless. This is the dashd invariant. ─
+    const StepCost s2 = step("payment-rotation (SML unchanged)");
+    EXPECT_EQ(s2.il, 0u) << "no SML entry changed -> no leaf may be re-hashed";
+    EXPECT_EQ(s2.in, 0u) << "no SML entry changed -> no internal node may be re-hashed";
+    EXPECT_EQ(s2.nl, static_cast<uint64_t>(N)) << "naive re-hashes everything anyway";
+
+    // ── Step 3: PoSe ban one MN (isValid flip) — 1 leaf changed, same set. ──
+    state[7].isValid = false;
+    const StepCost s3 = step("pose-ban 1 MN (isValid flip, same set)");
+    EXPECT_EQ(s3.il, 1u) << "exactly one leaf changed";
+    EXPECT_GE(s3.in, 1u);
+    EXPECT_LE(s3.in, 12u) << "single-leaf update must be O(log n), not O(n)";
+    EXPECT_LT(s3.in, s3.nn) << "incremental node work must beat the full rebuild";
+
+    // ── Step 4: confirmedHash crosses on three MNs — 3 leaves, same set. ───
+    state[10].confirmedHash = incmerkle_protx_of(900010);
+    state[20].confirmedHash = incmerkle_protx_of(900020);
+    state[30].confirmedHash = incmerkle_protx_of(900030);
+    const StepCost s4 = step("confirmedHash on 3 MNs (same set)");
+    EXPECT_EQ(s4.il, 3u) << "exactly three leaves changed";
+    EXPECT_LE(s4.in, 3u * 12u) << "three O(log n) paths";
+    EXPECT_LT(s4.in, s4.nn);
+
+    // ── Step 5: ProReg adds a new MN (structural, shifts sorted positions). ─
+    state[N] = incmerkle_mk_entry(N, true);
+    const StepCost s5 = step("proreg add 1 MN (structural)");
+    EXPECT_EQ(s5.il, 1u) << "only the new leaf is hashed; all others reused";
+    EXPECT_LT(s5.il, s5.nl) << "naive re-hashes the whole grown list";
+
+    // ── Step 6: collateral spend removes one MN (structural). ──────────────
+    state.erase(50);
+    const StepCost s6 = step("collateral-spend remove 1 MN (structural)");
+    EXPECT_EQ(s6.il, 0u) << "a removal hashes no leaf; survivors reuse cached hashes";
+
+    // ── Step 7: another quiet block — back to zero work. ───────────────────
+    const StepCost s7 = step("quiet block (SML unchanged)");
+    EXPECT_EQ(s7.il, 0u);
+    EXPECT_EQ(s7.in, 0u);
+
+    // ── Aggregate proof of the reduced hash-count. ─────────────────────────
+    std::cout << "  [#154 KAT] TOTAL  naive leaf=" << tot_nl << " node=" << tot_nn
+              << "  |  incr leaf=" << tot_il << " node=" << tot_in << "\n";
+
+    // Steady-state (everything after the unavoidable cold build): incremental
+    // hashed exactly the 5 leaves that actually changed (1+3+1 over steps
+    // 2..7), while naive re-hashed the full list on all six blocks.
+    const uint64_t steady_incr_leaf  = tot_il - s1.il;
+    const uint64_t steady_naive_leaf = tot_nl - s1.nl;
+    EXPECT_EQ(steady_incr_leaf, 5u) << "0+1+3+1+0+0 across steps 2..7";
+    EXPECT_GT(steady_naive_leaf, 1500u) << "naive re-hashes ~N leaves every block";
+    EXPECT_LT(tot_il, tot_nl);
+    EXPECT_LT(tot_in, tot_nn);
+    // Order-of-magnitude reduction overall (dominated by the cold build here;
+    // on a real 1.5M-block fold the cold build is a one-time cost and the
+    // steady-state ratio — 5 vs ~1800 above — is what matters).
+    EXPECT_LT(tot_il * 3, tot_nl) << "incremental leaf hashing is a small fraction of naive";
+
+    // The cache's root reflects the last mutation, and its size tracks the set.
+    EXPECT_EQ(cache.root().GetHex(), s7.root);
+    EXPECT_EQ(cache.size(), state.size());
+}
+
+// reset() drops the diff base so the next update() rebuilds in full — the
+// contract the fold relies on across seed()/load_snapshot() (wholesale state
+// replacement). After a reset the root must still equal the naive recompute of
+// the NEW list, and the rebuild must re-hash every leaf (nothing carried over).
+TEST(DashReplayFoldIncrementalMerkle, ResetForcesFullRebuildAndStaysCorrect)
+{
+    IncrementalSmlMerkle cache;
+
+    std::vector<CSimplifiedMNListEntry> listA;
+    for (uint32_t i = 0; i < 64; ++i) listA.push_back(incmerkle_mk_entry(i));
+    const uint256 rootA_incr = cache.update(listA);
+    const uint256 rootA_naive =
+        CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>(listA)).CalcMerkleRoot();
+    EXPECT_EQ(rootA_incr.GetHex(), rootA_naive.GetHex());
+
+    // A completely different list (as a snapshot resume would install).
+    std::vector<CSimplifiedMNListEntry> listB;
+    for (uint32_t i = 1000; i < 1090; ++i) listB.push_back(incmerkle_mk_entry(i));
+
+    cache.reset();
+    EXPECT_FALSE(cache.valid());
+
+    const uint64_t l0 = sml_leaf_hash_count();
+    const uint256 rootB_incr = cache.update(listB);
+    const uint64_t hashed = sml_leaf_hash_count() - l0;
+    const uint256 rootB_naive =
+        CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>(listB)).CalcMerkleRoot();
+
+    EXPECT_EQ(rootB_incr.GetHex(), rootB_naive.GetHex());
+    EXPECT_EQ(hashed, listB.size()) << "post-reset rebuild re-hashes every leaf";
+    EXPECT_NE(rootB_incr.GetHex(), rootA_incr.GetHex());
+}
+
+// Fuzz-ish invariant sweep: a long pseudo-random walk of adds / removes /
+// value-changes / no-ops, asserting the incremental root byte-matches the
+// naive recompute at every one of many steps. This is the reward-safety net —
+// if any mutation shape produced a divergent root, one of these steps reds.
+TEST(DashReplayFoldIncrementalMerkle, RandomWalkAlwaysMatchesNaive)
+{
+    IncrementalSmlMerkle cache;
+    std::map<uint32_t, CSimplifiedMNListEntry> state;
+    uint32_t next_seed = 0;
+    for (; next_seed < 128; ++next_seed) state[next_seed] = incmerkle_mk_entry(next_seed);
+
+    // Deterministic LCG — reproducible, no external RNG dependency.
+    uint64_t rng = 0xC0FFEEULL;
+    auto nextu = [&]() { rng = rng * 6364136223846793005ULL + 1442695040888963407ULL; return rng >> 33; };
+
+    for (int stepno = 0; stepno < 400; ++stepno) {
+        const uint32_t op = nextu() % 5;
+        if (op == 0) {
+            // add
+            state[next_seed] = incmerkle_mk_entry(next_seed);
+            ++next_seed;
+        } else if (op == 1 && state.size() > 8) {
+            // remove a pseudo-random existing key
+            auto it = state.begin();
+            std::advance(it, static_cast<long>(nextu() % state.size()));
+            state.erase(it);
+        } else if (op == 2 && !state.empty()) {
+            // value-change: flip isValid
+            auto it = state.begin();
+            std::advance(it, static_cast<long>(nextu() % state.size()));
+            it->second.isValid = !it->second.isValid;
+        } else if (op == 3 && !state.empty()) {
+            // value-change: bump confirmedHash
+            auto it = state.begin();
+            std::advance(it, static_cast<long>(nextu() % state.size()));
+            it->second.confirmedHash = incmerkle_protx_of(500000u + stepno);
+        }
+        // op == 4 (and the guarded fall-throughs): no-op quiet block.
+
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(state.size());
+        for (const auto& [k, e] : state) { (void)k; v.push_back(e); }
+
+        const uint256 ri = cache.update(v);
+        const uint256 rn =
+            CSimplifiedMNList(std::vector<CSimplifiedMNListEntry>(v)).CalcMerkleRoot();
+        ASSERT_EQ(ri.GetHex(), rn.GetHex())
+            << "random-walk divergence at step " << stepno
+            << " (op=" << op << ", size=" << state.size() << ")";
+    }
 }


### PR DESCRIPTION
## What

Incremental leaf-hash merkle cache for the DASH replay-fold self-check. The fold's per-block self-check recomputes the full ~4900-leaf `merkleRootMNList` in SHA256 every block (O(n)/block). This ports dashd's invariance so unchanged leaves are never re-hashed.

**This is the CPU-side dashd-parity port for #154.** It stacks with the fetch-routing fix (`fix/bulk-fetch-use-fast-local-primary`) and the SIMD/SHA-NI work (#1288). The routing fix removed the dominant *network* bottleneck (live: 16 -> 415 blk/s on the .191 self-derive once bulk was routed to the fast LAN archival peer). This cache removes the *CPU* merkle cost, which becomes the visible floor once fetch is unblocked (CPU 26% at 415 blk/s, dominated by the full-list recompute), and makes CPU-bound hosts fast too.

## dashd approach ported

dashd `CDeterministicMN::to_sml_entry()` excludes `nLastPaidHeight`/`nPoSePenalty`, so payment rotation leaves the simplified entry byte-unchanged -> cached root, zero hashing. This ports that invariance and extends it: change-blocks recompute only the O(k·log n) affected root paths (value change) or rebuild the tree from cached leaf hashes (add/remove), never re-hashing survivors.

## Files
- `src/impl/dash/coin/vendor/incremental_sml_merkle.hpp` (new, 275) — `IncrementalSmlMerkle`: per-leaf hash cache keyed by `proRegTxHash` + cached pairwise tree; `reset()` for wholesale replacement.
- `src/impl/dash/coin/vendor/simplifiedmns.hpp` (+41) — shared `sml_leaf_hash_count()`/`sml_node_hash_count()` instrumentation seams; `merkle_pair_hash` exposed public-static so the incremental tree reuses the exact pairing routine (byte-identity by construction).
- `src/impl/dash/coin/replay_fold_engine.hpp` (+54) — `m_sml_cache` + `compute_sml_root_incremental()` wired into `fold_block`; naive `compute_sml_root()` retained verbatim as the oracle for G6/`mn_diff_store`/prestate; `#ifndef NDEBUG` assert cross-checks incremental vs naive every block; cache `reset()` on `seed()`/`load_snapshot()`.
- `test/test_dash_replay_fold.cpp` (+268) — KAT `DashReplayFoldIncrementalMerkle`, folded into the allowlisted `test_dash_mn_state` target so CI builds+runs it (avoids the #143 NOT_BUILT trap).

## Reward-safety

- The fold's committed-root compare stays the authority. Any hypothetical cache bug fails **closed** (poison + re-seed), never mis-folds.
- Naive path retained as pure oracle; `#ifndef NDEBUG` cross-check every block.
- Only the self-check root computation is incrementalized; fold mutation rules (`RebuildListFromBlock` port) untouched.

## Proof (KAT independently re-run against real vendored headers)

Roots **byte-identical** at every step; **0 divergences** over a 400-step random add/remove/value-change/no-op walk:
```
[cold-build N=300]    incr leaf=300 node=303 | root=86f4310483cfc715
[payment-rotation]    incr leaf=0   node=0   | root=86f4310483cfc715   (0 hashes)
[pose-ban 1 MN]       incr leaf=1   node=9   | root=f31fe283d382abea   (O(log n))
[confirmedHash on 3]  incr leaf=3   node=22  | root=1c5758efa545acda
[proreg add 1 MN]     incr leaf=1   node=305 | root=e197bc76fd404ae6
[collateral remove 1] incr leaf=0   node=303 | root=d45b4c03a4411062
random-walk: 400 steps, divergences=0
RESULT: ALL CHECKS PASSED
```

## Estimate (honest)

Modeled ~5-6x on the fold's CPU merkle portion (Amdahl-bounded by ~16-17% non-merkle fold work). The *live* dominant win on the .191 derive came from the routing fix, not this — so treat this as the CPU-side complement (CPU-bound hosts + stacking with SIMD), not the live critical-path number. Live DIP3->tip wall-clock with the cache active is the outstanding soak.

Do not self-merge — reward-path, operator tap.
