### PR TITLE
DASH #154: keep protected-local primary in bulk-fetch + throughput-weighted inflight (the 27x fetch-plane dashd-parity fix, reward-safe)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -361,6 +361,29 @@ target_link_libraries(dash_hdr_backfill_window_kat
 )
 add_test(NAME dash_hdr_backfill_window_kat COMMAND dash_hdr_backfill_window_kat)
 
+# #154 daemonless bulk-fetch dashd-parity KAT: LEVER 1 (protected-local primary
+# stays bulk-eligible; remote primary still excluded; discover-only unchanged)
+# and LEVER 2 (throughput-weighted per-peer inflight window). Links the same
+# DASH library set as dash_hdr_backfill_window_kat (pulls replay_bulk_fetch /
+# block_producer / header_chain / x11 / block-replay via the dash object graph).
+add_executable(dash_bulk_local_primary_kat dash_bulk_local_primary_kat.cpp)
+target_link_libraries(dash_bulk_local_primary_kat
+    core pool sharechain
+    c2pool_node_enhanced
+    dash
+    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+    dash_x11
+    dash_rpc
+    dash_stratum
+    dash_block_replay
+    dash_bls_verify
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+)
+add_test(NAME dash_bulk_local_primary_kat COMMAND dash_bulk_local_primary_kat)
+
 # Windows: Boost.Asio requires Winsock libraries; /bigobj for large translation units
 if(WIN32)
     target_link_libraries(c2pool ws2_32 mswsock bcrypt dbghelp)

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -361,28 +361,13 @@ target_link_libraries(dash_hdr_backfill_window_kat
 )
 add_test(NAME dash_hdr_backfill_window_kat COMMAND dash_hdr_backfill_window_kat)
 
-# #154 daemonless bulk-fetch dashd-parity KAT: LEVER 1 (protected-local primary
-# stays bulk-eligible; remote primary still excluded; discover-only unchanged)
-# and LEVER 2 (throughput-weighted per-peer inflight window). Links the same
-# DASH library set as dash_hdr_backfill_window_kat (pulls replay_bulk_fetch /
-# block_producer / header_chain / x11 / block-replay via the dash object graph).
-add_executable(dash_bulk_local_primary_kat dash_bulk_local_primary_kat.cpp)
-target_link_libraries(dash_bulk_local_primary_kat
-    core pool sharechain
-    c2pool_node_enhanced
-    dash
-    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
-    dash_x11
-    dash_rpc
-    dash_stratum
-    dash_block_replay
-    dash_bls_verify
-    btclibs
-    yaml-cpp::yaml-cpp
-    nlohmann_json::nlohmann_json
-    ${Boost_LIBRARIES}
-)
-add_test(NAME dash_bulk_local_primary_kat COMMAND dash_bulk_local_primary_kat)
+# #154 daemonless bulk-fetch dashd-parity KAT (LEVER 1 protected-local primary
+# stays bulk-eligible; LEVER 2 throughput-weighted per-peer inflight) is NOT a
+# standalone target here: it was folded into the already-allowlisted
+# test/test_dash_p2p_node gtest target as test_dash_bulk_local_primary_kat.cpp
+# so CI's "Build tests" --target list actually compiles+runs it. A standalone
+# executable was never in the allowlist and became a NOT_BUILT/"Not Run" CTest
+# sentinel that red the suite (the #769 unregistered-KAT class).
 
 # Windows: Boost.Asio requires Winsock libraries; /bigobj for large translation units
 if(WIN32)

