### PR TITLE
dash daemonless: cross-restart cumulative serve-gate accounting + QC-NULL-SERVE counters (#127 null-arm soak measurability)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -302,6 +302,12 @@ std::string g_replay_mnlist_seed_file;        // --replay-mnlist-seed-file FILE 
 // serve are both fine WITHOUT proving the serve is daemonless.
 bool        g_no_dashd_mn_seed = false;       // --embedded-no-dashd-mn-seed
 
+// --serve-gate-state-file: path to the cross-restart cumulative serve-gate
+// accounting state (JSON). Empty (default) => OFF; the serve path is
+// byte-identical. Non-consensus, non-reward: a soak convenience whose
+// bad read fails to a clean zero and never wedges the node.
+std::string g_serve_gate_state_file;           // --serve-gate-state-file
+
 // ── PR-2 FORWARD: --replay-mined-commitment-index ─────────────────────────
 // Arms the forward half of dashd's mined-commitment store
 // (mined_commitment_index.hpp, ported from v23.1.7 llmq/blockprocessor.cpp)
@@ -2810,6 +2816,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // consulted, i.e. during an actual embedded outage.
     const bool xcheck_wanted = (testnet || embedded_mainnet);
     work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
+    // Cross-restart cumulative serve-gate accounting. Empty path keeps the
+    // per-process behaviour byte-for-byte; when set, note_arm_decision()
+    // write-throughs the combined prior+live roll-up + QC-NULL-SERVE
+    // counters so a STANDING soak is readable across restarts.
+    work_source->set_serve_gate_state_file(g_serve_gate_state_file);
+    if (!g_serve_gate_state_file.empty())
+        std::cout << "[run] serve-gate cumulative accounting ARMED: state="
+                  << g_serve_gate_state_file << "\n";
     // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
     // either way: with it off the donation still misses every swapped
     // template -- it just no longer does so silently.
@@ -8919,6 +8933,12 @@ int main(int argc, char** argv)
             bestcl_policy = argv[++i];
         else if (std::strcmp(argv[i], "--coinbase-text") == 0 && i + 1 < argc)
             coinbase_text = argv[++i];
+        // Cross-restart cumulative serve-gate accounting (#127 follow-up):
+        // path to a small JSON state file. Empty (default) => OFF and the
+        // serve path is byte-identical. Non-consensus, non-reward: a soak
+        // convenience whose bad read fails to a clean zero, never wedges.
+        else if (std::strcmp(argv[i], "--serve-gate-state-file") == 0 && i + 1 < argc)
+            g_serve_gate_state_file = argv[++i];
         else if (std::strcmp(argv[i], "--embedded-oracle-shadow") == 0)
             embedded_oracle_shadow = true;
         else if (std::strcmp(argv[i], "--embedded-shadow-compare") == 0)

--- a/src/impl/dash/coin/serve_gate_persist.hpp
+++ b/src/impl/dash/coin/serve_gate_persist.hpp
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// CUMULATIVE, CROSS-RESTART persistence for the serve-gate roll-up, plus the
+/// explicit QC null-arm serve counters that make the 4.51% DKG-floor coverage
+/// and the never-a-reject conjunct measurable PROGRAM-LEVEL over a standing
+/// soak instead of only within a single process.
+///
+/// THE DEFECT THIS CLOSES (measured on hotel-primary, 2026-08-23): the
+/// [EMBED-GATE-ROLLUP] denominator `observed=` equalled wall-clock since the
+/// LAST restart — 7211 s at the 06:00 tick for a 04:00 restart — because
+/// ServeGateJournal is deliberately pure policy (no I/O, no clock of its own)
+/// and every counter it holds resets when the process does. So the gate that
+/// actually matters for the dashd cut — "the null-arm covered the 4.51% DKG
+/// floor with 0 rejects over a STANDING soak" — cannot be read program-level:
+/// each restart zeroes the numerators and the denominator, and there is no
+/// explicit null-served counter at all (null-serving is only inferable from
+/// the '(was null-served)' instant-upgrade log lines, which the arm emits only
+/// on the null->real transition, never on a plain null serve).
+///
+/// This header is the I/O layer ServeGateJournal refuses to be — kept OUT of
+/// serve_gate_journal.hpp on purpose, exactly as serve_gate_rollup_json.hpp is,
+/// so that header stays pure. It maintains a small JSON state file:
+///
+///   * load_serve_gate_state() reads the PRIOR-process totals at startup and
+///     bumps restart_count (a missing OR corrupt file yields a clean zero — a
+///     soak state file is a convenience, never a consensus input, so a bad
+///     read must never wedge the node);
+///   * combine() folds the CURRENT process's live ServeGateJournal::Rollup and
+///     its live-incremented QcNullServeCounters on top of the frozen prior;
+///   * save_serve_gate_state_atomic() write-throughs that combined view via a
+///     temp-file + rename, so a crash mid-write can never truncate the state.
+///
+/// DOUBLE-COUNT SAFETY — the file holds ONLY prior-process totals, frozen at
+/// the moment of load. combine() = prior + live, and `live` is the process's
+/// own already-cumulative rollup / monotonic counters, so writing on EVERY
+/// roll-up tick REPLACES the live part rather than adding it: N writes within
+/// one process produce the identical total as one write. There is no path that
+/// folds this process's contribution into `prior`, so re-saving is idempotent.
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+
+namespace dash {
+namespace coin {
+
+/// Explicit, per-LLMQ-type tallies over the DKG mining-window (required,
+/// not-yet-mined) tips the null-arm governs, plus the global never-a-reject
+/// conjunct. These are EVENT counts (not seconds): the current process
+/// increments them live and combine() sums them onto the persisted prior.
+///
+/// INVARIANT (held by note()): for every type,
+///     window_open[t] == null_served[t] + real_served[t] + fell_back[t].
+/// A required mining-window tip is encountered exactly once and takes exactly
+/// one of the three dispositions:
+///   * NullServed — no verified real commitment cached AND the freshness
+///                  predicate held (has_mined==false on a view proven current
+///                  at pindexPrev): the byte-parity null was served, dashd's
+///                  own null-then-real cadence;
+///   * RealServed — a verified real commitment existed for the slot, so the
+///                  null-arm was NEVER consulted (verified_for precedes
+///                  null_evidence): the serve-exactness guarantee, counted;
+///   * FellBack   — freshness was unproven, so the whole height failed closed
+///                  to the fallback (today's benign 4.51% gap, never a reject).
+struct QcNullServeCounters {
+    enum class Disposition { NullServed, RealServed, FellBack };
+
+    std::map<int, int64_t> window_open;   ///< required mining-window tips seen
+    std::map<int, int64_t> null_served;   ///< served the byte-parity null
+    std::map<int, int64_t> real_served;   ///< a verified real commitment existed
+    std::map<int, int64_t> fell_back;     ///< freshness unproven => fail-closed
+
+    /// The never-a-reject conjunct. submits_from_null counts block submissions
+    /// whose template carried at least one null commitment; rejects_from_null
+    /// counts how many the NETWORK rejected. The soak gate is
+    /// rejects_from_null == 0 for submits_from_null > 0. The reject door is a
+    /// consensus verdict on the whole block, not a per-LLMQ-type fact, so this
+    /// pair is global, not typed.
+    int64_t submits_from_null{0};
+    int64_t rejects_from_null{0};
+
+    /// Record one required mining-window tip and its disposition. Bumps
+    /// window_open AND exactly one disposition, preserving the invariant above.
+    void note(int llmq_type, Disposition d) {
+        window_open[llmq_type] += 1;
+        switch (d) {
+            case Disposition::NullServed: null_served[llmq_type] += 1; break;
+            case Disposition::RealServed: real_served[llmq_type] += 1; break;
+            case Disposition::FellBack:   fell_back[llmq_type]   += 1; break;
+        }
+    }
+
+    /// Record one block submission from a null-carrying template and whether
+    /// the network rejected it. `rejected` must be false on every real soak;
+    /// the counter exists so a single reject is loud and cumulative.
+    void note_submit(bool rejected) {
+        submits_from_null += 1;
+        if (rejected) rejects_from_null += 1;
+    }
+
+    /// prior + live: sum every typed bucket and both global counters. Used by
+    /// combine() to fold the live process onto the frozen persisted prior.
+    void add(const QcNullServeCounters& o) {
+        for (const auto& kv : o.window_open) window_open[kv.first] += kv.second;
+        for (const auto& kv : o.null_served) null_served[kv.first] += kv.second;
+        for (const auto& kv : o.real_served) real_served[kv.first] += kv.second;
+        for (const auto& kv : o.fell_back)   fell_back[kv.first]   += kv.second;
+        submits_from_null += o.submits_from_null;
+        rejects_from_null += o.rejects_from_null;
+    }
+
+    static int64_t sum(const std::map<int, int64_t>& m) {
+        int64_t s = 0;
+        for (const auto& kv : m) s += kv.second;
+        return s;
+    }
+    int64_t total_window_open() const { return sum(window_open); }
+    int64_t total_null_served() const { return sum(null_served); }
+    int64_t total_real_served() const { return sum(real_served); }
+    int64_t total_fell_back()   const { return sum(fell_back); }
+};
+
+/// The ON-DISK cumulative state: prior-process roll-up totals + the null-serve
+/// counters + a restart counter. combine() produces the value that is BOTH
+/// persisted and printed; load/save move it through the JSON state file.
+struct ServeGateCumulative {
+    /// Number of processes that have contributed to this file (bumped once per
+    /// load). Distinguishes "one long clean run" from "N restarts covered the
+    /// floor" — the standing-soak claim needs it.
+    int64_t restart_count{0};
+    /// Cumulative wall clock OBSERVED across all processes (the denominator);
+    /// the sum of each process's ServeGateJournal::Rollup::observed_sec.
+    int64_t observed_sec{0};
+    /// Cumulative seconds off the embedded arm across all processes.
+    int64_t off_embedded_sec{0};
+    /// Cumulative per-cause seconds across all processes.
+    std::map<std::string, int64_t> cause_totals;
+    /// Cumulative null-arm serve counters across all processes.
+    QcNullServeCounters null_serve;
+};
+
+/// prior (frozen, from the file) + this process's live rollup and counters.
+/// restart_count and every prior total ride through unchanged; only the live
+/// deltas are added. Because `prior` never absorbs the live part, calling this
+/// on every roll-up tick and re-saving is idempotent (replace, not add).
+inline ServeGateCumulative combine(const ServeGateCumulative& prior,
+                                   const ServeGateJournal::Rollup& live_time,
+                                   const QcNullServeCounters& live_counters) {
+    ServeGateCumulative c = prior;
+    c.observed_sec     += live_time.observed_sec;
+    c.off_embedded_sec += live_time.off_embedded_sec;
+    for (const auto& pc : live_time.per_cause)
+        c.cause_totals[pc.first] += pc.second;
+    c.null_serve.add(live_counters);
+    return c;
+}
+
+// ── JSON shape ──────────────────────────────────────────────────────────────
+// std::map<int,int64_t> serializes as a JSON object with STRING keys ("4":13),
+// the natural shape for an LLMQ-type-keyed histogram. All numeric fields are
+// int64 so the denominator never silently narrows on a long soak.
+
+inline nlohmann::json to_json(const std::map<int, int64_t>& m) {
+    nlohmann::json j = nlohmann::json::object();
+    for (const auto& kv : m) j[std::to_string(kv.first)] = kv.second;
+    return j;
+}
+
+inline std::map<int, int64_t> int_map_from_json(const nlohmann::json& j) {
+    std::map<int, int64_t> m;
+    if (j.is_object())
+        for (auto it = j.begin(); it != j.end(); ++it)
+            m[std::stoi(it.key())] = it.value().get<int64_t>();
+    return m;
+}
+
+inline nlohmann::json to_json(const QcNullServeCounters& n) {
+    nlohmann::json j = nlohmann::json::object();
+    j["window_open"]       = to_json(n.window_open);
+    j["null_served"]       = to_json(n.null_served);
+    j["real_served"]       = to_json(n.real_served);
+    j["fell_back"]         = to_json(n.fell_back);
+    j["submits_from_null"] = n.submits_from_null;
+    j["rejects_from_null"] = n.rejects_from_null;
+    return j;
+}
+
+inline QcNullServeCounters null_counters_from_json(const nlohmann::json& j) {
+    QcNullServeCounters n;
+    if (!j.is_object()) return n;
+    if (j.contains("window_open")) n.window_open = int_map_from_json(j["window_open"]);
+    if (j.contains("null_served")) n.null_served = int_map_from_json(j["null_served"]);
+    if (j.contains("real_served")) n.real_served = int_map_from_json(j["real_served"]);
+    if (j.contains("fell_back"))   n.fell_back   = int_map_from_json(j["fell_back"]);
+    if (j.contains("submits_from_null")) n.submits_from_null = j["submits_from_null"].get<int64_t>();
+    if (j.contains("rejects_from_null")) n.rejects_from_null = j["rejects_from_null"].get<int64_t>();
+    return n;
+}
+
+inline nlohmann::json to_json(const ServeGateCumulative& c) {
+    nlohmann::json j = nlohmann::json::object();
+    j["restart_count"]    = c.restart_count;
+    j["observed_sec"]     = c.observed_sec;
+    j["off_embedded_sec"] = c.off_embedded_sec;
+    j["cause_totals"]     = c.cause_totals;  // std::map<string,int64> -> object
+    j["null_serve"]       = to_json(c.null_serve);
+    return j;
+}
+
+inline ServeGateCumulative cumulative_from_json(const nlohmann::json& j) {
+    ServeGateCumulative c;
+    if (!j.is_object()) return c;
+    if (j.contains("restart_count"))    c.restart_count    = j["restart_count"].get<int64_t>();
+    if (j.contains("observed_sec"))     c.observed_sec     = j["observed_sec"].get<int64_t>();
+    if (j.contains("off_embedded_sec")) c.off_embedded_sec = j["off_embedded_sec"].get<int64_t>();
+    if (j.contains("cause_totals") && j["cause_totals"].is_object())
+        for (auto it = j["cause_totals"].begin(); it != j["cause_totals"].end(); ++it)
+            c.cause_totals[it.key()] = it.value().get<int64_t>();
+    if (j.contains("null_serve")) c.null_serve = null_counters_from_json(j["null_serve"]);
+    return c;
+}
+
+// ── load / atomic save ──────────────────────────────────────────────────────
+
+/// Read the prior cumulative state from `path`. A missing OR unparseable file
+/// yields a clean zero state (the soak file is a convenience, never a consensus
+/// input — a bad read must not wedge the node). When `bump_restart` is true
+/// (the production default: one call per process at startup) restart_count is
+/// incremented, so the file records how many processes have covered the soak.
+inline ServeGateCumulative load_serve_gate_state(const std::string& path,
+                                                 bool bump_restart = true) {
+    ServeGateCumulative c;
+    std::ifstream in(path);
+    if (in) {
+        try {
+            nlohmann::json j;
+            in >> j;
+            c = cumulative_from_json(j);
+        } catch (...) {
+            c = ServeGateCumulative{};  // corrupt => clean zero, still counted
+        }
+    }
+    if (bump_restart) c.restart_count += 1;
+    return c;
+}
+
+/// Write `c` to `path` atomically: serialize to `path + ".tmp"`, flush, then
+/// rename over `path`. A crash before the rename leaves the previous good file
+/// intact; a crash after leaves the new one — a reader never sees a truncated
+/// state. Returns false (without touching `path`) on any I/O failure.
+inline bool save_serve_gate_state_atomic(const std::string& path,
+                                         const ServeGateCumulative& c) {
+    const std::string tmp = path + ".tmp";
+    {
+        std::ofstream out(tmp, std::ios::out | std::ios::trunc);
+        if (!out) return false;
+        out << to_json(c).dump(2) << '\n';
+        out.flush();
+        if (!out) {
+            out.close();
+            std::remove(tmp.c_str());
+            return false;
+        }
+    }
+    if (std::rename(tmp.c_str(), path.c_str()) != 0) {
+        std::remove(tmp.c_str());
+        return false;
+    }
+    return true;
+}
+
+// ── operator-facing log lines ────────────────────────────────────────────────
+
+/// The CUMULATIVE roll-up line, printed ALONGSIDE the per-process
+/// [EMBED-GATE-ROLLUP] so an operator reads the standing-soak denominator, not
+/// the since-last-restart one. Denominator first (a percentage whose
+/// denominator is implicit is how the best-share bug shipped), then per-cause.
+inline std::string cumulative_rollup_line(const ServeGateCumulative& c) {
+    std::ostringstream os;
+    os << "[EMBED-GATE-ROLLUP-CUM] restarts=" << c.restart_count
+       << " observed=" << c.observed_sec << "s"
+       << " off_embedded=" << c.off_embedded_sec << "s";
+    if (c.observed_sec > 0)
+        os << " (" << (c.off_embedded_sec * 100 / c.observed_sec)
+           << "% of wall clock)";
+    os << " causes:";
+    if (c.cause_totals.empty()) {
+        os << " (none)";
+    } else {
+        for (const auto& kv : c.cause_totals) {
+            os << " " << kv.first << "=" << kv.second << "s";
+            if (c.observed_sec > 0)
+                os << "(" << (kv.second * 100 / c.observed_sec) << "%)";
+        }
+    }
+    return os.str();
+}
+
+/// The [QC-NULL-SERVE] counter line: per-type window-open / null / real /
+/// fell-back plus the never-a-reject conjunct. This is the line that makes
+/// "the null-arm covered the DKG floor, 0 rejects" greppable across restarts.
+inline std::string qc_null_serve_line(const QcNullServeCounters& n) {
+    std::ostringstream os;
+    os << "[QC-NULL-SERVE]"
+       << " window_open=" << n.total_window_open()
+       << " null=" << n.total_null_served()
+       << " real=" << n.total_real_served()
+       << " fell_back=" << n.total_fell_back()
+       << " submits=" << n.submits_from_null
+       << " rejects=" << n.rejects_from_null;
+    // Per-type breakout, so a floor type that never null-served is visible.
+    for (const auto& kv : n.window_open) {
+        const int t = kv.first;
+        os << " | type" << t << ":"
+           << "win=" << kv.second
+           << ",null=" << (n.null_served.count(t) ? n.null_served.at(t) : 0)
+           << ",real=" << (n.real_served.count(t) ? n.real_served.at(t) : 0)
+           << ",fb=" << (n.fell_back.count(t) ? n.fell_back.at(t) : 0);
+    }
+    return os.str();
+}
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -1304,6 +1304,9 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
     coin::ServeGateJournal::Decision d;
     coin::ServeGateJournal::Rollup rollup;
     bool emit_rollup = false;
+    coin::ServeGateCumulative cum_combined;
+    coin::QcNullServeCounters cum_counters_snapshot;
+    bool have_cum = false;
     {
         std::lock_guard<std::mutex> lk(serve_gate_mutex_);
         d = serve_gate_journal_.observe(served, why.cause, now_sec);
@@ -1321,6 +1324,19 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             last_rollup_sec_ = now_sec;
             rollup           = serve_gate_journal_.rollup(now_sec);
             emit_rollup      = true;
+            // (a)+(b) cross-restart cumulative accounting: load the prior
+            // state ONCE, snapshot this process's live QC-NULL-SERVE counters.
+            // combine()+save_atomic()+log run OFF the lock below (no file I/O
+            // under serve_gate_mutex_). Empty path => dormant, byte-unchanged.
+            if (!serve_gate_state_path_.empty()) {
+                if (!serve_gate_prior_loaded_) {
+                    serve_gate_prior_ =
+                        coin::load_serve_gate_state(serve_gate_state_path_);
+                    serve_gate_prior_loaded_ = true;
+                }
+                cum_counters_snapshot = null_serve_counters_;
+                have_cum = true;
+            }
         }
     }
 
@@ -1345,6 +1361,21 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             }
         }
         LOG_WARNING << os.str();
