### PR TITLE
dash(daemonless): serve own valid tx set on divergence — internal-consistency referee (--embedded-tx-serve-own-set)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -425,6 +425,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
+        << "           [--embedded-tx-serve-own-set]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
@@ -806,6 +807,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // body path (G1-G4 guards, mempool.hpp) only enters block
              // production when the operator explicitly arms it.
              bool embedded_serve_mempool_txs = false,
+             // --embedded-tx-serve-own-set: when a served embedded
+             // template's mempool selection diverges from dashd's, serve
+             // OUR OWN internally-consistent valid set instead of falling
+             // back to dashd on tx-merkle difference. DEFAULT OFF. MUST NOT
+             // be armed until the [MEMPOOL-VALIDITY] gate has reached
+             // open() (576 clean heights) in a dashd-oracle soak -- the
+             // internal-consistency referee shares the selector's UTXO view
+             // and cannot alone catch the already-mined/stale-view class
+             // (h=2526403). When --embedded-shadow-compare is also on, the
+             // own-set path auto-fail-closes until that gate is open.
+             bool embedded_tx_serve_own_set = false,
              // --embedded-shadow-compare: OBSERVE-only serve-vs-dashd block-
              // template field diff (diagnostic; NOT a serve gate). Off the hot
              // path (worker-thread dashd fetch). Default false; only meaningful
@@ -2806,6 +2818,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // consulted, i.e. during an actual embedded outage.
     const bool xcheck_wanted = (testnet || embedded_mainnet);
     work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
+    // --embedded-tx-serve-own-set: serve own valid tx set on a divergent
+    // mempool selection instead of the dashd-parity swap (DEFAULT OFF).
+    work_source->set_tx_serve_own_set(embedded_tx_serve_own_set);
+    std::cout << "[DASH-STRATUM-GBT] tx-serve own-set referee: "
+              << (embedded_tx_serve_own_set
+                      ? "ON (--embedded-tx-serve-own-set: divergent-but-valid"
+                        " mempool set served as own; validity-gate-coupled"
+                        " when shadow-compare is bound)"
+                      : "OFF (dashd-parity backstop on any tx-merkle divergence)")
+              << std::endl;
     // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
     // either way: with it off the donation still misses every swapped
     // template -- it just no longer does so silently.
@@ -9243,6 +9265,7 @@ int main(int argc, char** argv)
     // (mempool_validity_gate.hpp) reports zero transactions refused by dashd's
     // testmempoolaccept over its sustained window.
     bool embedded_serve_mempool_txs = false;
+    bool embedded_tx_serve_own_set = false;  // --embedded-tx-serve-own-set, default OFF
     bool embedded_accrue_asset_locks = false;  // #107 PHASE 2, default OFF
     bool embedded_accrue_asset_unlocks = false;  // #143 Variant B (type-9), default OFF
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
@@ -9372,6 +9395,8 @@ int main(int argc, char** argv)
             embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
             embedded_serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-tx-serve-own-set") == 0)
+            embedded_tx_serve_own_set = true;
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks") == 0)
             embedded_accrue_asset_locks = true;   // #107 PHASE 2
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-unlocks") == 0)
@@ -9686,6 +9711,7 @@ int main(int argc, char** argv)
                         oracle_class_coverage, coin_p2p_peers, bestcl_policy,
                         embedded_utxo_immature_serve_empty,
                         embedded_serve_mempool_txs,
+                        embedded_tx_serve_own_set,
                         embedded_shadow_compare,
                         embedded_mempool_ingest,
                         pin_local_tx_hex_path,

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -820,6 +820,23 @@ inline DashWorkData build_embedded_workdata(
     }
     w.m_mempool_tx_count = static_cast<uint32_t>(selected.size());
 
+    // -- INTERNAL-CONSISTENCY STAMP for the serve-time tx-serve referee ----
+    // armed iff the mempool-serving path actually ran (--embedded-serve-
+    // mempool-txs ON and the UTXO lane mature). suppress_mempool_txs already
+    // encodes exactly that inverse (node_coin_state.hpp make_embedded_work_
+    // inputs). When suppressed the body is coinbase-only, the referee stays
+    // dormant, and this template is byte-identical to before this line.
+    //
+    // all_mempool_fee_fold_proven: EVERY entry `selected` returned above came
+    // through the selector's exclusion-discipline -- get_sorted_txs_with_fees
+    // takes only fee_fold_proven entries (mempool.hpp: `if(!e.fee_fold_proven)
+    // continue;`), so every tx in the mempool-sourced range has each vin
+    // present-and-unspent in our UTXO view with in_sum>=out_sum. Recording the
+    // guarantee (rather than trusting the call site) lets the referee fail-
+    // close if a future selection path ever admits an unproven tx.
+    w.m_tx_serve_stamp.armed = !suppress_mempool_txs;
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+
     // ── Underfill guard ─────────────────────────────────────────────
     // Do not silently treat a near-empty DASH template as healthy when the
     // DASH mempool held fee-paying backlog that should have filled it. We
@@ -971,6 +988,10 @@ inline DashWorkData build_embedded_workdata(
         // dashd augments coinbasevalue by the superblock total (the accrued
         // treasury slice released this block).
         w.m_coinbase_value += static_cast<uint64_t>(superblock_total);
+        // Referee reconstructs m_coinbase_value from subsidy + Sum(fees) +
+        // this treasury slice; 0 on every non-superblock height.
+        w.m_tx_serve_stamp.superblock_total =
+            static_cast<uint64_t>(superblock_total);
     }
 
     // E2d: fold the DIP-0004 type-5 CCbTx extra_payload so the block is

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -629,6 +629,30 @@ public:
         return j;
     }
 