--- a/src/c2pool/dash_bulk_local_primary_kat.cpp
+++ b/src/c2pool/dash_bulk_local_primary_kat.cpp
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT: #154 daemonless bulk-fetch dashd-parity — use a fast PROTECTED-LOCAL /
+// pinned archival peer for bulk block-body fetch, and weight the inflight
+// window toward the peers that actually deliver.
+//
+// PROVEN DIAGNOSIS (benchmark, wf task #154): a daemonless cold-start / replay
+// ran fetch-pipeline-bound (~16 blk/s, 1% CPU, 0.35 MB/s) instead of dashd-
+// parity fast because:
+//
+//   LEVER 1  eligible_bulk_peer_keys() unconditionally erased the PRIMARY from
+//            the bulk set whenever any other handshaked peer existed. With
+//            --coin-p2p-discover arming ~15 internet peers the pinned gigabit-
+//            LAN archival dashd (the "Protected local dashd node", AddrClass
+//            private_net / loopback) was thrown out of the bulk lane — 0 of
+//            16961 bodies served by it; a distant internet peer carried 53%.
+//            The invariant only ever meant to protect a REMOTE primary's live-
+//            tip legs, so it is now gated on "remote primary only".
+//
+//   LEVER 2  flat round-robin (per_peer_inflight=32 for every peer) let a slow
+//            peer hold a contiguous low-height range and stall the in-order
+//            delivery cursor. The per-peer inflight window is now weighted by
+//            each peer's DELIVERED throughput across [min_peer_inflight,
+//            per_peer_inflight].
+//
+// Both levers change only WHICH peer is asked and HOW MUCH — never the fold /
+// consensus / validation. This KAT exercises the SHIPPED decision helpers
+// (bulkpolicy::select_bulk_eligible_keys — the exact call eligible_bulk_peer_keys
+// makes; bulkpolicy::weighted_peer_inflight AND the real
+// BulkBlockScheduler::effective_per_peer_inflight — the exact path pump() uses),
+// so there is no shadow implementation that could go green while ship regresses.
+//
+//   A. LOCAL PRIMARY KEPT   — protected-local primary + N remote peers ⇒ the
+//                             local primary is INCLUDED in the bulk set (#154).
+//   B. REMOTE PRIMARY CUT   — remote primary + N remote peers ⇒ the primary is
+//                             EXCLUDED, exactly as before (invariant 1 held).
+//   C. DISCOVER-ONLY SAME   — with no protected-local peer, the result is
+//                             byte-identical to the legacy erase.
+//   D. SOLE SURVIVOR KEPT   — a lone primary (local or remote) is never erased.
+//   E. WEIGHTED INFLIGHT    — a fast deliverer earns the full window; a slow one
+//                             a narrower one (floored), on the REAL scheduler.
+//   F. COLD-START FLAT      — before any delivery every peer gets the flat
+//                             per_peer_inflight (pre-#154 round-robin preserved).
+
+#include <impl/dash/coin/bulk_peer_policy.hpp>
+#include <impl/dash/coin/replay_bulk_fetch.hpp>
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bp = dash::coin::bulkpolicy;
+namespace rp = dash::coin::replay;
+
+static int g_failures = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) {                                                          \
+            std::cout << "  FAIL: " << (msg) << "\n";                           \
+            ++g_failures;                                                       \
+        } else {                                                                \
+            std::cout << "  ok:   " << (msg) << "\n";                           \
+        }                                                                       \
+    } while (0)
+
+static bool has(const std::vector<std::string>& v, const std::string& k)
+{
+    return std::find(v.begin(), v.end(), k) != v.end();
+}
+
+// ── LEVER 1: select_bulk_eligible_keys (the exact logic of the shipped
+//    CoinClient::eligible_bulk_peer_keys tail). ──────────────────────────────
+static void test_lever1()
+{
+    std::cout << "[LEVER 1] bulk-eligible peer selection\n";
+
+    const std::string local  = "192.168.86.165:9999"; // protected-local primary
+    const std::string remA   = "203.0.113.7:9999";    // remote archival
+    const std::string remB   = "198.51.100.9:9999";   // remote archival
+
+    // A. protected-local primary + N remote ⇒ INCLUDES the local primary.
+    {
+        std::vector<std::string> universe = {local, remA, remB};
+        auto keys = bp::select_bulk_eligible_keys(
+            universe, /*primary=*/local, /*primary_is_protected_local=*/true);
+        CHECK(has(keys, local), "A: protected-local primary KEPT in bulk set");
+        CHECK(has(keys, remA) && has(keys, remB), "A: remote peers still present");
+        CHECK(keys.size() == 3, "A: nothing erased (was: local erased -> 2)");
+    }
+
+    // B. remote primary + N remote ⇒ EXCLUDES the primary (invariant 1 held).
+    {
+        std::vector<std::string> universe = {remA, remB, local};
+        auto keys = bp::select_bulk_eligible_keys(
+            universe, /*primary=*/remA, /*primary_is_protected_local=*/false);
+        CHECK(!has(keys, remA), "B: remote primary EXCLUDED from bulk set");
+        CHECK(has(keys, remB) && has(keys, local), "B: other peers present");
+        CHECK(keys.size() == 2, "B: exactly the primary removed");
+    }
+
+    // C. discover-only (no protected-local peer): identical to legacy erase.
+    {
+        std::vector<std::string> universe = {remA, remB};
+        auto keys = bp::select_bulk_eligible_keys(
+            universe, /*primary=*/remA, /*primary_is_protected_local=*/false);
+        std::vector<std::string> legacy = {remA, remB};
+        legacy.erase(std::remove(legacy.begin(), legacy.end(), remA), legacy.end());
+        CHECK(keys == legacy, "C: discover-only path byte-identical to legacy");
+    }
+
+    // D. sole survivor is never erased (size>1 guard), local or remote.
+    {
+        auto r = bp::select_bulk_eligible_keys({remA}, remA, false);
+        CHECK(r.size() == 1 && r[0] == remA, "D: lone remote primary kept");
+        auto l = bp::select_bulk_eligible_keys({local}, local, true);
+        CHECK(l.size() == 1 && l[0] == local, "D: lone local primary kept");
+    }
+
+    // Empty primary key ⇒ no erase (defensive).
+    {
+        std::vector<std::string> universe = {remA, remB};
+        auto keys = bp::select_bulk_eligible_keys(universe, "", false);
+        CHECK(keys.size() == 2, "empty primary key erases nothing");
+    }
+}
+
+// ── LEVER 2 (pure): weighted_peer_inflight across [floor, base]. ────────────
+static void test_lever2_pure()
+{
+    std::cout << "[LEVER 2] weighted_peer_inflight (pure)\n";
+    const std::uint32_t base = 32, floor = 8;
+
+    CHECK(bp::weighted_peer_inflight(base, floor, 0, 0) == base,
+          "cold start (max=0) -> flat base");
+    CHECK(bp::weighted_peer_inflight(base, floor, 0, 100) == floor,
+          "zero-delivery peer -> floor");
+    CHECK(bp::weighted_peer_inflight(base, floor, 100, 100) == base,
+          "fastest peer -> full base");
+    CHECK(bp::weighted_peer_inflight(base, floor, 50, 100) == 20,
+          "half-rate peer -> floor + span/2 (8 + 12 = 20)");
+    // A slow peer is always strictly between floor and base, never below floor.
+    auto slow = bp::weighted_peer_inflight(base, floor, 1, 16);
+    CHECK(slow >= floor && slow < base, "slow-but-delivering peer within (floor,base)");
+    // floor > base is clamped (never underflows / exceeds base).
+    CHECK(bp::weighted_peer_inflight(base, 40, 50, 100) == base,
+          "floor>base clamped to base");
+}
+
+// ── LEVER 2 (integration): the REAL BulkBlockScheduler reflects delivered
+//    throughput, and is flat before any delivery. ─────────────────────────────
+static void test_lever2_scheduler()
+{
+    std::cout << "[LEVER 2] BulkBlockScheduler::effective_per_peer_inflight (real)\n";
+
+    rp::BulkBlockScheduler sched;
+    rp::BulkBlockScheduler::Config cfg;
+    cfg.window            = 2000;
+    cfg.per_peer_inflight = 32;
+    cfg.min_peer_inflight = 8;
+    cfg.batch             = 16;
+    sched.configure(cfg);
+    sched.reset(1);
+    sched.set_target_end(100000);
+
+    const std::vector<std::string> peers = {"fast", "slow"};
+    auto hash_at = [](std::uint32_t h) -> std::optional<uint256> {
+        return std::optional<uint256>(uint256(static_cast<std::uint64_t>(h)));
+    };
+
+    // F. Cold start: no peer has delivered ⇒ every peer flat at per_peer_inflight.
+    CHECK(sched.effective_per_peer_inflight("fast") == 32, "F: cold-start flat (fast)");
+    CHECK(sched.effective_per_peer_inflight("slow") == 32, "F: cold-start flat (slow)");
+
+    // Assign a batch to each peer, then deliver ALL of fast's bodies and only
+    // ONE of slow's — fast becomes the high-throughput deliverer.
+    auto assign = sched.pump(/*now=*/1, peers, hash_at, /*buffered=*/0);
+    std::map<std::string, std::vector<uint256>> got;
+    for (const auto& a : assign)
+        for (const auto& [h, hash] : a.blocks)
+            got[a.peer].push_back(hash);
+    CHECK(!got["fast"].empty() && !got["slow"].empty(),
+          "E-pre: both peers were assigned a fresh range");
+
+    for (const auto& hash : got["fast"]) sched.on_body(hash, 1024);
+    if (!got["slow"].empty()) sched.on_body(got["slow"].front(), 1024);
+
+    const std::uint32_t eff_fast = sched.effective_per_peer_inflight("fast");
+    const std::uint32_t eff_slow = sched.effective_per_peer_inflight("slow");
+    CHECK(eff_fast == 32, "E: fast (top deliverer) earns the full window");
+    CHECK(eff_slow >= 8 && eff_slow < 32, "E: slow peer window narrowed but floored");
+    CHECK(eff_slow < eff_fast, "E: slow window strictly below fast window");
+}
+
+int main()
+{
+    std::cout << "=== #154 bulk local-primary + weighted-inflight KAT ===\n";
+    test_lever1();
+    test_lever2_pure();
+    test_lever2_scheduler();
+
+    if (g_failures == 0)
+        std::cout << "ALL PASS\n";
+    else
+        std::cout << g_failures << " CHECK(S) FAILED\n";
+    return g_failures == 0 ? 0 : 1;
+}