+
+        // CUMULATIVE line ALONGSIDE the per-process one: prior + this process,
+        // write-through to the state file so a STANDING soak (across restarts)
+        // is readable from the log/file alone — closing the observed=7211s
+        // per-process denominator trap (04:00 restart) the critic found. File
+        // I/O is OFF serve_gate_mutex_; serve_gate_prior_ is immutable after
+        // its one-time load, so reading it here without the lock is safe.
+        if (have_cum) {
+            cum_combined =
+                coin::combine(serve_gate_prior_, rollup, cum_counters_snapshot);
+            coin::save_serve_gate_state_atomic(serve_gate_state_path_,
+                                               cum_combined);
+            LOG_WARNING << coin::cumulative_rollup_line(cum_combined);
+            LOG_WARNING << coin::qc_null_serve_line(cum_combined.null_serve);
+        }
     }
 
     // A CAUSE SEGMENT closed on THIS decision (a cause change or a resume):

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -60,6 +60,7 @@
 
 #include <impl/dash/coin/node_coin_state.hpp>   // coin::NodeCoinState, coin::DashWorkData seam
 #include <impl/dash/coin/serve_gate_journal.hpp> // coin::ServeGateJournal — decline rate policy (DEFECT-3)
+#include <impl/dash/coin/serve_gate_persist.hpp> // cross-restart cumulative accounting + QC-NULL-SERVE counters
 #include <impl/dash/coin/embedded_shadow_compare.hpp> // coin::EmbeddedShadowCompare — OBSERVE-only serve-vs-dashd diff
 #include <impl/dash/stratum/get_work.hpp>       // dash::stratum::get_work() fused capstone
 
