### PR TITLE
dash: port the mined-commitment UndoBlock half and arm the index on live tips

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -5528,7 +5528,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             [&coin_state, &stratum_server, hc = header_chain.get(),
              addr_ver, p2sh_ver, ws = work_source.get(),
              cp = coin_p2p.get(), sml_base, m = maintainer.get(),
-             mnl = mn_ckpt_lane.get(), qcms = qc_ms_prefetch_handle]
+             mnl = mn_ckpt_lane.get(), qcms = qc_ms_prefetch_handle,
+             // PR-2 UNDO. By REFERENCE (same lifetime class as the qc_plan_fn
+             // capture above): the index is constructed later in this function,
+             // and on a reorg its symmetric UndoBlock half must roll the tip
+             // back before the new branch is folded forward.
+             &mined_commitment_index]
             (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height,
              bool was_reorg) {
                 // E2d bridge driver. Safe + REACHABLE here: HeaderChain fires
@@ -5567,6 +5572,37 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                 << " -> SML wipe + cold-resync";
                     m->on_sml_reorg();
                     *sml_base = uint256::ZERO;
+                }
+                // PR-2 UNDO: roll the mined-commitment store back over the
+                // disconnected tail. dashd's UndoBlock, expressed over the
+                // store's retained journal: walk the cursor down to the fork
+                // point (the first height whose recorded hash still matches the
+                // switched chain) erasing each orphaned block's mined records,
+                // so has_mined_commitment() cannot answer true for a commitment
+                // the new branch never mined. A reorg deeper than the retained
+                // undo window fails closed to a cold rebuild + re-seed on the
+                // next contiguous fold — the over-mandating (never phantom)
+                // direction.
+                if (was_reorg && mined_commitment_index
+                    && mined_commitment_index->armed()) {
+                    std::string uerr;
+                    const auto ur = mined_commitment_index->handle_reorg(
+                        [hc](uint32_t q) -> std::optional<uint256> {
+                            if (auto e = hc->get_header_by_height(q))
+                                return e->hash;
+                            return std::nullopt;
+                        },
+                        &uerr);
+                    if (ur == dash::coin::MinedUndoResult::Undone) {
+                        LOG_INFO << "[QC-MINED-INDEX] reorg undo -> "
+                                 << mined_commitment_index->summary();
+                    } else {
+                        LOG_WARNING << "[QC-MINED-INDEX] reorg undo could not "
+                                       "roll back exactly (" << uerr
+                                    << ") -> cold rebuild; store will re-seed on "
+                                       "the next contiguous fold";
+                        mined_commitment_index->clear_for_cold_rebuild();
+                    }
                 }
                 // SML axis: pull the mnlistdiff current AT the new tip. dashcore
                 // computes block (tip+1)'s CbTx merkleRootMNList/Quorums from the
@@ -7066,10 +7102,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 mi->seed_cursor(replay_fold_engine->height());
                 dash::coin::TipPosture posture;
                 posture.live = (replay_live_tail != nullptr);
+                // The header-chain reorg seam (set_on_tip_changed below) drives
+                // mi->handle_reorg() on every branch switch, so a live tip is
+                // now reorg-safe: dashd's UndoBlock half is ported AND wired.
+                posture.reorg_undo_wired = true;
                 posture.declared_by =
                     replay_live_tail
                         ? "FoldLiveTail is wired (live tip blocks are folded "
-                          "into this same consumer)"
+                          "into this same consumer); header-chain reorg seam "
+                          "drives handle_reorg on disconnect"
                         : "no FoldLiveTail: this consumer sees only replayed "
                           "historical bodies";
                 const auto verdict = mi->arm(posture);

--- a/src/impl/dash/coin/mined_commitment_index.hpp
+++ b/src/impl/dash/coin/mined_commitment_index.hpp
@@ -43,24 +43,30 @@
 /// already consume.
 ///
 /// ───────────────────────────────────────────────────────────────────────────
-/// FORWARD HALF ONLY — AND THE CODE ENFORCES IT
+/// BOTH HALVES — AND THE CODE ENFORCES THE SYMMETRY
 /// ───────────────────────────────────────────────────────────────────────────
 ///
-/// `UndoBlock` (llmq/blockprocessor.cpp:383-408) is NOT ported. It erases the
-/// same three records and re-offers the commitment as mineable when a block is
-/// DISCONNECTED. Without it a reorg leaves a phantom mined record, `has_mined`
-/// answers true for a commitment the new chain never mined, the slot drops out
-/// of the mandatory set, and the template we serve is short one type-6 tx —
-/// `bad-qc-missing` (blockprocessor.cpp:198), i.e. a LOST BLOCK. This is not
-/// hypothetical on this fleet: the hotel primary lost 2508008 to a stale payee
-/// and orphaned 2517855.
+/// `UndoBlock` (llmq/blockprocessor.cpp:383-408) IS now ported — `undo_input`,
+/// `undo_block` and `handle_reorg` below. It erases the same records the
+/// forward half wrote and gives the slot back to whoever mines next when a
+/// block is DISCONNECTED. Without it a reorg would leave a phantom mined
+/// record, `has_mined` would answer true for a commitment the new chain never
+/// mined, the slot would drop out of the mandatory set, and the template we
+/// serve would be short one type-6 tx — `bad-qc-missing`
+/// (blockprocessor.cpp:198), i.e. a LOST BLOCK. This is not hypothetical on
+/// this fleet: the hotel primary lost 2508008 to a stale payee and orphaned
+/// 2517855.
 ///
-/// So the index REFUSES TO ARM on a node whose tip is live (`arm()` below).
-/// The refusal is a code path, not a paragraph in a design doc: whoever turns
-/// the flag on next month gets a named refusal instead of a silent gamble.
+/// Because add and remove are now symmetric, the index MAY arm on a live tip —
+/// but ONLY when the caller declares it has wired a disconnect handler that
+/// drives the undo (`TipPosture.reorg_undo_wired`, `arm()` below). A live tip
+/// with no such wiring still gets a named refusal, not a silent gamble: the
+/// undo half existing in this file is not the same as a caller actually
+/// CALLING it on every reorg, and the guard demands the latter.
 /// A second, independent guard runs per block — `process_block()` refuses any
-/// height it did not expect next, so the store can only ever be built by a
-/// strictly forward, contiguous walk.
+/// height it did not expect next, so the forward store is built by a strictly
+/// contiguous walk, and undo unwinds that walk in strict LIFO (dashd
+/// DisconnectTip order).
 ///
 /// ───────────────────────────────────────────────────────────────────────────
 /// TRUST BOUNDARY