--- a/src/impl/dash/coin/bulk_peer_policy.hpp
+++ b/src/impl/dash/coin/bulk_peer_policy.hpp
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// #154 bulk-lane peer policy — pure, dependency-free decision helpers shared by
+// the coin P2P client (WHICH peer is bulk-eligible, p2p_client.hpp
+// eligible_bulk_peer_keys) and the replay bulk scheduler (HOW MUCH inflight
+// budget each peer gets, replay_bulk_fetch.hpp BulkBlockScheduler::pump). Kept
+// free of any coin / boost / leveldb dependency so BOTH real call sites AND the
+// KAT link against the exact same logic — no duplicated shadow implementation
+// that could go green while the shipped path regresses.
+//
+// ROOT CAUSE these two levers fix (benchmark-proven, wf task #154): a daemonless
+// cold-start / replay ran fetch-pipeline-bound (~16 blk/s) instead of dashd-
+// parity fast because
+//   (1) eligible_bulk_peer_keys() unconditionally erased the PRIMARY from the
+//       bulk set whenever any other handshaked peer existed. With
+//       --coin-p2p-discover arming ~15 internet peers, the pinned gigabit-LAN
+//       archival dashd (the "Protected local dashd node") was thrown out of the
+//       bulk lane — 0 of 16961 bodies served by it, a distant internet peer
+//       carried 53%; and
+//   (2) flat round-robin (per_peer_inflight=32 for every peer) let a slow peer
+//       hold a contiguous low-height range and stall the in-order delivery
+//       cursor (buffer rides the window ceiling, timeout climbs to 10k+).
+//
+// SAFETY: these change only WHICH peer serves block bodies and HOW MUCH each is
+// asked for. They do NOT touch fold / consensus / block validation — every body
+// is still verified identically by the fold.
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace bulkpolicy {
+
+// LEVER 1 (Priority Invariant #1, made REMOTE-primary-only). `universe` is the
+// handshaked+serving bulk-peer key set. Exclude the PRIMARY from the bulk lane
+// ONLY when it is a REMOTE primary — it carries every live-tip request/response
+// leg, so loading it with bulk bodies would block the tip lane — AND at least
+// one other peer exists to serve bulk. A pinned PROTECTED-LOCAL primary
+// (loopback / private-LAN "Protected local dashd node") is KEPT bulk-eligible:
+// during a historical replay there is no tip-lane pressure and the local node
+// is the fastest deliverer, so excluding it was pure throughput loss (#154).
+inline std::vector<std::string> select_bulk_eligible_keys(
+    std::vector<std::string> universe,
+    const std::string& primary_key,
+    bool primary_is_protected_local)
+{
+    if (universe.size() > 1 && !primary_key.empty() &&
+        !primary_is_protected_local)
+    {
+        universe.erase(
+            std::remove(universe.begin(), universe.end(), primary_key),
+            universe.end());
+    }
+    return universe;
+}
+
+// LEVER 2 (throughput-weighted inflight window, anti head-of-line-blocking).
+// Scale a peer's per-peer inflight budget by its DELIVERED block throughput
+// relative to the fastest peer in the set, linearly across [floor, base]. A
+// slow / timing-out peer thus claims a SMALLER contiguous low-height range and
+// can no longer stall the in-order delivery cursor; the fast local / archival
+// deliverer earns the big window and fills the shared work-ahead budget.
+//
+// DEGENERATE cold start — nobody has delivered a body yet (max_delivered == 0),
+// or this is the sole/lead peer (peer_delivered >= max_delivered) — returns the
+// flat `base`, BYTE-IDENTICAL to the pre-#154 round-robin. This is what keeps
+// the discover-only path (uniform delivery converges every peer back to `base`)
+// and the KAT / any embedding without per-peer throughput data unregressed.
+inline std::uint32_t weighted_peer_inflight(
+    std::uint32_t base,           // Config::per_peer_inflight
+    std::uint32_t floor,          // Config::min_peer_inflight (clamped to base)
+    std::uint64_t peer_delivered, // this peer's PeerTally::blocks
+    std::uint64_t max_delivered)  // max PeerTally::blocks across the peer set
+{
+    if (floor > base) floor = base;
+    if (max_delivered == 0) return base;               // cold start -> flat
+    if (peer_delivered >= max_delivered) return base;  // the fastest peer
+    const std::uint32_t span = base - floor;
+    const std::uint32_t bonus = static_cast<std::uint32_t>(
+        (static_cast<std::uint64_t>(span) * peer_delivered) / max_delivered);
+    std::uint32_t eff = floor + bonus;
+    if (eff < floor) eff = floor;
+    if (eff > base)  eff = base;
+    return eff;
+}
+
+} // namespace bulkpolicy
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -90,6 +90,7 @@
 #include <impl/dash/crypto/hash_x11.hpp>   // block identity on Dash = X11(header)
 #include <impl/dash/coin/governance_object.hpp> // govobject_hash / govvote_signature_hash (dashcore-exact digests)
 #include <impl/dash/coin/historical_sml.hpp>    // HistoricalMnListDiffDemux (reward-critical tip/historical split)