@@ -362,6 +363,30 @@ public:
     /// Pure-daemonless mode (no rpc) therefore leaves it off and relies on the
     /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
+
+    /// Path to the cross-restart cumulative serve-gate state file (JSON).
+    /// Empty (default) => the cumulative accounting is OFF and this class is
+    /// byte-identical to before: no load, no save, no extra log line. When set
+    /// (--serve-gate-state-file), note_arm_decision() write-throughs the
+    /// combined prior+live roll-up + QC-NULL-SERVE counters on each roll-up
+    /// tick so a STANDING soak is readable across restarts.
+    void set_serve_gate_state_file(std::string p) { serve_gate_state_path_ = std::move(p); }
+
+    /// (b) QC-NULL-SERVE live hooks. Record one required DKG mining-window tip
+    /// and its disposition (null-served / real-served / fell-back), and one
+    /// block submission from a null-carrying template (never-a-reject
+    /// conjunct). Thread-safe (serve_gate_mutex_). The per-tip disposition call
+    /// site is the daemonless_qc_commitments fold consumer (soak-gated wiring);
+    /// note_null_submit is called from the block-submit path.
+    void note_null_serve_disposition(int llmq_type,
+                                     coin::QcNullServeCounters::Disposition d) const {
+        std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+        null_serve_counters_.note(llmq_type, d);
+    }
+    void note_null_submit(bool rejected) const {
+        std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+        null_serve_counters_.note_submit(rejected);
+    }
 
     /// PIN SPLICE ON THE XCHECK-SWAPPED ARM (--pin-splice-xcheck-arm).
     /// DEFAULT OFF -- this is the money path.