+    /// Thread-safe readiness snapshot for the SERVE PATH (work_source.cpp).
+    /// TRUE only when a dashd testmempoolaccept oracle is bound AND the mempool
+    /// validity gate has accrued its sustained clean window (open()).
+    ///
+    /// The tx-serve-own-set referee consults this so that serving OUR OWN valid
+    /// tx set -- dropping the dashd-tx-merkle PARITY backstop -- cannot begin
+    /// until the SELECTOR has been PROVEN dashd-acceptable over the window.
+    /// This is the direct runtime answer to the field finding at h=2526403:
+    /// our fee_fold_proven selection can still offer transactions dashd rejects
+    /// (the already-mined / stale-UTXO-view class), and the internal-
+    /// consistency referee shares a UTXO view with the selector, so it cannot
+    /// independently catch that class. Only dashd's external view (this gate,
+    /// or the parity backstop) can. Requiring open() here keeps the parity
+    /// backstop in force until the gate demonstrates the class is gone.
+    ///
+    /// Returns false when no oracle is bound: the gate cannot be proven without
+    /// dashd, so it fail-closes. (A post-proof PURE-daemonless node runs with
+    /// no shadow-compare object at all; the caller bypasses the coupling only
+    /// when the probe is absent, never when it is present-but-empty.)
+    bool validity_gate_open() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return static_cast<bool>(accept_) && validity_.open();
+    }
+
 private:
     void worker_loop() {
         for (;;) {

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -207,6 +207,43 @@ struct DashWorkData {
     // inference from a reject string. Diagnostic: no consensus path reads it.
     std::vector<uint8_t>  m_mempool_probe_depends_in_set;
 
+    // -- EMBEDDED TX-SERVE INTERNAL-CONSISTENCY STAMP -----------------------
+    // Written ONLY by the embedded builder when it produces a mempool-tx-
+    // carrying body (embedded_gbt.hpp; armed == !suppress_mempool_txs). The
+    // serve-time internal-consistency referee (tx_serve_referee.hpp) reads it
+    // to decide whether c2pool may serve ITS OWN valid tx set instead of
+    // falling back to dashd merely because our tx-merkle-root differs. A
+    // divergent-but-internally-consistent set is a NORMAL, perfectly valid
+    // block; the safety requirement is per-tx validity + no double-spend +
+    // coinbase fee-consistency, NOT tx-set parity with dashd.
+    //
+    // The two facts here are the ones the referee cannot re-derive from the
+    // wire body alone: whether every mempool-range tx passed the fee-fold
+    // proof (mempool.hpp exclusion-discipline: the vin-present/unspent,
+    // in_sum>=out_sum guarantee), and the treasury/superblock slice that was
+    // added to m_coinbase_value on a funded superblock height (so the referee
+    // can assert m_coinbase_value == subsidy + Sum(m_tx_fees) + superblock).
+    // armed == false on every non-serving build (coinbase-only, dashd
+    // fallback) -> the referee never runs and behaviour is byte-identical.
+    struct EmbeddedTxServeStamp {
+        // The mempool-serving path produced this body (--embedded-serve-
+        // mempool-txs ON at build time). When false the referee is dormant.
+        bool     armed{false};
+        // Every tx in the mempool-sourced range [m_mempool_tx_first_index,
+        // +m_mempool_tx_count) passed the fee-fold proof at selection. The
+        // selector already refuses non-proven entries (mempool.hpp:~1018
+        // "if(!e.fee_fold_proven) continue;"); this records that guarantee so
+        // the referee can fail-close if a future selection path ever admits an
+        // unproven tx.
+        bool     all_mempool_fee_fold_proven{false};
+        // Treasury payout total added to m_coinbase_value at a funded
+        // superblock height (0 on every ordinary block). Lets the referee
+        // reconstruct the coinbase value exactly from (subsidy + fees +
+        // superblock) rather than approximating it.
+        uint64_t superblock_total{0};
+    };
+    EmbeddedTxServeStamp m_tx_serve_stamp;
+
     // ── PIN OUTCOMES (see PinOutcome above) ───────────────────────────────
     // One entry per configured pinned local tx, written by the splice on the
     // SERVED dashd-fallback arm. Empty on the embedded arm (which splices in

--- a/src/impl/dash/coin/tx_serve_referee.hpp
+++ b/src/impl/dash/coin/tx_serve_referee.hpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// SERVE-TIME INTERNAL-CONSISTENCY REFEREE for the embedded (daemonless)
+/// block-template tx-serving path.
+///
+/// == WHAT THIS REPLACES, AND WHY =============================================
+/// The prior referee (work_source.cpp #130 branch, cause
+/// "gbt-xcheck-txmerkle-mismatch") was a dashd-PARITY test: it recomputed the
+/// non-coinbase tx-merkle-root of OUR selection and dashd's getblocktemplate
+/// and, on ANY difference, threw away our template and served dashd's instead.
+///
+/// That is the wrong question. Two independently-connected nodes never hold
+/// identical mempools (relay is gossip; admission is per-node policy over a
+/// per-node UTXO view; each side snapshots at a different instant), so a
+/// DIFFERENT-BUT-VALID tx set is NORMAL and produces a perfectly valid block.
+/// The consensus requirement for the tx set is NOT parity with dashd; it is:
+///
+///   (a) coinbase fee-consistency -- the coinbase claims exactly the block
+///       subsidy + the sum of the served per-tx fees (+ the treasury slice on
+///       a funded superblock height). An over-claim is the bad-cb-amount
+///       orphan vector.
+///   (b) every served mempool tx is fee_fold_proven -- each vin present and
+///       unspent in our UTXO view at build time, in_sum >= out_sum (the
+///       selector's exclusion-discipline, strictly stronger than fee_known).
+///   (c) no intra-set double-spend -- no two served txs spend the same coin.
+///   (d) per-tx consensus/policy validity beyond (a)-(c) -- delegated to the
+///       MEMPOOL VALIDITY GATE (mempool_validity_gate.hpp), a sustained
+///       testmempoolaccept readiness window that gates the ARMING of
+///       --embedded-serve-mempool-txs. Once armed, that residual is covered;
+///       it is NOT a per-template serve gate and must not re-introduce a
+///       set-difference-from-dashd fallback.
+///
+/// When (a)-(c) hold on an armed template the block is reward-safe: serving OUR
+/// OWN set is correct and the daemonless mandate is met. If any fails the
+/// caller MUST fail-close to the dashd fallback (safety preserved). The dashd
+/// tx-merkle cross-check is kept as a SHADOW/diagnostic (the caller logs the
+/// divergence) but is no longer serve-blocking.
+///
+/// == WHY THESE CHECKS ARE SOUND BY CONSTRUCTION ==============================
+/// (a) embedded_gbt.hpp: block_value = reward + total_fees; m_coinbase_value =
+///     block_value (+ superblock_total on a funded superblock height). Every
+///     m_tx_fees entry is 0 (type-6 quorum commitments, zero-fee pins) or a
+///     real fee that was folded into total_fees (asset-unlock payload fees;
+///     mempool-selected fees), so Sum(m_tx_fees) == total_fees EXACTLY. The
+///     subsidy is a pure function of height (subsidy.hpp), re-derived here with
+///     the SAME function the builder used, so the equality below is the
+///     builder's own invariant re-asserted at serve time -- it catches any
+///     corruption of m_coinbase_value / m_tx_fees / the superblock slice
+///     between build and serve.
+/// (b) mempool.hpp get_sorted_txs_with_fees selects ONLY fee_fold_proven
+///     entries ("if(!e.fee_fold_proven) continue;"). The builder records that
+///     guarantee in the stamp; the referee fail-closes if it is ever false.
+/// (c) folded here over the actual served vins -- fully independent of dashd.
+
+#include <impl/dash/coin/rpc_data.hpp>
+// utxo_adapter.hpp declares dash::coin::dash_txid, which subsidy.hpp uses in
+// its computed_block_fees helper at namespace-parse time -- include it FIRST
+// so this header is self-contained (work_source.cpp already has it via
+// block_producer.hpp, but the referee unit test includes us standalone).
+#include <impl/dash/coin/utxo_adapter.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace dash {
+namespace coin {
+
+/// Verdict of tx_serve_internal_referee. serve_own_set == true means the
+/// embedded template is reward-safe to serve as-is despite differing from
+/// dashd's tx set; false means the caller must fail-close to dashd and record
+/// fail_cause. detail is a human-readable line for the log / status surface.
+struct TxServeRefereeVerdict {
+    bool        serve_own_set{false};
+    std::string fail_cause;   // empty iff serve_own_set
+    std::string detail;
+};
+
+/// Runs the internal-consistency referee over an armed embedded template. The
+/// caller invokes this only on the tx-serve axis (m_mempool_tx_count > 0) after
+/// the CbTx axes (#1216 creditPool / quorum / MN-root) have already been
+/// cleared, so this function reasons about the tx SELECTION axis alone.
+inline TxServeRefereeVerdict tx_serve_internal_referee(const DashWorkData& w)
+{
+    TxServeRefereeVerdict v;
+
+    // (pre) PROVENANCE. Only a body the embedded mempool-serving path built
+    // and stamped is eligible. A template that reached this axis with
+    // m_mempool_tx_count>0 but no stamp is not one this referee can vouch for
+    // -> fail-close. (Byte-neutral in practice: the caller runs the referee
+    // only when the serve flag armed the build, which is exactly when the
+    // stamp is set.)
+    if (!w.m_tx_serve_stamp.armed) {
+        v.fail_cause = "tx-serve-unstamped";
+        v.detail     = "template carries mempool txs but no embedded serve"
+                       " stamp (unproven provenance)";
+        return v;
+    }
+
+    // (b) Every served mempool tx passed the fee-fold proof at selection.
+    if (!w.m_tx_serve_stamp.all_mempool_fee_fold_proven) {
+        v.fail_cause = "tx-serve-fee-fold-unproven";
+        v.detail     = "a served mempool tx is not fee_fold_proven";
+        return v;
+    }
+
+    // (a) COINBASE FEE-CONSISTENCY. coinbase_value must equal subsidy + the sum
+    // of served per-tx fees + the treasury slice. Any over-claim is
+    // bad-cb-amount; equality is the by-construction invariant re-asserted.
+    uint64_t fee_sum = 0;
+    for (uint64_t f : w.m_tx_fees) fee_sum += f;
+    const uint64_t subsidy =
+        static_cast<uint64_t>(compute_dash_block_reward_post_v20(w.m_height));
+    const uint64_t expect =
+        subsidy + fee_sum + w.m_tx_serve_stamp.superblock_total;
+    if (w.m_coinbase_value != expect) {
+        v.fail_cause = "tx-serve-coinbase-inconsistent";
+        v.detail     = "coinbase_value=" + std::to_string(w.m_coinbase_value)
+                     + " != subsidy=" + std::to_string(subsidy)
+                     + " + fees=" + std::to_string(fee_sum)
+                     + " + superblock="
+                     + std::to_string(w.m_tx_serve_stamp.superblock_total);
+        return v;
+    }
+
+    // (c) NO INTRA-SET DOUBLE-SPEND. No two served txs may spend the same
+    // outpoint. Folds over the actual served vins (coinbase is not in m_txs);
+    // type-6 quorum commitments and type-9 unlocks carry no vin, so they add
+    // nothing. The "inputs unspent at tip" half of the double-spend guard is
+    // the fee-fold proof (b), taken against the live UTXO view at build time.
+    std::set<std::pair<std::string, uint32_t>> spent;
+    for (const auto& tx : w.m_txs) {
+        for (const auto& in : tx.vin) {
+            auto key = std::make_pair(in.prevout.hash.GetHex(),
+                                      in.prevout.index);
+            if (!spent.insert(key).second) {
+                v.fail_cause = "tx-serve-double-spend";
+                v.detail     = "two served txs spend outpoint "
+                             + key.first + ":" + std::to_string(key.second);
+                return v;
+            }
+        }
+    }
+
+    v.serve_own_set = true;
+    v.detail = "internally consistent: coinbase fee-exact ("
+             + std::to_string(w.m_coinbase_value) + "="
+             + std::to_string(subsidy) + "+" + std::to_string(fee_sum)
+             + "+" + std::to_string(w.m_tx_serve_stamp.superblock_total)
+             + "), all fee_fold_proven, no double-spend";
+    return v;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -43,6 +43,7 @@
 #include <impl/dash/params.hpp>               // dash::make_coin_params
 #include <impl/dash/coin/vendor/cbtx.hpp>     // vendor::parse_cbtx (GBT-xcheck creditPool)
 #include <impl/dash/coin/special_tx_pool_delta.hpp> // #107: explain the pool delta
+#include <impl/dash/coin/tx_serve_referee.hpp>  // tx-serve internal-consistency referee (own-set vs dashd-parity)
 #include <impl/dash/coin/serve_staleness.hpp> // serve-staleness sentinel (steady_now_ms + the incident catalogue)
 
 #include <core/address_utils.hpp>             // core::address_to_script (mint payout from username)
@@ -1121,25 +1122,92 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     const uint256 dref_txroot =
                         coin::compute_merkle_root(dref.m_tx_hashes);
                     if (emb_txroot != dref_txroot) {
-                        LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck tx-merkleroot"
-                                    << " MISMATCH at h=" << sel.work.m_height
-                                    << " embedded txs=" << sel.work.m_tx_hashes.size()
-                                    << " root=" << emb_txroot.GetHex().substr(0, 16)
-                                    << " dashd txs=" << dref.m_tx_hashes.size()
-                                    << " root=" << dref_txroot.GetHex().substr(0, 16)
-                                    << " — serving dashd template (reward-safety"
-                                       " backstop: a divergent mempool tx selection"
-                                       " / commitment order is the bad-txns-"
-                                       "merkleroot orphan vector)";
-                        coin::DeclineReport xcheck;
-                        xcheck.viable    = false;
-                        xcheck.cause     = "gbt-xcheck-txmerkle-mismatch";
-                        xcheck.value     = emb_txroot.GetHex();
-                        xcheck.threshold = dref_txroot.GetHex();
-                        sel = coin::WorkSelection{ std::move(dref),
-                                                   coin::WorkSource::DashdFallback,
-                                                   std::move(xcheck) };
-                        served_via_xcheck_swap = true;
+                        // The embedded selection DIVERGES from dashd's. Two
+                        // independently-connected nodes never hold identical
+                        // mempools, so a divergent-but-VALID set is NORMAL and
+                        // yields a perfectly valid block. Whether we may serve
+                        // OUR OWN set or must fall back to dashd is decided
+                        // here, per --embedded-tx-serve-own-set:
+                        //
+                        //   OFF (default, shipped posture): the legacy dashd-
+                        //   PARITY backstop -- swap to dashd on ANY divergence
+                        //   (cause gbt-xcheck-txmerkle-mismatch). Byte-
+                        //   identical to before this change.
+                        //
+                        //   ON: run the INTERNAL-CONSISTENCY referee
+                        //   (tx_serve_referee.hpp): coinbase fee-exact, every
+                        //   served tx fee_fold_proven, no intra-set double-
+                        //   spend. The referee shares the selector's UTXO
+                        //   view, so it CANNOT catch a tx that view still
+                        //   shows unspent while dashd sees it spent (already-
+                        //   mined / stale-view class, field-observed at
+                        //   h=2526403: probed=4 invalid=4 on fee_fold_proven
+                        //   txs). The MEMPOOL VALIDITY GATE catches exactly
+                        //   that class via dashd testmempoolaccept over a
+                        //   sustained clean window, so when a shadow-compare
+                        //   probe is bound we require it OPEN before trusting
+                        //   the referee. With NO probe bound (pure daemonless,
+                        //   post-proof) the operator's arming of the flag is
+                        //   the proof. Either way, failure fail-closes to
+                        //   dashd -- safety is preserved on every branch.
+                        const bool gate_proven =
+                            !shadow_compare_ || shadow_compare_->validity_gate_open();
+                        coin::TxServeRefereeVerdict rv;
+                        const bool serve_own =
+                            tx_serve_own_set_ && gate_proven
+                            && (rv = coin::tx_serve_internal_referee(sel.work))
+                                   .serve_own_set;
+                        if (serve_own) {
+                            // SERVE OUR OWN VALID SET. The dashd divergence is
+                            // a SHADOW (diagnostic), not a fallback trigger.
+                            tx_serve_own_set_serves_.fetch_add(
+                                1, std::memory_order_relaxed);
+                            LOG_INFO << "[DASH-STRATUM-GBT] tx-serve OWN-SET at h="
+                                     << sel.work.m_height
+                                     << " embedded txs=" << sel.work.m_tx_hashes.size()
+                                     << " root=" << emb_txroot.GetHex().substr(0, 16)
+                                     << " != dashd txs=" << dref.m_tx_hashes.size()
+                                     << " root=" << dref_txroot.GetHex().substr(0, 16)
+                                     << " â SERVING OWN VALID SET (" << rv.detail
+                                     << "); a different-but-valid selection is not"
+                                        " a fallback trigger";
+                            // sel stays Embedded â NO swap.
+                        } else {
+                            // FAIL-CLOSE to dashd. Own-set OFF (legacy parity),
+                            // validity gate not yet proven-open, or the referee
+                            // refused an internal-consistency defect.
+                            std::string cause =
+                                !tx_serve_own_set_
+                                    ? std::string("gbt-xcheck-txmerkle-mismatch")
+                                    : (!gate_proven
+                                           ? std::string("tx-serve-validity-gate-not-open")
+                                           : rv.fail_cause);
+                            if (tx_serve_own_set_)
+                                tx_serve_own_set_failclose_.fetch_add(
+                                    1, std::memory_order_relaxed);
+                            LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck tx-merkleroot"
+                                        << " MISMATCH at h=" << sel.work.m_height
+                                        << " embedded txs=" << sel.work.m_tx_hashes.size()
+                                        << " root=" << emb_txroot.GetHex().substr(0, 16)
+                                        << " dashd txs=" << dref.m_tx_hashes.size()
+                                        << " root=" << dref_txroot.GetHex().substr(0, 16)
+                                        << " â serving dashd template (cause="
+                                        << cause
+                                        << (tx_serve_own_set_ && !gate_proven
+                                                ? "; own-set armed but validity"
+                                                  " gate not open"
+                                                : "")
+                                        << ")";
+                            coin::DeclineReport xcheck;
+                            xcheck.viable    = false;
+                            xcheck.cause     = cause;
+                            xcheck.value     = emb_txroot.GetHex();
+                            xcheck.threshold = dref_txroot.GetHex();
+                            sel = coin::WorkSelection{ std::move(dref),
+                                                       coin::WorkSource::DashdFallback,
+                                                       std::move(xcheck) };
+                            served_via_xcheck_swap = true;
+                        }
                     }
                 }
             }
@@ -1553,6 +1621,17 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
     // from the operator surface, not inferred from log archaeology.
     j["serve_recheck_fail_count"] =
         serve_recheck_fail_count_.load(std::memory_order_relaxed);
+
+    // --embedded-tx-serve-own-set observability (lock-free). serves = times a
+    // divergent-from-dashd mempool selection was served as OUR OWN valid set
+    // (internal-consistency referee passed AND the validity gate was proven
+    // open); failclose = times such a divergence fell back to dashd (own-set
+    // off, validity gate not open, or a referee defect). Both zero until the
+    // flag is armed.
+    j["tx_serve_own_set_serves"] =
+        tx_serve_own_set_serves_.load(std::memory_order_relaxed);
+    j["tx_serve_own_set_failclose"] =
+        tx_serve_own_set_failclose_.load(std::memory_order_relaxed);
 
     // TRY_LOCK, not lock_guard. serve_gate_mutex_ is taken by the SERVE PATH
     // (note_arm_decision, :759; the found-block ledger, :1478). Blocking here

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -363,6 +363,24 @@ public:
     /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
 
+    /// TX-SERVE-OWN-SET referee (--embedded-tx-serve-own-set). DEFAULT OFF.
+    ///
+    /// When OFF (default, and the shipped posture): a divergent-from-dashd
+    /// mempool tx selection SWAPS to dashd's template exactly as before
+    /// (cause gbt-xcheck-txmerkle-mismatch) -- byte-identical to today.
+    ///
+    /// When ON: on a tx-merkle divergence the arm runs the INTERNAL-
+    /// CONSISTENCY referee (tx_serve_referee.hpp) instead of the dashd-parity
+    /// backstop. If the embedded template is internally consistent (coinbase
+    /// fee-exact, every served tx fee_fold_proven, no intra-set double-spend)
+    /// AND -- when a shadow-compare validity probe is bound -- the mempool
+    /// validity gate is currently open(), c2pool SERVES ITS OWN valid set (the
+    /// divergence is logged as a shadow, not a fallback). Otherwise it fail-
+    /// closes to the dashd template. The validity-gate coupling is the runtime
+    /// guard against the already-mined / stale-UTXO-view class the referee
+    /// cannot catch alone (h=2526403 field finding); see set_shadow_compare.
+    void set_tx_serve_own_set(bool v) { tx_serve_own_set_ = v; }
+
     /// PIN SPLICE ON THE XCHECK-SWAPPED ARM (--pin-splice-xcheck-arm).
     /// DEFAULT OFF -- this is the money path.
     ///
@@ -724,6 +742,10 @@ private:
     bool is_testnet_{false};
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
+    bool tx_serve_own_set_{false};   // --embedded-tx-serve-own-set: serve own valid tx set instead of dashd-parity swap (DEFAULT OFF)
+    // Observability for the own-set referee (lock-free; published in embedded_arm_status_json).
+    mutable std::atomic<uint64_t> tx_serve_own_set_serves_{0};      // divergent set served as own (referee passed)
+    mutable std::atomic<uint64_t> tx_serve_own_set_failclose_{0};   // divergent set fail-closed to dashd (referee/gate refused)
     bool pin_splice_xcheck_arm_{false};  // money path: splice pins onto an xcheck-SWAPPED template (default OFF)
     bool pin_splice_block_budget_{false};  // money path: ENFORCE the block-size budget (changes served bytes; default OFF)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1179,6 +1179,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     #                       mutation case.
     add_executable(test_dash_stratum_work_source
         test_dash_stratum_work_source.cpp
+        # test_dash_tx_serve_referee.cpp: internal-consistency referee unit KAT
+        # (tx_serve_referee.hpp). Folded into this already-built target (it links
+        # the full dash_stratum set the referee header needs) per the #769 rule.
+        test_dash_tx_serve_referee.cpp
         test_dash_submit_gate_scaling.cpp
         test_dash_serve_staleness_seam.cpp
         test_dash_serve_staleness_unit.cpp

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2302,6 +2302,173 @@ TEST(DashStratumC1MainnetGate, GbtXcheckTxMerkleMatchServesEmbeddedUnchanged)
         << "a matching tx-merkleroot must NOT record a swap";
 }
 
+// =============================================================================
+// --embedded-tx-serve-own-set : SERVE OUR OWN VALID SET on a divergent-from-
+// dashd mempool selection, instead of the dashd-tx-merkle PARITY swap. The two
+// tests below are the load-bearing red->green through the work source:
+//
+//   * with the flag OFF the divergent set SWAPS to dashd (unchanged behaviour,
+//     proven by GbtXcheckServesDashdOnTxMerkleMismatch above);
+//   * with the flag ON and the validity-gate coupling satisfied, the SAME
+//     divergent set is served as EMBEDDED (this file);
+//   * with the flag ON but a validity probe bound and NOT yet open, it fail-
+//     closes to dashd -- the runtime guard against the already-mined / stale-
+//     UTXO-view class the internal-consistency referee cannot catch alone.
+// =============================================================================
+TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetServesEmbeddedOnConsistentTxDivergence)
+{
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x51;
+
+    // (0) Capture the EMBEDDED template (xcheck OFF): CbTx roots for dref to
+    // match, and the served tx set the flag-ON serve must reproduce byte-for-
+    // byte (serving OUR OWN set means the embedded body is untouched).
+    dash::coin::vendor::CCbTx emb_cb;
+    std::vector<uint256> emb_txids;
+    uint32_t emb_mempool_n = 0;
+    {
+        ::core::coin::UTXOViewCache utxo(nullptr);
+        auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+        auto never = []() -> dash::coin::DashWorkData { return {}; };
+        dash::stratum::DASHWorkSource ws(*cs, never, xcheck_submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
+        emb_txids     = t->m_tx_hashes;
+        emb_mempool_n = t->m_mempool_tx_count;
+    }
+    ASSERT_GT(emb_mempool_n, 0u)
+        << "fixture broken: no mempool txs served -> the m_mempool_tx_count>0"
+           " gate would skip the branch and this KAT would be vacuous";
+    const uint256 emb_txroot = dash::coin::compute_merkle_root(emb_txids);
+
+    // dashd fallback: SAME height + SAME CbTx roots (so only the tx axis
+    // diverges), DIFFERENT non-coinbase tx set.
+    std::vector<uint256> dref_txids(1);
+    dref_txids[0].SetHex(std::string(64, 'e'));
+    ASSERT_NE(emb_txroot, dash::coin::compute_merkle_root(dref_txids));
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.merkleRootMNList   = emb_cb.merkleRootMNList;
+        cb.merkleRootQuorums  = emb_cb.merkleRootQuorums;
+        cb.creditPoolBalance  = emb_cb.creditPoolBalance;
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        w.m_tx_hashes         = dref_txids;
+        w.m_mempool_tx_count  = 1;
+        return w;
+    };
+
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+    dash::stratum::DASHWorkSource ws(*cs, fallback, xcheck_submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+    // NO shadow-compare bound -> the validity-gate coupling is bypassed
+    // (pure-daemonless, operator-armed posture); the referee decides alone.
+    ws.set_tx_serve_own_set(true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    // The served body is OUR OWN embedded set, NOT dashd's, despite the tx-
+    // merkle divergence.
+    EXPECT_EQ(t->m_tx_hashes, emb_txids)
+        << "own-set: a divergent-but-consistent embedded template is served"
+           " unchanged, not swapped for dashd's";
+    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), emb_txroot);
+    const auto st = ws.embedded_arm_status_json();
+    EXPECT_EQ(st.value("arm", std::string{}), "EMBEDDED")
+        << "the divergence must leave the embedded arm serving";
+    EXPECT_NE(st.value("no_work_reason", std::string{}), "gbt-xcheck-txmerkle-mismatch")
+        << "own-set must NOT record a parity swap";
+    EXPECT_GE(st.value("tx_serve_own_set_serves", (uint64_t)0), (uint64_t)1)
+        << "the referee must have actively served the divergent set as own";
+}
+
+TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetFailClosesWhenValidityGateNotOpen)
+{
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x51;
+
+    dash::coin::vendor::CCbTx emb_cb;
+    {
+        ::core::coin::UTXOViewCache utxo(nullptr);
+        auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+        auto never = []() -> dash::coin::DashWorkData { return {}; };
+        dash::stratum::DASHWorkSource ws(*cs, never, xcheck_submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
+        ASSERT_GT(t->m_mempool_tx_count, 0u);
+    }
+
+    std::vector<uint256> dref_txids(1);
+    dref_txids[0].SetHex(std::string(64, 'e'));
+    const uint256 dref_txroot = dash::coin::compute_merkle_root(dref_txids);
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.merkleRootMNList   = emb_cb.merkleRootMNList;
+        cb.merkleRootQuorums  = emb_cb.merkleRootQuorums;
+        cb.creditPoolBalance  = emb_cb.creditPoolBalance;
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        w.m_tx_hashes         = dref_txids;
+        w.m_mempool_tx_count  = 1;
+        return w;
+    };
+
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+    dash::stratum::DASHWorkSource ws(*cs, fallback, xcheck_submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+    ws.set_tx_serve_own_set(true);
+
+    // Bind a shadow-compare with a testmempoolaccept oracle -> the mempool
+    // validity gate is ARMED but has accrued ZERO clean heights, so open() is
+    // false. The own-set path must therefore fail-close to dashd even though
+    // the embedded template is internally consistent: the runtime guard against
+    // serving a set the validity gate has not yet proven dashd-acceptable.
+    auto oracle = []() -> std::optional<dash::coin::DashWorkData> { return std::nullopt; };
+    auto accept = [](const std::string&) -> nlohmann::json { return nlohmann::json(); };
+    auto sc = std::make_shared<dash::coin::EmbeddedShadowCompare>(oracle, accept);
+    ws.set_shadow_compare(sc);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), dref_txroot)
+        << "validity gate not open -> must serve dashd's body, not own";
+    const auto st = ws.embedded_arm_status_json();
+    EXPECT_EQ(st.value("arm", std::string{}), "dashd-fallback");
+    EXPECT_EQ(st.value("no_work_reason", std::string{}), "tx-serve-validity-gate-not-open")
+        << "the fail-close cause must name the un-open validity gate";
+    ws.set_shadow_compare(nullptr);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tip-transition fallback leak: on every new block the serve path re-sources
 // during the body-pending window and (correctly) gets the dashd fallback; the

--- a/test/test_dash_tx_serve_referee.cpp
+++ b/test/test_dash_tx_serve_referee.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// RED->GREEN KAT for the serve-time INTERNAL-CONSISTENCY referee
+// (tx_serve_referee.hpp) that replaces the dashd-tx-merkle PARITY backstop on
+// the --embedded-tx-serve-own-set path.
+//
+// The referee decides whether a divergent-from-dashd embedded template may be
+// served as OUR OWN valid set. It must:
+//   (serve) pass a template that is internally consistent -- coinbase fee-exact
+//           (coinbase_value == subsidy + Sum(fees) + superblock), every served
+//           mempool tx fee_fold_proven, no intra-set double-spend -- EVEN when
+//           its tx set (and hence tx-merkle-root) differs from dashd's.
+//   (fail)  fail-close to the dashd fallback when ANY of those does not hold:
+//           an over/under-claiming coinbase, an unproven tx, a double-spend, or
+//           an unstamped (unknown-provenance) template.
+//
+// Each fail-close case is load-bearing: flip the single field under test back
+// to its consistent value and the same template SERVES, proving the referee
+// reacts to that field and nothing else.
+
+#include <impl/dash/coin/tx_serve_referee.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using dash::coin::DashWorkData;
+using dash::coin::MutableTransaction;
+using dash::coin::Transaction;
+using dash::coin::tx_serve_internal_referee;
+
+// A one-output spend of outpoint (hash, idx). scriptPubKey/value are immaterial
+// to the referee (it reads vins for the double-spend fold and fees from
+// m_tx_fees), so keep it minimal and deterministic.
+MutableTransaction spend(const uint256& h, uint32_t idx)
+{
+    MutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash  = h;
+    tx.vin[0].prevout.index = idx;
+    tx.vout.resize(1);
+    tx.vout[0].value = 1000;
+    return tx;
+}
+
+uint256 h_of(uint8_t b)
+{
+    uint256 u;
+    u.begin()[0] = b;
+    return u;
+}
+
+// A minimally internally-consistent ARMED embedded template that carries one
+// mempool-sourced tx of fee `fee` spending outpoint (0x11:0). By construction
+// coinbase_value == subsidy(height) + fee + superblock, so the referee SERVES
+// it. Each negative test perturbs exactly ONE field.
+DashWorkData make_consistent(uint32_t height, uint64_t fee)
+{
+    DashWorkData w;
+    w.m_height = height;
+
+    MutableTransaction tx = spend(h_of(0x11), 0);
+    w.m_txs.push_back(Transaction(tx));
+    w.m_tx_hashes.push_back(h_of(0xaa));   // referee ignores hashes; realism only
+    w.m_tx_fees.push_back(fee);
+    w.m_mempool_tx_first_index = 0;
+    w.m_mempool_tx_count       = 1;
+
+    w.m_tx_serve_stamp.armed                       = true;
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+    w.m_tx_serve_stamp.superblock_total            = 0;
+
+    const uint64_t subsidy = static_cast<uint64_t>(
+        dash::coin::compute_dash_block_reward_post_v20(height));
+    w.m_coinbase_value = subsidy + fee;   // consistent
+    return w;
+}
+
+// A realistic post-checkpoint mainnet height (past V20 / MN_RR).
+constexpr uint32_t kH = 2'525'000;
+
+}  // namespace
+
+// ── SERVE: internally consistent, divergent-from-dashd is irrelevant ────────
+TEST(DashTxServeReferee, ServesOwnSetWhenInternallyConsistent)
+{
+    const DashWorkData w = make_consistent(kH, 10'000);
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_TRUE(v.serve_own_set) << v.detail;
+    EXPECT_TRUE(v.fail_cause.empty());
+}
+
+// ── SERVE: a funded superblock slice is accounted, not mistaken for over-claim
+TEST(DashTxServeReferee, ServesWithSuperblockSliceAccounted)
+{
+    DashWorkData w = make_consistent(kH, 7'500);
+    // Coinbase carries an additional treasury slice; the stamp records it, so
+    // coinbase_value == subsidy + fee + superblock still holds exactly.
+    w.m_tx_serve_stamp.superblock_total = 4'200'000;
+    w.m_coinbase_value += 4'200'000;
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_TRUE(v.serve_own_set) << v.detail;
+}
+
+// ── FAIL-CLOSE (a): coinbase over-claims fees (bad-cb-amount vector) ─────────
+TEST(DashTxServeReferee, FailClosesOnCoinbaseFeeOverclaim)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    w.m_coinbase_value += 1;   // one duff more than subsidy + fees
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-coinbase-inconsistent") << v.detail;
+
+    // Load-bearing: restore consistency and the SAME template serves.
+    w.m_coinbase_value -= 1;
+    EXPECT_TRUE(tx_serve_internal_referee(w).serve_own_set);
+}
+
+// ── FAIL-CLOSE (a): coinbase under-claims (per-tx fee vector corrupted) ──────
+TEST(DashTxServeReferee, FailClosesWhenFeeVectorDoesNotReconcileCoinbase)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    // The served body grew a tx-fee entry the coinbase never folded in.
+    w.m_tx_fees.push_back(5'000);
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-coinbase-inconsistent") << v.detail;
+}
+
+// ── FAIL-CLOSE (b): a served tx is not fee_fold_proven ──────────────────────
+TEST(DashTxServeReferee, FailClosesOnUnprovenFeeFold)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = false;
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-fee-fold-unproven") << v.detail;
+
+    // Load-bearing: re-prove and the SAME template serves.
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+    EXPECT_TRUE(tx_serve_internal_referee(w).serve_own_set);
+}
+
+// ── FAIL-CLOSE (c): two served txs spend the same outpoint ──────────────────
+TEST(DashTxServeReferee, FailClosesOnIntraSetDoubleSpend)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    // A SECOND served tx spends the SAME coin (0x11:0) as the first. Keep the
+    // coinbase and stamp consistent so ONLY the double-spend axis can fail.
+    MutableTransaction dup = spend(h_of(0x11), 0);
+    dup.vout[0].value = 500;
+    w.m_txs.push_back(Transaction(dup));
+    w.m_tx_hashes.push_back(h_of(0xbb));
+    w.m_tx_fees.push_back(500);
+    w.m_mempool_tx_count = 2;
+    const uint64_t subsidy = static_cast<uint64_t>(
+        dash::coin::compute_dash_block_reward_post_v20(kH));
+    w.m_coinbase_value = subsidy + 10'000 + 500;   // fee-consistent
+
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-double-spend") << v.detail;
+
+    // Load-bearing: point the duplicate at a DIFFERENT coin and it serves.
+    w.m_txs.back() = Transaction(spend(h_of(0x22), 0));
+    EXPECT_TRUE(tx_serve_internal_referee(w).serve_own_set);
+}
+
+// ── FAIL-CLOSE (pre): unstamped template (unknown provenance) ───────────────
+TEST(DashTxServeReferee, FailClosesOnUnstampedTemplate)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    w.m_tx_serve_stamp.armed = false;   // not built by the serving path
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-unstamped") << v.detail;
+}


