### PR TITLE
dash(daemonless): SmlResyncWatchdog clamped perpetual retry — close the 18-min tip-body-pending fallback wedge

### DIFF
--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -2382,7 +2382,7 @@ private:
                             << discriminating_hash_tail(m_state.sml_current_hash())
                             << " != tip ..." << discriminating_hash_tail(m_hdr_prev_hash)
                             << ") — re-requesting getmnlistd (attempt "
-                            << req->attempt << "/3) before the doomed-tip demote";
+                            << req->attempt << ") before the doomed-tip demote";
                 m_on_sml_rerequest(req->base, req->target);
             }
         }

--- a/src/impl/dash/coin/sml_resync_watchdog.hpp
+++ b/src/impl/dash/coin/sml_resync_watchdog.hpp
@@ -56,9 +56,12 @@
 //   * only after `min_quiet` seconds of no SML progress (well above a normal
 //     round trip, well below a block interval);
 //   * geometric backoff between attempts;
-//   * at most `max_attempts` per stuck (tip, sml) pair — after that we wait for
-//     the next block exactly as today, so a genuinely unreachable peer sees the
-//     same traffic it sees now plus a bounded constant;
+//   * geometric backoff for the first `max_attempts` tries, then the interval
+//     is CLAMPED and the re-ask CONTINUES at that clamped cadence for as long
+//     as the pair stays stuck — so a genuinely unreachable peer sees a bounded
+//     ~1 request per clamp-interval, never a burst, but an 18-min block gap can
+//     no longer strand the arm on the dashd fallback with healthy peers idle
+//     (the armed-once-never-re-armed failure the old hard stop caused);
 //   * any observed SML progress, or a tip change, resets everything.
 
 #include <cstdint>
@@ -80,8 +83,12 @@ public:
         int64_t  min_quiet_sec{20};
         /// Multiplier applied to the wait after each attempt.
         int64_t  backoff_mult{2};
-        /// Hard cap per stuck (tip, sml) pair. After this we go quiet and let
-        /// the next tip change do what it does today.
+        /// Backoff CLAMP for a stuck (tip, sml) pair. The re-ask interval
+        /// grows geometrically for the first max_attempts tries and then
+        /// stays pinned at that interval; the watchdog keeps re-asking at that
+        /// clamped cadence for as long as the pair stays stuck (a stalled
+        /// chain never changes the pair), because going silent forever here is
+        /// the 18-min-wedge bug. Any SML progress or tip change resets it.
         uint32_t max_attempts{3};
     };
 
@@ -127,11 +134,22 @@ public:
             return std::nullopt;   // never retry on the FIRST sighting
         }
 
-        if (m_attempts >= m_cfg.max_attempts) return std::nullopt;
-
-        // Wait: min_quiet before the first attempt, then geometric backoff.
+        // Wait: min_quiet before the first attempt, then geometric backoff,
+        // CLAMPED at the max_attempts-th interval. Past the cap the interval
+        // stops GROWING but the re-request never STOPS. Going silent forever
+        // for a stuck (tip, sml) pair is the 18-min-wedge bug: while the chain
+        // is stalled the pair never changes, so a hard stop left the embedded
+        // arm on the dashd fallback with healthy peers idle until the NEXT
+        // block, and across an 18-min block gap that is an 18-min hole (the
+        // armed-once-never-re-armed class). A retry clamped at the cap cadence
+        // bounds the traffic to one request per
+        // ~(min_quiet * backoff_mult^max_attempts) seconds, keeps rotating
+        // peers through the caller's re-ask, and still resets the instant the
+        // SML makes progress or the tip moves.
+        const uint32_t steps =
+            (m_attempts < m_cfg.max_attempts) ? m_attempts : m_cfg.max_attempts;
         int64_t wait = m_cfg.min_quiet_sec;
-        for (uint32_t i = 0; i < m_attempts; ++i) wait *= m_cfg.backoff_mult;
+        for (uint32_t i = 0; i < steps; ++i) wait *= m_cfg.backoff_mult;
         const int64_t since = (m_last_try >= 0) ? m_last_try : m_since_sec;
         if (now_sec - since < wait) return std::nullopt;
 

--- a/test/test_dash_sml_resync_watchdog.cpp
+++ b/test/test_dash_sml_resync_watchdog.cpp
@@ -114,16 +114,21 @@ TEST(DashSmlResyncWatchdog, ReachingTheTipClearsEverything)
     EXPECT_EQ(w.attempts(), 0u);
 }
 
-// ── Bounded: backoff, then silence ──────────────────────────────────────────
+// ── Bounded: geometric backoff, then a CLAMPED perpetual retry ──────────────
 // The failure mode of a retry is hammering a peer that is already struggling,
