### PR TITLE
dash(redistribute): port pplns+boost into mint path

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3096,8 +3096,54 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // Fee policy: one roll per job build (p2pool's per-get_work
                 // fee roll); resolve the share identity + donation.
                 const uint32_t roll_x100 = static_cast<uint32_t>(nonce_rng() % 10000u);
+
+                // --redistribute pplns/boost: when the miner's stratum
+                // credentials do NOT decode to a P2PKH script, the share is
+                // minted under a payout identity chosen from the accrued PPLNS
+                // window (weighted-random for pplns; zero-share boost else
+                // pplns for boost). Gather the SAME oracle-window weights the
+                // DASH payout uses (consensus-neutral local choice — every peer
+                // still recomputes identical coinbase outputs). Only walk the
+                // chain when the miner is actually broken-cred AND the mode is
+                // pplns/boost, so miner-ok / fee / donate jobs pay nothing.
+                dash::mint::RedistributeInputs redistribute;
+                {
+                    const bool miner_broken =
+                        !dash::stratum::pubkey_hash_from_p2pkh(payout_script).has_value();
+                    const bool needs_redist =
+                        fee_policy.redistribute ==
+                            dash::mint::MintFeePolicy::Redistribute::PPLNS ||
+                        fee_policy.redistribute ==
+                            dash::mint::MintFeePolicy::Redistribute::BOOST;
+                    if (miner_broken && needs_redist) {
+                        redistribute.candidates =
+                            dash::mint::gather_redistribute_candidates(
+                                guard->chain, mint_params, prev_share_hash,
+                                wd.m_bits);
+                        redistribute.pplns_roll =
+                            (static_cast<uint64_t>(nonce_rng()) << 32) |
+                            static_cast<uint64_t>(nonce_rng());
+                        redistribute.boost_zero_roll =
+                            (static_cast<uint64_t>(nonce_rng()) << 32) |
+                            static_cast<uint64_t>(nonce_rng());
+                        if (fee_policy.redistribute ==
+                                dash::mint::MintFeePolicy::Redistribute::BOOST &&
+                            stratum_server) {
+                            for (const auto& [pk, rate] :
+                                     stratum_server->get_local_addr_rates()) {
+                                if (rate <= 0.0)
+                                    continue;
+                                uint160 h;
+                                std::memcpy(h.data(), pk.data(), 20);
+                                redistribute.connected.push_back(
+                                    dash::pubkey_hash_to_script2(h));
+                            }
+                        }
+                    }
+                }
+
                 auto identity = dash::mint::resolve_mint_identity(
-                    fee_policy, payout_script, roll_x100);
+                    fee_policy, payout_script, roll_x100, redistribute);
                 if (!identity) {
                     static int redist_log = 0;
                     if (redist_log++ % 50 == 0)

--- a/src/impl/dash/mint_runloop.hpp
+++ b/src/impl/dash/mint_runloop.hpp
@@ -47,6 +47,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -298,6 +299,87 @@ struct ResolvedIdentity
     bool substituted{false};                   // true when NOT the miner's own
 };
 
