### PR TITLE
dash(daemonless): DSTX ingest visibility + tip-body-busy tx-inv retry (mempool-ingest-completeness)

### DIFF
--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -761,6 +761,45 @@ private:
         }
     }
 
+    /// Re-issue getdata for tx/dstx invs parked while a tip body was in flight
+    /// (mempool-ingest-completeness). One pass per pool tick. The tip body
+    /// ALWAYS keeps priority: nothing drains while a body is outstanding, and
+    /// the loop bails the instant a body arrives mid-drain. Each retry rides
+    /// the SAME inflight budget/cap and txid-keyed dedup as a first-time pull
+    /// (the inv hash IS the txid for both lanes), and echoes the ANNOUNCED
+    /// type so a DSTX is re-asked as MSG_DSTX. The getdata goes to a
+    /// handshaked peer (tx relay is gossiped — any peer holding it in mempool
+    /// serves it; a peer that lacks it answers notfound, which is benign and
+    /// self-correcting, exactly like the block watchdog's cross-peer re-ask).
+    void drain_tx_retry_busy(int64_t now)
+    {
+        if (m_tx_retry_busy.empty())    return;
+        if (!m_pending_bodies.empty())  return;   // tip body still wins
+        // A peer to ask: prefer the active session, else any handshaked peer.
+        PeerSession* peer = (m_active && m_active->handshake.complete())
+                            ? m_active : nullptr;
+        if (!peer)
+            for (auto& up : m_pool)
+                if (up->handshake.complete()) { peer = up.get(); break; }
+        if (!peer) return;   // no one to ask yet — keep the queue for next tick
+        expire_tx_pulls(now);
+        while (!m_tx_retry_busy.empty())
+        {
+            if (!m_pending_bodies.empty()) break;                 // a body arrived
+            if (m_tx_pull_inflight.size() >= m_tx_pull_inflight_cap) break;  // budget
+            const TxRetry r = m_tx_retry_busy.front();
+            m_tx_retry_busy.pop_front();
+            if (m_tx_pull_inflight.count(r.hash)) continue;       // already in flight
+            m_tx_pull_inflight.emplace(r.hash, now);
+            const bool is_dstx = (r.type == static_cast<uint32_t>(inventory_type::dstx));
+            if (is_dstx) ++m_dstx_pull_sent; else ++m_tx_pull_sent;
+            ++m_tx_retry_drained;
+            auto getdata_msg = message_getdata::make_raw(
+                {inventory_type(static_cast<inventory_type::inv_type>(r.type), r.hash)});
+            peer->write(getdata_msg);
+        }
+    }
+
     // ── MEMPOOL INGEST (phase 1): the MSG_TX pull ────────────────────────
     // The whole reason every embedded template is EMPTY. inv_type_is_pulled()
     // admits quorum_final_commitment and clsig only, so a peer's inv(MSG_TX)
@@ -807,6 +846,24 @@ private:
     uint64_t m_tx_pull_skipped_busy{0};
     uint64_t m_tx_received{0};       // tx bodies that arrived
     uint64_t m_tx_pull_expired{0};   // getdata that never got an answer
+
+    // ── Tip-body-busy retry queue (mempool-ingest-completeness) ──────────
+    // A tx/dstx inv admitted by InvDedup but then SKIPPED because a tip body
+    // was in flight is parked here — NOT dropped. InvDedup holds the (type,
+    // hash) for its 600 s TTL, so a re-announcement from any other peer is
+    // suppressed and the tx would otherwise be stranded until the entry ages
+    // out (by which time it is usually already mined). When the tip body
+    // clears, drain_tx_retry_busy() re-issues the getdata, recovering the
+    // ~2 % of invs this window costs. Bounded FIFO: a sustained body-in-flight
+    // burst drops the OLDEST parked inv, never grows unbounded. Dormant unless
+    // the owning lane (m_tx_pull_enabled / m_dstx_pull_enabled) is armed — the
+    // park site is downstream of the is_tx/is_dstx flag gate — so a
+    // default-configured node parks nothing and its wire is byte-identical.
+    struct TxRetry { uint32_t type; uint256 hash; };
+    std::deque<TxRetry> m_tx_retry_busy;
+    size_t   m_tx_retry_busy_cap{256};
+    uint64_t m_tx_retry_requeued{0};   // invs parked while a tip body was busy
+    uint64_t m_tx_retry_drained{0};    // parked invs later re-issued as getdata
 
     // ── SPORK listener (state + telemetry ONLY — nothing gates on it) ────
     // Seeded with the assume-active mainnet defaults (7/7 active, matching