-// so the cap is the safety property, not a nicety.
-TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenStopsAtTheCap)
+// so the interval must never collapse. But going SILENT forever is the OTHER
+// bug: an 18-min block gap never changes the (tip, sml) pair, so a hard stop at
+// max_attempts stranded the arm on the dashd fallback for the whole gap with
+// healthy peers idle. After max_attempts the interval is pinned at its cap and
+// the re-ask CONTINUES at that clamped cadence — bounded to ~1 request per cap
+// interval, but never giving up.
+TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenClampsAndKeepsRetrying)
 {
     SmlResyncWatchdog w(fast());
     const uint256 tip = blk(0x11), sml = blk(0x22);
     w.observe(tip, sml, 1000);
 
-    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());          // +20
+    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());          // +20  attempt 1
     EXPECT_FALSE(w.observe(tip, sml, 1059).has_value());         // needs +40
     ASSERT_TRUE(w.observe(tip, sml, 1060).has_value());          // attempt 2
     EXPECT_FALSE(w.observe(tip, sml, 1139).has_value());         // needs +80
@@ -131,12 +136,60 @@ TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenStopsAtTheCap)
     ASSERT_TRUE(third.has_value());
     EXPECT_EQ(third->attempt, 3u);
 
-    // Cap reached: from here we are silent and the next block does what it
-    // does today. A stuck peer therefore sees today's traffic plus at most
-    // max_attempts extra requests, ever.
-    EXPECT_FALSE(w.observe(tip, sml, 5000).has_value());
-    EXPECT_FALSE(w.observe(tip, sml, 99999).has_value());
-    EXPECT_EQ(w.attempts(), 3u);
+    // Cap reached (max_attempts=3): the interval is now CLAMPED at
+    // min_quiet * backoff^max_attempts = 20 * 2^3 = 160 s and stays there.
+    EXPECT_FALSE(w.observe(tip, sml, 1140 + 159).has_value())
+        << "inside the clamped interval nothing is re-sent";
+    auto fourth = w.observe(tip, sml, 1140 + 160);
+    ASSERT_TRUE(fourth.has_value())
+        << "past the clamped interval the re-ask CONTINUES — going silent "
+           "forever here is the measured 18-min fallback wedge";
+    EXPECT_EQ(fourth->attempt, 4u) << "attempts keep counting past the cap";
+
+    // ...and it keeps going, never faster than the clamped cadence.
+    EXPECT_FALSE(w.observe(tip, sml, 1140 + 160 + 159).has_value());
+    ASSERT_TRUE(w.observe(tip, sml, 1140 + 160 + 160).has_value());
+}
+
+// ── RED->GREEN: a wedged tip must NOT go silent forever ─────────────────────
+// The measured 1068 s wedge (hotel primary, 2026-08-23 03:39:40 -> ~03:58):
+// SmlResyncWatchdog fired attempts 1/3, 2/3, 3/3 and then went SILENT while the
+// chain sat on the SAME tip for ~18 min with 8 healthy peers idle — the arm
+// served the dashd fallback the entire time. The (tip, sml) pair never changed
+// (no new block), so the old hard stop at max_attempts never re-armed: the
+// armed-once-never-re-armed class (#1151 / #1162 / #103). This pins that past
+// the cap the re-ask CONTINUES at the clamped cadence, so an 18-min block gap
+// can recover a lost diff instead of wedging on it.
+//
+// RED on the pre-fix code: observe() returned std::nullopt for every call past
+// max_attempts, so the loop below counted ZERO re-asks during the wedge.
+TEST(DashSmlResyncWatchdog, WedgedTipIsReAskedPerpetuallyNotSilencedAtTheCap)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11), sml = blk(0x22);
+
+    // Exhaust the geometric budget exactly as the hotel wedge did (1/3..3/3).
+    w.observe(tip, sml, 1000);
+    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());
+    ASSERT_TRUE(w.observe(tip, sml, 1060).has_value());
+    ASSERT_TRUE(w.observe(tip, sml, 1140).has_value());
+    ASSERT_GE(w.attempts(), 3u);
+
+    // Now the chain STALLS on this tip for 18 minutes. Poll the watchdog once a
+    // second — exactly like check_tip_body_overdue's high-cadence clock — and
+    // count the re-asks it emits. The pre-fix code emitted ZERO here.
+    const int64_t wedge_start = 1140;
+    int reasks_during_wedge = 0;
+    for (int64_t t = wedge_start + 1; t <= wedge_start + 18 * 60; ++t) {
+        if (w.observe(tip, sml, t).has_value()) ++reasks_during_wedge;
+    }
+
+    EXPECT_GT(reasks_during_wedge, 0)
+        << "the wedged tip must keep being re-asked — going silent forever here "
+           "is the measured 1068 s dashd-fallback wedge";
+    EXPECT_LE(reasks_during_wedge, (18 * 60) / 150)
+        << "but still bounded to ~one request per clamp interval, never a burst "
+           "against a peer that is already struggling";
 }
 
 // A new tip is a new situation: the previous budget described a lag that no
