### PR TITLE
dash daemonless: pay block H from the pre-block payout (h=2525714 self-ProUpReg) — clean successor to #1311

### DIFF
--- a/src/impl/dash/coin/mn_state_machine.hpp
+++ b/src/impl/dash/coin/mn_state_machine.hpp
@@ -1284,6 +1284,28 @@ public:
                            : std::optional<uint256>{ranked.front()};
         r.projected_payee = projected;
 
+        // -- Pre-block payout snapshot (dashd payment ordering) ----
+        // dashd pays block H's masternode from the PRE-block list: payments.cpp
+        // GetBlockTxOuts reads oldList.GetMNPayee(pindexPrev)->pdmnState->
+        // scriptPayout, i.e. the payout AS OF H-1, BEFORE this block's special
+        // txs are folded (deterministicmns.cpp BuildNewListFromBlock applies the
+        // ProUpRegTx only afterwards). The pass-3 coinbase cross-check below must
+        // therefore compare against that pre-block script, NOT the entry pass 1
+        // is about to rewrite. Capture it here, before pass 1 -- exactly as
+        // DmlFoldEngine::fold_block captures payee_script_pre (replay_fold_engine
+        // .hpp). Without it, when the projected payee's OWN ProUpRegTx rides the
+        // very block it is paid in (mainnet h=2525714, proTx f5a49888...:
+        // scriptPayout a7f7252d -> Xv4Ys1mi in-block, coinbase pays the pre-block
+        // a7f7252d), pass 1 rewrites scriptPayout to Xv4Ys1mi and pass 3 no longer
+        // finds the paid script -- a FALSE payee_desync that fail-closes the
+        // daemonless bridge.
+        std::vector<unsigned char> projected_script_pre;
+        if (projected) {
+            auto ppit = m_entries.find(*projected);
+            if (ppit != m_entries.end())
+                projected_script_pre = ppit->second.scriptPayout.m_data;
+        }
+
         // Past the guards, so this block WILL be applied: any pending
         // re-adjudication belongs to an earlier height and is now unusable
         // (its `ranked` was computed on a list this block is about to change).