+// ── weighted redistribution engine (pplns / boost) ───────────────────────────
+//
+// Port of the LTC Redistributor selection semantics (src/impl/ltc/
+// redistribute.hpp: pick_pplns :416-438, pick_boost :306-414) into the DASH
+// mint path. This is a LOCAL, consensus-NEUTRAL choice of which payout script a
+// broken-credential share is minted under — the DASH analogue of p2pool's
+// address fallback ("-f"): it only decides whose PPLNS weight THIS node's share
+// carries. Every peer still recomputes identical coinbase outputs from each
+// share's recorded m_pubkey_hash (dash::pplns::compute_payouts), so nothing
+// here touches DIP4 CbTx / merkleRootMNList / quorum commitments / block
+// validity. It is the same share-identity field the --fee path substitutes.
+//
+// The candidate weights are gathered from the SAME oracle window the DASH
+// payout uses (get_cumulative_weights via pplns_weights_for below), keyed by
+// scriptPubKey, so redistribution is proportional to real accrued PPLNS weight.
+struct WeightedCandidate
+{
+    std::vector<unsigned char> payout_script;  // P2PKH scriptPubKey
+    uint64_t                   weight{0};      // accrued PPLNS weight (oracle window)
+};
+
+// Bundle of the impure inputs the pplns/boost arms need. Default-constructed
+// (all empty) preserves the pre-port fail-closed decline: an empty candidate
+// set (cold chain) yields nullopt, exactly the historical genesis behaviour.
+struct RedistributeInputs
+{
+    std::vector<WeightedCandidate>              candidates;  // pplns weights, oracle window
+    std::vector<std::vector<unsigned char>>     connected;   // boost: live-rate miner scripts
+    uint64_t                                    pplns_roll{0};      // weighted-random draw
+    uint64_t                                    boost_zero_roll{0}; // zero-share pick draw
+};
+
+// Pure deterministic selector (KAT surface) — the cumulative weighted-random
+// walk of ltc::Redistributor::pick_pplns (redistribute.hpp:428-437). `roll` is
+// reduced modulo the grand total, then the entry whose cumulative band it lands
+// in is returned. Empty or all-zero-weight -> nullopt (caller fails closed).
+inline std::optional<std::vector<unsigned char>> select_weighted(
+    const std::vector<WeightedCandidate>& cands, uint64_t roll)
+{
+    uint64_t total = 0;
+    for (const auto& c : cands) total += c.weight;
+    if (total == 0)
+        return std::nullopt;
+    const uint64_t r = roll % total;
+    uint64_t cumulative = 0;
+    for (const auto& c : cands) {
+        cumulative += c.weight;
+        if (r < cumulative)
+            return c.payout_script;
+    }
+    return cands.back().payout_script;
+}
+
+// Pure boost selector — mirrors ltc::Redistributor::pick_boost's V1 zero-share
+// arm + pplns final fallback (redistribute.hpp:393-414). A currently-connected
+// miner (live pseudoshare rate this window) that carries ZERO pplns weight is
+// "boosted": picked uniformly so it starts accruing. When every connected miner
+// already has weight (or none are connected), fall through to the weighted
+// pplns selector — i.e. boost degrades to pplns exactly as LTC does at runtime
+// (its V2 graduated path is never wired). Consensus-neutral, like select_weighted.
+inline std::optional<std::vector<unsigned char>> select_boost(
+    const std::vector<WeightedCandidate>& pplns_cands,
+    const std::vector<std::vector<unsigned char>>& connected_scripts,
+    uint64_t zero_roll,
+    uint64_t pplns_roll)
+{
+    if (!connected_scripts.empty()) {
+        std::set<std::vector<unsigned char>> have;
+        for (const auto& c : pplns_cands)
+            if (c.weight > 0)
+                have.insert(c.payout_script);
+        std::vector<std::vector<unsigned char>> zero_miners;
+        for (const auto& s : connected_scripts)
+            if (!s.empty() && have.find(s) == have.end())
+                zero_miners.push_back(s);
+        if (!zero_miners.empty())
+            return zero_miners[zero_roll % zero_miners.size()];
+    }
+    return select_weighted(pplns_cands, pplns_roll);
+}
+
 // Deterministic core (KAT-able): the caller supplies the fee roll as
 // roll_x100 in [0, 10000) — one roll per job build, matching p2pool's
 // per-get_work fee roll. Substitution triggers when roll_x100 <