@@ -119,6 +125,14 @@ struct MinedCommitmentIndexConfig {
     /// height window is the wrong shape here: mainnet's LLMQ_50_60 active
     /// commitments are 775k blocks old and never leave the active set.
     uint16_t    keep_cycles{4};
+    /// How many of the most-recently-ingested heights keep a rollback journal
+    /// entry (see UndoEntry / handle_reorg). This is the DEPTH the reorg-undo
+    /// path can roll back EXACTLY, and it is the same shape as the replay UTXO
+    /// fold's undo window (replay_utxo_fold.hpp ships 100): a reorg deeper than
+    /// this cannot be rolled back commitment-for-commitment and fails closed
+    /// into a cold rebuild. dashd reorgs are 1-2 blocks in practice; 100 is a
+    /// wide margin bounded to a few hundred journal entries.
+    uint32_t    undo_window{100};
 };
 
 /// What the caller declares about the chain position it is feeding from.
@@ -130,6 +144,13 @@ struct MinedCommitmentIndexConfig {
 /// heuristic like "the tip looks old".
 struct TipPosture {
     bool        live{true};
+    /// Set only when the caller has wired dashd's UndoBlock half — a
+    /// disconnect handler that calls handle_reorg() (or undo_input/undo_block)
+    /// so a branch switch rolls the store back exactly. This is what makes a
+    /// LIVE tip safe to arm: without it a disconnected block would leave a
+    /// phantom mined record. It is a DECLARATION about the wiring, read off
+    /// structure (is a reorg handler installed for this store?), never guessed.
+    bool        reorg_undo_wired{false};
     /// Names WHO declared it. Reproduced verbatim in the refusal so the
     /// operator can see which wiring decided, not just that something did.
     std::string declared_by{"unspecified"};
@@ -171,6 +192,33 @@ inline const char* mined_ingest_result_name(MinedIngestResult r)
         case MinedIngestResult::BadQcHeight:         return "bad-qc-height";
         case MinedIngestResult::BadQcBlock:          return "bad-qc-block";
         case MinedIngestResult::BaseUnresolvable:    return "quorum-base-unresolvable";
+    }
+    return "n/a";
+}
+
+/// Per-disconnect outcome for the UndoBlock port (undo_input / undo_block /
+/// handle_reorg). Every non-Undone value NAMES why the rollback could not be
+/// applied, so a refusal here is as legible as a forward refusal.
+enum class MinedUndoResult : uint8_t {
+    Undone = 0,
+    NotArmed,             // arm() was never called, or refused
+    NotTip,               // dashd disconnects the TIP only (DisconnectTip)
+    BeyondUndoWindow,     // reorg deeper than the retained journal => cold rebuild
+    BodyNotBound,         // undo_block: body merkle root != header commitment
+    BadQcPayload,         // undo_block: type-6 payload unparseable
+    BadQcCommitmentType,  // llmqType not in this network's chainparams llmq list
+};
+
+inline const char* mined_undo_result_name(MinedUndoResult r)
+{
+    switch (r) {
+        case MinedUndoResult::Undone:              return "undone";
+        case MinedUndoResult::NotArmed:            return "not-armed";
+        case MinedUndoResult::NotTip:              return "not-tip";
+        case MinedUndoResult::BeyondUndoWindow:    return "beyond-undo-window";
+        case MinedUndoResult::BodyNotBound:        return "body-not-bound";
+        case MinedUndoResult::BadQcPayload:        return "bad-qc-payload";
+        case MinedUndoResult::BadQcCommitmentType: return "bad-qc-commitment-type";
     }
     return "n/a";
 }
@@ -230,26 +278,34 @@ public:
             m_arm_reason = v.reason;
             return v;
         }
-        if (posture.live) {
+        if (posture.live && !posture.reorg_undo_wired) {
             v.reason =
                 "mined-commitment index REFUSED TO ARM: the node's tip is "
-                "LIVE (declared by " + posture.declared_by + "). This is the "
-                "FORWARD half only — dashd's UndoBlock "
-                "(v23.1.7 llmq/blockprocessor.cpp:383-408) is NOT ported, so "
-                "a disconnected block would leave a phantom mined record; "
-                "has_mined_commitment() would then answer true for a "
-                "commitment the new chain never mined, the slot would drop "
-                "out of the mandatory set, and the served template would be "
-                "short one qfcommit => bad-qc-missing "
-                "(blockprocessor.cpp:198) => LOST BLOCK. Arm this only on a "
-                "replay/backfill consumer, or land the undo half first.";
+                "LIVE (declared by " + posture.declared_by + ") and NO "
+                "reorg-undo handler is wired. dashd's UndoBlock "
+                "(v23.1.7 llmq/blockprocessor.cpp:383-408) is ported here "
+                "(undo_input/undo_block + handle_reorg), but the CALLER must "
+                "install a disconnect handler that drives it and declare "
+                "TipPosture.reorg_undo_wired. Until then a disconnected block "
+                "would leave a phantom mined record; has_mined_commitment() "
+                "would answer true for a commitment the new chain never mined, "
+                "the slot would drop out of the mandatory set, and the served "
+                "template would be short one qfcommit => bad-qc-missing "
+                "(blockprocessor.cpp:198) => LOST BLOCK. Arm this on a "
+                "replay/backfill consumer, or wire the undo handler first.";
             m_armed = false;
             m_arm_reason = v.reason;
             return v;
         }
         v.armed  = true;
-        v.reason = "mined-commitment index ARMED (forward-only; tip declared "
-                   "NOT live by " + posture.declared_by + ")";
+        v.reason = posture.live
+            ? ("mined-commitment index ARMED on a LIVE tip: dashd's UndoBlock "
+               "(v23.1.7 llmq/blockprocessor.cpp:383-408) is ported "
+               "(undo_input/undo_block + handle_reorg), so a disconnected "
+               "block is rolled back exactly. Reorg-undo declared wired by "
+               + posture.declared_by + ".")
+            : ("mined-commitment index ARMED (forward-only; tip declared NOT "
+               "live by " + posture.declared_by + ")");
         m_armed = true;
         m_arm_reason = v.reason;
         return v;
@@ -360,8 +416,9 @@ public:
                         + (m_seeded ? "" : " (NO seeded cursor)")
                         + " and this port is forward-only — only h="
                         + std::to_string(m_height + 1) + " is ingestible. "
-                        "UndoBlock is not ported, so a gap can never be "
-                        "closed by re-walking.");
+                        "The reorg-undo half rolls the TIP back (handle_reorg); "
+                        "it never fills a forward gap, so a skipped height must "
+                        "be refused, not silently absorbed.");
         // Re-assert the per-block dup rule on the parsed path too: a caller
         // that assembled the input itself must not be able to smuggle two
         // non-rotated commitments of one type past bad-qc-dup.
@@ -452,6 +509,14 @@ public:
         }
 
         // ── The two writes (blockprocessor.cpp:359-368) ──────────────────
