### PR TITLE
web: re-source local-hashrate stat-log graph from RateMonitor (fix flat/zero hashrate history)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7171,13 +7171,28 @@ void MiningInterface::update_stat_log()
         entry.connected_count = static_cast<int>(workers.size());  // raw TCP connections
         std::set<std::string> worker_combos;
         for (const auto& [sid, w] : workers) {
-            double existing = entry.local_hash_rates.value(w.username, 0.0);
-            entry.local_hash_rates[w.username] = existing + w.hashrate;
-            double existing_dead = entry.local_dead_hash_rates.value(w.username, 0.0);
-            entry.local_dead_hash_rates[w.username] = existing_dead + w.dead_hashrate;
             std::string combo = w.username;
             if (!w.worker_name.empty()) combo += "." + w.worker_name;
             worker_combos.insert(combo);
+        }
+        // Hash-rate series: source from the RateMonitor (windowed, p2pool-correct
+        // get_local_rates), NOT the per-session WorkerInfo.hashrate estimate. The
+        // per-session field is updated only on pseudoshare-accept and always
+        // carries dead=0, which rendered the local-hashrate history graph flat/zero
+        // on live prod. Fall back to the per-session sum only if the seam is unset.
+        if (m_local_rates_fn) {
+            auto [rates, dead_rates] = m_local_rates_fn();
+            for (const auto& [user, hr] : rates)
+                entry.local_hash_rates[user] = hr;
+            for (const auto& [user, dhr] : dead_rates)
+                entry.local_dead_hash_rates[user] = dhr;
+        } else {
+            for (const auto& [sid, w] : workers) {
+                double existing = entry.local_hash_rates.value(w.username, 0.0);
+                entry.local_hash_rates[w.username] = existing + w.hashrate;
+                double existing_dead = entry.local_dead_hash_rates.value(w.username, 0.0);
+                entry.local_dead_hash_rates[w.username] = existing_dead + w.dead_hashrate;
+            }
         }
         entry.miner_count = static_cast<int>(entry.local_hash_rates.size());
         entry.worker_count = static_cast<int>(worker_combos.size());
@@ -8714,6 +8729,12 @@ bool WebServer::start_stratum_server()
             mining_interface_->set_stratum_rate_stats_fn([ss]() -> MiningInterface::RateStats {
                 auto s = ss->get_rate_stats();
                 return {s.hashrate, s.effective_dt, s.total_datums, s.dead_datums};
+            });
+            // Feed the stat-log graph series from the RateMonitor per-user rates
+            // (get_local_rates), so the local-hashrate history graph reflects live
+            // windowed hashrate instead of the flat per-session estimate.
+            mining_interface_->set_local_rates_fn([ss]() {
+                return ss->get_local_rates();
             });
         }
         return started;

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -625,6 +625,16 @@ public:
     void set_stratum_rate_stats_fn(std::function<RateStats()> fn) { m_stratum_rate_stats_fn = thread_safe_wrap(std::move(fn)); }
     RateStats get_stratum_rate_stats() const { return m_stratum_rate_stats_fn ? m_stratum_rate_stats_fn() : RateStats{}; }
 
+    // Per-user hashrate + dead-hashrate from the stratum RateMonitor (p2pool
+    // get_local_rates, work.py:1965-1973). The stat-log graph series reads from
+    // THIS, not per-session WorkerInfo.hashrate: the latter is refreshed only on
+    // pseudoshare-accept and always carries dead=0, which flattened the local
+    // hashrate history graph to zero on live prod (founding-bug class).
+    using local_rates_fn_t = std::function<std::pair<
+        std::unordered_map<std::string, double>,
+        std::unordered_map<std::string, double>>()>;
+    void set_local_rates_fn(local_rates_fn_t fn) { m_local_rates_fn = std::move(fn); }
+
     // Per-worker stratum registry provider (display only). On the LTC path the
     // dashboard's OWN core::StratumServer registers workers straight into
     // m_stratum_workers (register_stratum_worker). Coin targets that run their
@@ -1257,6 +1267,7 @@ private:
     std::vector<unsigned char> m_donation_script;   // protocol donation scriptPubKey
     std::function<double()> m_stratum_hashrate_fn;  // callback to get stratum total hashrate
     std::function<RateStats()> m_stratum_rate_stats_fn;  // callback to get rate monitor stats
+    local_rates_fn_t m_local_rates_fn;  // RateMonitor per-user rates for stat-log graph series
 
     // Cached network difficulty (computed from bits in refresh_work)
     std::atomic<double> m_network_difficulty{0.0};


### PR DESCRIPTION
## What

The stat-log local-hashrate graph series was built from per-session `w.hashrate`
snapshots at web_server.cpp:6876, a path that reads dead/zero and renders a
flat-or-zero hashrate history — even while the live `/local_stats` local_hashps
gauge (sourced from RateMonitor) reports correctly. Same shape as the founding
0-stub bug: the dashboard graph lies about a metric the node actually knows.

## Fix

Re-source the graph series from RateMonitor (the same estimator feeding the live
gauge) instead of the dead per-session field. Web layer only, non-consensus.

- src/core/web_server.cpp / .hpp — 36 insertions, no consensus surface touched.

## Verification

Pending CI green (mergeStateStatus CLEAN). Designated reviewer to review before merge.