+#include <impl/dash/coin/bulk_peer_policy.hpp>   // #154 select_bulk_eligible_keys (LEVER 1 pure logic)
 
 #include <algorithm>
 #include <chrono>
@@ -107,6 +108,7 @@
 
 #include <core/config.hpp>
 #include <core/log.hpp>
+#include <core/netaddress.hpp>   // classify_address / AddrClass (#154 protected-local primary predicate)
 #include <core/random.hpp>
 #include <core/factory.hpp>
 #include <core/timer.hpp>
@@ -1410,7 +1412,8 @@ public:
     /// fallback: if the CanServeBlocks filter empties the set (a transient
     /// all-pruned/all-demoted pool), fall back to the raw handshaked set so the
     /// lane never freezes — the same Pass-0/Pass-1 shape as next_bulk_peer().
-    /// Primary excluded unless it is the only survivor (priority invariant 1).
+    /// A REMOTE primary is excluded unless it is the only survivor (priority
+    /// invariant 1); a pinned PROTECTED-LOCAL primary is KEPT (see #154 below).
     std::vector<std::string> eligible_bulk_peer_keys() const
     {
         std::vector<std::string> serving, handshaked;
@@ -1423,10 +1426,29 @@ public:
         }
         std::vector<std::string> keys =
             serving.empty() ? std::move(handshaked) : std::move(serving);
-        const std::string prim = primary_peer_key();
-        if (keys.size() > 1 && !prim.empty())
-            keys.erase(std::remove(keys.begin(), keys.end(), prim), keys.end());
-        return keys;
+        // #154 LEVER 1: priority invariant 1 keeps the bulk lane off the PRIMARY
+        // while any other handshaked peer exists — but that invariant exists only
+        // to protect the live-tip request/response legs a REMOTE primary carries.
+        // A pinned PROTECTED-LOCAL primary (a loopback / LAN archival dashd — the
+        // "Protected local dashd node") carries no tip-lane pressure during a
+        // historical replay and is the FASTEST bulk deliverer, so it stays
+        // bulk-eligible. The pure decision lives in bulkpolicy so this shipped
+        // path and the KAT exercise identical logic.
+        return bulkpolicy::select_bulk_eligible_keys(
+            std::move(keys), primary_peer_key(), primary_is_protected_local());
+    }
+
+    /// True when the PRIMARY is a pinned PROTECTED-LOCAL dashd node: its address
+    /// classifies as loopback or private-LAN (AddrClass loopback / private_net —
+    /// the same local/private class CoinPeerManager::set_local_node pins as the
+    /// "Protected local dashd node"). #154: such a primary is kept bulk-eligible;
+    /// a REMOTE primary (routable) is still excluded from the bulk lane. No
+    /// primary ⇒ false (nothing to protect, nothing to keep).
+    bool primary_is_protected_local() const
+    {
+        if (!m_primary) return false;
+        const AddrClass c = classify_address(m_primary->addr.address());
+        return c == AddrClass::loopback || c == AddrClass::private_net;
     }
 
     /// dashd FindNextBlocksToDownload per-(peer,height) coverage for the replay