+        // The rollback journal records, per height, EXACTLY the keys these
+        // writes touched, so handle_reorg can erase them without re-supplying
+        // the body — dashd re-parses the disconnected CBlock in UndoBlock; we
+        // keep a compact per-height journal instead, the same shape the replay
+        // UTXO fold keeps a BlockUndo (replay_utxo_fold.hpp).
+        UndoEntry undo;
+        undo.block_hash = block_hash;
+        undo.writes.reserve(staged.size());
         for (auto& rec : staged) {
             const LlmqParamsView* p = params_for(rec.commitment.llmqType);
             const uint8_t t = rec.commitment.llmqType;
@@ -462,14 +527,183 @@ public:
             else
                 m_by_height[t][rec.mined_height] = v;
             m_mined[key_of(t, rec.commitment.quorumHash)] = rec;
+            undo.writes.push_back(UndoWrite{t, rec.commitment.quorumHash,
+                                            rec.quorum_index, p->use_rotation});
             ++m_stats.commitments_mined;
         }
+        m_undo_journal[height] = std::move(undo);
+        trim_undo_journal();
 
         m_height = height;
         ++m_stats.blocks_ingested;
         prune(height);
         if (err) err->clear();
         return MinedIngestResult::Applied;
+    }
+
+    // ── UndoBlock — the symmetric reorg port ─────────────────────────────
+
+    /// Port of `CQuorumBlockProcessor::UndoBlock`'s STORE half
+    /// (v23.1.7 llmq/blockprocessor.cpp:383-408). dashd, on DisconnectBlock,
+    /// re-reads the disconnected block's commitments via GetCommitmentsFromBlock
+    /// (:391), skips nulls (:394), and for every non-null one ERASES the two
+    /// records ProcessCommitment wrote — DB_MINED_COMMITMENT by (llmqType,
+    /// quorumHash) (:399) and the inversed-height key at THIS block's height
+    /// (:402-406) — then re-offers the commitment as mineable (:408). This is
+    /// the exact inverse of process_input's two writes.
+    ///
+    /// NOT ported here, symmetrically to the forward half:
+    ///   * AddMineableCommitment (:408) — re-offering a disconnected commitment
+    ///     as mineable is MineableCommitmentCache's job, unchanged; this store
+    ///     only owns the MINED question. Erasing the mined record is already
+    ///     enough for compute_required_qc_slots to re-mandate the slot.
+    ///   * PreComputeQuorumMembers (:387) — a cache warm-up with no store effect.
+    ///
+    /// dashd only ever disconnects the TIP (DisconnectTip walks the active
+    /// chain back one block at a time), so undo is LIFO: `in.height` must be the
+    /// current cursor. That is the same invariant that makes the forward walk
+    /// contiguous, run backwards.
+    MinedUndoResult undo_input(const MinedBlockInput& in, std::string* err = nullptr)
+    {
+        auto fail = [&](MinedUndoResult r, const std::string& why) {
+            if (err)
+                *err = "h=" + std::to_string(in.height) + " "
+                     + mined_undo_result_name(r) + ": " + why;
+            ++m_stats.blocks_undo_refused;
+            return r;
+        };
+        if (!m_armed)
+            return fail(MinedUndoResult::NotArmed, m_arm_reason);
+        if (!m_seeded || in.height != m_height)
+            return fail(MinedUndoResult::NotTip,
+                        "UndoBlock disconnects the TIP only (dashd "
+                        "DisconnectTip). The store cursor is at h="
+                        + std::to_string(m_height)
+                        + (m_seeded ? "" : " (NO seeded cursor)")
+                        + " — only that height is disconnectable.");
+        // GetCommitmentsFromBlock + the null skip (blockprocessor.cpp:391-394):
+        // build the erase list from the body, exactly as the forward path built
+        // the write list.
+        std::vector<UndoWrite> writes;
+        for (const auto& qc : in.commitments) {
+            const LlmqParamsView* p = params_for(qc.llmqType);
+            if (p == nullptr)
+                return fail(MinedUndoResult::BadQcCommitmentType,
+                            "llmqType " + std::to_string(int(qc.llmqType))
+                            + " is not in this network's chainparams llmq list");
+            if (is_null_commitment(qc))
+                continue;   // dashd: `if (qc.IsNull()) continue;` (:394)
+            writes.push_back(UndoWrite{qc.llmqType, qc.quorumHash,
+                                       qc.quorumIndex, p->use_rotation});
+        }
+        erase_writes_at(in.height, writes);
+        m_undo_journal.erase(in.height);
+        m_height = in.height - 1;
+        ++m_stats.blocks_disconnected;
+        if (err) err->clear();
+        return MinedUndoResult::Undone;
+    }
+
+    /// The BODY entry point for undo — mirror of process_block. Re-parses the
+    /// disconnected block's type-6 payloads (the GetCommitmentsFromBlock half
+    /// of dashd's UndoBlock) and asserts the body binds to its header, then
+    /// hands the parsed commitments to undo_input. Whoever has the disconnected
+    /// body uses this; the live reorg path, which does not retain bodies, uses
+    /// handle_reorg (journal-driven) instead.
+    MinedUndoResult undo_block(uint32_t height, const uint256& block_hash,
+                               const BlockType& block, std::string* err = nullptr)
+    {
+        auto fail = [&](MinedUndoResult r, const std::string& why) {
+            if (err)
+                *err = "h=" + std::to_string(height) + " "
+                     + mined_undo_result_name(r) + ": " + why;
+            ++m_stats.blocks_undo_refused;
+            return r;
+        };
+        if (!block_body_binds_to_header(block))
+            return fail(MinedUndoResult::BodyNotBound,
+                        "body merkle root != header commitment — a forged or "
+                        "mutated body must never drive an erase either");
+        MinedBlockInput in;
+        in.height     = height;
+        in.block_hash = block_hash;
+        for (size_t i = 0; i < block.m_txs.size(); ++i) {
+            const auto& tx = block.m_txs[i];
+            if (tx.type != vendor::CFinalCommitmentTxPayload::SPECIALTX_TYPE)
+                continue;
+            vendor::CFinalCommitmentTxPayload payload;
+            if (!vendor::parse_qfcommit_payload(tx.extra_payload, payload))
+                return fail(MinedUndoResult::BadQcPayload,
+                            "tx[" + std::to_string(i) + "] type-6 payload is "
+                            "unparseable");
+            in.commitments.push_back(std::move(payload.commitment));
+        }
+        return undo_input(in, err);
+    }
+
+    /// The LIVE reorg driver. A branch switch disconnects every tip block that
+    /// is no longer on the (already-switched) chain. This walks the cursor
+    /// DOWN, and at each height compares the journal's recorded block hash
+    /// against `hash_at_height` (the new chain): the FIRST height that still
+    /// matches is the fork point, and everything above it is rolled back from
+    /// the journal — no disconnected body needed. It is the exact analogue of
+    /// the credit-pool axis's fork-point search (coin_state_maintainer.hpp), and
+    /// dashd's per-block DisconnectTip loop expressed over the retained journal.
+    ///
+    /// A reorg deeper than the retained undo window cannot be rolled back
+    /// exactly; this refuses BeyondUndoWindow and the caller must
+    /// clear_for_cold_rebuild() (mirrors on_sml_reorg's cold-resync) — the
+    /// fail-CLOSED direction: an empty store over-mandates slots, it never
+    /// serves a phantom.
+    MinedUndoResult handle_reorg(const HashAtHeightFn& hash_at_height,
+                                 std::string* err = nullptr)
+    {
+        auto fail = [&](MinedUndoResult r, const std::string& why) {
+            if (err)
+                *err = mined_undo_result_name(r) + std::string(": ") + why;
+            ++m_stats.blocks_undo_refused;
+            return r;
+        };
+        if (!m_armed)
+            return fail(MinedUndoResult::NotArmed, m_arm_reason);
+        while (m_seeded && m_height > 0) {
+            auto jit = m_undo_journal.find(m_height);
+            if (jit == m_undo_journal.end())
+                return fail(MinedUndoResult::BeyondUndoWindow,
+                            "reorg is deeper than the retained undo window ("
+                            + std::to_string(m_cfg.undo_window)
+                            + " blocks): no journal entry for tip h="
+                            + std::to_string(m_height)
+                            + ". The store cannot roll back exactly and must be "
+                              "cold-rebuilt (clear_for_cold_rebuild + re-seed).");
+            auto on_chain = hash_at_height ? hash_at_height(m_height)
+                                           : std::nullopt;
+            if (on_chain && !on_chain->IsNull()
+                && *on_chain == jit->second.block_hash)
+                break;   // fork point: this tip block is still on the new chain
+            erase_writes_at(m_height, jit->second.writes);
+            m_undo_journal.erase(jit);
+            --m_height;
+            ++m_stats.blocks_disconnected;
+        }
+        if (err) err->clear();
+        return MinedUndoResult::Undone;
+    }
+
+    /// Fail-closed reset for a reorg beyond the undo window (or any axis that
+    /// invalidated the store). Empties every record and drops the cursor, so
+    /// process_input refuses until the caller re-seeds and re-seeds the cursor —
+    /// the same cold-resync contract on_sml_reorg gives the SML axis. The arm
+    /// verdict and config are kept.
+    void clear_for_cold_rebuild()
+    {
+        m_mined.clear();
+        m_by_height.clear();
+        m_by_height_indexed.clear();
+        m_undo_journal.clear();
+        m_seeded = false;
+        m_height = 0;
+        ++m_stats.cold_rebuilds;
     }
 
     // ── Readers ──────────────────────────────────────────────────────────
