### PR TITLE
dgb(redistribute): plumb fee operator-identity

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -108,7 +108,8 @@ void print_banner(const char* argv0, const core::CoinParams& p)
         << " [--version] [--help] [--selftest] [--run] [--stratum [H:]P] [--http [H:]P]\n"
         << "       [--coin-daemon H:P] [--coin-magic HEX] [--regtest]\n"
         << "       [--regtest-force-won-share] [--no-p2p-relay]\n"
-        << "       [--redistribute SPEC] [--sharechain-port P]\n"
+        << "       [--redistribute SPEC] [--node-owner-address ADDR]\n"
+        << "       [--sharechain-port P]\n"
         << "       [--data-dir PATH] [--dev-relax-algo-softforks]\n"
         << "       [--coin-p2p-discover]\n\n"
         << "  --data-dir PATH  root all per-instance state here (default ~/.c2pool);\n"
@@ -182,6 +183,7 @@ int run_node(const core::CoinParams& params, bool testnet,
              bool regtest = false, bool force_won_share = false,
              bool no_p2p_relay = false,
              const std::string& redistribute_spec = "",
+             const std::string& node_owner_address = "",
              bool dev_relax_algo_softforks = false,
              bool coin_p2p_discover = false,
              const std::string& http_addr = "0.0.0.0",
@@ -971,14 +973,26 @@ int run_node(const core::CoinParams& params, bool testnet,
         redistributor->set_hybrid_weights(dgb::parse_redistribute_spec(redistribute_spec));
         // "donate" identity: P2SH hash160 == COMBINED_DONATION_SCRIPT[2..22]
         // (V36 1-of-2 forrestv+maintainer combined donation, byte-identical to
-        // the gentx donation output). "fee" needs an operator payout identity
-        // not yet plumbed here -> pick() returns a null hash for it and the
-        // fallback yields an empty script (fail-safe: never a burn output).
+        // the gentx donation output).
         {
             const auto& ds = dgb::PoolConfig::COMBINED_DONATION_SCRIPT;
             uint160 donation_hash;
             std::memcpy(donation_hash.data(), ds.data() + 2, 20);
             redistributor->set_donation_identity(donation_hash, /*P2SH=*/2);
+        }
+        // "fee" identity: the node operator's payout address -> hash160, decoded
+        // via core::address_to_hash160 (mirrors main_ltc.cpp's set_operator_
+        // identity wiring; DGB has no MiningInterface bridge). Absent a
+        // --node-owner-address the operator identity stays null and a bare
+        // --redistribute fee remains the fail-safe empty-script no-op (never a
+        // burn output). CONSENSUS-SAFE: node-local pubkey_hash choice only.
+        if (dgb::set_operator_identity_from_address(*redistributor, node_owner_address)) {
+            std::cout << "[DGB] redistribute fee identity ARMED: operator payout \""
+                      << node_owner_address << "\" -> hash160" << std::endl;
+        } else if (!node_owner_address.empty()) {
+            std::cout << "[DGB] WARNING: --node-owner-address \"" << node_owner_address
+                      << "\" did not decode to a hash160; fee arm stays null "
+                         "(empty script, no burn)" << std::endl;
         }
         auto& redist_tracker = p2p_node.tracker();
         work_source->set_fallback_payout_fn(
@@ -1526,6 +1540,7 @@ int main(int argc, char** argv)
     std::string rpc_endpoint;               // --coin-rpc HOST:PORT (external digibyted submit arm)
     std::string rpc_conf_path;              // --coin-rpc-auth PATH to digibyte.conf (creds source)
     std::string redistribute_spec;         // --redistribute SPEC (node-local payout policy, #307)
+    std::string node_owner_address;        // --node-owner-address ADDR (operator payout identity for --redistribute fee, #307)
     // ── #82 regtest-gated forced-won-share LIVE seam (decision (a), 2026-06-21) ──
     // --regtest-force-won-share synthesizes ONE won share into the live
     // ShareTracker and fires m_on_block_found AFTER both broadcast arms are
@@ -1611,6 +1626,9 @@ int main(int argc, char** argv)
         if (std::strcmp(argv[i], "--redistribute") == 0 && i + 1 < argc) {
             redistribute_spec = argv[++i];     // pplns|fee|boost|donate or hybrid "boost:70,donate:20"
         }
+        if (std::strcmp(argv[i], "--node-owner-address") == 0 && i + 1 < argc) {
+            node_owner_address = argv[++i];    // operator payout addr -> "fee" identity (#307 fee arm)
+        }
         if (std::strcmp(argv[i], "--sharechain-port") == 0 && i + 1 < argc) {
             // --sharechain-port PORT - bind the sharechain (pool P2P) listener on
             // a non-default port so a SECOND isolated c2pool-dgb instance can run
@@ -1634,7 +1652,7 @@ int main(int argc, char** argv)
                         coin_daemon, coin_magic, coin_genesis,
                         rpc_endpoint, rpc_conf_path,
                         regtest, force_won_share, no_p2p_relay,
-                        redistribute_spec, dev_relax_algo_softforks,
+                        redistribute_spec, node_owner_address, dev_relax_algo_softforks,
                         coin_p2p_discover,
                         http_addr, http_port);
 

--- a/src/impl/dgb/redistribute.hpp
+++ b/src/impl/dgb/redistribute.hpp
@@ -27,6 +27,7 @@
 
 #include <core/log.hpp>
 #include <core/target_utils.hpp>
+#include <core/address_utils.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -497,5 +498,39 @@ private:
             pplns_cache_.push_back({e.script, e.hash, e.type, e.weight});
     }
 };
+
+// Configure the FEE-mode operator payout identity from a node-owner address.
+// This is the DGB analogue of main_ltc.cpp's operator-identity wiring
+// (set_operator_identity fed by get_node_fee_hash160): DGB has no
+// MiningInterface bridge, so the hash160 is decoded directly from the
+// operator's base58check / bech32 payout address via core::address_to_hash160.
+//
+// Returns true iff the address decoded to a 20-byte hash160 and the identity
+// was set; on empty / undecodable input it returns false and leaves the
+// operator identity NULL (fail-safe: --redistribute fee then yields an empty
+// script, never a burn output to the all-zero hash).
+//
+// CONSENSUS-SAFE: only selects the pubkey_hash this node stamps onto shares it
+// mints from broken-credential submissions; it touches nothing on the
+// sharechain (validation / codec / PPLNS unchanged).
+inline bool set_operator_identity_from_address(Redistributor& redistributor,
+                                               const std::string& address)
+{
+    if (address.empty())
+        return false;
+    std::string addr_type;
+    const std::string h160 = core::address_to_hash160(address, addr_type);
+    if (h160.size() != 40)
+        return false;  // undecodable / non-convertible (segwit v0 P2WSH, P2TR)
+    uint160 op_hash;
+    for (int i = 0; i < 20; ++i)
+        op_hash.data()[i] = static_cast<uint8_t>(
+            std::stoul(h160.substr(i * 2, 2), nullptr, 16));
+    // addr_type: "p2sh" -> 2, everything else -> 0 (P2PKH). Matches the fallback
+    // closure's script builder in main_dgb.cpp (0x76a914..88ac for P2PKH vs
+    // 0xa914..87 for P2SH) and the ltc operator-identity convention.
+    redistributor.set_operator_identity(op_hash, (addr_type == "p2sh") ? 2 : 0);
+    return true;
+}
 
 } // namespace dgb