--- a/src/impl/dash/coin/replay_bulk_fetch.hpp
+++ b/src/impl/dash/coin/replay_bulk_fetch.hpp
@@ -86,6 +86,7 @@
 #include "block.hpp"
 #include "block_producer.hpp"   // block_body_binds_to_header (body↔header bind)
 #include "header_chain.hpp"     // check_pow / x11_hash / DashChainParams
+#include "bulk_peer_policy.hpp" // #154 weighted_peer_inflight (LEVER 2 pure logic)
 
 #include <core/leveldb_store.hpp>
 #include <core/log.hpp>
@@ -793,6 +794,14 @@ public:
     {
         uint32_t window{2000};            // max heights ahead of the delivered cursor (spec §4.3 bounded work-ahead)
         uint32_t per_peer_inflight{32};   // outstanding bodies per peer (keeps reply queues short — priority inv. 4)
+        // #154 LEVER 2 floor: the minimum per-peer inflight window a peer keeps
+        // even when it is the slowest deliverer. effective_per_peer_inflight()
+        // scales linearly across [min_peer_inflight, per_peer_inflight] by the
+        // peer's DELIVERED throughput relative to the fastest peer, so a slow /
+        // timing-out peer can no longer claim a wide contiguous low-height range
+        // and stall the in-order delivery cursor. Set == per_peer_inflight to
+        // restore byte-identical flat round-robin.
+        uint32_t min_peer_inflight{8};
         uint32_t batch{16};               // invs per getdata message
         int64_t  request_timeout_sec{30}; // unanswered this long ⇒ re-request elsewhere
         // dashd net_processing BLOCK_STALLING_TIMEOUT parity (reactive half of
@@ -880,6 +889,24 @@ public:
     uint64_t notfound_count() const { return m_notfound; }
     uint64_t timeout_count() const { return m_timeouts; }
     const std::map<std::string, PeerTally>& tallies() const { return m_tallies; }
+
+    /// #154 LEVER 2: this peer's throughput-weighted inflight window. Scales
+    /// across [min_peer_inflight, per_peer_inflight] by the peer's DELIVERED
+    /// block count relative to the fastest peer in the set. Degenerate cold
+    /// start (no peer has delivered ⇒ flat per_peer_inflight) is byte-identical
+    /// to the pre-#154 round-robin. Public so the KAT asserts the weighting and
+    /// the flat degenerate case on the REAL scheduler state.
+    uint32_t effective_per_peer_inflight(const std::string& peer) const
+    {
+        uint64_t max_delivered = 0;
+        for (const auto& [key, t] : m_tallies)
+            max_delivered = std::max(max_delivered, t.blocks);
+        auto it = m_tallies.find(peer);
+        const uint64_t mine = (it == m_tallies.end()) ? 0 : it->second.blocks;
+        return bulkpolicy::weighted_peer_inflight(
+            m_cfg.per_peer_inflight, m_cfg.min_peer_inflight, mine,
+            max_delivered);
+    }
 
     /// Peers currently held off fresh-range assignment (stall-demoted). Purely
     /// observational — for telemetry / the live [BULK] line.
@@ -1043,13 +1070,19 @@ public:
         {
             const std::string& peer = peers[(m_rr + pi) % peers.size()];
             auto& tally = m_tallies[peer];
-            if (tally.inflight >= m_cfg.per_peer_inflight) continue;
+            // #154 LEVER 2: throughput-weighted per-peer inflight ceiling (flat
+            // per_peer_inflight until peers have delivered, then the fast local /
+            // archival deliverer earns a wider window and a slow / timing-out
+            // peer a narrower one — so the laggard cannot hold a wide contiguous
+            // low-height range and stall the in-order delivery cursor).
+            const uint32_t peer_cap = effective_per_peer_inflight(peer);
+            if (tally.inflight >= peer_cap) continue;
             // A demoted peer still takes retries below, but is skipped for fresh
             // contiguous ranges while any healthy peer remains.
             const bool fresh_ok =
                 !any_fresh_eligible || tally.demoted_until <= now;
             uint32_t capacity = std::min<uint32_t>(
-                m_cfg.batch, m_cfg.per_peer_inflight - tally.inflight);
+                m_cfg.batch, peer_cap - tally.inflight);
 
             Assignment a;
             a.peer = peer;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1380,7 +1380,14 @@ if (BUILD_TESTING AND GTest_FOUND)
     # same #769 reason as every TU above: this target IS in the build.yml
     # "Build tests" --target allowlist, and a standalone target would be a
     # NOT_BUILT sentinel.
-    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp test_dash_replay_bulk_fetch.cpp test_dash_spork.cpp)
+    # Ninth TU: test_dash_bulk_local_primary_kat.cpp — #154 daemonless bulk-fetch
+    # dashd-parity KAT (LEVER 1 protected-local primary stays bulk-eligible +
+    # LEVER 2 throughput-weighted per-peer inflight). Folded here for the same
+    # #769 reason as every TU above: this target IS in the build.yml "Build tests"
+    # --target allowlist AND already compiles coin/replay_bulk_fetch.hpp, so its
+    # link set resolves BulkBlockScheduler/bulkpolicy with no new deps; a
+    # standalone executable was a NOT_BUILT/"Not Run" CTest sentinel.
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp test_dash_replay_bulk_fetch.cpp test_dash_spork.cpp test_dash_bulk_local_primary_kat.cpp)
     target_compile_definitions(test_dash_p2p_node PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_p2p_node PRIVATE

--- a/test/test_dash_bulk_local_primary_kat.cpp
+++ b/test/test_dash_bulk_local_primary_kat.cpp
@@ -41,6 +41,15 @@
 //                             a narrower one (floored), on the REAL scheduler.
 //   F. COLD-START FLAT      — before any delivery every peer gets the flat
 //                             per_peer_inflight (pre-#154 round-robin preserved).
+//
+// FOLDED (was standalone src/c2pool/dash_bulk_local_primary_kat.cpp with a
+// main()) into the already-allowlisted test_dash_p2p_node target — a standalone
+// executable was NOT in the build.yml "Build tests" --target list, so CTest saw
+// it registered-but-not-built ("Not Run") and red'd the suite (the #769 /
+// unregistered-KAT NOT_BUILT class). Separate TU, own anonymous namespace +
+// distinct DashBulkLocalPrimaryKat suite, gtest_main-provided main() → no clash.
+
+#include <gtest/gtest.h>
 
 #include <impl/dash/coin/bulk_peer_policy.hpp>
 #include <impl/dash/coin/replay_bulk_fetch.hpp>
@@ -48,38 +57,25 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <functional>
-#include <iostream>
 #include <map>
 #include <optional>
 #include <string>
 #include <vector>
 
+namespace {
+
 namespace bp = dash::coin::bulkpolicy;
 namespace rp = dash::coin::replay;
 
-static int g_failures = 0;
-#define CHECK(cond, msg)                                                        \
-    do {                                                                        \
-        if (!(cond)) {                                                          \
-            std::cout << "  FAIL: " << (msg) << "\n";                           \
-            ++g_failures;                                                       \
-        } else {                                                                \
-            std::cout << "  ok:   " << (msg) << "\n";                           \
-        }                                                                       \
-    } while (0)
-
-static bool has(const std::vector<std::string>& v, const std::string& k)
+bool has(const std::vector<std::string>& v, const std::string& k)
 {
     return std::find(v.begin(), v.end(), k) != v.end();
 }
 
 // ── LEVER 1: select_bulk_eligible_keys (the exact logic of the shipped
 //    CoinClient::eligible_bulk_peer_keys tail). ──────────────────────────────
-static void test_lever1()
+TEST(DashBulkLocalPrimaryKat, Lever1BulkEligibleSelection)
 {
-    std::cout << "[LEVER 1] bulk-eligible peer selection\n";
-
     const std::string local  = "192.168.86.165:9999"; // protected-local primary
     const std::string remA   = "203.0.113.7:9999";    // remote archival
     const std::string remB   = "198.51.100.9:9999";   // remote archival
@@ -89,9 +85,9 @@ static void test_lever1()
         std::vector<std::string> universe = {local, remA, remB};
         auto keys = bp::select_bulk_eligible_keys(
             universe, /*primary=*/local, /*primary_is_protected_local=*/true);
-        CHECK(has(keys, local), "A: protected-local primary KEPT in bulk set");
-        CHECK(has(keys, remA) && has(keys, remB), "A: remote peers still present");
-        CHECK(keys.size() == 3, "A: nothing erased (was: local erased -> 2)");
+        EXPECT_TRUE(has(keys, local)) << "A: protected-local primary KEPT in bulk set";
+        EXPECT_TRUE(has(keys, remA) && has(keys, remB)) << "A: remote peers still present";
+        EXPECT_EQ(keys.size(), 3u) << "A: nothing erased (was: local erased -> 2)";
     }
 
     // B. remote primary + N remote ⇒ EXCLUDES the primary (invariant 1 held).
@@ -99,9 +95,9 @@ static void test_lever1()
         std::vector<std::string> universe = {remA, remB, local};
         auto keys = bp::select_bulk_eligible_keys(
             universe, /*primary=*/remA, /*primary_is_protected_local=*/false);
-        CHECK(!has(keys, remA), "B: remote primary EXCLUDED from bulk set");
-        CHECK(has(keys, remB) && has(keys, local), "B: other peers present");
-        CHECK(keys.size() == 2, "B: exactly the primary removed");
+        EXPECT_TRUE(!has(keys, remA)) << "B: remote primary EXCLUDED from bulk set";
+        EXPECT_TRUE(has(keys, remB) && has(keys, local)) << "B: other peers present";
+        EXPECT_EQ(keys.size(), 2u) << "B: exactly the primary removed";
     }
 
     // C. discover-only (no protected-local peer): identical to legacy erase.
@@ -111,53 +107,50 @@ static void test_lever1()
             universe, /*primary=*/remA, /*primary_is_protected_local=*/false);
         std::vector<std::string> legacy = {remA, remB};
         legacy.erase(std::remove(legacy.begin(), legacy.end(), remA), legacy.end());