@@ -1305,6 +1362,11 @@ public:
     /// pool timer would. Paired with set_now_fn this replaces the io_context
     /// entirely for policy tests — no real timer, no real waiting, no race.
     void tick_for_test() { on_pool_tick(); }
+    /// Test-only: simulate the block handler having consumed every tracked
+    /// tip body (the ONLY in-tree place m_pending_bodies is erased), so a KAT
+    /// can drive the body-busy -> body-clear transition drain_tx_retry_busy
+    /// keys on without constructing a hash-matched block body.
+    void clear_pending_bodies_for_test() { m_pending_bodies.clear(); }
 
     /// TEST-ONLY: exercise the bulk/historical body peer SELECTION directly
     /// (announcer-less path), returning the chosen peer's key — the seam the
@@ -1650,10 +1712,23 @@ public:
              + "/" + std::to_string(m_tx_pull_inflight_cap)
              + " skipped(budget)=" + std::to_string(m_tx_pull_skipped_budget)
              + " skipped(tip-body-busy)=" + std::to_string(m_tx_pull_skipped_busy)
-             + " expired=" + std::to_string(m_tx_pull_expired);
+             + " expired=" + std::to_string(m_tx_pull_expired)
+             + " retry(parked/drained)=" + std::to_string(m_tx_retry_requeued)
+             + "/" + std::to_string(m_tx_retry_drained)
+             + " dstx_inv=" + std::to_string(m_dstx_inv_seen)
+             + " dstx_getdata=" + std::to_string(m_dstx_pull_sent)
+             + " dstx_received=" + std::to_string(m_dstx_received);
     }
     uint64_t tx_received_count() const { return m_tx_received; }
     size_t   tx_pull_inflight()  const { return m_tx_pull_inflight.size(); }
+    uint64_t tx_pull_sent_count()        const { return m_tx_pull_sent; }
+    uint64_t tx_pull_skipped_busy_count()const { return m_tx_pull_skipped_busy; }
+    size_t   tx_retry_busy_count()       const { return m_tx_retry_busy.size(); }
+    uint64_t tx_retry_requeued_count()   const { return m_tx_retry_requeued; }
+    uint64_t tx_retry_drained_count()    const { return m_tx_retry_drained; }
+    uint64_t dstx_inv_seen_count()       const { return m_dstx_inv_seen; }
+    uint64_t dstx_pull_sent_count()      const { return m_dstx_pull_sent; }
+    uint64_t dstx_received_count()       const { return m_dstx_received; }
 
     /// Request a full block via plain MSG_BLOCK getdata (E2 pull seam).
     /// Routed to the peer that ANNOUNCED this block (block_source), which holds
@@ -2685,6 +2760,7 @@ private:
         }
 
         service_pending_bodies(now);
+        drain_tx_retry_busy(now);
         prune_stale_dials(now);
         // dashd acquisition parity: while behind on archival coverage, dial
         // more and rotate the frozen full pool's worst non-server out for a
@@ -3046,6 +3122,14 @@ private:
                 // stale template on every attached rig.
                 if (!m_pending_bodies.empty()) {
                     ++m_tx_pull_skipped_busy;
+                    // Do NOT let the 600 s InvDedup TTL strand it: park the
+                    // announcement and re-issue the getdata the moment the
+                    // tip body clears (drain_tx_retry_busy on the pool tick).
+                    if (m_tx_retry_busy.size() >= m_tx_retry_busy_cap)
+                        m_tx_retry_busy.pop_front();
+                    m_tx_retry_busy.push_back(
+                        TxRetry{static_cast<uint32_t>(inv.m_type), inv.m_hash});
+                    ++m_tx_retry_requeued;
                     continue;
                 }
                 if (m_tx_pull_inflight.size() >= m_tx_pull_inflight_cap) {

--- a/test/test_dash_coin_p2p_client.cpp
+++ b/test/test_dash_coin_p2p_client.cpp
@@ -736,4 +736,96 @@ TEST(DashCoinP2PClient, pool_tick_timer_is_actually_armed_on_the_io_context)
            "clock-driven test above would still pass with the tick deleted";
 }
 