### PR DESCRIPTION
## What

Redesigns the `gbt-xcheck-txmerkle-mismatch` serve-gate. Today, when the embedded (daemonless) template carries mempool transactions and our non-coinbase tx-merkle-root differs from dashd's, the arm **swaps to dashd's template**. That is a dashd-**parity** referee: it treats any different-but-valid selection as unsafe.

This PR replaces it, behind a **default-OFF** flag `--embedded-tx-serve-own-set`, with an **internal-consistency referee** (`src/impl/dash/coin/tx_serve_referee.hpp`). A different-but-valid mempool tx set is normal (two independently-connected nodes never hold identical mempools) and produces a perfectly valid block. The requirement is **per-tx validity + no double-spend + coinbase fee-consistency**, not tx-set parity with dashd.

## The referee

On a tx-merkle divergence with the flag ON, the arm serves **our own** set when all hold, else fail-closes to dashd:

- **(a) coinbase fee-consistency** — `m_coinbase_value == subsidy(height) + Σ(m_tx_fees) + superblock_total`. The subsidy is re-derived with the same height-pure `compute_dash_block_reward_post_v20` the builder used, so this is the builder's own invariant re-asserted at serve time; it catches any corruption of the coinbase value / per-tx fee vector / superblock slice between build and serve. Over-claim is the `bad-cb-amount` orphan vector.
- **(b) fee-fold proof** — every served mempool tx passed the selector's exclusion-discipline (`mempool.hpp` `if(!e.fee_fold_proven) continue;`: each vin present-and-unspent in our UTXO view, in_sum ≥ out_sum). Stamped at build; the referee fail-closes if ever false.
- **(c) no intra-set double-spend** — folded over the served vins, fully independent of dashd.
- **(pre) provenance** — an unstamped template (not built by the serving path) fail-closes.