-        CHECK(keys == legacy, "C: discover-only path byte-identical to legacy");
+        EXPECT_EQ(keys, legacy) << "C: discover-only path byte-identical to legacy";
     }
 
     // D. sole survivor is never erased (size>1 guard), local or remote.
     {
         auto r = bp::select_bulk_eligible_keys({remA}, remA, false);
-        CHECK(r.size() == 1 && r[0] == remA, "D: lone remote primary kept");
+        EXPECT_TRUE(r.size() == 1 && r[0] == remA) << "D: lone remote primary kept";
         auto l = bp::select_bulk_eligible_keys({local}, local, true);
-        CHECK(l.size() == 1 && l[0] == local, "D: lone local primary kept");
+        EXPECT_TRUE(l.size() == 1 && l[0] == local) << "D: lone local primary kept";
     }
 
     // Empty primary key ⇒ no erase (defensive).
     {
         std::vector<std::string> universe = {remA, remB};
         auto keys = bp::select_bulk_eligible_keys(universe, "", false);
-        CHECK(keys.size() == 2, "empty primary key erases nothing");
+        EXPECT_EQ(keys.size(), 2u) << "empty primary key erases nothing";
     }
 }
 
 // ── LEVER 2 (pure): weighted_peer_inflight across [floor, base]. ────────────
