### PR TITLE
dash #154: port dashd AddMN unique-property refusal into rotated quarter fill (1800288 qi31 wall)

### DIFF
--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -304,6 +304,73 @@ struct ProRegLess {
 };
 using ProRegSet = std::set<uint256, ProRegLess>;
 
+/// dashd CDeterministicMNList::AddMN, member-derivation edition
+/// (evo/deterministicmns.cpp:421-476). A CDeterministicMNList refuses a
+/// masternode that would DUPLICATE any of a set of unique properties —
+/// proTxHash, collateralOutpoint, pubKeyOperator, keyIDOwner, service — and
+/// the rotation code (BuildNewQuorumQuarterMembers, llmq/utils.cpp) leans on
+/// that refusal: every AddMN there is wrapped in a try/catch, so a colliding
+/// candidate is SILENTLY DROPPED (union) or SKIPPED (quarter fill), not
+/// added. Modelling MnsUsedAtH / MnsUsedAtHIndexed as a bare proTxHash set
+/// loses exactly this: a REMOVED masternode retained pre-V19 (skip_removed
+/// =false) still holds its collateral/operator slot, so a DIFFERENT-proTxHash
+/// RE-REGISTRATION on the SAME collateral (or operator key) must be rejected
+/// from that quorum's fill — a proTxHash-only set wrongly accepts it and the
+/// whole subsequent fill shifts by one (mainnet 1800288 quorumIndex 31).
+///
+/// The properties enforced here are the ones a QuorumMnEntry carries:
+/// proTxHash always; collateralOutpoint when has_collateral (the replay-fed
+/// / full-DIP3 list — the SML-fed list cannot and degrades to proTxHash+
+/// operator only, exactly as it already fails ties closed); pubKeyOperator
+/// when non-null. keyIDOwner and service are not carried, so those two of
+/// dashd's five unique properties are not modelled — a strict subset, and
+/// re-registration (the retained-removed-MN case that bites here) always
+/// reuses the collateralOutpoint, which IS modelled.
+struct UniqueMnList {
+    ProRegSet                          protx;
+    std::set<std::array<uint8_t, 36>>  collateral;   // 32-byte hash ‖ LE index
+    std::set<std::array<uint8_t, 48>>  operators;     // BLS operator pubkey
+
+    static std::array<uint8_t, 36> coll_key(const QuorumMnEntry& e)
+    {
+        std::array<uint8_t, 36> k{};
+        std::memcpy(k.data(), e.collateral_hash.data(), 32);
+        k[32] = static_cast<uint8_t>(e.collateral_index & 0xff);
+        k[33] = static_cast<uint8_t>((e.collateral_index >> 8) & 0xff);
+        k[34] = static_cast<uint8_t>((e.collateral_index >> 16) & 0xff);
+        k[35] = static_cast<uint8_t>((e.collateral_index >> 24) & 0xff);
+        return k;
+    }
+    static bool operator_active(const QuorumMnEntry& e)
+    {
+        for (uint8_t b : e.pub_key_operator) if (b != 0) return true;
+        return false;   // CBLSLazyPublicKey() default → not a unique property
+    }
+
+    bool   has_mn(const uint256& h) const { return protx.count(h) != 0; }
+    size_t size() const { return protx.size(); }   // == GetCounts().total()
+
+    /// AddMN: false on ANY unique-property collision (the caught throw),
+    /// true when the entry is admitted. Checks are made BEFORE any mutation
+    /// so a rejected add leaves the list untouched (dashd's rollback).
+    bool try_add(const QuorumMnEntry& e)
+    {
+        if (protx.count(e.proTxHash)) return false;          // duplicate proTxHash
+        const bool op = operator_active(e);
+        std::array<uint8_t, 36> ck{};
+        if (e.has_collateral) {
+            ck = coll_key(e);
+            if (collateral.count(ck)) return false;          // duplicate collateral
+        }
+        if (op && operators.count(e.pub_key_operator))
+            return false;                                    // duplicate operator
+        protx.insert(e.proTxHash);
+        if (e.has_collateral) collateral.insert(ck);
+        if (op) operators.insert(e.pub_key_operator);
+        return true;
+    }
+};
+
 inline MnRef find_by_protx(const std::vector<QuorumMnEntry>& list,
                            const uint256& protx)
 {
@@ -442,9 +509,16 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
     //     bootstrap window [1737792,1899072) lives here): a DEPARTED member
     //     still CONSUMES its used-slot (no HasMN skip); the PoSe-ban check only
     //     applies to members actually present in the H list.
-    ProRegSet          used_all;
-    std::vector<MnRef> used_all_refs;
-    std::vector<ProRegSet> used_indexed(num_quorums);
+    // MnsUsedAtH is the UNION (across quorum indexes) and MnsUsedAtHIndexed[i]
+    // the PER-INDEX list; dashd AddMN's each into a CDeterministicMNList inside
+    // its OWN try/catch (utils.cpp:378-385), so a unique-property collision
+    // drops a member from ONE list independently of the other. Both are
+    // UniqueMnList here (proTxHash + collateral + operator uniqueness), NOT a
+    // bare proTxHash set — the retained-removed-MN / re-registration case
+    // (mainnet 1800288 qi31) collides on collateralOutpoint and MUST be caught.
+    UniqueMnList              used_all;
+    std::vector<MnRef>        used_all_refs;
+    std::vector<UniqueMnList> used_indexed(num_quorums);
     for (size_t idx = 0; idx < num_quorums; ++idx) {
         for (size_t c = 0; c < previous_quarters.size(); ++c) { // H-C,H-2C,H-3C
             if (idx >= previous_quarters[c].size()) continue;
@@ -458,9 +532,14 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
                 } else if (!at_h->is_valid) {
                     continue;    // allMns.IsMNPoSeBanned (present but banned)
                 }
-                if (used_all.insert(mn->proTxHash).second)
+                // Two INDEPENDENT AddMN try/catches (union, then per-index):
+                // a member rejected by the union on a collision still enters
+                // its per-index list if that list has no clashing property,
+                // and vice versa. used_all_refs holds exactly what the union
+                // admitted (== MnsUsedAtH, the input to CalculateQuorum).
+                if (used_all.try_add(*mn))
                     used_all_refs.push_back(mn);
-                used_indexed[idx].insert(mn->proTxHash);
+                used_indexed[idx].try_add(*mn);
             }
         }
     }