@@ -149,7 +202,8 @@ TEST(DashSmlResyncWatchdog, NewTipRestartsTheBudget)
     w.observe(blk(0x11), sml, 1020);
     w.observe(blk(0x11), sml, 1060);
     ASSERT_TRUE(w.observe(blk(0x11), sml, 1140).has_value());
-    EXPECT_FALSE(w.observe(blk(0x11), sml, 9000).has_value());   // capped
+    EXPECT_TRUE(w.observe(blk(0x11), sml, 9000).has_value())     // clamped, still re-asking
+        << "past the clamp the same stuck pair keeps being re-asked, not silenced";
 
     EXPECT_FALSE(w.observe(blk(0x44), sml, 9001).has_value());   // new tip: first sighting
     EXPECT_EQ(w.attempts(), 0u);


### PR DESCRIPTION
## What

Close the tip-body-pending dashd-fallback wedge that charges ~5% of embedded-serve wall-clock on the hotel `EMBED-GATE` rollup (measured 1422s/25311s; one episode alone = ~1068s).

**One-line mechanism change** in `SmlResyncWatchdog::observe` (`src/impl/dash/coin/sml_resync_watchdog.hpp`): after `max_attempts`, instead of going **silent forever** for a stuck `(tip, sml)` pair, the backoff interval is **clamped** at its cap and the re-ask **continues** at that clamped cadence.

## Why the cause label lied

The tip **body** is not the pole: it is fetched on `inv` in ~100-220 ms (body-first fold already lands h-1 for free; `pending_bodies=0`, `body_rerequests=1/day`). The charged wall-clock is the **fourth promotion axis, sml-currency** (`coin_state_maintainer.hpp:2323`), which — unlike dashd, whose `CDeterministicMNManager::ProcessBlock` derives the new MN list locally from the block body — closes only on a `getmnlistd` network round trip.

`SmlResyncWatchdog` exists to re-ask for a lost/never-answered tip `mnlistdiff`, but it hard-stopped at `max_attempts` (`if (m_attempts >= m_cfg.max_attempts) return std::nullopt;`). **While the chain is stalled the `(tip, sml)` pair never changes**, so the hard stop never re-armed. Measured on the hotel primary 2026-08-23 03:39:40 -> ~03:58: the watchdog fired attempts 1/3, 2/3, 3/3 then went silent for ~18 min with 8 healthy peers idle — an 18-min block gap turned one lost diff into an 18-min fallback wedge. This is the **armed-once-never-re-armed** class (#1151 / #1162 / #103).

## The fix (retry cadence only)

Past `max_attempts` the wait is pinned at `min_quiet * backoff^max_attempts` and the re-ask keeps firing at that cadence for as long as the pair stays stuck. This:

- **bounds traffic** to ~1 request per clamp interval (never a burst against a struggling peer — the original safety concern);
- **re-arms** so a stalled tip is re-asked until a peer answers or the tip moves;
- emits a request that is **byte-identical** to the one the tip-change path already sends, so it can only make the state the promotion gate reads arrive **sooner** — it cannot widen what is served;
- still **resets** on any SML progress or tip change.

The companion `coin_state_maintainer.hpp` change is a one-word log-string edit (`attempt N/3` -> `attempt N`) since retries are no longer capped at 3.

## Safety basis

**reward_or_consensus = FALSE.** No gate, predicate, threshold, or consensus check is touched. The watchdog emits a getmnlistd request and nothing else; the `dmn-stale` predicate, serve gate, and base-continuity guard are untouched. A gate satisfied earlier because its input arrived is categorically different from a gate that was lowered — nothing here can serve a template that would not have been served one block later anyway. This is the one-shot half of the researched closure path; the bigger dashd-parity port (advance the SML from the tip-body fold, feeding `merkleRootMNList` = money path) is deliberately **not** in this PR.

## Test — red -> green KAT

`test/test_dash_sml_resync_watchdog.cpp`:

- **`WedgedTipIsReAskedPerpetuallyNotSilencedAtTheCap`** (new): drives the watchdog to the cap, then polls it once/second across an 18-min stall and counts re-asks. **RED on pre-fix code: 0 re-asks during the wedge. GREEN after: bounded, non-zero.**
- `BacksOffGeometricallyThenClampsAndKeepsRetrying` and `NewTipRestartsTheBudget` updated for the clamped-perpetual contract.

Built and run on the build host against the exact shipped header + test:
- **RED** (original header): 3 FAILED (the wedge-closure assertions; key KAT `reasks_during_wedge=0`).
- **GREEN** (this branch): 9/9 PASSED.

Merge/deploy is at the operator's discretion; not merged, not force-pushed.
