### PR TITLE
dash(daemonless): validity gate — do not reset clean_run on Window-1 propagation

### DIFF
--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -698,7 +698,19 @@ private:
             std::lock_guard<std::mutex> lk(mu_);
             counters_.apply(o);
         }
-        probe_validity(served);
+        // TIP CONTEXT for the validity gate. dashd's getblocktemplate height is
+        // its NEXT block (tip+1); ours (served.m_height) is likewise our next
+        // block. dashd building a STRICTLY HIGHER block than us means dashd has
+        // already connected the block at our template's height (or beyond) while
+        // OUR tip is still its parent — the propagation Window 1 in which a tx
+        // dashd reports "txn-already-known" was mined in a block WE HAVE NOT YET
+        // CONNECTED. From our tip that tx is a valid unconfirmed tx and our
+        // template is a valid fork competitor, so the gate must not treat it as
+        // a staleness defect. When the oracle is absent we cannot tell, and pass
+        // false (conservative: already-known stays INVALID, gate stays CLOSED).
+        const bool dashd_ahead =
+            dashd.has_value() && dashd->m_height > served.m_height;
+        probe_validity(served, dashd_ahead);
     }
 
     /// THE MEMPOOL VALIDITY GATE, on the SAME worker thread as the oracle
@@ -709,7 +721,7 @@ private:
     ///
     /// This CANNOT change what is served. Its only outputs are log lines, the
     /// counters, and a readiness verdict on a DEFAULT-OFF flag.