@@ -767,6 +792,16 @@ private:
     // first arm decision, so the first observation seeds the cadence without
     // emitting an empty summary. Guarded by serve_gate_mutex_.
     mutable int64_t                 last_rollup_sec_{-1};
+
+    // Cross-restart cumulative accounting (flag-gated by serve_gate_state_path_).
+    // serve_gate_prior_ is the PRIOR-process state loaded once at the first
+    // roll-up tick; null_serve_counters_ are this process's live QC-NULL-SERVE
+    // tallies. Both guarded by serve_gate_mutex_; combine()+save happen OFF the
+    // lock in note_arm_decision. Empty path => all of this stays dormant.
+    std::string                        serve_gate_state_path_;
+    mutable coin::ServeGateCumulative  serve_gate_prior_;
+    mutable bool                       serve_gate_prior_loaded_{false};
+    mutable coin::QcNullServeCounters  null_serve_counters_;
 
     // ── Serve-staleness observation (lock-free by requirement) ─────────────
     // Written on the serve path (get_current_work_template /

--- a/test/test_dash_serve_gate_journal.cpp
+++ b/test/test_dash_serve_gate_journal.cpp
@@ -29,6 +29,13 @@
 
 #include <impl/dash/coin/serve_gate_journal.hpp>
 #include <impl/dash/coin/serve_gate_rollup_json.hpp>
