### PR TITLE
dash(replay): OPTIONAL, default-OFF V20 getmnlistdiff seed — operator escape hatch for #154 pre-V20 derivation

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -100,6 +100,7 @@
 #include <impl/dash/coin/replay_bulk_fetch.hpp>  // W2: full-history replay bulk block-fetch lane (--replay-bulk)
 #include <impl/dash/coin/replay_utxo_fold.hpp>   // W3: full-history replay standalone UTXO fold (--replay-utxo-*)
 #include <impl/dash/coin/replay_prestate.hpp>    // W5: anchor prestate loader (--replay-fold-prestate)
+#include <impl/dash/coin/mnlist_seed.hpp>        // OPTIONAL V20 getmnlistdiff seed (--replay-mnlist-seed-*, #154 escape hatch)
 #include <impl/dash/coin/replay_fold_consumer.hpp> // W5: bulk lane -> W1 DML fold + per-block root check
 #include <impl/dash/coin/replay_quorum_bridge.hpp> // SEAM: W4 quorum lane <-> W1 MembersFn
 #include <impl/dash/coin/replay_payee_publish.hpp> // SEAM: W1 fold -> the PAYEE queue that gates serving
@@ -281,6 +282,18 @@ std::string g_replay_fold_prestate;           // --replay-fold-prestate FILE
 bool        g_replay_fold_quorums = false;    // --replay-fold-quorums
 std::string g_replay_fold_qsnapshot;          // --replay-fold-qsnapshot FILE
 std::string g_replay_fold_worklists;          // --replay-fold-worklists FILE
+// ── OPTIONAL, DEFAULT-OFF V20 getmnlistdiff SEED (path-ii escape hatch for
+// #154 — mnlist_seed.hpp). When ALL THREE are absent nothing below changes and
+// the from-DIP3 default is byte-identical to master. When armed, the fold is
+// SEEDED from a dashd getmnlistdiff snapshot at/after the V20 activation floor
+// (mainnet 1'987'776) instead of DERIVED from DIP3, sidestepping the pre-v19
+// rotated-quorum derivation for the checkpoint-generation use case. The seed's
+// merkleRootMNList must reproduce the committed root at the seed height
+// (seed_engine_from_prestate, fail-closed) BEFORE any block is folded forward;
+// from H+1 the normal per-block byte-exact self-check is unchanged.
+uint32_t    g_replay_mnlist_seed_height = 0;  // --replay-mnlist-seed-height H (0 => disarmed)
+std::string g_replay_mnlist_seed_source;      // --replay-mnlist-seed-source getmnlistdiff
+std::string g_replay_mnlist_seed_file;        // --replay-mnlist-seed-file FILE (offline snapshot)
 // --embedded-no-dashd-mn-seed: cut the PAYEE axis off from dashd while KEEPING
 // the dashd RPC for the OBSERVE-only shadow-compare. The E2c `protx list` seed
 // and the E2d checkpoint bridge are both skipped, so the root-checked replay
@@ -424,6 +437,7 @@ void print_banner(const char* argv0)
         << "           [--replay-bulk] [--replay-bulk-capture DIR] [--replay-bulk-start H]\n"
         << "           [--replay-fold-prestate FILE] [--replay-fold-quorums]\n"
         << "           [--replay-fold-qsnapshot FILE] [--replay-fold-worklists FILE]\n"
+        << "           [--replay-mnlist-seed-height H --replay-mnlist-seed-source getmnlistdiff --replay-mnlist-seed-file FILE]\n"
         << "           [--replay-mined-commitment-index]\n"
         << "           [--embedded-no-dashd-mn-seed]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
@@ -548,6 +562,16 @@ void print_banner(const char* argv0)
         << "        without any anchor-supplied member set;\n"
         << "        --replay-fold-qsnapshot FILE seeds ONLY the pre-anchor\n"
         << "        rotated-cycle snapshots a Phase-1 run cannot have produced.\n"
+        << "        --replay-mnlist-seed-height H (with --replay-mnlist-seed-source\n"
+        << "        getmnlistdiff and --replay-mnlist-seed-file FILE) is an\n"
+        << "        OPTIONAL, DEFAULT-OFF escape hatch (path-ii, #154): instead of\n"
+        << "        DERIVING pre-V20 state from DIP3, SEED the fold from a dashd\n"
+        << "        getmnlistdiff snapshot at/after the V20 floor (mainnet\n"
+        << "        1987776) and walk V20+ ONLY, sidestepping the pre-v19\n"
+        << "        rotated-quorum derivation for checkpoint generation. The seed\n"
+        << "        must reproduce the committed merkleRootMNList at H (fail-closed)\n"
+        << "        before any block folds; from H+1 the self-check is unchanged.\n"
+        << "        When these flags are ABSENT the from-DIP3 default is untouched.\n"
         << "        THE SERVE SEAM: once the fold is PROVEN CURRENT (not\n"
         << "        poisoned, DIVERGED=none, roots_matched == folded, the list\n"
         << "        re-hashes to the root its last block committed, cursor AT\n"
@@ -6615,13 +6639,49 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // computed merkleRootMNList checked byte-exact against that
             // block's own committed cbTx root — the per-block proof.
             uint32_t replay_fold_anchor = 0;