`(d)` per-tx consensus/policy validity beyond (a)–(c) is delegated to the **MEMPOOL VALIDITY GATE** (`mempool_validity_gate.hpp`), the sustained `testmempoolaccept` readiness window that gates arming — **see the safety note below, this is load-bearing.**

The dashd tx-merkle cross-check is kept as a **shadow/diagnostic** (logged divergence), never serve-blocking. With the flag OFF the branch is byte-identical to today.

## Safety basis (re-verified against source)

1. **Coinbase fee-total == Σ served fees BY CONSTRUCTION.** `embedded_gbt.hpp`: `block_value = reward + total_fees` (:715), `m_coinbase_value = block_value` (:720), `+= superblock_total` on a funded superblock (:973). `Σ(m_tx_fees)` = `total_fees` exactly: quorum (:762) and pin (:186) fees are 0; asset-unlock payload fees are folded into `total_fees` (:683/790); mempool fees are `s.fee` (:818). MN-collateral spends are dropped from both `selected` and `total_fees` in lockstep (:640-660). **Holds.**
2. **Only fee_fold_proven txs are selected.** `mempool.hpp:1018`. **Holds.**
3. **No double-spend** — conflict detection at mempool add + per-build revalidation; plus the referee's own intra-set fold. **Holds.**
4. **Served merkle is over our own set** — `bad-txns-merkleroot` cannot arise from internal inconsistency. **Holds.**
5. **Validity gate is wired** — fed from `EmbeddedShadowCompare::probe_validity` over the served/candidate mempool range; it is an **arming-readiness** verdict, not a per-template serve gate. **Holds — with the caveat below.**