@@ -1585,7 +1607,9 @@ public:
             // payee whose MN was removed by THIS block's passes 1/2 is
             // silently skipped (no mark, no desync).
             if (it != m_entries.end()) {
-                if (paid_in_cb(it->second.scriptPayout.m_data)) {
+                // Cross-check the coinbase against the PRE-block payout
+                // (captured at pass 0), mirroring dashd GetBlockTxOuts.
+                if (paid_in_cb(projected_script_pre)) {
                     mark_paid(it);
                     // The accepted coinbase also attests the paid MN's
                     // CURRENT operator-reward split — cross-check a KNOWN

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -921,7 +921,7 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_replay_mnlist_seed.cpp)
     target_link_libraries(test_dash_mn_state PRIVATE
         GTest::gtest_main GTest::gtest
-        dash_x11 core
+        dash_bls_verify dash_x11 core
         nlohmann_json::nlohmann_json
         ${Boost_LIBRARIES}
     )

--- a/test/test_dash_mn_state.cpp
+++ b/test/test_dash_mn_state.cpp
@@ -1588,3 +1588,71 @@ TEST(DashMnReviveBanState, LoadRetiresTheMeasurement) {
     EXPECT_FALSE(f.m.ban_state_measured_for(2514574));
     EXPECT_EQ(f.m.apply_block(f.blk, 2514574).revive_unmeasured, 1u);
 }
+
+// --- same-block self-ProUpReg: pay the PRE-block script (dashd ordering) ----
+// Mainnet h=2525714 (proTx f5a49888ec1d00db...): the projected payee's OWN
+// ProUpRegTx rides the very block it is paid in, moving its payout script
+// a7f7252d -> Xv4Ys1mi. dashd pays block H's masternode from the list AS OF H-1
+// (payments.cpp GetBlockTxOuts reads oldList.GetMNPayee(pindexPrev)->pdmnState->
+// scriptPayout BEFORE the block's special txs fold in BuildNewListFromBlock), so
+// the coinbase correctly pays the PRE-block a7f7252d. Cross-checking the entry
+// pass 1 just rewrote (Xv4Ys1mi) is a FALSE payee_desync that fail-closes the
+// daemonless bridge. RED before the pass-0 snapshot fix, GREEN after.
+TEST(DashMnState, ProjectedPayeePaidByPreBlockScriptWhenSelfProUpRegSameBlock) {
+    MnStateMachine m;
+    auto s_old  = script_bytes(0xA7, 25);   // pre-block payout, paid by coinbase
+    auto s_new  = script_bytes(0x54, 25);   // in-block ProUpReg's new payout
+    auto op_key = seq_array<48>(0x55);       // UNCHANGED operator key -> no ban
+
+    MNState a;
+    a.isValid                 = true;
+    a.scriptPayout.m_data     = s_old;
+    a.pubKeyOperator          = op_key;
+    a.nRegisteredHeight       = 2'500'940;
+    a.nLastPaidHeight         = 2'521'534;   // oldest paid -> projected winner
+    a.collateralOutpoint.hash = raw256_byte(0, 0xA7);
+    uint256 hA = raw256_byte(0, 0x01);
+
+    // A more-recently-paid MN so the ranked queue has a runner-up and the
+    // projection is unambiguous (A is the sole eligible winner this block).
+    MNState b = a;
+    b.scriptPayout.m_data     = script_bytes(0xB0, 25);
+    b.nLastPaidHeight         = 2'525'000;
+    b.collateralOutpoint.hash = raw256_byte(0, 0xB0);
+    uint256 hB = raw256_byte(0, 0x02);
+
+    m.load(std::vector<std::pair<uint256, MNState>>{{hA, a}, {hB, b}});
+
+    // Block H=2525714: coinbase pays A's PRE-block script (s_old); A's OWN
+    // ProUpRegTx (same operator key -> no ResetOperatorFields/ban) rewrites its
+    // payout to s_new within the same block.
+    CProUpRegTx upreg;
+    upreg.nVersion            = ProTxVersion::BASIC_BLS;
+    upreg.proTxHash           = hA;
+    upreg.pubKeyOperator      = op_key;      // unchanged -> stays valid, stays payee
+    upreg.keyIDVoting         = raw160(0x66);
+    upreg.scriptPayout.m_data = s_new;
+    upreg.inputsHash          = raw256(0x34);
+    upreg.vchSig              = {0x01};
+
+    BlockType blk;
+    blk.m_txs.push_back(coinbase_tx(std::vector<std::vector<unsigned char>>{s_old}));
+    blk.m_txs.push_back(special_tx(CProUpRegTx::SPECIALTX_TYPE, protx_payload(upreg)));
+
+    auto r = m.apply_block(blk, 2'525'714);
+
+    // The ProUpReg applied: post-block state carries the new payout...
+    EXPECT_EQ(r.updated, 1u);
+    EXPECT_EQ(m.entries().at(hA).scriptPayout.m_data, s_new)
+        << "post-block state must carry the in-block ProUpReg's new payout";
+
+    // ...but the payment is attributed to A on its PRE-block script -- no desync.
+    EXPECT_FALSE(r.payee_desync)
+        << "coinbase pays the script dashd pays from the H-1 list; cross-checking "
+           "the mutated post-block script is a false payee_desync (h=2525714 class)";
+    EXPECT_EQ(r.paid, 1u);
+    ASSERT_TRUE(r.projected_payee.has_value());
+    EXPECT_EQ(*r.projected_payee, hA);
+    EXPECT_EQ(m.entries().at(hA).nLastPaidHeight, 2'525'714u)
+        << "the projected payee must be marked paid at this height";
+}


### PR DESCRIPTION
## Clean successor to #1311 — payee-desync fix only

`#1311` went CONFLICTING because it also carried a divergent copy of the whole
`#154` tower (mainnet trust-anchor bump, BLS opkey point-compare, quarter-fill
quorum uniqueness, pre/post-V20 hash-modifier). That tower has since landed on
master via **#1304** (quarter-fill quorum uniqueness) + **#1310** (opkey
point-compare + V20 hash-modifier KAT), so it is now redundant.

This PR re-roots **only** the payee-desync delta onto current master. No history
rewrite, no force-push — a fresh branch off `master` HEAD.

### Root cause
`MnStateMachine::apply_block` cross-checked the coinbase against the projected
payee's **live** `scriptPayout`, read in pass 3 **after** pass 1 folds the
block's own special txs. When the projected payee's `ProUpRegTx` rides the very
block it is paid in, pass 1 rewrites `scriptPayout` before pass 3 reads it — so
the coinbase (which dashd pays from the H-1 list) no longer matches the mutated
post-block entry. Result: a **false** `payee_desync` that fail-closes the
daemonless masternode-set bridge and blocks the full dashd-cut.

Observed on mainnet **h=2525714**: proTx `f5a49888ec1d00db`, in-block ProUpReg
moves `scriptPayout` `a7f7252d -> Xv4Ys1mi`; the coinbase correctly pays the
pre-block `a7f7252d`.

### dashd port
dashd pays block H's masternode from the **pre-block** list:
`payments.cpp GetBlockTxOuts` reads
`oldList.GetMNPayee(pindexPrev)->pdmnState->scriptPayout` **before** the block's
special txs fold in `deterministicmns.cpp BuildNewListFromBlock`
(`specialtxman.cpp:399` ordering). `DmlFoldEngine::fold_block` already captures
`payee_script_pre` before its special-tx pass; this ports the same pre-block
snapshot into the state machine's pass 0 and cross-checks the coinbase against
**that**, not the value pass 1 rewrites.

### Fix
Snapshot the projected payee's payout script at **pass 0** (before pass 1) and
cross-check the coinbase against that pre-block script, mirroring dashd.

### KAT
`DashMnState.ProjectedPayeePaidByPreBlockScriptWhenSelfProUpRegSameBlock`
(pins h=2525714): **RED** before the snapshot (`payee_desync`, `paid=0`),
**GREEN** after (`paid=1`). Verified locally on this branch off master
(Release, `-DC2POOL_DASH_BLS=ON`): red on master without the hpp fix, green with
it. The `test_dash_mn_state` link gains `dash_bls_verify` to match sibling dash
test targets (needed to build the aggregate exe; not already on master).

### Diff (minimal — 3 files)
- `src/impl/dash/coin/mn_state_machine.hpp` — pass-0 pre-block payout snapshot + pass-3 cross-check against it
- `test/test_dash_mn_state.cpp` — the KAT
- `test/CMakeLists.txt` — `dash_bls_verify` link for `test_dash_mn_state`

**consensus / reward-path change — hold for operator merge tap.** Supersedes
#1311 (integrator to close #1311 separately).
