### PR TITLE
dash(daemonless): cumulative cross-restart never-a-reject serve-gate ledger

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2810,6 +2810,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // consulted, i.e. during an actual embedded outage.
     const bool xcheck_wanted = (testnet || embedded_mainnet);
     work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
+    // CUMULATIVE cross-restart serve-gate ledger: persist the never-a-reject
+    // accounting to <data-dir>/<net_subdir>/serve_gate_ledger.json so the
+    // standing "% embedded / null-arm covered the 4.51% floor / 0 rejects over
+    // N heights" figure survives the >=3 restarts the dashd-cut soak spans
+    // (ServeGateJournal wipes on restart). Stamp C2POOL_VERSION so the figure
+    // always names the binary that produced it (measurement-without-commit).
+    {
+        const std::string ledger_path =
+            (core::filesystem::config_path() / net_subdir /
+             "serve_gate_ledger.json").string();
+#ifdef C2POOL_VERSION
+        work_source->set_serve_gate_ledger_path(ledger_path, C2POOL_VERSION);
+#else
+        work_source->set_serve_gate_ledger_path(ledger_path, "dev");
+#endif
+    }
     // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
     // either way: with it off the donation still misses every swapped
     // template -- it just no longer does so silently.

--- a/src/impl/dash/coin/serve_gate_ledger.hpp
+++ b/src/impl/dash/coin/serve_gate_ledger.hpp
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// ServeGateLedger — the CUMULATIVE, CROSS-RESTART companion to
+/// ServeGateJournal.
+///
+/// THE DEFECT THIS CLOSES (critic, 2026-08-23): the EMBED-GATE roll-up and
+/// every ServeGateJournal counter live entirely in-process. `m_cause_totals`,
+/// `m_first_observed_sec`, `m_episode_start_sec` are member state fed a
+/// std::chrono::steady_clock (PROCESS-MONOTONIC) clock — so the whole roll-up
+/// WIPES on every restart and the program-level "% embedded / never-a-reject"
+/// figure is per-process, not standing. The dashd-cut acceptance gate is a
+/// CUMULATIVE never-a-reject claim spanning >=3 restarts ("the null-arm covered
+/// the 4.51% DKG floor, 0 rejects over N heights"), which the journal cannot
+/// express: a claim you cannot carry across a restart is not a soak claim.
+///
+/// ServeGateLedger is the persisted aggregator. Design constraints, copied
+/// verbatim from ServeGateJournal's discipline because the two must never
+/// disagree:
+///
+///   * PURE POLICY — no I/O, no clock of its own, no JSON. The caller passes
+///     monotonic seconds; a companion header (serve_gate_ledger_json.hpp) owns
+///     serialize/deserialize + the atomic tmp+rename file. Header-only so it
+///     folds into the allowlisted dash test targets exactly like the journal.
+///
+///   * ONLY DURATIONS/DELTAS CROSS PROCESSES. The steady_clock second is
+///     process-monotonic, so a raw `now_sec` can never be persisted/restored.
+///     observed_sec accumulates as (now - last_seen) DELTAS banked per serve;
+///     off_embedded_sec / per_cause bank the journal's OWN closed-segment
+///     durations (Decision.prev_cause_sec) — the exact quantity the journal
+///     folds into m_cause_totals, so ledger and journal cannot diverge.
+///
+///   * CRASH LOSES <=1 FLUSH, NEVER DOUBLE-COUNTS. Closed segments are banked
+///     into cumulative totals as they close. The currently-OPEN segment's
+///     partial is written to a REPLACED (never accumulated) carry field and
+///     folded exactly once on the next clean load — approximating the segment
+///     the crashed process never got to close, without ever re-banking a
+///     segment the new process's fresh journal will bank itself.
+///
+///   * MEASUREMENT-WITHOUT-COMMIT RULE. The persisted blob carries a schema
+///     version, an epochs counter (++ on every load), and the writing binary's
+///     commit sha, so a cumulative figure is never read without knowing which
+///     code produced it.
+///
+/// NULL-ARM IS FIRST CLASS. A null-arm serve is journaled as plain
+/// Served::Embedded and logs arm=EMBEDDED — indistinguishable from a
+/// real-quorum serve (the 08-23 grep-case trap). The ledger splits Embedded
+/// into EmbeddedReal / EmbeddedNull so "null-arm served the 4.51% floor" is a
+/// first-class counter, and cross-checks that a null was served ONLY when no
+/// real quorum was available (real_quorum_available_but_null_served MUST stay
+/// 0 — that would be a null served where dashd had a real committed quorum).
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+
+namespace dash {
+namespace coin {
+
+class ServeGateLedger {
+public:
+    static constexpr uint32_t kSchemaVersion = 1;
+
+    /// Which arm produced a serve / won a block. Mirrors ServeGateJournal's
+    /// three-valued disposition but SPLITS Embedded so the null arm is
+    /// countable on its own axis.
+    ///   EmbeddedReal — embedded template built on a real committed quorum;
+    ///   EmbeddedNull — embedded template served coinbase-only over the DKG
+    ///                  floor with the SAME null quorum commitment dashd uses
+    ///                  (#127 parity), NOT a real quorum;
+    ///   Fallback     — a real dashd getblocktemplate was served instead;
+    ///   NoWork       — SET-GAP: neither arm produced a mineable template.
+    enum class Arm : uint8_t {
+        Unknown      = 0,
+        EmbeddedReal = 1,
+        EmbeddedNull = 2,
+        Fallback     = 3,
+        NoWork       = 4,
+    };
+
+    static const char* arm_name(Arm a) {
+        switch (a) {
+            case Arm::EmbeddedReal: return "embedded_real";
+            case Arm::EmbeddedNull: return "embedded_null";
+            case Arm::Fallback:     return "fallback";
+            case Arm::NoWork:       return "no_work";
+            case Arm::Unknown:      break;
+        }
+        return "unknown";
+    }
+
+    static bool is_embedded(Arm a) {
+        return a == Arm::EmbeddedReal || a == Arm::EmbeddedNull;
+    }
+
+    /// The entire persisted state. A plain aggregate so the JSON companion can
+    /// serialize/deserialize field-by-field and the KAT can compare two
+    /// ledgers with ==. Every field is a cumulative TOTAL or a DELTA-safe
+    /// duration — no raw process-monotonic clock value ever lands here.
+    struct Totals {
+        // ── provenance (measurement-without-commit rule) ──────────────────
+        uint32_t    schema_version{kSchemaVersion};
+        uint64_t    epochs{0};            ///< ++ on every load (restart count+1)
+        std::string last_writer_commit;   ///< git sha of the writing binary
+
+        // ── wall clock (delta-accumulated; safe across processes) ─────────
+        int64_t observed_sec{0};          ///< cumulative wall clock observed
+        int64_t off_embedded_sec{0};      ///< cumulative seconds off embedded
+        std::map<std::string, int64_t> per_cause_sec;  ///< closed segments only
+
+        // ── serve dispositions (per template re-source) ───────────────────
+        uint64_t serves_embedded_real{0};
+        uint64_t serves_embedded_null{0};
+        uint64_t serves_fallback{0};
+        uint64_t serves_no_work{0};
+
+        // ── blocks ────────────────────────────────────────────────────────
+        uint64_t blocks_won_embedded_real{0};
+        uint64_t blocks_won_embedded_null{0};
+        uint64_t blocks_won_fallback{0};
+        uint64_t blocks_submitted{0};
+        uint64_t blocks_confirmed{0};
+        uint64_t blocks_orphaned{0};
+        uint64_t local_payee_guard_rejects{0};
+
+        // ── the never-a-reject numerators (hard gate: embedded == 0) ──────
+        uint64_t rpc_rejected_embedded_real{0};
+        uint64_t rpc_rejected_embedded_null{0};
+        uint64_t rpc_rejected_fallback{0};
+        uint64_t orphaned_embedded_real{0};   ///< validity-attributable
+        uint64_t orphaned_embedded_null{0};   ///< validity-attributable
+        std::map<std::string, uint64_t> rpc_reject_reasons;
+
+        // ── null-arm first class ──────────────────────────────────────────
+        /// A null was served on a DKG-floor tip where NO real quorum existed
+        /// (the correct, dashd-parity case).
+        uint64_t null_dkg_floor_tips_served{0};
+        /// A null was served where a real committed quorum WAS available. This
+        /// MUST stay 0 — a non-zero value means the null arm fired when it
+        /// should not have, and stops the cut.
+        uint64_t null_real_quorum_available_but_null_served{0};
+
+        // ── rolling never-a-reject height span ────────────────────────────
+        /// First / last parent-chain height in the CURRENT clean (0-reject)
+        /// span. start==0 means the span is empty (just reset by a reject).
+        uint64_t nr_span_start_height{0};
+        uint64_t nr_span_last_height{0};
+        /// Cumulative count of rejects (any arm) that broke a span, and the
+        /// height of the most recent one (0 = never rejected).
+        uint64_t nr_total_rejects{0};
+        uint64_t nr_last_reject_height{0};
+
+        // ── open-segment carry (REPLACED each flush; folded once on load) ──
+        /// The partial duration of the segment currently in progress at flush
+        /// time. NOT part of off_embedded_sec/per_cause until folded on the
+        /// next load — that fold is the only place it is ever added, and it is
+        /// cleared immediately after, so it can never be folded twice.
+        std::string carry_cause;
+        int64_t     carry_sec{0};
+
+        bool operator==(const Totals& o) const {
+            return schema_version == o.schema_version && epochs == o.epochs &&
+                   last_writer_commit == o.last_writer_commit &&
+                   observed_sec == o.observed_sec &&
+                   off_embedded_sec == o.off_embedded_sec &&
+                   per_cause_sec == o.per_cause_sec &&
+                   serves_embedded_real == o.serves_embedded_real &&
+                   serves_embedded_null == o.serves_embedded_null &&
+                   serves_fallback == o.serves_fallback &&
+                   serves_no_work == o.serves_no_work &&
+                   blocks_won_embedded_real == o.blocks_won_embedded_real &&
+                   blocks_won_embedded_null == o.blocks_won_embedded_null &&
+                   blocks_won_fallback == o.blocks_won_fallback &&
+                   blocks_submitted == o.blocks_submitted &&
+                   blocks_confirmed == o.blocks_confirmed &&
+                   blocks_orphaned == o.blocks_orphaned &&
+                   local_payee_guard_rejects == o.local_payee_guard_rejects &&
+                   rpc_rejected_embedded_real == o.rpc_rejected_embedded_real &&
+                   rpc_rejected_embedded_null == o.rpc_rejected_embedded_null &&
+                   rpc_rejected_fallback == o.rpc_rejected_fallback &&
+                   orphaned_embedded_real == o.orphaned_embedded_real &&
+                   orphaned_embedded_null == o.orphaned_embedded_null &&
+                   rpc_reject_reasons == o.rpc_reject_reasons &&
+                   null_dkg_floor_tips_served == o.null_dkg_floor_tips_served &&
+                   null_real_quorum_available_but_null_served ==
+                       o.null_real_quorum_available_but_null_served &&
+                   nr_span_start_height == o.nr_span_start_height &&
+                   nr_span_last_height == o.nr_span_last_height &&
+                   nr_total_rejects == o.nr_total_rejects &&
+                   nr_last_reject_height == o.nr_last_reject_height &&
+                   carry_cause == o.carry_cause && carry_sec == o.carry_sec;
+        }
+        bool operator!=(const Totals& o) const { return !(*this == o); }
+    };
+
+    ServeGateLedger() = default;
+
+    /// Restore from a persisted blob and count this as one more epoch. This is
+    /// the ONLY place carry is folded: the crashed/previous process's open
+    /// segment is banked into the cumulative totals exactly once, then cleared
+    /// so it can never be folded again. epochs is bumped so the on-disk figure
+    /// always names how many process lifetimes it spans.
+    void load(const Totals& persisted) {
+        m_t = persisted;
+        // Fold the previous process's open-segment partial exactly once.
+        if (m_t.carry_sec > 0 && !m_t.carry_cause.empty()) {
+            m_t.off_embedded_sec += m_t.carry_sec;
+            m_t.per_cause_sec[m_t.carry_cause] += m_t.carry_sec;
+        }
+        m_t.carry_sec = 0;
+        m_t.carry_cause.clear();
+        m_t.epochs += 1;
+        m_t.schema_version = kSchemaVersion;
+        // A new process: no last-seen clock yet, and no open segment carried in
+        // memory (the fold above already accounted for the previous one).
+        m_have_last_seen = false;
+        m_open_cause.clear();
+        m_open_start_sec = -1;
+    }
+
+    /// Stamp the writing binary's commit into the blob about to be flushed.
+    void set_writer_commit(const std::string& sha) { m_t.last_writer_commit = sha; }
+
+    /// HOOK h1 — bank ONE serve decision. Call once per template re-source,
+    /// under the SAME serve_gate_mutex_ the journal observe() ran under, with:
+    ///   arm            — resolved disposition (EmbeddedReal/EmbeddedNull/...);
+    ///   current_cause  — the live first-unmet condition (why.cause) when off
+    ///                    embedded; ignored (and cleared) when serving. Passed
+    ///                    explicitly because Decision does not echo the current
+    ///                    cause on suppressed lines (only prev_cause on the
+    ///                    lines that CLOSE a segment);
+    ///   d              — the SAME ServeGateJournal::Decision observe() just
+    ///                    returned (its prev_cause_sec is exactly what the
+    ///                    journal banks into m_cause_totals, so ledger and
+    ///                    journal cannot disagree on closed segments);
+    ///   now_sec        — monotonic seconds (process clock; only its DELTA and
+    ///                    within-process open-segment span are used, never the
+    ///                    absolute value — that is why totals cross restarts);
+    ///   real_quorum_available — for EmbeddedNull only: was a real committed
+    ///                    quorum available at this tip? true here is a defect (a
+    ///                    null served where dashd had a real quorum), counted so.
+    void bank_serve(Arm arm, const std::string& current_cause,
+                    const ServeGateJournal::Decision& d, int64_t now_sec,
+                    bool real_quorum_available = false) {
+        // observed_sec grows by the DELTA since the last banked serve. First
+        // call in a process contributes 0 (no prior sample) — this is why only
+        // deltas cross restarts: the absolute clock is never persisted.
+        if (m_have_last_seen && now_sec >= m_last_seen_sec)
+            m_t.observed_sec += (now_sec - m_last_seen_sec);
+        m_last_seen_sec  = now_sec;
+        m_have_last_seen = true;
+
+        // Bank the closed segment this decision reported, mirroring the
+        // journal's m_cause_totals fold EXACTLY (same field, same guard).
+        if (d.prev_cause_sec >= 0 && !d.previous_cause.empty()) {
+            m_t.off_embedded_sec += d.prev_cause_sec;
+            m_t.per_cause_sec[d.previous_cause] += d.prev_cause_sec;
+        }
+
+        // Track the currently-OPEN segment with the ledger's own segment clock,
+        // exactly as the journal tracks m_cause_start_sec — Decision cannot
+        // supply the open partial on suppressed lines (cause_sec is -1 there),
+        // so the ledger measures it itself. A NEW segment (transition into
+        // decline, or a cause change) restarts the clock at now_sec; a flush
+        // then snapshots (last_seen - open_start) as carry.
+        if (is_embedded(arm)) {
+            m_open_cause.clear();
+            m_open_start_sec = -1;
+        } else {
+            if (m_open_cause != current_cause || m_open_start_sec < 0) {
+                m_open_cause     = current_cause;
+                m_open_start_sec = now_sec;
+            }
+        }
+
+        switch (arm) {
+            case Arm::EmbeddedReal: ++m_t.serves_embedded_real; break;
+            case Arm::EmbeddedNull:
+                ++m_t.serves_embedded_null;
+                if (real_quorum_available)
+                    ++m_t.null_real_quorum_available_but_null_served;
+                else
+                    ++m_t.null_dkg_floor_tips_served;
+                break;
+            case Arm::Fallback: ++m_t.serves_fallback; break;
+            case Arm::NoWork:   ++m_t.serves_no_work;  break;
+            case Arm::Unknown:  break;
+        }
+    }
+
+    /// HOOK h3 — snapshot the open segment into the REPLACED carry field, ready
+    /// to be persisted. Idempotent; call immediately before every flush. Does
+    /// NOT touch the cumulative totals (carry is folded only on load). The
+    /// partial is (last banked serve - open-segment start), a within-process
+    /// duration — never an absolute clock value.
+    void snapshot_carry_for_flush() {
+        if (!m_open_cause.empty() && m_open_start_sec >= 0 &&
+            m_have_last_seen && m_last_seen_sec > m_open_start_sec) {
+            m_t.carry_cause = m_open_cause;
+            m_t.carry_sec   = m_last_seen_sec - m_open_start_sec;
+        } else {
+            m_t.carry_cause.clear();
+            m_t.carry_sec = 0;
+        }
+    }
+
+    // ── block / verdict hooks (h-blocks) ──────────────────────────────────
+
+    /// A block was won and submitted on `arm` at parent-chain `height`. The
+    /// clean span is extended optimistically; a later reject/validity-orphan
+    /// breaks it.
+    void record_block_won(Arm arm, uint64_t height) {
+        switch (arm) {
+            case Arm::EmbeddedReal: ++m_t.blocks_won_embedded_real; break;
+            case Arm::EmbeddedNull: ++m_t.blocks_won_embedded_null; break;
+            case Arm::Fallback:     ++m_t.blocks_won_fallback;      break;
+            default: break;
+        }
+        ++m_t.blocks_submitted;
+        extend_clean_span(height);
+    }
+
+    /// submitblock (or the daemonless header verdict) resolved. accepted=true
+    /// when the RPC returned null / the header chain adopted the block;
+    /// accepted=false with a reason string is a REJECT — it increments the
+    /// per-arm reject counter and BREAKS the never-a-reject span.
+    void record_rpc_verdict(Arm arm, uint64_t height, bool accepted,
+                            const std::string& reject_reason) {
+        if (accepted) return;
+        switch (arm) {
+            case Arm::EmbeddedReal: ++m_t.rpc_rejected_embedded_real; break;
+            case Arm::EmbeddedNull: ++m_t.rpc_rejected_embedded_null; break;
+            case Arm::Fallback:     ++m_t.rpc_rejected_fallback;      break;
+            default: break;
+        }
+        if (!reject_reason.empty()) ++m_t.rpc_reject_reasons[reject_reason];
+        break_clean_span(height);
+    }
+
+    /// The post-broadcast confirm/orphan lane resolved a verdict. A
+    /// validity-attributable orphan on an embedded arm breaks the span (it is a
+    /// silent reject); a race orphan (validity_attributable=false) does not.
+    void record_confirm(Arm /*arm*/, uint64_t /*height*/) { ++m_t.blocks_confirmed; }
+    void record_orphan(Arm arm, uint64_t height, bool validity_attributable) {
+        ++m_t.blocks_orphaned;
+        if (validity_attributable) {
+            if (arm == Arm::EmbeddedReal) ++m_t.orphaned_embedded_real;
+            else if (arm == Arm::EmbeddedNull) ++m_t.orphaned_embedded_null;
+            if (is_embedded(arm)) break_clean_span(height);
+        }
+    }
+
+    /// The pre-broadcast payee guard refused to submit locally. Counted, but it
+    /// prevented a submit rather than being rejected by the network, so it does
+    /// NOT break the never-a-reject span (nothing reached the chain).
+    void record_payee_guard_reject(uint64_t /*height*/) {
+        ++m_t.local_payee_guard_rejects;
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────
+
+    const Totals& totals() const { return m_t; }
+
+    /// The cumulative never-a-reject claim: no embedded block was rejected by
+    /// RPC and no embedded block was orphaned for a validity reason, over every
+    /// epoch. This is the hard cut gate.
+    bool never_a_reject() const {
+        return m_t.rpc_rejected_embedded_real == 0 &&
+               m_t.rpc_rejected_embedded_null == 0 &&
+               m_t.orphaned_embedded_real == 0 &&
+               m_t.orphaned_embedded_null == 0;
+    }
+
+    /// Length of the current clean span in heights (inclusive), 0 when empty.
+    uint64_t clean_span_heights() const {
+        if (m_t.nr_span_start_height == 0) return 0;
+        return m_t.nr_span_last_height - m_t.nr_span_start_height + 1;
+    }
+
+    uint64_t serves_total() const {
+        return m_t.serves_embedded_real + m_t.serves_embedded_null +
+               m_t.serves_fallback + m_t.serves_no_work;
+    }
+    uint64_t serves_embedded_total() const {
+        return m_t.serves_embedded_real + m_t.serves_embedded_null;
+    }
+
+private:
+    void extend_clean_span(uint64_t height) {
+        if (height == 0) return;
+        if (m_t.nr_span_start_height == 0 || height < m_t.nr_span_start_height)
+            m_t.nr_span_start_height = height;
+        if (height > m_t.nr_span_last_height)
+            m_t.nr_span_last_height = height;
+    }
+    void break_clean_span(uint64_t height) {
+        ++m_t.nr_total_rejects;
+        m_t.nr_last_reject_height = height;
+        m_t.nr_span_start_height  = 0;
+        m_t.nr_span_last_height   = 0;
+    }
+
+    Totals m_t;
+
+    // In-memory-only tracking of the open segment + last-seen clock. NONE of
+    // this is persisted directly: observed_sec banks deltas, and the open
+    // segment is snapshotted into Totals::carry only at flush time.
+    bool        m_have_last_seen{false};
+    int64_t     m_last_seen_sec{0};
+    std::string m_open_cause;
+    /// Start of the currently-open off-embedded segment (process-monotonic);
+    /// -1 while the embedded arm is serving. The flush snapshots
+    /// (m_last_seen_sec - m_open_start_sec) as carry.
+    int64_t     m_open_start_sec{-1};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/serve_gate_ledger_json.hpp
+++ b/src/impl/dash/coin/serve_gate_ledger_json.hpp
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// The ONE serialize/deserialize + atomic-file definition for
+/// ServeGateLedger::Totals, kept OUT of serve_gate_ledger.hpp so that header
+/// stays pure policy (no I/O, no JSON, no clock) exactly as serve_gate_journal
+/// keeps its own JSON in serve_gate_rollup_json.hpp. The producer
+/// (DASHWorkSource) and the KAT share this single definition, so a test cannot
+/// pin a shape the producer does not emit.
+///
+/// Persistence contract:
+///   * write-through to <data-dir>/<net_subdir>/serve_gate_ledger.json;
+///   * ATOMIC — serialize to "<path>.tmp", fsync, rename over the target, so a
+///     crash mid-write never leaves a half-written ledger (a torn cumulative
+///     figure is worse than a stale one);
+///   * schema v1 with epochs + last_writer_commit already in Totals (the
+///     measurement-without-commit rule), so a blob is never read without
+///     knowing which code produced it and how many process lifetimes it spans.
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <impl/dash/coin/serve_gate_ledger.hpp>
+
+namespace dash {
+namespace coin {
+
+inline nlohmann::json serve_gate_ledger_to_json(const ServeGateLedger::Totals& t)
+{
+    nlohmann::json j;
+    j["schema_version"]     = t.schema_version;
+    j["epochs"]             = t.epochs;
+    j["last_writer_commit"] = t.last_writer_commit;
+
+    j["observed_sec"]       = t.observed_sec;
+    j["off_embedded_sec"]   = t.off_embedded_sec;
+    nlohmann::json pc = nlohmann::json::object();
+    for (const auto& kv : t.per_cause_sec) pc[kv.first] = kv.second;
+    j["per_cause_sec"]      = std::move(pc);
+
+    j["serves_embedded_real"] = t.serves_embedded_real;
+    j["serves_embedded_null"] = t.serves_embedded_null;
+    j["serves_fallback"]      = t.serves_fallback;
+    j["serves_no_work"]       = t.serves_no_work;
+
+    j["blocks_won_embedded_real"] = t.blocks_won_embedded_real;
+    j["blocks_won_embedded_null"] = t.blocks_won_embedded_null;
+    j["blocks_won_fallback"]      = t.blocks_won_fallback;
+    j["blocks_submitted"]         = t.blocks_submitted;
+    j["blocks_confirmed"]         = t.blocks_confirmed;
+    j["blocks_orphaned"]          = t.blocks_orphaned;
+    j["local_payee_guard_rejects"] = t.local_payee_guard_rejects;
+
+    j["rpc_rejected_embedded_real"] = t.rpc_rejected_embedded_real;
+    j["rpc_rejected_embedded_null"] = t.rpc_rejected_embedded_null;
+    j["rpc_rejected_fallback"]      = t.rpc_rejected_fallback;
+    j["orphaned_embedded_real"]     = t.orphaned_embedded_real;
+    j["orphaned_embedded_null"]     = t.orphaned_embedded_null;
+    nlohmann::json rr = nlohmann::json::object();
+    for (const auto& kv : t.rpc_reject_reasons) rr[kv.first] = kv.second;
+    j["rpc_reject_reasons"]         = std::move(rr);
+
+    j["null_dkg_floor_tips_served"] = t.null_dkg_floor_tips_served;
+    j["null_real_quorum_available_but_null_served"] =
+        t.null_real_quorum_available_but_null_served;
+
+    j["nr_span_start_height"]  = t.nr_span_start_height;
+    j["nr_span_last_height"]   = t.nr_span_last_height;
+    j["nr_total_rejects"]      = t.nr_total_rejects;
+    j["nr_last_reject_height"] = t.nr_last_reject_height;
+
+    j["carry_cause"] = t.carry_cause;
+    j["carry_sec"]   = t.carry_sec;
+    return j;
+}
+
+inline ServeGateLedger::Totals serve_gate_ledger_from_json(const nlohmann::json& j)
+{
+    ServeGateLedger::Totals t;
+    auto u32 = [&](const char* k, uint32_t d) { return j.value(k, d); };
+    auto u64 = [&](const char* k, uint64_t d) { return j.value(k, d); };
+    auto i64 = [&](const char* k, int64_t d) { return j.value(k, d); };
+    auto str = [&](const char* k) { return j.value(k, std::string{}); };
+
+    t.schema_version     = u32("schema_version", ServeGateLedger::kSchemaVersion);
+    t.epochs             = u64("epochs", 0);
+    t.last_writer_commit = str("last_writer_commit");
+
+    t.observed_sec     = i64("observed_sec", 0);
+    t.off_embedded_sec = i64("off_embedded_sec", 0);
+    if (j.contains("per_cause_sec") && j["per_cause_sec"].is_object())
+        for (auto it = j["per_cause_sec"].begin(); it != j["per_cause_sec"].end(); ++it)
+            t.per_cause_sec[it.key()] = it.value().get<int64_t>();
+
+    t.serves_embedded_real = u64("serves_embedded_real", 0);
+    t.serves_embedded_null = u64("serves_embedded_null", 0);
+    t.serves_fallback      = u64("serves_fallback", 0);
+    t.serves_no_work       = u64("serves_no_work", 0);
+
+    t.blocks_won_embedded_real = u64("blocks_won_embedded_real", 0);
+    t.blocks_won_embedded_null = u64("blocks_won_embedded_null", 0);
+    t.blocks_won_fallback      = u64("blocks_won_fallback", 0);
+    t.blocks_submitted         = u64("blocks_submitted", 0);
+    t.blocks_confirmed         = u64("blocks_confirmed", 0);
+    t.blocks_orphaned          = u64("blocks_orphaned", 0);
+    t.local_payee_guard_rejects = u64("local_payee_guard_rejects", 0);
+
+    t.rpc_rejected_embedded_real = u64("rpc_rejected_embedded_real", 0);
+    t.rpc_rejected_embedded_null = u64("rpc_rejected_embedded_null", 0);
+    t.rpc_rejected_fallback      = u64("rpc_rejected_fallback", 0);
+    t.orphaned_embedded_real     = u64("orphaned_embedded_real", 0);
+    t.orphaned_embedded_null     = u64("orphaned_embedded_null", 0);
+    if (j.contains("rpc_reject_reasons") && j["rpc_reject_reasons"].is_object())
+        for (auto it = j["rpc_reject_reasons"].begin(); it != j["rpc_reject_reasons"].end(); ++it)
+            t.rpc_reject_reasons[it.key()] = it.value().get<uint64_t>();
+
+    t.null_dkg_floor_tips_served = u64("null_dkg_floor_tips_served", 0);
+    t.null_real_quorum_available_but_null_served =
+        u64("null_real_quorum_available_but_null_served", 0);
+
+    t.nr_span_start_height  = u64("nr_span_start_height", 0);
+    t.nr_span_last_height   = u64("nr_span_last_height", 0);
+    t.nr_total_rejects      = u64("nr_total_rejects", 0);
+    t.nr_last_reject_height = u64("nr_last_reject_height", 0);
+
+    t.carry_cause = str("carry_cause");
+    t.carry_sec   = i64("carry_sec", 0);
+    return t;
+}
+
+/// Atomic write-through: serialize `t` to `<path>.tmp`, flush+fsync, then
+/// rename over `path`. Returns false on any I/O error (the caller keeps the
+/// in-memory ledger; a failed flush loses at most one cadence of durations).
+inline bool serve_gate_ledger_save(const std::string& path,
+                                   const ServeGateLedger::Totals& t)
+{
+    const std::string tmp = path + ".tmp";
+    {
+        std::ofstream os(tmp, std::ios::binary | std::ios::trunc);
+        if (!os) return false;
+        os << serve_gate_ledger_to_json(t).dump(2);
+        os.flush();
+        if (!os) return false;
+    }
+    // Best-effort durability: rename is atomic on the same filesystem.
+    if (std::rename(tmp.c_str(), path.c_str()) != 0) {
+        std::remove(tmp.c_str());
+        return false;
+    }
+    return true;
+}
+
+/// Load a persisted ledger blob. Returns false (and leaves `out` default) when
+/// the file is absent or unparseable — a fresh node starts at epoch 0.
+inline bool serve_gate_ledger_load(const std::string& path,
+                                   ServeGateLedger::Totals& out)
+{
+    std::ifstream is(path, std::ios::binary);
+    if (!is) return false;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    if (ss.str().empty()) return false;
+    try {
+        out = serve_gate_ledger_from_json(nlohmann::json::parse(ss.str()));
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -37,6 +37,7 @@
 
 #include <impl/dash/stratum/submit_payee_guard.hpp>  // check_submit_payee (won-block stale-payee gate)
 #include <impl/dash/coin/serve_gate_rollup_json.hpp>  // serve_gate_rollup_json — #119 follow-up web leg (per-cause TIME)
+#include <impl/dash/coin/serve_gate_ledger_json.hpp>  // serve_gate_ledger_{to_json,save,load} — cumulative cross-restart accounting
 #include <impl/dash/coinbase_builder.hpp>     // compute_dash_payouts, build, split_coinb, merkle helpers
 #include <impl/dash/coin/block_producer.hpp>  // compute_merkle_root, append_compact_size, target_from_nbits
 #include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11 (X11 PoW SSOT)
@@ -1304,9 +1305,29 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
     coin::ServeGateJournal::Decision d;
     coin::ServeGateJournal::Rollup rollup;
     bool emit_rollup = false;
+    // Cumulative-ledger flush payload, captured under the lock and emitted /
+    // persisted OUTSIDE it (I/O off the held mutex; the LevelDB found-block
+    // ledger takes the same lock, and the status surface try_locks it).
+    coin::ServeGateLedger::Totals cum_totals;
+    std::string cum_path;
+    bool emit_cum = false;
     {
         std::lock_guard<std::mutex> lk(serve_gate_mutex_);
         d = serve_gate_journal_.observe(served, why.cause, now_sec);
+        // CUMULATIVE cross-restart accounting: bank the SAME decision the
+        // journal just returned, so ledger and journal cannot disagree (the
+        // ledger consumes Decision.prev_cause_sec — the exact quantity the
+        // journal folds into m_cause_totals). Embedded maps to embedded_real
+        // here; the null-arm split (embedded_null) is a follow-up that sets
+        // DashWorkData.m_qc_null_slots — until then a null serve counts as
+        // embedded_real, never as a fallback, so the never-a-reject denominator
+        // is unaffected. why.cause is ignored by the ledger while serving.
+        const auto ledger_arm =
+            served_embedded ? coin::ServeGateLedger::Arm::EmbeddedReal
+            : (served == coin::ServeGateJournal::Served::NoWork)
+                ? coin::ServeGateLedger::Arm::NoWork
+                : coin::ServeGateLedger::Arm::Fallback;
+        serve_gate_ledger_.bank_serve(ledger_arm, why.cause, d, now_sec);
         last_decline_      = served_embedded ? coin::DeclineReport{} : why;
         last_arm_embedded_ = served_embedded;
         arm_ever_observed_ = true;
@@ -1321,6 +1342,13 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             last_rollup_sec_ = now_sec;
             rollup           = serve_gate_journal_.rollup(now_sec);
             emit_rollup      = true;
+            // Piggyback the cumulative flush on the same hourly tick. Snapshot
+            // the open segment into carry (folded once on next load), copy the
+            // totals for the log line, and grab the path for the write-through.
+            serve_gate_ledger_.snapshot_carry_for_flush();
+            cum_totals = serve_gate_ledger_.totals();
+            cum_path   = serve_gate_ledger_path_;
+            emit_cum   = true;
         }
     }
 
@@ -1345,6 +1373,67 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             }
         }
         LOG_WARNING << os.str();
+    }
+
+    if (emit_cum) {
+        // Write-through FIRST (atomic tmp+rename), so the standing figure the
+        // line reports is the one now on disk; a failed write keeps the
+        // in-memory ledger and simply loses this cadence of durations. Empty
+        // path = set_serve_gate_ledger_path() was never called (the ledger
+        // still accumulates + logs, it just does not persist across restarts).
+        if (!cum_path.empty())
+            coin::serve_gate_ledger_save(cum_path, cum_totals);
+        // The operator-facing standing total: "null-arm covered the 4.51%
+        // floor, 0 rejects over N heights", carried ACROSS restarts (epochs=N).
+        // DENOMINATOR (observed) first, then the never-a-reject numerators —
+        // any reject on an embedded arm is the hard cut-stopper, so it is named
+        // explicitly and can never hide behind a percentage.
+        const bool nar =
+            cum_totals.rpc_rejected_embedded_real == 0 &&
+            cum_totals.rpc_rejected_embedded_null == 0 &&
+            cum_totals.orphaned_embedded_real == 0 &&
+            cum_totals.orphaned_embedded_null == 0;
+        const uint64_t serves_emb =
+            cum_totals.serves_embedded_real + cum_totals.serves_embedded_null;
+        const uint64_t serves_all = serves_emb + cum_totals.serves_fallback +
+                                     cum_totals.serves_no_work;
+        const uint64_t nr_span =
+            cum_totals.nr_span_start_height == 0
+                ? 0
+                : (cum_totals.nr_span_last_height -
+                   cum_totals.nr_span_start_height + 1);
+        std::ostringstream cs;
+        cs << "[EMBED-CUMULATIVE] epochs=" << cum_totals.epochs
+           << " commit=" << (cum_totals.last_writer_commit.empty()
+                                 ? "unknown" : cum_totals.last_writer_commit)
+           << " observed=" << cum_totals.observed_sec << "s"
+           << " off_embedded=" << cum_totals.off_embedded_sec << "s";
+        if (cum_totals.observed_sec > 0)
+            cs << " (" << (cum_totals.off_embedded_sec * 100 /
+                           cum_totals.observed_sec) << "% off)";
+        cs << " serves{real=" << cum_totals.serves_embedded_real
+           << " null=" << cum_totals.serves_embedded_null
+           << " fallback=" << cum_totals.serves_fallback
+           << " no_work=" << cum_totals.serves_no_work << "}";
+        if (serves_all > 0)
+            cs << " embedded=" << (serves_emb * 100 / serves_all) << "%";
+        cs << " blocks{won_real=" << cum_totals.blocks_won_embedded_real
+           << " won_null=" << cum_totals.blocks_won_embedded_null
+           << " won_fallback=" << cum_totals.blocks_won_fallback
+           << " submitted=" << cum_totals.blocks_submitted
+           << " confirmed=" << cum_totals.blocks_confirmed
+           << " orphaned=" << cum_totals.blocks_orphaned << "}"
+           << " rejects{rpc_real=" << cum_totals.rpc_rejected_embedded_real
+           << " rpc_null=" << cum_totals.rpc_rejected_embedded_null
+           << " rpc_fallback=" << cum_totals.rpc_rejected_fallback
+           << " payee_guard=" << cum_totals.local_payee_guard_rejects << "}"
+           << " null_arm{dkg_floor=" << cum_totals.null_dkg_floor_tips_served
+           << " real_quorum_but_null="
+           << cum_totals.null_real_quorum_available_but_null_served << "}"
+           << " never_a_reject=" << (nar ? "true" : "false")
+           << " reject_free_span=" << nr_span << "h"
+           << " total_rejects=" << cum_totals.nr_total_rejects;
+        LOG_WARNING << cs.str();
     }
 
     // A CAUSE SEGMENT closed on THIS decision (a cause change or a resume):
@@ -1587,6 +1676,11 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
                                  .count();
         j["gate_rollup"] =
             coin::serve_gate_rollup_json(serve_gate_journal_.rollup(now_sec));
+        // CUMULATIVE cross-restart companion (the per-process gate_rollup above
+        // wipes on restart; this survives via the persisted ledger, epochs=N).
+        // Same lock already held; the ledger is a plain in-memory aggregate.
+        j["gate_rollup_cumulative"] =
+            coin::serve_gate_ledger_to_json(serve_gate_ledger_.totals());
     }
     if (!arm_ever_observed_) {
         j["arm"]               = "unknown";
@@ -2488,6 +2582,27 @@ void DASHWorkSource::set_mint_share_fn(MintShareFn fn)
 {
     std::lock_guard<std::mutex> lk(mint_share_mutex_);
     mint_share_fn_ = std::move(fn);
+}
+
+void DASHWorkSource::set_serve_gate_ledger_path(const std::string& path,
+                                                const std::string& writer_commit)
+{
+    std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+    serve_gate_ledger_path_ = path;
+    // Restore any persisted blob so the cumulative figure carries across this
+    // restart (folds the previous process's open-segment carry exactly once,
+    // bumps epochs). Absent/unparseable => fresh at epoch 0. load() is called
+    // unconditionally so epochs increments even from a default blob.
+    coin::ServeGateLedger::Totals persisted;
+    coin::serve_gate_ledger_load(path, persisted);  // best-effort; leaves default on miss
+    serve_gate_ledger_.load(persisted);
+    serve_gate_ledger_.set_writer_commit(writer_commit);
+    LOG_INFO << "[EMBED-CUMULATIVE] ledger restored: epochs="
+             << serve_gate_ledger_.totals().epochs
+             << " observed=" << serve_gate_ledger_.totals().observed_sec << "s"
+             << " never_a_reject="
+             << (serve_gate_ledger_.never_a_reject() ? "true" : "false")
+             << " path=" << path;
 }
 
 void DASHWorkSource::set_pplns_weights_fn(PplnsWeightsFn fn)

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -60,6 +60,7 @@
 
 #include <impl/dash/coin/node_coin_state.hpp>   // coin::NodeCoinState, coin::DashWorkData seam
 #include <impl/dash/coin/serve_gate_journal.hpp> // coin::ServeGateJournal — decline rate policy (DEFECT-3)
+#include <impl/dash/coin/serve_gate_ledger.hpp>  // coin::ServeGateLedger — cumulative cross-restart never-a-reject accounting
 #include <impl/dash/coin/embedded_shadow_compare.hpp> // coin::EmbeddedShadowCompare — OBSERVE-only serve-vs-dashd diff
 #include <impl/dash/stratum/get_work.hpp>       // dash::stratum::get_work() fused capstone
 
@@ -454,6 +455,18 @@ public:
                            const std::string& miner, bool reached_network)>;
     void set_on_found_block_fn(FoundBlockFn fn);
 
+    /// Wire the CUMULATIVE cross-restart serve-gate ledger to its persisted
+    /// backing file (<data-dir>/<net_subdir>/serve_gate_ledger.json). Loads any
+    /// existing blob (folding the previous process's carry, bumping epochs) and
+    /// stamps `writer_commit` (C2POOL_VERSION) so the standing figure always
+    /// names the binary that produced it. Idempotent-ish: call ONCE at wiring
+    /// time, before the first template is sourced. While unset the ledger still
+    /// accumulates in memory and logs [EMBED-CUMULATIVE], it just never persists
+    /// across a restart — so this call is what turns the per-process figure into
+    /// the standing, cut-gate figure.
+    void set_serve_gate_ledger_path(const std::string& path,
+                                    const std::string& writer_commit);
+
     /// Wire the sharechain mint dispatch (stage 4d follow-up). While unbound,
     /// share-target submissions are accepted for vardiff + loudly logged.
     void set_mint_share_fn(MintShareFn fn);
@@ -767,6 +780,19 @@ private:
     // first arm decision, so the first observation seeds the cadence without
     // emitting an empty summary. Guarded by serve_gate_mutex_.
     mutable int64_t                 last_rollup_sec_{-1};
+
+    // CUMULATIVE cross-restart never-a-reject accounting. ServeGateJournal wipes
+    // on restart (its clock is process-monotonic steady_clock seconds), so the
+    // program-level "% embedded / never-a-reject" figure is per-process. The
+    // ledger banks the SAME events the journal sees (from note_arm_decision,
+    // under serve_gate_mutex_) into cumulative totals, persisted write-through
+    // to serve_gate_ledger_path_ (atomic tmp+rename) on the hourly roll-up tick
+    // so the standing claim survives >=3 restarts. Guarded by serve_gate_mutex_.
+    mutable coin::ServeGateLedger    serve_gate_ledger_;
+    // Persisted backing file; empty until set_serve_gate_ledger_path() (then the
+    // ledger accumulates in memory + logs, but never persists). Set once at
+    // wiring time; read on the hourly flush. Guarded by serve_gate_mutex_.
+    std::string                      serve_gate_ledger_path_;
 
     // ── Serve-staleness observation (lock-free by requirement) ─────────────
     // Written on the serve path (get_current_work_template /

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -318,6 +318,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_serve_gate_journal PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_serve_gate_journal "" AUTO)
 
+    # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
+    # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on
+    # restart; the ledger survives via write-through JSON). Pure-policy header +
+    # JSON companion; the KAT does a real atomic save->load round-trip through a
+    # temp file. Same link set as the journal KAT.
+    add_executable(test_dash_serve_gate_ledger test_dash_serve_gate_ledger.cpp)
+    target_link_libraries(test_dash_serve_gate_ledger PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_serve_gate_ledger PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
+    gtest_add_tests(test_dash_serve_gate_ledger "" AUTO)
+
     # DASH S8 pool-node leaf 4 — share_tracker.hpp KAT: DensePPLNSWindow decayed
     # weight ring buffer (compute_v36_weights), decay table, donation split,
     # window slides. PoW-independent consensus core; socket-free, chain-free.

--- a/test/test_dash_serve_gate_ledger.cpp
+++ b/test/test_dash_serve_gate_ledger.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// ServeGateLedger cross-restart never-a-reject accounting KAT.
+///
+/// THE DEFECT THIS PINS (critic, 2026-08-23): the EMBED-GATE roll-up and every
+/// ServeGateJournal counter are in-process members fed a process-monotonic
+/// steady_clock, so they WIPE on every restart. The dashd-cut acceptance gate
+/// is a CUMULATIVE never-a-reject claim spanning >=3 restarts ("the null-arm
+/// covered the 4.51% DKG floor, 0 rejects over N heights") — a claim the
+/// journal structurally cannot carry across a restart.
+///
+/// RED (without ServeGateLedger, or with a journal-style wipe): after a
+/// simulated restart every cumulative count reads 0 and the never-a-reject span
+/// resets, so the standing claim is unprovable.
+/// GREEN (with ServeGateLedger): counts survive save→load, epochs increments,
+/// the open-segment carry folds exactly once (no double-count), and a reject
+/// increments the reject counter AND breaks the never-a-reject span.
+///
+/// Pure-policy suite: the ledger takes caller-supplied monotonic seconds, no
+/// clock of its own; persistence is a real atomic tmp+rename round-trip through
+/// a temp file (the JSON companion), never a hand-rebuilt shape.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+#include <impl/dash/coin/serve_gate_ledger.hpp>
+#include <impl/dash/coin/serve_gate_ledger_json.hpp>
+
+using dash::coin::ServeGateJournal;
+using dash::coin::ServeGateLedger;
+using Arm = ServeGateLedger::Arm;
+
+namespace {
+
+std::string temp_ledger_path(const char* stem) {
+    auto p = std::filesystem::temp_directory_path() /
+             (std::string("c2pool_ledger_kat_") + stem + "_" +
+              std::to_string(::getpid()) + ".json");
+    std::filesystem::remove(p);
+    return p.string();
+}
+
+// A ledger banking the SAME Decision the journal returns must agree with the
+// journal's own closed-segment histogram to the second — that is the whole
+// point of feeding it Decision.prev_cause_sec rather than a re-derived number.
+TEST(DashServeGateLedger, LedgerAndJournalCannotDisagree) {
+    ServeGateJournal j(300);
+    ServeGateLedger  led;
+    const int64_t t0 = 1000;
+
+    // A 40 s qc-plan-underivable segment, then a 10 s dmn-stale segment, then
+    // resume. Feed every observation to both; bank the ledger from the journal
+    // Decision so they read the same closed-segment durations.
+    auto feed_decline = [&](const std::string& cause, int64_t t) {
+        auto d = j.observe(false, cause, t);
+        led.bank_serve(Arm::Fallback, cause, d, t);
+    };
+    auto feed_serve = [&](int64_t t) {
+        auto d = j.observe(true, "", t);
+        led.bank_serve(Arm::EmbeddedReal, "", d, t);
+    };
+
+    for (int64_t t = t0; t < t0 + 40; ++t) feed_decline("qc-plan-underivable", t);
+    for (int64_t t = t0 + 40; t < t0 + 50; ++t) feed_decline("dmn-stale", t);
+    feed_serve(t0 + 50);  // resume: closes the final (dmn-stale) segment
+
+    auto roll = j.rollup(t0 + 50);
+    const auto& T = led.totals();
+    // off_embedded matches the journal's closed-segment total.
+    EXPECT_EQ(T.off_embedded_sec, roll.off_embedded_sec);
+    EXPECT_EQ(T.per_cause_sec.at("qc-plan-underivable"), 40);
+    EXPECT_EQ(T.per_cause_sec.at("dmn-stale"), 10);
+    // observed_sec = wall clock spanned by the banked deltas (t0 .. t0+50).
+    EXPECT_EQ(T.observed_sec, 50);
+}
+
+// The load-bearing cross-restart test: counts survive save→load, epochs
+// increments, and the open-segment carry folds EXACTLY once.
+TEST(DashServeGateLedger, CrossRestartPersistsAndFoldsCarryOnce) {
+    const std::string path = temp_ledger_path("restart");
+    ServeGateJournal j(300);
+
+    // ── epoch 1 ──────────────────────────────────────────────────────────
+    ServeGateLedger led1;
+    led1.set_writer_commit("deadbeefcafe");
+    const int64_t t0 = 500;
+    // 20 s serving (embedded_real), banking observed_sec deltas.
+    for (int64_t t = t0; t < t0 + 20; ++t) {
+        auto d = j.observe(true, "", t);
+        led1.bank_serve(Arm::EmbeddedReal, "", d, t);
+    }
+    // Then decline into an OPEN qc-plan-underivable segment for 30 s, never
+    // resumed (the process is about to "crash").
+    for (int64_t t = t0 + 20; t < t0 + 50; ++t) {
+        auto d = j.observe(false, "qc-plan-underivable", t);
+        led1.bank_serve(Arm::Fallback, "qc-plan-underivable", d, t);
+    }
+    // A won embedded_real block at height 100 (extends the clean span).
+    led1.record_block_won(Arm::EmbeddedReal, 100);
+    led1.record_rpc_verdict(Arm::EmbeddedReal, 100, /*accepted=*/true, "");
+
+    // Flush: snapshot the open 30 s segment into carry, write-through.
+    led1.snapshot_carry_for_flush();
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_save(path, led1.totals()));
+
+    const auto T1 = led1.totals();
+    EXPECT_EQ(T1.serves_embedded_real, 20u);
+    EXPECT_EQ(T1.serves_fallback, 30u);
+    EXPECT_EQ(T1.off_embedded_sec, 0);         // segment still OPEN, not banked
+    EXPECT_EQ(T1.carry_sec, 29);               // open-segment partial in carry
+    EXPECT_EQ(T1.carry_cause, "qc-plan-underivable");
+    EXPECT_EQ(T1.epochs, 0u);                  // not loaded yet
+    EXPECT_EQ(T1.blocks_won_embedded_real, 1u);
+
+    // ── restart: epoch 2 ─────────────────────────────────────────────────
+    ServeGateLedger::Totals loaded;
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_load(path, loaded));
+    ServeGateLedger led2;
+    led2.load(loaded);
+    const auto& T2 = led2.totals();
+
+    // Counts SURVIVED the restart (the journal cannot do this).
+    EXPECT_EQ(T2.serves_embedded_real, 20u);
+    EXPECT_EQ(T2.serves_fallback, 30u);
+    EXPECT_EQ(T2.blocks_won_embedded_real, 1u);
+    EXPECT_EQ(T2.observed_sec, T1.observed_sec);        // wall clock preserved
+    EXPECT_EQ(T2.last_writer_commit, "deadbeefcafe");
+    // epochs incremented.
+    EXPECT_EQ(T2.epochs, 1u);
+    // Carry folded exactly once into the cumulative total, then cleared.
+    EXPECT_EQ(T2.off_embedded_sec, 29);
+    EXPECT_EQ(T2.per_cause_sec.at("qc-plan-underivable"), 29);
+    EXPECT_EQ(T2.carry_sec, 0);
+    EXPECT_TRUE(T2.carry_cause.empty());
+
+    // ── save again + load AGAIN: the carry must NOT fold a second time ────
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_save(path, led2.totals()));
+    ServeGateLedger::Totals loaded2;
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_load(path, loaded2));
+    ServeGateLedger led3;
+    led3.load(loaded2);
+    const auto& T3 = led3.totals();
+    EXPECT_EQ(T3.off_embedded_sec, 29);                 // NOT 58 — no double-count
+    EXPECT_EQ(T3.per_cause_sec.at("qc-plan-underivable"), 29);
+    EXPECT_EQ(T3.epochs, 2u);                           // three lifetimes total
+
+    std::filesystem::remove(path);
+}
+
+// A reject increments the per-arm reject counter AND breaks the never-a-reject
+// span; the never_a_reject() cut gate flips false and stays false.
+TEST(DashServeGateLedger, RejectBreaksNeverARejectSpan) {
+    ServeGateLedger led;
+    EXPECT_TRUE(led.never_a_reject());
+    EXPECT_EQ(led.clean_span_heights(), 0u);
+
+    // Clean run: three embedded blocks accepted over heights 2000..2002.
+    for (uint64_t h = 2000; h <= 2002; ++h) {
+        led.record_block_won(Arm::EmbeddedReal, h);
+        led.record_rpc_verdict(Arm::EmbeddedReal, h, /*accepted=*/true, "");
+    }
+    EXPECT_TRUE(led.never_a_reject());
+    EXPECT_EQ(led.clean_span_heights(), 3u);            // 2000..2002 inclusive
+    EXPECT_EQ(led.totals().nr_total_rejects, 0u);
+
+    // A reject on an embedded_real block at 2003.
+    led.record_block_won(Arm::EmbeddedReal, 2003);
+    led.record_rpc_verdict(Arm::EmbeddedReal, 2003, /*accepted=*/false,
+                           "bad-cb-payee");
+    EXPECT_FALSE(led.never_a_reject());                 // hard gate tripped
+    EXPECT_EQ(led.totals().rpc_rejected_embedded_real, 1u);
+    EXPECT_EQ(led.totals().nr_total_rejects, 1u);
+    EXPECT_EQ(led.totals().nr_last_reject_height, 2003u);
+    EXPECT_EQ(led.totals().rpc_reject_reasons.at("bad-cb-payee"), 1u);
+    // Span reset by the reject.
+    EXPECT_EQ(led.clean_span_heights(), 0u);
+}
+
+// A validity-attributable orphan on an embedded arm is a SILENT reject: it
+// breaks the span too. A race orphan (validity_attributable=false) does not.
+TEST(DashServeGateLedger, ValidityOrphanBreaksSpanRaceOrphanDoesNot) {
+    ServeGateLedger led;
+    led.record_block_won(Arm::EmbeddedNull, 3000);
+    led.record_block_won(Arm::EmbeddedNull, 3001);
+    EXPECT_EQ(led.clean_span_heights(), 2u);
+
+    // Race orphan: disambiguated by the RPC verdict as NOT validity-caused.
+    led.record_orphan(Arm::EmbeddedNull, 3001, /*validity_attributable=*/false);
+    EXPECT_TRUE(led.never_a_reject());
+    EXPECT_EQ(led.clean_span_heights(), 2u);            // untouched
+
+    // Validity orphan: a silent reject on the null arm.
+    led.record_orphan(Arm::EmbeddedNull, 3001, /*validity_attributable=*/true);
+    EXPECT_FALSE(led.never_a_reject());
+    EXPECT_EQ(led.totals().orphaned_embedded_null, 1u);
+    EXPECT_EQ(led.clean_span_heights(), 0u);
+}
+
+// Null-arm first class: a null served where NO real quorum existed is the
+// correct DKG-floor case; a null served where a real quorum WAS available is
+// the defect the cut gate forbids (must stay 0).
+TEST(DashServeGateLedger, NullArmDkgFloorVsRealQuorumAvailable) {
+    ServeGateLedger led;
+    ServeGateJournal j(300);
+    auto d = j.observe(true, "", 10);  // a serving decision
+
+    // Correct: null over the DKG floor, no real quorum available.
+    led.bank_serve(Arm::EmbeddedNull, "", d, 10, /*real_quorum_available=*/false);
+    EXPECT_EQ(led.totals().serves_embedded_null, 1u);
+    EXPECT_EQ(led.totals().null_dkg_floor_tips_served, 1u);
+    EXPECT_EQ(led.totals().null_real_quorum_available_but_null_served, 0u);
+
+    // Defect: a null served while a real committed quorum existed.
+    led.bank_serve(Arm::EmbeddedNull, "", d, 11, /*real_quorum_available=*/true);
+    EXPECT_EQ(led.totals().null_dkg_floor_tips_served, 1u);
+    EXPECT_EQ(led.totals().null_real_quorum_available_but_null_served, 1u);
+}
+
+// observed_sec accumulates DELTAS, so it is monotone across a restart and never
+// depends on the absolute (process-monotonic) clock value. A second process
+// whose clock starts far lower must still ADD its wall clock, not reset.
+TEST(DashServeGateLedger, ObservedSecIsDeltaAccumulatedAcrossRestart) {
+    ServeGateJournal j(300);
+
+    ServeGateLedger a;
+    for (int64_t t = 9000; t < 9010; ++t)  // process A clock: high
+        a.bank_serve(Arm::EmbeddedReal, "", j.observe(true, "", t), t);
+    EXPECT_EQ(a.totals().observed_sec, 9);
+
+    // Restart: process B clock starts LOW (5). Deltas, not absolutes.
+    ServeGateLedger b;
+    b.load(a.totals());
+    EXPECT_EQ(b.totals().observed_sec, 9);              // carried forward
+    ServeGateJournal j2(300);
+    for (int64_t t = 5; t < 15; ++t)                    // 9 s more
+        b.bank_serve(Arm::EmbeddedReal, "", j2.observe(true, "", t), t);
+    EXPECT_EQ(b.totals().observed_sec, 18);             // 9 + 9, monotone
+}
+
+}  // namespace