-static void test_lever2_pure()
+TEST(DashBulkLocalPrimaryKat, Lever2WeightedInflightPure)
 {
-    std::cout << "[LEVER 2] weighted_peer_inflight (pure)\n";
     const std::uint32_t base = 32, floor = 8;
 
-    CHECK(bp::weighted_peer_inflight(base, floor, 0, 0) == base,
-          "cold start (max=0) -> flat base");
-    CHECK(bp::weighted_peer_inflight(base, floor, 0, 100) == floor,
-          "zero-delivery peer -> floor");
-    CHECK(bp::weighted_peer_inflight(base, floor, 100, 100) == base,
-          "fastest peer -> full base");
-    CHECK(bp::weighted_peer_inflight(base, floor, 50, 100) == 20,
-          "half-rate peer -> floor + span/2 (8 + 12 = 20)");
+    EXPECT_EQ(bp::weighted_peer_inflight(base, floor, 0, 0), base)
+        << "cold start (max=0) -> flat base";
+    EXPECT_EQ(bp::weighted_peer_inflight(base, floor, 0, 100), floor)
+        << "zero-delivery peer -> floor";
+    EXPECT_EQ(bp::weighted_peer_inflight(base, floor, 100, 100), base)
+        << "fastest peer -> full base";
+    EXPECT_EQ(bp::weighted_peer_inflight(base, floor, 50, 100), 20u)
+        << "half-rate peer -> floor + span/2 (8 + 12 = 20)";
     // A slow peer is always strictly between floor and base, never below floor.
     auto slow = bp::weighted_peer_inflight(base, floor, 1, 16);
-    CHECK(slow >= floor && slow < base, "slow-but-delivering peer within (floor,base)");
+    EXPECT_TRUE(slow >= floor && slow < base) << "slow-but-delivering peer within (floor,base)";
     // floor > base is clamped (never underflows / exceeds base).
-    CHECK(bp::weighted_peer_inflight(base, 40, 50, 100) == base,
-          "floor>base clamped to base");
+    EXPECT_EQ(bp::weighted_peer_inflight(base, 40, 50, 100), base)
+        << "floor>base clamped to base";
 }
 
 // ── LEVER 2 (integration): the REAL BulkBlockScheduler reflects delivered
 //    throughput, and is flat before any delivery. ─────────────────────────────
-static void test_lever2_scheduler()
+TEST(DashBulkLocalPrimaryKat, Lever2WeightedInflightScheduler)
 {
-    std::cout << "[LEVER 2] BulkBlockScheduler::effective_per_peer_inflight (real)\n";
-
     rp::BulkBlockScheduler sched;
     rp::BulkBlockScheduler::Config cfg;
     cfg.window            = 2000;
@@ -174,8 +167,8 @@ static void test_lever2_scheduler()
     };
 
     // F. Cold start: no peer has delivered ⇒ every peer flat at per_peer_inflight.
-    CHECK(sched.effective_per_peer_inflight("fast") == 32, "F: cold-start flat (fast)");
-    CHECK(sched.effective_per_peer_inflight("slow") == 32, "F: cold-start flat (slow)");
+    EXPECT_EQ(sched.effective_per_peer_inflight("fast"), 32u) << "F: cold-start flat (fast)";
+    EXPECT_EQ(sched.effective_per_peer_inflight("slow"), 32u) << "F: cold-start flat (slow)";
 
     // Assign a batch to each peer, then deliver ALL of fast's bodies and only
     // ONE of slow's — fast becomes the high-throughput deliverer.
@@ -184,29 +177,17 @@ static void test_lever2_scheduler()
     for (const auto& a : assign)
         for (const auto& [h, hash] : a.blocks)
             got[a.peer].push_back(hash);
