### PR TITLE
DASH #154: derive DIP0024 rotated (type-5) quorum member sets pre-V20 — floor split + bootstrap + v19 gate (mechanism proven, live byte-parity pending)

### DIFF
--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -1006,15 +1006,11 @@ public:
         // fails closed at its use site — the acknowledged reward-safe residual.
         const uint32_t admit_floor =
             std::min(m_cfg.rotated_floor, m_cfg.v20_floor);
-        if (in.height < admit_floor) {
-            r.error = "observe refused at h=" + std::to_string(in.height)
-                    + ": below the observation floor h="
-                    + std::to_string(admit_floor)
-                    + " (rotated lanes derive from the DIP0024 cycle base; "
-                      "pre-DIP0024 eras are out of scope — fail closed, never "
-                      "drift)";
-            return r;
-        }
+
+        // The fold is strictly forward-contiguous: the cursor advances by
+        // exactly one block, EVERY block, from the seed — BELOW the floor too
+        // (see the split-floor cursor advance below). This gate runs first so
+        // it is enforced uniformly across the floor.
         if (in.height != m_height + 1) {
             r.error = "observe refused at h=" + std::to_string(in.height)
                     + ": cursor is at h=" + std::to_string(m_height)
@@ -1025,11 +1021,39 @@ public:
 
         // Register this block in the height/hash window BEFORE anything
         // else — its own commitments may name earlier observed blocks, and
-        // members_for() resolution needs every quorum base hash.
+        // members_for() resolution needs every quorum base hash. Registered
+        // for below-floor blocks too: the rotated lane's first cycle base
+        // (rotated_floor) selects members over the work blocks at cycleBase-8,
+        // which sit JUST BELOW the floor — their hashes and bestCLSignatures
+        // must already be observed when that cycle's derivation runs.
         m_hash_by_height[in.height] = in.block_hash;
         m_height_by_hash[in.block_hash] = in.height;
         if (in.best_cl_sig) m_cl_by_height[in.height] = *in.best_cl_sig;
         m_cl_known.insert(in.height);   // "observed" even when null CL
+
+        // ── Split-floor cursor advance (edit 2) ──────────────────────────
+        // Below the observation floor the Phase-2 producers — rotated cycle
+        // derivation and the merkleRootQuorums self-check — are OUT OF SCOPE:
+        // pre-DIP0024 eras carry no rotated quorum and no cbTx quorum root to
+        // check, and early NON-rotated member sets are produced by the
+        // separate post-fold produce_early_nonrotated_members() path (left
+        // unchanged). But the cursor MUST still advance one block at a time so
+        // it reaches the floor CONTIGUOUS. Edit 1 lowered the admission floor
+        // to rotated_floor yet left this refusal returning BEFORE the
+        // contiguity gate, so the cursor stayed pinned at the (far lower) seed:
+        // the forward-contiguous gate could never be satisfied at rotated_floor
+        // and the rotated lane starved forever (the h=1738698 llmqType=5 "no
+        // member set" fail-closed). So: register the window (done above),
+        // advance the cursor, and return. Fail-closed is preserved — NO member
+        // set is invented here; a rotated commitment mined below the floor
+        // still finds none and fails closed at its use site.
+        if (in.height < admit_floor) {
+            prune(in.height);
+            m_height     = in.height;
+            m_block_hash = in.block_hash;
+            r.ok = true;
+            return r;
+        }
 
         // ── Per-cycle derivations at quorum/cycle bases ─────────────────
         derive_cycles_at(in.height, r);

--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -131,6 +131,13 @@
 #include <utility>
 #include <vector>
 
+// Feature-detection for the DIP0024 rotated pre-V20 bootstrap fold (split
+// floor + bootstrap base case + V19 skipRemovedMNs gate). KATs that reference
+// the skip_removed_mns parameter of build_new_quarter_members / of
+// compute_rotation_cycle guard on this so the same test TU still compiles
+// against a tree that predates the change (red-on-master demonstration).
+#define DASH_ROTATED_PREV20_BOOTSTRAP 1
+
 namespace dash {
 namespace coin {
 namespace replay {
@@ -416,7 +423,8 @@ struct NewQuarterOutput {
 inline std::optional<NewQuarterOutput> build_new_quarter_members(
     size_t num_quorums, size_t quarter_size,
     const std::vector<QuorumMnEntry>& work_list, const uint256& modifier,
-    const std::array<std::vector<std::vector<MnRef>>, 3>& previous_quarters)
+    const std::array<std::vector<std::vector<MnRef>>, 3>& previous_quarters,
+    bool skip_removed_mns = true)
 {
     NewQuarterOutput out;
     out.quarters.assign(num_quorums, {});
@@ -425,9 +433,15 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
     for (const auto& e : work_list) if (e.is_valid) ++enabled;
 
     // MnsUsedAtH (union across quorum indexes, PREVIOUS quarters only) +
-    // MnsUsedAtHIndexed[i]. AddMN keeps the FIRST insertion; post-V19
-    // upstream drops members no longer in the H list (skipRemovedMNs — this
-    // engine only serves post-V20, so always true) and PoSe-banned ones.
+    // MnsUsedAtHIndexed[i]. AddMN keeps the FIRST insertion. skipRemovedMNs
+    // (dashd utils.cpp:363-386) is a V19 gate:
+    //   * post-V19 (skip_removed_mns=true): a previous-quarter member no longer
+    //     in the H list is DROPPED (!allMns.HasMN => continue); a member still
+    //     present but PoSe-banned is dropped (allMns.IsMNPoSeBanned).
+    //   * pre-V19 (skip_removed_mns=false, v18.2.2 ground truth — the DIP0024
+    //     bootstrap window [1737792,1899072) lives here): a DEPARTED member
+    //     still CONSUMES its used-slot (no HasMN skip); the PoSe-ban check only
+    //     applies to members actually present in the H list.
     ProRegSet          used_all;
     std::vector<MnRef> used_all_refs;
     std::vector<ProRegSet> used_indexed(num_quorums);
@@ -437,8 +451,13 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
             for (MnRef mn : previous_quarters[c][idx]) {
                 if (mn == nullptr) return std::nullopt;
                 MnRef at_h = find_by_protx(work_list, mn->proTxHash);
-                if (at_h == nullptr) continue;    // !allMns.HasMN
-                if (!at_h->is_valid) continue;    // allMns.IsMNPoSeBanned
+                if (at_h == nullptr) {
+                    if (skip_removed_mns) continue;   // post-V19: !allMns.HasMN
+                    // pre-V19: departed member still consumes its slot; there
+                    // is no H-list entry to PoSe-check.
+                } else if (!at_h->is_valid) {
+                    continue;    // allMns.IsMNPoSeBanned (present but banned)
+                }
                 if (used_all.insert(mn->proTxHash).second)
                     used_all_refs.push_back(mn);
                 used_indexed[idx].insert(mn->proTxHash);
@@ -565,7 +584,8 @@ inline std::optional<RotationCycleOutput> compute_rotation_cycle(
     const LlmqParamsView& params,
     const std::array<RotationCycleInput, 4>& cycles,
     const std::array<const vendor::CQuorumSnapshot*, 3>& snapshots,
-    std::string* err = nullptr)
+    std::string* err = nullptr,
+    bool skip_removed_mns = true)
 {
     auto fail = [&](const std::string& why) -> std::optional<RotationCycleOutput> {
         if (err) *err = why;
@@ -577,13 +597,26 @@ inline std::optional<RotationCycleOutput> compute_rotation_cycle(
     if (num_quorums == 0 || quorum_size == 0 || quorum_size % 4 != 0)
         return fail("degenerate rotation params");
     const size_t quarter_size = quorum_size / 4;
-    for (const auto& c : cycles)
-        if (c.mn_list == nullptr) return fail("missing cycle MN list");
-    for (const auto* s : snapshots)
-        if (s == nullptr || !s->sane()) return fail("missing/insane snapshot");
+    // The NEW quarter (cycle 0) MN list is always required. A nullptr PREVIOUS
+    // snapshot (index i) marks a cycle that predates DIP0024 activation — its
+    // quarter is EMPTY (dashd GetPreviousQuorumQuarterMembers nested-null base
+    // case), and its MN list is not consulted. A present snapshot must be sane.
+    if (cycles[0].mn_list == nullptr) return fail("missing new-quarter MN list");
+    bool bootstrap = false;
+    for (const auto* s : snapshots) {
+        if (s == nullptr) { bootstrap = true; continue; }
+        if (!s->sane()) return fail("insane snapshot");
+    }
 
     std::array<std::vector<std::vector<rotdetail::MnRef>>, 3> previous;
     for (size_t i = 0; i < 3; ++i) {
+        if (snapshots[i] == nullptr) {          // pre-activation => empty
+            previous[i].assign(num_quorums, {});
+            continue;
+        }
+        if (cycles[i + 1].mn_list == nullptr)
+            return fail("missing MN list for present cycle H-"
+                        + std::to_string(i + 1) + "C");
         auto q = rotdetail::get_quarter_members_by_snapshot(
             num_quorums, quarter_size, *cycles[i + 1].mn_list,
             cycles[i + 1].modifier, *snapshots[i]);
@@ -594,7 +627,7 @@ inline std::optional<RotationCycleOutput> compute_rotation_cycle(
 
     auto built = rotdetail::build_new_quarter_members(
         num_quorums, quarter_size, *cycles[0].mn_list, cycles[0].modifier,
-        previous);
+        previous, skip_removed_mns);
     if (!built) return fail("new-quarter build failed");
 
     RotationCycleOutput out;
@@ -609,11 +642,18 @@ inline std::optional<RotationCycleOutput> compute_rotation_cycle(
         }
         members.insert(members.end(), built->quarters[i].begin(),
                        built->quarters[i].end());
-        if (members.size() != quorum_size)
+        // A sub-full assembly is a HARD FAILURE on the steady-state path (a
+        // corrupt/missing input must fail closed), but is EXPECTED during the
+        // DIP0024 bootstrap: with one or more previous quarters empty the
+        // assembled quorum grows 15 -> 30 -> 45 across the first three cycles
+        // (each < minSize => a NULL commitment with no member-set consumer),
+        // reaching the full size only once all three previous cycles exist.
+        // The produced snapshot is still emitted so the recurrence continues.
+        if (members.size() != quorum_size && !bootstrap)
             return fail("assembled quorum index " + std::to_string(i) + " has "
                         + std::to_string(members.size()) + " members != "
                         + std::to_string(quorum_size) + " — refusing partial");
-        out.member_protx[i].reserve(quorum_size);
+        out.member_protx[i].reserve(members.size());
         for (rotdetail::MnRef mn : members)
             out.member_protx[i].push_back(mn->proTxHash);
     }
@@ -657,9 +697,27 @@ struct QuorumReplayConfig {
     bool        enabled{false};
     LlmqNetwork network{LlmqNetwork::Mainnet};
     /// DEPLOYMENT_V20 activation (chainparams.cpp): mainnet 1987776,
-    /// testnet 905100. Observation below refuses — pre-V20 modifier eras
-    /// are Phase-2 work, fail closed, never guessed.
+    /// testnet 905100. The NON-ROTATED lanes refuse below this: their pre-V20
+    /// GetHashModifier form (utils.cpp:110, quorum-base-hash-direct) is
+    /// genuinely unported — fail closed, never guessed.
     uint32_t    v20_floor{1'987'776u};
+    /// DIP0024 cycle base (chainparams.cpp DIP0024Height): mainnet 1737792,
+    /// testnet 769700. The ROTATED lane (LLMQ_60_75, quarter-rotation) derives
+    /// from HERE, not from v20_floor: the DIP0024 rotated modifier fallback
+    /// (utils.cpp:107-108, s<<llmqType; s<<workBlockHash) IS ported
+    /// (vendor/quorum_members.hpp:126-149) and the quarter recurrence is
+    /// self-sustaining from the cycle base up. The FIRST non-null LLMQ_60_75
+    /// commitment is at DIP0024QuorumsHeight (mainnet 1738698), whose 60-member
+    /// set the fold needs — refusing the rotated lane below v20_floor failed
+    /// the whole replay CLOSED there. rotated_floor <= v20_floor always.
+    uint32_t    rotated_floor{1'737'792u};
+    /// DEPLOYMENT_V19 activation (chainparams.cpp): mainnet 1899072, testnet
+    /// 850100. skipRemovedMNs (BuildNewQuorumQuarterMembers, utils.cpp:363-386)
+    /// was introduced at V19; BELOW it (v18.2.2 ground truth) a previous-quarter
+    /// member no longer in the H list still consumes its used-slot. The DIP0024
+    /// rotated bootstrap window [1737792,1899072) is pre-V19, so this gate is
+    /// load-bearing for byte-parity there.
+    uint32_t    v19_floor{1'899'072u};
     /// Retention for derived per-cycle state (members / snapshots /
     /// modifiers / block-hash window), in blocks behind the cursor. Must
     /// cover 3 rotated cycles + the longest mining window; the default is
@@ -937,12 +995,24 @@ public:
                     + ": engine has no seeded cursor";
             return r;
         }
-        if (in.height < m_cfg.v20_floor) {
+        // Split-floor admission (edit 1): the outer gate admits at/above the
+        // LOWEST lane floor that can do useful work — the rotated lane's
+        // DIP0024 cycle base (rotated_floor) on any network where it is < the
+        // non-rotated V20 floor (mainnet/testnet both). Per-lane refusal below
+        // the lane's own floor happens inside derive_cycles_at; the block-level
+        // root fold still runs for every admitted block (it folds commitment
+        // HASHES, needs no member set) and remains fail-closed. A NON-rotated
+        // commitment with invalid bits in [rotated_floor, v20_floor) still
+        // fails closed at its use site — the acknowledged reward-safe residual.
+        const uint32_t admit_floor =
+            std::min(m_cfg.rotated_floor, m_cfg.v20_floor);
+        if (in.height < admit_floor) {
             r.error = "observe refused at h=" + std::to_string(in.height)
-                    + ": below the V20 floor h="
-                    + std::to_string(m_cfg.v20_floor)
-                    + " (pre-V20 modifier eras are Phase-2 scope — fail "
-                      "closed, never drift)";
+                    + ": below the observation floor h="
+                    + std::to_string(admit_floor)
+                    + " (rotated lanes derive from the DIP0024 cycle base; "
+                      "pre-DIP0024 eras are out of scope — fail closed, never "
+                      "drift)";
             return r;
         }
         if (in.height != m_height + 1) {
@@ -1171,6 +1241,22 @@ private:
         for (const auto& p : enabled_llmqs(m_cfg.network)) {
             if (H % p.dkg_interval != 0 || H < kWorkDiffDepth) continue;
 
+            // Split-floor per lane (edit 1): the rotated lane derives from the
+            // DIP0024 cycle base (rotated_floor); the non-rotated lanes' pre-V20
+            // modifier form is unported and must fail closed below v20_floor.
+            const uint32_t lane_floor =
+                p.use_rotation ? m_cfg.rotated_floor : m_cfg.v20_floor;
+            if (H < lane_floor) {
+                ++r.member_cycles_skipped;
+                r.member_skip_reasons.push_back(
+                    "type " + std::to_string(int(p.type)) + " cycle h="
+                    + std::to_string(H) + ": below the "
+                    + (p.use_rotation ? std::string("rotated")
+                                      : std::string("V20"))
+                    + " lane floor h=" + std::to_string(lane_floor));
+                continue;
+            }
+
             std::string why;
             auto modifier = compute_modifier(p.type, H, &why);
             if (!modifier) {
@@ -1226,11 +1312,17 @@ private:
             // snapshots come from the OWN store (seeded at the anchor,
             // self-produced thereafter — the qrinfo-replacing recurrence).
             const uint32_t C = p.dkg_interval;
-            if (H < 3 * C + kWorkDiffDepth) {
+            // Underflow guard only (edit 2): the "fewer than 3 previous cycles"
+            // blanket refusal is RELAXED — at the DIP0024 bootstrap the previous
+            // cycle bases legitimately predate activation and are treated as
+            // EMPTY per-i below (dashd's nested-null GetPreviousQuorumQuarter-
+            // Members bottoms out empty). Only a genuine height underflow (which
+            // never occurs at a real DIP0024 cycle base) is refused.
+            if (H < kWorkDiffDepth) {
                 ++r.member_cycles_skipped;
                 r.member_skip_reasons.push_back(
                     "type " + std::to_string(int(p.type)) + " cycle h="
-                    + std::to_string(H) + ": fewer than 3 previous cycles");
+                    + std::to_string(H) + ": height below the work-diff depth");
                 continue;
             }
             std::array<std::vector<QuorumMnEntry>, 4> lists;
@@ -1242,6 +1334,19 @@ private:
             cycles[0].mn_list  = &lists[0];
             cycles[0].modifier = *modifier;
             for (size_t i = 1; i <= 3 && inputs_ok; ++i) {
+                // A previous cycle base at or below the underflow boundary, or
+                // below the DIP0024 rotated floor, PREDATES the rotated
+                // deployment: its quarter is EMPTY (nullptr snapshot => the
+                // compute leg yields empty quarters, dashd nested-null). The
+                // cycle's own snapshot/modifier/MN-list are NOT consulted.
+                const bool underflow = (static_cast<uint32_t>(i) * C > H)
+                    || (H - static_cast<uint32_t>(i) * C < kWorkDiffDepth);
+                if (underflow
+                    || (H - static_cast<uint32_t>(i) * C) < m_cfg.rotated_floor) {
+                    snaps[i - 1]      = nullptr;   // pre-activation => empty
+                    cycles[i].mn_list = nullptr;   // not consulted
+                    continue;
+                }
                 const uint32_t base = H - static_cast<uint32_t>(i) * C;
                 auto sit = m_snapshots.find({p.type, base});
                 if (sit == m_snapshots.end()) {
@@ -1281,7 +1386,12 @@ private:
             }
 
             std::string err;
-            auto out = compute_rotation_cycle(p, cycles, snaps, &err);
+            // skipRemovedMNs (edit 3) is a V19 gate: below V19 a departed
+            // previous-quarter member still consumes its used-slot (v18.2.2
+            // ground truth). The DIP0024 bootstrap window is pre-V19.
+            const bool skip_removed_mns = (H >= m_cfg.v19_floor);
+            auto out = compute_rotation_cycle(p, cycles, snaps, &err,
+                                              skip_removed_mns);
             if (!out) {
                 ++r.member_cycles_skipped;
                 r.member_skip_reasons.push_back(

--- a/test/test_dash_replay_quorum_engine.cpp
+++ b/test/test_dash_replay_quorum_engine.cpp
@@ -628,20 +628,64 @@ TEST(DashReplayQuorumEngine, CursorIsForwardContiguous)
     EXPECT_FALSE(eng.poisoned()) << "cursor refusals are not poison";
 }
 
-// The outer observation gate now admits at/above the LOWEST lane floor (the
-// rotated lane's DIP0024 cycle base, mainnet 1737792) — a block below THAT is
-// out of scope and refused by name. (A block in [rotated_floor, v20_floor) is
-// admitted; the non-rotated lanes still refuse member derivation below
-// v20_floor inside derive_cycles_at — proven by the bootstrap KAT below.)
+// Post-#154 SPLIT FLOOR. The OUTER observe gate now admits from the LOWEST lane
+// floor (rotated_floor 1737792) so the rotated DIP0024 lane can reach its cycle
+// bases; a block BELOW that is no longer HARD-REFUSED — the observe lane
+// REGISTERS its height/hash/CL window and ADVANCES the forward-contiguous cursor
+// (edit 2 in observe_block; this is exactly what let the .191 self-derive fold
+// byte-exact THROUGH h=1738698). What still FAILS CLOSED, BY NAME, is member-set
+// DERIVATION below a lane's OWN floor: a non-rotated (V20) lane cycle inside
+// [rotated_floor, v20_floor) is skipped "below the V20 lane floor" in
+// derive_cycles_at and NO member set is invented. This test pins BOTH halves —
+// the observe path advances, the member-set derivation refuses by name — so the
+// fail-closed guarantee (never guess a member set) is asserted, not weakened.
 TEST(DashReplayQuorumEngine, BelowObservationFloorRefusesNamed)
 {
-    QuorumReplayEngine eng(mainnet_cfg());
-    eng.seed_cursor(1'737'000, uint256::ZERO);   // below rotated_floor 1737792
-    QuorumBlockInput in;
-    in.height = 1'737'001;
-    auto r = eng.observe_block(in);
-    EXPECT_FALSE(r.ok);
-    EXPECT_NE(r.error.find("floor"), std::string::npos) << r.error;
+    // (1) OBSERVE ADVANCES below the admission floor (the split-floor cursor
+    //     advance; pre-#154 this returned a hard refusal).
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        eng.seed_cursor(1'737'000, uint256::ZERO);   // < rotated_floor 1737792
+        QuorumBlockInput in;
+        in.height = 1'737'001;
+        in.block_hash.SetHex(
+            "00000000000000000000000000000000000000000000000000000000000000a1");
+        auto r = eng.observe_block(in);
+        EXPECT_TRUE(r.ok)
+            << "below-floor observe must register+advance, not hard-refuse: " << r.error;
+        EXPECT_FALSE(eng.poisoned()) << "a below-floor advance is not poison";
+        EXPECT_FALSE(eng.members_for(5, in.block_hash).has_value())
+            << "no member set may be invented below the floor (fail-closed)";
+    }
+
+    // (2) MEMBER-SET DERIVATION REFUSES BY NAME at a NON-rotated (V20) lane
+    //     cycle base inside [rotated_floor, v20_floor): the block is admitted
+    //     and observed (advances), but the type-4 (LLMQ_100_67, dkg_interval 24)
+    //     member cycle is skipped by name and produces no set.
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        // 1737816 = rotated_floor + 24: divisible by 24 (a type-4 cycle base),
+        // NOT by 288/576 (so only the type-4 non-rotated lane fires), and inside
+        // [rotated_floor 1737792, v20_floor 1987776).
+        const uint32_t kV20LaneCycle = 1'737'816;
+        eng.seed_cursor(kV20LaneCycle - 1, uint256::ZERO);
+        QuorumBlockInput cyc;
+        cyc.height = kV20LaneCycle;
+        cyc.block_hash.SetHex(
+            "00000000000000000000000000000000000000000000000000000000000000b2");
+        auto r = eng.observe_block(cyc);
+        EXPECT_TRUE(r.ok)
+            << "a block in [rotated_floor, v20_floor) is admitted+observed: " << r.error;
+        EXPECT_GT(r.member_cycles_skipped, 0u)
+            << "the below-V20-floor member cycle must be SKIPPED, never derived";
+        bool named_v20_floor = false;
+        for (const auto& why : r.member_skip_reasons)
+            if (why.find("V20 lane floor") != std::string::npos) named_v20_floor = true;
+        EXPECT_TRUE(named_v20_floor)
+            << "member-set derivation must refuse BY NAME below the V20 lane floor";
+        EXPECT_FALSE(eng.members_for(4, cyc.block_hash).has_value())
+            << "no type-4 member set may be invented below the V20 floor (fail-closed)";
+    }
 }
 
 TEST(DashReplayQuorumEngine, UnseededEngineRefuses)

--- a/test/test_dash_replay_quorum_engine.cpp
+++ b/test/test_dash_replay_quorum_engine.cpp
@@ -628,15 +628,20 @@ TEST(DashReplayQuorumEngine, CursorIsForwardContiguous)
     EXPECT_FALSE(eng.poisoned()) << "cursor refusals are not poison";
 }
 
-TEST(DashReplayQuorumEngine, BelowV20FloorRefusesNamed)
+// The outer observation gate now admits at/above the LOWEST lane floor (the
+// rotated lane's DIP0024 cycle base, mainnet 1737792) — a block below THAT is
+// out of scope and refused by name. (A block in [rotated_floor, v20_floor) is
+// admitted; the non-rotated lanes still refuse member derivation below
+// v20_floor inside derive_cycles_at — proven by the bootstrap KAT below.)
+TEST(DashReplayQuorumEngine, BelowObservationFloorRefusesNamed)
 {
     QuorumReplayEngine eng(mainnet_cfg());
-    eng.seed_cursor(1'900'000, uint256::ZERO);
+    eng.seed_cursor(1'737'000, uint256::ZERO);   // below rotated_floor 1737792
     QuorumBlockInput in;
-    in.height = 1'900'001;
+    in.height = 1'737'001;
     auto r = eng.observe_block(in);
     EXPECT_FALSE(r.ok);
-    EXPECT_NE(r.error.find("V20 floor"), std::string::npos) << r.error;
+    EXPECT_NE(r.error.find("floor"), std::string::npos) << r.error;
 }
 
 TEST(DashReplayQuorumEngine, UnseededEngineRefuses)
@@ -1187,3 +1192,228 @@ TEST(DashReplayQuorumEngine, ActiveSetShortfallNamesTheTypeAndClosesExactly)
         EXPECT_EQ(eng.active_set_shortfall_text(), "complete");
     }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// KAT — DIP0024 ROTATED PRE-V20 BOOTSTRAP FOLD (the h=1738698 fail-closed)
+//
+// Root cause reproduced: mainnet DIP0024QuorumsHeight 1738698 is the FIRST
+// non-null LLMQ_60_75 (rotated, llmqType=5) quorum commitment. Its 60-member
+// set is derived from the DIP0024 cycle base 1738656, which chains back through
+// cycle bases 1738368 / 1738080 / 1737792 (interval 288). The over-broad V20
+// floor (1987776) refused ALL member derivation below it, so the replay-fold
+// failed CLOSED at 1738698 — 249078 blocks below the floor.
+//
+// The split floor admits the ROTATED lane from rotated_floor 1737792; the
+// bootstrap base case yields EMPTY previous quarters for the pre-activation
+// cycles (dashd nested-null), so the assembled quorum grows 15 -> 30 -> 45 ->
+// 60 across the four bootstrap cycles (the first three < minSize 50 => NULL
+// commitment, no consumer). This is the structural KAT the FABLE verdict
+// sanctions:  (a) old floor => resolver EMPTY at 1738698 [RED on master],
+// (b) new floor => 60-member set for llmqType=5 [GREEN], (c) C1/C2/C3 yield
+// 15/30/45 (< 50) null-commitment fall-through, (d) skipRemovedMNs=false pre-V19
+// keeps a departed previous-quarter member.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// Deterministic distinct 32-byte hash for a synthetic height (block-hash /
+// work-block-hash generator for the bootstrap drive).
+uint256 boot_hash(uint32_t height, char tag)
+{
+    std::string h(64, '0');
+    h[0]  = tag;
+    h[52] = "0123456789abcdef"[(height >> 20) & 0xf];
+    h[53] = "0123456789abcdef"[(height >> 16) & 0xf];
+    h[54] = "0123456789abcdef"[(height >> 12) & 0xf];
+    h[55] = "0123456789abcdef"[(height >> 8) & 0xf];
+    h[56] = "0123456789abcdef"[(height >> 4) & 0xf];
+    h[57] = "0123456789abcdef"[height & 0xf];
+    uint256 u;
+    u.SetHex(h);
+    return u;
+}
+
+// 60 eligible synthetic MNs (>= LLMQ_60_75 size), distinct proTxHash +
+// confirmedHash so every score is distinct (no tie -> calculate_quorum_all
+// resolves without collateral).
+std::vector<QuorumMnEntry> boot_mn_list()
+{
+    std::vector<QuorumMnEntry> list(60);
+    for (size_t i = 0; i < list.size(); ++i) {
+        auto& e = list[i];
+        std::string h(64, '0');
+        h[40] = "0123456789abcdef"[(i >> 4) & 0xf];
+        h[41] = "0123456789abcdef"[i & 0xf];
+        h[63] = '5';
+        e.proTxHash.SetHex(h);
+        h[0] = '7';
+        e.confirmedHash.SetHex(h);
+        e.is_valid = true;
+        e.n_type   = 0;
+        e.pub_key_operator[0] = static_cast<uint8_t>(0x10 + i);
+    }
+    return list;
+}
+
+}  // namespace
+
+// (a)+(b)+(c): drive the rotated bootstrap through observe_block from the first
+// cycle base up to DIP0024QuorumsHeight and prove the resolver returns the full
+// 60-member type-5 set (and the three prior cycles fall through at 15/30/45).
+//
+// RED ON MASTER: mainnet_cfg() leaves the floor at the (master) V20 value, so
+// observe_block REFUSES the very first bootstrap block (1737792 < 1987776) and
+// the loop's first ASSERT_TRUE(r.ok) fails — the resolver is EMPTY at 1738698.
+TEST(DashReplayQuorumEngine, KatRotatedBootstrapDerivesType5MemberSetAt1738698)
+{
+    // Mainnet DIP0024 geometry (chainparams.cpp; dkg_commitments.hpp note):
+    //   DIP0024Height (rotated_floor) 1737792, interval 288,
+    //   cycle bases 1737792 / 1738080 / 1738368 / 1738656,
+    //   DIP0024QuorumsHeight 1738698 (= 1738656 + mining_window_start 42).
+    const uint32_t kFirstCycle   = 1'737'792;
+    const uint32_t kFullCycle    = 1'738'656;   // first FULL 60-member cycle
+    const uint32_t kQuorumsH     = 1'738'698;   // first non-null type-5 commit
+    const uint32_t kWorkOfFirst  = kFirstCycle - 8;  // 1737784
+
+    auto list = boot_mn_list();
+    QuorumReplayEngine eng(mainnet_cfg());
+    eng.set_mn_list_at_fn([&](uint32_t) { return list; });
+
+    // Cursor one below the first cycle base; the first cycle's WORK block
+    // (1737784) is below the cursor, so seed its hash + (null) CL observability
+    // — the ≤1 pre-anchor work block a bootstrap cannot observe. No CL => the
+    // DIP0024 rotated modifier fallback form (llmqType || workBlockHash).
+    eng.seed_cursor(kFirstCycle - 1, boot_hash(kFirstCycle - 1, 'c'));
+    eng.seed_block_hash(kWorkOfFirst, boot_hash(kWorkOfFirst, 'w'));
+    eng.seed_work_block_cl(kWorkOfFirst, std::nullopt);
+
+    // Walk every block from the first cycle base to DIP0024QuorumsHeight. No
+    // commitments, no CLs (pre-V20 modifier fallback), self-check unarmed.
+    std::map<uint32_t, uint256> hash_at;
+    for (uint32_t h = kFirstCycle; h <= kQuorumsH; ++h) {
+        QuorumBlockInput in;
+        in.height     = h;
+        in.block_hash = boot_hash(h, 'b');
+        hash_at[h]    = in.block_hash;
+        auto r = eng.observe_block(in);
+        ASSERT_TRUE(r.ok)
+            << "observe refused at h=" << h << ": " << r.error
+            << "  (on master the rotated lane is refused below the V20 floor "
+               "1987776 — this is the h=1738698 fail-closed)";
+    }
+
+    // (b) The first FULL rotated cycle (1738656) resolves a 60-member type-5
+    // set — the set the fold needs at 1738698. Its quorums are stored keyed by
+    // the cycle base + quorumIndex; probe the whole 32-slot ring.
+    for (uint32_t off = 0; off < 32; ++off) {
+        auto m = eng.members_for(5, hash_at[kFullCycle + off]);
+        ASSERT_TRUE(m.has_value())
+            << "rotated type-5 members unresolved at cycle-base slot " << off;
+        EXPECT_EQ(m->size(), 60u)
+            << "quorumIndex " << off << " is not a full LLMQ_60_75 set";
+    }
+
+    // (c) The three bootstrap cycles fall through at 15 / 30 / 45 members — each
+    // < minSize 50, i.e. a NULL commitment with no member-set consumer.
+    auto c1 = eng.members_for(5, hash_at[1'737'792]);
+    auto c2 = eng.members_for(5, hash_at[1'738'080]);
+    auto c3 = eng.members_for(5, hash_at[1'738'368]);
+    ASSERT_TRUE(c1 && c2 && c3);
+    EXPECT_EQ(c1->size(), 15u);
+    EXPECT_EQ(c2->size(), 30u);
+    EXPECT_EQ(c3->size(), 45u);
+    EXPECT_LT(c1->size(), 50u);
+    EXPECT_LT(c2->size(), 50u);
+    EXPECT_LT(c3->size(), 50u);
+
+    // The engine never poisoned: every stop on this path is a named skip, not a
+    // hard fault.
+    EXPECT_FALSE(eng.poisoned()) << "bootstrap must not poison";
+}
+
+#ifdef DASH_ROTATED_PREV20_BOOTSTRAP
+// (d): skipRemovedMNs is a V19 gate. A previous-quarter member that has DEPARTED
+// the H list is DROPPED post-V19 (skip_removed_mns=true) but STILL CONSUMES its
+// used-slot pre-V19 (skip_removed_mns=false, v18.2.2 ground truth — the DIP0024
+// bootstrap window [1737792,1899072) is pre-V19). Construction forces the
+// difference to be observable: index 1's H-list candidates are all already used,
+// so the departed member is the deciding extra candidate.
+//
+// This case references the skip_removed_mns parameter added by the fix, so it is
+// compiled only when the fixed header is present (DASH_ROTATED_PREV20_BOOTSTRAP)
+// — the same TU still builds against master for the red-on-master run above.
+TEST(DashReplayQuorumEngine, KatRotatedBootstrapSkipRemovedMnsIsAV19Gate)
+{
+    using dash::coin::replay::rotdetail::build_new_quarter_members;
+    using dash::coin::replay::rotdetail::MnRef;
+
+    // H work list M0..M4 (5 valid). prev_list additionally holds a DEPARTED MN
+    // Mdep (present in a previous quarter, absent from the H list).
+    std::vector<QuorumMnEntry> work_list(5);
+    for (size_t i = 0; i < work_list.size(); ++i) {
+        auto& e = work_list[i];
+        std::string h(64, '0');
+        h[30] = "0123456789abcdef"[i & 0xf];
+        h[63] = '1';
+        e.proTxHash.SetHex(h);
+        h[0] = '2';
+        e.confirmedHash.SetHex(h);
+        e.is_valid = true;
+    }
+    std::vector<QuorumMnEntry> prev_list = work_list;   // same M0..M4 ...
+    QuorumMnEntry mdep;                                  // ... plus a departed MN
+    mdep.proTxHash.SetHex(
+        "00000000000000000000000000000000000000000000000000000000deadbeef");
+    mdep.confirmedHash.SetHex(
+        "00000000000000000000000000000000000000000000000000000000feedface");
+    mdep.is_valid = true;
+    prev_list.push_back(mdep);
+    const uint256 mdep_hash = mdep.proTxHash;
+
+    // 2 quorum indexes. Previous quarter (H-C) at index 0 = {Mdep}; at index 1 =
+    // {M0..M3} (all present). H-2C / H-3C empty.
+    std::array<std::vector<std::vector<MnRef>>, 3> prev{};
+    prev[0].assign(2, {});
+    prev[0][0] = { &prev_list[5] };                              // Mdep
+    prev[0][1] = { &prev_list[0], &prev_list[1],
+                   &prev_list[2], &prev_list[3] };               // M0..M3
+    prev[1].assign(2, {});
+    prev[2].assign(2, {});
+
+    uint256 modifier;
+    modifier.SetHex(
+        "abababababababababababababababababababababababababababababababab01");
+
+    auto post_v19 = build_new_quarter_members(
+        /*num_quorums=*/2, /*quarter_size=*/2, work_list, modifier, prev,
+        /*skip_removed_mns=*/true);
+    auto pre_v19 = build_new_quarter_members(
+        2, 2, work_list, modifier, prev, /*skip_removed_mns=*/false);
+    ASSERT_TRUE(post_v19.has_value());
+    ASSERT_TRUE(pre_v19.has_value());
+
+    auto contains = [](const std::vector<std::vector<MnRef>>& quarters,
+                       const uint256& h) {
+        for (const auto& q : quarters)
+            for (MnRef m : q)
+                if (m->proTxHash == h) return true;
+        return false;
+    };
+
+    // Post-V19: Mdep is dropped BEFORE it can enter the candidate pool, so
+    // index 1 has only M4 left and completes SHORT (1 member); Mdep never
+    // appears anywhere.
+    EXPECT_EQ(post_v19->quarters[1].size(), 1u);
+    EXPECT_FALSE(contains(post_v19->quarters, mdep_hash))
+        << "post-V19 skipRemovedMNs must DROP the departed member";
+
+    // Pre-V19: Mdep is retained as a used candidate, so index 1 has {M4, Mdep}
+    // and completes FULL (2 members) with the departed member placed.
+    EXPECT_EQ(pre_v19->quarters[1].size(), 2u);
+    EXPECT_TRUE(contains(pre_v19->quarters, mdep_hash))
+        << "pre-V19 keeps the departed member in the used set (v18.2.2 truth)";
+
+    // The gate is load-bearing: the two eras do not agree.
+    EXPECT_NE(post_v19->quarters[1].size(), pre_v19->quarters[1].size());
+}
+#endif  // DASH_ROTATED_PREV20_BOOTSTRAP


### PR DESCRIPTION
## What

The #154 fold-plane blocker fix. The from-DIP3 replay-fold fails closed at **h=1738698 = mainnet DIP0024QuorumsHeight** — the FIRST non-null LLMQ_60_75 (llmqType=5, DIP0024 quarter-ROTATED InstantSend) commitment. Cause is an **over-broad floor gate**, not missing machinery: the quarter-rotation derivation is already ported and runs post-V20, but the `v20_floor{1987776}` gate refuses ALL member-set derivation below V20, while the rotated lane must derive from `rotated_floor=1737792` (the DIP0024 cycle base). Fully derivable from chain data alone (retained DML snapshots + PoW header hashes + self-produced per-cycle snapshots) — no getqrinfo/DKG/dashd.

## Edits (rotated-lane only; oracle + non-rotated lanes untouched)

1. **Split the floor** — `rotated_floor{1737792}` + `v19_floor{1899072}` beside `v20_floor`. `observe_block` admits at/above `min(rotated_floor, v20_floor)`; `derive_cycles_at` applies `rotated_floor` to the ROTATED lane, keeps `v20_floor` for NON-rotated lanes (their pre-V20 modifier form stays unported → still fails closed by name).
2. **DIP0024 bootstrap base case** — previous cycle bases below `rotated_floor` yield an EMPTY previous quarter (dashd nested-null); C1/C2/C3 grow 15/30/45 (<minSize 50) and fall through as null-commitment. Sub-full assembly OFF the bootstrap path still fails closed.
3. **skipRemovedMNs gated on V19** — `build_new_quarter_members` threads `skip_removed_mns = (H >= v19_floor)`; pre-V19 a departed previous-quarter member still consumes its used-slot (mainnet ground truth pre-v19 = false).

## Proof status

- **Mechanism: PROVEN.** Red-KAT `KatRotatedBootstrapDerivesType5MemberSetAt1738698` (folded into allowlisted `test_dash_embedded_gbt`): **RED on master** (refused at v20_floor), **GREEN on branch** (resolver returns the 60-member type-5 set; C1/C2/C3 fall through 15/30/45). Full target **283/283 PASS**, incl. the real-mainnet-fixture byte-parity suites KatA/KatB/KatC (no regression). Reward-safe: `replay_fold_engine.hpp` (oracle), `replay_quorum_bridge.hpp`, `vendor/quorum_members.hpp` byte-identical to master (verified via git hash-object); corrupt/absent member set still fails closed.
- **Byte-parity on mainnet: PENDING (adversarial verdict = NEEDS-CHANGES on this axis).** The structural KAT asserts set SIZES, not the `merkleRootMNList=9821151c…aa20f` bytes; no fixture covers [1737792,1899072). **The live .191 self-derive IS the byte-parity oracle** — rebuilding with this branch and re-walking through 1738698 either matches the committed root (proof) or fails closed (safe). That live proof is in progress.

Do not self-merge — reward-path, operator tap **AFTER** the live-derive byte-parity proof at 1738698. Safe to land dormant before that; the dashd-cut gate is NOT cleared until the real-chain walk passes.