### PR DESCRIPTION
## What

A **cumulative, cross-restart never-a-reject accounting ledger** for the DASH embedded serve gate — the persisted companion to `ServeGateJournal`.

**The gap (critic, 2026-08-23):** `ServeGateJournal` and its `[EMBED-GATE-ROLLUP]` are in-process members fed a process-monotonic `steady_clock`, so the whole roll-up **wipes on every restart**. The dashd-cut acceptance gate is a *cumulative* never-a-reject claim spanning **>=3 restarts** ("null-arm covered the 4.51% DKG floor, 0 rejects over N heights") — structurally unprovable from the journal.

## How

- **`serve_gate_ledger.hpp`** — pure policy (no I/O, no clock, no JSON), mirrors the journal. Banks the **same** events the journal sees, consuming `Decision.prev_cause_sec` (exactly what the journal folds into `m_cause_totals`) so ledger and journal cannot disagree. `observed_sec` accumulates **deltas** (only durations cross processes); the open segment rides a **replaced carry** field folded **exactly once** on load — crash loses <=1 flush, never double-counts. Null-arm is first class (`null_dkg_floor_tips_served` vs `null_real_quorum_available_but_null_served`, which must stay `0`). Rolling never-a-reject height span; `never_a_reject()` is the hard cut gate.
- **`serve_gate_ledger_json.hpp`** — one serialize/atomic-persist (`tmp`+`rename`) definition, schema v1 with `epochs` + `last_writer_commit` (measurement-without-commit).
- **Wiring** — banked in `note_arm_decision` under `serve_gate_mutex_`; the existing hourly roll-up tick additionally flushes write-through to `<data-dir>/<net_subdir>/serve_gate_ledger.json` and emits **`[EMBED-CUMULATIVE]`** (standing totals) + `gate_rollup_cumulative` on the web surface. Restored on startup (`set_serve_gate_ledger_path`, folds prior carry, bumps epochs).

## Test (red/green)

New linking target **`test_dash_serve_gate_ledger`** (6 cases): cross-restart persistence + carry-fold-once (no double count) + epoch merge; reject-breaks-never-a-reject-span; validity-orphan vs race-orphan; null-arm classification; delta-accumulated `observed_sec` across a restart. Verified **red** with a journal-style wipe and a reject-not-counted defect, **green** with the ledger.

Built + tested on workstation-191: KAT `[PASSED] 6 tests`; full `c2pool-dash` binary links green; `work_source.cpp` + `main_dash.cpp` TUs compile clean.

## Scope / safety

**Telemetry/accounting only — no serve, submit, or payout path altered.** The `ServeGateJournal` enum and its four timing KATs are untouched. Block-won arm attribution + reject-reason persistence (`FoundBlockRecord` v2) is a follow-up; this PR provides the ledger API those hooks call.

**Do not merge** pending review.