@@ -476,7 +555,7 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
     {
         size_t i = 0;
         for (MnRef mn : *sorted_all) {
-            if (used_all.count(mn->proTxHash))
+            if (used_all.has_mn(mn->proTxHash))
                 out.snapshot.activeQuorumMembers[i] = true;
             ++i;
         }
@@ -491,7 +570,7 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
     std::vector<MnRef> not_used;
     not_used.reserve(work_list.size());
     for (const auto& e : work_list) {
-        if (used_all.count(e.proTxHash)) continue;
+        if (used_all.has_mn(e.proTxHash)) continue;   // !MnsUsedAtH.HasMN
         if (!e.is_valid) continue;
         not_used.push_back(&e);
     }
@@ -522,8 +601,16 @@ inline std::optional<NewQuarterOutput> build_new_quarter_members(
             if (++iters > max_iters) return std::nullopt;
             bool skip = true;
             MnRef cand = (*sorted_combined)[idx];
-            if (!used_indexed[i].count(cand->proTxHash)) {
-                used_indexed[i].insert(cand->proTxHash);
+            // dashd: !MnsUsedAtHIndexed[i].HasMN(cand) THEN AddMN(cand) inside
+            // a try/catch (utils.cpp:415-427). AddMN throws — and the caught
+            // throw leaves skip=true — when cand DUPLICATES a unique property
+            // (collateralOutpoint / operator) of a member already in this
+            // quarter's list, e.g. a retained removed MN it re-registers. A
+            // bare proTxHash set never throws and would wrongly admit it,
+            // shifting the whole fill by one (1800288 qi31: 72b0847… wrongly
+            // admitted where dashd retains 7cfcf4… at the same slot).
+            if (!used_indexed[i].has_mn(cand->proTxHash)
+                && used_indexed[i].try_add(*cand)) {
                 out.quarters[i].push_back(cand);
                 updated = true;
                 skip    = false;

--- a/test/test_dash_replay_quorum_engine.cpp
+++ b/test/test_dash_replay_quorum_engine.cpp
@@ -1015,6 +1015,104 @@ TEST(DashReplayQuorumEngine, ScoreTieNeedsCollateralToResolve)
     EXPECT_EQ((*sorted)[1], &a);
 }
 
+// ── Quarter-fill unique-property refusal (mainnet 1800288 qi31 wall) ────────
+// dashd's MnsUsedAtHIndexed[i] is a CDeterministicMNList; AddMN throws (and
+// BuildNewQuorumQuarterMembers CATCHES it) when a fill candidate duplicates a
+// unique property — collateralOutpoint / operator — of a member already in the
+// quarter. A retained-but-REMOVED masternode (pre-V19 skip_removed=false keeps
+// its slot) that has been RE-REGISTERED under a NEW proTxHash on the SAME
+// collateral is exactly that: dashd SKIPS the re-registration and keeps the
+// removed MN's slot, so the fill does not shift. Modelling the used set as a
+// bare proTxHash std::set loses the refusal (distinct proTxHash ⇒ wrongly
+// admitted), which is the 1800288 qi31 divergence (merkleRootMNList wall at
+// 1800598). RED on the proTxHash-set master, GREEN once UniqueMnList enforces
+// collateralOutpoint uniqueness the way dashd's AddMN does.
+TEST(DashReplayQuorumEngine, QuarterFillRefusesReRegistrationOnRetainedCollateral)
+{
+    using dash::coin::replay::rotdetail::build_new_quarter_members;
+    using MnRef = const QuorumMnEntry*;
+
+    auto set256 = [](uint256& h, const std::string& hex) { h.SetHex(hex); };
+
+    // The retained REMOVED masternode Y: a member of the previous quarter,
+    // no longer in the H work list, holding collateral C.
+    QuorumMnEntry y;
+    set256(y.proTxHash,
+           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    set256(y.confirmedHash,
+           "1111111111111111111111111111111111111111111111111111111111111111");
+    y.is_valid       = true;   // was valid when selected; only later removed
+    y.has_collateral = true;
+    set256(y.collateral_hash,
+           "00000000000000000000000000000000000000000000000000000000000000cc");
+    y.collateral_index = 1;
+
+    // Z: the RE-REGISTRATION — a DIFFERENT proTxHash on the SAME collateral C,
+    // present and valid in the H work list.
+    QuorumMnEntry z;
+    set256(z.proTxHash,
+           "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+    set256(z.confirmedHash,
+           "2222222222222222222222222222222222222222222222222222222222222222");
+    z.is_valid       = true;
+    z.has_collateral = true;
+    set256(z.collateral_hash,
+           "00000000000000000000000000000000000000000000000000000000000000cc");
+    z.collateral_index = 1;   // == Y's outpoint
+
+    // A: an unrelated valid MN on its own collateral D.
+    QuorumMnEntry a;
+    set256(a.proTxHash,
+           "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc");
+    set256(a.confirmedHash,
+           "3333333333333333333333333333333333333333333333333333333333333333");
+    a.is_valid       = true;
+    a.has_collateral = true;
+    set256(a.collateral_hash,
+           "00000000000000000000000000000000000000000000000000000000000000dd");
+    a.collateral_index = 0;
+
+    uint256 modifier;
+    set256(modifier,
+           "4444444444444444444444444444444444444444444444444444444444444444");
+
+    // One rotated quorum, quarter size 2. Work list = {A, Z} (Y is REMOVED,
+    // so it is not here). previous_quarters[H-C][qi0] retains Y.
+    const std::vector<QuorumMnEntry> work_list{a, z};
+    std::array<std::vector<std::vector<MnRef>>, 3> previous_quarters{};
+    previous_quarters[0] = {{&y}};   // H-C, quorumIndex 0, member Y
+
+    auto out = build_new_quarter_members(
+        /*num_quorums=*/1, /*quarter_size=*/2, work_list, modifier,
+        previous_quarters, /*skip_removed_mns=*/false);   // pre-V19 retention
+    ASSERT_TRUE(out.has_value());
+    ASSERT_EQ(out->quarters.size(), 1u);
+
+    bool z_selected = false;
+    for (MnRef m : out->quarters[0])
+        if (m->proTxHash == z.proTxHash) z_selected = true;
+
+    // The consensus claim: dashd never admits Z into this quarter, because Z's
+    // collateralOutpoint is already held by the retained (removed) Y. A
+    // proTxHash-only used set wrongly admits it — that is the wall.
+    EXPECT_FALSE(z_selected)
+        << "a re-registration on a retained removed MN's collateral must be "
+           "refused from the quarter fill, exactly as dashd's AddMN throws";
+
+    // Control: with skip_removed_mns=TRUE (post-V19) Y is DROPPED from the used
+    // set (not retained), so its collateral no longer blocks Z, and Z IS a
+    // legitimate quarter member — proving the refusal is gated on retention,
+    // not a blanket collateral ban.
+    auto out_v19 = build_new_quarter_members(
+        1, 2, work_list, modifier, previous_quarters, /*skip_removed_mns=*/true);
+    ASSERT_TRUE(out_v19.has_value());
+    bool z_v19 = false;
+    for (MnRef m : out_v19->quarters[0])
+        if (m->proTxHash == z.proTxHash) z_v19 = true;
+    EXPECT_TRUE(z_v19)
+        << "post-V19 the removed MN is not retained, so Z is admissible";
+}
+
 // The parsed-block adapter (W1's consumer shape): cbTx fields + type-6
 // payloads lifted from a synthetic block; unparseable payloads fail closed.
 TEST(DashReplayQuorumEngine, InputFromBlockAdapterLiftsCbTxAndCommitments)


### PR DESCRIPTION
## The wall (task #154, #1 dashd-cut blocker)

The self-derive fold matches dashd **byte-exact for h 1028161..1800597** and HARD-STOPS at **1800598** (`merkleRootMNList` `451de5...` vs committed `8f0f61aa0741ab4409ee4a43ebbfb3ceb1f8d0edeb18b004207e5f2b137cf46c`).

Root cause: the DIP0024 rotated **new-quarter member set for cycle base 1800288, quorumIndex 31** (llmqType 5, LLMQ_60_75) is wrong. The fill wrongly admits `72b0847688c3...` where dashd retains the removed MN `7cfcf4adf314...` at that slot, then shifts every later member up by one — `1a1cee4d...` slides from idx57 (invalid) to idx56 (valid), so it is never PoSe-punished at h=1800331, enters 1800598 under-penalized, and the root diverges.

## The diverging line

dashd models `MnsUsedAtH` / `MnsUsedAtHIndexed[i]` as `CDeterministicMNList`s. `AddMN` (`evo/deterministicmns.cpp:421-476`) throws on a **duplicate unique property** — collateralOutpoint, pubKeyOperator, keyIDOwner, service — not just proTxHash, and `BuildNewQuorumQuarterMembers` (`llmq/utils.cpp:378-427`) **catches** that throw: a colliding candidate is silently dropped from the union or **skipped** in the quarter fill.

`replay_quorum_engine.hpp` modelled both used lists as **bare proTxHash `std::set`s** (`used_all`, `used_indexed[i]`), and the fill loop admitted any candidate whose proTxHash was absent. So a **removed masternode retained pre-V19** (`skip_removed_mns=false` keeps its slot) that has been **re-registered under a new proTxHash on the same collateral outpoint** was wrongly admitted — its distinct proTxHash defeated the only check the fold had. `72b0847...` registers on an *external* collateral (`acdb8ea3...:1`), the re-registration signature.

## The port

`UniqueMnList` — a faithful port of `AddMN`'s uniqueness over the properties a `QuorumMnEntry` carries: proTxHash always, collateralOutpoint when `has_collateral` (the replay-fed / full-DIP3 list), pubKeyOperator when non-null. `try_add()` returns false on any collision, reproducing the caught throw in **both** the union pre-loop (two independent `AddMN`s, per dashd) and the fill loop (`HasMN` then `AddMN`); `size()` is `GetCounts().total()`. keyIDOwner/service are not carried by `QuorumMnEntry` (a strict subset of dashd's five properties) — but re-registration always reuses the collateralOutpoint, which is enforced.

## Proof

- **New KAT** `QuarterFillRefusesReRegistrationOnRetainedCollateral`: a retained removed MN Y holds collateral C; a re-registration Z (new proTxHash, collateral C) present in the H list must be refused from the quarter fill. **RED on master** (Z wrongly admitted: `z_selected Actual: true`), **GREEN with the fix**. A post-V19 control (`skip_removed_mns=true` drops Y ⇒ Z admissible) proves the refusal is retention-gated, not a blanket ban.
- **No regression**: all 22 `DashReplayQuorumEngine.*` tests green, including the all-32-slot byte-parity KAT for cycle 2516544 (`KatB_RotationMembersMatchDashdForAll32Slots`) and the pre-V19 bootstrap gate KATs.

The full-fold crossing of the 1800598 wall is left to the warm self-derive, which will cross it once master carries this fix.