+// ── (e) Mempool-ingest completeness — DSTX visibility + body-busy retry ─────
+//
+// Two mechanisms the daemonless mempool-ingest lane depends on, pinned here:
+//
+//   1. tx_ingest_status() surfaces the DSTX counters. dashd announces CoinJoin
+//      broadcast txs ONLY via inv(MSG_DSTX=16), never MSG_TX, so the whole
+//      DSTX class — 17.2 % of mined block txs, ~half the mempool BYTES — is
+//      invisible in [MEMPOOL-INGEST] logs unless the counters the client
+//      already keeps are printed. An armed DSTX lane is unmeasurable without
+//      them.
+//
+//   2. A tx/dstx inv admitted by InvDedup but skipped because a tip body was
+//      in flight is PARKED and re-issued when the body clears — not stranded
+//      behind the 600 s InvDedup TTL (which suppresses every re-announcement
+//      from every peer, losing the tx until the entry ages out, by which time
+//      it is usually already mined).
+
+TEST(DashCoinP2PIngest, dstx_counters_are_visible_in_tx_ingest_status)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, /*services=*/5, /*height=*/2526000,
+                                 "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    // Arm the DSTX lane (the --embedded-ingest-dstx runtime opt-in).
+    rig.client.set_dstx_pull(true);
+
+    // dashd announces a mixing tx as inv(MSG_DSTX=16) — the inv hash is the
+    // plain txid. With no tip body in flight it earns a getdata immediately
+    // and the counters the client keeps must move.
+    auto dstx_inv = dash::coin::p2p::message_inv::make_raw(
+        std::vector<dash::coin::p2p::inventory_type>{
+            dash::coin::p2p::inventory_type(
+                dash::coin::p2p::inventory_type::dstx, uint256::ONE)});
+    rig.deliver(std::move(dstx_inv));
+
+    const std::string status = rig.client.tx_ingest_status();
+    // RED on the pre-change code: tx_ingest_status() never prints a dstx
+    // field, so the armed lane cannot be measured. GREEN with the instrument.
+    EXPECT_NE(status.find("dstx_inv=1"), std::string::npos) << status;
+    EXPECT_NE(status.find("dstx_getdata=1"), std::string::npos) << status;
+    EXPECT_NE(status.find("dstx_received=0"), std::string::npos) << status;
+}
+
+TEST(DashCoinP2PIngest, tx_inv_skipped_while_body_in_flight_is_retried_not_stranded)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, /*services=*/5, /*height=*/2526000,
+                                 "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+    ASSERT_GE(rig.client.handshaked_peer_count(), 1u);
+
+    rig.client.set_tx_pull(true);
+
+    // A tracked tip body is in flight — strict priority means no tx getdata
+    // may go out while it is outstanding.
+    rig.client.request_block_tracked(uint256::ONE);
+    ASSERT_GE(rig.client.pending_body_count(), 1u);
+
+    // A tx inv arrives while the body is outstanding: admitted by InvDedup,
+    // then skipped by the tip-body-priority rule.
+    const uint256 txid = uint256(static_cast<uint64_t>(0xAAull));
+    auto tx_inv = dash::coin::p2p::message_inv::make_raw(
+        std::vector<dash::coin::p2p::inventory_type>{
+            dash::coin::p2p::inventory_type(
+                dash::coin::p2p::inventory_type::tx, txid)});
+    rig.deliver(std::move(tx_inv));
+
+    // Skipped: nothing in flight yet, and the announcement was parked.
+    EXPECT_EQ(rig.client.tx_pull_inflight(), 0u);
+    EXPECT_EQ(rig.client.tx_pull_sent_count(), 0u);
+    EXPECT_EQ(rig.client.tx_pull_skipped_busy_count(), 1u);
+    EXPECT_EQ(rig.client.tx_retry_busy_count(), 1u);
+
+    // The tip body lands — pending bodies clear. The next pool tick must
+    // re-issue the parked getdata.
+    rig.client.clear_pending_bodies_for_test();
+    rig.client.tick_for_test();
+
+    // RED on the pre-change code: the skipped inv is never re-pulled (stranded
+    // behind the 600 s InvDedup TTL), so tx_pull_inflight() stays 0 forever.
+    // GREEN with the retry queue: exactly one getdata is now in flight.
+    EXPECT_EQ(rig.client.tx_pull_inflight(), 1u);
+    EXPECT_EQ(rig.client.tx_pull_sent_count(), 1u);
+    EXPECT_EQ(rig.client.tx_retry_busy_count(), 0u);
+    EXPECT_EQ(rig.client.tx_retry_drained_count(), 1u);
+}
+
 } // namespace