--- a/src/impl/dgb/test/redistribute_test.cpp
+++ b/src/impl/dgb/test/redistribute_test.cpp
@@ -186,15 +186,92 @@ TEST(DgbRedistribute, DonateIdentityRoundTripsCombinedDonationP2SH)
 
 TEST(DgbRedistribute, FeeWithoutOperatorIdentityIsFailSafeNull)
 {
-    // main_dgb does not (yet) plumb an operator payout identity, so a bare
-    // --redistribute fee must yield a NULL pubkey -> the fallback returns an
-    // empty script (never a burn output to the all-zero hash).
+    // A bare --redistribute fee with NO --node-owner-address leaves the operator
+    // payout identity unset, so pick() must yield a NULL pubkey -> the fallback
+    // returns an empty script (never a burn output to the all-zero hash). The
+    // address-plumbed path is covered by
+    // FeeIdentityPlumbedFromNodeOwnerAddressMintsOperatorScript below.
     dgb::Redistributor r;
     r.set_mode(dgb::RedistributeMode::FEE);   // operator identity unset
     dgb::ShareTracker tracker;
     uint256 best;
     auto res = r.pick(tracker, best);
     EXPECT_TRUE(res.pubkey_hash.IsNull());
+}
+
+// --- #307 fee-identity PLUMBING (this PR) ---------------------------------
+// --redistribute fee + a configured --node-owner-address must mint under the
+// operator's payout script, NOT the empty-script no-op.
+//
+// RED before this PR: main_dgb never called set_operator_identity for the fee
+// arm, so pick(FEE) handed back a null hash and the fallback closure returned
+// {} (empty script). GREEN after: dgb::set_operator_identity_from_address
+// decodes the operator address to a hash160 and arms the FEE identity, so the
+// fee arm mints the operator P2PKH script. This test reproduces main_dgb.cpp's
+// fallback-payout script builder byte-for-byte.
+TEST(DgbRedistribute, FeeIdentityPlumbedFromNodeOwnerAddressMintsOperatorScript)
+{
+    // Canonical DGB mainnet P2PKH address (base58 version byte 0x1e) whose
+    // hash160 is 0102..14. Independently derived: base58check over
+    // 0x1e || hash160 || sha256d(0x1e||hash160)[:4].
+    const std::string kNodeOwnerAddr = "D5ERdEN1gsouFSs7zsq7VYJxyWP6dP28H1";
+    static const uint8_t kExpectedH160[20] = {
+        0x01,0x02,0x03,0x04,0x05,0x06,0x07,0x08,0x09,0x0a,
+        0x0b,0x0c,0x0d,0x0e,0x0f,0x10,0x11,0x12,0x13,0x14};
+
+    dgb::Redistributor r;
+    r.set_hybrid_weights(dgb::parse_redistribute_spec("fee")); // --redistribute fee
+    dgb::ShareTracker tracker;   // empty
+    uint256 best;                // null
+
+    // Reproduce main_dgb.cpp's fallback-payout closure: pick() -> script bytes
+    // (RAW 20-byte / script-order path, NOT uint160::GetHex which reverses).
+    auto fallback_script = [&]() -> std::vector<unsigned char> {
+        dgb::RedistributeResult rr = r.pick(tracker, best);
+        if (rr.pubkey_hash.IsNull()) return {};    // the master no-op
+        unsigned char hb[20];
+        std::memcpy(hb, rr.pubkey_hash.data(), 20);
+        std::vector<unsigned char> sp;
+        if (rr.pubkey_type == 2) {                 // P2SH:  a9 14 <h160> 87
+            sp = {0xa9, 0x14};
+            sp.insert(sp.end(), hb, hb + 20);
+            sp.push_back(0x87);
+        } else {                                   // P2PKH: 76 a9 14 <h160> 88 ac
+            sp = {0x76, 0xa9, 0x14};
+            sp.insert(sp.end(), hb, hb + 20);
+            sp.push_back(0x88);
+            sp.push_back(0xac);
+        }
+        return sp;
+    };
+
+    // RED baseline (no operator identity, exactly master's shipped fee arm):
+    // the fallback yields an EMPTY script.
+    EXPECT_TRUE(fallback_script().empty());
+
+    // GREEN (the fix): plumb the operator identity from the node-owner address.
+    ASSERT_TRUE(dgb::set_operator_identity_from_address(r, kNodeOwnerAddr));
+
+    // The fee arm now mints under the operator's P2PKH payout identity.
+    dgb::RedistributeResult armed = r.pick(tracker, best);
+    ASSERT_FALSE(armed.pubkey_hash.IsNull());
+    EXPECT_EQ(armed.pubkey_type, 0);   // P2PKH (0x1e is not a P2SH version byte)
+    EXPECT_EQ(std::memcmp(armed.pubkey_hash.data(), kExpectedH160, 20), 0);
+
+    // ...and the fallback closure builds the canonical 25-byte P2PKH script.
+    std::vector<unsigned char> expected = {0x76, 0xa9, 0x14};
+    expected.insert(expected.end(), kExpectedH160, kExpectedH160 + 20);
+    expected.push_back(0x88);
+    expected.push_back(0xac);
+    EXPECT_EQ(fallback_script(), expected);
+
+    // Empty / undecodable address -> false, operator identity left untouched
+    // (fail-safe: the fee arm stays the empty-script no-op).
+    dgb::Redistributor r2;
+    EXPECT_FALSE(dgb::set_operator_identity_from_address(r2, ""));
+    EXPECT_FALSE(dgb::set_operator_identity_from_address(r2, "not-a-valid-address"));
+    r2.set_mode(dgb::RedistributeMode::FEE);
+    EXPECT_TRUE(r2.pick(tracker, best).pubkey_hash.IsNull());
 }
 
 } // namespace