+#include <impl/dash/coin/serve_gate_persist.hpp>
+
+#include <cstdio>
+#include <fstream>
+
+#include <unistd.h>  // getpid
+
 
 #include <string>
 
@@ -384,6 +391,251 @@ TEST(DashServeGateJournal, RollupJsonShapePinsTheWebField) {
     EXPECT_EQ(empty["off_embedded_sec"].get<int64_t>(), 0);
     EXPECT_TRUE(empty["per_cause"].is_array());
     EXPECT_TRUE(empty["per_cause"].empty());
+}
+
+
+// ── NULL-ARM DKG-FLOOR COVERAGE: cross-restart cumulative accounting ─────────
+//
+// THE DEFECT THIS PINS (hotel-primary, 2026-08-23): the [EMBED-GATE-ROLLUP]
+// denominator `observed=` equals wall clock since the LAST restart (7211 s at
+// the 06:00 tick for a 04:00 restart), because ServeGateJournal is pure policy
+// and every counter resets with the process. So the dashd-cut gate that
+// matters — "the null-arm covered the 4.51% DKG floor with 0 rejects over a
+// STANDING soak" — was unprovable program-level, and there was no explicit
+// null-served counter at all. serve_gate_persist.hpp is the write-through
+// cumulative layer that closes both halves.
+//
+// RED ON MASTER: serve_gate_persist.hpp does not exist there, so this TU does
+// not COMPILE — the intended failure this branch turns green (same red shape
+// as NoWorkIsTheDistinctThirdArmState above).
+
+using dash::coin::QcNullServeCounters;
+using dash::coin::ServeGateCumulative;
+using Disposition = dash::coin::QcNullServeCounters::Disposition;
+
+inline std::string na_temp_path(const char* tag) {
+    std::string p = ::testing::TempDir();
+    if (!p.empty() && p.back() != '/') p += '/';
+    p += "na_serve_gate_";
+    p += tag;
+    p += "_";
+    p += std::to_string(static_cast<long long>(::getpid()));
+    p += ".json";
+    std::remove(p.c_str());
+    return p;
+}
+
+// THE CORE GAP: cumulative observed/off-embedded/per-cause seconds AND the
+// null-serve counters survive a restart and ACCUMULATE across processes, and
+// restart_count records how many processes covered the soak. On master the
+// only cumulative view is per-process; this proves the wipe is gone.
+TEST(DashServeGateCumulative, StateSurvivesRestartAndAccumulates) {
+    const std::string path = na_temp_path("restart");
+
+    // ── process 1 ────────────────────────────────────────────────────────
+    ServeGateJournal j1(1000000);
+    j1.observe(false, "qc-plan-underivable", 0);
+    j1.observe(true, "", 10);                 // 10 s off-embedded on qc-plan
+    // ... serving continues; roll-up read at t=100.
+    ServeGateCumulative prior1 = dash::coin::load_serve_gate_state(path);
+    EXPECT_EQ(prior1.restart_count, 1);       // fresh file: first process
+    EXPECT_EQ(prior1.observed_sec, 0);
+
+    QcNullServeCounters c1;
+    c1.note(4, Disposition::NullServed);
+    c1.note(4, Disposition::NullServed);
+    c1.note(4, Disposition::NullServed);
+    c1.note(2, Disposition::NullServed);
+    c1.note_submit(false);
+    c1.note_submit(false);
+
+    ServeGateCumulative cum1 = dash::coin::combine(prior1, j1.rollup(100), c1);
+    EXPECT_EQ(cum1.restart_count, 1);
+    EXPECT_EQ(cum1.observed_sec, 100);
+    EXPECT_EQ(cum1.off_embedded_sec, 10);
+    ASSERT_EQ(cum1.cause_totals.count("qc-plan-underivable"), 1u);
+    EXPECT_EQ(cum1.cause_totals["qc-plan-underivable"], 10);
+    EXPECT_EQ(cum1.null_serve.total_null_served(), 4);
+    EXPECT_EQ(cum1.null_serve.submits_from_null, 2);
+    EXPECT_EQ(cum1.null_serve.rejects_from_null, 0);
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(path, cum1));
+
+    // ── process 2 (a restart) ────────────────────────────────────────────
+    ServeGateCumulative prior2 = dash::coin::load_serve_gate_state(path);
+    EXPECT_EQ(prior2.restart_count, 2);       // bumped: second process
+    EXPECT_EQ(prior2.observed_sec, 100);      // process 1's denominator carried
+    EXPECT_EQ(prior2.off_embedded_sec, 10);
+    EXPECT_EQ(prior2.cause_totals["qc-plan-underivable"], 10);
+    EXPECT_EQ(prior2.null_serve.total_null_served(), 4);
+
+    ServeGateJournal j2(1000000);
+    j2.observe(false, "dmn-stale", 0);
+    j2.observe(true, "", 5);                   // 5 s off-embedded on dmn-stale
+    QcNullServeCounters c2;
+    c2.note(4, Disposition::RealServed);       // a real quorum existed -> NOT null
+    c2.note(4, Disposition::RealServed);
+    c2.note(4, Disposition::FellBack);         // freshness unproven -> fail-closed
+
+    ServeGateCumulative cum2 = dash::coin::combine(prior2, j2.rollup(50), c2);
+    EXPECT_EQ(cum2.restart_count, 2);
+    EXPECT_EQ(cum2.observed_sec, 150);         // 100 + 50, across processes
+    EXPECT_EQ(cum2.off_embedded_sec, 15);      // 10 + 5
+    EXPECT_EQ(cum2.cause_totals["qc-plan-underivable"], 10);  // process 1's
+    EXPECT_EQ(cum2.cause_totals["dmn-stale"], 5);             // process 2's
+    EXPECT_EQ(cum2.null_serve.total_null_served(), 4);        // carried
+    EXPECT_EQ(cum2.null_serve.total_real_served(), 2);        // this process
+    EXPECT_EQ(cum2.null_serve.total_fell_back(), 1);
+    EXPECT_EQ(cum2.null_serve.total_window_open(), 7);        // 4 + 2 + 1
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(path, cum2));
+
+    // ── process 3: the accumulation is durable ───────────────────────────
+    ServeGateCumulative prior3 = dash::coin::load_serve_gate_state(path);
+    EXPECT_EQ(prior3.restart_count, 3);
+    EXPECT_EQ(prior3.observed_sec, 150);
+    EXPECT_EQ(prior3.off_embedded_sec, 15);
+    EXPECT_EQ(prior3.null_serve.total_null_served(), 4);
+    EXPECT_EQ(prior3.null_serve.total_real_served(), 2);
+    EXPECT_EQ(prior3.null_serve.total_fell_back(), 1);
+    EXPECT_EQ(prior3.null_serve.submits_from_null, 2);
+    EXPECT_EQ(prior3.null_serve.rejects_from_null, 0);
+
+    std::remove(path.c_str());
+}
+
+// SERVE-EXACTNESS, expressed as the counter invariant: a required mining-window
+// tip takes EXACTLY one disposition, so window_open == null + real + fell_back
+// per type; the null-arm is counted as null ONLY on the floor tips and as real
+// wherever a verified commitment existed (it was never consulted there). Plus
+// the never-a-reject conjunct: submits from null-carrying templates > 0,
+// rejects == 0. Round-trips through the state file unchanged.
+TEST(DashServeGateCumulative, NullServeCountersLockServeExactness) {
+    QcNullServeCounters n;
+
+    // DKG-floor tips (phase-10 type-4, window-open type-2): the null was served.
+    for (int i = 0; i < 13; ++i) n.note(4, Disposition::NullServed);
+    n.note(2, Disposition::NullServed);
+
+    // A verified real commitment existed for the slot: the null-arm is NEVER
+    // consulted here (verified_for precedes null_evidence). Counted as REAL.
+    for (int i = 0; i < 5; ++i) n.note(4, Disposition::RealServed);
+    n.note(2, Disposition::RealServed);
+    n.note(2, Disposition::RealServed);
+
+    // Freshness unproven: the whole height fails closed to fallback (benign gap).
+    n.note(4, Disposition::FellBack);
+
+    // Block submissions from null-carrying templates — none rejected.
+    for (int i = 0; i < 8; ++i) n.note_submit(false);
+
+    // The dispositions are distinct and correctly bucketed.
+    EXPECT_EQ(n.null_served[4], 13);
+    EXPECT_EQ(n.null_served[2], 1);
+    EXPECT_EQ(n.real_served[4], 5);
+    EXPECT_EQ(n.real_served[2], 2);
+    EXPECT_EQ(n.fell_back[4], 1);
+
+    // THE INVARIANT: every window-open tip took exactly one disposition, so the
+    // null-arm can neither double-count nor fire on a real-quorum tip.
+    EXPECT_EQ(n.window_open[4], 13 + 5 + 1);
+    EXPECT_EQ(n.window_open[2], 1 + 2);
+    EXPECT_EQ(n.total_window_open(),
+              n.total_null_served() + n.total_real_served() + n.total_fell_back());
+
+    // Never-a-reject conjunct.
+    EXPECT_EQ(n.submits_from_null, 8);
+    EXPECT_EQ(n.rejects_from_null, 0);
+
+    // Survives persistence byte-for-byte (bump_restart=false to compare exactly).
+    const std::string path = na_temp_path("exact");
+    ServeGateCumulative c;
+    c.null_serve = n;
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(path, c));
+    ServeGateCumulative back =
+        dash::coin::load_serve_gate_state(path, /*bump_restart=*/false);
+    EXPECT_EQ(back.null_serve.null_served[4], 13);
+    EXPECT_EQ(back.null_serve.real_served[4], 5);
+    EXPECT_EQ(back.null_serve.fell_back[4], 1);
+    EXPECT_EQ(back.null_serve.window_open[2], 3);
+    EXPECT_EQ(back.null_serve.submits_from_null, 8);
+    EXPECT_EQ(back.null_serve.rejects_from_null, 0);
+    std::remove(path.c_str());
+}
+
+// A missing OR corrupt state file yields a clean zero (still counted as a
+// restart) — the soak file is a convenience, never a consensus input, so a bad
+// read must never wedge the node or invent totals.
+TEST(DashServeGateCumulative, MissingOrCorruptFileYieldsCleanZero) {
+    // Missing.
+    const std::string missing = na_temp_path("missing");
+    ServeGateCumulative m = dash::coin::load_serve_gate_state(missing);
+    EXPECT_EQ(m.restart_count, 1);
+    EXPECT_EQ(m.observed_sec, 0);
+    EXPECT_EQ(m.off_embedded_sec, 0);
+    EXPECT_TRUE(m.cause_totals.empty());
+    EXPECT_EQ(m.null_serve.total_window_open(), 0);
+
+    // Corrupt: half-written JSON must not throw, must reset to zero.
+    const std::string corrupt = na_temp_path("corrupt");
+    {
+        std::ofstream out(corrupt);
+        out << "{ \"observed_sec\": 999, this is not valid js";
+    }
+    ServeGateCumulative c = dash::coin::load_serve_gate_state(corrupt);
+    EXPECT_EQ(c.restart_count, 1);   // still counted
+    EXPECT_EQ(c.observed_sec, 0);    // NOT the 999 from the truncated file
+    EXPECT_TRUE(c.cause_totals.empty());
+    std::remove(corrupt.c_str());
+}
+
+// combine() = prior + live, and prior never absorbs the live part, so saving on
+// every roll-up tick is idempotent: two saves in one process from a growing
+// rollup REPLACE rather than add (20 s, not 10+20=30).
+TEST(DashServeGateCumulative, CombineIsReplaceNotAddWithinOneProcess) {
+    const std::string path = na_temp_path("replace");
+    ServeGateCumulative prior;  // frozen zero
+
+    ServeGateJournal j(1000000);
+    j.observe(false, "cause-x", 0);            // opens an off-embedded segment
+
+    // Tick 1 at t=10.
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(
+        path, dash::coin::combine(prior, j.rollup(10), {})));
+    // Tick 2 at t=20 — SAME frozen prior, larger live rollup.
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(
+        path, dash::coin::combine(prior, j.rollup(20), {})));
+
+    ServeGateCumulative loaded =
+        dash::coin::load_serve_gate_state(path, /*bump_restart=*/false);
+    EXPECT_EQ(loaded.observed_sec, 20);        // replace, not 30
+    EXPECT_EQ(loaded.off_embedded_sec, 20);
+    EXPECT_EQ(loaded.cause_totals["cause-x"], 20);
+    std::remove(path.c_str());
+}
+
+// The operator log lines render the cumulative shape: denominator first, the
+// never-a-reject conjunct visible, per-type null/real breakout present.
+TEST(DashServeGateCumulative, LogLinesRenderCumulativeShape) {
+    ServeGateCumulative c;
+    c.restart_count = 3;
+    c.observed_sec = 200;
+    c.off_embedded_sec = 20;
+    c.cause_totals["qc-plan-underivable"] = 18;
+    c.null_serve.note(4, Disposition::NullServed);
+    c.null_serve.note(4, Disposition::RealServed);
+    c.null_serve.note_submit(false);
+
+    const std::string roll = dash::coin::cumulative_rollup_line(c);
+    EXPECT_NE(roll.find("[EMBED-GATE-ROLLUP-CUM]"), std::string::npos);
+    EXPECT_NE(roll.find("restarts=3"), std::string::npos);
+    EXPECT_NE(roll.find("observed=200s"), std::string::npos);
+    EXPECT_NE(roll.find("qc-plan-underivable=18s"), std::string::npos);
+
+    const std::string ns = dash::coin::qc_null_serve_line(c.null_serve);
+    EXPECT_NE(ns.find("[QC-NULL-SERVE]"), std::string::npos);
+    EXPECT_NE(ns.find("null=1"), std::string::npos);
+    EXPECT_NE(ns.find("real=1"), std::string::npos);
+    EXPECT_NE(ns.find("rejects=0"), std::string::npos);
+    EXPECT_NE(ns.find("type4:"), std::string::npos);
 }
 
 }  // namespace