-    CHECK(!got["fast"].empty() && !got["slow"].empty(),
-          "E-pre: both peers were assigned a fresh range");
+    EXPECT_TRUE(!got["fast"].empty() && !got["slow"].empty())
+        << "E-pre: both peers were assigned a fresh range";
 
     for (const auto& hash : got["fast"]) sched.on_body(hash, 1024);
     if (!got["slow"].empty()) sched.on_body(got["slow"].front(), 1024);
 
     const std::uint32_t eff_fast = sched.effective_per_peer_inflight("fast");
     const std::uint32_t eff_slow = sched.effective_per_peer_inflight("slow");
-    CHECK(eff_fast == 32, "E: fast (top deliverer) earns the full window");
-    CHECK(eff_slow >= 8 && eff_slow < 32, "E: slow peer window narrowed but floored");
-    CHECK(eff_slow < eff_fast, "E: slow window strictly below fast window");
+    EXPECT_EQ(eff_fast, 32u) << "E: fast (top deliverer) earns the full window";
+    EXPECT_TRUE(eff_slow >= 8 && eff_slow < 32) << "E: slow peer window narrowed but floored";
+    EXPECT_TRUE(eff_slow < eff_fast) << "E: slow window strictly below fast window";
 }
 
-int main()
-{
-    std::cout << "=== #154 bulk local-primary + weighted-inflight KAT ===\n";
-    test_lever1();
-    test_lever2_pure();
-    test_lever2_scheduler();
-
-    if (g_failures == 0)
-        std::cout << "ALL PASS\n";
-    else
-        std::cout << g_failures << " CHECK(S) FAILED\n";
-    return g_failures == 0 ? 0 : 1;
-}
+} // namespace


### PR DESCRIPTION
## What

The **dominant** dashd-parity fix for #154. Generalizes the live operational unblock (16 -> 415 blk/s on the .191 self-derive) into code: stop erasing a **protected-local** (LAN) primary peer from the bulk-body-fetch lane, and allocate per-peer inflight by throughput instead of flat round-robin.

## Root cause

`eligible_bulk_peer_keys()` unconditionally erased the PRIMARY peer from the bulk-eligible set whenever any other handshaked peer existed (Priority Invariant #1). With `--coin-p2p-discover` (15 internet peers), the fast gigabit-LAN archival node (`.165`, tag `class=4` = "Protected local dashd node") was excluded from bulk -> fold became fetch-pipeline-bound at ~16 blk/s, CPU 1.3%, 0.35 MB/s. Live benchmark settled it: dashd fed from the *same* `.165` does 264-607 blk/s at 70% CPU (validation-bound, LAN idle-capacity to spare); c2pool refused to fetch bulk bodies from that node. Not CPU, not the LAN — routing.

`class=4` maps to `AddrClass::private_net` (ordinal 4) in `core/netaddress.hpp:269` — LAN addrs like `192.168.86.165`. `set_local_node()` logs `class=<int>`. `PeerSession` carries only `addr`, so the protected-local predicate classifies that address (loopback || private_net, matching existing `PeerEndpoint::is_local()`).

## Changes (5 files, +390/−7)

**New pure, dependency-free header** `src/impl/dash/coin/bulk_peer_policy.hpp` — both shipped call sites and the KAT link the same logic (no shadow impl): `select_bulk_eligible_keys(...)` (LEVER 1), `weighted_peer_inflight(...)` (LEVER 2).

**LEVER 1 — `p2p_client.hpp`** — `eligible_bulk_peer_keys()` delegates the erase decision to `bulkpolicy::select_bulk_eligible_keys(...)`, gated on `primary_is_protected_local()` (`classify_address(m_primary->addr) == loopback || private_net`). A **remote** primary is still excluded from bulk (tip-lane invariant preserved); a **protected-local** primary is now KEPT bulk-eligible.

**LEVER 2 — `replay_bulk_fetch.hpp`** — new `Config::min_peer_inflight{8}` floor + `effective_per_peer_inflight(peer)` -> `bulkpolicy::weighted_peer_inflight(...)`. `pump()` replaces the two flat `per_peer_inflight` uses with the per-peer throughput-weighted ceiling. Degenerate cold start (no deliveries) returns flat -> byte-identical to prior round-robin (anti head-of-line blocking without changing cold-start behaviour).

**KAT** — `src/c2pool/dash_bulk_local_primary_kat.cpp` + CMake target `dash_bulk_local_primary_kat` (mirrors `dash_hdr_backfill_window_kat`, CI-built).

## Proof — KAT built + RAN, 22 checks ALL PASS

- **LEVER 1:** protected-local primary + N remote => local primary **INCLUDED** (was excluded); remote primary + N remote => primary **EXCLUDED**; **discover-only path byte-identical to legacy erase**; sole-survivor kept; empty primary key erases nothing.
- **LEVER 2:** cold-start flat=32 every peer; fast deliverer earns full 32; slow peer narrowed but floored (>=8, <32, strictly < fast).

`-fsyntax-only` clean for the KAT TU and a TU including modified `p2p_client.hpp`.

## Reward-safety

This changes **which peer serves block bodies**, never the fold/consensus logic. Bodies are validated by the fold's committed-root compare regardless of source; a wrong/malicious body fails closed exactly as before. Discover-only and remote-primary behaviour are unchanged (proven byte-identical in the KAT). Effect: any daemonless node with a fast local/archival peer uses it for bulk = dashd-parity cold-start (removes the "cold header-sync sheds rigs" hot-cut blocker).

Complements PR #1297 (CPU-side incremental merkle cache). This is the network/fetch plane; #1297 is the CPU plane; they stack.

Do not self-merge — reward-path, operator tap.