### PR DESCRIPTION
## The gap

`--redistribute fee` on DGB minted under a **null operator identity**, so the fee arm was a silent no-op:

- `dgb::Redistributor::pick_for_mode(FEE, ...)` returns `{operator_hash_, operator_type_}`, but `operator_hash_` was default-constructed (null) because `main_dgb` **never called `set_operator_identity`**.
- The fallback closure (`main_dgb.cpp`) sees `r.pubkey_hash.IsNull()` and returns `{}` (empty script, fail-safe).
- DGB had **no operator-address source at all** — unlike LTC, no node-owner / payout address flag was parsed. The self-documenting comment in `main_dgb.cpp` said as much: *"fee needs an operator payout identity not yet plumbed here"*.

So this is a **parse + plumb**, not a one-line wiring add.

## The fix

Mirrors `main_ltc.cpp` operator-identity wiring, adapted because DGB has no `MiningInterface`/`get_node_fee_hash160` bridge:

1. **Parse** `--node-owner-address ADDR` (same flag name as LTC). Threaded through `run_node(...)` into the `--redistribute` block, plus a usage line.
2. **Plumb** a new helper `dgb::set_operator_identity_from_address(Redistributor&, address)` in `src/impl/dgb/redistribute.hpp`: decodes the address to a hash160 via the existing `core::address_to_hash160` and arms the FEE identity (P2PKH, or P2SH for a P2SH version byte, matching the fallback closures script builder). Returns `false` on empty/undecodable input, leaving the operator identity null.
3. Absent `--node-owner-address`, the operator identity stays null and a bare `--redistribute fee` remains the fail-safe empty-script no-op (never a burn output).