@@ -690,6 +924,10 @@ public:
         uint64_t commitments_mined{0};
         uint64_t commitments_null{0};
         uint64_t commitments_seeded{0};
+        uint64_t blocks_disconnected{0};   // UndoBlock port: heights rolled back
+        uint64_t commitments_erased{0};    // mined records removed by undo
+        uint64_t blocks_undo_refused{0};   // undo/reorg refusals
+        uint64_t cold_rebuilds{0};         // clear_for_cold_rebuild() calls
     };
     const Stats& stats() const { return m_stats; }
     size_t       size() const  { return m_mined.size(); }
@@ -730,7 +968,9 @@ public:
                       + " mined=" + std::to_string(m_mined.size())
                       + " blocks=" + std::to_string(m_stats.blocks_ingested)
                       + " refused=" + std::to_string(m_stats.blocks_refused)
-                      + " nulls=" + std::to_string(m_stats.commitments_null);
+                      + " nulls=" + std::to_string(m_stats.commitments_null)
+                      + " disconnected="
+                      + std::to_string(m_stats.blocks_disconnected);
         if (!m_armed) return s + " reason=\"" + m_arm_reason + "\"";
         const auto miss = active_set_shortfall(m_height);
         if (miss.empty()) return s + " active_set=COMPLETE";
@@ -753,6 +993,24 @@ public:
     }
 
 private:
+    /// One erased key for the rollback journal — enough to invert the two
+    /// writes without the disconnected body: which map (rotation) and which
+    /// keys (type, quorumHash, quorumIndex). The mined height is the journal
+    /// key itself.
+    struct UndoWrite {
+        uint8_t  llmq_type{0};
+        uint256  quorum_hash;
+        int16_t  quorum_index{0};
+        bool     rotation{false};
+    };
+    /// Per-height rollback record: the block hash this height ingested (the
+    /// fork-point discriminator handle_reorg compares against the new chain)
+    /// plus every mined record written at it.
+    struct UndoEntry {
+        uint256                block_hash;
+        std::vector<UndoWrite> writes;
+    };
+
     const std::vector<LlmqParamsView>& chainparams_llmqs() const
     {
         // The CHAINPARAMS list, not the runtime-enabled one: upstream's
@@ -787,6 +1045,39 @@ private:
     {
         auto it = m_mined.find(key_of(type, qh));
         return it == m_mined.end() ? nullptr : &it->second;
+    }
+
+    /// The inverse of process_input's two writes, for one height. Removes the
+    /// DB_MINED_COMMITMENT record by (type, quorumHash) and the inversed-height
+    /// entry at `height` — exactly what dashd's UndoBlock erases. Erasing a key
+    /// prune() already dropped is a harmless no-op, which is why undo is
+    /// prune-independent: the journal, not the count-bounded inversed indices,
+    /// is the authority on what a height wrote.
+    void erase_writes_at(uint32_t height, const std::vector<UndoWrite>& writes)
+    {
+        for (const auto& w : writes) {
+            m_mined.erase(key_of(w.llmq_type, w.quorum_hash));
+            if (w.rotation) {
+                auto it = m_by_height_indexed.find(w.llmq_type);
+                if (it != m_by_height_indexed.end()) {
+                    auto qit = it->second.find(w.quorum_index);
+                    if (qit != it->second.end()) qit->second.erase(height);
+                }
+            } else {
+                auto it = m_by_height.find(w.llmq_type);
+                if (it != m_by_height.end()) it->second.erase(height);
+            }
+            ++m_stats.commitments_erased;
+        }
+    }
+
+    /// Keep only the last `undo_window` heights of rollback journal. Bounds the
+    /// journal exactly as prune() bounds the inversed indices — the reorg depth
+    /// beyond this is fail-closed in handle_reorg, never silently unrepairable.
+    void trim_undo_journal()
+    {
+        while (m_undo_journal.size() > m_cfg.undo_window)
+            m_undo_journal.erase(m_undo_journal.begin());
     }
 
     /// Bound the in-memory inversed-height indices BY COUNT, never by height.
@@ -856,6 +1147,9 @@ private:
     // …_Q_INDEXED: type -> quorumIndex -> minedHeight -> value
     std::map<uint8_t, std::map<int16_t, std::map<uint32_t, IndexValue>>>
         m_by_height_indexed;
+    // Rollback journal for the UndoBlock port: minedHeight -> UndoEntry,
+    // bounded to the last undo_window heights (trim_undo_journal).
+    std::map<uint32_t, UndoEntry> m_undo_journal;
 };
 
 } // namespace coin