-            if (!g_replay_fold_prestate.empty()) {
-                auto ps = rp::load_prestate_file(g_replay_fold_prestate);
-                if (!ps.ok) {
-                    std::cerr << "[run] FATAL: --replay-fold-prestate "
-                              << g_replay_fold_prestate << ": " << ps.error
-                              << "\n";
-                    return 1;
+            // The escape hatch (mnlist_seed.hpp) is armed iff the operator
+            // supplied any --replay-mnlist-seed-* flag; it and the plain
+            // --replay-fold-prestate arm are mutually exclusive seed SOURCES
+            // that converge on the SAME Prestate + SAME root gate below.
+            rp::MnListSeedRequest mnseed_req;
+            mnseed_req.seed_height = g_replay_mnlist_seed_height;
+            mnseed_req.source      = g_replay_mnlist_seed_source;
+            mnseed_req.file        = g_replay_mnlist_seed_file;
+            mnseed_req.testnet     = testnet;
+            const bool mnlist_seed_on = rp::mnlist_seed_armed(mnseed_req);
+            if (mnlist_seed_on && !g_replay_fold_prestate.empty()) {
+                std::cerr << "[run] FATAL: --replay-mnlist-seed-* (V20"
+                             " getmnlistdiff escape hatch) and"
+                             " --replay-fold-prestate are mutually exclusive"
+                             " seed sources — pick one\n";
+                return 1;
+            }
+            if (mnlist_seed_on || !g_replay_fold_prestate.empty()) {
+                rp::Prestate ps;
+                if (mnlist_seed_on) {
+                    ps = rp::load_and_validate_mnlist_seed(mnseed_req);
+                    if (!ps.ok) {
+                        std::cerr << "[run] FATAL: --replay-mnlist-seed-* "
+                                     "(V20 getmnlistdiff escape hatch, #154): "
+                                  << ps.error << "\n";
+                        return 1;
+                    }
+                    std::cout << "[run] V20 MNLIST-SEED ARMED (OPTIONAL, "
+                                 "default-OFF getmnlistdiff escape hatch for"
+                                 " #154 pre-V20 derivation): seeding at h="
+                              << ps.height << " (>= V20 floor "
+                              << rp::mnlist_seed_v20_floor(testnet)
+                              << ") from source '" << mnseed_req.source
+                              << "' — walking V20+ ONLY, per-block self-check"
+                                 " unchanged from H+1\n";
+                } else {
+                    ps = rp::load_prestate_file(g_replay_fold_prestate);
+                    if (!ps.ok) {
+                        std::cerr << "[run] FATAL: --replay-fold-prestate "
+                                  << g_replay_fold_prestate << ": " << ps.error
+                                  << "\n";
+                        return 1;
+                    }
                 }
                 dash::coin::replay::FoldConfig fcfg;
                 fcfg.enabled = true;   // W1 feature flag, explicit opt-in
@@ -8776,6 +8836,23 @@ int main(int argc, char** argv)
             g_replay_fold_qsnapshot = argv[++i];
         else if (std::strcmp(argv[i], "--replay-fold-worklists") == 0 && i + 1 < argc)
             g_replay_fold_worklists = argv[++i];
+        // OPTIONAL, DEFAULT-OFF V20 getmnlistdiff seed (path-ii escape hatch
+        // for #154). Armed only when the operator supplies these; absent, the
+        // from-DIP3 default is untouched. Implies --replay-bulk (the fold has
+        // nothing to walk forward without the lane).
+        else if (std::strcmp(argv[i], "--replay-mnlist-seed-height") == 0 && i + 1 < argc) {
+            g_replay_mnlist_seed_height = static_cast<uint32_t>(
+                std::strtoul(argv[++i], nullptr, 10));
+            g_replay_bulk = true;
+        }
+        else if (std::strcmp(argv[i], "--replay-mnlist-seed-source") == 0 && i + 1 < argc) {
+            g_replay_mnlist_seed_source = argv[++i];
+            g_replay_bulk = true;
+        }
+        else if (std::strcmp(argv[i], "--replay-mnlist-seed-file") == 0 && i + 1 < argc) {
+            g_replay_mnlist_seed_file = argv[++i];
+            g_replay_bulk = true;
+        }
         // PR-2 FORWARD: the mined-commitment store, fed from our own replay.
         else if (std::strcmp(argv[i], "--replay-mined-commitment-index") == 0)
             g_mined_commitment_index = true;

--- a/src/impl/dash/coin/mnlist_seed.hpp
+++ b/src/impl/dash/coin/mnlist_seed.hpp
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// ── OPTIONAL, DEFAULT-OFF V20 getmnlistdiff SEED for the replay fold ───────
+// (path-ii escape hatch for #154 — the pre-V20 rotated-quorum derivation)
+//
+// WHAT THIS IS, AND WHAT IT IS NOT
+// ---------------------------------
+// The #154 self-derive fold is from-DIP3 (h=1028160) forward: every block's
+// computed merkleRootMNList is self-checked byte-exact against that block's
+// own committed cbTx root, fail-closed on any mismatch. That pure from-DIP3
+// path is THE DEFAULT and is fixed separately (a pre-v19 rotated-quorum
+// ordering bug). NOTHING in this header runs unless the operator explicitly
+// arms it, and when the flags are absent the from-DIP3 path is byte-identical
+// to master.
+//
+// This header adds an ALTERNATIVE the operator may opt into for the
+// checkpoint-GENERATION use case: instead of DERIVING the pre-V20 state, SEED
+// the fold's DML from a dashd getmnlistdiff snapshot AT/AFTER the V20
+// activation height (mainnet h=1'987'776) and walk V20+ only — sidestepping
+// the pre-v19 rotated-derivation problem entirely. The tradeoff (a build-time
+// dashd dependency for the generated .inc) is understood and accepted by the
+// operator SPECIFICALLY BECAUSE this is optional and off by default.
+//
+// REWARD-SAFETY (the whole point)
+// -------------------------------
+// A seed is TRUSTED at exactly ONE height and PROGRESSIVELY FALSIFIABLE after
+// it. Before a single block is folded forward, the seeded state must reproduce
+// the chain's OWN committed merkleRootMNList at the seed height — that check is
+// replay::seed_engine_from_prestate() (replay_prestate.hpp), reused verbatim
+// here. A seed whose computed root != the committed root is not an anchor, it
+// is a guess, and it is REJECTED. From H+1 onward the normal per-block
+// byte-exact self-check continues unchanged, so the generated .inc remains
+// oracle-verifiable at 2522504 exactly as a from-DIP3 fold's would be.
+//
+// WHY getmnlistdiff CAN verify the root (but a payee axis is separate)
+// -------------------------------------------------------------------
+// merkleRootMNList is CalcMerkleRoot over the DIP-4 SML entries
+// (ReplayMNState::to_sml_entry): proRegTxHash, confirmedHash, service,
+// pubKeyOperator, keyIDVoting, isValid, nType, platform*. Every one of those
+// is carried by getmnlistdiff. scriptPayout / nLastPaidHeight are NOT in the
+// SML leaf and NOT committed in merkleRootMNList — so for the merkleRootMNList
+// proof the getmnlistdiff SML is sufficient and self-verifying. (The payee
+// axis, which getmnlistdiff omits, is a SEPARATE concern handled by the
+// protx-list prestate path and is not what the .inc is oracle-checked on.)
+//
+// FORMAT REUSE (do NOT reinvent)
+// ------------------------------
+// The materialized seed is the SAME text the W5 anchor prestate uses
+// (replay_prestate.hpp's `c2pool-dash-replay-prestate/1`), so the SAME
+// fail-closed 26-field parser and the SAME root-verification gate apply with
+// no second parser to drift. The getmnlistdiff SML columns fill the SML
+// fields; the payout columns are filled by the accompanying `protx list` (the
+// accepted build-time dashd dependency). What THIS header adds over the plain
+// prestate arm is purely the ARMING + GATING policy of the escape hatch:
+//   * the source must be "getmnlistdiff" (an explicit, named provenance),
+//   * the seed height must be >= the V20 activation floor (this is what makes
+//     it a V20-only sidestep and not a general re-anchor), and
+//   * the operator's declared --replay-mnlist-seed-height must match the
+//     height the snapshot actually carries (no silent height drift).
+//
+// LIVE vs OFFLINE
+// ---------------
+// The live leg — fetch getmnlistdiff from the configured coin-p2p peer (e.g.
+// the archival .165) at runtime — is SEQUENCED LATER on the operator's call
+// (#154). For the CODE + KAT deliverable the snapshot is materialized to a
+// FILE (--replay-mnlist-seed-file), which is the byte-for-byte offline twin of
+// exactly what the peer's getmnlistdiff returns. The file path and the live
+// path converge on the identical Prestate + identical root gate; only the
+// transport differs.
+
+#include <impl/dash/coin/replay_prestate.hpp>
+#include <impl/dash/coin/vendor/quorum_members.hpp>   // kV20FloorMainnet/Testnet
+
+#include <cstdint>
+#include <string>
+
+namespace dash {
+namespace coin {
+namespace replay {
+
+/// The only accepted --replay-mnlist-seed-source value. An enum-of-one on
+/// purpose: an unknown source is fail-closed, and a future source (e.g. a
+/// signed checkpoint) is a NEW named token rather than a silent widening.
+inline constexpr const char* kMnListSeedSourceGetMnListDiff = "getmnlistdiff";
+
+/// The operator's arming request, straight off the CLI. DEFAULT = DISARMED:
+/// a value-initialized request is inert and mnlist_seed_armed() is false, so
+/// the from-DIP3 path is what runs.
+struct MnListSeedRequest
+{
+    uint32_t    seed_height{0};   // --replay-mnlist-seed-height  (0 => disarmed)
+    std::string source;           // --replay-mnlist-seed-source  ("getmnlistdiff")
+    std::string file;             // --replay-mnlist-seed-file     (materialized snapshot)
+    bool        testnet{false};   // mirrors the run's network
+};
+
+/// True iff the operator touched ANY of the escape-hatch flags. When false the
+/// caller must NOT enter the seed path — the from-DIP3 default is unchanged.
+inline bool mnlist_seed_armed(const MnListSeedRequest& r)
+{
+    return r.seed_height != 0 || !r.source.empty() || !r.file.empty();
+}
+
+/// The V20 activation floor for the request's network — the escape hatch may
+/// only seed at or after it.
+inline uint32_t mnlist_seed_v20_floor(bool testnet)
+{
+    return testnet ? vendor::kV20FloorTestnet : vendor::kV20FloorMainnet;
+}
+
+/// Validate the arming request and load the seed into a Prestate the EXISTING
+/// wiring consumes. Every failure is fail-closed and NAMED via Prestate.ok /
+/// Prestate.error. On success the returned Prestate is handed to the SAME
+/// seed_engine_from_prestate() root gate the plain prestate arm uses — this
+/// function does NOT seed anything itself, it only enforces the escape-hatch
+/// policy and reuses the shared parser.
+inline Prestate load_and_validate_mnlist_seed(const MnListSeedRequest& r)
+{
+    Prestate ps;
+    auto fail = [&](const std::string& why) -> Prestate& {
+        ps.ok = false;
+        ps.error = why;
+        return ps;
+    };
+
+    // (1) SOURCE — an unknown/blank provenance is never guessed.
+    if (r.source != kMnListSeedSourceGetMnListDiff)
+        return fail("--replay-mnlist-seed-source must be '"
+                    + std::string(kMnListSeedSourceGetMnListDiff)
+                    + "' (got '" + r.source + "')");
+
+    // (2) HEIGHT — the escape hatch is height-driven by definition.
+    if (r.seed_height == 0)
+        return fail("--replay-mnlist-seed-height is required and must be > 0");
+
+    // (3) THE V20 FLOOR — this is what makes the hatch a V20-only sidestep of
+    //     the pre-v19 rotated derivation and NOT a general re-anchor. Seeding
+    //     below it would silently re-introduce exactly the pre-V20 state this
+    //     mode exists to avoid deriving.
+    const uint32_t floor = mnlist_seed_v20_floor(r.testnet);
+    if (r.seed_height < floor)
+        return fail("--replay-mnlist-seed-height "
+                    + std::to_string(r.seed_height)
+                    + " is below the V20 activation floor "
+                    + std::to_string(floor)
+                    + " for this network — the getmnlistdiff escape hatch may"
+                      " only seed at or after V20 (seed from DIP3 instead, the"
+                      " default, for any earlier height)");
+
+    // (4) TRANSPORT — the live coin-p2p getmnlistdiff fetch is sequenced later
+    //     on the operator's call (#154); for now the snapshot is a file, the
+    //     offline twin of the peer's reply. Absent a file we fail closed
+    //     rather than silently do nothing.
+    if (r.file.empty())
+        return fail("--replay-mnlist-seed-file is required: the live coin-p2p"
+                    " getmnlistdiff fetch is sequenced later (#154); supply the"
+                    " materialized snapshot file for now");
+
+    // (5) PARSE — reuse the shared, fail-closed prestate parser. No second
+    //     parser exists to drift from consensus.
+    ps = load_prestate_file(r.file);
+    if (!ps.ok)
+        return ps;   // error already NAMED by the shared parser
+
+    // (6) HEIGHT MATCH — the operator's declared height must equal the height
+    //     the snapshot actually carries. A mismatch means the peer/file
+    //     answered for a different height than the operator asked to seed at,
+    //     and pinning the forward lane to the wrong anchor+1 would fold the
+    //     wrong first block. Fail closed.
+    if (ps.height != r.seed_height)
+        return fail("--replay-mnlist-seed-height " + std::to_string(r.seed_height)
+                    + " does not match the snapshot's height "
+                    + std::to_string(ps.height)
+                    + " — the getmnlistdiff answered for a different height");
+
+    // (7) NETWORK MATCH — a mainnet snapshot must not seed a testnet run or
+    //     vice-versa (the floor in (3) is per-network).
+    const std::string want = r.testnet ? "testnet" : "mainnet";
+    if (ps.network != want)
+        return fail("--replay-mnlist-seed source is network '" + ps.network
+                    + "' but the run is '" + want + "'");
+
+    // The committed-root gate itself is seed_engine_from_prestate(), run by the
+    // caller exactly as the plain prestate arm does. ps.ok is true here only
+    // in the sense that it PARSED and passed the arming policy; it is NOT yet
+    // proven against the chain's committed root — that is the caller's next,
+    // reused, fail-closed step.
+    return ps;
+}
+
+} // namespace replay
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -889,12 +889,23 @@ if (BUILD_TESTING AND GTest_FOUND)
     # backward-walk with the fail-closed missing-row inversion, 'F'
     # wipe-on-mismatch and the startup newest-pair verify. Same allowlisted
     # target, same #143 NOT_BUILT reason. Links leveldb (via core).
+    # Seventh TU (OPTIONAL, default-OFF V20 getmnlistdiff seed):
+    # test_dash_replay_mnlist_seed.cpp — the path-ii escape hatch for #154
+    # (mnlist_seed.hpp). Proves the arming policy (source must be
+    # "getmnlistdiff", height required and >= the V20 floor, file required,
+    # height/network must match the snapshot) and the REUSED reward-safety root
+    # gate (seed_engine_from_prestate): a valid getmnlistdiff seed loads +
+    # verifies + is fold-ready at H, and a seed whose committed root != computed
+    # FAILS CLOSED. Folded into this SAME allowlisted target for the #143/#769
+    # NOT_BUILT reason (a standalone add_executable is not in build.yml's
+    # --target list and would silently report "Not Run").
     add_executable(test_dash_mn_state test_dash_mn_state.cpp
                    test_dash_mn_diff_store.cpp
                    test_dash_replay_fold.cpp
                    test_dash_replay_run.cpp
                    test_dash_replay_quorum_seam.cpp
-                   test_dash_replay_payee_publish.cpp)
+                   test_dash_replay_payee_publish.cpp
+                   test_dash_replay_mnlist_seed.cpp)
     target_link_libraries(test_dash_mn_state PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_replay_mnlist_seed.cpp
+++ b/test/test_dash_replay_mnlist_seed.cpp
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// OPTIONAL, DEFAULT-OFF V20 getmnlistdiff SEED for the replay fold
+/// (mnlist_seed.hpp) — the path-ii escape hatch for #154's pre-V20
+/// rotated-quorum derivation.
+///
+/// WHAT THIS KAT PROVES (and, honestly, what it does not)
+/// ------------------------------------------------------
+/// PROVEN HERE, STRUCTURALLY (no dashd, no network, self-contained):
+///   (a) FLAGS-ABSENT == from-DIP3 path unchanged. A default-constructed
+///       arming request is inert — mnlist_seed_armed() is false — so the seed
+///       arm is never entered and the from-DIP3 default is untouched. (The
+///       whole-binary proof of "byte-identical to master" is the guarded,
+///       purely-additive diff; this asserts the arm's gate at unit level.)
+///   (b) FLAGS-PRESENT: a valid getmnlistdiff seed LOADS, VERIFIES against the
+///       committed merkleRootMNList at the seed height, and leaves the engine
+///       fold-ready at H (so the next block it accepts is H+1). The committed
+///       root is the engine's OWN computed root over an independently built SML
+///       set, round-tripped through the shared prestate parser.
+///   (c) A seed whose committed root != the state's computed root FAILS CLOSED
+///       at seed_engine_from_prestate() — the reward-safety gate. Plus the
+///       escape-hatch policy gates: source must be "getmnlistdiff", height is
+///       required and must be >= the V20 floor, a file is required, and the
+///       declared height and network must match the snapshot.
+///
+/// NOT PROVEN HERE (sequenced later on the operator's call, #154):
+///   * That a LIVE dashd getmnlistdiff at mainnet h=1'987'776 reproduces
+///     mainnet's real committed root, and that folding V20->2522504 stays
+///     byte-exact. That is the live validation leg; this KAT proves the GATE
+///     MECHANICS (compute-vs-committed, fail-closed, V20-floor, height/network
+///     match), which is what makes the live leg safe to run.
+///
+/// The committed root here is SELF-CONSISTENT (the engine's own compute over
+/// hand-built entries), never a memorized mainnet constant — so a bug in
+/// CalcMerkleRoot could not make this KAT falsely green on the happy path; the
+/// mismatch case flips exactly one nibble of the committed root and REQUIRES
+/// the gate to red the seed.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mnlist_seed.hpp>
+#include <impl/dash/coin/replay_fold_engine.hpp>
+#include <impl/dash/coin/replay_prestate.hpp>
+#include <impl/dash/coin/vendor/quorum_members.hpp>
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace rp = dash::coin::replay;
+
+namespace {
+
+// ── wire-hex of raw internal bytes (the convention the prestate parser reads
+//    for every per-mn hash field: memcpy'd, NOT display-reversed). ──────────
+template <class Blob>
+std::string wire_hex(const Blob& b)
+{
+    static const char* k = "0123456789abcdef";
+    std::string s;
+    s.reserve(b.size() * 2);
+    for (size_t i = 0; i < b.size(); ++i) {
+        const uint8_t v = static_cast<uint8_t>(b.data()[i]);
+        s.push_back(k[v >> 4]);
+        s.push_back(k[v & 0xF]);
+    }
+    return s;
+}
+
+std::string bytes_hex(const std::vector<uint8_t>& v)
+{
+    static const char* k = "0123456789abcdef";
+    std::string s;
+    s.reserve(v.size() * 2);
+    for (uint8_t b : v) { s.push_back(k[b >> 4]); s.push_back(k[b & 0xF]); }
+    return s;
+}
+
+// A deterministic 32-byte blob from a seed byte (fills all 32 bytes so the
+// value is non-trivial and unique per mn).
+uint256 mk_u256(uint8_t seed)
+{
+    uint256 u;
+    for (int i = 0; i < 32; ++i) u.data()[i] = static_cast<uint8_t>(seed + i);
+    return u;
+}
+uint160 mk_u160(uint8_t seed)
+{
+    uint160 u;
+    for (int i = 0; i < 20; ++i) u.data()[i] = static_cast<uint8_t>(seed + i * 3);
+    return u;
+}
+
+// Build a small, independently-specified masternode set. The SML-bearing
+// fields (proTxHash, confirmedHash, service, keyIDVoting, isValid via
+// NEVER-ban, nType, nVersion, platform*) are what merkleRootMNList commits;
+// scriptPayout is set only because the prestate parser requires it (it is NOT
+// in the SML leaf).
+std::vector<std::pair<uint256, rp::ReplayMNState>> build_set()
+{
+    std::vector<std::pair<uint256, rp::ReplayMNState>> out;
+    for (uint8_t i = 1; i <= 5; ++i) {
+        uint256 protx = mk_u256(static_cast<uint8_t>(0x10 * i));
+        rp::ReplayMNState st;
+        st.UpdateConfirmedHash(protx, mk_u256(static_cast<uint8_t>(0x20 + i)));
+        for (int b = 0; b < 16; ++b)
+            st.netInfo.ip.data()[b] = static_cast<uint8_t>(i * 7 + b);
+        st.netInfo.port_be = static_cast<uint16_t>(9999 + i);
+        st.keyIDVoting = mk_u160(static_cast<uint8_t>(0x30 + i));
+        st.keyIDOwner  = mk_u160(static_cast<uint8_t>(0x40 + i));
+        // A minimal well-formed P2PKH payout (25 bytes) — required by the
+        // parser, irrelevant to merkleRootMNList.
+        std::vector<uint8_t> spk = {0x76, 0xa9, 0x14};
+        for (int b = 0; b < 20; ++b) spk.push_back(static_cast<uint8_t>(i + b));
+        spk.push_back(0x88); spk.push_back(0xac);
+        st.scriptPayout.m_data.assign(spk.begin(), spk.end());
+        st.nRegisteredHeight   = 1'900'000 + i;
+        st.nLastPaidHeight     = 2'000'000 + i;
+        st.nPoSeBanHeight      = rp::ReplayMNState::NEVER;   // isValid == true
+        st.nPoSeRevivedHeight  = rp::ReplayMNState::NEVER;
+        st.collateralOutpoint.hash  = mk_u256(static_cast<uint8_t>(0x50 + i));
+        st.collateralOutpoint.index = i;
+        st.internalId               = 500 + i;
+        out.emplace_back(protx, std::move(st));
+    }
+    return out;
+}
+
+// Serialize a set into the SHARED prestate text format
+// (c2pool-dash-replay-prestate/1) that mnlist_seed reuses — the SAME 26 fields
+// in the SAME order the fail-closed parser reads. `mnroot_display` is written
+// as-given so a test can inject a WRONG root and prove the gate reds.
+std::string serialize_seed(const std::vector<std::pair<uint256, rp::ReplayMNState>>& set,
+                           const std::string& network,
+                           uint32_t height,
+                           const std::string& blockhash_display,
+                           const std::string& mnroot_display)
+{
+    std::ostringstream os;
+    os << rp::kPrestateMagic << "\n";
+    os << "network " << network << "\n";
+    os << "height " << height << "\n";
+    os << "blockhash " << blockhash_display << "\n";
+    os << "mnroot " << mnroot_display << "\n";
+    os << "count " << set.size() << "\n";
+    for (const auto& [protx, st] : set) {
+        os << "mn "
+           << wire_hex(protx) << " "
+           << wire_hex(st.confirmedHash) << " "
+           << wire_hex(st.netInfo.ip) << " "
+           << st.netInfo.port_be << " "
+           << "- "                                   // pubKeyOperator (null)
+           << wire_hex(st.keyIDVoting) << " "
+           << wire_hex(st.keyIDOwner) << " "
+           << st.nVersion << " "
+           << st.nType << " "
+           << "- "                                   // platformNodeID
+           << st.platformP2PPort << " "
+           << st.platformHTTPPort << " "
+           << st.nOperatorReward << " "
+           << bytes_hex(std::vector<uint8_t>(st.scriptPayout.m_data.begin(),
+                                             st.scriptPayout.m_data.end())) << " "
+           << "- "                                   // scriptOperatorPayout
+           << st.nRegisteredHeight << " "
+           << st.nLastPaidHeight << " "
+           << st.nConsecutivePayments << " "
+           << st.nPoSePenalty << " "
+           << st.nPoSeBanHeight << " "
+           << st.nPoSeRevivedHeight << " "
+           << st.nRevocationReason << " "
+           << wire_hex(st.collateralOutpoint.hash) << " "
+           << st.collateralOutpoint.index << " "
+           << st.internalId << "\n";
+    }
+    return os.str();
+}
+
+// The committed root of a set == the engine's own compute over it, seeded at
+// `height`. This is what a real getmnlistdiff at `height` would have to
+// reproduce; we mint it locally so the KAT is self-contained.
+uint256 root_of(const std::vector<std::pair<uint256, rp::ReplayMNState>>& set,
+                uint32_t height)
+{
+    rp::FoldConfig cfg; cfg.enabled = true;
+    rp::DmlFoldEngine eng(cfg);
+    auto copy = set;
+    eng.seed(std::move(copy), set.size(), height, mk_u256(0xAA), "mainnet");
+    return eng.compute_sml_root();
+}
+
+std::string write_temp(const std::string& body, const std::string& tag)
+{
+    const auto p = std::filesystem::temp_directory_path()
+                 / ("c2pool_mnseed_kat_" + tag + "_"
+                    + std::to_string(::getpid()) + ".txt");
+    std::ofstream(p, std::ios::binary) << body;
+    return p.string();
+}
+
+constexpr uint32_t kV20 = dash::coin::vendor::kV20FloorMainnet; // 1'987'776
+
+} // namespace
+
+// ── (a) FLAGS-ABSENT — the arm is inert, from-DIP3 default is unchanged ─────
+TEST(DashMnListSeed, DisarmedByDefault_FromDip3Unchanged)
+{
+    rp::MnListSeedRequest req;                       // all defaults
+    EXPECT_FALSE(rp::mnlist_seed_armed(req));
+    // Touching ANY single flag arms it (and only then is the seed arm entered).
+    rp::MnListSeedRequest h; h.seed_height = kV20;
+    EXPECT_TRUE(rp::mnlist_seed_armed(h));
+    rp::MnListSeedRequest s; s.source = rp::kMnListSeedSourceGetMnListDiff;
+    EXPECT_TRUE(rp::mnlist_seed_armed(s));
+    rp::MnListSeedRequest f; f.file = "/x";
+    EXPECT_TRUE(rp::mnlist_seed_armed(f));
+}
+
+// ── (c) POLICY GATE: unknown/blank source is never guessed ──────────────────
+TEST(DashMnListSeed, SourceGateRejectsUnknown)
+{
+    rp::MnListSeedRequest req;
+    req.seed_height = kV20; req.source = "rpc"; req.file = "/whatever";
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("getmnlistdiff"), std::string::npos);
+}
+
+// ── (c) POLICY GATE: height is required ─────────────────────────────────────
+TEST(DashMnListSeed, HeightRequired)
+{
+    rp::MnListSeedRequest req;
+    req.source = rp::kMnListSeedSourceGetMnListDiff; req.file = "/whatever";
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("height"), std::string::npos);
+}
+
+// ── (c) THE ESCAPE-HATCH GATE: below the V20 floor is rejected ──────────────
+TEST(DashMnListSeed, V20FloorRejectsPreV20SeedHeight)
+{
+    rp::MnListSeedRequest req;
+    req.source = rp::kMnListSeedSourceGetMnListDiff;
+    req.seed_height = 1'028'160;                            // DIP3 height, < V20
+    req.file = "/whatever";
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("V20"), std::string::npos);
+}
+
+// ── (c) POLICY GATE: a file (offline snapshot) is required for now ──────────
+TEST(DashMnListSeed, FileRequired)
+{
+    rp::MnListSeedRequest req;
+    req.source = rp::kMnListSeedSourceGetMnListDiff; req.seed_height = kV20;
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("file"), std::string::npos);
+}
+
+// ── (b) HAPPY PATH: seed loads, verifies against the committed root, and is
+//        left fold-ready at H (next accepted block is H+1). ──────────────────
+TEST(DashMnListSeed, SeedLoadsVerifiesAndIsFoldReady)
+{
+    const uint32_t H = kV20 + 10;                    // >= V20 floor
+    auto set = build_set();
+    const uint256 root = root_of(set, H);
+    const std::string body = serialize_seed(set, "mainnet", H,
+                                            mk_u256(0xAA).GetHex(), root.GetHex());
+    const std::string path = write_temp(body, "ok");
+
+    rp::MnListSeedRequest req;
+    req.source = rp::kMnListSeedSourceGetMnListDiff;
+    req.seed_height = H; req.file = path; req.testnet = false;
+
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    ASSERT_TRUE(ps.ok) << ps.error;
+    EXPECT_EQ(ps.height, H);
+    EXPECT_EQ(ps.entries.size(), set.size());
+
+    // THE REWARD-SAFETY GATE (reused verbatim from the prestate arm): seed +
+    // re-verify the committed merkleRootMNList before any forward fold.
+    rp::FoldConfig cfg; cfg.enabled = true;
+    rp::DmlFoldEngine eng(cfg);
+    const std::string serr = rp::seed_engine_from_prestate(eng, ps);
+    EXPECT_TRUE(serr.empty()) << serr;
+    EXPECT_EQ(eng.compute_sml_root().GetHex(), root.GetHex());
+    EXPECT_EQ(eng.height(), H);                       // fold-forward-ready: next is H+1
+    EXPECT_EQ(eng.size(), set.size());
+
+    std::filesystem::remove(path);
+}
+
+// ── (c) REWARD-SAFETY: a seed whose committed root != computed FAILS CLOSED ──
+TEST(DashMnListSeed, MismatchedCommittedRootFailsClosed)
+{
+    const uint32_t H = kV20 + 10;
+    auto set = build_set();
+    const uint256 root = root_of(set, H);
+
+    // Flip one nibble of the committed root — the state is byte-identical, only
+    // the CLAIMED root diverges. The gate must red.
+    std::string wrong = root.GetHex();
+    wrong[0] = (wrong[0] == '0') ? '1' : '0';
+    ASSERT_NE(wrong, root.GetHex());
+
+    const std::string body = serialize_seed(set, "mainnet", H,
+                                            mk_u256(0xAA).GetHex(), wrong);
+    const std::string path = write_temp(body, "bad");
+
+    rp::MnListSeedRequest req;
+    req.source = rp::kMnListSeedSourceGetMnListDiff;
+    req.seed_height = H; req.file = path;
+
+    // Parsing + policy still pass (the text is well-formed) ...
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    ASSERT_TRUE(ps.ok) << ps.error;
+
+    // ... but the root gate REJECTS the seed — it is a guess, not an anchor.
+    rp::FoldConfig cfg; cfg.enabled = true;
+    rp::DmlFoldEngine eng(cfg);
+    const std::string serr = rp::seed_engine_from_prestate(eng, ps);
+    EXPECT_FALSE(serr.empty());
+    EXPECT_NE(serr.find("ANCHOR SEED REJECTED"), std::string::npos);
+
+    std::filesystem::remove(path);
+}
+
+// ── (c) POLICY GATE: declared height must match the snapshot's height ───────
+TEST(DashMnListSeed, HeightMismatchFailsClosed)
+{
+    const uint32_t Hfile = kV20 + 10;
+    auto set = build_set();
+    const uint256 root = root_of(set, Hfile);
+    const std::string body = serialize_seed(set, "mainnet", Hfile,
+                                            mk_u256(0xAA).GetHex(), root.GetHex());
+    const std::string path = write_temp(body, "hmm");
+
+    rp::MnListSeedRequest req;
+    req.source = rp::kMnListSeedSourceGetMnListDiff;
+    req.seed_height = Hfile + 1;                      // operator asked a DIFFERENT height
+    req.file = path;
+
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("does not match"), std::string::npos);
+
+    std::filesystem::remove(path);
+}
+
+// ── (c) POLICY GATE: network of the snapshot must match the run ─────────────
+TEST(DashMnListSeed, NetworkMismatchFailsClosed)
+{
+    const uint32_t H = kV20 + 10;
+    auto set = build_set();
+    const uint256 root = root_of(set, H);
+    const std::string body = serialize_seed(set, "testnet", H,
+                                            mk_u256(0xAA).GetHex(), root.GetHex());
+    const std::string path = write_temp(body, "net");
+
+    rp::MnListSeedRequest req;                        // testnet=false (mainnet run)
+    req.source = rp::kMnListSeedSourceGetMnListDiff;
+    req.seed_height = H; req.file = path;
+
+    const auto ps = rp::load_and_validate_mnlist_seed(req);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("network"), std::string::npos);
+
+    std::filesystem::remove(path);
+}