@@ -306,7 +388,8 @@ struct ResolvedIdentity
 inline std::optional<ResolvedIdentity> resolve_mint_identity(
     const MintFeePolicy& policy,
     const std::vector<unsigned char>& miner_script,
-    uint32_t roll_x100)
+    uint32_t roll_x100,
+    const RedistributeInputs& redistribute = {})
 {
     const bool miner_ok =
         dash::stratum::pubkey_hash_from_p2pkh(miner_script).has_value();
@@ -332,9 +415,26 @@ inline std::optional<ResolvedIdentity> resolve_mint_identity(
             return ResolvedIdentity{policy.node_owner_script, 65535, true};
         return std::nullopt;
     case MintFeePolicy::Redistribute::PPLNS:
-    case MintFeePolicy::Redistribute::BOOST:
-    default:
-        return std::nullopt;   // weighted redistribution engine: later port
+    default: {
+        // Weighted-random over the accrued PPLNS window (ltc pick_pplns). Empty
+        // window (cold chain) -> decline, preserving the fail-closed genesis
+        // behaviour. donation_u16 is the normal dev-fee decay, as the fee arm.
+        auto script = select_weighted(redistribute.candidates,
+                                      redistribute.pplns_roll);
+        if (script)
+            return ResolvedIdentity{*script, policy.donation_u16, true};
+        return std::nullopt;
+    }
+    case MintFeePolicy::Redistribute::BOOST: {
+        // Zero-share boost, else pplns fallback (ltc pick_boost V1 + final).
+        auto script = select_boost(redistribute.candidates,
+                                   redistribute.connected,
+                                   redistribute.boost_zero_roll,
+                                   redistribute.pplns_roll);
+        if (script)
+            return ResolvedIdentity{*script, policy.donation_u16, true};
+        return std::nullopt;
+    }
     }
 }
 
@@ -548,6 +648,33 @@ pplns_weights_for(ChainT& chain,
     if (out.weights.empty())
         return std::nullopt;
     return out;
+}
+
+// ── gather_redistribute_candidates ───────────────────────────────────────────
+//
+// Impure gather feeding resolve_mint_identity's pplns/boost arms: walks the
+// SAME oracle window the DASH payout uses (pplns_weights_for -> get_cumulative_
+// weights) and returns the per-scriptPubKey accrued weight as a candidate list.
+// Reusing pplns_weights_for guarantees the redistribution weights are bit-for-bit
+// the payout weights (grandparent start, min(height,RCL)-1 window, 288->64
+// normalization). Empty (cold chain / no window) -> empty vector -> the arm
+// declines fail-closed, exactly the pre-port genesis behaviour.
+template <typename ChainT>
+inline std::vector<WeightedCandidate> gather_redistribute_candidates(
+    ChainT& chain,
+    const core::CoinParams& params,
+    const uint256& prev_share_hash,
+    uint32_t block_bits)
+{
+    std::vector<WeightedCandidate> cands;
+    auto w = pplns_weights_for(chain, params, prev_share_hash, block_bits);
+    if (!w)
+        return cands;
+    cands.reserve(w->weights.size());
+    for (const auto& [script, weight] : w->weights)
+        if (weight > 0)
+            cands.push_back(WeightedCandidate{script, weight});
+    return cands;
 }
 
 } // namespace dash::mint

--- a/test/test_dash_mint_runloop.cpp
+++ b/test/test_dash_mint_runloop.cpp
@@ -807,3 +807,165 @@ TEST(DashMintRunloopPoolShareCap, FrozenDesiredTargetIsTheModulatedOne)
     EXPECT_EQ(built->frozen.desired_target.GetHex(),
         "000000000000016635c48b2e932ea609a3b4aa32cefaa1ba023ea945da766f85");
 }