--- a/test/test_dash_mined_commitment_index.cpp
+++ b/test/test_dash_mined_commitment_index.cpp
@@ -77,6 +77,7 @@ using dash::coin::MinedCommitmentIndex;
 using dash::coin::MinedCommitmentIndexConfig;
 using dash::coin::MinedBlockInput;
 using dash::coin::MinedIngestResult;
+using dash::coin::MinedUndoResult;
 using dash::coin::TipPosture;
 using dash::coin::vendor::CFinalCommitment;
 using dash::coin::vendor::CFinalCommitmentTxPayload;
@@ -221,6 +222,47 @@ MinedCommitmentIndex make_armed(LlmqNetwork net = LlmqNetwork::Mainnet)
     const auto v = idx.arm(posture);
     EXPECT_TRUE(v.armed) << v.reason;
     return idx;
+}
+
+/// An armed index with pruning and journal trimming turned OFF for the span of
+/// a KAT, so a derived merkleRootQuorums at a PAST height is reconstructed from
+/// the full retained history rather than the count-bounded window — the undo
+/// KATs compare roots at a rolled-back cursor, and the count bound would
+/// otherwise legitimately evict a past-height active entry over 3101 blocks.
+MinedCommitmentIndex make_armed_full(LlmqNetwork net = LlmqNetwork::Mainnet)
+{
+    MinedCommitmentIndexConfig cfg;
+    cfg.enabled     = true;
+    cfg.network     = net;
+    cfg.keep_cycles = 65535;      // no inversed-index pruning within the window
+    cfg.undo_window = 1000000u;   // journal retains the whole KAT window
+    MinedCommitmentIndex idx(cfg);
+    TipPosture posture;
+    posture.live = false;
+    posture.declared_by = "KAT: replay-only consumer";
+    const auto v = idx.arm(posture);
+    EXPECT_TRUE(v.armed) << v.reason;
+    return idx;
+}
+
+/// Parse the scan into the contiguous list of MinedBlockInput above the anchor
+/// (heights 2513686..2516786), nulls included, in tx order.
+std::vector<MinedBlockInput> build_scan_inputs(const std::vector<ScanBlock>& scan)
+{
+    std::vector<MinedBlockInput> ins;
+    for (const auto& b : scan) {
+        if (b.height <= 2513685) continue;
+        MinedBlockInput in;
+        in.height     = b.height;
+        in.block_hash = b.block_hash;
+        for (const auto& hex : b.qc_hex) {
+            auto p = parse_qc_payload_hex(hex);
+            EXPECT_TRUE(p.has_value());
+            if (p) in.commitments.push_back(p->commitment);
+        }
+        ins.push_back(std::move(in));
+    }
+    return ins;
 }
 
 /// Seed the anchor's 88-commitment active set. Columns:
@@ -1101,5 +1143,408 @@ TEST(DashMinedCommitmentIndex, ProcessBlockRefusesABodyNotBoundToItsHeader)
         EXPECT_EQ(idx.stats().commitments_mined, 0u);
         EXPECT_EQ(idx.stats().blocks_ingested, 0u);
         EXPECT_EQ(idx.stats().blocks_refused, 1u);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE UNDO HALF — dashd's CQuorumBlockProcessor::UndoBlock