**Consensus-safe:** the operator hash160 only selects the `pubkey_hash` this node stamps onto shares it mints from broken-credential submissions. Nothing on the sharechain (validation / codec / PPLNS) changes — same class as the already-shipping `donate` identity.

## The KAT (red -> green)

`dgb_redistribute_test` (already in both `build.yml` `--target` allowlists):

`FeeIdentityPlumbedFromNodeOwnerAddressMintsOperatorScript` reproduces `main_dgb` fallback-script builder byte-for-byte over a canonical DGB mainnet P2PKH address.

- **RED** (identity unarmed = master state): the fee arm yields an **empty script**. Proven by neutering the helper to a no-op and rebuilding — the test fails at the `set_operator_identity_from_address` assertion.
- **GREEN** (after the fix): the fee arm mints the operator 25-byte P2PKH script `76 a9 14 <hash160> 88 ac`; empty/undecodable address returns `false` and leaves the identity untouched.

Local: `c2pool` (DGB target) links, `dgb_redistribute_test` **9/9 green**. Existing `FeeWithoutOperatorIdentityIsFailSafeNull` retained as the no-address fail-safe pin.

## Files

- `src/impl/dgb/redistribute.hpp` — `+set_operator_identity_from_address` helper, `+#include <core/address_utils.hpp>`
- `src/c2pool/main_dgb.cpp` — `--node-owner-address` parse + `run_node` param + call-site wiring + usage line + stale-comment removal
- `src/impl/dgb/test/redistribute_test.cpp` — red->green KAT + refreshed fail-safe comment

DO NOT MERGE / DO NOT release — steward + operator review.