+
+
+// ── (11-13) --redistribute pplns+boost port KATs ─────────────────────────────
+//
+// The gap these cover: on master resolve_mint_identity's PPLNS/BOOST arms
+// returned std::nullopt ("weighted redistribution engine: later port"), so a
+// miner whose stratum credentials do not decode to a P2PKH script DECLINED the
+// producer job — and pplns is the DEFAULT mode. These KATs assert the port:
+// such a share now resolves to a VALID payout identity chosen weighted-random
+// over the accrued PPLNS window (pplns) or zero-share-boosted then pplns
+// (boost). Consensus-neutral: it only chooses whose PPLNS weight THIS node's
+// broken-cred share carries; every peer recomputes identical coinbase outputs.
+
+// (11) Broken-credential miner under pplns AND boost -> valid identity, not
+//      decline. RED on master (nullopt); GREEN after the selector port.
+TEST(DashMintRunloopRedistribute, PplnsAndBoostResolveBrokenCredToValidIdentity)
+{
+    const auto params = easy_params();
+    dash::ShareTracker tracker;
+    tracker.m_coin_params = params;
+
+    // Chain g1(A) <- g2(B) <- g3(C tip). Oracle window on tip=g3 credits A,B.
+    const uint160 miner_a = h160_uniform(0xa1);
+    const uint160 miner_b = h160_uniform(0xb2);
+    const uint160 miner_c = h160_uniform(0xc3);
+    const uint256 g1 = mint_onto(tracker, params, uint256(), miner_a, 11);
+    ASSERT_FALSE(g1.IsNull());
+    const uint256 g2 = mint_onto(tracker, params, g1, miner_b, 12);
+    ASSERT_FALSE(g2.IsNull());
+    const uint256 g3 = mint_onto(tracker, params, g2, miner_c, 13);
+    ASSERT_FALSE(g3.IsNull());
+
+    const auto wd = make_workdata();
+    auto candidates = dash::mint::gather_redistribute_candidates(
+        tracker.chain, params, g3, wd.m_bits);
+    ASSERT_FALSE(candidates.empty());   // the window has accrued weight
+
+    const auto script_a = dash::pubkey_hash_to_script2(miner_a);
+    const auto script_b = dash::pubkey_hash_to_script2(miner_b);
+    const auto script_c = dash::pubkey_hash_to_script2(miner_c);
+    const std::vector<unsigned char> broken_script = {0x00, 0x14};  // not P2PKH
+
+    auto in_window = [&](const std::vector<unsigned char>& sc) {
+        for (const auto& c : candidates) if (c.payout_script == sc) return true;
+        return false;
+    };
+    EXPECT_TRUE(in_window(script_a));
+    EXPECT_TRUE(in_window(script_b));
+    EXPECT_FALSE(in_window(script_c));   // the tip carries no weight yet
+
+    dash::mint::MintFeePolicy policy;
+    policy.donation_u16 = 66;
+
+    // PPLNS (the DEFAULT): broken cred -> a valid identity from the window.
+    {
+        policy.redistribute = dash::mint::MintFeePolicy::Redistribute::PPLNS;
+        dash::mint::RedistributeInputs ri;
+        ri.candidates = candidates;
+        ri.pplns_roll = 12345;
+        auto id = dash::mint::resolve_mint_identity(policy, broken_script, 5000, ri);
+        ASSERT_TRUE(id.has_value());          // RED on master (was nullopt)
+        EXPECT_TRUE(id->substituted);
+        EXPECT_TRUE(id->payout_script == script_a || id->payout_script == script_b);
+        EXPECT_EQ(id->donation_u16, 66);
+    }
+
+    // BOOST, no connected miners -> degrades to the pplns selector (ltc parity).
+    {
+        policy.redistribute = dash::mint::MintFeePolicy::Redistribute::BOOST;
+        dash::mint::RedistributeInputs ri;
+        ri.candidates = candidates;
+        ri.pplns_roll = 777;
+        auto id = dash::mint::resolve_mint_identity(policy, broken_script, 5000, ri);
+        ASSERT_TRUE(id.has_value());          // RED on master (was nullopt)
+        EXPECT_TRUE(id->payout_script == script_a || id->payout_script == script_b);
+    }
+
+    // BOOST with a connected miner carrying ZERO window weight (C) -> boosted:
+    // the share is minted under C so it begins accruing.
+    {
+        policy.redistribute = dash::mint::MintFeePolicy::Redistribute::BOOST;
+        dash::mint::RedistributeInputs ri;
+        ri.candidates = candidates;
+        ri.connected = { script_c };
+        ri.boost_zero_roll = 0;
+        auto id = dash::mint::resolve_mint_identity(policy, broken_script, 5000, ri);
+        ASSERT_TRUE(id.has_value());
+        EXPECT_EQ(id->payout_script, script_c);
+    }
+
+    // Cold window (no candidates) stays fail-closed under both modes.
+    {
+        dash::mint::RedistributeInputs empty;
+        policy.redistribute = dash::mint::MintFeePolicy::Redistribute::PPLNS;
+        EXPECT_FALSE(
+            dash::mint::resolve_mint_identity(policy, broken_script, 0, empty).has_value());
+        policy.redistribute = dash::mint::MintFeePolicy::Redistribute::BOOST;
+        EXPECT_FALSE(
+            dash::mint::resolve_mint_identity(policy, broken_script, 0, empty).has_value());
+    }
+
+    // A miner WITH valid credentials is never redistributed (keeps its own).
+    {
+        policy.redistribute = dash::mint::MintFeePolicy::Redistribute::PPLNS;
+        dash::mint::RedistributeInputs ri;
+        ri.candidates = candidates;
+        auto id = dash::mint::resolve_mint_identity(policy, script_a, 5000, ri);
+        ASSERT_TRUE(id.has_value());
+        EXPECT_FALSE(id->substituted);
+        EXPECT_EQ(id->payout_script, script_a);
+    }
+}
+
+// (12) The pure deterministic selector core: fixed candidates + fixed roll ->
+//      fixed pick (cumulative weighted-random walk, ltc pick_pplns parity).
+TEST(DashMintRunloopRedistribute, SelectWeightedIsDeterministicAndProportional)
+{
+    using dash::mint::WeightedCandidate;
+    const std::vector<unsigned char> A = {1};
+    const std::vector<unsigned char> B = {2};
+    std::vector<WeightedCandidate> cands = {{A, 10}, {B, 30}};   // total 40
+
+    // roll in [0,10) -> A; [10,40) -> B (cumulative bands).
+    EXPECT_EQ(*dash::mint::select_weighted(cands, 0),  A);
+    EXPECT_EQ(*dash::mint::select_weighted(cands, 9),  A);
+    EXPECT_EQ(*dash::mint::select_weighted(cands, 10), B);
+    EXPECT_EQ(*dash::mint::select_weighted(cands, 39), B);
+    // roll reduced modulo total: 40 == 0 -> A again.
+    EXPECT_EQ(*dash::mint::select_weighted(cands, 40), A);
+
+    // Empty / all-zero -> nullopt (caller fails closed).
+    EXPECT_FALSE(dash::mint::select_weighted({}, 0).has_value());
+    std::vector<WeightedCandidate> zeros = {{A, 0}, {B, 0}};
+    EXPECT_FALSE(dash::mint::select_weighted(zeros, 5).has_value());
+}
+
+// (13) Boost zero-share selection: a connected miner absent from the pplns
+//      window is boosted; when all connected miners already carry weight (or
+//      none connected) it degrades to the pplns selector.
+TEST(DashMintRunloopRedistribute, SelectBoostZeroSharePrefersConnectedNewcomer)
+{
+    using dash::mint::WeightedCandidate;
+    const std::vector<unsigned char> A = {0xa};
+    const std::vector<unsigned char> B = {0xb};
+    const std::vector<unsigned char> C = {0xc};
+    std::vector<WeightedCandidate> cands = {{A, 100}, {B, 100}};   // total 200
+
+    // C is connected but has zero window weight -> boosted.
+    auto pick = dash::mint::select_boost(cands, {C}, /*zero_roll=*/0, /*pplns_roll=*/0);
+    ASSERT_TRUE(pick.has_value());
+    EXPECT_EQ(*pick, C);
+
+    // All connected miners already carry weight -> pplns fallback (A or B).
+    auto fb = dash::mint::select_boost(cands, {A, B}, 0, 0);
+    ASSERT_TRUE(fb.has_value());
+    EXPECT_TRUE(*fb == A || *fb == B);
+
+    // No connected list -> pure pplns fallback; roll 150 lands in B's band.
+    auto pf = dash::mint::select_boost(cands, {}, 0, /*pplns_roll=*/150);
+    ASSERT_TRUE(pf.has_value());
+    EXPECT_EQ(*pf, B);
+}