+// (v23.1.7 llmq/blockprocessor.cpp:383-408), ported as undo_input / undo_block
+// / handle_reorg. These KATs are what let the index ARM on a live tip: without
+// a proven symmetric rollback a reorg would leave a phantom mined record and
+// drop a MANDATORY qfcommit out of the served template (bad-qc-missing, a lost
+// block). Each is red-provable by breaking exactly the arm it names.
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ── KAT-L — the port itself: a disconnected block's mined records are erased
+//    EXACTLY, and re-connecting the same blocks reproduces identical state.
+//
+//    Connect the anchor + a 3101-block run, snapshot the store at a fork height
+//    A (cursor, size, derived merkleRootQuorums, the has_mined set), connect on
+//    to the tip B, then DISCONNECT B..A+1 in strict LIFO through undo_input.
+//    After the undo the store must be byte-for-byte the A snapshot again:
+//    every commitment mined ABOVE the fork is gone (no phantom), every one at
+//    or below it survives, size and derived root are identical. Re-connecting
+//    the same tail then reproduces the B snapshot exactly — add and remove are
+//    inverse.
+//
+//    RED: make erase_writes_at() a no-op (or drop the `m_mined.erase(...)` in
+//    it, or stop undo_input decrementing m_height). A disconnected block's
+//    mined records then linger: has_mined_commitment stays true for a
+//    commitment the roll-back removed, idx.size() does not return to sizeA, and
+//    the derived root at A no longer matches — the phantom-record failure the
+//    whole arm exists to prevent.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndexUndo, UndoErasesExactlyAndReconnectReproducesState)
+{
+    const auto scan = load_scan();
+    ASSERT_GE(scan.size(), 3000u);
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+    const auto ins = build_scan_inputs(scan);
+    ASSERT_GE(ins.size(), 100u);
+
+    // Heights that mined at least one non-null commitment.
+    std::vector<uint32_t> nn_heights;
+    for (const auto& in : ins) {
+        for (const auto& c : in.commitments)
+            if (!MinedCommitmentIndex::is_null_commitment(c)) {
+                nn_heights.push_back(in.height);
+                break;
+            }
+    }
+    ASSERT_GE(nn_heights.size(), 2u)
+        << "the window must mine non-null commitments at >=2 heights";
+    const uint32_t lateH = nn_heights.back();
+    ASSERT_GT(lateH, nn_heights.front());
+    const uint32_t A = lateH - 1;             // the fork / split cursor
+    const uint32_t B = ins.back().height;     // the full tip
+    ASSERT_LE(nn_heights.front(), A);
+    ASSERT_LT(A, B);
+
+    // Non-null (type,quorumHash) mined at/below A, and those FIRST mined above
+    // A. A quorum is mined at most once (bad-qc-dup), so the two sets are
+    // disjoint by construction.
+    std::vector<std::pair<uint8_t, uint256>> early, late;
+    for (const auto& in : ins) {
+        for (const auto& c : in.commitments) {
+            if (MinedCommitmentIndex::is_null_commitment(c)) continue;
+            const std::pair<uint8_t, uint256> k{c.llmqType, c.quorumHash};
+            if (in.height <= A) {
+                early.push_back(k);
+            } else if (std::find(early.begin(), early.end(), k) == early.end()) {
+                late.push_back(k);
+            }
+        }
+    }
+    ASSERT_FALSE(early.empty());
+    ASSERT_FALSE(late.empty());
+
+    auto idx = make_armed_full();
+    ASSERT_EQ(seed_anchor(idx), 88u);
+    idx.seed_cursor(2513685);
+
+    // ── Connect to A; snapshot.
+    size_t iA = 0;
+    for (; iA < ins.size(); ++iA) {
+        std::string err;
+        ASSERT_EQ(idx.process_input(ins[iA], at_h, &err),
+                  MinedIngestResult::Applied) << err;
+        if (ins[iA].height == A) break;
+    }
+    ASSERT_EQ(idx.height(), A);
+    const size_t  sizeA = idx.size();
+    const uint256 rootA = root_from_index(idx, A);
+    for (const auto& [t, qh] : early)
+        ASSERT_TRUE(idx.has_mined_commitment(t, qh));
+
+    // ── Connect to B; snapshot.
+    for (size_t i = iA + 1; i < ins.size(); ++i) {
+        std::string err;
+        ASSERT_EQ(idx.process_input(ins[i], at_h, &err),
+                  MinedIngestResult::Applied) << err;
+    }
+    ASSERT_EQ(idx.height(), B);
+    const size_t  sizeB = idx.size();
+    const uint256 rootB = root_from_index(idx, B);
+    ASSERT_GT(sizeB, sizeA);
+    for (const auto& [t, qh] : late)
+        ASSERT_TRUE(idx.has_mined_commitment(t, qh));
+
+    // ── DISCONNECT B..A+1 in strict LIFO through the UndoBlock port.
+    for (size_t i = ins.size(); i-- > iA + 1; ) {
+        std::string err;
+        ASSERT_EQ(idx.undo_input(ins[i], &err), MinedUndoResult::Undone) << err;
+        ASSERT_EQ(idx.height(), ins[i].height - 1)
+            << "each disconnect steps the cursor back exactly one";
+    }
+
+    // EXACT rollback to the A snapshot.
+    EXPECT_EQ(idx.height(), A);
+    EXPECT_EQ(idx.size(), sizeA);
+    EXPECT_EQ(root_from_index(idx, A).GetHex(), rootA.GetHex())
+        << "the derived merkleRootQuorums at the fork must be identical after "
+           "the roll-back";
+    for (const auto& [t, qh] : early)
+        EXPECT_TRUE(idx.has_mined_commitment(t, qh))
+            << "a commitment mined at/below the fork must survive the undo";
+    for (const auto& [t, qh] : late)
+        EXPECT_FALSE(idx.has_mined_commitment(t, qh))
+            << "a commitment mined ABOVE the fork must be erased — dashd "
+               "UndoBlock (blockprocessor.cpp:399); a lingering one is the "
+               "phantom mined record that arming on a live tip forbids";
+
+    // ── RE-CONNECT the same tail: the B snapshot is reproduced byte-for-byte.
+    for (size_t i = iA + 1; i < ins.size(); ++i) {
+        std::string err;
+        ASSERT_EQ(idx.process_input(ins[i], at_h, &err),
+                  MinedIngestResult::Applied)
+            << "re-connect from the rolled-back cursor must be contiguous: "
+            << err;
+    }
+    EXPECT_EQ(idx.height(), B);
+    EXPECT_EQ(idx.size(), sizeB);
+    EXPECT_EQ(root_from_index(idx, B).GetHex(), rootB.GetHex());
+    for (const auto& [t, qh] : late)
+        EXPECT_TRUE(idx.has_mined_commitment(t, qh));
+    for (const auto& [t, qh] : early)
+        EXPECT_TRUE(idx.has_mined_commitment(t, qh));
+    EXPECT_EQ(idx.stats().blocks_disconnected,
+              static_cast<uint64_t>(ins.size() - (iA + 1)));
+}
+
+// ── KAT-M — handle_reorg: the LIVE driver rolls the tip back to the fork point
+//    a switched chain implies, and lands on EXACTLY the state a forward-only
+//    walk to that fork would have produced.
+//
+//    Connect anchor + the full run to tip B. Then present a divergent chain to
+//    handle_reorg — real block hashes at/below a fork F, a flipped hash above
+//    it — as production's header chain would after a branch switch. The store
+//    must disconnect every height above F (journal-driven, no body re-supplied)
+//    and stop at F. A reference index connected forward-only to F must match it
+//    record-for-record: same size, same derived merkleRootQuorums.
+//
+//    RED: make handle_reorg's fork test `*on_chain == jit->second.block_hash`
+//    always false (it then rolls back past the fork), or make erase_writes_at()
+//    a no-op (the tip is not rolled back at all). Either way the post-reorg
+//    store no longer equals the forward-to-F reference.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndexUndo, HandleReorgRollsBackToForkPointExactly)
+{
+    const auto scan = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+    const auto ins = build_scan_inputs(scan);
+    ASSERT_GE(ins.size(), 100u);
+
+    std::vector<uint32_t> nn_heights;
+    for (const auto& in : ins)
+        for (const auto& c : in.commitments)
+            if (!MinedCommitmentIndex::is_null_commitment(c)) {
+                nn_heights.push_back(in.height);
+                break;
+            }
+    ASSERT_GE(nn_heights.size(), 2u);
+    const uint32_t F = nn_heights.back() - 1;   // a fork with a non-null above it
+
+    // Build the store forward to the tip.
+    auto idx = make_armed_full();
+    ASSERT_EQ(seed_anchor(idx), 88u);
+    idx.seed_cursor(2513685);
+    for (const auto& in : ins) {
+        std::string err;
+        ASSERT_EQ(idx.process_input(in, at_h, &err), MinedIngestResult::Applied)
+            << err;
+    }
+    const uint32_t B = idx.height();
+    ASSERT_GT(B, F);
+
+    // Reference: a fresh store walked forward-only to F.
+    auto ref = make_armed_full();
+    ASSERT_EQ(seed_anchor(ref), 88u);
+    ref.seed_cursor(2513685);
+    for (const auto& in : ins) {
+        if (in.height > F) break;
+        std::string err;
+        ASSERT_EQ(ref.process_input(in, at_h, &err), MinedIngestResult::Applied)
+            << err;
+    }
+    ASSERT_EQ(ref.height(), F);
+
+    // The switched chain: truth at/below F, a divergent hash above it.
+    auto reorg_at_h = [&hashes, F](uint32_t h) -> std::optional<uint256> {
+        auto it = hashes.find(h);
+        if (it == hashes.end()) return std::nullopt;
+        if (h <= F) return it->second;
+        uint256 flipped = it->second;
+        flipped.data()[0] ^= 0xff;              // a block the new branch lacks
+        return flipped;
+    };
+
+    std::string uerr;
+    ASSERT_EQ(idx.handle_reorg(reorg_at_h, &uerr), MinedUndoResult::Undone)
+        << uerr;
+
+    // Landed on the fork, and IS the forward-to-F state.
+    EXPECT_EQ(idx.height(), F);
+    EXPECT_EQ(idx.size(), ref.size())
+        << "handle_reorg must leave exactly the mined set a forward walk to the "
+           "fork would have";
+    EXPECT_EQ(root_from_index(idx, F).GetHex(), root_from_index(ref, F).GetHex());
+    EXPECT_EQ(idx.stats().blocks_disconnected, B - F);
+
+    // Every commitment first mined above the fork is gone; the fork's own set
+    // is intact and answers has_mined identically to the reference.
+    for (const auto& in : ins) {
+        for (const auto& c : in.commitments) {
+            if (MinedCommitmentIndex::is_null_commitment(c)) continue;
+            EXPECT_EQ(idx.has_mined_commitment(c.llmqType, c.quorumHash),
+                      ref.has_mined_commitment(c.llmqType, c.quorumHash))
+                << "post-reorg has_mined disagrees with the forward-to-fork "
+                   "reference for a type=" << int(c.llmqType) << " quorum";
+        }
+    }
+
+    // And it can fold forward again from the fork.
+    for (const auto& in : ins) {
+        if (in.height <= F) continue;
+        std::string err;
+        ASSERT_EQ(idx.process_input(in, at_h, &err), MinedIngestResult::Applied)
+            << "re-fold from the fork must be contiguous: " << err;
+    }
+    EXPECT_EQ(idx.height(), B);
+}
+
+// ── KAT-N — the arm gate, both directions. With the undo half ported, a LIVE
+//    tip ARMS when the caller declares a reorg-undo handler wired, and still
+//    REFUSES (naming UndoBlock, bad-qc-missing and who declared it) when it
+//    does not. Existence of the undo code is not the same as a caller driving
+//    it, and the guard demands the latter.
+//
+//    RED: change `if (posture.live && !posture.reorg_undo_wired)` in arm() to
+//    `if (posture.live)` — the wired arm is then refused and the first
+//    EXPECT_TRUE fails; or to `if (false)` — the unwired live tip arms and the
+//    unsafe-refusal half fails.
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndexUndo, ArmsOnLiveTipOnlyWhenReorgUndoWired)
+{
+    MinedCommitmentIndexConfig cfg;
+    cfg.enabled = true;
+
+    // LIVE + wired -> ARMS.
+    {
+        MinedCommitmentIndex idx(cfg);
+        TipPosture p;
+        p.live             = true;
+        p.reorg_undo_wired = true;
+        p.declared_by      = "header-chain reorg seam drives handle_reorg";
+        const auto v = idx.arm(p);
+        EXPECT_TRUE(v.armed) << v.reason;
+        EXPECT_TRUE(idx.armed());
+        EXPECT_NE(v.reason.find("UndoBlock"), std::string::npos)
+            << "the arming verdict names the ported half: " << v.reason;
+        EXPECT_NE(v.reason.find("header-chain reorg seam drives handle_reorg"),
+                  std::string::npos)
+            << "and who declared the wiring: " << v.reason;
+    }
+
+    // LIVE + NOT wired -> REFUSES, and still names the risk.
+    {
+        MinedCommitmentIndex idx(cfg);
+        TipPosture p;
+        p.live             = true;
+        p.reorg_undo_wired = false;
+        p.declared_by      = "FoldLiveTail wired but no undo handler";
+        const auto v = idx.arm(p);
+        EXPECT_FALSE(v.armed);
+        EXPECT_FALSE(idx.armed());
+        EXPECT_NE(v.reason.find("UndoBlock"), std::string::npos) << v.reason;
+        EXPECT_NE(v.reason.find("bad-qc-missing"), std::string::npos) << v.reason;
+        EXPECT_NE(v.reason.find("FoldLiveTail wired but no undo handler"),
+                  std::string::npos) << v.reason;
+    }
+}
+
+// ── KAT-O — undo_block, the BODY entry point (mirror of process_block): it
+//    parses the disconnected block's type-6 payloads itself and asserts the
+//    body binds to its header before erasing, and undo is strictly LIFO.
+//
+//    RED: delete undo_block's `block_body_binds_to_header` guard (a forged body
+//    then drives an erase), or delete undo_input's `in.height != m_height`
+//    clause (a non-tip disconnect is silently accepted).
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashMinedCommitmentIndexUndo, UndoBlockBodyPathAndLifoGuard)
+{
+    const auto scan   = load_scan();
+    const auto hashes = build_hash_map(scan);
+    auto at_h = hash_fn(hashes);
+
+    const auto subj = first_type4_commitment(scan);
+    ASSERT_TRUE(subj.has_value());
+
+    const ScanBlock* sb = nullptr;
+    for (const auto& b : scan)
+        if (b.height == subj->mined_height) sb = &b;
+    ASSERT_NE(sb, nullptr);
+    ASSERT_FALSE(sb->qc_hex.empty());
+
+    // A header-bound body: coinbase-shaped tx 0, then the real type-6 txs.
+    dash::coin::BlockType blk;
+    blk.m_bits = 0x19158dc7u;
+    {
+        dash::coin::MutableTransaction coinbase;
+        coinbase.version = 3;
+        coinbase.type    = 0;
+        dash::coin::TxIn cin;
+        cin.prevout.hash  = uint256::ZERO;
+        cin.prevout.index = 0xffffffffu;
+        coinbase.vin.push_back(cin);
+        blk.m_txs.push_back(std::move(coinbase));
+    }
+    for (const auto& hex : sb->qc_hex) {
+        dash::coin::MutableTransaction tx;
+        tx.version       = 3;
+        tx.type          = CFinalCommitmentTxPayload::SPECIALTX_TYPE;
+        tx.extra_payload = from_hex(hex);
+        ASSERT_FALSE(tx.extra_payload.empty());
+        blk.m_txs.push_back(std::move(tx));
+    }
+    {
+        std::vector<uint256> txids;
+        for (const auto& tx : blk.m_txs) {
+            auto packed = ::pack(tx);
+            txids.push_back(::Hash(packed.get_span()));
+        }
+        blk.m_merkle_root = dash::coin::compute_merkle_root(txids);
+    }
+    ASSERT_TRUE(dash::coin::block_body_binds_to_header(blk));
+
+    // Connect the block, then UNDO it through the body entry point.
+    auto idx = make_armed_full();
+    idx.seed_cursor(subj->mined_height - 1);
+    std::string err;
+    ASSERT_EQ(idx.process_block(subj->mined_height, sb->block_hash, blk, at_h,
+                                &err),
+              MinedIngestResult::Applied) << err;
+    ASSERT_TRUE(idx.has_mined_commitment(subj->commitment.llmqType,
+                                         subj->commitment.quorumHash));
+    ASSERT_EQ(idx.height(), subj->mined_height);
+
+    ASSERT_EQ(idx.undo_block(subj->mined_height, sb->block_hash, blk, &err),
+              MinedUndoResult::Undone) << err;
+    EXPECT_EQ(idx.height(), subj->mined_height - 1)
+        << "undo_block rolls the cursor back one";
+    EXPECT_FALSE(idx.has_mined_commitment(subj->commitment.llmqType,
+                                          subj->commitment.quorumHash))
+        << "the body entry point must erase the same records process_block "
+           "wrote";
+    EXPECT_EQ(idx.stats().blocks_disconnected, 1u);
+
+    // LIFO guard: a body that does not bind to its header must not drive an
+    // erase, and only the TIP is disconnectable.
+    {
+        auto idx2 = make_armed_full();
+        idx2.seed_cursor(subj->mined_height - 1);
+        ASSERT_EQ(idx2.process_block(subj->mined_height, sb->block_hash, blk,
+                                     at_h, &err),
+                  MinedIngestResult::Applied) << err;
+
+        dash::coin::BlockType forged = blk;
+        forged.m_txs[0].locktime ^= 1u;         // m_merkle_root NOT updated
+        ASSERT_FALSE(dash::coin::block_body_binds_to_header(forged));
+        EXPECT_EQ(idx2.undo_block(subj->mined_height, sb->block_hash, forged,
+                                  &err),
+                  MinedUndoResult::BodyNotBound);
+        EXPECT_TRUE(idx2.has_mined_commitment(subj->commitment.llmqType,
+                                              subj->commitment.quorumHash))
+            << "a forged body must NOT erase anything";
+        EXPECT_EQ(idx2.height(), subj->mined_height);
+
+        // Disconnecting a non-tip height is refused not-tip.
+        MinedBlockInput wrong;
+        wrong.height = subj->mined_height - 5;   // not the cursor
+        EXPECT_EQ(idx2.undo_input(wrong, &err), MinedUndoResult::NotTip);
+        EXPECT_NE(err.find("not-tip"), std::string::npos) << err;
+        EXPECT_EQ(idx2.height(), subj->mined_height)
+            << "a refused disconnect must not move the cursor";
     }
 }