## ⚠️ Field finding folded in — the validity gate is NOT yet proven-clean

Hotel money node, h=2526403:

```
[MEMPOOL-VALIDITY] h=2526403 probed=4 valid=0 already_in_mempool=0 invalid=4
  clean_run=0/576 ... sample=REPEAT-HEIGHT(no-advance) gate=CLOSED
```

Traced: the probe set is the **fee_fold_proven-filtered selection** (`mempool_probe_set` → served range or candidate set). So `invalid=4` are transactions **our selector already vouched for** (fee_fold_proven) that dashd's `testmempoolaccept` still rejects — the **already-mined / stale-UTXO-view class** (our mempool/UTXO view briefly lags a just-connected block; see the standing `mempool ingest admits already-confirmed txs` issue). And `apply()` resets `consecutive_clean = 0` on an invalid **wherever observed, including repeat heights** (`mempool_validity_gate.hpp:433`), so the run genuinely is not accruing — this is the gate working, not a counting bug.

**Consequence:** the internal-consistency referee **shares the selector's UTXO view**, so it cannot independently catch this class — (a)/(b)/(c) all pass on an already-mined tx that our stale view shows unspent, and serving it would orphan the block. Only dashd's external view (the parity backstop, or the validity gate as an arming precondition) catches it. **The parity gate is doing real protective work today.**