### PR DESCRIPTION
## The gap

`resolve_mint_identity` (src/impl/dash/mint_runloop.hpp) resolves the payout
identity a producer job freezes. Its `PPLNS` and `BOOST` arms returned
`std::nullopt` with the comment *"weighted redistribution engine: later port"*
(mint_runloop.hpp:334-337 on master). A miner whose stratum credentials do **not**
decode to a P2PKH script therefore **DECLINED the producer job** under those
modes — and `pplns` is the **DEFAULT** `--redistribute` mode. `fee` and `donate`
already resolved (they mint under the node owner); `pplns`/`boost` did not.

## The port

Ports the LTC `Redistributor` selection semantics
(src/impl/ltc/redistribute.hpp) into the DASH mint path, reusing DASH's own
oracle-window aggregation so redistribution weight == real accrued PPLNS weight.

**src/impl/dash/mint_runloop.hpp**
- `select_weighted()` — pure cumulative weighted-random walk, the port of
  `ltc::Redistributor::pick_pplns` (redistribute.hpp:416-438). This is the KAT
  surface: fixed candidates + fixed roll → fixed pick.
- `select_boost()` — pure zero-share boost + pplns fallback, the port of
  `pick_boost`'s V1 arm (redistribute.hpp:393-414). A connected miner with zero
  window weight is boosted; otherwise it degrades to the pplns selector — exactly
  as LTC `boost` behaves at runtime (its V2 graduated path is never wired in
  `main_ltc`).