### PR DESCRIPTION
## What

Closes the **cumulative-accounting gap** the null-arm completeness critic found: the `[EMBED-GATE-ROLLUP]` denominator `observed=` resets every restart (measured on hotel-primary 2026-08-23: `observed=7211s` at the 06:00 tick = wall-clock since the 04:00 restart), and there is **no explicit null-served counter**, so the dashd-cut gate — *"the null-arm covered the 4.51% DKG floor with 0 rejects over a **standing** soak"* — cannot be proven program-level.

This is **measurement only**. Nothing on the reward/consensus path changes and the flag defaults **OFF**.

## Why the serve path is untouched

R1/R2 re-confirmed against master that the null-arm serve-exactness is already correct: `daemonless_qc_commitments` tries `cache->verified_for` (real BLS-verified commitment) **first** and consults `null_evidence` **only on a miss**; `build_null_commitment` is the all-false byte-shape dashd itself emits on a local cache miss (`blockprocessor.cpp:748-763`); any unproven freshness fails the **whole height** closed to the fallback. So the null-arm fires on exactly the DKG-floor tips and never when a real quorum exists — the gap the critic flagged is the **accounting**, not the serve.

## Changes (in-scope: quorum/null-arm serve path + EMBED-GATE accounting only)

- **`serve_gate_persist.hpp`** (new) — the I/O layer `ServeGateJournal` deliberately isn't:
  - `ServeGateCumulative` (restart_count + observed/off_embedded/per-cause seconds + `QcNullServeCounters`) moved through a small JSON state file;
  - `combine(prior, live_rollup, live_counters) = prior + live`; the file holds **only** frozen prior totals, so write-through on every tick **replaces** (never adds) the live part — N saves == one;
  - load (missing/corrupt ⇒ clean zero, restart_count bumped) + **atomic** temp-file+rename save;
  - `QcNullServeCounters` — per-LLMQ-type `window_open/null_served/real_served/fell_back` with the invariant `window_open == null+real+fell_back`, plus the global never-a-reject conjunct `submits_from_null / rejects_from_null`;
  - `cumulative_rollup_line` / `qc_null_serve_line` renderers.