-    void probe_validity(const DashWorkData& w) {
+    void probe_validity(const DashWorkData& w, bool dashd_ahead_of_serve_height) {
         if (!accept_) return;
         const auto set = mempool_probe_set(w);
 
@@ -727,7 +739,8 @@ private:
             answers.push_back(std::move(a));
         }
 
-        const auto sample = mempool_validity_sample(w.m_height, set, answers);
+        const auto sample = mempool_validity_sample(w.m_height, set, answers,
+                                                    dashd_ahead_of_serve_height);
         std::lock_guard<std::mutex> lk(mu_);
         validity_.apply(sample);
         for (const auto& line : mempool_validity_log_lines(sample, validity_)) {

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -124,8 +124,26 @@ namespace coin {
 
 /// dashd's reject-reason for "I already hold this transaction", verbatim
 /// (Dash Core validation.cpp: TxValidationResult TX_CONFLICT,
-/// "txn-already-in-mempool"). The ONE exempted reason. Compared for EQUALITY.
+/// "txn-already-in-mempool"). The ONE unconditionally-exempted reason.
+/// Compared for EQUALITY.
 inline constexpr const char* kAlreadyInMempoolReason = "txn-already-in-mempool";
+
+/// dashd's reject-reason for "this transaction is ALREADY CONFIRMED in my
+/// active chain", verbatim (Dash Core MemPoolAccept::PreChecks: a tx whose
+/// outputs are already present as coins in dashd's UTXO view —
+/// `HaveCoin(COutPoint(hash, out))` — returns TX_CONFLICT "txn-already-known").
+/// This is a CONDITIONAL exemption, not an unconditional one: it is benign
+/// ONLY when the block that confirmed the tx is one WE HAVE NOT YET CONNECTED
+/// (propagation Window 1 — our tip is h-1, someone else mined h and dashd
+/// connected it before we did; from our tip the tx is a valid UNCONFIRMED tx
+/// and our template is a valid fork competitor at height h, never an orphan).
+/// It is a genuine DEFECT only when dashd sits on OUR parent (or behind) and
+/// still reports the tx confirmed — i.e. it was confirmed at or below OUR
+/// serve-tip while we still serve it (the intra-node eviction-lag class,
+/// "Window 2"). The caller supplies the tip context (classify_mempool_accept's
+/// `dashd_ahead_of_serve_height`), which alone decides which case applies.
+/// Compared for EQUALITY.
+inline constexpr const char* kAlreadyConfirmedReason = "txn-already-known";
 
 /// The ONE reject-reason that can mean ONLY "I do not know this input" — the
 /// answer a SINGLE-transaction probe gets for a child whose parent rides the
@@ -149,6 +167,10 @@ inline bool is_missing_or_spent_reason(const std::string& reason)
 enum class MempoolAcceptVerdict : uint8_t {
     Valid,              // allowed == true
     AlreadyInMempool,   // allowed == false, reason == txn-already-in-mempool
+    ConfirmedAhead,     // reason == txn-already-known AND dashd is ahead of our
+                        // serve-tip -> benign propagation (Window 1). NOT a
+                        // defect and NOT evidence: it neither resets nor
+                        // advances the readiness run.
     Invalid,            // allowed == false, any other reason -> A DEFECT
     Unprobed            // no answer, or an in-set-parent probe artefact
 };
@@ -158,6 +180,7 @@ inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
     switch (v) {
         case MempoolAcceptVerdict::Valid:            return "VALID";
         case MempoolAcceptVerdict::AlreadyInMempool: return "ALSO-VALID(already-in-mempool)";
+        case MempoolAcceptVerdict::ConfirmedAhead:   return "PROPAGATION(confirmed-in-not-yet-connected-block)";
         case MempoolAcceptVerdict::Invalid:          return "INVALID";
         default:                                     return "UNPROBED";
     }
@@ -188,8 +211,20 @@ struct MempoolProbeTx {
 /// `entry` is the single result object (`{"txid":..,"allowed":..,
 /// "reject-reason":..}`); a null/non-object entry means the probe produced no
 /// answer (RPC blip, daemon absent) and yields Unprobed.
+///
+/// `dashd_ahead_of_serve_height` is the sample-level tip context: TRUE when
+/// dashd's chain tip is STRICTLY AHEAD of the block WE built the probed
+/// template for (dashd's next-block height > our served height). It is
+/// consulted for EXACTLY ONE reason string — "txn-already-known" — to separate
+/// benign propagation (Window 1: dashd already connected a block we have not)
+/// from a genuine intra-node staleness defect (Window 2: dashd sits on our
+/// parent and still holds the tx confirmed at/below our serve-tip). It changes
+/// NOTHING for any other reason: every real reject stays a reject. Defaulting
+/// to FALSE preserves the pre-tip-context behaviour (already-known -> INVALID)
+/// for callers that cannot supply it — the conservative, gate-CLOSED direction.
 inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
-                                                   const nlohmann::json& entry)
+                                                   const nlohmann::json& entry,
+                                                   bool dashd_ahead_of_serve_height = false)
 {
     MempoolAcceptResult r;
     r.txid = tx.txid;
@@ -212,6 +247,27 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
     if (r.reason == kAlreadyInMempoolReason) {
         r.verdict = MempoolAcceptVerdict::AlreadyInMempool;
         return r;
+    }
+
+    // dashd says the tx is ALREADY CONFIRMED in its chain ("txn-already-known").
+    // Whether that is a defect depends ENTIRELY on WHICH block confirmed it,
+    // which the tip context decides (see kAlreadyConfirmedReason). dashd AHEAD
+    // of our serve-tip => it was confirmed in a block we have not connected =>
+    // benign propagation (Window 1): our template is a valid fork competitor at
+    // our height, so this must NOT reset the readiness run. dashd NOT ahead
+    // (on our parent, or behind) => confirmed at/below OUR serve-tip while we
+    // still serve it => a genuine current-tip staleness defect (Window 2) =>
+    // falls through to INVALID and resets, exactly as a served already-mined tx
+    // should. This is the ONLY reason whose disposition the tip context can
+    // change; the field-measured invalids were 23/23 this class, all Window 1.
+    if (r.reason == kAlreadyConfirmedReason) {
+        if (dashd_ahead_of_serve_height) {
+            r.verdict        = MempoolAcceptVerdict::ConfirmedAhead;
+            r.unprobed_cause = "confirmed-in-block-we-have-not-connected(propagation)";
+            return r;
+        }
+        // else: dashd on our parent or behind -> a real at/below-serve-tip
+        // defect; fall through to INVALID below.
     }
 
     // The ONLY excused rejection beyond the named one: a child probed alone
@@ -261,12 +317,20 @@ struct MempoolValiditySample {
     size_t   already_in_mempool{0};
     size_t   invalid{0};
     size_t   unprobed{0};
+    /// Benign propagation (Window 1): dashd reported the tx already-CONFIRMED in
+    /// a block WE HAVE NOT YET CONNECTED. Neither a defect nor evidence — it is
+    /// counted here only so the log/JSON can say how much of the "already-known"
+    /// traffic was the propagation transient rather than a real staleness.
+    size_t   confirmed_ahead{0};
     /// The defects, verbatim — txid + dashd's reason. These are what the
     /// refusal line prints.
     std::vector<MempoolAcceptResult> invalids;
 
     /// A height that actually OBSERVED validity. A height whose probe set was
-    /// empty, or whose every entry came back Unprobed, observed nothing.
+    /// empty, or whose every entry came back Unprobed / ConfirmedAhead,
+    /// observed nothing about CURRENT-TIP validity — a ConfirmedAhead answer is
+    /// dashd speaking from a NEWER tip than the one we probed for, so it is not
+    /// evidence either way (see the tip-context note on kAlreadyConfirmedReason).
     bool evidence_bearing() const
     {
         return (valid + already_in_mempool + invalid) > 0;
@@ -277,10 +341,18 @@ struct MempoolValiditySample {
 /// PURE. Classify a whole probe set against the per-transaction answers.
 /// `answers[i]` is dashd's result object for `set[i]`; a shorter answers vector
 /// means the remaining entries got no answer (Unprobed), never a pass.
+///
+/// `dashd_ahead_of_serve_height` is the sample-level tip context threaded into
+/// each per-tx classification (see classify_mempool_accept). It ONLY affects
+/// the "txn-already-known" reason: dashd-ahead makes that a benign
+/// ConfirmedAhead (propagation Window 1, no reset), dashd-not-ahead keeps it a
+/// current-tip Invalid. Defaults FALSE so legacy/test callers get the pre-
+/// tip-context behaviour unchanged.
 inline MempoolValiditySample
 mempool_validity_sample(uint32_t height,
                         const std::vector<MempoolProbeTx>& set,
-                        const std::vector<nlohmann::json>& answers)
+                        const std::vector<nlohmann::json>& answers,
+                        bool dashd_ahead_of_serve_height = false)
 {
     MempoolValiditySample s;
     s.height = height;
@@ -288,10 +360,12 @@ mempool_validity_sample(uint32_t height,
     for (size_t i = 0; i < set.size(); ++i) {
         const nlohmann::json& a = (i < answers.size()) ? answers[i]
                                                        : nlohmann::json();
-        const MempoolAcceptResult r = classify_mempool_accept(set[i], a);
+        const MempoolAcceptResult r =
+            classify_mempool_accept(set[i], a, dashd_ahead_of_serve_height);
         switch (r.verdict) {
             case MempoolAcceptVerdict::Valid:            ++s.valid; break;
             case MempoolAcceptVerdict::AlreadyInMempool: ++s.already_in_mempool; break;
+            case MempoolAcceptVerdict::ConfirmedAhead:   ++s.confirmed_ahead; break;
             case MempoolAcceptVerdict::Invalid:
                 ++s.invalid;
                 s.invalids.push_back(r);
@@ -394,6 +468,13 @@ struct MempoolValidityGate {
     uint64_t txs_valid{0};
     uint64_t txs_already_in_mempool{0};
     uint64_t txs_unprobed{0};
+    /// Benign propagation transients (already-CONFIRMED in a block we have not
+    /// yet connected) seen over every applied sample. NOT defects, NOT
+    /// evidence — this counter exists so the operator can see how much of the
+    /// "already-known" traffic the tip context reclassified out of the invalid
+    /// bucket. A large value here with consecutive_clean advancing is the whole
+    /// point: propagation no longer stalls the readiness run.
+    uint64_t txs_confirmed_ahead{0};
     uint64_t repeat_txs_probed{0};
 
     /// DEFECTS ARE COUNTED WHEREVER THEY ARE OBSERVED — counted sample or
@@ -421,8 +502,9 @@ struct MempoolValidityGate {
             // moved: a later probe of this same height that DOES find
             // transactions is the first evidence there, and must count.
             ++samples_without_evidence;
-            txs_unprobed     += s.unprobed;
-            last_disposition  = SampleDisposition::NoEvidence;
+            txs_unprobed        += s.unprobed;
+            txs_confirmed_ahead += s.confirmed_ahead;
+            last_disposition     = SampleDisposition::NoEvidence;
             return;
         }
 
@@ -456,6 +538,7 @@ struct MempoolValidityGate {
         txs_valid              += s.valid;
         txs_already_in_mempool += s.already_in_mempool;
         txs_unprobed           += s.unprobed;
+        txs_confirmed_ahead    += s.confirmed_ahead;
         last_disposition        = SampleDisposition::Counted;
 
         if (s.invalid > 0) return;        // already reset above
@@ -487,6 +570,7 @@ struct MempoolValidityGate {
         j["txs-already-in-mempool"]    = txs_already_in_mempool;
         j["txs-invalid"]               = txs_invalid;
         j["txs-unprobed"]              = txs_unprobed;
+        j["txs-confirmed-ahead-propagation"] = txs_confirmed_ahead;
         j["last-invalid-height"]       = last_invalid_height;
         j["last-invalid-txid"]         = last_invalid_txid;
         j["last-invalid-reason"]       = last_invalid_reason;
@@ -525,6 +609,7 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " valid="     + std::to_string(s.valid)
         + " already_in_mempool=" + std::to_string(s.already_in_mempool)
         + " invalid="   + std::to_string(s.invalid)
+        + " confirmed_ahead=" + std::to_string(s.confirmed_ahead)
         + " unprobed="  + std::to_string(s.unprobed)
         + " clean_run=" + std::to_string(g.consecutive_clean) + "/"
         + std::to_string(g.required)
@@ -532,8 +617,13 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " sample=" + MempoolValidityGate::disposition_name(g.last_disposition)
         + " gate=" + (g.open() ? "OPEN" : "CLOSED");
     if (!s.evidence_bearing())
-        l += " (no-evidence: nothing to probe at this height — the run neither"
-             " advances nor resets)";
+        l += s.confirmed_ahead > 0
+             ? " (no-evidence: every probed tx is already CONFIRMED in a block we"
+               " have not yet connected — benign propagation Window 1, dashd is"
+               " ahead of the height we built for; the run neither advances nor"
+               " resets, and this is NOT a staleness defect)"
+             : " (no-evidence: nothing to probe at this height — the run neither"
+               " advances nor resets)";
     else if (g.last_disposition == MempoolValidityGate::SampleDisposition::RepeatHeight)
         l += " (repeat-height: h<=" + std::to_string(g.last_counted_height)
            + " is already banked — the probe fires ~5-6x per block, so this"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -604,7 +604,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # genesis short-circuit), resumable cursor across reopen, versioned-format
     # fail-loud, 100-block undo window retention, disconnect/reconnect set-
     # hash identity. Same target, no new allowlist entry.
-    add_executable(test_dash_mempool test_dash_mempool.cpp test_dash_replay_utxo_fold.cpp)
+    # test_dash_mempool_validity_gate.cpp also rides the test_dash_embedded_gbt
+    # target above, but that target currently FAILS TO LINK (a pre-existing
+    # #154-era gap: test_dash_replay_v19_type4_punish.cpp needs opkey_* from
+    # bls_verify.cpp). Fold the gate suite into this LINKING target too so the
+    # readiness-gate KATs — including the tip-context propagation split — are
+    # actually built and run. Header-only over mempool_validity_gate.hpp +
+    # nlohmann/json; no new SCC dependency, no new build.yml --target (#769).
+    add_executable(test_dash_mempool test_dash_mempool.cpp test_dash_replay_utxo_fold.cpp
+        test_dash_mempool_validity_gate.cpp)
     target_link_libraries(test_dash_mempool PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -988,17 +996,13 @@ if (BUILD_TESTING AND GTest_FOUND)
         # suite above, and is folded into this target for the same #769
         # reason (the push bot cannot add a build.yml --target).
         test_dash_mined_commitment_index.cpp
-        # test_dash_mempool_validity_gate.cpp: THE condition that decides when
-        # --embedded-serve-mempool-txs may be armed
-        # (mempool_validity_gate.hpp). Pins the three-valued
-        # testmempoolaccept logic, the exact-name "txn-already-in-mempool"
-        # exemption, "a missing answer is never a pass", the refusal line's
-        # txid/reason/threshold (#1038/#1039 discipline), the sustained-window
-        # arithmetic, and the two directions the retired `ours_only == 0`
-        # set-membership test got wrong. Folded into this target per the same
-        # #769 rule as the leaves above (the push bot cannot add a build.yml
-        # --target, so a standalone executable would be a NOT_BUILT sentinel).
-        test_dash_mempool_validity_gate.cpp
+        # test_dash_mempool_validity_gate.cpp — MOVED to the test_dash_mempool
+        # target (a LINKING one). It rode here for the #769 "no standalone
+        # target" rule, but this target (test_dash_embedded_gbt) currently
+        # FAILS TO LINK (the #154-era test_dash_replay_v19_type4_punish.cpp
+        # opkey_* gap below), so the readiness-gate KATs never actually ran.
+        # test_dash_mempool links cleanly and is header-only-compatible with the
+        # gate, so the suite lives there now — CI builds and runs it.
         # test_dash_replay_v19_type4_punish.cpp: the h=1516043 divergence class
         # (replay_quorum_engine.hpp produce_early_nonrotated_members) — the
         # pre-v19 PLATFORM quorum (LLMQ_100_67) must draw from ALL confirmed+

--- a/test/test_dash_mempool_validity_gate.cpp
+++ b/test/test_dash_mempool_validity_gate.cpp
@@ -115,17 +115,137 @@ TEST(DashMempoolValidityGate, AnyOtherReasonIsInvalidAndCarriesItVerbatim) {
 // ── 2. THE EXEMPTION IS BY EXACT NAME ───────────────────────────────────────
 
 TEST(DashMempoolValidityGate, NearMissReasonIsNotExempted) {
-    // "txn-already-known" is a DIFFERENT dashd reason (the transaction is in a
-    // block / recently rejected, not in the mempool). Excusing it would widen
-    // the gate by prefix-matching, and a tx we would serve that dashd has
-    // already MINED is a staleness defect worth stopping on.
+    // None of these is the exact "txn-already-in-mempool" name. Excusing them
+    // would widen the gate by prefix-matching. "txn-already-known" is a REAL
+    // dashd reason (the tx is already CONFIRMED in dashd's chain), but WITHOUT
+    // tip context (the default here) we cannot tell benign propagation from a
+    // current-tip staleness defect, so the conservative reading is INVALID —
+    // exactly the pre-tip-context behaviour, and the gate-CLOSED direction.
+    // The tip-aware benign path is pinned separately below.
     for (const char* reason : {"txn-already-known",
                                "txn-already-in-mempool-ish",
                                "already-in-mempool"}) {
         const auto r = classify_mempool_accept(tx("dd"), refused("dd", reason));
         EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid)
-            << "reason=" << reason << " must NOT be exempted";
+            << "reason=" << reason << " must NOT be exempted without tip context";
     }
+}
+
+// ── 2b. THE PROPAGATION WINDOW: "txn-already-known" IS TIP-CONDITIONAL ───────
+//
+// FIELD MEASUREMENT (creditpool-arm + cert soaks, heights 2526398..2526404):
+// 23/23 of the live [MEMPOOL-VALIDITY] invalids were reason="txn-already-known"
+// and EVERY ONE was confirmed at EXACTLY the probe height — i.e. mined in the
+// very block our template competed for, while our tip was legitimately h-1.
+// That is benign propagation (Window 1): dashd connected block h before we did,
+// so it answers "already confirmed"; our template is a valid FORK COMPETITOR at
+// height h, never an orphan. The old gate reset the clean run on every one of
+// these, which is why clean_run was pinned at 0/576 forever. These KATs pin the
+// tip-context split that fixes it.
+
+TEST(DashMempoolValidityGate, AlreadyKnownWithDashdAheadIsBenignPropagationNotInvalid) {
+    // dashd is AHEAD of the height we built for -> the tx was confirmed in a
+    // block WE HAVE NOT YET CONNECTED -> benign, not a defect.
+    const auto r = classify_mempool_accept(
+        tx("mined_elsewhere"), refused("mined_elsewhere", "txn-already-known"),
+        /*dashd_ahead_of_serve_height=*/true);
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::ConfirmedAhead);
+}
+
+TEST(DashMempoolValidityGate, AlreadyKnownWithDashdNotAheadIsStillAnInvalidDefect) {
+    // dashd sits on OUR parent (not ahead) and STILL reports the tx confirmed
+    // -> it was confirmed at/below our serve-tip while we serve it: a genuine
+    // current-tip staleness defect (Window 2). The gate MUST still catch this.
+    const auto r = classify_mempool_accept(
+        tx("stale"), refused("stale", "txn-already-known"),
+        /*dashd_ahead_of_serve_height=*/false);
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid);
+    EXPECT_EQ(r.reason, "txn-already-known");
+}
+
+TEST(DashMempoolValidityGate, PropagationTransientDoesNotResetTheCleanRun) {
+    // The whole point. A clean run in progress must SURVIVE a height whose only
+    // "invalids" are already-confirmed-in-a-block-we-haven't-connected txs.
+    MempoolValidityGate g;
+    feed_clean(g, 100);
+    ASSERT_EQ(g.consecutive_clean, 100u);
+
+    // A propagation sample: 4 txs, all "txn-already-known", dashd AHEAD.
+    const std::vector<MempoolProbeTx> set{tx("p1"), tx("p2"), tx("p3"), tx("p4")};
+    const std::vector<nlohmann::json> ans{
+        refused("p1", "txn-already-known"), refused("p2", "txn-already-known"),
+        refused("p3", "txn-already-known"), refused("p4", "txn-already-known")};
+    const auto s = mempool_validity_sample(50000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/true);
+    // Not evidence, not a defect: 4 confirmed-ahead, 0 invalid.
+    EXPECT_EQ(s.confirmed_ahead, 4u);
+    EXPECT_EQ(s.invalid, 0u);
+    EXPECT_FALSE(s.evidence_bearing());
+
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 100u) << "propagation Window 1 must NOT reset";
+    EXPECT_EQ(g.txs_invalid, 0u);
+    EXPECT_EQ(g.txs_confirmed_ahead, 4u);
+}
+
+TEST(DashMempoolValidityGate, TheSamePropagationSampleWithoutTipContextWouldHaveResetIt) {
+    // RED->GREEN CONTRAST. Feed the IDENTICAL already-known set the way the
+    // pre-fix gate saw it (no tip context => dashd_ahead=false): it classifies
+    // as 4 INVALID and nukes a 100-height run to 0. This is the exact live
+    // defect (clean_run stuck at 0/576). The only difference from the test above
+    // is the tip-context bit, which is what the fix threads through.
+    MempoolValidityGate g;
+    feed_clean(g, 100);
+    ASSERT_EQ(g.consecutive_clean, 100u);
+
+    const std::vector<MempoolProbeTx> set{tx("p1"), tx("p2"), tx("p3"), tx("p4")};
+    const std::vector<nlohmann::json> ans{
+        refused("p1", "txn-already-known"), refused("p2", "txn-already-known"),
+        refused("p3", "txn-already-known"), refused("p4", "txn-already-known")};
+    const auto s = mempool_validity_sample(50000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/false);
+    EXPECT_EQ(s.invalid, 4u);
+    EXPECT_EQ(s.confirmed_ahead, 0u);
+
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 0u) << "no tip context => conservative reset";
+    EXPECT_EQ(g.best_consecutive_clean, 100u);
+}
+
+TEST(DashMempoolValidityGate, PropagationDoesNotMaskAGenuineInvalidInTheSameSample) {
+    // Belt: a sample carrying BOTH benign propagation AND a real defect still
+    // resets. The confirmed-ahead reclassification must never swallow a true
+    // invalid that shares the height.
+    MempoolValidityGate g;
+    feed_clean(g, 100);
+    const std::vector<MempoolProbeTx> set{tx("ahead"), tx("realbad")};
+    const std::vector<nlohmann::json> ans{
+        refused("ahead", "txn-already-known"),
+        refused("realbad", "bad-txns-inputs-missingorspent")};
+    const auto s = mempool_validity_sample(50000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/true);
+    EXPECT_EQ(s.confirmed_ahead, 1u);
+    EXPECT_EQ(s.invalid, 1u);
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 0u) << "a real defect still resets";
+    EXPECT_EQ(g.last_invalid_reason, "bad-txns-inputs-missingorspent");
+}
+
+TEST(DashMempoolValidityGate, AMixedValidAndPropagationHeightStillAdvances) {
+    // A height with at least one genuinely VALID tx is evidence and advances,
+    // even when the rest of the set is benign propagation.
+    MempoolValidityGate g;
+    feed_clean(g, 10);
+    const std::vector<MempoolProbeTx> set{tx("good"), tx("ahead")};
+    const std::vector<nlohmann::json> ans{
+        allowed_true("good"), refused("ahead", "txn-already-known")};
+    const auto s = mempool_validity_sample(60000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/true);
+    EXPECT_TRUE(s.evidence_bearing());
+    EXPECT_EQ(s.valid, 1u);
+    EXPECT_EQ(s.confirmed_ahead, 1u);
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 11u);
 }
 
 // ── 3. A MISSING ANSWER IS NEVER A PASS ─────────────────────────────────────


### PR DESCRIPTION
## What & why

The **mempool validity gate** (`mempool_validity_gate.hpp`) is the readiness
condition that decides when `--embedded-serve-mempool-txs` may be armed. It
reset its consecutive-clean run on **any** `testmempoolaccept` reject —
including the benign propagation transient that dominates the live signal —
so `clean_run` stayed pinned at **0/576 forever**. That is what blocks arming
**PR #1314** (`--embedded-tx-serve-own-set`) and the operator's
"served txs valid + not spent earlier" guarantee.

## Measurement: the split is 23/23 Window-1, 0/23 Window-2

Correlating every live `[MEMPOOL-VALIDITY]` invalid (creditpool-arm + cert
soaks, h=2526398..2526404) against dashd's actual confirmation height:

| probe height | invalid txs | confirmed at | class |
|---|---|---|---|
| 2526398..2526404 | 23 unique | **exactly the probe height** | **Window 1 (benign)** |

Every invalid was `reason=txn-already-known` and every one was mined in the
**very block our template competed for**, while our tip was legitimately h-1.
None were confirmed at/below our serve-tip. So they are all benign
propagation — dashd connected block h before we did; our template is a valid
**fork competitor** at height h, never an orphan — and **zero** are real
intra-node eviction lag.

## The fix (validity gate only)

`txn-already-known` (Dash Core `MemPoolAccept::PreChecks`: the tx's outputs are
already coins in dashd's UTXO view) means **already confirmed**, distinct from
`txn-already-in-mempool`. Whether that is a defect depends on WHICH block
confirmed it — the **tip context** decides:

- **dashd ahead** of the height we built for (its `getblocktemplate` height >
  our served height) ⇒ confirmed in a block **we have not yet connected** ⇒
  new verdict `ConfirmedAhead`: **not a defect, not evidence** — neither resets
  nor advances the run.
- **dashd not ahead** (on our parent, or behind) and still reports the tx
  confirmed ⇒ confirmed **at/below our serve-tip** while we serve it ⇒ a
  genuine current-tip staleness defect ⇒ stays `INVALID` and resets.

Only `txn-already-known` is tip-conditional; every other reject reason resets
unchanged. The tip context reuses the `getblocktemplate` oracle the
shadow-compare worker already fetches — **no new RPC**. Oracle absent ⇒ context
false ⇒ conservative (already-known stays INVALID, gate stays CLOSED).

## Scope

This is the **validity-gate half only**. Window-2 synchronous
evict-on-connect (`removeForBlock` ordering in `mempool.hpp`) is a **separate**
change — the measurement shows Window 2 does not currently occur, and this gate
still catches it (the dashd-not-ahead branch) if it ever regresses.

## KAT — red→green

`test_dash_mempool_validity_gate.cpp`:
- a propagation sample of all `txn-already-known` with dashd ahead does **not**
  reset a 100-height clean run;
- the **identical** sample without tip context **does** reset (the pre-fix live
  defect);
- a genuine invalid sharing the height still resets;
- a mixed valid+propagation height still advances.

**RED on HEAD:** the suite cannot compile without the `ConfirmedAhead` verdict /
tip-context API. **GREEN:** 30/30 gate tests pass (built + run on workstation-191
via `test_dash_mempool`). The gate suite is moved out of the pre-existing
non-linking `test_dash_embedded_gbt` target (a #154-era `opkey_*` link gap) into
the linking `test_dash_mempool` target so CI actually runs it.

## Unblocks

Arming PR #1314 and the operator's "not spent earlier" guarantee: the gate can
now accrue its sustained clean window instead of being reset to 0 by normal
block propagation.

**Do not merge — operator-gated.**