- `gather_redistribute_candidates()` — reuses the **same** oracle-window
  aggregation the DASH payout uses (`pplns_weights_for` →
  `get_cumulative_weights`), keyed by scriptPubKey.
- `resolve_mint_identity()` gains a defaulted `RedistributeInputs` param; the
  `PPLNS`/`BOOST` arms now select from it. Empty window (cold chain) still
  declines fail-closed — the pre-port genesis behaviour is preserved, and the
  existing `ResolveMintIdentityFeeAndRedistribute` KAT is unchanged.

**src/c2pool/main_dash.cpp** — at the producer-job build site the chain guard,
tip, and per-address rates are already in scope; gather candidates only when the
miner is broken-cred AND the mode is `pplns`/`boost`, then pass them to
`resolve_mint_identity`.

## The KAT (red → green)

`test/test_dash_mint_runloop.cpp`, target `test_dash_share_hash_link`:
- **`PplnsAndBoostResolveBrokenCredToValidIdentity`** — builds a real
  sharechain, gathers the oracle-window candidates, and asserts a
  broken-credential share under `pplns` **and** under `boost` resolves to a
  valid P2PKH identity (not decline); plus the zero-share boost picks a
  connected newcomer, cold-window stays fail-closed, and a valid-cred miner is
  never redistributed.
- **`SelectWeightedIsDeterministicAndProportional`** / **`SelectBoostZeroShare
  PrefersConnectedNewcomer`** — the deterministic selector cores.

**RED proof:** with the `pplns`/`boost` arm stubbed back to `nullopt` (master
behaviour, wiring intact) the KAT fails at `test_dash_mint_runloop.cpp:870`
`Value of: id.has_value() Actual: false Expected: true`. With the port it
passes. Full DASH test binary: **77/77 green**. `c2pool-dash` node binary builds
clean (Release).

## Reward-path DEPLOY note — consensus-NEUTRAL

The chosen script only sets **this node's broken-cred share's `m_pubkey_hash`**
(the local sharechain identity — the DASH analogue of p2pool's `-f` address
fallback). It does **not** touch the block: every peer recomputes identical
coinbase outputs from each share's recorded `m_pubkey_hash` via
`dash::pplns::compute_payouts`; DIP4 CbTx / `merkleRootMNList` / quorum
commitments / block validity are untouched. It is the **same field** the
shipping `--fee` arm already substitutes. The weighted draw is non-deterministic
by design (expectation = proportional); the KAT covers the deterministic
selection core, not the rng draw.

**DO NOT MERGE / DO NOT release** — steward + operator review.

---