**Rollout chosen (safest):**
- The whole redesign is behind `--embedded-tx-serve-own-set`, **default OFF** → merging this PR is byte-neutral in production.
- **Runtime coupling (option a):** when an `--embedded-shadow-compare` validity probe is bound, own-set serving requires the gate `open()` (576 clean heights) or it fail-closes to the parity backstop (`cause=tx-serve-validity-gate-not-open`). A soak with the oracle present therefore auto-fail-closes until the class is gone. With no probe bound (pure daemonless, post-proof) the operator's arming is the proof.

## Verdict — shippable now, arming BLOCKED

The code + proven referee are shippable as dormant, default-OFF. **Production arming is blocked on:** (i) fixing the already-confirmed-tx ingest / UTXO-view lag so the selector stops offering dashd-invalid txs, and (ii) the validity gate then accruing 576 clean heights in a dashd-oracle soak. Per the h=2526403 evidence it has not. Arming before that could serve dashd-invalid txs and orphan blocks.

## Tests

- `test/test_dash_tx_serve_referee.cpp` — referee unit KATs: serve on internal consistency, superblock slice accounted, and 5 fail-close cases (coinbase over-claim, fee-vector non-reconcile, unproven fee-fold, intra-set double-spend, unstamped). Each fail-close restores the single field and re-serves — load-bearing.
- `test/test_dash_stratum_work_source.cpp` — two integration KATs: own-set serves EMBEDDED on a consistent divergence from a synthetic dashd reference (`tx_serve_own_set_serves ≥ 1`); own-set fail-closes to dashd when a bound validity probe is not open.
- **Red proven** by neutering the referee (`false && …`): the own-set KAT serves dashd (`own-set-serves=0`), RED. Green with the change.
- Full `test_dash_stratum_work_source` suite: **124/124**. `c2pool-dash` binary builds + links.

## Merge / deploy

**Operator-gated.** This is a serve/reward-path change. Do not merge or arm on the money node until the validity-gate precondition above is met. Base is `integrator/fix-payee-desync-same-block-proupreg` (this branch = base + one commit).