- **Live wiring** flag-gated by `--serve-gate-state-file PATH` (empty default ⇒ **OFF**, byte-identical serve path). When set, `note_arm_decision` loads prior once and, on each hourly roll-up tick, write-throughs the combined state and prints `[EMBED-GATE-ROLLUP-CUM]` + `[QC-NULL-SERVE]` alongside the per-process line. File I/O runs **off** `serve_gate_mutex_`.
- Public hooks `note_null_serve_disposition` / `note_null_submit`. The per-tip disposition call site is the `daemonless_qc_commitments` fold consumer, deliberately left as a **soak-gated follow-up** (it touches the consensus fold).

## KAT (red → green)

`test_dash_serve_gate_journal` (allowlisted, header-only-friendly, already links `nlohmann_json` — avoids the pre-broken `test_dash_embedded_gbt` opkey link gap). 5 new cases, **RED on master** (the new header does not exist there → TU does not compile, same red shape as `NoWorkIsTheDistinctThirdArmState`) / **GREEN here**:

- `StateSurvivesRestartAndAccumulates` — seconds **and** null-serve counters accumulate across 3 simulated processes; `restart_count 1→2→3`. The per-process wipe is gone.
- `NullServeCountersLockServeExactness` — the disposition invariant locks that the null-arm is counted null **only** on floor tips and real wherever a verified commitment exists; `rejects==0`.
- `MissingOrCorruptFileYieldsCleanZero`, `CombineIsReplaceNotAddWithinOneProcess`, `LogLinesRenderCumulativeShape`.

Full suite **17/17 green**; `c2pool-dash` binary builds + links with the wiring (workstation-191, gcc13/Release).

## Not merged — operator-gated

Serve-path-adjacent (money/consensus). Fix item **(c)** — flip `--embedded-null-arm` default / pin `--serve-gate-state-file` in the money-node drop-in — is an operator decision, made once (a)+(b) prove the standing soak.