### PR DESCRIPTION
## What

An **OPTIONAL, default-OFF** replay mode that **seeds** the DASH replay-fold's MN-list state from a dashd `getmnlistdiff` snapshot at/after the **V20 activation floor** (mainnet h=1987776) and walks **V20+ only** — an operator escape hatch for **#154**.

This is **path-ii, operator-directed**. It is **NOT the default** and **never changes from-DIP3 behaviour when its flags are absent**.

### Background
The #154 self-derive normally folds from DIP3 (h=1028160) forward, self-checking `merkleRootMNList` byte-exact vs each block's committed cbTx root, fail-closed. That pure from-DIP3 path is **THE DEFAULT** and is being fixed separately (a pre-v19 rotated-quorum ordering bug). This PR adds an alternative: instead of *deriving* the pre-V20 state, **seed** it from a `getmnlistdiff` at V20 and fold V20+ only, sidestepping the pre-v19 rotated-derivation problem for the **checkpoint-generation** use case. The tradeoff (a build-time dashd dependency for the generated `.inc`) is understood and accepted by the operator **specifically because it is optional and off by default**.

## CLI (all OPTIONAL, default-OFF)

| flag | meaning |
|---|---|
| `--replay-mnlist-seed-height H` | seed height; must be `>=` the V20 floor |
| `--replay-mnlist-seed-source getmnlistdiff` | named provenance (only accepted value) |
| `--replay-mnlist-seed-file FILE` | materialized snapshot (offline twin of the peer's `getmnlistdiff`; the live coin-p2p fetch is **sequenced later**, #154) |

When **all three are absent**, the from-DIP3 default is **byte-identical to master** — the new code is purely additive and guarded on `mnlist_seed_armed()`.

## Reward-safety

The seed's computed `merkleRootMNList` must reproduce the chain's **own committed root** at the seed height **before any block is folded forward** — `replay::seed_engine_from_prestate()`, reused verbatim, **fail-closed** if not. From H+1 the normal per-block byte-exact self-check is **unchanged**, so the generated `.inc` stays oracle-verifiable at 2522504. `getmnlistdiff` carries every SML field `merkleRootMNList` commits; `scriptPayout` is not in the SML leaf and not committed, so the root check is exact without a payee axis.

## Reuse (does NOT reinvent)

The seed materializes into the **same** prestate text format + the **same** fail-closed 26-field parser (`replay_prestate.hpp`) and converges on the **same** `seed_engine_from_prestate` root gate and the **same** anchor+1 lane pin the plain `--replay-fold-prestate` arm uses — no second parser, no new root gate. `mnlist_seed.hpp` adds **only** the escape-hatch arming policy: source must be `getmnlistdiff`, height required and `>=` the V20 floor, file required, declared height + network must match the snapshot. `--replay-mnlist-seed-*` and `--replay-fold-prestate` are mutually exclusive seed sources.

## KAT

`test/test_dash_replay_mnlist_seed.cpp` (folded into the allowlisted `test_dash_mn_state` target per the #143/#769 NOT_BUILT rule) — **9 cases, all green**:
- flags-absent is inert (from-DIP3 unchanged);
- policy gates: source / height / **V20-floor** / file / height-match / network-match;
- happy path: seed **loads + verifies against the committed root + is fold-ready at H**;
- **reward-safety: a committed root != computed FAILS CLOSED** at `seed_engine_from_prestate`.

```
[  PASSED  ] 9 tests.  (DashMnListSeed.*)
```
Full target: 132 passed, 1 skipped (the CI-inert data-driven `DashReplayRun.AnchorToTipRootChain`), no regressions.

## Honest status: structural vs live

- **Structural (proven here):** the gate mechanics — compute-vs-committed, fail-closed, V20-floor, height/network match. The committed root in the KAT is the engine's **own** compute over hand-built entries (never a memorized mainnet constant), so a `CalcMerkleRoot` bug could not make it falsely green; the mismatch case flips one nibble and **requires** the gate to red.
- **Live-unproven (sequenced later, #154):** that a **live** dashd `getmnlistdiff` at mainnet h=1987776 reproduces mainnet's real committed root and that folding V20→2522504 stays byte-exact. That is the live validation leg (seed at 1987776 + walk to 2522504), on the operator's call. `--replay-mnlist-seed-file` is the offline transport for now; the live coin-p2p fetch converges on the identical Prestate + identical root gate.

Build proof: KAT compiled + 9/9 green against the identical fold/prestate API; `main_dash.cpp` wiring passes `-fsyntax-only` against master headers.

**Do not merge** — CODE + KAT + PR only; live validation sequenced later.