### PR DESCRIPTION
## Gap: mempool-ingest-completeness (DSTX class) — instrument + body-busy retry

Co-local measurement on workstation-191 (keystone-soak, `--embedded-mempool-ingest`, 16 p2p peers) vs dashd `192.168.86.165` over 13.5 h / 306 blocks found the embedded mempool missing an entire tx class present in dashd's: **DSTX (CoinJoin broadcast) transactions — 1363/7905 = 17.2% of mined block txs and ~half the mempool BYTES** (byte ratio ours/dashd ≈ 0.49; corr(per-block miss, cj_count)=0.749; missed==cj_count exactly in 13/15 recent blocks).

### Root cause (already understood, machinery already merged)
dashd announces CoinJoin txs **only** via `inv(MSG_DSTX=16)`, never `MSG_TX`. The embedded DSTX getdata lane (`--embedded-ingest-dstx` → `set_dstx_pull`, admission `Mempool::add_dstx`) is fully wired and reward-safe (BLS-verified; unpriceable DSTX admitted `fee=0`, `fee_fold_proven=false` → template-excluded). It is **default-OFF** — so the primary closure of the class gap is **arming the flag at deploy**, which is an operator decision (reward/consensus) and is **not** part of this PR.

This PR ships the two supporting code items the research called out, both **flag-scoped and reward-safe**:

### 1. Instrument the DSTX lane (telemetry only)
`tx_ingest_status()` already kept `m_dstx_inv_seen / m_dstx_pull_sent / m_dstx_received` but never printed them, so an armed lane was invisible in `[MEMPOOL-INGEST]` logs and could not be measured on a soak. Now printed as `dstx_inv= dstx_getdata= dstx_received=` (plus `retry(parked/drained)=`). No behavioural change; off-lane the fields read zero.

### 2. Retry the tip-body-busy-skipped invs (~2% residual)
A tx/dstx inv admitted by `InvDedup` but skipped because a tip body was in flight (`skipped(tip-body-busy)=137/13.5h`) was then suppressed by the 600 s `InvDedup` TTL for every re-announcement from every peer — stranded until it aged out, usually after it was already mined. It is now **parked** in a bounded FIFO and re-issued the instant the tip body clears (`drain_tx_retry_busy`, one pass per pool tick). The retry rides the **same** inflight budget/cap and txid-keyed dedup as a first-time pull (the DSTX inv hash IS the plain txid), echoes the announced type, and can only re-fetch a tx we already decided to pull — it never changes selection or pricing. Dormant unless the owning lane (`m_tx_pull_enabled`/`m_dstx_pull_enabled`) is armed, so a default-configured node parks nothing and its wire is byte-identical.

### Safety basis
- Both changes are downstream of the existing per-lane flag gates; **default configuration behaviour and wire are unchanged**.
- The retry cannot introduce a tx the node did not already choose to pull; it only recovers one it dropped. No new admission, no selection/fee change.
- Strict tip-body priority preserved: nothing drains while a body is outstanding, and the drain bails the instant a body arrives mid-pass.

### Tests
`test/test_dash_coin_p2p_client.cpp`, suite `DashCoinP2PIngest`:
- `dstx_counters_are_visible_in_tx_ingest_status` — arms DSTX, delivers `inv(MSG_DSTX)`, asserts the counters surface. **Red** when the instrument hunk is removed.
- `tx_inv_skipped_while_body_in_flight_is_retried_not_stranded` — parks a tx inv behind a pending body, clears the body, ticks, asserts exactly one getdata is re-issued. **Red** when the retry hunk is removed (inflight stays 0 forever).

Both proven red→green on workstation-191. Full `test_dash_p2p_node` suite green (160/160).

### Merge / deploy gate
Touches the reward/consensus tx-ingest path (flag-scoped, dormant by default). **Merge and deploy are operator-gated.** Arming `--embedded-ingest-dstx` on the canary/soak is the separate operator step that actually closes the 17.2%/byte-0.49 class gap; re-run the per-block removed/eligible measurement after arming (expected aggregate coverage ~0.96+, byte ratio ~1.0).