### PR DESCRIPTION
**consensus-adjacent index; do not auto-merge; review required.**

Closes the arming half of the DASHD-CUT qc-availability work (task #146). Touches the mined-commitment index that decides which type-6 commitments a served template must carry — review-gated.

## What was unported

`src/impl/dash/coin/mined_commitment_index.hpp` shipped only the **forward** half of dashd's `CQuorumBlockProcessor`: `ProcessBlock` → `ProcessCommitment`'s two DB writes. The symmetric **`UndoBlock`** was never ported, so `arm()` refused any node whose tip is **live**. That refusal was the reason the index could not reduce the `qc-plan-underivable` gap on the live daemonless path: it could only arm on a frozen replay/backfill consumer.

Without a reorg-safe removal, a disconnected block would leave a **phantom** mined record → `has_mined_commitment()` answers true for a commitment the new chain never mined → a mandatory `qfcommit` drops out of the served template → dashd rejects the found block `bad-qc-missing` → a **lost block**.

## dashd reference ported (dashpay/dash v23.1.7)

- `src/llmq/blockprocessor.cpp` — `CQuorumBlockProcessor::UndoBlock` (lines 383-408): `GetCommitmentsFromBlock` → skip nulls → for each non-null commitment `Erase(DB_MINED_COMMITMENT, (llmqType, quorumHash))` and `Erase` the inversed-height key (`BuildInversedHeightKeyIndexed` for rotated types, else `BuildInversedHeightKey`) at the disconnected block's height, then `AddMineableCommitment`.
- Symmetric forward writes it inverts: `ProcessCommitment` (same file, DB writes at :359-368).

`AddMineableCommitment` (re-offering the commitment as mineable) and `PreComputeQuorumMembers` are deliberately **not** ported here — the same trust-boundary carve-out the forward half already documents: this store owns only the *mined* question; re-offering is `MineableCommitmentCache`'s job and is unchanged.

## The fix

`src/impl/dash/coin/mined_commitment_index.hpp`:
- `undo_input()` — 1:1 inverse of `process_input`'s two writes; LIFO (only the tip is disconnectable, matching dashd `DisconnectTip`).
- `undo_block()` — body entry point mirroring `process_block`: re-parses type-6 payloads and asserts `block_body_binds_to_header` before erasing.
- `handle_reorg()` — the live driver. Walks the cursor down to the fork point a switched chain implies, rolling back each orphaned height from a bounded per-height **rollback journal** (same shape the replay UTXO fold keeps a `BlockUndo`; `undo_window` default 100). A reorg deeper than the retained window fails **closed** via `clear_for_cold_rebuild()` (over-mandates slots, never serves a phantom) — mirrors `on_sml_reorg`'s cold-resync contract.
- `arm()` now arms a **live** tip when the caller declares `TipPosture.reorg_undo_wired`; a live tip with no undo handler still gets the named refusal (the undo code existing is not the same as a caller driving it).

`src/c2pool/main_dash.cpp`: wires `handle_reorg()` into the header-chain reorg seam (`set_on_tip_changed`, `was_reorg`) and sets `posture.reorg_undo_wired = true`, so `--replay-mined-commitment-index` arms on the live daemonless path.

## Red→green KAT proof

Four KATs added to `test/test_dash_mined_commitment_index.cpp`, each red-provable by breaking the arm it names. Verified explicitly by building in this environment:

- **Neuter `erase_writes_at()` (the core of the port) → RED:** `UndoErasesExactlyAndReconnectReproducesState`, `HandleReorgRollsBackToForkPointExactly`, `UndoBlockBodyPathAndLifoGuard` all **FAIL** (phantom records linger; size/root do not return to the pre-connect snapshot). `ArmsOnLiveTipOnlyWhenReorgUndoWired` correctly still passes (it does not erase).
- **Break the `arm()` live gate (`&& !reorg_undo_wired` → `if (posture.live)`) → RED:** `ArmsOnLiveTipOnlyWhenReorgUndoWired` **FAILS**.
- **With the fix restored → GREEN:** all 4 undo KATs + the 12 pre-existing forward KATs pass.

What the KATs assert: connect the anchor + 3101 real mainnet blocks, disconnect the tail in strict LIFO, and prove the store is byte-for-byte the pre-connect snapshot again (cursor, size, derived `merkleRootQuorums`, and the `has_mined` set — every commitment mined above the fork gone, every one at/below it intact); re-connecting reproduces the tip state exactly. `handle_reorg` lands on the exact state a forward-only walk to the fork would have produced.

## Build + test results (real, this environment)

- `conan install` (offline, cached deps) + `cmake` configure: OK, GTest found.
- `cmake --build build_t --target test_dash_embedded_gbt`: **built + linked, 0 errors** (the mined-commitment suite is folded into this executable).
- `src/c2pool/main_dash.cpp` object compiled standalone: **0 errors** (only pre-existing warnings) — the live wiring compiles.
- Test run: **`287 / 287` pass** in `test_dash_embedded_gbt`, including the **16** `DashMinedCommitmentIndex*` tests (12 forward + 4 undo). No regressions.

toolchain: gcc 13.3, Release, Boost 1.90 (conan).

## Attribution

No AI/model attribution anywhere (commit, code, tests, this body). Plain human-style commit.
