### PR TITLE
dash(daemonless): full-stack serve-path landing (8 PRs) — tx-serve own-set, validity/window gates, null-arm accounting, DSTX

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -302,6 +302,12 @@ std::string g_replay_mnlist_seed_file;        // --replay-mnlist-seed-file FILE 
 // serve are both fine WITHOUT proving the serve is daemonless.
 bool        g_no_dashd_mn_seed = false;       // --embedded-no-dashd-mn-seed
 
+// --serve-gate-state-file: path to the cross-restart cumulative serve-gate
+// accounting state (JSON). Empty (default) => OFF; the serve path is
+// byte-identical. Non-consensus, non-reward: a soak convenience whose
+// bad read fails to a clean zero and never wedges the node.
+std::string g_serve_gate_state_file;           // --serve-gate-state-file
+
 // ── PR-2 FORWARD: --replay-mined-commitment-index ─────────────────────────
 // Arms the forward half of dashd's mined-commitment store
 // (mined_commitment_index.hpp, ported from v23.1.7 llmq/blockprocessor.cpp)
@@ -2866,6 +2872,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         work_source->set_serve_gate_ledger_path(ledger_path, "dev");
 #endif
     }
+    // Cross-restart cumulative serve-gate accounting. Empty path keeps the
+    // per-process behaviour byte-for-byte; when set, note_arm_decision()
+    // write-throughs the combined prior+live roll-up + QC-NULL-SERVE
+    // counters so a STANDING soak is readable across restarts.
+    work_source->set_serve_gate_state_file(g_serve_gate_state_file);
+    if (!g_serve_gate_state_file.empty())
+        std::cout << "[run] serve-gate cumulative accounting ARMED: state="
+                  << g_serve_gate_state_file << "\n";
     // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
     // either way: with it off the donation still misses every swapped
     // template -- it just no longer does so silently.
@@ -8978,6 +8992,12 @@ int main(int argc, char** argv)
             bestcl_policy = argv[++i];
         else if (std::strcmp(argv[i], "--coinbase-text") == 0 && i + 1 < argc)
             coinbase_text = argv[++i];
+        // Cross-restart cumulative serve-gate accounting (#127 follow-up):
+        // path to a small JSON state file. Empty (default) => OFF and the
+        // serve path is byte-identical. Non-consensus, non-reward: a soak
+        // convenience whose bad read fails to a clean zero, never wedges.
+        else if (std::strcmp(argv[i], "--serve-gate-state-file") == 0 && i + 1 < argc)
+            g_serve_gate_state_file = argv[++i];
         else if (std::strcmp(argv[i], "--embedded-oracle-shadow") == 0)
             embedded_oracle_shadow = true;
         else if (std::strcmp(argv[i], "--embedded-shadow-compare") == 0)

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2424,6 +2424,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // spends. The dashd fallback is unaffected.
             node_coin_state.set_utxo_ready_fn(
                 [&utxo_lane]() { return utxo_lane.mining_utxo_ready(); });
+            // WINDOW-2 currency gate (Window 2 = intra-node eviction lag).
+            // The serve tip can be promoted to H by the diff-driven path
+            // (CoinStateMaintainer mnlistdiff-at-tip / cbTx credit-pool
+            // re-anchor) BEFORE this UTXO lane connects+evicts block H. In that
+            // window the view is at H-1 and a template on H could pack a tx
+            // already spent by H (invalid, thrown-away block). This predicate
+            // lets make_embedded_work_inputs serve coinbase-only until the view
+            // catches up -- dashd's removeForBlock-before-SetTip invariant,
+            // fail-closed. Only material when --embedded-serve-mempool-txs is
+            // armed; coinbase-only / fallback postures are byte-unchanged.
+            // On the LIVE full-block path the utxo-lane subscription (2438,
+            // subscriber 1) connects+evicts BEFORE the maintainer promotes the
+            // serve tip (3908, subscriber 2) on the same io thread, so this
+            // predicate is already true there and suppresses nothing.
+            node_coin_state.set_utxo_current_fn(
+                [&utxo_lane](const uint256& tip_hash) {
+                    return utxo_lane.utxo_current_at(tip_hash);
+                });
             // What the arm DOES during that window. Default (flag absent):
             // REFUSE -- p2pool semantics, the project design law: an unsynced
             // node does not serve block templates; miners idling is correct,

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2850,6 +2850,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         " when shadow-compare is bound)"
                       : "OFF (dashd-parity backstop on any tx-merkle divergence)")
               << std::endl;
+    // CUMULATIVE cross-restart serve-gate ledger: persist the never-a-reject
+    // accounting to <data-dir>/<net_subdir>/serve_gate_ledger.json so the
+    // standing "% embedded / null-arm covered the 4.51% floor / 0 rejects over
+    // N heights" figure survives the >=3 restarts the dashd-cut soak spans
+    // (ServeGateJournal wipes on restart). Stamp C2POOL_VERSION so the figure
+    // always names the binary that produced it (measurement-without-commit).
+    {
+        const std::string ledger_path =
+            (core::filesystem::config_path() / net_subdir /
+             "serve_gate_ledger.json").string();
+#ifdef C2POOL_VERSION
+        work_source->set_serve_gate_ledger_path(ledger_path, C2POOL_VERSION);
+#else
+        work_source->set_serve_gate_ledger_path(ledger_path, "dev");
+#endif
+    }
     // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
     // either way: with it off the donation still misses every swapped
     // template -- it just no longer does so silently.

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -425,6 +425,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
+        << "           [--embedded-tx-serve-own-set]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
@@ -810,6 +811,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // body path (G1-G4 guards, mempool.hpp) only enters block
              // production when the operator explicitly arms it.
              bool embedded_serve_mempool_txs = false,
+             // --embedded-tx-serve-own-set: when a served embedded
+             // template's mempool selection diverges from dashd's, serve
+             // OUR OWN internally-consistent valid set instead of falling
+             // back to dashd on tx-merkle difference. DEFAULT OFF. MUST NOT
+             // be armed until the [MEMPOOL-VALIDITY] gate has reached
+             // open() (576 clean heights) in a dashd-oracle soak -- the
+             // internal-consistency referee shares the selector's UTXO view
+             // and cannot alone catch the already-mined/stale-view class
+             // (h=2526403). When --embedded-shadow-compare is also on, the
+             // own-set path auto-fail-closes until that gate is open.
+             bool embedded_tx_serve_own_set = false,
              // --embedded-shadow-compare: OBSERVE-only serve-vs-dashd block-
              // template field diff (diagnostic; NOT a serve gate). Off the hot
              // path (worker-thread dashd fetch). Default false; only meaningful
@@ -2810,6 +2822,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // consulted, i.e. during an actual embedded outage.
     const bool xcheck_wanted = (testnet || embedded_mainnet);
     work_source->set_gbt_xcheck(xcheck_wanted && static_cast<bool>(rpc));
+    // --embedded-tx-serve-own-set: serve own valid tx set on a divergent
+    // mempool selection instead of the dashd-parity swap (DEFAULT OFF).
+    work_source->set_tx_serve_own_set(embedded_tx_serve_own_set);
+    std::cout << "[DASH-STRATUM-GBT] tx-serve own-set referee: "
+              << (embedded_tx_serve_own_set
+                      ? "ON (--embedded-tx-serve-own-set: divergent-but-valid"
+                        " mempool set served as own; validity-gate-coupled"
+                        " when shadow-compare is bound)"
+                      : "OFF (dashd-parity backstop on any tx-merkle divergence)")
+              << std::endl;
     // Pin splice on the xcheck-SWAPPED arm (default OFF). Announce the state
     // either way: with it off the donation still misses every swapped
     // template -- it just no longer does so silently.
@@ -8757,6 +8779,7 @@ int main(int argc, char** argv)
     // (mempool_validity_gate.hpp) reports zero transactions refused by dashd's
     // testmempoolaccept over its sustained window.
     bool embedded_serve_mempool_txs = false;
+    bool embedded_tx_serve_own_set = false;  // --embedded-tx-serve-own-set, default OFF
     bool embedded_accrue_asset_locks = false;  // #107 PHASE 2, default OFF
     bool embedded_accrue_asset_unlocks = false;  // #143 Variant B (type-9), default OFF
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
@@ -8886,6 +8909,8 @@ int main(int argc, char** argv)
             embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
             embedded_serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-tx-serve-own-set") == 0)
+            embedded_tx_serve_own_set = true;
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks") == 0)
             embedded_accrue_asset_locks = true;   // #107 PHASE 2
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-unlocks") == 0)
@@ -9204,6 +9229,7 @@ int main(int argc, char** argv)
                         oracle_class_coverage, coin_p2p_peers, bestcl_policy,
                         embedded_utxo_immature_serve_empty,
                         embedded_serve_mempool_txs,
+                        embedded_tx_serve_own_set,
                         embedded_shadow_compare,
                         embedded_mempool_ingest,
                         pin_local_tx_hex_path,

--- a/src/impl/dash/coin/coin_state_maintainer.hpp
+++ b/src/impl/dash/coin/coin_state_maintainer.hpp
@@ -2382,7 +2382,7 @@ private:
                             << discriminating_hash_tail(m_state.sml_current_hash())
                             << " != tip ..." << discriminating_hash_tail(m_hdr_prev_hash)
                             << ") — re-requesting getmnlistd (attempt "
-                            << req->attempt << "/3) before the doomed-tip demote";
+                            << req->attempt << ") before the doomed-tip demote";
                 m_on_sml_rerequest(req->base, req->target);
             }
         }

--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -820,6 +820,23 @@ inline DashWorkData build_embedded_workdata(
     }
     w.m_mempool_tx_count = static_cast<uint32_t>(selected.size());
 
+    // -- INTERNAL-CONSISTENCY STAMP for the serve-time tx-serve referee ----
+    // armed iff the mempool-serving path actually ran (--embedded-serve-
+    // mempool-txs ON and the UTXO lane mature). suppress_mempool_txs already
+    // encodes exactly that inverse (node_coin_state.hpp make_embedded_work_
+    // inputs). When suppressed the body is coinbase-only, the referee stays
+    // dormant, and this template is byte-identical to before this line.
+    //
+    // all_mempool_fee_fold_proven: EVERY entry `selected` returned above came
+    // through the selector's exclusion-discipline -- get_sorted_txs_with_fees
+    // takes only fee_fold_proven entries (mempool.hpp: `if(!e.fee_fold_proven)
+    // continue;`), so every tx in the mempool-sourced range has each vin
+    // present-and-unspent in our UTXO view with in_sum>=out_sum. Recording the
+    // guarantee (rather than trusting the call site) lets the referee fail-
+    // close if a future selection path ever admits an unproven tx.
+    w.m_tx_serve_stamp.armed = !suppress_mempool_txs;
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+
     // ── Underfill guard ─────────────────────────────────────────────
     // Do not silently treat a near-empty DASH template as healthy when the
     // DASH mempool held fee-paying backlog that should have filled it. We
@@ -971,6 +988,10 @@ inline DashWorkData build_embedded_workdata(
         // dashd augments coinbasevalue by the superblock total (the accrued
         // treasury slice released this block).
         w.m_coinbase_value += static_cast<uint64_t>(superblock_total);
+        // Referee reconstructs m_coinbase_value from subsidy + Sum(fees) +
+        // this treasury slice; 0 on every non-superblock height.
+        w.m_tx_serve_stamp.superblock_total =
+            static_cast<uint64_t>(superblock_total);
     }
 
     // E2d: fold the DIP-0004 type-5 CCbTx extra_payload so the block is

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -629,6 +629,30 @@ public:
         return j;
     }
 
+    /// Thread-safe readiness snapshot for the SERVE PATH (work_source.cpp).
+    /// TRUE only when a dashd testmempoolaccept oracle is bound AND the mempool
+    /// validity gate has accrued its sustained clean window (open()).
+    ///
+    /// The tx-serve-own-set referee consults this so that serving OUR OWN valid
+    /// tx set -- dropping the dashd-tx-merkle PARITY backstop -- cannot begin
+    /// until the SELECTOR has been PROVEN dashd-acceptable over the window.
+    /// This is the direct runtime answer to the field finding at h=2526403:
+    /// our fee_fold_proven selection can still offer transactions dashd rejects
+    /// (the already-mined / stale-UTXO-view class), and the internal-
+    /// consistency referee shares a UTXO view with the selector, so it cannot
+    /// independently catch that class. Only dashd's external view (this gate,
+    /// or the parity backstop) can. Requiring open() here keeps the parity
+    /// backstop in force until the gate demonstrates the class is gone.
+    ///
+    /// Returns false when no oracle is bound: the gate cannot be proven without
+    /// dashd, so it fail-closes. (A post-proof PURE-daemonless node runs with
+    /// no shadow-compare object at all; the caller bypasses the coupling only
+    /// when the probe is absent, never when it is present-but-empty.)
+    bool validity_gate_open() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return static_cast<bool>(accept_) && validity_.open();
+    }
+
 private:
     void worker_loop() {
         for (;;) {

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -698,7 +698,19 @@ private:
             std::lock_guard<std::mutex> lk(mu_);
             counters_.apply(o);
         }
-        probe_validity(served);
+        // TIP CONTEXT for the validity gate. dashd's getblocktemplate height is
+        // its NEXT block (tip+1); ours (served.m_height) is likewise our next
+        // block. dashd building a STRICTLY HIGHER block than us means dashd has
+        // already connected the block at our template's height (or beyond) while
+        // OUR tip is still its parent — the propagation Window 1 in which a tx
+        // dashd reports "txn-already-known" was mined in a block WE HAVE NOT YET
+        // CONNECTED. From our tip that tx is a valid unconfirmed tx and our
+        // template is a valid fork competitor, so the gate must not treat it as
+        // a staleness defect. When the oracle is absent we cannot tell, and pass
+        // false (conservative: already-known stays INVALID, gate stays CLOSED).
+        const bool dashd_ahead =
+            dashd.has_value() && dashd->m_height > served.m_height;
+        probe_validity(served, dashd_ahead);
     }
 
     /// THE MEMPOOL VALIDITY GATE, on the SAME worker thread as the oracle
@@ -709,7 +721,7 @@ private:
     ///
     /// This CANNOT change what is served. Its only outputs are log lines, the
     /// counters, and a readiness verdict on a DEFAULT-OFF flag.
-    void probe_validity(const DashWorkData& w) {
+    void probe_validity(const DashWorkData& w, bool dashd_ahead_of_serve_height) {
         if (!accept_) return;
         const auto set = mempool_probe_set(w);
 
@@ -727,7 +739,8 @@ private:
             answers.push_back(std::move(a));
         }
 
-        const auto sample = mempool_validity_sample(w.m_height, set, answers);
+        const auto sample = mempool_validity_sample(w.m_height, set, answers,
+                                                    dashd_ahead_of_serve_height);
         std::lock_guard<std::mutex> lk(mu_);
         validity_.apply(sample);
         for (const auto& line : mempool_validity_log_lines(sample, validity_)) {

--- a/src/impl/dash/coin/gbt_quorum_staleness.hpp
+++ b/src/impl/dash/coin/gbt_quorum_staleness.hpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// GBT-xcheck quorum-root staleness classifier — CLASSIFY a merkleRootQuorums
+/// divergence before swapping to dashd, instead of treating EVERY difference as
+/// an embedded error.
+///
+/// BACKGROUND. The #127 null-arm reward-safety backstop (work_source.cpp) cross-
+/// checks our embedded CbTx merkleRootQuorums against dashd's getblocktemplate
+/// and, on ANY difference, HARD-swaps to dashd's template on the theory that a
+/// wrong quorum root is the bad-cbtx-quorummerkleroot reject vector. That is the
+/// right default — but it has ONE inverted case.
+///
+/// MEASURED (mainnet, 2026-08). At each 24-block LLMQ DKG commitment boundary
+/// (observed heights 2525987, 2526011, 2526035, 2526059, ... — a clean 24-block
+/// cadence, episodes <1s) dashd's getblocktemplate momentarily serves the
+/// PREVIOUS cycle's quorum root while our embedded arm has already advanced to
+/// the freshly-committed one. Chain truth (dashd RPC, mined blocks): block
+/// 2525987's CbTx merkleRootQuorums == our EMBEDDED root; dashd's own GBT at
+/// that instant served the stale prior-cycle value (which equals OUR root one
+/// cycle earlier). Same at 2526011. So in this ~1s window the reward-safety
+/// direction is INVERTED: swapping to dashd serves the chain-would-reject
+/// template, and it is the EMBEDDED root the chain commits.
+///
+/// This classifier isolates exactly that case and NOTHING else. It is a pure,
+/// stateless predicate over the two parsed CbTx roots plus the last root the two
+/// arms AGREED on (kept by the caller), so a KAT can pin it without a live
+/// daemon, a stratum session, or a populated coin state (mirrors
+/// special_tx_pool_delta.hpp).
+///
+/// SAFE-DIRECTION CONTRACT. Returns true (⇒ caller KEEPS embedded) ONLY when:
+///   (1) the quorum roots actually differ (emb_quorum != dref_quorum);
+///   (2) the MN-list root axis AGREES (mnlist_matches) — a simultaneous
+///       quorum+MN divergence is body-divergence, not a pure DKG boundary, and
+///       must take the ordinary swap;
+///   (3) a prior AGREED quorum root exists (both arms matched at an earlier
+///       serve) AND dashd's current root EQUALS it (dashd REGRESSED to the
+///       pre-boundary value) AND our embedded root has ADVANCED PAST it
+///       (emb_quorum != last_agreed).
+///
+/// The inverse skew — embedded stale, dashd fresh — makes dref the NEW value,
+/// so dref != last_agreed and the predicate returns false: the caller swaps to
+/// dashd, which is the reward-safe direction. With no prior agreement (cold
+/// start) it also returns false (swap). A two-cycle dashd lag (dref equals a
+/// root older than last_agreed) likewise returns false (swap) — we only assert
+/// the chain-proven single-cycle-boundary case.
+
+#include <core/uint256.hpp>
+
+namespace dash {
+namespace coin {
+
+/// See file header. `last_agreed` is the most recent quorum root at which the
+/// embedded and dashd arms matched, or nullptr when no such agreement has been
+/// observed yet (cold start).
+inline bool quorumroot_dashd_is_stale(const uint256& emb_quorum,
+                                      const uint256& dref_quorum,
+                                      bool           mnlist_matches,
+                                      const uint256* last_agreed)
+{
+    if (emb_quorum == dref_quorum) return false;   // no divergence to classify
+    if (!mnlist_matches)           return false;   // mixed divergence ⇒ swap
+    if (last_agreed == nullptr)    return false;   // no history ⇒ swap
+    if (last_agreed->IsNull())     return false;   // unset sentinel ⇒ swap
+    // dashd regressed to the pre-boundary root while embedded advanced past it.
+    return dref_quorum == *last_agreed && emb_quorum != *last_agreed;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -124,8 +124,26 @@ namespace coin {
 
 /// dashd's reject-reason for "I already hold this transaction", verbatim
 /// (Dash Core validation.cpp: TxValidationResult TX_CONFLICT,
-/// "txn-already-in-mempool"). The ONE exempted reason. Compared for EQUALITY.
+/// "txn-already-in-mempool"). The ONE unconditionally-exempted reason.
+/// Compared for EQUALITY.
 inline constexpr const char* kAlreadyInMempoolReason = "txn-already-in-mempool";
+
+/// dashd's reject-reason for "this transaction is ALREADY CONFIRMED in my
+/// active chain", verbatim (Dash Core MemPoolAccept::PreChecks: a tx whose
+/// outputs are already present as coins in dashd's UTXO view —
+/// `HaveCoin(COutPoint(hash, out))` — returns TX_CONFLICT "txn-already-known").
+/// This is a CONDITIONAL exemption, not an unconditional one: it is benign
+/// ONLY when the block that confirmed the tx is one WE HAVE NOT YET CONNECTED
+/// (propagation Window 1 — our tip is h-1, someone else mined h and dashd
+/// connected it before we did; from our tip the tx is a valid UNCONFIRMED tx
+/// and our template is a valid fork competitor at height h, never an orphan).
+/// It is a genuine DEFECT only when dashd sits on OUR parent (or behind) and
+/// still reports the tx confirmed — i.e. it was confirmed at or below OUR
+/// serve-tip while we still serve it (the intra-node eviction-lag class,
+/// "Window 2"). The caller supplies the tip context (classify_mempool_accept's
+/// `dashd_ahead_of_serve_height`), which alone decides which case applies.
+/// Compared for EQUALITY.
+inline constexpr const char* kAlreadyConfirmedReason = "txn-already-known";
 
 /// The ONE reject-reason that can mean ONLY "I do not know this input" — the
 /// answer a SINGLE-transaction probe gets for a child whose parent rides the
@@ -149,6 +167,10 @@ inline bool is_missing_or_spent_reason(const std::string& reason)
 enum class MempoolAcceptVerdict : uint8_t {
     Valid,              // allowed == true
     AlreadyInMempool,   // allowed == false, reason == txn-already-in-mempool
+    ConfirmedAhead,     // reason == txn-already-known AND dashd is ahead of our
+                        // serve-tip -> benign propagation (Window 1). NOT a
+                        // defect and NOT evidence: it neither resets nor
+                        // advances the readiness run.
     Invalid,            // allowed == false, any other reason -> A DEFECT
     Unprobed            // no answer, or an in-set-parent probe artefact
 };
@@ -158,6 +180,7 @@ inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
     switch (v) {
         case MempoolAcceptVerdict::Valid:            return "VALID";
         case MempoolAcceptVerdict::AlreadyInMempool: return "ALSO-VALID(already-in-mempool)";
+        case MempoolAcceptVerdict::ConfirmedAhead:   return "PROPAGATION(confirmed-in-not-yet-connected-block)";
         case MempoolAcceptVerdict::Invalid:          return "INVALID";
         default:                                     return "UNPROBED";
     }
@@ -188,8 +211,20 @@ struct MempoolProbeTx {
 /// `entry` is the single result object (`{"txid":..,"allowed":..,
 /// "reject-reason":..}`); a null/non-object entry means the probe produced no
 /// answer (RPC blip, daemon absent) and yields Unprobed.
+///
+/// `dashd_ahead_of_serve_height` is the sample-level tip context: TRUE when
+/// dashd's chain tip is STRICTLY AHEAD of the block WE built the probed
+/// template for (dashd's next-block height > our served height). It is
+/// consulted for EXACTLY ONE reason string — "txn-already-known" — to separate
+/// benign propagation (Window 1: dashd already connected a block we have not)
+/// from a genuine intra-node staleness defect (Window 2: dashd sits on our
+/// parent and still holds the tx confirmed at/below our serve-tip). It changes
+/// NOTHING for any other reason: every real reject stays a reject. Defaulting
+/// to FALSE preserves the pre-tip-context behaviour (already-known -> INVALID)
+/// for callers that cannot supply it — the conservative, gate-CLOSED direction.
 inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
-                                                   const nlohmann::json& entry)
+                                                   const nlohmann::json& entry,
+                                                   bool dashd_ahead_of_serve_height = false)
 {
     MempoolAcceptResult r;
     r.txid = tx.txid;
@@ -212,6 +247,27 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
     if (r.reason == kAlreadyInMempoolReason) {
         r.verdict = MempoolAcceptVerdict::AlreadyInMempool;
         return r;
+    }
+
+    // dashd says the tx is ALREADY CONFIRMED in its chain ("txn-already-known").
+    // Whether that is a defect depends ENTIRELY on WHICH block confirmed it,
+    // which the tip context decides (see kAlreadyConfirmedReason). dashd AHEAD
+    // of our serve-tip => it was confirmed in a block we have not connected =>
+    // benign propagation (Window 1): our template is a valid fork competitor at
+    // our height, so this must NOT reset the readiness run. dashd NOT ahead
+    // (on our parent, or behind) => confirmed at/below OUR serve-tip while we
+    // still serve it => a genuine current-tip staleness defect (Window 2) =>
+    // falls through to INVALID and resets, exactly as a served already-mined tx
+    // should. This is the ONLY reason whose disposition the tip context can
+    // change; the field-measured invalids were 23/23 this class, all Window 1.
+    if (r.reason == kAlreadyConfirmedReason) {
+        if (dashd_ahead_of_serve_height) {
+            r.verdict        = MempoolAcceptVerdict::ConfirmedAhead;
+            r.unprobed_cause = "confirmed-in-block-we-have-not-connected(propagation)";
+            return r;
+        }
+        // else: dashd on our parent or behind -> a real at/below-serve-tip
+        // defect; fall through to INVALID below.
     }
 
     // The ONLY excused rejection beyond the named one: a child probed alone
@@ -261,12 +317,20 @@ struct MempoolValiditySample {
     size_t   already_in_mempool{0};
     size_t   invalid{0};
     size_t   unprobed{0};
+    /// Benign propagation (Window 1): dashd reported the tx already-CONFIRMED in
+    /// a block WE HAVE NOT YET CONNECTED. Neither a defect nor evidence — it is
+    /// counted here only so the log/JSON can say how much of the "already-known"
+    /// traffic was the propagation transient rather than a real staleness.
+    size_t   confirmed_ahead{0};
     /// The defects, verbatim — txid + dashd's reason. These are what the
     /// refusal line prints.
     std::vector<MempoolAcceptResult> invalids;
 
     /// A height that actually OBSERVED validity. A height whose probe set was
-    /// empty, or whose every entry came back Unprobed, observed nothing.
+    /// empty, or whose every entry came back Unprobed / ConfirmedAhead,
+    /// observed nothing about CURRENT-TIP validity — a ConfirmedAhead answer is
+    /// dashd speaking from a NEWER tip than the one we probed for, so it is not
+    /// evidence either way (see the tip-context note on kAlreadyConfirmedReason).
     bool evidence_bearing() const
     {
         return (valid + already_in_mempool + invalid) > 0;
@@ -277,10 +341,18 @@ struct MempoolValiditySample {
 /// PURE. Classify a whole probe set against the per-transaction answers.
 /// `answers[i]` is dashd's result object for `set[i]`; a shorter answers vector
 /// means the remaining entries got no answer (Unprobed), never a pass.
+///
+/// `dashd_ahead_of_serve_height` is the sample-level tip context threaded into
+/// each per-tx classification (see classify_mempool_accept). It ONLY affects
+/// the "txn-already-known" reason: dashd-ahead makes that a benign
+/// ConfirmedAhead (propagation Window 1, no reset), dashd-not-ahead keeps it a
+/// current-tip Invalid. Defaults FALSE so legacy/test callers get the pre-
+/// tip-context behaviour unchanged.
 inline MempoolValiditySample
 mempool_validity_sample(uint32_t height,
                         const std::vector<MempoolProbeTx>& set,
-                        const std::vector<nlohmann::json>& answers)
+                        const std::vector<nlohmann::json>& answers,
+                        bool dashd_ahead_of_serve_height = false)
 {
     MempoolValiditySample s;
     s.height = height;
@@ -288,10 +360,12 @@ mempool_validity_sample(uint32_t height,
     for (size_t i = 0; i < set.size(); ++i) {
         const nlohmann::json& a = (i < answers.size()) ? answers[i]
                                                        : nlohmann::json();
-        const MempoolAcceptResult r = classify_mempool_accept(set[i], a);
+        const MempoolAcceptResult r =
+            classify_mempool_accept(set[i], a, dashd_ahead_of_serve_height);
         switch (r.verdict) {
             case MempoolAcceptVerdict::Valid:            ++s.valid; break;
             case MempoolAcceptVerdict::AlreadyInMempool: ++s.already_in_mempool; break;
+            case MempoolAcceptVerdict::ConfirmedAhead:   ++s.confirmed_ahead; break;
             case MempoolAcceptVerdict::Invalid:
                 ++s.invalid;
                 s.invalids.push_back(r);
@@ -394,6 +468,13 @@ struct MempoolValidityGate {
     uint64_t txs_valid{0};
     uint64_t txs_already_in_mempool{0};
     uint64_t txs_unprobed{0};
+    /// Benign propagation transients (already-CONFIRMED in a block we have not
+    /// yet connected) seen over every applied sample. NOT defects, NOT
+    /// evidence — this counter exists so the operator can see how much of the
+    /// "already-known" traffic the tip context reclassified out of the invalid
+    /// bucket. A large value here with consecutive_clean advancing is the whole
+    /// point: propagation no longer stalls the readiness run.
+    uint64_t txs_confirmed_ahead{0};
     uint64_t repeat_txs_probed{0};
 
     /// DEFECTS ARE COUNTED WHEREVER THEY ARE OBSERVED — counted sample or
@@ -421,8 +502,9 @@ struct MempoolValidityGate {
             // moved: a later probe of this same height that DOES find
             // transactions is the first evidence there, and must count.
             ++samples_without_evidence;
-            txs_unprobed     += s.unprobed;
-            last_disposition  = SampleDisposition::NoEvidence;
+            txs_unprobed        += s.unprobed;
+            txs_confirmed_ahead += s.confirmed_ahead;
+            last_disposition     = SampleDisposition::NoEvidence;
             return;
         }
 
@@ -456,6 +538,7 @@ struct MempoolValidityGate {
         txs_valid              += s.valid;
         txs_already_in_mempool += s.already_in_mempool;
         txs_unprobed           += s.unprobed;
+        txs_confirmed_ahead    += s.confirmed_ahead;
         last_disposition        = SampleDisposition::Counted;
 
         if (s.invalid > 0) return;        // already reset above
@@ -487,6 +570,7 @@ struct MempoolValidityGate {
         j["txs-already-in-mempool"]    = txs_already_in_mempool;
         j["txs-invalid"]               = txs_invalid;
         j["txs-unprobed"]              = txs_unprobed;
+        j["txs-confirmed-ahead-propagation"] = txs_confirmed_ahead;
         j["last-invalid-height"]       = last_invalid_height;
         j["last-invalid-txid"]         = last_invalid_txid;
         j["last-invalid-reason"]       = last_invalid_reason;
@@ -525,6 +609,7 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " valid="     + std::to_string(s.valid)
         + " already_in_mempool=" + std::to_string(s.already_in_mempool)
         + " invalid="   + std::to_string(s.invalid)
+        + " confirmed_ahead=" + std::to_string(s.confirmed_ahead)
         + " unprobed="  + std::to_string(s.unprobed)
         + " clean_run=" + std::to_string(g.consecutive_clean) + "/"
         + std::to_string(g.required)
@@ -532,8 +617,13 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " sample=" + MempoolValidityGate::disposition_name(g.last_disposition)
         + " gate=" + (g.open() ? "OPEN" : "CLOSED");
     if (!s.evidence_bearing())
-        l += " (no-evidence: nothing to probe at this height — the run neither"
-             " advances nor resets)";
+        l += s.confirmed_ahead > 0
+             ? " (no-evidence: every probed tx is already CONFIRMED in a block we"
+               " have not yet connected — benign propagation Window 1, dashd is"
+               " ahead of the height we built for; the run neither advances nor"
+               " resets, and this is NOT a staleness defect)"
+             : " (no-evidence: nothing to probe at this height — the run neither"
+               " advances nor resets)";
     else if (g.last_disposition == MempoolValidityGate::SampleDisposition::RepeatHeight)
         l += " (repeat-height: h<=" + std::to_string(g.last_counted_height)
            + " is already banked — the probe fires ~5-6x per block, so this"

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -503,6 +503,22 @@ public:
         m_utxo_ready_fn = std::move(fn);
     }
 
+    /// WINDOW-2 currency gate (--embedded-serve-mempool-txs only). Optional
+    /// predicate answering "has the embedded UTXO view already connected+
+    /// evicted the block whose hash is passed?" (UtxoLane::utxo_current_at).
+    /// When set AND mempool-tx serving is armed, make_embedded_work_inputs
+    /// suppresses the fee-carrying body while the just-promoted serve tip is
+    /// NOT yet current in the UTXO/mempool view -- the diff-driven promotion
+    /// can race ahead of the full-block connect, and a template built on that
+    /// tip could otherwise select a tx already spent/conflicted by it (an
+    /// invalid, thrown-away block). Coinbase-only in that sub-second window
+    /// reproduces dashd's invariant (removeForBlock runs inside ConnectBlock,
+    /// before any template on the new tip). Unset (default) => no Window-2
+    /// gate, byte-identical to the pre-existing behaviour.
+    void set_utxo_current_fn(std::function<bool(const uint256&)> fn) {
+        m_utxo_current_fn = std::move(fn);
+    }
+
     /// What to do during the immature window the predicate above reports.
     ///
     /// ── WHY THE DEFAULT IS Refuse (operator design law, p2pool semantics) ────
@@ -1326,15 +1342,36 @@ public:
         // utxo-immature serving window names itself; otherwise the default-OFF
         // --embedded-serve-mempool-txs posture does. Fee-carrying templates
         // require BOTH a mature UTXO lane AND the explicit operator opt-in.
+        const bool utxo_immature_serving =
+            utxo_immature
+            && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet;
+        // WINDOW 2 (intra-node eviction lag). The serve tip was promoted to H
+        // by the diff-driven path (mnlistdiff-at-tip / cbTx credit-pool
+        // re-anchor) BEFORE the embedded UTXO lane connected block H, so the
+        // view is still at H-1: H's spent outpoints resolve as unspent and the
+        // selection stale-input guard (which checks vins against the LIVE view)
+        // is structurally blind to them, so H's txs would be packed into an H+1
+        // template -> bad-txns-inputs-missingorspent on a winning share = a
+        // thrown-away found block. dashd cannot expose this window because
+        // CTxMemPool::removeForBlock runs synchronously inside ConnectBlock
+        // before SetTip. Reproduce that invariant fail-closed: while the just-
+        // promoted serve tip is NOT yet current in the UTXO/mempool view, serve
+        // coinbase-only (fees=0, exact). Only armed when mempool-tx serving is
+        // ON and the currency fn is wired; self-heals when the raced full_block
+        // connects and evicts (median tip-body window 0.771s, p90 2.9s).
+        const bool utxo_stale_at_tip =
+            m_serve_mempool_txs
+            && static_cast<bool>(m_utxo_current_fn)
+            && !m_utxo_current_fn(m_prev_hash);
         e.suppress_mempool_txs =
-            (utxo_immature
-             && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet)
-            || !m_serve_mempool_txs;
+            utxo_immature_serving || utxo_stale_at_tip || !m_serve_mempool_txs;
+        // Most-specific cause first so soak greps attribute the window. The
+        // cold-start immature window names itself; the Window-2 eviction lag is
+        // next; the default-OFF posture is the residual.
         e.suppress_cause =
-            (utxo_immature
-             && m_utxo_immature_policy == UtxoImmaturePolicy::ServeEmptyTxSet)
-                ? "utxo-immature-serving"
-                : "mempool-txs-disabled";
+              utxo_immature_serving ? "utxo-immature-serving"
+            : utxo_stale_at_tip     ? "utxo-stale-at-tip"
+            :                         "mempool-txs-disabled";
         if (m_require_resolvable_payee && !payee_resolvable) {
             LOG_WARNING << "[EMBED-GATE] h=" << (m_prev_height + 1)
                         << " REFUSE embedded template: MN payment due but payee"
@@ -1791,6 +1828,9 @@ private:
     // (test_dash_submit_gate_scaling.cpp). mutable because the gate is const.
     mutable uint64_t m_emit_ok_calls{0};
     std::function<bool()> m_utxo_ready_fn;   // optional UTXO maturity gate (E2b)
+    // WINDOW-2 currency gate: optional predicate "is the UTXO view current at
+    // this tip hash?" (UtxoLane::utxo_current_at). Unset => no Window-2 gate.
+    std::function<bool(const uint256&)> m_utxo_current_fn;
     // Default REFUSES the immature window (p2pool semantics: an unsynced node
     // does not serve templates) -- byte-identical to the pre-policy behaviour.
     // ServeEmptyTxSet is the pure-daemonless opt-in (subsidy-only block beats

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -761,6 +761,45 @@ private:
         }
     }
 
+    /// Re-issue getdata for tx/dstx invs parked while a tip body was in flight
+    /// (mempool-ingest-completeness). One pass per pool tick. The tip body
+    /// ALWAYS keeps priority: nothing drains while a body is outstanding, and
+    /// the loop bails the instant a body arrives mid-drain. Each retry rides
+    /// the SAME inflight budget/cap and txid-keyed dedup as a first-time pull
+    /// (the inv hash IS the txid for both lanes), and echoes the ANNOUNCED
+    /// type so a DSTX is re-asked as MSG_DSTX. The getdata goes to a
+    /// handshaked peer (tx relay is gossiped — any peer holding it in mempool
+    /// serves it; a peer that lacks it answers notfound, which is benign and
+    /// self-correcting, exactly like the block watchdog's cross-peer re-ask).
+    void drain_tx_retry_busy(int64_t now)
+    {
+        if (m_tx_retry_busy.empty())    return;
+        if (!m_pending_bodies.empty())  return;   // tip body still wins
+        // A peer to ask: prefer the active session, else any handshaked peer.
+        PeerSession* peer = (m_active && m_active->handshake.complete())
+                            ? m_active : nullptr;
+        if (!peer)
+            for (auto& up : m_pool)
+                if (up->handshake.complete()) { peer = up.get(); break; }
+        if (!peer) return;   // no one to ask yet — keep the queue for next tick
+        expire_tx_pulls(now);
+        while (!m_tx_retry_busy.empty())
+        {
+            if (!m_pending_bodies.empty()) break;                 // a body arrived
+            if (m_tx_pull_inflight.size() >= m_tx_pull_inflight_cap) break;  // budget
+            const TxRetry r = m_tx_retry_busy.front();
+            m_tx_retry_busy.pop_front();
+            if (m_tx_pull_inflight.count(r.hash)) continue;       // already in flight
+            m_tx_pull_inflight.emplace(r.hash, now);
+            const bool is_dstx = (r.type == static_cast<uint32_t>(inventory_type::dstx));
+            if (is_dstx) ++m_dstx_pull_sent; else ++m_tx_pull_sent;
+            ++m_tx_retry_drained;
+            auto getdata_msg = message_getdata::make_raw(
+                {inventory_type(static_cast<inventory_type::inv_type>(r.type), r.hash)});
+            peer->write(getdata_msg);
+        }
+    }
+
     // ── MEMPOOL INGEST (phase 1): the MSG_TX pull ────────────────────────
     // The whole reason every embedded template is EMPTY. inv_type_is_pulled()
     // admits quorum_final_commitment and clsig only, so a peer's inv(MSG_TX)
@@ -807,6 +846,24 @@ private:
     uint64_t m_tx_pull_skipped_busy{0};
     uint64_t m_tx_received{0};       // tx bodies that arrived
     uint64_t m_tx_pull_expired{0};   // getdata that never got an answer
+
+    // ── Tip-body-busy retry queue (mempool-ingest-completeness) ──────────
+    // A tx/dstx inv admitted by InvDedup but then SKIPPED because a tip body
+    // was in flight is parked here — NOT dropped. InvDedup holds the (type,
+    // hash) for its 600 s TTL, so a re-announcement from any other peer is
+    // suppressed and the tx would otherwise be stranded until the entry ages
+    // out (by which time it is usually already mined). When the tip body
+    // clears, drain_tx_retry_busy() re-issues the getdata, recovering the
+    // ~2 % of invs this window costs. Bounded FIFO: a sustained body-in-flight
+    // burst drops the OLDEST parked inv, never grows unbounded. Dormant unless
+    // the owning lane (m_tx_pull_enabled / m_dstx_pull_enabled) is armed — the
+    // park site is downstream of the is_tx/is_dstx flag gate — so a
+    // default-configured node parks nothing and its wire is byte-identical.
+    struct TxRetry { uint32_t type; uint256 hash; };
+    std::deque<TxRetry> m_tx_retry_busy;
+    size_t   m_tx_retry_busy_cap{256};
+    uint64_t m_tx_retry_requeued{0};   // invs parked while a tip body was busy
+    uint64_t m_tx_retry_drained{0};    // parked invs later re-issued as getdata
 
     // ── SPORK listener (state + telemetry ONLY — nothing gates on it) ────
     // Seeded with the assume-active mainnet defaults (7/7 active, matching
@@ -1305,6 +1362,11 @@ public:
     /// pool timer would. Paired with set_now_fn this replaces the io_context
     /// entirely for policy tests — no real timer, no real waiting, no race.
     void tick_for_test() { on_pool_tick(); }
+    /// Test-only: simulate the block handler having consumed every tracked
+    /// tip body (the ONLY in-tree place m_pending_bodies is erased), so a KAT
+    /// can drive the body-busy -> body-clear transition drain_tx_retry_busy
+    /// keys on without constructing a hash-matched block body.
+    void clear_pending_bodies_for_test() { m_pending_bodies.clear(); }
 
     /// TEST-ONLY: exercise the bulk/historical body peer SELECTION directly
     /// (announcer-less path), returning the chosen peer's key — the seam the
@@ -1650,10 +1712,23 @@ public:
              + "/" + std::to_string(m_tx_pull_inflight_cap)
              + " skipped(budget)=" + std::to_string(m_tx_pull_skipped_budget)
              + " skipped(tip-body-busy)=" + std::to_string(m_tx_pull_skipped_busy)
-             + " expired=" + std::to_string(m_tx_pull_expired);
+             + " expired=" + std::to_string(m_tx_pull_expired)
+             + " retry(parked/drained)=" + std::to_string(m_tx_retry_requeued)
+             + "/" + std::to_string(m_tx_retry_drained)
+             + " dstx_inv=" + std::to_string(m_dstx_inv_seen)
+             + " dstx_getdata=" + std::to_string(m_dstx_pull_sent)
+             + " dstx_received=" + std::to_string(m_dstx_received);
     }
     uint64_t tx_received_count() const { return m_tx_received; }
     size_t   tx_pull_inflight()  const { return m_tx_pull_inflight.size(); }
+    uint64_t tx_pull_sent_count()        const { return m_tx_pull_sent; }
+    uint64_t tx_pull_skipped_busy_count()const { return m_tx_pull_skipped_busy; }
+    size_t   tx_retry_busy_count()       const { return m_tx_retry_busy.size(); }
+    uint64_t tx_retry_requeued_count()   const { return m_tx_retry_requeued; }
+    uint64_t tx_retry_drained_count()    const { return m_tx_retry_drained; }
+    uint64_t dstx_inv_seen_count()       const { return m_dstx_inv_seen; }
+    uint64_t dstx_pull_sent_count()      const { return m_dstx_pull_sent; }
+    uint64_t dstx_received_count()       const { return m_dstx_received; }
 
     /// Request a full block via plain MSG_BLOCK getdata (E2 pull seam).
     /// Routed to the peer that ANNOUNCED this block (block_source), which holds
@@ -2685,6 +2760,7 @@ private:
         }
 
         service_pending_bodies(now);
+        drain_tx_retry_busy(now);
         prune_stale_dials(now);
         // dashd acquisition parity: while behind on archival coverage, dial
         // more and rotate the frozen full pool's worst non-server out for a
@@ -3046,6 +3122,14 @@ private:
                 // stale template on every attached rig.
                 if (!m_pending_bodies.empty()) {
                     ++m_tx_pull_skipped_busy;
+                    // Do NOT let the 600 s InvDedup TTL strand it: park the
+                    // announcement and re-issue the getdata the moment the
+                    // tip body clears (drain_tx_retry_busy on the pool tick).
+                    if (m_tx_retry_busy.size() >= m_tx_retry_busy_cap)
+                        m_tx_retry_busy.pop_front();
+                    m_tx_retry_busy.push_back(
+                        TxRetry{static_cast<uint32_t>(inv.m_type), inv.m_hash});
+                    ++m_tx_retry_requeued;
                     continue;
                 }
                 if (m_tx_pull_inflight.size() >= m_tx_pull_inflight_cap) {

--- a/src/impl/dash/coin/rpc_data.hpp
+++ b/src/impl/dash/coin/rpc_data.hpp
@@ -207,6 +207,43 @@ struct DashWorkData {
     // inference from a reject string. Diagnostic: no consensus path reads it.
     std::vector<uint8_t>  m_mempool_probe_depends_in_set;
 
+    // -- EMBEDDED TX-SERVE INTERNAL-CONSISTENCY STAMP -----------------------
+    // Written ONLY by the embedded builder when it produces a mempool-tx-
+    // carrying body (embedded_gbt.hpp; armed == !suppress_mempool_txs). The
+    // serve-time internal-consistency referee (tx_serve_referee.hpp) reads it
+    // to decide whether c2pool may serve ITS OWN valid tx set instead of
+    // falling back to dashd merely because our tx-merkle-root differs. A
+    // divergent-but-internally-consistent set is a NORMAL, perfectly valid
+    // block; the safety requirement is per-tx validity + no double-spend +
+    // coinbase fee-consistency, NOT tx-set parity with dashd.
+    //
+    // The two facts here are the ones the referee cannot re-derive from the
+    // wire body alone: whether every mempool-range tx passed the fee-fold
+    // proof (mempool.hpp exclusion-discipline: the vin-present/unspent,
+    // in_sum>=out_sum guarantee), and the treasury/superblock slice that was
+    // added to m_coinbase_value on a funded superblock height (so the referee
+    // can assert m_coinbase_value == subsidy + Sum(m_tx_fees) + superblock).
+    // armed == false on every non-serving build (coinbase-only, dashd
+    // fallback) -> the referee never runs and behaviour is byte-identical.
+    struct EmbeddedTxServeStamp {
+        // The mempool-serving path produced this body (--embedded-serve-
+        // mempool-txs ON at build time). When false the referee is dormant.
+        bool     armed{false};
+        // Every tx in the mempool-sourced range [m_mempool_tx_first_index,
+        // +m_mempool_tx_count) passed the fee-fold proof at selection. The
+        // selector already refuses non-proven entries (mempool.hpp:~1018
+        // "if(!e.fee_fold_proven) continue;"); this records that guarantee so
+        // the referee can fail-close if a future selection path ever admits an
+        // unproven tx.
+        bool     all_mempool_fee_fold_proven{false};
+        // Treasury payout total added to m_coinbase_value at a funded
+        // superblock height (0 on every ordinary block). Lets the referee
+        // reconstruct the coinbase value exactly from (subsidy + fees +
+        // superblock) rather than approximating it.
+        uint64_t superblock_total{0};
+    };
+    EmbeddedTxServeStamp m_tx_serve_stamp;
+
     // ── PIN OUTCOMES (see PinOutcome above) ───────────────────────────────
     // One entry per configured pinned local tx, written by the splice on the
     // SERVED dashd-fallback arm. Empty on the embedded arm (which splices in

--- a/src/impl/dash/coin/serve_gate_ledger.hpp
+++ b/src/impl/dash/coin/serve_gate_ledger.hpp
@@ -1,0 +1,421 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// ServeGateLedger — the CUMULATIVE, CROSS-RESTART companion to
+/// ServeGateJournal.
+///
+/// THE DEFECT THIS CLOSES (critic, 2026-08-23): the EMBED-GATE roll-up and
+/// every ServeGateJournal counter live entirely in-process. `m_cause_totals`,
+/// `m_first_observed_sec`, `m_episode_start_sec` are member state fed a
+/// std::chrono::steady_clock (PROCESS-MONOTONIC) clock — so the whole roll-up
+/// WIPES on every restart and the program-level "% embedded / never-a-reject"
+/// figure is per-process, not standing. The dashd-cut acceptance gate is a
+/// CUMULATIVE never-a-reject claim spanning >=3 restarts ("the null-arm covered
+/// the 4.51% DKG floor, 0 rejects over N heights"), which the journal cannot
+/// express: a claim you cannot carry across a restart is not a soak claim.
+///
+/// ServeGateLedger is the persisted aggregator. Design constraints, copied
+/// verbatim from ServeGateJournal's discipline because the two must never
+/// disagree:
+///
+///   * PURE POLICY — no I/O, no clock of its own, no JSON. The caller passes
+///     monotonic seconds; a companion header (serve_gate_ledger_json.hpp) owns
+///     serialize/deserialize + the atomic tmp+rename file. Header-only so it
+///     folds into the allowlisted dash test targets exactly like the journal.
+///
+///   * ONLY DURATIONS/DELTAS CROSS PROCESSES. The steady_clock second is
+///     process-monotonic, so a raw `now_sec` can never be persisted/restored.
+///     observed_sec accumulates as (now - last_seen) DELTAS banked per serve;
+///     off_embedded_sec / per_cause bank the journal's OWN closed-segment
+///     durations (Decision.prev_cause_sec) — the exact quantity the journal
+///     folds into m_cause_totals, so ledger and journal cannot diverge.
+///
+///   * CRASH LOSES <=1 FLUSH, NEVER DOUBLE-COUNTS. Closed segments are banked
+///     into cumulative totals as they close. The currently-OPEN segment's
+///     partial is written to a REPLACED (never accumulated) carry field and
+///     folded exactly once on the next clean load — approximating the segment
+///     the crashed process never got to close, without ever re-banking a
+///     segment the new process's fresh journal will bank itself.
+///
+///   * MEASUREMENT-WITHOUT-COMMIT RULE. The persisted blob carries a schema
+///     version, an epochs counter (++ on every load), and the writing binary's
+///     commit sha, so a cumulative figure is never read without knowing which
+///     code produced it.
+///
+/// NULL-ARM IS FIRST CLASS. A null-arm serve is journaled as plain
+/// Served::Embedded and logs arm=EMBEDDED — indistinguishable from a
+/// real-quorum serve (the 08-23 grep-case trap). The ledger splits Embedded
+/// into EmbeddedReal / EmbeddedNull so "null-arm served the 4.51% floor" is a
+/// first-class counter, and cross-checks that a null was served ONLY when no
+/// real quorum was available (real_quorum_available_but_null_served MUST stay
+/// 0 — that would be a null served where dashd had a real committed quorum).
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+
+namespace dash {
+namespace coin {
+
+class ServeGateLedger {
+public:
+    static constexpr uint32_t kSchemaVersion = 1;
+
+    /// Which arm produced a serve / won a block. Mirrors ServeGateJournal's
+    /// three-valued disposition but SPLITS Embedded so the null arm is
+    /// countable on its own axis.
+    ///   EmbeddedReal — embedded template built on a real committed quorum;
+    ///   EmbeddedNull — embedded template served coinbase-only over the DKG
+    ///                  floor with the SAME null quorum commitment dashd uses
+    ///                  (#127 parity), NOT a real quorum;
+    ///   Fallback     — a real dashd getblocktemplate was served instead;
+    ///   NoWork       — SET-GAP: neither arm produced a mineable template.
+    enum class Arm : uint8_t {
+        Unknown      = 0,
+        EmbeddedReal = 1,
+        EmbeddedNull = 2,
+        Fallback     = 3,
+        NoWork       = 4,
+    };
+
+    static const char* arm_name(Arm a) {
+        switch (a) {
+            case Arm::EmbeddedReal: return "embedded_real";
+            case Arm::EmbeddedNull: return "embedded_null";
+            case Arm::Fallback:     return "fallback";
+            case Arm::NoWork:       return "no_work";
+            case Arm::Unknown:      break;
+        }
+        return "unknown";
+    }
+
+    static bool is_embedded(Arm a) {
+        return a == Arm::EmbeddedReal || a == Arm::EmbeddedNull;
+    }
+
+    /// The entire persisted state. A plain aggregate so the JSON companion can
+    /// serialize/deserialize field-by-field and the KAT can compare two
+    /// ledgers with ==. Every field is a cumulative TOTAL or a DELTA-safe
+    /// duration — no raw process-monotonic clock value ever lands here.
+    struct Totals {
+        // ── provenance (measurement-without-commit rule) ──────────────────
+        uint32_t    schema_version{kSchemaVersion};
+        uint64_t    epochs{0};            ///< ++ on every load (restart count+1)
+        std::string last_writer_commit;   ///< git sha of the writing binary
+
+        // ── wall clock (delta-accumulated; safe across processes) ─────────
+        int64_t observed_sec{0};          ///< cumulative wall clock observed
+        int64_t off_embedded_sec{0};      ///< cumulative seconds off embedded
+        std::map<std::string, int64_t> per_cause_sec;  ///< closed segments only
+
+        // ── serve dispositions (per template re-source) ───────────────────
+        uint64_t serves_embedded_real{0};
+        uint64_t serves_embedded_null{0};
+        uint64_t serves_fallback{0};
+        uint64_t serves_no_work{0};
+
+        // ── blocks ────────────────────────────────────────────────────────
+        uint64_t blocks_won_embedded_real{0};
+        uint64_t blocks_won_embedded_null{0};
+        uint64_t blocks_won_fallback{0};
+        uint64_t blocks_submitted{0};
+        uint64_t blocks_confirmed{0};
+        uint64_t blocks_orphaned{0};
+        uint64_t local_payee_guard_rejects{0};
+
+        // ── the never-a-reject numerators (hard gate: embedded == 0) ──────
+        uint64_t rpc_rejected_embedded_real{0};
+        uint64_t rpc_rejected_embedded_null{0};
+        uint64_t rpc_rejected_fallback{0};
+        uint64_t orphaned_embedded_real{0};   ///< validity-attributable
+        uint64_t orphaned_embedded_null{0};   ///< validity-attributable
+        std::map<std::string, uint64_t> rpc_reject_reasons;
+
+        // ── null-arm first class ──────────────────────────────────────────
+        /// A null was served on a DKG-floor tip where NO real quorum existed
+        /// (the correct, dashd-parity case).
+        uint64_t null_dkg_floor_tips_served{0};
+        /// A null was served where a real committed quorum WAS available. This
+        /// MUST stay 0 — a non-zero value means the null arm fired when it
+        /// should not have, and stops the cut.
+        uint64_t null_real_quorum_available_but_null_served{0};
+
+        // ── rolling never-a-reject height span ────────────────────────────
+        /// First / last parent-chain height in the CURRENT clean (0-reject)
+        /// span. start==0 means the span is empty (just reset by a reject).
+        uint64_t nr_span_start_height{0};
+        uint64_t nr_span_last_height{0};
+        /// Cumulative count of rejects (any arm) that broke a span, and the
+        /// height of the most recent one (0 = never rejected).
+        uint64_t nr_total_rejects{0};
+        uint64_t nr_last_reject_height{0};
+
+        // ── open-segment carry (REPLACED each flush; folded once on load) ──
+        /// The partial duration of the segment currently in progress at flush
+        /// time. NOT part of off_embedded_sec/per_cause until folded on the
+        /// next load — that fold is the only place it is ever added, and it is
+        /// cleared immediately after, so it can never be folded twice.
+        std::string carry_cause;
+        int64_t     carry_sec{0};
+
+        bool operator==(const Totals& o) const {
+            return schema_version == o.schema_version && epochs == o.epochs &&
+                   last_writer_commit == o.last_writer_commit &&
+                   observed_sec == o.observed_sec &&
+                   off_embedded_sec == o.off_embedded_sec &&
+                   per_cause_sec == o.per_cause_sec &&
+                   serves_embedded_real == o.serves_embedded_real &&
+                   serves_embedded_null == o.serves_embedded_null &&
+                   serves_fallback == o.serves_fallback &&
+                   serves_no_work == o.serves_no_work &&
+                   blocks_won_embedded_real == o.blocks_won_embedded_real &&
+                   blocks_won_embedded_null == o.blocks_won_embedded_null &&
+                   blocks_won_fallback == o.blocks_won_fallback &&
+                   blocks_submitted == o.blocks_submitted &&
+                   blocks_confirmed == o.blocks_confirmed &&
+                   blocks_orphaned == o.blocks_orphaned &&
+                   local_payee_guard_rejects == o.local_payee_guard_rejects &&
+                   rpc_rejected_embedded_real == o.rpc_rejected_embedded_real &&
+                   rpc_rejected_embedded_null == o.rpc_rejected_embedded_null &&
+                   rpc_rejected_fallback == o.rpc_rejected_fallback &&
+                   orphaned_embedded_real == o.orphaned_embedded_real &&
+                   orphaned_embedded_null == o.orphaned_embedded_null &&
+                   rpc_reject_reasons == o.rpc_reject_reasons &&
+                   null_dkg_floor_tips_served == o.null_dkg_floor_tips_served &&
+                   null_real_quorum_available_but_null_served ==
+                       o.null_real_quorum_available_but_null_served &&
+                   nr_span_start_height == o.nr_span_start_height &&
+                   nr_span_last_height == o.nr_span_last_height &&
+                   nr_total_rejects == o.nr_total_rejects &&
+                   nr_last_reject_height == o.nr_last_reject_height &&
+                   carry_cause == o.carry_cause && carry_sec == o.carry_sec;
+        }
+        bool operator!=(const Totals& o) const { return !(*this == o); }
+    };
+
+    ServeGateLedger() = default;
+
+    /// Restore from a persisted blob and count this as one more epoch. This is
+    /// the ONLY place carry is folded: the crashed/previous process's open
+    /// segment is banked into the cumulative totals exactly once, then cleared
+    /// so it can never be folded again. epochs is bumped so the on-disk figure
+    /// always names how many process lifetimes it spans.
+    void load(const Totals& persisted) {
+        m_t = persisted;
+        // Fold the previous process's open-segment partial exactly once.
+        if (m_t.carry_sec > 0 && !m_t.carry_cause.empty()) {
+            m_t.off_embedded_sec += m_t.carry_sec;
+            m_t.per_cause_sec[m_t.carry_cause] += m_t.carry_sec;
+        }
+        m_t.carry_sec = 0;
+        m_t.carry_cause.clear();
+        m_t.epochs += 1;
+        m_t.schema_version = kSchemaVersion;
+        // A new process: no last-seen clock yet, and no open segment carried in
+        // memory (the fold above already accounted for the previous one).
+        m_have_last_seen = false;
+        m_open_cause.clear();
+        m_open_start_sec = -1;
+    }
+
+    /// Stamp the writing binary's commit into the blob about to be flushed.
+    void set_writer_commit(const std::string& sha) { m_t.last_writer_commit = sha; }
+
+    /// HOOK h1 — bank ONE serve decision. Call once per template re-source,
+    /// under the SAME serve_gate_mutex_ the journal observe() ran under, with:
+    ///   arm            — resolved disposition (EmbeddedReal/EmbeddedNull/...);
+    ///   current_cause  — the live first-unmet condition (why.cause) when off
+    ///                    embedded; ignored (and cleared) when serving. Passed
+    ///                    explicitly because Decision does not echo the current
+    ///                    cause on suppressed lines (only prev_cause on the
+    ///                    lines that CLOSE a segment);
+    ///   d              — the SAME ServeGateJournal::Decision observe() just
+    ///                    returned (its prev_cause_sec is exactly what the
+    ///                    journal banks into m_cause_totals, so ledger and
+    ///                    journal cannot disagree on closed segments);
+    ///   now_sec        — monotonic seconds (process clock; only its DELTA and
+    ///                    within-process open-segment span are used, never the
+    ///                    absolute value — that is why totals cross restarts);
+    ///   real_quorum_available — for EmbeddedNull only: was a real committed
+    ///                    quorum available at this tip? true here is a defect (a
+    ///                    null served where dashd had a real quorum), counted so.
+    void bank_serve(Arm arm, const std::string& current_cause,
+                    const ServeGateJournal::Decision& d, int64_t now_sec,
+                    bool real_quorum_available = false) {
+        // observed_sec grows by the DELTA since the last banked serve. First
+        // call in a process contributes 0 (no prior sample) — this is why only
+        // deltas cross restarts: the absolute clock is never persisted.
+        if (m_have_last_seen && now_sec >= m_last_seen_sec)
+            m_t.observed_sec += (now_sec - m_last_seen_sec);
+        m_last_seen_sec  = now_sec;
+        m_have_last_seen = true;
+
+        // Bank the closed segment this decision reported, mirroring the
+        // journal's m_cause_totals fold EXACTLY (same field, same guard).
+        if (d.prev_cause_sec >= 0 && !d.previous_cause.empty()) {
+            m_t.off_embedded_sec += d.prev_cause_sec;
+            m_t.per_cause_sec[d.previous_cause] += d.prev_cause_sec;
+        }
+
+        // Track the currently-OPEN segment with the ledger's own segment clock,
+        // exactly as the journal tracks m_cause_start_sec — Decision cannot
+        // supply the open partial on suppressed lines (cause_sec is -1 there),
+        // so the ledger measures it itself. A NEW segment (transition into
+        // decline, or a cause change) restarts the clock at now_sec; a flush
+        // then snapshots (last_seen - open_start) as carry.
+        if (is_embedded(arm)) {
+            m_open_cause.clear();
+            m_open_start_sec = -1;
+        } else {
+            if (m_open_cause != current_cause || m_open_start_sec < 0) {
+                m_open_cause     = current_cause;
+                m_open_start_sec = now_sec;
+            }
+        }
+
+        switch (arm) {
+            case Arm::EmbeddedReal: ++m_t.serves_embedded_real; break;
+            case Arm::EmbeddedNull:
+                ++m_t.serves_embedded_null;
+                if (real_quorum_available)
+                    ++m_t.null_real_quorum_available_but_null_served;
+                else
+                    ++m_t.null_dkg_floor_tips_served;
+                break;
+            case Arm::Fallback: ++m_t.serves_fallback; break;
+            case Arm::NoWork:   ++m_t.serves_no_work;  break;
+            case Arm::Unknown:  break;
+        }
+    }
+
+    /// HOOK h3 — snapshot the open segment into the REPLACED carry field, ready
+    /// to be persisted. Idempotent; call immediately before every flush. Does
+    /// NOT touch the cumulative totals (carry is folded only on load). The
+    /// partial is (last banked serve - open-segment start), a within-process
+    /// duration — never an absolute clock value.
+    void snapshot_carry_for_flush() {
+        if (!m_open_cause.empty() && m_open_start_sec >= 0 &&
+            m_have_last_seen && m_last_seen_sec > m_open_start_sec) {
+            m_t.carry_cause = m_open_cause;
+            m_t.carry_sec   = m_last_seen_sec - m_open_start_sec;
+        } else {
+            m_t.carry_cause.clear();
+            m_t.carry_sec = 0;
+        }
+    }
+
+    // ── block / verdict hooks (h-blocks) ──────────────────────────────────
+
+    /// A block was won and submitted on `arm` at parent-chain `height`. The
+    /// clean span is extended optimistically; a later reject/validity-orphan
+    /// breaks it.
+    void record_block_won(Arm arm, uint64_t height) {
+        switch (arm) {
+            case Arm::EmbeddedReal: ++m_t.blocks_won_embedded_real; break;
+            case Arm::EmbeddedNull: ++m_t.blocks_won_embedded_null; break;
+            case Arm::Fallback:     ++m_t.blocks_won_fallback;      break;
+            default: break;
+        }
+        ++m_t.blocks_submitted;
+        extend_clean_span(height);
+    }
+
+    /// submitblock (or the daemonless header verdict) resolved. accepted=true
+    /// when the RPC returned null / the header chain adopted the block;
+    /// accepted=false with a reason string is a REJECT — it increments the
+    /// per-arm reject counter and BREAKS the never-a-reject span.
+    void record_rpc_verdict(Arm arm, uint64_t height, bool accepted,
+                            const std::string& reject_reason) {
+        if (accepted) return;
+        switch (arm) {
+            case Arm::EmbeddedReal: ++m_t.rpc_rejected_embedded_real; break;
+            case Arm::EmbeddedNull: ++m_t.rpc_rejected_embedded_null; break;
+            case Arm::Fallback:     ++m_t.rpc_rejected_fallback;      break;
+            default: break;
+        }
+        if (!reject_reason.empty()) ++m_t.rpc_reject_reasons[reject_reason];
+        break_clean_span(height);
+    }
+
+    /// The post-broadcast confirm/orphan lane resolved a verdict. A
+    /// validity-attributable orphan on an embedded arm breaks the span (it is a
+    /// silent reject); a race orphan (validity_attributable=false) does not.
+    void record_confirm(Arm /*arm*/, uint64_t /*height*/) { ++m_t.blocks_confirmed; }
+    void record_orphan(Arm arm, uint64_t height, bool validity_attributable) {
+        ++m_t.blocks_orphaned;
+        if (validity_attributable) {
+            if (arm == Arm::EmbeddedReal) ++m_t.orphaned_embedded_real;
+            else if (arm == Arm::EmbeddedNull) ++m_t.orphaned_embedded_null;
+            if (is_embedded(arm)) break_clean_span(height);
+        }
+    }
+
+    /// The pre-broadcast payee guard refused to submit locally. Counted, but it
+    /// prevented a submit rather than being rejected by the network, so it does
+    /// NOT break the never-a-reject span (nothing reached the chain).
+    void record_payee_guard_reject(uint64_t /*height*/) {
+        ++m_t.local_payee_guard_rejects;
+    }
+
+    // ── queries ───────────────────────────────────────────────────────────
+
+    const Totals& totals() const { return m_t; }
+
+    /// The cumulative never-a-reject claim: no embedded block was rejected by
+    /// RPC and no embedded block was orphaned for a validity reason, over every
+    /// epoch. This is the hard cut gate.
+    bool never_a_reject() const {
+        return m_t.rpc_rejected_embedded_real == 0 &&
+               m_t.rpc_rejected_embedded_null == 0 &&
+               m_t.orphaned_embedded_real == 0 &&
+               m_t.orphaned_embedded_null == 0;
+    }
+
+    /// Length of the current clean span in heights (inclusive), 0 when empty.
+    uint64_t clean_span_heights() const {
+        if (m_t.nr_span_start_height == 0) return 0;
+        return m_t.nr_span_last_height - m_t.nr_span_start_height + 1;
+    }
+
+    uint64_t serves_total() const {
+        return m_t.serves_embedded_real + m_t.serves_embedded_null +
+               m_t.serves_fallback + m_t.serves_no_work;
+    }
+    uint64_t serves_embedded_total() const {
+        return m_t.serves_embedded_real + m_t.serves_embedded_null;
+    }
+
+private:
+    void extend_clean_span(uint64_t height) {
+        if (height == 0) return;
+        if (m_t.nr_span_start_height == 0 || height < m_t.nr_span_start_height)
+            m_t.nr_span_start_height = height;
+        if (height > m_t.nr_span_last_height)
+            m_t.nr_span_last_height = height;
+    }
+    void break_clean_span(uint64_t height) {
+        ++m_t.nr_total_rejects;
+        m_t.nr_last_reject_height = height;
+        m_t.nr_span_start_height  = 0;
+        m_t.nr_span_last_height   = 0;
+    }
+
+    Totals m_t;
+
+    // In-memory-only tracking of the open segment + last-seen clock. NONE of
+    // this is persisted directly: observed_sec banks deltas, and the open
+    // segment is snapshotted into Totals::carry only at flush time.
+    bool        m_have_last_seen{false};
+    int64_t     m_last_seen_sec{0};
+    std::string m_open_cause;
+    /// Start of the currently-open off-embedded segment (process-monotonic);
+    /// -1 while the embedded arm is serving. The flush snapshots
+    /// (m_last_seen_sec - m_open_start_sec) as carry.
+    int64_t     m_open_start_sec{-1};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/serve_gate_ledger_json.hpp
+++ b/src/impl/dash/coin/serve_gate_ledger_json.hpp
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// The ONE serialize/deserialize + atomic-file definition for
+/// ServeGateLedger::Totals, kept OUT of serve_gate_ledger.hpp so that header
+/// stays pure policy (no I/O, no JSON, no clock) exactly as serve_gate_journal
+/// keeps its own JSON in serve_gate_rollup_json.hpp. The producer
+/// (DASHWorkSource) and the KAT share this single definition, so a test cannot
+/// pin a shape the producer does not emit.
+///
+/// Persistence contract:
+///   * write-through to <data-dir>/<net_subdir>/serve_gate_ledger.json;
+///   * ATOMIC — serialize to "<path>.tmp", fsync, rename over the target, so a
+///     crash mid-write never leaves a half-written ledger (a torn cumulative
+///     figure is worse than a stale one);
+///   * schema v1 with epochs + last_writer_commit already in Totals (the
+///     measurement-without-commit rule), so a blob is never read without
+///     knowing which code produced it and how many process lifetimes it spans.
+
+#include <cstdio>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <impl/dash/coin/serve_gate_ledger.hpp>
+
+namespace dash {
+namespace coin {
+
+inline nlohmann::json serve_gate_ledger_to_json(const ServeGateLedger::Totals& t)
+{
+    nlohmann::json j;
+    j["schema_version"]     = t.schema_version;
+    j["epochs"]             = t.epochs;
+    j["last_writer_commit"] = t.last_writer_commit;
+
+    j["observed_sec"]       = t.observed_sec;
+    j["off_embedded_sec"]   = t.off_embedded_sec;
+    nlohmann::json pc = nlohmann::json::object();
+    for (const auto& kv : t.per_cause_sec) pc[kv.first] = kv.second;
+    j["per_cause_sec"]      = std::move(pc);
+
+    j["serves_embedded_real"] = t.serves_embedded_real;
+    j["serves_embedded_null"] = t.serves_embedded_null;
+    j["serves_fallback"]      = t.serves_fallback;
+    j["serves_no_work"]       = t.serves_no_work;
+
+    j["blocks_won_embedded_real"] = t.blocks_won_embedded_real;
+    j["blocks_won_embedded_null"] = t.blocks_won_embedded_null;
+    j["blocks_won_fallback"]      = t.blocks_won_fallback;
+    j["blocks_submitted"]         = t.blocks_submitted;
+    j["blocks_confirmed"]         = t.blocks_confirmed;
+    j["blocks_orphaned"]          = t.blocks_orphaned;
+    j["local_payee_guard_rejects"] = t.local_payee_guard_rejects;
+
+    j["rpc_rejected_embedded_real"] = t.rpc_rejected_embedded_real;
+    j["rpc_rejected_embedded_null"] = t.rpc_rejected_embedded_null;
+    j["rpc_rejected_fallback"]      = t.rpc_rejected_fallback;
+    j["orphaned_embedded_real"]     = t.orphaned_embedded_real;
+    j["orphaned_embedded_null"]     = t.orphaned_embedded_null;
+    nlohmann::json rr = nlohmann::json::object();
+    for (const auto& kv : t.rpc_reject_reasons) rr[kv.first] = kv.second;
+    j["rpc_reject_reasons"]         = std::move(rr);
+
+    j["null_dkg_floor_tips_served"] = t.null_dkg_floor_tips_served;
+    j["null_real_quorum_available_but_null_served"] =
+        t.null_real_quorum_available_but_null_served;
+
+    j["nr_span_start_height"]  = t.nr_span_start_height;
+    j["nr_span_last_height"]   = t.nr_span_last_height;
+    j["nr_total_rejects"]      = t.nr_total_rejects;
+    j["nr_last_reject_height"] = t.nr_last_reject_height;
+
+    j["carry_cause"] = t.carry_cause;
+    j["carry_sec"]   = t.carry_sec;
+    return j;
+}
+
+inline ServeGateLedger::Totals serve_gate_ledger_from_json(const nlohmann::json& j)
+{
+    ServeGateLedger::Totals t;
+    auto u32 = [&](const char* k, uint32_t d) { return j.value(k, d); };
+    auto u64 = [&](const char* k, uint64_t d) { return j.value(k, d); };
+    auto i64 = [&](const char* k, int64_t d) { return j.value(k, d); };
+    auto str = [&](const char* k) { return j.value(k, std::string{}); };
+
+    t.schema_version     = u32("schema_version", ServeGateLedger::kSchemaVersion);
+    t.epochs             = u64("epochs", 0);
+    t.last_writer_commit = str("last_writer_commit");
+
+    t.observed_sec     = i64("observed_sec", 0);
+    t.off_embedded_sec = i64("off_embedded_sec", 0);
+    if (j.contains("per_cause_sec") && j["per_cause_sec"].is_object())
+        for (auto it = j["per_cause_sec"].begin(); it != j["per_cause_sec"].end(); ++it)
+            t.per_cause_sec[it.key()] = it.value().get<int64_t>();
+
+    t.serves_embedded_real = u64("serves_embedded_real", 0);
+    t.serves_embedded_null = u64("serves_embedded_null", 0);
+    t.serves_fallback      = u64("serves_fallback", 0);
+    t.serves_no_work       = u64("serves_no_work", 0);
+
+    t.blocks_won_embedded_real = u64("blocks_won_embedded_real", 0);
+    t.blocks_won_embedded_null = u64("blocks_won_embedded_null", 0);
+    t.blocks_won_fallback      = u64("blocks_won_fallback", 0);
+    t.blocks_submitted         = u64("blocks_submitted", 0);
+    t.blocks_confirmed         = u64("blocks_confirmed", 0);
+    t.blocks_orphaned          = u64("blocks_orphaned", 0);
+    t.local_payee_guard_rejects = u64("local_payee_guard_rejects", 0);
+
+    t.rpc_rejected_embedded_real = u64("rpc_rejected_embedded_real", 0);
+    t.rpc_rejected_embedded_null = u64("rpc_rejected_embedded_null", 0);
+    t.rpc_rejected_fallback      = u64("rpc_rejected_fallback", 0);
+    t.orphaned_embedded_real     = u64("orphaned_embedded_real", 0);
+    t.orphaned_embedded_null     = u64("orphaned_embedded_null", 0);
+    if (j.contains("rpc_reject_reasons") && j["rpc_reject_reasons"].is_object())
+        for (auto it = j["rpc_reject_reasons"].begin(); it != j["rpc_reject_reasons"].end(); ++it)
+            t.rpc_reject_reasons[it.key()] = it.value().get<uint64_t>();
+
+    t.null_dkg_floor_tips_served = u64("null_dkg_floor_tips_served", 0);
+    t.null_real_quorum_available_but_null_served =
+        u64("null_real_quorum_available_but_null_served", 0);
+
+    t.nr_span_start_height  = u64("nr_span_start_height", 0);
+    t.nr_span_last_height   = u64("nr_span_last_height", 0);
+    t.nr_total_rejects      = u64("nr_total_rejects", 0);
+    t.nr_last_reject_height = u64("nr_last_reject_height", 0);
+
+    t.carry_cause = str("carry_cause");
+    t.carry_sec   = i64("carry_sec", 0);
+    return t;
+}
+
+/// Atomic write-through: serialize `t` to `<path>.tmp`, flush+fsync, then
+/// rename over `path`. Returns false on any I/O error (the caller keeps the
+/// in-memory ledger; a failed flush loses at most one cadence of durations).
+inline bool serve_gate_ledger_save(const std::string& path,
+                                   const ServeGateLedger::Totals& t)
+{
+    const std::string tmp = path + ".tmp";
+    {
+        std::ofstream os(tmp, std::ios::binary | std::ios::trunc);
+        if (!os) return false;
+        os << serve_gate_ledger_to_json(t).dump(2);
+        os.flush();
+        if (!os) return false;
+    }
+    // Best-effort durability: rename is atomic on the same filesystem.
+    if (std::rename(tmp.c_str(), path.c_str()) != 0) {
+        std::remove(tmp.c_str());
+        return false;
+    }
+    return true;
+}
+
+/// Load a persisted ledger blob. Returns false (and leaves `out` default) when
+/// the file is absent or unparseable — a fresh node starts at epoch 0.
+inline bool serve_gate_ledger_load(const std::string& path,
+                                   ServeGateLedger::Totals& out)
+{
+    std::ifstream is(path, std::ios::binary);
+    if (!is) return false;
+    std::stringstream ss;
+    ss << is.rdbuf();
+    if (ss.str().empty()) return false;
+    try {
+        out = serve_gate_ledger_from_json(nlohmann::json::parse(ss.str()));
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/serve_gate_persist.hpp
+++ b/src/impl/dash/coin/serve_gate_persist.hpp
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// CUMULATIVE, CROSS-RESTART persistence for the serve-gate roll-up, plus the
+/// explicit QC null-arm serve counters that make the 4.51% DKG-floor coverage
+/// and the never-a-reject conjunct measurable PROGRAM-LEVEL over a standing
+/// soak instead of only within a single process.
+///
+/// THE DEFECT THIS CLOSES (measured on hotel-primary, 2026-08-23): the
+/// [EMBED-GATE-ROLLUP] denominator `observed=` equalled wall-clock since the
+/// LAST restart — 7211 s at the 06:00 tick for a 04:00 restart — because
+/// ServeGateJournal is deliberately pure policy (no I/O, no clock of its own)
+/// and every counter it holds resets when the process does. So the gate that
+/// actually matters for the dashd cut — "the null-arm covered the 4.51% DKG
+/// floor with 0 rejects over a STANDING soak" — cannot be read program-level:
+/// each restart zeroes the numerators and the denominator, and there is no
+/// explicit null-served counter at all (null-serving is only inferable from
+/// the '(was null-served)' instant-upgrade log lines, which the arm emits only
+/// on the null->real transition, never on a plain null serve).
+///
+/// This header is the I/O layer ServeGateJournal refuses to be — kept OUT of
+/// serve_gate_journal.hpp on purpose, exactly as serve_gate_rollup_json.hpp is,
+/// so that header stays pure. It maintains a small JSON state file:
+///
+///   * load_serve_gate_state() reads the PRIOR-process totals at startup and
+///     bumps restart_count (a missing OR corrupt file yields a clean zero — a
+///     soak state file is a convenience, never a consensus input, so a bad
+///     read must never wedge the node);
+///   * combine() folds the CURRENT process's live ServeGateJournal::Rollup and
+///     its live-incremented QcNullServeCounters on top of the frozen prior;
+///   * save_serve_gate_state_atomic() write-throughs that combined view via a
+///     temp-file + rename, so a crash mid-write can never truncate the state.
+///
+/// DOUBLE-COUNT SAFETY — the file holds ONLY prior-process totals, frozen at
+/// the moment of load. combine() = prior + live, and `live` is the process's
+/// own already-cumulative rollup / monotonic counters, so writing on EVERY
+/// roll-up tick REPLACES the live part rather than adding it: N writes within
+/// one process produce the identical total as one write. There is no path that
+/// folds this process's contribution into `prior`, so re-saving is idempotent.
+
+#include <cstdint>
+#include <cstdio>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+
+namespace dash {
+namespace coin {
+
+/// Explicit, per-LLMQ-type tallies over the DKG mining-window (required,
+/// not-yet-mined) tips the null-arm governs, plus the global never-a-reject
+/// conjunct. These are EVENT counts (not seconds): the current process
+/// increments them live and combine() sums them onto the persisted prior.
+///
+/// INVARIANT (held by note()): for every type,
+///     window_open[t] == null_served[t] + real_served[t] + fell_back[t].
+/// A required mining-window tip is encountered exactly once and takes exactly
+/// one of the three dispositions:
+///   * NullServed — no verified real commitment cached AND the freshness
+///                  predicate held (has_mined==false on a view proven current
+///                  at pindexPrev): the byte-parity null was served, dashd's
+///                  own null-then-real cadence;
+///   * RealServed — a verified real commitment existed for the slot, so the
+///                  null-arm was NEVER consulted (verified_for precedes
+///                  null_evidence): the serve-exactness guarantee, counted;
+///   * FellBack   — freshness was unproven, so the whole height failed closed
+///                  to the fallback (today's benign 4.51% gap, never a reject).
+struct QcNullServeCounters {
+    enum class Disposition { NullServed, RealServed, FellBack };
+
+    std::map<int, int64_t> window_open;   ///< required mining-window tips seen
+    std::map<int, int64_t> null_served;   ///< served the byte-parity null
+    std::map<int, int64_t> real_served;   ///< a verified real commitment existed
+    std::map<int, int64_t> fell_back;     ///< freshness unproven => fail-closed
+
+    /// The never-a-reject conjunct. submits_from_null counts block submissions
+    /// whose template carried at least one null commitment; rejects_from_null
+    /// counts how many the NETWORK rejected. The soak gate is
+    /// rejects_from_null == 0 for submits_from_null > 0. The reject door is a
+    /// consensus verdict on the whole block, not a per-LLMQ-type fact, so this
+    /// pair is global, not typed.
+    int64_t submits_from_null{0};
+    int64_t rejects_from_null{0};
+
+    /// Record one required mining-window tip and its disposition. Bumps
+    /// window_open AND exactly one disposition, preserving the invariant above.
+    void note(int llmq_type, Disposition d) {
+        window_open[llmq_type] += 1;
+        switch (d) {
+            case Disposition::NullServed: null_served[llmq_type] += 1; break;
+            case Disposition::RealServed: real_served[llmq_type] += 1; break;
+            case Disposition::FellBack:   fell_back[llmq_type]   += 1; break;
+        }
+    }
+
+    /// Record one block submission from a null-carrying template and whether
+    /// the network rejected it. `rejected` must be false on every real soak;
+    /// the counter exists so a single reject is loud and cumulative.
+    void note_submit(bool rejected) {
+        submits_from_null += 1;
+        if (rejected) rejects_from_null += 1;
+    }
+
+    /// prior + live: sum every typed bucket and both global counters. Used by
+    /// combine() to fold the live process onto the frozen persisted prior.
+    void add(const QcNullServeCounters& o) {
+        for (const auto& kv : o.window_open) window_open[kv.first] += kv.second;
+        for (const auto& kv : o.null_served) null_served[kv.first] += kv.second;
+        for (const auto& kv : o.real_served) real_served[kv.first] += kv.second;
+        for (const auto& kv : o.fell_back)   fell_back[kv.first]   += kv.second;
+        submits_from_null += o.submits_from_null;
+        rejects_from_null += o.rejects_from_null;
+    }
+
+    static int64_t sum(const std::map<int, int64_t>& m) {
+        int64_t s = 0;
+        for (const auto& kv : m) s += kv.second;
+        return s;
+    }
+    int64_t total_window_open() const { return sum(window_open); }
+    int64_t total_null_served() const { return sum(null_served); }
+    int64_t total_real_served() const { return sum(real_served); }
+    int64_t total_fell_back()   const { return sum(fell_back); }
+};
+
+/// The ON-DISK cumulative state: prior-process roll-up totals + the null-serve
+/// counters + a restart counter. combine() produces the value that is BOTH
+/// persisted and printed; load/save move it through the JSON state file.
+struct ServeGateCumulative {
+    /// Number of processes that have contributed to this file (bumped once per
+    /// load). Distinguishes "one long clean run" from "N restarts covered the
+    /// floor" — the standing-soak claim needs it.
+    int64_t restart_count{0};
+    /// Cumulative wall clock OBSERVED across all processes (the denominator);
+    /// the sum of each process's ServeGateJournal::Rollup::observed_sec.
+    int64_t observed_sec{0};
+    /// Cumulative seconds off the embedded arm across all processes.
+    int64_t off_embedded_sec{0};
+    /// Cumulative per-cause seconds across all processes.
+    std::map<std::string, int64_t> cause_totals;
+    /// Cumulative null-arm serve counters across all processes.
+    QcNullServeCounters null_serve;
+};
+
+/// prior (frozen, from the file) + this process's live rollup and counters.
+/// restart_count and every prior total ride through unchanged; only the live
+/// deltas are added. Because `prior` never absorbs the live part, calling this
+/// on every roll-up tick and re-saving is idempotent (replace, not add).
+inline ServeGateCumulative combine(const ServeGateCumulative& prior,
+                                   const ServeGateJournal::Rollup& live_time,
+                                   const QcNullServeCounters& live_counters) {
+    ServeGateCumulative c = prior;
+    c.observed_sec     += live_time.observed_sec;
+    c.off_embedded_sec += live_time.off_embedded_sec;
+    for (const auto& pc : live_time.per_cause)
+        c.cause_totals[pc.first] += pc.second;
+    c.null_serve.add(live_counters);
+    return c;
+}
+
+// ── JSON shape ──────────────────────────────────────────────────────────────
+// std::map<int,int64_t> serializes as a JSON object with STRING keys ("4":13),
+// the natural shape for an LLMQ-type-keyed histogram. All numeric fields are
+// int64 so the denominator never silently narrows on a long soak.
+
+inline nlohmann::json to_json(const std::map<int, int64_t>& m) {
+    nlohmann::json j = nlohmann::json::object();
+    for (const auto& kv : m) j[std::to_string(kv.first)] = kv.second;
+    return j;
+}
+
+inline std::map<int, int64_t> int_map_from_json(const nlohmann::json& j) {
+    std::map<int, int64_t> m;
+    if (j.is_object())
+        for (auto it = j.begin(); it != j.end(); ++it)
+            m[std::stoi(it.key())] = it.value().get<int64_t>();
+    return m;
+}
+
+inline nlohmann::json to_json(const QcNullServeCounters& n) {
+    nlohmann::json j = nlohmann::json::object();
+    j["window_open"]       = to_json(n.window_open);
+    j["null_served"]       = to_json(n.null_served);
+    j["real_served"]       = to_json(n.real_served);
+    j["fell_back"]         = to_json(n.fell_back);
+    j["submits_from_null"] = n.submits_from_null;
+    j["rejects_from_null"] = n.rejects_from_null;
+    return j;
+}
+
+inline QcNullServeCounters null_counters_from_json(const nlohmann::json& j) {
+    QcNullServeCounters n;
+    if (!j.is_object()) return n;
+    if (j.contains("window_open")) n.window_open = int_map_from_json(j["window_open"]);
+    if (j.contains("null_served")) n.null_served = int_map_from_json(j["null_served"]);
+    if (j.contains("real_served")) n.real_served = int_map_from_json(j["real_served"]);
+    if (j.contains("fell_back"))   n.fell_back   = int_map_from_json(j["fell_back"]);
+    if (j.contains("submits_from_null")) n.submits_from_null = j["submits_from_null"].get<int64_t>();
+    if (j.contains("rejects_from_null")) n.rejects_from_null = j["rejects_from_null"].get<int64_t>();
+    return n;
+}
+
+inline nlohmann::json to_json(const ServeGateCumulative& c) {
+    nlohmann::json j = nlohmann::json::object();
+    j["restart_count"]    = c.restart_count;
+    j["observed_sec"]     = c.observed_sec;
+    j["off_embedded_sec"] = c.off_embedded_sec;
+    j["cause_totals"]     = c.cause_totals;  // std::map<string,int64> -> object
+    j["null_serve"]       = to_json(c.null_serve);
+    return j;
+}
+
+inline ServeGateCumulative cumulative_from_json(const nlohmann::json& j) {
+    ServeGateCumulative c;
+    if (!j.is_object()) return c;
+    if (j.contains("restart_count"))    c.restart_count    = j["restart_count"].get<int64_t>();
+    if (j.contains("observed_sec"))     c.observed_sec     = j["observed_sec"].get<int64_t>();
+    if (j.contains("off_embedded_sec")) c.off_embedded_sec = j["off_embedded_sec"].get<int64_t>();
+    if (j.contains("cause_totals") && j["cause_totals"].is_object())
+        for (auto it = j["cause_totals"].begin(); it != j["cause_totals"].end(); ++it)
+            c.cause_totals[it.key()] = it.value().get<int64_t>();
+    if (j.contains("null_serve")) c.null_serve = null_counters_from_json(j["null_serve"]);
+    return c;
+}
+
+// ── load / atomic save ──────────────────────────────────────────────────────
+
+/// Read the prior cumulative state from `path`. A missing OR unparseable file
+/// yields a clean zero state (the soak file is a convenience, never a consensus
+/// input — a bad read must not wedge the node). When `bump_restart` is true
+/// (the production default: one call per process at startup) restart_count is
+/// incremented, so the file records how many processes have covered the soak.
+inline ServeGateCumulative load_serve_gate_state(const std::string& path,
+                                                 bool bump_restart = true) {
+    ServeGateCumulative c;
+    std::ifstream in(path);
+    if (in) {
+        try {
+            nlohmann::json j;
+            in >> j;
+            c = cumulative_from_json(j);
+        } catch (...) {
+            c = ServeGateCumulative{};  // corrupt => clean zero, still counted
+        }
+    }
+    if (bump_restart) c.restart_count += 1;
+    return c;
+}
+
+/// Write `c` to `path` atomically: serialize to `path + ".tmp"`, flush, then
+/// rename over `path`. A crash before the rename leaves the previous good file
+/// intact; a crash after leaves the new one — a reader never sees a truncated
+/// state. Returns false (without touching `path`) on any I/O failure.
+inline bool save_serve_gate_state_atomic(const std::string& path,
+                                         const ServeGateCumulative& c) {
+    const std::string tmp = path + ".tmp";
+    {
+        std::ofstream out(tmp, std::ios::out | std::ios::trunc);
+        if (!out) return false;
+        out << to_json(c).dump(2) << '\n';
+        out.flush();
+        if (!out) {
+            out.close();
+            std::remove(tmp.c_str());
+            return false;
+        }
+    }
+    if (std::rename(tmp.c_str(), path.c_str()) != 0) {
+        std::remove(tmp.c_str());
+        return false;
+    }
+    return true;
+}
+
+// ── operator-facing log lines ────────────────────────────────────────────────
+
+/// The CUMULATIVE roll-up line, printed ALONGSIDE the per-process
+/// [EMBED-GATE-ROLLUP] so an operator reads the standing-soak denominator, not
+/// the since-last-restart one. Denominator first (a percentage whose
+/// denominator is implicit is how the best-share bug shipped), then per-cause.
+inline std::string cumulative_rollup_line(const ServeGateCumulative& c) {
+    std::ostringstream os;
+    os << "[EMBED-GATE-ROLLUP-CUM] restarts=" << c.restart_count
+       << " observed=" << c.observed_sec << "s"
+       << " off_embedded=" << c.off_embedded_sec << "s";
+    if (c.observed_sec > 0)
+        os << " (" << (c.off_embedded_sec * 100 / c.observed_sec)
+           << "% of wall clock)";
+    os << " causes:";
+    if (c.cause_totals.empty()) {
+        os << " (none)";
+    } else {
+        for (const auto& kv : c.cause_totals) {
+            os << " " << kv.first << "=" << kv.second << "s";
+            if (c.observed_sec > 0)
+                os << "(" << (kv.second * 100 / c.observed_sec) << "%)";
+        }
+    }
+    return os.str();
+}
+
+/// The [QC-NULL-SERVE] counter line: per-type window-open / null / real /
+/// fell-back plus the never-a-reject conjunct. This is the line that makes
+/// "the null-arm covered the DKG floor, 0 rejects" greppable across restarts.
+inline std::string qc_null_serve_line(const QcNullServeCounters& n) {
+    std::ostringstream os;
+    os << "[QC-NULL-SERVE]"
+       << " window_open=" << n.total_window_open()
+       << " null=" << n.total_null_served()
+       << " real=" << n.total_real_served()
+       << " fell_back=" << n.total_fell_back()
+       << " submits=" << n.submits_from_null
+       << " rejects=" << n.rejects_from_null;
+    // Per-type breakout, so a floor type that never null-served is visible.
+    for (const auto& kv : n.window_open) {
+        const int t = kv.first;
+        os << " | type" << t << ":"
+           << "win=" << kv.second
+           << ",null=" << (n.null_served.count(t) ? n.null_served.at(t) : 0)
+           << ",real=" << (n.real_served.count(t) ? n.real_served.at(t) : 0)
+           << ",fb=" << (n.fell_back.count(t) ? n.fell_back.at(t) : 0);
+    }
+    return os.str();
+}
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/sml_resync_watchdog.hpp
+++ b/src/impl/dash/coin/sml_resync_watchdog.hpp
@@ -56,9 +56,12 @@
 //   * only after `min_quiet` seconds of no SML progress (well above a normal
 //     round trip, well below a block interval);
 //   * geometric backoff between attempts;
-//   * at most `max_attempts` per stuck (tip, sml) pair — after that we wait for
-//     the next block exactly as today, so a genuinely unreachable peer sees the
-//     same traffic it sees now plus a bounded constant;
+//   * geometric backoff for the first `max_attempts` tries, then the interval
+//     is CLAMPED and the re-ask CONTINUES at that clamped cadence for as long
+//     as the pair stays stuck — so a genuinely unreachable peer sees a bounded
+//     ~1 request per clamp-interval, never a burst, but an 18-min block gap can
+//     no longer strand the arm on the dashd fallback with healthy peers idle
+//     (the armed-once-never-re-armed failure the old hard stop caused);
 //   * any observed SML progress, or a tip change, resets everything.
 
 #include <cstdint>
@@ -80,8 +83,12 @@ public:
         int64_t  min_quiet_sec{20};
         /// Multiplier applied to the wait after each attempt.
         int64_t  backoff_mult{2};
-        /// Hard cap per stuck (tip, sml) pair. After this we go quiet and let
-        /// the next tip change do what it does today.
+        /// Backoff CLAMP for a stuck (tip, sml) pair. The re-ask interval
+        /// grows geometrically for the first max_attempts tries and then
+        /// stays pinned at that interval; the watchdog keeps re-asking at that
+        /// clamped cadence for as long as the pair stays stuck (a stalled
+        /// chain never changes the pair), because going silent forever here is
+        /// the 18-min-wedge bug. Any SML progress or tip change resets it.
         uint32_t max_attempts{3};
     };
 
@@ -127,11 +134,22 @@ public:
             return std::nullopt;   // never retry on the FIRST sighting
         }
 
-        if (m_attempts >= m_cfg.max_attempts) return std::nullopt;
-
-        // Wait: min_quiet before the first attempt, then geometric backoff.
+        // Wait: min_quiet before the first attempt, then geometric backoff,
+        // CLAMPED at the max_attempts-th interval. Past the cap the interval
+        // stops GROWING but the re-request never STOPS. Going silent forever
+        // for a stuck (tip, sml) pair is the 18-min-wedge bug: while the chain
+        // is stalled the pair never changes, so a hard stop left the embedded
+        // arm on the dashd fallback with healthy peers idle until the NEXT
+        // block, and across an 18-min block gap that is an 18-min hole (the
+        // armed-once-never-re-armed class). A retry clamped at the cap cadence
+        // bounds the traffic to one request per
+        // ~(min_quiet * backoff_mult^max_attempts) seconds, keeps rotating
+        // peers through the caller's re-ask, and still resets the instant the
+        // SML makes progress or the tip moves.
+        const uint32_t steps =
+            (m_attempts < m_cfg.max_attempts) ? m_attempts : m_cfg.max_attempts;
         int64_t wait = m_cfg.min_quiet_sec;
-        for (uint32_t i = 0; i < m_attempts; ++i) wait *= m_cfg.backoff_mult;
+        for (uint32_t i = 0; i < steps; ++i) wait *= m_cfg.backoff_mult;
         const int64_t since = (m_last_try >= 0) ? m_last_try : m_since_sec;
         if (now_sec - since < wait) return std::nullopt;
 

--- a/src/impl/dash/coin/tx_serve_referee.hpp
+++ b/src/impl/dash/coin/tx_serve_referee.hpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// SERVE-TIME INTERNAL-CONSISTENCY REFEREE for the embedded (daemonless)
+/// block-template tx-serving path.
+///
+/// == WHAT THIS REPLACES, AND WHY =============================================
+/// The prior referee (work_source.cpp #130 branch, cause
+/// "gbt-xcheck-txmerkle-mismatch") was a dashd-PARITY test: it recomputed the
+/// non-coinbase tx-merkle-root of OUR selection and dashd's getblocktemplate
+/// and, on ANY difference, threw away our template and served dashd's instead.
+///
+/// That is the wrong question. Two independently-connected nodes never hold
+/// identical mempools (relay is gossip; admission is per-node policy over a
+/// per-node UTXO view; each side snapshots at a different instant), so a
+/// DIFFERENT-BUT-VALID tx set is NORMAL and produces a perfectly valid block.
+/// The consensus requirement for the tx set is NOT parity with dashd; it is:
+///
+///   (a) coinbase fee-consistency -- the coinbase claims exactly the block
+///       subsidy + the sum of the served per-tx fees (+ the treasury slice on
+///       a funded superblock height). An over-claim is the bad-cb-amount
+///       orphan vector.
+///   (b) every served mempool tx is fee_fold_proven -- each vin present and
+///       unspent in our UTXO view at build time, in_sum >= out_sum (the
+///       selector's exclusion-discipline, strictly stronger than fee_known).
+///   (c) no intra-set double-spend -- no two served txs spend the same coin.
+///   (d) per-tx consensus/policy validity beyond (a)-(c) -- delegated to the
+///       MEMPOOL VALIDITY GATE (mempool_validity_gate.hpp), a sustained
+///       testmempoolaccept readiness window that gates the ARMING of
+///       --embedded-serve-mempool-txs. Once armed, that residual is covered;
+///       it is NOT a per-template serve gate and must not re-introduce a
+///       set-difference-from-dashd fallback.
+///
+/// When (a)-(c) hold on an armed template the block is reward-safe: serving OUR
+/// OWN set is correct and the daemonless mandate is met. If any fails the
+/// caller MUST fail-close to the dashd fallback (safety preserved). The dashd
+/// tx-merkle cross-check is kept as a SHADOW/diagnostic (the caller logs the
+/// divergence) but is no longer serve-blocking.
+///
+/// == WHY THESE CHECKS ARE SOUND BY CONSTRUCTION ==============================
+/// (a) embedded_gbt.hpp: block_value = reward + total_fees; m_coinbase_value =
+///     block_value (+ superblock_total on a funded superblock height). Every
+///     m_tx_fees entry is 0 (type-6 quorum commitments, zero-fee pins) or a
+///     real fee that was folded into total_fees (asset-unlock payload fees;
+///     mempool-selected fees), so Sum(m_tx_fees) == total_fees EXACTLY. The
+///     subsidy is a pure function of height (subsidy.hpp), re-derived here with
+///     the SAME function the builder used, so the equality below is the
+///     builder's own invariant re-asserted at serve time -- it catches any
+///     corruption of m_coinbase_value / m_tx_fees / the superblock slice
+///     between build and serve.
+/// (b) mempool.hpp get_sorted_txs_with_fees selects ONLY fee_fold_proven
+///     entries ("if(!e.fee_fold_proven) continue;"). The builder records that
+///     guarantee in the stamp; the referee fail-closes if it is ever false.
+/// (c) folded here over the actual served vins -- fully independent of dashd.
+
+#include <impl/dash/coin/rpc_data.hpp>
+// utxo_adapter.hpp declares dash::coin::dash_txid, which subsidy.hpp uses in
+// its computed_block_fees helper at namespace-parse time -- include it FIRST
+// so this header is self-contained (work_source.cpp already has it via
+// block_producer.hpp, but the referee unit test includes us standalone).
+#include <impl/dash/coin/utxo_adapter.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+
+#include <cstdint>
+#include <set>
+#include <string>
+#include <utility>
+
+namespace dash {
+namespace coin {
+
+/// Verdict of tx_serve_internal_referee. serve_own_set == true means the
+/// embedded template is reward-safe to serve as-is despite differing from
+/// dashd's tx set; false means the caller must fail-close to dashd and record
+/// fail_cause. detail is a human-readable line for the log / status surface.
+struct TxServeRefereeVerdict {
+    bool        serve_own_set{false};
+    std::string fail_cause;   // empty iff serve_own_set
+    std::string detail;
+};
+
+/// Runs the internal-consistency referee over an armed embedded template. The
+/// caller invokes this only on the tx-serve axis (m_mempool_tx_count > 0) after
+/// the CbTx axes (#1216 creditPool / quorum / MN-root) have already been
+/// cleared, so this function reasons about the tx SELECTION axis alone.
+inline TxServeRefereeVerdict tx_serve_internal_referee(const DashWorkData& w)
+{
+    TxServeRefereeVerdict v;
+
+    // (pre) PROVENANCE. Only a body the embedded mempool-serving path built
+    // and stamped is eligible. A template that reached this axis with
+    // m_mempool_tx_count>0 but no stamp is not one this referee can vouch for
+    // -> fail-close. (Byte-neutral in practice: the caller runs the referee
+    // only when the serve flag armed the build, which is exactly when the
+    // stamp is set.)
+    if (!w.m_tx_serve_stamp.armed) {
+        v.fail_cause = "tx-serve-unstamped";
+        v.detail     = "template carries mempool txs but no embedded serve"
+                       " stamp (unproven provenance)";
+        return v;
+    }
+
+    // (b) Every served mempool tx passed the fee-fold proof at selection.
+    if (!w.m_tx_serve_stamp.all_mempool_fee_fold_proven) {
+        v.fail_cause = "tx-serve-fee-fold-unproven";
+        v.detail     = "a served mempool tx is not fee_fold_proven";
+        return v;
+    }
+
+    // (a) COINBASE FEE-CONSISTENCY. coinbase_value must equal subsidy + the sum
+    // of served per-tx fees + the treasury slice. Any over-claim is
+    // bad-cb-amount; equality is the by-construction invariant re-asserted.
+    uint64_t fee_sum = 0;
+    for (uint64_t f : w.m_tx_fees) fee_sum += f;
+    const uint64_t subsidy =
+        static_cast<uint64_t>(compute_dash_block_reward_post_v20(w.m_height));
+    const uint64_t expect =
+        subsidy + fee_sum + w.m_tx_serve_stamp.superblock_total;
+    if (w.m_coinbase_value != expect) {
+        v.fail_cause = "tx-serve-coinbase-inconsistent";
+        v.detail     = "coinbase_value=" + std::to_string(w.m_coinbase_value)
+                     + " != subsidy=" + std::to_string(subsidy)
+                     + " + fees=" + std::to_string(fee_sum)
+                     + " + superblock="
+                     + std::to_string(w.m_tx_serve_stamp.superblock_total);
+        return v;
+    }
+
+    // (c) NO INTRA-SET DOUBLE-SPEND. No two served txs may spend the same
+    // outpoint. Folds over the actual served vins (coinbase is not in m_txs);
+    // type-6 quorum commitments and type-9 unlocks carry no vin, so they add
+    // nothing. The "inputs unspent at tip" half of the double-spend guard is
+    // the fee-fold proof (b), taken against the live UTXO view at build time.
+    std::set<std::pair<std::string, uint32_t>> spent;
+    for (const auto& tx : w.m_txs) {
+        for (const auto& in : tx.vin) {
+            auto key = std::make_pair(in.prevout.hash.GetHex(),
+                                      in.prevout.index);
+            if (!spent.insert(key).second) {
+                v.fail_cause = "tx-serve-double-spend";
+                v.detail     = "two served txs spend outpoint "
+                             + key.first + ":" + std::to_string(key.second);
+                return v;
+            }
+        }
+    }
+
+    v.serve_own_set = true;
+    v.detail = "internally consistent: coinbase fee-exact ("
+             + std::to_string(w.m_coinbase_value) + "="
+             + std::to_string(subsidy) + "+" + std::to_string(fee_sum)
+             + "+" + std::to_string(w.m_tx_serve_stamp.superblock_total)
+             + "), all fee_fold_proven, no double-spend";
+    return v;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/utxo_lane.hpp
+++ b/src/impl/dash/coin/utxo_lane.hpp
@@ -158,6 +158,33 @@ public:
         return ready;
     }
 
+    /// WINDOW-2 currency predicate (intra-node eviction lag).
+    ///
+    /// Reports whether the embedded UTXO view has ALREADY connected the block
+    /// identified by `tip_hash` -- i.e. its spends are applied and (because
+    /// connect_one calls Mempool::remove_for_block on the same block, same io
+    /// thread, before returning) that block's txs + newly-conflicting mempool
+    /// txs are evicted. `get_best_block()` is set atomically by the per-block
+    /// flush() inside connect_one, so equality is exact.
+    ///
+    /// The serve tip can be promoted to a height H by a DIFFERENT, earlier
+    /// event than the UTXO connect: the diff-driven promotion in
+    /// CoinStateMaintainer (mnlistdiff-at-tip / cbTx credit-pool re-anchor)
+    /// advances the serve tip with no UTXO/mempool axis among its promotion
+    /// conjuncts. In that window the view is still at H-1, H's spent outpoints
+    /// still resolve as unspent, and H's txs would pass the selection guard
+    /// into an H+1 template -> bad-txns-inputs-missingorspent on a winning
+    /// share = a thrown-away found block. dashd cannot expose this window
+    /// because CTxMemPool::removeForBlock runs synchronously inside
+    /// ConnectBlock BEFORE SetTip. The serve path consults this predicate and
+    /// serves coinbase-only (fees=0, exact) until the view catches up -- the
+    /// fail-closed equivalent of dashd's atomicity across two async events
+    /// (header arrival vs body arrival) that c2pool cannot hold one lock over.
+    bool utxo_current_at(const uint256& tip_hash) const
+    {
+        return m_cache && m_cache->get_best_block() == tip_hash;
+    }
+
     /// The E2a seam — subscribe to dash::interfaces::Node::block_connected
     /// (the leg-3 event of block_connect_ingest.hpp; it pairs block+height,
     /// so no header-chain lookup is needed here). Transliterates the LTC

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -43,6 +43,7 @@
 #include <impl/dash/params.hpp>               // dash::make_coin_params
 #include <impl/dash/coin/vendor/cbtx.hpp>     // vendor::parse_cbtx (GBT-xcheck creditPool)
 #include <impl/dash/coin/special_tx_pool_delta.hpp> // #107: explain the pool delta
+#include <impl/dash/coin/tx_serve_referee.hpp>  // tx-serve internal-consistency referee (own-set vs dashd-parity)
 #include <impl/dash/coin/serve_staleness.hpp> // serve-staleness sentinel (steady_now_ms + the incident catalogue)
 
 #include <core/address_utils.hpp>             // core::address_to_script (mint payout from username)
@@ -1121,25 +1122,92 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                     const uint256 dref_txroot =
                         coin::compute_merkle_root(dref.m_tx_hashes);
                     if (emb_txroot != dref_txroot) {
-                        LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck tx-merkleroot"
-                                    << " MISMATCH at h=" << sel.work.m_height
-                                    << " embedded txs=" << sel.work.m_tx_hashes.size()
-                                    << " root=" << emb_txroot.GetHex().substr(0, 16)
-                                    << " dashd txs=" << dref.m_tx_hashes.size()
-                                    << " root=" << dref_txroot.GetHex().substr(0, 16)
-                                    << " — serving dashd template (reward-safety"
-                                       " backstop: a divergent mempool tx selection"
-                                       " / commitment order is the bad-txns-"
-                                       "merkleroot orphan vector)";
-                        coin::DeclineReport xcheck;
-                        xcheck.viable    = false;
-                        xcheck.cause     = "gbt-xcheck-txmerkle-mismatch";
-                        xcheck.value     = emb_txroot.GetHex();
-                        xcheck.threshold = dref_txroot.GetHex();
-                        sel = coin::WorkSelection{ std::move(dref),
-                                                   coin::WorkSource::DashdFallback,
-                                                   std::move(xcheck) };
-                        served_via_xcheck_swap = true;
+                        // The embedded selection DIVERGES from dashd's. Two
+                        // independently-connected nodes never hold identical
+                        // mempools, so a divergent-but-VALID set is NORMAL and
+                        // yields a perfectly valid block. Whether we may serve
+                        // OUR OWN set or must fall back to dashd is decided
+                        // here, per --embedded-tx-serve-own-set:
+                        //
+                        //   OFF (default, shipped posture): the legacy dashd-
+                        //   PARITY backstop -- swap to dashd on ANY divergence
+                        //   (cause gbt-xcheck-txmerkle-mismatch). Byte-
+                        //   identical to before this change.
+                        //
+                        //   ON: run the INTERNAL-CONSISTENCY referee
+                        //   (tx_serve_referee.hpp): coinbase fee-exact, every
+                        //   served tx fee_fold_proven, no intra-set double-
+                        //   spend. The referee shares the selector's UTXO
+                        //   view, so it CANNOT catch a tx that view still
+                        //   shows unspent while dashd sees it spent (already-
+                        //   mined / stale-view class, field-observed at
+                        //   h=2526403: probed=4 invalid=4 on fee_fold_proven
+                        //   txs). The MEMPOOL VALIDITY GATE catches exactly
+                        //   that class via dashd testmempoolaccept over a
+                        //   sustained clean window, so when a shadow-compare
+                        //   probe is bound we require it OPEN before trusting
+                        //   the referee. With NO probe bound (pure daemonless,
+                        //   post-proof) the operator's arming of the flag is
+                        //   the proof. Either way, failure fail-closes to
+                        //   dashd -- safety is preserved on every branch.
+                        const bool gate_proven =
+                            !shadow_compare_ || shadow_compare_->validity_gate_open();
+                        coin::TxServeRefereeVerdict rv;
+                        const bool serve_own =
+                            tx_serve_own_set_ && gate_proven
+                            && (rv = coin::tx_serve_internal_referee(sel.work))
+                                   .serve_own_set;
+                        if (serve_own) {
+                            // SERVE OUR OWN VALID SET. The dashd divergence is
+                            // a SHADOW (diagnostic), not a fallback trigger.
+                            tx_serve_own_set_serves_.fetch_add(
+                                1, std::memory_order_relaxed);
+                            LOG_INFO << "[DASH-STRATUM-GBT] tx-serve OWN-SET at h="
+                                     << sel.work.m_height
+                                     << " embedded txs=" << sel.work.m_tx_hashes.size()
+                                     << " root=" << emb_txroot.GetHex().substr(0, 16)
+                                     << " != dashd txs=" << dref.m_tx_hashes.size()
+                                     << " root=" << dref_txroot.GetHex().substr(0, 16)
+                                     << " â SERVING OWN VALID SET (" << rv.detail
+                                     << "); a different-but-valid selection is not"
+                                        " a fallback trigger";
+                            // sel stays Embedded â NO swap.
+                        } else {
+                            // FAIL-CLOSE to dashd. Own-set OFF (legacy parity),
+                            // validity gate not yet proven-open, or the referee
+                            // refused an internal-consistency defect.
+                            std::string cause =
+                                !tx_serve_own_set_
+                                    ? std::string("gbt-xcheck-txmerkle-mismatch")
+                                    : (!gate_proven
+                                           ? std::string("tx-serve-validity-gate-not-open")
+                                           : rv.fail_cause);
+                            if (tx_serve_own_set_)
+                                tx_serve_own_set_failclose_.fetch_add(
+                                    1, std::memory_order_relaxed);
+                            LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck tx-merkleroot"
+                                        << " MISMATCH at h=" << sel.work.m_height
+                                        << " embedded txs=" << sel.work.m_tx_hashes.size()
+                                        << " root=" << emb_txroot.GetHex().substr(0, 16)
+                                        << " dashd txs=" << dref.m_tx_hashes.size()
+                                        << " root=" << dref_txroot.GetHex().substr(0, 16)
+                                        << " â serving dashd template (cause="
+                                        << cause
+                                        << (tx_serve_own_set_ && !gate_proven
+                                                ? "; own-set armed but validity"
+                                                  " gate not open"
+                                                : "")
+                                        << ")";
+                            coin::DeclineReport xcheck;
+                            xcheck.viable    = false;
+                            xcheck.cause     = cause;
+                            xcheck.value     = emb_txroot.GetHex();
+                            xcheck.threshold = dref_txroot.GetHex();
+                            sel = coin::WorkSelection{ std::move(dref),
+                                                       coin::WorkSource::DashdFallback,
+                                                       std::move(xcheck) };
+                            served_via_xcheck_swap = true;
+                        }
                     }
                 }
             }
@@ -1553,6 +1621,17 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
     // from the operator surface, not inferred from log archaeology.
     j["serve_recheck_fail_count"] =
         serve_recheck_fail_count_.load(std::memory_order_relaxed);
+
+    // --embedded-tx-serve-own-set observability (lock-free). serves = times a
+    // divergent-from-dashd mempool selection was served as OUR OWN valid set
+    // (internal-consistency referee passed AND the validity gate was proven
+    // open); failclose = times such a divergence fell back to dashd (own-set
+    // off, validity gate not open, or a referee defect). Both zero until the
+    // flag is armed.
+    j["tx_serve_own_set_serves"] =
+        tx_serve_own_set_serves_.load(std::memory_order_relaxed);
+    j["tx_serve_own_set_failclose"] =
+        tx_serve_own_set_failclose_.load(std::memory_order_relaxed);
 
     // TRY_LOCK, not lock_guard. serve_gate_mutex_ is taken by the SERVE PATH
     // (note_arm_decision, :759; the found-block ledger, :1478). Blocking here

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -37,6 +37,7 @@
 
 #include <impl/dash/stratum/submit_payee_guard.hpp>  // check_submit_payee (won-block stale-payee gate)
 #include <impl/dash/coin/serve_gate_rollup_json.hpp>  // serve_gate_rollup_json — #119 follow-up web leg (per-cause TIME)
+#include <impl/dash/coin/serve_gate_ledger_json.hpp>  // serve_gate_ledger_{to_json,save,load} — cumulative cross-restart accounting
 #include <impl/dash/coinbase_builder.hpp>     // compute_dash_payouts, build, split_coinb, merkle helpers
 #include <impl/dash/coin/block_producer.hpp>  // compute_merkle_root, append_compact_size, target_from_nbits
 #include <impl/dash/crypto/hash_x11.hpp>      // dash::crypto::hash_x11 (X11 PoW SSOT)
@@ -1428,9 +1429,29 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
     coin::ServeGateJournal::Decision d;
     coin::ServeGateJournal::Rollup rollup;
     bool emit_rollup = false;
+    // Cumulative-ledger flush payload, captured under the lock and emitted /
+    // persisted OUTSIDE it (I/O off the held mutex; the LevelDB found-block
+    // ledger takes the same lock, and the status surface try_locks it).
+    coin::ServeGateLedger::Totals cum_totals;
+    std::string cum_path;
+    bool emit_cum = false;
     {
         std::lock_guard<std::mutex> lk(serve_gate_mutex_);
         d = serve_gate_journal_.observe(served, why.cause, now_sec);
+        // CUMULATIVE cross-restart accounting: bank the SAME decision the
+        // journal just returned, so ledger and journal cannot disagree (the
+        // ledger consumes Decision.prev_cause_sec — the exact quantity the
+        // journal folds into m_cause_totals). Embedded maps to embedded_real
+        // here; the null-arm split (embedded_null) is a follow-up that sets
+        // DashWorkData.m_qc_null_slots — until then a null serve counts as
+        // embedded_real, never as a fallback, so the never-a-reject denominator
+        // is unaffected. why.cause is ignored by the ledger while serving.
+        const auto ledger_arm =
+            served_embedded ? coin::ServeGateLedger::Arm::EmbeddedReal
+            : (served == coin::ServeGateJournal::Served::NoWork)
+                ? coin::ServeGateLedger::Arm::NoWork
+                : coin::ServeGateLedger::Arm::Fallback;
+        serve_gate_ledger_.bank_serve(ledger_arm, why.cause, d, now_sec);
         last_decline_      = served_embedded ? coin::DeclineReport{} : why;
         last_arm_embedded_ = served_embedded;
         arm_ever_observed_ = true;
@@ -1445,6 +1466,13 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             last_rollup_sec_ = now_sec;
             rollup           = serve_gate_journal_.rollup(now_sec);
             emit_rollup      = true;
+            // Piggyback the cumulative flush on the same hourly tick. Snapshot
+            // the open segment into carry (folded once on next load), copy the
+            // totals for the log line, and grab the path for the write-through.
+            serve_gate_ledger_.snapshot_carry_for_flush();
+            cum_totals = serve_gate_ledger_.totals();
+            cum_path   = serve_gate_ledger_path_;
+            emit_cum   = true;
         }
     }
 
@@ -1469,6 +1497,67 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             }
         }
         LOG_WARNING << os.str();
+    }
+
+    if (emit_cum) {
+        // Write-through FIRST (atomic tmp+rename), so the standing figure the
+        // line reports is the one now on disk; a failed write keeps the
+        // in-memory ledger and simply loses this cadence of durations. Empty
+        // path = set_serve_gate_ledger_path() was never called (the ledger
+        // still accumulates + logs, it just does not persist across restarts).
+        if (!cum_path.empty())
+            coin::serve_gate_ledger_save(cum_path, cum_totals);
+        // The operator-facing standing total: "null-arm covered the 4.51%
+        // floor, 0 rejects over N heights", carried ACROSS restarts (epochs=N).
+        // DENOMINATOR (observed) first, then the never-a-reject numerators —
+        // any reject on an embedded arm is the hard cut-stopper, so it is named
+        // explicitly and can never hide behind a percentage.
+        const bool nar =
+            cum_totals.rpc_rejected_embedded_real == 0 &&
+            cum_totals.rpc_rejected_embedded_null == 0 &&
+            cum_totals.orphaned_embedded_real == 0 &&
+            cum_totals.orphaned_embedded_null == 0;
+        const uint64_t serves_emb =
+            cum_totals.serves_embedded_real + cum_totals.serves_embedded_null;
+        const uint64_t serves_all = serves_emb + cum_totals.serves_fallback +
+                                     cum_totals.serves_no_work;
+        const uint64_t nr_span =
+            cum_totals.nr_span_start_height == 0
+                ? 0
+                : (cum_totals.nr_span_last_height -
+                   cum_totals.nr_span_start_height + 1);
+        std::ostringstream cs;
+        cs << "[EMBED-CUMULATIVE] epochs=" << cum_totals.epochs
+           << " commit=" << (cum_totals.last_writer_commit.empty()
+                                 ? "unknown" : cum_totals.last_writer_commit)
+           << " observed=" << cum_totals.observed_sec << "s"
+           << " off_embedded=" << cum_totals.off_embedded_sec << "s";
+        if (cum_totals.observed_sec > 0)
+            cs << " (" << (cum_totals.off_embedded_sec * 100 /
+                           cum_totals.observed_sec) << "% off)";
+        cs << " serves{real=" << cum_totals.serves_embedded_real
+           << " null=" << cum_totals.serves_embedded_null
+           << " fallback=" << cum_totals.serves_fallback
+           << " no_work=" << cum_totals.serves_no_work << "}";
+        if (serves_all > 0)
+            cs << " embedded=" << (serves_emb * 100 / serves_all) << "%";
+        cs << " blocks{won_real=" << cum_totals.blocks_won_embedded_real
+           << " won_null=" << cum_totals.blocks_won_embedded_null
+           << " won_fallback=" << cum_totals.blocks_won_fallback
+           << " submitted=" << cum_totals.blocks_submitted
+           << " confirmed=" << cum_totals.blocks_confirmed
+           << " orphaned=" << cum_totals.blocks_orphaned << "}"
+           << " rejects{rpc_real=" << cum_totals.rpc_rejected_embedded_real
+           << " rpc_null=" << cum_totals.rpc_rejected_embedded_null
+           << " rpc_fallback=" << cum_totals.rpc_rejected_fallback
+           << " payee_guard=" << cum_totals.local_payee_guard_rejects << "}"
+           << " null_arm{dkg_floor=" << cum_totals.null_dkg_floor_tips_served
+           << " real_quorum_but_null="
+           << cum_totals.null_real_quorum_available_but_null_served << "}"
+           << " never_a_reject=" << (nar ? "true" : "false")
+           << " reject_free_span=" << nr_span << "h"
+           << " total_rejects=" << cum_totals.nr_total_rejects;
+        LOG_WARNING << cs.str();
     }
 
     // A CAUSE SEGMENT closed on THIS decision (a cause change or a resume):
@@ -1722,6 +1811,11 @@ nlohmann::json DASHWorkSource::embedded_arm_status_json() const
                                  .count();
         j["gate_rollup"] =
             coin::serve_gate_rollup_json(serve_gate_journal_.rollup(now_sec));
+        // CUMULATIVE cross-restart companion (the per-process gate_rollup above
+        // wipes on restart; this survives via the persisted ledger, epochs=N).
+        // Same lock already held; the ledger is a plain in-memory aggregate.
+        j["gate_rollup_cumulative"] =
+            coin::serve_gate_ledger_to_json(serve_gate_ledger_.totals());
     }
     if (!arm_ever_observed_) {
         j["arm"]               = "unknown";
@@ -2623,6 +2717,27 @@ void DASHWorkSource::set_mint_share_fn(MintShareFn fn)
 {
     std::lock_guard<std::mutex> lk(mint_share_mutex_);
     mint_share_fn_ = std::move(fn);
+}
+
+void DASHWorkSource::set_serve_gate_ledger_path(const std::string& path,
+                                                const std::string& writer_commit)
+{
+    std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+    serve_gate_ledger_path_ = path;
+    // Restore any persisted blob so the cumulative figure carries across this
+    // restart (folds the previous process's open-segment carry exactly once,
+    // bumps epochs). Absent/unparseable => fresh at epoch 0. load() is called
+    // unconditionally so epochs increments even from a default blob.
+    coin::ServeGateLedger::Totals persisted;
+    coin::serve_gate_ledger_load(path, persisted);  // best-effort; leaves default on miss
+    serve_gate_ledger_.load(persisted);
+    serve_gate_ledger_.set_writer_commit(writer_commit);
+    LOG_INFO << "[EMBED-CUMULATIVE] ledger restored: epochs="
+             << serve_gate_ledger_.totals().epochs
+             << " observed=" << serve_gate_ledger_.totals().observed_sec << "s"
+             << " never_a_reject="
+             << (serve_gate_ledger_.never_a_reject() ? "true" : "false")
+             << " path=" << path;
 }
 
 void DASHWorkSource::set_pplns_weights_fn(PplnsWeightsFn fn)

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -44,6 +44,7 @@
 #include <impl/dash/coin/vendor/cbtx.hpp>     // vendor::parse_cbtx (GBT-xcheck creditPool)
 #include <impl/dash/coin/special_tx_pool_delta.hpp> // #107: explain the pool delta
 #include <impl/dash/coin/tx_serve_referee.hpp>  // tx-serve internal-consistency referee (own-set vs dashd-parity)
+#include <impl/dash/coin/gbt_quorum_staleness.hpp>   // GBT-xcheck quorumroot-dashd-stale classifier
 #include <impl/dash/coin/serve_staleness.hpp> // serve-staleness sentinel (steady_now_ms + the incident catalogue)
 
 #include <core/address_utils.hpp>             // core::address_to_script (mint payout from username)
@@ -1023,6 +1024,19 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                 // hotel behaviour is unchanged. The sel.source==Embedded guard skips
                 // this when the creditPool branch above already swapped (and MOVED
                 // dref), so dref is never double-served.
+                // Record the last quorum root the two arms AGREED on -- the
+                // reference the DKG-boundary staleness classifier below compares
+                // against. Guarded by sel.source==Embedded so a creditPool swap
+                // above (which MOVED dref) can never make this read a moved-from
+                // dref.m_height (the source guard short-circuits first).
+                if (emb_ok && dref_ok
+                    && sel.source == coin::WorkSource::Embedded
+                    && dref.m_height == sel.work.m_height
+                    && emb_cb.merkleRootQuorums == dref_cb.merkleRootQuorums) {
+                    std::lock_guard<std::mutex> lk(quorum_root_cache_mutex_);
+                    last_agreed_quorum_root_ = emb_cb.merkleRootQuorums;
+                    has_agreed_quorum_root_  = true;
+                }
                 if (emb_ok && dref_ok
                     && sel.source == coin::WorkSource::Embedded
                     && dref.m_height == sel.work.m_height
@@ -1030,6 +1044,47 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                         || emb_cb.merkleRootMNList != dref_cb.merkleRootMNList)) {
                     const bool quorums_differ =
                         emb_cb.merkleRootQuorums != dref_cb.merkleRootQuorums;
+                    const bool mnlist_matches =
+                        emb_cb.merkleRootMNList == dref_cb.merkleRootMNList;
+                    // GBT-xcheck quorumroot-dashd-stale reclassification. At an
+                    // LLMQ DKG commitment boundary dashd's getblocktemplate
+                    // briefly serves the PREVIOUS cycle's quorum root while our
+                    // embedded arm already carries the freshly-committed one --
+                    // chain-proven (mainnet 2525987 / 2526011): the mined block
+                    // commits the EMBEDDED root, so swapping to dashd here would
+                    // serve the would-be-rejected bad-cbtx-quorummerkleroot
+                    // template. Isolated by the pure predicate; the inverse skew
+                    // (embedded stale, dashd fresh) fails it and takes the swap.
+                    bool dashd_stale = false;
+                    if (quorums_differ) {
+                        uint256 agreed;
+                        bool     have_agreed;
+                        {
+                            std::lock_guard<std::mutex> lk(quorum_root_cache_mutex_);
+                            agreed      = last_agreed_quorum_root_;
+                            have_agreed = has_agreed_quorum_root_;
+                        }
+                        dashd_stale = coin::quorumroot_dashd_is_stale(
+                            emb_cb.merkleRootQuorums, dref_cb.merkleRootQuorums,
+                            mnlist_matches, have_agreed ? &agreed : nullptr);
+                    }
+                    if (dashd_stale) {
+                        // KEEP embedded: classification-only, no swap. sel stays
+                        // Embedded, served_via_xcheck_swap stays false, and the
+                        // embedded arm's own pins ride untouched.
+                        LOG_INFO << "[DASH-STRATUM-GBT] GBT-xcheck quorumroot-dashd-stale"
+                                 << " at h=" << sel.work.m_height
+                                 << " embedded quorums="
+                                 << emb_cb.merkleRootQuorums.GetHex().substr(0, 16)
+                                 << " dashd quorums="
+                                 << dref_cb.merkleRootQuorums.GetHex().substr(0, 16)
+                                 << " (== last agreed root one cycle earlier) —"
+                                    " KEEP embedded: the chain commits the embedded"
+                                    " quorum root at the DKG boundary; dashd's GBT"
+                                    " is momentarily serving the pre-boundary cycle"
+                                    " (swapping would serve a bad-cbtx-"
+                                    "quorummerkleroot template)";
+                    } else {
                     LOG_WARNING << "[DASH-STRATUM-GBT] GBT-xcheck "
                                 << (quorums_differ ? "merkleRootQuorums"
                                                    : "merkleRootMNList")
@@ -1058,6 +1113,7 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                                                coin::WorkSource::DashdFallback,
                                                std::move(xcheck) };
                     served_via_xcheck_swap = true;
+                    }
                 }
                 // #130 tx-serving reward-safety — NON-COINBASE tx-merkleroot
                 // xcheck. The #1216 creditPool / quorum / MN branches above

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -1435,6 +1435,9 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
     coin::ServeGateLedger::Totals cum_totals;
     std::string cum_path;
     bool emit_cum = false;
+    coin::ServeGateCumulative cum_combined;
+    coin::QcNullServeCounters cum_counters_snapshot;
+    bool have_cum = false;
     {
         std::lock_guard<std::mutex> lk(serve_gate_mutex_);
         d = serve_gate_journal_.observe(served, why.cause, now_sec);
@@ -1473,6 +1476,19 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             cum_totals = serve_gate_ledger_.totals();
             cum_path   = serve_gate_ledger_path_;
             emit_cum   = true;
+            // (a)+(b) cross-restart cumulative accounting: load the prior
+            // state ONCE, snapshot this process's live QC-NULL-SERVE counters.
+            // combine()+save_atomic()+log run OFF the lock below (no file I/O
+            // under serve_gate_mutex_). Empty path => dormant, byte-unchanged.
+            if (!serve_gate_state_path_.empty()) {
+                if (!serve_gate_prior_loaded_) {
+                    serve_gate_prior_ =
+                        coin::load_serve_gate_state(serve_gate_state_path_);
+                    serve_gate_prior_loaded_ = true;
+                }
+                cum_counters_snapshot = null_serve_counters_;
+                have_cum = true;
+            }
         }
     }
 
@@ -1497,6 +1513,21 @@ void DASHWorkSource::note_arm_decision(coin::ServeGateJournal::Served served,
             }
         }
         LOG_WARNING << os.str();
+
+        // CUMULATIVE line ALONGSIDE the per-process one: prior + this process,
+        // write-through to the state file so a STANDING soak (across restarts)
+        // is readable from the log/file alone — closing the observed=7211s
+        // per-process denominator trap (04:00 restart) the critic found. File
+        // I/O is OFF serve_gate_mutex_; serve_gate_prior_ is immutable after
+        // its one-time load, so reading it here without the lock is safe.
+        if (have_cum) {
+            cum_combined =
+                coin::combine(serve_gate_prior_, rollup, cum_counters_snapshot);
+            coin::save_serve_gate_state_atomic(serve_gate_state_path_,
+                                               cum_combined);
+            LOG_WARNING << coin::cumulative_rollup_line(cum_combined);
+            LOG_WARNING << coin::qc_null_serve_line(cum_combined.null_serve);
+        }
     }
 
     if (emit_cum) {

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -60,6 +60,7 @@
 
 #include <impl/dash/coin/node_coin_state.hpp>   // coin::NodeCoinState, coin::DashWorkData seam
 #include <impl/dash/coin/serve_gate_journal.hpp> // coin::ServeGateJournal — decline rate policy (DEFECT-3)
+#include <impl/dash/coin/serve_gate_ledger.hpp>  // coin::ServeGateLedger — cumulative cross-restart never-a-reject accounting
 #include <impl/dash/coin/embedded_shadow_compare.hpp> // coin::EmbeddedShadowCompare — OBSERVE-only serve-vs-dashd diff
 #include <impl/dash/stratum/get_work.hpp>       // dash::stratum::get_work() fused capstone
 
@@ -472,6 +473,18 @@ public:
                            const std::string& miner, bool reached_network)>;
     void set_on_found_block_fn(FoundBlockFn fn);
 
+    /// Wire the CUMULATIVE cross-restart serve-gate ledger to its persisted
+    /// backing file (<data-dir>/<net_subdir>/serve_gate_ledger.json). Loads any
+    /// existing blob (folding the previous process's carry, bumping epochs) and
+    /// stamps `writer_commit` (C2POOL_VERSION) so the standing figure always
+    /// names the binary that produced it. Idempotent-ish: call ONCE at wiring
+    /// time, before the first template is sourced. While unset the ledger still
+    /// accumulates in memory and logs [EMBED-CUMULATIVE], it just never persists
+    /// across a restart — so this call is what turns the per-process figure into
+    /// the standing, cut-gate figure.
+    void set_serve_gate_ledger_path(const std::string& path,
+                                    const std::string& writer_commit);
+
     /// Wire the sharechain mint dispatch (stage 4d follow-up). While unbound,
     /// share-target submissions are accepted for vardiff + loudly logged.
     void set_mint_share_fn(MintShareFn fn);
@@ -799,6 +812,19 @@ private:
     // first arm decision, so the first observation seeds the cadence without
     // emitting an empty summary. Guarded by serve_gate_mutex_.
     mutable int64_t                 last_rollup_sec_{-1};
+
+    // CUMULATIVE cross-restart never-a-reject accounting. ServeGateJournal wipes
+    // on restart (its clock is process-monotonic steady_clock seconds), so the
+    // program-level "% embedded / never-a-reject" figure is per-process. The
+    // ledger banks the SAME events the journal sees (from note_arm_decision,
+    // under serve_gate_mutex_) into cumulative totals, persisted write-through
+    // to serve_gate_ledger_path_ (atomic tmp+rename) on the hourly roll-up tick
+    // so the standing claim survives >=3 restarts. Guarded by serve_gate_mutex_.
+    mutable coin::ServeGateLedger    serve_gate_ledger_;
+    // Persisted backing file; empty until set_serve_gate_ledger_path() (then the
+    // ledger accumulates in memory + logs, but never persists). Set once at
+    // wiring time; read on the hourly flush. Guarded by serve_gate_mutex_.
+    std::string                      serve_gate_ledger_path_;
 
     // ── Serve-staleness observation (lock-free by requirement) ─────────────
     // Written on the serve path (get_current_work_template /

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -363,6 +363,24 @@ public:
     /// independent seed-height + pre-emit gates.
     void set_gbt_xcheck(bool v) { gbt_xcheck_ = v; }
 
+    /// TX-SERVE-OWN-SET referee (--embedded-tx-serve-own-set). DEFAULT OFF.
+    ///
+    /// When OFF (default, and the shipped posture): a divergent-from-dashd
+    /// mempool tx selection SWAPS to dashd's template exactly as before
+    /// (cause gbt-xcheck-txmerkle-mismatch) -- byte-identical to today.
+    ///
+    /// When ON: on a tx-merkle divergence the arm runs the INTERNAL-
+    /// CONSISTENCY referee (tx_serve_referee.hpp) instead of the dashd-parity
+    /// backstop. If the embedded template is internally consistent (coinbase
+    /// fee-exact, every served tx fee_fold_proven, no intra-set double-spend)
+    /// AND -- when a shadow-compare validity probe is bound -- the mempool
+    /// validity gate is currently open(), c2pool SERVES ITS OWN valid set (the
+    /// divergence is logged as a shadow, not a fallback). Otherwise it fail-
+    /// closes to the dashd template. The validity-gate coupling is the runtime
+    /// guard against the already-mined / stale-UTXO-view class the referee
+    /// cannot catch alone (h=2526403 field finding); see set_shadow_compare.
+    void set_tx_serve_own_set(bool v) { tx_serve_own_set_ = v; }
+
     /// PIN SPLICE ON THE XCHECK-SWAPPED ARM (--pin-splice-xcheck-arm).
     /// DEFAULT OFF -- this is the money path.
     ///
@@ -729,6 +747,10 @@ private:
     bool is_testnet_{false};
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
+    bool tx_serve_own_set_{false};   // --embedded-tx-serve-own-set: serve own valid tx set instead of dashd-parity swap (DEFAULT OFF)
+    // Observability for the own-set referee (lock-free; published in embedded_arm_status_json).
+    mutable std::atomic<uint64_t> tx_serve_own_set_serves_{0};      // divergent set served as own (referee passed)
+    mutable std::atomic<uint64_t> tx_serve_own_set_failclose_{0};   // divergent set fail-closed to dashd (referee/gate refused)
     bool pin_splice_xcheck_arm_{false};  // money path: splice pins onto an xcheck-SWAPPED template (default OFF)
     bool pin_splice_block_budget_{false};  // money path: ENFORCE the block-size budget (changes served bytes; default OFF)
 

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -61,6 +61,7 @@
 #include <impl/dash/coin/node_coin_state.hpp>   // coin::NodeCoinState, coin::DashWorkData seam
 #include <impl/dash/coin/serve_gate_journal.hpp> // coin::ServeGateJournal — decline rate policy (DEFECT-3)
 #include <impl/dash/coin/serve_gate_ledger.hpp>  // coin::ServeGateLedger — cumulative cross-restart never-a-reject accounting
+#include <impl/dash/coin/serve_gate_persist.hpp> // cross-restart cumulative accounting + QC-NULL-SERVE counters
 #include <impl/dash/coin/embedded_shadow_compare.hpp> // coin::EmbeddedShadowCompare — OBSERVE-only serve-vs-dashd diff
 #include <impl/dash/stratum/get_work.hpp>       // dash::stratum::get_work() fused capstone
 
@@ -381,6 +382,30 @@ public:
     /// guard against the already-mined / stale-UTXO-view class the referee
     /// cannot catch alone (h=2526403 field finding); see set_shadow_compare.
     void set_tx_serve_own_set(bool v) { tx_serve_own_set_ = v; }
+
+    /// Path to the cross-restart cumulative serve-gate state file (JSON).
+    /// Empty (default) => the cumulative accounting is OFF and this class is
+    /// byte-identical to before: no load, no save, no extra log line. When set
+    /// (--serve-gate-state-file), note_arm_decision() write-throughs the
+    /// combined prior+live roll-up + QC-NULL-SERVE counters on each roll-up
+    /// tick so a STANDING soak is readable across restarts.
+    void set_serve_gate_state_file(std::string p) { serve_gate_state_path_ = std::move(p); }
+
+    /// (b) QC-NULL-SERVE live hooks. Record one required DKG mining-window tip
+    /// and its disposition (null-served / real-served / fell-back), and one
+    /// block submission from a null-carrying template (never-a-reject
+    /// conjunct). Thread-safe (serve_gate_mutex_). The per-tip disposition call
+    /// site is the daemonless_qc_commitments fold consumer (soak-gated wiring);
+    /// note_null_submit is called from the block-submit path.
+    void note_null_serve_disposition(int llmq_type,
+                                     coin::QcNullServeCounters::Disposition d) const {
+        std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+        null_serve_counters_.note(llmq_type, d);
+    }
+    void note_null_submit(bool rejected) const {
+        std::lock_guard<std::mutex> lk(serve_gate_mutex_);
+        null_serve_counters_.note_submit(rejected);
+    }
 
     /// PIN SPLICE ON THE XCHECK-SWAPPED ARM (--pin-splice-xcheck-arm).
     /// DEFAULT OFF -- this is the money path.
@@ -825,6 +850,15 @@ private:
     // ledger accumulates in memory + logs, but never persists). Set once at
     // wiring time; read on the hourly flush. Guarded by serve_gate_mutex_.
     std::string                      serve_gate_ledger_path_;
+    // Cross-restart cumulative accounting (flag-gated by serve_gate_state_path_).
+    // serve_gate_prior_ is the PRIOR-process state loaded once at the first
+    // roll-up tick; null_serve_counters_ are this process's live QC-NULL-SERVE
+    // tallies. Both guarded by serve_gate_mutex_; combine()+save happen OFF the
+    // lock in note_arm_decision. Empty path => all of this stays dormant.
+    std::string                        serve_gate_state_path_;
+    mutable coin::ServeGateCumulative  serve_gate_prior_;
+    mutable bool                       serve_gate_prior_loaded_{false};
+    mutable coin::QcNullServeCounters  null_serve_counters_;
 
     // ── Serve-staleness observation (lock-free by requirement) ─────────────
     // Written on the serve path (get_current_work_template /

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -751,6 +751,16 @@ private:
     // Observability for the own-set referee (lock-free; published in embedded_arm_status_json).
     mutable std::atomic<uint64_t> tx_serve_own_set_serves_{0};      // divergent set served as own (referee passed)
     mutable std::atomic<uint64_t> tx_serve_own_set_failclose_{0};   // divergent set fail-closed to dashd (referee/gate refused)
+    // GBT-xcheck quorumroot-dashd-stale classifier state -- the fix for the
+    // inverted reward-safety direction at LLMQ DKG commitment boundaries.
+    // last_agreed_quorum_root_ is the most recent merkleRootQuorums both the
+    // embedded and dashd arms matched on; the classifier KEEPS embedded when
+    // dashd's current root REGRESSES to it while embedded ADVANCES past it.
+    // Touched only inside the single-flight template re-source, but guarded for
+    // defence in depth; mutable because resource_template_now() is const.
+    mutable std::mutex quorum_root_cache_mutex_;
+    mutable uint256    last_agreed_quorum_root_;
+    mutable bool       has_agreed_quorum_root_{false};
     bool pin_splice_xcheck_arm_{false};  // money path: splice pins onto an xcheck-SWAPPED template (default OFF)
     bool pin_splice_block_budget_{false};  // money path: ENFORCE the block-size budget (changes served bytes; default OFF)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -617,7 +617,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # genesis short-circuit), resumable cursor across reopen, versioned-format
     # fail-loud, 100-block undo window retention, disconnect/reconnect set-
     # hash identity. Same target, no new allowlist entry.
-    add_executable(test_dash_mempool test_dash_mempool.cpp test_dash_replay_utxo_fold.cpp)
+    # test_dash_mempool_validity_gate.cpp also rides the test_dash_embedded_gbt
+    # target above, but that target currently FAILS TO LINK (a pre-existing
+    # #154-era gap: test_dash_replay_v19_type4_punish.cpp needs opkey_* from
+    # bls_verify.cpp). Fold the gate suite into this LINKING target too so the
+    # readiness-gate KATs — including the tip-context propagation split — are
+    # actually built and run. Header-only over mempool_validity_gate.hpp +
+    # nlohmann/json; no new SCC dependency, no new build.yml --target (#769).
+    add_executable(test_dash_mempool test_dash_mempool.cpp test_dash_replay_utxo_fold.cpp
+        test_dash_mempool_validity_gate.cpp)
     target_link_libraries(test_dash_mempool PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -1010,18 +1018,7 @@ if (BUILD_TESTING AND GTest_FOUND)
         # dash_mainnet_quorum_scan_* / _active_quorums_ fixtures as the W4
         # suite above, and is folded into this target for the same #769
         # reason (the push bot cannot add a build.yml --target).
-        test_dash_mined_commitment_index.cpp
-        # test_dash_mempool_validity_gate.cpp: THE condition that decides when
-        # --embedded-serve-mempool-txs may be armed
-        # (mempool_validity_gate.hpp). Pins the three-valued
-        # testmempoolaccept logic, the exact-name "txn-already-in-mempool"
-        # exemption, "a missing answer is never a pass", the refusal line's
-        # txid/reason/threshold (#1038/#1039 discipline), the sustained-window
-        # arithmetic, and the two directions the retired `ours_only == 0`
-        # set-membership test got wrong. Folded into this target per the same
-        # #769 rule as the leaves above (the push bot cannot add a build.yml
-        # --target, so a standalone executable would be a NOT_BUILT sentinel).
-        test_dash_mempool_validity_gate.cpp)
+        test_dash_mined_commitment_index.cpp)
     target_compile_definitions(test_dash_embedded_gbt PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_embedded_gbt PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1193,6 +1193,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     #                       mutation case.
     add_executable(test_dash_stratum_work_source
         test_dash_stratum_work_source.cpp
+        # test_dash_tx_serve_referee.cpp: internal-consistency referee unit KAT
+        # (tx_serve_referee.hpp). Folded into this already-built target (it links
+        # the full dash_stratum set the referee header needs) per the #769 rule.
+        test_dash_tx_serve_referee.cpp
         test_dash_submit_gate_scaling.cpp
         test_dash_serve_staleness_seam.cpp
         test_dash_serve_staleness_unit.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -318,6 +318,21 @@ if (BUILD_TESTING AND GTest_FOUND)
     target_link_libraries(test_dash_serve_gate_journal PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_serve_gate_journal "" AUTO)
 
+    # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
+    # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on
+    # restart; the ledger survives via write-through JSON). Pure-policy header +
+    # JSON companion; the KAT does a real atomic save->load round-trip through a
+    # temp file. Same link set as the journal KAT.
+    add_executable(test_dash_serve_gate_ledger test_dash_serve_gate_ledger.cpp)
+    target_link_libraries(test_dash_serve_gate_ledger PRIVATE
+        GTest::gtest_main GTest::gtest
+        dash_x11 core
+        nlohmann_json::nlohmann_json
+        ${Boost_LIBRARIES}
+    )
+    target_link_libraries(test_dash_serve_gate_ledger PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
+    gtest_add_tests(test_dash_serve_gate_ledger "" AUTO)
+
     # DASH S8 pool-node leaf 4 — share_tracker.hpp KAT: DensePPLNSWindow decayed
     # weight ring buffer (compute_v36_weights), decay table, donation split,
     # window slides. PoW-independent consensus core; socket-free, chain-free.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1197,6 +1197,7 @@ if (BUILD_TESTING AND GTest_FOUND)
         test_dash_submit_gate_scaling.cpp
         test_dash_serve_staleness_seam.cpp
         test_dash_serve_staleness_unit.cpp
+        test_dash_gbt_quorum_staleness.cpp
         ${CMAKE_SOURCE_DIR}/src/impl/dash/coin/zmq_tip_notify.cpp)
     target_link_libraries(test_dash_stratum_work_source PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -308,7 +308,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # DASH serve-gate journal per-cause time KAT (h=2518004 count-vs-time trap):
     # pure, header-only policy object; no socket/ltc/pool dependency. Mirrors
     # the test_dash_min_protocol_gate link set.
-    add_executable(test_dash_serve_gate_journal test_dash_serve_gate_journal.cpp)
+    add_executable(test_dash_serve_gate_journal test_dash_serve_gate_journal.cpp test_dash_serve_gate_ledger.cpp)
     target_link_libraries(test_dash_serve_gate_journal PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core
@@ -323,15 +323,6 @@ if (BUILD_TESTING AND GTest_FOUND)
     # restart; the ledger survives via write-through JSON). Pure-policy header +
     # JSON companion; the KAT does a real atomic save->load round-trip through a
     # temp file. Same link set as the journal KAT.
-    add_executable(test_dash_serve_gate_ledger test_dash_serve_gate_ledger.cpp)
-    target_link_libraries(test_dash_serve_gate_ledger PRIVATE
-        GTest::gtest_main GTest::gtest
-        dash_x11 core
-        nlohmann_json::nlohmann_json
-        ${Boost_LIBRARIES}
-    )
-    target_link_libraries(test_dash_serve_gate_ledger PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
-    gtest_add_tests(test_dash_serve_gate_ledger "" AUTO)
 
     # DASH S8 pool-node leaf 4 — share_tracker.hpp KAT: DensePPLNSWindow decayed
     # weight ring buffer (compute_v36_weights), decay table, donation split,

--- a/test/test_dash_coin_p2p_client.cpp
+++ b/test/test_dash_coin_p2p_client.cpp
@@ -736,4 +736,96 @@ TEST(DashCoinP2PClient, pool_tick_timer_is_actually_armed_on_the_io_context)
            "clock-driven test above would still pass with the tick deleted";
 }
 
+// ── (e) Mempool-ingest completeness — DSTX visibility + body-busy retry ─────
+//
+// Two mechanisms the daemonless mempool-ingest lane depends on, pinned here:
+//
+//   1. tx_ingest_status() surfaces the DSTX counters. dashd announces CoinJoin
+//      broadcast txs ONLY via inv(MSG_DSTX=16), never MSG_TX, so the whole
+//      DSTX class — 17.2 % of mined block txs, ~half the mempool BYTES — is
+//      invisible in [MEMPOOL-INGEST] logs unless the counters the client
+//      already keeps are printed. An armed DSTX lane is unmeasurable without
+//      them.
+//
+//   2. A tx/dstx inv admitted by InvDedup but skipped because a tip body was
+//      in flight is PARKED and re-issued when the body clears — not stranded
+//      behind the 600 s InvDedup TTL (which suppresses every re-announcement
+//      from every peer, losing the tx until the entry ages out, by which time
+//      it is usually already mined).
+
+TEST(DashCoinP2PIngest, dstx_counters_are_visible_in_tx_ingest_status)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, /*services=*/5, /*height=*/2526000,
+                                 "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+
+    // Arm the DSTX lane (the --embedded-ingest-dstx runtime opt-in).
+    rig.client.set_dstx_pull(true);
+
+    // dashd announces a mixing tx as inv(MSG_DSTX=16) — the inv hash is the
+    // plain txid. With no tip body in flight it earns a getdata immediately
+    // and the counters the client keeps must move.
+    auto dstx_inv = dash::coin::p2p::message_inv::make_raw(
+        std::vector<dash::coin::p2p::inventory_type>{
+            dash::coin::p2p::inventory_type(
+                dash::coin::p2p::inventory_type::dstx, uint256::ONE)});
+    rig.deliver(std::move(dstx_inv));
+
+    const std::string status = rig.client.tx_ingest_status();
+    // RED on the pre-change code: tx_ingest_status() never prints a dstx
+    // field, so the armed lane cannot be measured. GREEN with the instrument.
+    EXPECT_NE(status.find("dstx_inv=1"), std::string::npos) << status;
+    EXPECT_NE(status.find("dstx_getdata=1"), std::string::npos) << status;
+    EXPECT_NE(status.find("dstx_received=0"), std::string::npos) << status;
+}
+
+TEST(DashCoinP2PIngest, tx_inv_skipped_while_body_in_flight_is_retried_not_stranded)
+{
+    ClientRig rig;
+    rig.wire_connected();
+    rig.deliver(rig.peer_version(70230, /*services=*/5, /*height=*/2526000,
+                                 "/Dash Core:21.1.0/"));
+    rig.deliver(dash::coin::p2p::message_verack::make_raw());
+    ASSERT_TRUE(rig.client.is_handshake_complete());
+    ASSERT_GE(rig.client.handshaked_peer_count(), 1u);
+
+    rig.client.set_tx_pull(true);
+
+    // A tracked tip body is in flight — strict priority means no tx getdata
+    // may go out while it is outstanding.
+    rig.client.request_block_tracked(uint256::ONE);
+    ASSERT_GE(rig.client.pending_body_count(), 1u);
+
+    // A tx inv arrives while the body is outstanding: admitted by InvDedup,
+    // then skipped by the tip-body-priority rule.
+    const uint256 txid = uint256(static_cast<uint64_t>(0xAAull));
+    auto tx_inv = dash::coin::p2p::message_inv::make_raw(
+        std::vector<dash::coin::p2p::inventory_type>{
+            dash::coin::p2p::inventory_type(
+                dash::coin::p2p::inventory_type::tx, txid)});
+    rig.deliver(std::move(tx_inv));
+
+    // Skipped: nothing in flight yet, and the announcement was parked.
+    EXPECT_EQ(rig.client.tx_pull_inflight(), 0u);
+    EXPECT_EQ(rig.client.tx_pull_sent_count(), 0u);
+    EXPECT_EQ(rig.client.tx_pull_skipped_busy_count(), 1u);
+    EXPECT_EQ(rig.client.tx_retry_busy_count(), 1u);
+
+    // The tip body lands — pending bodies clear. The next pool tick must
+    // re-issue the parked getdata.
+    rig.client.clear_pending_bodies_for_test();
+    rig.client.tick_for_test();
+
+    // RED on the pre-change code: the skipped inv is never re-pulled (stranded
+    // behind the 600 s InvDedup TTL), so tx_pull_inflight() stays 0 forever.
+    // GREEN with the retry queue: exactly one getdata is now in flight.
+    EXPECT_EQ(rig.client.tx_pull_inflight(), 1u);
+    EXPECT_EQ(rig.client.tx_pull_sent_count(), 1u);
+    EXPECT_EQ(rig.client.tx_retry_busy_count(), 0u);
+    EXPECT_EQ(rig.client.tx_retry_drained_count(), 1u);
+}
+
 } // namespace

--- a/test/test_dash_coin_state_maintainer.cpp
+++ b/test/test_dash_coin_state_maintainer.cpp
@@ -689,9 +689,15 @@ TEST(DashCoinStateMaintainer, FourthAxisColdSmlDoesNotBlockPromotion) {
 // STEP 3 — the LOAD-BEARING companion: the diff-phase sub-threshold re-request.
 // Without it the conjunct turns a dropped/lost getmnlistd into up to 30 s of
 // silent H-1 serving (which orphans past propagation). check_tip_body_overdue,
-// driven opportunistically (on_mempool_tx is the clock), fires ONE bounded
-// getmnlistd(base=sml, target=hdr-tip) after ~min_quiet, capped, before the
-// unchanged 30 s hard demote.
+// driven opportunistically (on_mempool_tx is the clock), fires the first
+// getmnlistd(base=sml, target=hdr-tip) after ~min_quiet, then re-asks on a
+// GEOMETRIC backoff for max_attempts tries and, past the cap, at a CLAMPED
+// perpetual cadence (min_quiet * backoff^max_attempts) — never a burst, but
+// never silent either (#1315: an unchanging stuck (tip, sml) pair used to go
+// silent at the cap and strand the arm on the dashd fallback for the whole
+// 18-min block gap). The 30 s hard doomed-tip demote is unchanged and still
+// governs; the re-ask only makes the promotion state arrive sooner, it never
+// widens what is served.
 // ════════════════════════════════════════════════════════════════════════
 TEST(DashCoinStateMaintainer, DiffPhaseReRequestFiresBoundedThenDefersToDemote) {
     NodeCoinState st;
@@ -703,9 +709,11 @@ TEST(DashCoinStateMaintainer, DiffPhaseReRequestFiresBoundedThenDefersToDemote) 
     m.set_now_fn([&now]() { return now; });
 
     std::vector<std::pair<uint256, uint256>> reqs;
+    std::vector<int64_t> req_times;  // wall-clock of each re-ask, to pin the cadence
     m.set_on_sml_rerequest(
-        [&reqs](const uint256& base, const uint256& target) {
+        [&reqs, &req_times, &now](const uint256& base, const uint256& target) {
             reqs.emplace_back(base, target);
+            req_times.push_back(now);
         });
 
     // Tip body-pending with the SML stuck one behind the tip.
@@ -738,15 +746,54 @@ TEST(DashCoinStateMaintainer, DiffPhaseReRequestFiresBoundedThenDefersToDemote) 
     EXPECT_EQ(reqs[0].first,  raw256(0xCD)) << "base = where the SML is";
     EXPECT_EQ(reqs[0].second, PREV_HASH)    << "target = the header tip";
 
-    // Geometric backoff + hard cap at 3: keep ticking well past any wait; the
-    // count must stop at 3, never grow unbounded (never hammer a struggling peer).
-    for (int64_t t = 1010; t <= 1200; t += 5) tick(t);
-    EXPECT_EQ(reqs.size(), 3u)
-        << "re-request must cap at max_attempts (3), then go quiet and let the "
-           "unchanged 30 s hard demote take over exactly as today";
+    // Geometric backoff, then a CLAMPED perpetual cadence: keep ticking on a 5 s
+    // clock across a long stall on the SAME stuck (tip, sml) pair. The re-ask
+    // must (a) keep going PAST the old max_attempts=3 cap — going silent here is
+    // the measured 18-min wedge (#1315) — while (b) never collapsing to a burst:
+    // past the cap the spacing is pinned at the clamp interval
+    //   min_quiet(4) * backoff(2)^max_attempts(3) = 32 s.
+    const int64_t kClampSec = 32;   // = 4 * 2^3
+    const int64_t kTickStep = 5;
+    int loop_ticks = 0;
+    for (int64_t t = 1010; t <= 1200; t += kTickStep) { tick(t); ++loop_ticks; }
 
-    // Throughout, the SML never reached the tip, so the conjunct kept the tip
-    // body-pending the entire time — it never promoted into a dmn-stale serve.
+    // (a) It did NOT stop at the old cap of 3 — the whole point of the fix.
+    EXPECT_GT(reqs.size(), 3u)
+        << "past max_attempts the re-ask must CONTINUE at the clamped cadence; "
+           "the pre-fix code went silent at 3 and stranded the 18-min wedge";
+
+    // Deterministic and bounded: over this exact window the clamped cadence
+    // yields precisely these re-asks — never one-per-tick.
+    EXPECT_EQ(reqs.size(), 7u)
+        << "first re-ask at ~min_quiet, geometric (8 s, 16 s), then clamped at "
+           "32 s for the rest of the window — a fixed, bounded schedule";
+    EXPECT_LT(static_cast<int>(reqs.size()), loop_ticks / 4)
+        << "the clamped cadence must stay far below one request per tick — "
+           "never a burst against a struggling peer";
+    ASSERT_EQ(reqs.size(), req_times.size());
+
+    // (b) Cadence proof: every gap AFTER the geometric ramp (attempts >= 4, i.e.
+    // from req index 3 on) sits at the clamp — at least kClampSec (never faster)
+    // and at most one tick past it (re-asks the instant the clamp elapses, so it
+    // is a steady clamped cadence, not a one-shot that then goes quiet).
+    for (size_t i = 4; i < req_times.size(); ++i) {
+        const int64_t gap = req_times[i] - req_times[i - 1];
+        EXPECT_GE(gap, kClampSec)
+            << "clamped interval must never collapse below the cap (i=" << i << ")";
+        EXPECT_LE(gap, kClampSec + kTickStep)
+            << "but it must re-ask as soon as the clamp elapses (i=" << i << ")";
+    }
+
+    // The re-ask stays byte-identical to the tip-change getmnlistd for the whole
+    // clamped run: base = where the SML is, target = the header tip.
+    EXPECT_EQ(reqs.back().first,  raw256(0xCD)) << "base = where the SML is";
+    EXPECT_EQ(reqs.back().second, PREV_HASH)    << "target = the header tip";
+
+    // STILL DEFERS TO DEMOTE: the perpetual re-ask does not change what is
+    // served. The SML never reached the tip, so the conjunct kept the tip
+    // body-pending the entire time (well past the 30 s doomed-tip demote
+    // boundary) — it never promoted into a dmn-stale serve. The clamped re-ask
+    // only tries to heal the stall sooner; the demote gate is untouched.
     EXPECT_TRUE(m.tip_body_pending());
 }
 

--- a/test/test_dash_gbt_quorum_staleness.cpp
+++ b/test/test_dash_gbt_quorum_staleness.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT for the GBT-xcheck quorumroot-dashd-stale classifier
+// (src/impl/dash/coin/gbt_quorum_staleness.hpp), wired into the #127 null-arm
+// reward-safety backstop in stratum/work_source.cpp.
+//
+// GAP (measured, mainnet 2026-08): at each LLMQ DKG commitment boundary
+// (24-block cadence: 2525987, 2526011, 2526035, ...) dashd's getblocktemplate
+// momentarily serves the PREVIOUS cycle's merkleRootQuorums while our embedded
+// arm has already advanced to the freshly-committed one. Chain truth: the mined
+// block's CbTx carries the EMBEDDED root, so the pre-fix code -- which HARD-
+// swaps to dashd on ANY quorum-root difference -- was serving a would-be-
+// rejected bad-cbtx-quorummerkleroot template in that ~1s window (the reward-
+// safety direction was INVERTED).
+//
+// RED  (pre-fix / always-swap): the classifier does not fire, embedded is never
+//      kept, and StaleBoundaryKeepsEmbedded FAILS.
+// GREEN (with the predicate): the DKG-boundary stale case is isolated and KEEPS
+//      embedded, while every inverse / no-history / mixed-divergence case still
+//      returns false so the ordinary swap runs.
+
+#include <impl/dash/coin/gbt_quorum_staleness.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using dash::coin::quorumroot_dashd_is_stale;
+
+// Chain-proven vectors (prefixes are the real mainnet roots from the 2525987 /
+// 2526011 episodes; padded to 64 hex for unambiguous distinctness).
+const uint256 kFresh = uint256S(  // embedded root the chain committed at h
+    "8b5f6344000000000000000000000000000000000000000000000000000000ee");
+const uint256 kStale = uint256S(  // dashd's momentarily-stale root == prior cycle
+    "164eeaf7000000000000000000000000000000000000000000000000000000aa");
+const uint256 kOlder = uint256S(  // two cycles back (a longer dashd lag)
+    "275ded6e000000000000000000000000000000000000000000000000000000bb");
+
+// The proven case: dashd regressed to the last-agreed (prior-cycle) root while
+// embedded advanced past it, and the MN-list root axis agrees. KEEP embedded.
+TEST(GbtQuorumStaleness, StaleBoundaryKeepsEmbedded)
+{
+    EXPECT_TRUE(quorumroot_dashd_is_stale(kFresh, kStale,
+                                          /*mnlist_matches=*/true, &kStale));
+}
+
+// Inverse skew: embedded is the stale one, dashd is fresh. dref != last_agreed,
+// so the predicate must return false and the caller SWAPS to dashd (reward-safe).
+TEST(GbtQuorumStaleness, InverseSkewSwapsToDashd)
+{
+    EXPECT_FALSE(quorumroot_dashd_is_stale(kStale, kFresh,
+                                           /*mnlist_matches=*/true, &kStale));
+}
+
+// No prior agreement (cold start): cannot assert embedded is right -> swap.
+TEST(GbtQuorumStaleness, NoHistorySwaps)
+{
+    EXPECT_FALSE(quorumroot_dashd_is_stale(kFresh, kStale,
+                                           /*mnlist_matches=*/true, nullptr));
+}
+
+// A null last-agreed sentinel is treated as "no history" -> swap.
+TEST(GbtQuorumStaleness, NullSentinelSwaps)
+{
+    const uint256 null_root;  // default-constructed == all-zero
+    EXPECT_FALSE(quorumroot_dashd_is_stale(kFresh, kStale,
+                                           /*mnlist_matches=*/true, &null_root));
+}
+
+// Simultaneous MN-list divergence means this is body-divergence, not a pure DKG
+// boundary; take the ordinary swap even though dref == last_agreed.
+TEST(GbtQuorumStaleness, MixedMnlistDivergenceSwaps)
+{
+    EXPECT_FALSE(quorumroot_dashd_is_stale(kFresh, kStale,
+                                           /*mnlist_matches=*/false, &kStale));
+}
+
+// Equal quorum roots: nothing to classify (the branch would not even be
+// entered) -> false.
+TEST(GbtQuorumStaleness, EqualRootsIsNotStale)
+{
+    EXPECT_FALSE(quorumroot_dashd_is_stale(kFresh, kFresh,
+                                           /*mnlist_matches=*/true, &kStale));
+}
+
+// A two-cycle dashd lag (dref equals a root OLDER than last_agreed) is outside
+// the chain-proven single-boundary case -> swap, do not assert embedded.
+TEST(GbtQuorumStaleness, TwoCycleLagSwaps)
+{
+    EXPECT_FALSE(quorumroot_dashd_is_stale(kFresh, kOlder,
+                                           /*mnlist_matches=*/true, &kStale));
+}
+
+// The reference IS the last-agreed and embedded advanced: symmetry check that a
+// DIFFERENT fresh embedded value still keeps embedded as long as dref regressed.
+TEST(GbtQuorumStaleness, AnyAdvancedEmbeddedOverRegressedDashdKeeps)
+{
+    EXPECT_TRUE(quorumroot_dashd_is_stale(kOlder /*advanced, != last_agreed*/,
+                                          kStale, /*mnlist_matches=*/true,
+                                          &kStale));
+}
+
+} // namespace

--- a/test/test_dash_mempool_validity_gate.cpp
+++ b/test/test_dash_mempool_validity_gate.cpp
@@ -115,17 +115,137 @@ TEST(DashMempoolValidityGate, AnyOtherReasonIsInvalidAndCarriesItVerbatim) {
 // ── 2. THE EXEMPTION IS BY EXACT NAME ───────────────────────────────────────
 
 TEST(DashMempoolValidityGate, NearMissReasonIsNotExempted) {
-    // "txn-already-known" is a DIFFERENT dashd reason (the transaction is in a
-    // block / recently rejected, not in the mempool). Excusing it would widen
-    // the gate by prefix-matching, and a tx we would serve that dashd has
-    // already MINED is a staleness defect worth stopping on.
+    // None of these is the exact "txn-already-in-mempool" name. Excusing them
+    // would widen the gate by prefix-matching. "txn-already-known" is a REAL
+    // dashd reason (the tx is already CONFIRMED in dashd's chain), but WITHOUT
+    // tip context (the default here) we cannot tell benign propagation from a
+    // current-tip staleness defect, so the conservative reading is INVALID —
+    // exactly the pre-tip-context behaviour, and the gate-CLOSED direction.
+    // The tip-aware benign path is pinned separately below.
     for (const char* reason : {"txn-already-known",
                                "txn-already-in-mempool-ish",
                                "already-in-mempool"}) {
         const auto r = classify_mempool_accept(tx("dd"), refused("dd", reason));
         EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid)
-            << "reason=" << reason << " must NOT be exempted";
+            << "reason=" << reason << " must NOT be exempted without tip context";
     }
+}
+
+// ── 2b. THE PROPAGATION WINDOW: "txn-already-known" IS TIP-CONDITIONAL ───────
+//
+// FIELD MEASUREMENT (creditpool-arm + cert soaks, heights 2526398..2526404):
+// 23/23 of the live [MEMPOOL-VALIDITY] invalids were reason="txn-already-known"
+// and EVERY ONE was confirmed at EXACTLY the probe height — i.e. mined in the
+// very block our template competed for, while our tip was legitimately h-1.
+// That is benign propagation (Window 1): dashd connected block h before we did,
+// so it answers "already confirmed"; our template is a valid FORK COMPETITOR at
+// height h, never an orphan. The old gate reset the clean run on every one of
+// these, which is why clean_run was pinned at 0/576 forever. These KATs pin the
+// tip-context split that fixes it.
+
+TEST(DashMempoolValidityGate, AlreadyKnownWithDashdAheadIsBenignPropagationNotInvalid) {
+    // dashd is AHEAD of the height we built for -> the tx was confirmed in a
+    // block WE HAVE NOT YET CONNECTED -> benign, not a defect.
+    const auto r = classify_mempool_accept(
+        tx("mined_elsewhere"), refused("mined_elsewhere", "txn-already-known"),
+        /*dashd_ahead_of_serve_height=*/true);
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::ConfirmedAhead);
+}
+
+TEST(DashMempoolValidityGate, AlreadyKnownWithDashdNotAheadIsStillAnInvalidDefect) {
+    // dashd sits on OUR parent (not ahead) and STILL reports the tx confirmed
+    // -> it was confirmed at/below our serve-tip while we serve it: a genuine
+    // current-tip staleness defect (Window 2). The gate MUST still catch this.
+    const auto r = classify_mempool_accept(
+        tx("stale"), refused("stale", "txn-already-known"),
+        /*dashd_ahead_of_serve_height=*/false);
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid);
+    EXPECT_EQ(r.reason, "txn-already-known");
+}
+
+TEST(DashMempoolValidityGate, PropagationTransientDoesNotResetTheCleanRun) {
+    // The whole point. A clean run in progress must SURVIVE a height whose only
+    // "invalids" are already-confirmed-in-a-block-we-haven't-connected txs.
+    MempoolValidityGate g;
+    feed_clean(g, 100);
+    ASSERT_EQ(g.consecutive_clean, 100u);
+
+    // A propagation sample: 4 txs, all "txn-already-known", dashd AHEAD.
+    const std::vector<MempoolProbeTx> set{tx("p1"), tx("p2"), tx("p3"), tx("p4")};
+    const std::vector<nlohmann::json> ans{
+        refused("p1", "txn-already-known"), refused("p2", "txn-already-known"),
+        refused("p3", "txn-already-known"), refused("p4", "txn-already-known")};
+    const auto s = mempool_validity_sample(50000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/true);
+    // Not evidence, not a defect: 4 confirmed-ahead, 0 invalid.
+    EXPECT_EQ(s.confirmed_ahead, 4u);
+    EXPECT_EQ(s.invalid, 0u);
+    EXPECT_FALSE(s.evidence_bearing());
+
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 100u) << "propagation Window 1 must NOT reset";
+    EXPECT_EQ(g.txs_invalid, 0u);
+    EXPECT_EQ(g.txs_confirmed_ahead, 4u);
+}
+
+TEST(DashMempoolValidityGate, TheSamePropagationSampleWithoutTipContextWouldHaveResetIt) {
+    // RED->GREEN CONTRAST. Feed the IDENTICAL already-known set the way the
+    // pre-fix gate saw it (no tip context => dashd_ahead=false): it classifies
+    // as 4 INVALID and nukes a 100-height run to 0. This is the exact live
+    // defect (clean_run stuck at 0/576). The only difference from the test above
+    // is the tip-context bit, which is what the fix threads through.
+    MempoolValidityGate g;
+    feed_clean(g, 100);
+    ASSERT_EQ(g.consecutive_clean, 100u);
+
+    const std::vector<MempoolProbeTx> set{tx("p1"), tx("p2"), tx("p3"), tx("p4")};
+    const std::vector<nlohmann::json> ans{
+        refused("p1", "txn-already-known"), refused("p2", "txn-already-known"),
+        refused("p3", "txn-already-known"), refused("p4", "txn-already-known")};
+    const auto s = mempool_validity_sample(50000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/false);
+    EXPECT_EQ(s.invalid, 4u);
+    EXPECT_EQ(s.confirmed_ahead, 0u);
+
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 0u) << "no tip context => conservative reset";
+    EXPECT_EQ(g.best_consecutive_clean, 100u);
+}
+
+TEST(DashMempoolValidityGate, PropagationDoesNotMaskAGenuineInvalidInTheSameSample) {
+    // Belt: a sample carrying BOTH benign propagation AND a real defect still
+    // resets. The confirmed-ahead reclassification must never swallow a true
+    // invalid that shares the height.
+    MempoolValidityGate g;
+    feed_clean(g, 100);
+    const std::vector<MempoolProbeTx> set{tx("ahead"), tx("realbad")};
+    const std::vector<nlohmann::json> ans{
+        refused("ahead", "txn-already-known"),
+        refused("realbad", "bad-txns-inputs-missingorspent")};
+    const auto s = mempool_validity_sample(50000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/true);
+    EXPECT_EQ(s.confirmed_ahead, 1u);
+    EXPECT_EQ(s.invalid, 1u);
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 0u) << "a real defect still resets";
+    EXPECT_EQ(g.last_invalid_reason, "bad-txns-inputs-missingorspent");
+}
+
+TEST(DashMempoolValidityGate, AMixedValidAndPropagationHeightStillAdvances) {
+    // A height with at least one genuinely VALID tx is evidence and advances,
+    // even when the rest of the set is benign propagation.
+    MempoolValidityGate g;
+    feed_clean(g, 10);
+    const std::vector<MempoolProbeTx> set{tx("good"), tx("ahead")};
+    const std::vector<nlohmann::json> ans{
+        allowed_true("good"), refused("ahead", "txn-already-known")};
+    const auto s = mempool_validity_sample(60000, set, ans,
+                                           /*dashd_ahead_of_serve_height=*/true);
+    EXPECT_TRUE(s.evidence_bearing());
+    EXPECT_EQ(s.valid, 1u);
+    EXPECT_EQ(s.confirmed_ahead, 1u);
+    g.apply(s);
+    EXPECT_EQ(g.consecutive_clean, 11u);
 }
 
 // ── 3. A MISSING ANSWER IS NEVER A PASS ─────────────────────────────────────

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -1241,6 +1241,153 @@ TEST(DashMempoolTxServing, UtxoImmatureCauseWinsOverDisabled) {
     EXPECT_STREQ(e.suppress_cause, "utxo-immature-serving");
 }
 
+// ════════════════════════════════════════════════════════════════════════
+// WINDOW-2 EVICTION-LAG GATE (intra-node ordering; close the thrown-away
+// found block). The serve tip can be promoted to H by the diff-driven path
+// (CoinStateMaintainer mnlistdiff-at-tip / cbTx credit-pool re-anchor) BEFORE
+// the embedded UTXO lane connects+evicts block H. In that sub-second window
+// the UTXO view is still at H-1, so H's spent outpoints resolve as unspent
+// and the selection stale-input guard is blind to them: a template built on H
+// would pack a tx already spent by H -> bad-txns-inputs-missingorspent on a
+// winning share = a thrown-away found block. dashd cannot expose this window
+// because CTxMemPool::removeForBlock runs synchronously inside ConnectBlock
+// BEFORE SetTip. The serve path consults NodeCoinState::set_utxo_current_fn
+// (UtxoLane::utxo_current_at at the wire) and serves coinbase-only until the
+// view catches up. The predicate is injected here exactly as the other gate
+// fns are; the wire one-liner (get_best_block()==tip) is covered by the
+// main_dash wiring.
+// ════════════════════════════════════════════════════════════════════════
+
+// RED (master) -> GREEN (fix) in one place: identical state, the ONLY toggle
+// is whether the currency fn is wired. Unset == the shipped-master behaviour;
+// wired == this fix.
+TEST(DashWindow2EvictionGate, StaleTipSuppressesBodyWithNamedCause) {
+    NodeCoinState st;
+    seed_healthy_armed(st);            // serve tip prev_hash == raw256(0xAB)
+    st.set_utxo_ready_fn([] { return true; });   // mature lane
+    st.set_serve_mempool_txs(true);              // fee-carrying opt-in ON
+
+    // RED: master ships NO Window-2 axis. With the currency fn UNSET, a serve
+    // tip promoted ahead of the UTXO view still serves the fee-carrying body
+    // -> the doomed tx leaks into the H+1 selection. This asserts the exact
+    // pre-fix behaviour the gate closes.
+    {
+        const auto e = st.make_embedded_work_inputs();
+        EXPECT_TRUE(e.has_state);
+        EXPECT_FALSE(e.suppress_mempool_txs)
+            << "master (no currency fn): the stale-tip body is served -- the bug";
+    }
+
+    // GREEN: wire the currency predicate. The UTXO view is at some OTHER hash
+    // (H-1), NOT the just-promoted serve tip (0xAB) -> Window 2 is open ->
+    // serve coinbase-only, cause named for the soak grep.
+    const uint256 view_tip_h_minus_1 = raw256(0x99);   // != serve tip 0xAB
+    st.set_utxo_current_fn(
+        [&](const uint256& tip) { return tip == view_tip_h_minus_1; });
+    {
+        const auto e = st.make_embedded_work_inputs();
+        EXPECT_TRUE(e.has_state) << "coinbase-only serving is not a refusal";
+        EXPECT_TRUE(e.suppress_mempool_txs)
+            << "stale tip: the fee-carrying body must be suppressed";
+        EXPECT_STREQ(e.suppress_cause, "utxo-stale-at-tip");
+    }
+}
+
+// Negative twin: once the UTXO view is current at the serve tip, the full
+// fee-carrying set is served again -- the gate self-heals, no permanent stall.
+TEST(DashWindow2EvictionGate, CurrentTipServesFullSet) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return true; });
+    st.set_serve_mempool_txs(true);
+    // view current AT the serve tip (0xAB) -- body H connected + evicted.
+    st.set_utxo_current_fn([](const uint256& tip) { return tip == raw256(0xAB); });
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.has_state);
+    EXPECT_FALSE(e.suppress_mempool_txs)
+        << "view current at tip: serve the full mempool-tx body";
+}
+
+// The gate is scoped to the fee-carrying opt-in. With serving OFF the body is
+// coinbase-only for the pre-existing reason regardless of currency, so the
+// Window-2 cause must NOT mask the default-OFF cause. Proves byte-unchanged
+// default posture (the gate cannot fire when unarmed).
+TEST(DashWindow2EvictionGate, InertWhenServingOff) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return true; });
+    // serving OFF (shipped default); wire a STALE currency fn anyway.
+    st.set_utxo_current_fn([](const uint256&) { return false; });
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.suppress_mempool_txs);
+    EXPECT_STREQ(e.suppress_cause, "mempool-txs-disabled")
+        << "unarmed: Window-2 must not fire, default cause stands";
+}
+
+// Cold-start immaturity is the deeper condition; when both windows are open at
+// once the immature cause wins so the soak attributes the (longer) window.
+TEST(DashWindow2EvictionGate, ImmatureCauseWinsOverStale) {
+    NodeCoinState st;
+    seed_healthy_armed(st);
+    st.set_utxo_ready_fn([] { return false; });   // immature lane
+    st.set_utxo_immature_policy(
+        dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet);
+    st.set_serve_mempool_txs(true);
+    st.set_utxo_current_fn([](const uint256&) { return false; });  // also stale
+    const auto e = st.make_embedded_work_inputs();
+    EXPECT_TRUE(e.suppress_mempool_txs);
+    EXPECT_STREQ(e.suppress_cause, "utxo-immature-serving");
+}
+
+// Template-selection proof (the task's "T absent from the next template
+// selection"): build the SAME projection twice and show the doomed tx T is
+// selected when the body is served (suppress=false, the master leak) and
+// ABSENT when the gate suppresses (suppress=true). This exercises the builder
+// path the gate feeds, independent of the header-only decision above.
+TEST(DashWindow2EvictionGate, DoomedTxAbsentFromTemplateWhenSuppressed) {
+    UTXOViewCache utxo(nullptr);
+    const uint256 coin_h = raw256(0x55);
+    utxo.add_coin(Outpoint(coin_h, 0),
+                  Coin(100'000, {}, /*height=*/1, /*cb=*/false));
+
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    st.mempool().set_utxo(&utxo);
+    // T spends coin_h[0] -- the very outpoint block H will spend. While the
+    // view is at H-1 the coin is live, so T prices and is selectable.
+    ASSERT_TRUE(st.mempool().add_tx(make_spend(coin_h, 0, 90'000, /*salt=*/7)));
+
+    const uint256 prev_hash = raw256(0xAB);
+    const uint32_t bits = 0x1b104be3u, mtp = 1'700'000'000u;
+    const uint32_t curtime = 1'700'000'123u, version = 0x20000000u;
+
+    // Served body (suppress=false): the doomed tx IS in the selection.
+    DashWorkData served = build_embedded_workdata(
+        H - 1, prev_hash, st.mnstates(), st.mempool(),
+        bits, mtp, DASH_PUBKEY_VER, DASH_P2SH_VER, curtime, version);
+    ASSERT_EQ(served.m_tx_hashes.size(), 1u)
+        << "precondition: T is selectable against the H-1 view (the leak)";
+
+    // Gate suppresses (Window 2 open): coinbase-only, T absent. suppress_mempool_txs
+    // is the 20th positional arg; txset_empty_cause the 21st.
+    DashWorkData gated = build_embedded_workdata(
+        H - 1, prev_hash, st.mnstates(), st.mempool(),
+        bits, mtp, DASH_PUBKEY_VER, DASH_P2SH_VER, curtime, version,
+        /*underfill_tripped=*/nullptr,
+        /*sml=*/nullptr, /*qmgr=*/nullptr,
+        /*best_cl_height=*/0, /*best_cl_sig=*/dash::coin::k_zero_cl_sig,
+        /*last_observed_credit_pool=*/0,
+        /*qc_commitments=*/nullptr, /*quorum_root_override=*/nullptr,
+        /*mn_rr_height=*/dash::coin::DASH_MN_RR_HEIGHT_MAINNET,
+        /*superblock_payments=*/nullptr,
+        /*mn_min_confirmations=*/dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress_mempool_txs=*/true,
+        /*txset_empty_cause=*/"utxo-stale-at-tip");
+    EXPECT_TRUE(gated.m_tx_hashes.empty())
+        << "gate open: the doomed tx must be absent from the template selection";
+    EXPECT_EQ(gated.m_tx_fees.size(), 0u);
+}
+
 // The opt-in relaxes ONLY this clause. Every other gate must still refuse —
 // otherwise "serve during immaturity" would have quietly become "serve
 // regardless", which is how a lost block gets shipped as a feature.

--- a/test/test_dash_serve_gate_journal.cpp
+++ b/test/test_dash_serve_gate_journal.cpp
@@ -29,6 +29,13 @@
 
 #include <impl/dash/coin/serve_gate_journal.hpp>
 #include <impl/dash/coin/serve_gate_rollup_json.hpp>
+#include <impl/dash/coin/serve_gate_persist.hpp>
+
+#include <cstdio>
+#include <fstream>
+
+#include <unistd.h>  // getpid
+
 
 #include <string>
 
@@ -384,6 +391,251 @@ TEST(DashServeGateJournal, RollupJsonShapePinsTheWebField) {
     EXPECT_EQ(empty["off_embedded_sec"].get<int64_t>(), 0);
     EXPECT_TRUE(empty["per_cause"].is_array());
     EXPECT_TRUE(empty["per_cause"].empty());
+}
+
+
+// ── NULL-ARM DKG-FLOOR COVERAGE: cross-restart cumulative accounting ─────────
+//
+// THE DEFECT THIS PINS (hotel-primary, 2026-08-23): the [EMBED-GATE-ROLLUP]
+// denominator `observed=` equals wall clock since the LAST restart (7211 s at
+// the 06:00 tick for a 04:00 restart), because ServeGateJournal is pure policy
+// and every counter resets with the process. So the dashd-cut gate that
+// matters — "the null-arm covered the 4.51% DKG floor with 0 rejects over a
+// STANDING soak" — was unprovable program-level, and there was no explicit
+// null-served counter at all. serve_gate_persist.hpp is the write-through
+// cumulative layer that closes both halves.
+//
+// RED ON MASTER: serve_gate_persist.hpp does not exist there, so this TU does
+// not COMPILE — the intended failure this branch turns green (same red shape
+// as NoWorkIsTheDistinctThirdArmState above).
+
+using dash::coin::QcNullServeCounters;
+using dash::coin::ServeGateCumulative;
+using Disposition = dash::coin::QcNullServeCounters::Disposition;
+
+inline std::string na_temp_path(const char* tag) {
+    std::string p = ::testing::TempDir();
+    if (!p.empty() && p.back() != '/') p += '/';
+    p += "na_serve_gate_";
+    p += tag;
+    p += "_";
+    p += std::to_string(static_cast<long long>(::getpid()));
+    p += ".json";
+    std::remove(p.c_str());
+    return p;
+}
+
+// THE CORE GAP: cumulative observed/off-embedded/per-cause seconds AND the
+// null-serve counters survive a restart and ACCUMULATE across processes, and
+// restart_count records how many processes covered the soak. On master the
+// only cumulative view is per-process; this proves the wipe is gone.
+TEST(DashServeGateCumulative, StateSurvivesRestartAndAccumulates) {
+    const std::string path = na_temp_path("restart");
+
+    // ── process 1 ────────────────────────────────────────────────────────
+    ServeGateJournal j1(1000000);
+    j1.observe(false, "qc-plan-underivable", 0);
+    j1.observe(true, "", 10);                 // 10 s off-embedded on qc-plan
+    // ... serving continues; roll-up read at t=100.
+    ServeGateCumulative prior1 = dash::coin::load_serve_gate_state(path);
+    EXPECT_EQ(prior1.restart_count, 1);       // fresh file: first process
+    EXPECT_EQ(prior1.observed_sec, 0);
+
+    QcNullServeCounters c1;
+    c1.note(4, Disposition::NullServed);
+    c1.note(4, Disposition::NullServed);
+    c1.note(4, Disposition::NullServed);
+    c1.note(2, Disposition::NullServed);
+    c1.note_submit(false);
+    c1.note_submit(false);
+
+    ServeGateCumulative cum1 = dash::coin::combine(prior1, j1.rollup(100), c1);
+    EXPECT_EQ(cum1.restart_count, 1);
+    EXPECT_EQ(cum1.observed_sec, 100);
+    EXPECT_EQ(cum1.off_embedded_sec, 10);
+    ASSERT_EQ(cum1.cause_totals.count("qc-plan-underivable"), 1u);
+    EXPECT_EQ(cum1.cause_totals["qc-plan-underivable"], 10);
+    EXPECT_EQ(cum1.null_serve.total_null_served(), 4);
+    EXPECT_EQ(cum1.null_serve.submits_from_null, 2);
+    EXPECT_EQ(cum1.null_serve.rejects_from_null, 0);
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(path, cum1));
+
+    // ── process 2 (a restart) ────────────────────────────────────────────
+    ServeGateCumulative prior2 = dash::coin::load_serve_gate_state(path);
+    EXPECT_EQ(prior2.restart_count, 2);       // bumped: second process
+    EXPECT_EQ(prior2.observed_sec, 100);      // process 1's denominator carried
+    EXPECT_EQ(prior2.off_embedded_sec, 10);
+    EXPECT_EQ(prior2.cause_totals["qc-plan-underivable"], 10);
+    EXPECT_EQ(prior2.null_serve.total_null_served(), 4);
+
+    ServeGateJournal j2(1000000);
+    j2.observe(false, "dmn-stale", 0);
+    j2.observe(true, "", 5);                   // 5 s off-embedded on dmn-stale
+    QcNullServeCounters c2;
+    c2.note(4, Disposition::RealServed);       // a real quorum existed -> NOT null
+    c2.note(4, Disposition::RealServed);
+    c2.note(4, Disposition::FellBack);         // freshness unproven -> fail-closed
+
+    ServeGateCumulative cum2 = dash::coin::combine(prior2, j2.rollup(50), c2);
+    EXPECT_EQ(cum2.restart_count, 2);
+    EXPECT_EQ(cum2.observed_sec, 150);         // 100 + 50, across processes
+    EXPECT_EQ(cum2.off_embedded_sec, 15);      // 10 + 5
+    EXPECT_EQ(cum2.cause_totals["qc-plan-underivable"], 10);  // process 1's
+    EXPECT_EQ(cum2.cause_totals["dmn-stale"], 5);             // process 2's
+    EXPECT_EQ(cum2.null_serve.total_null_served(), 4);        // carried
+    EXPECT_EQ(cum2.null_serve.total_real_served(), 2);        // this process
+    EXPECT_EQ(cum2.null_serve.total_fell_back(), 1);
+    EXPECT_EQ(cum2.null_serve.total_window_open(), 7);        // 4 + 2 + 1
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(path, cum2));
+
+    // ── process 3: the accumulation is durable ───────────────────────────
+    ServeGateCumulative prior3 = dash::coin::load_serve_gate_state(path);
+    EXPECT_EQ(prior3.restart_count, 3);
+    EXPECT_EQ(prior3.observed_sec, 150);
+    EXPECT_EQ(prior3.off_embedded_sec, 15);
+    EXPECT_EQ(prior3.null_serve.total_null_served(), 4);
+    EXPECT_EQ(prior3.null_serve.total_real_served(), 2);
+    EXPECT_EQ(prior3.null_serve.total_fell_back(), 1);
+    EXPECT_EQ(prior3.null_serve.submits_from_null, 2);
+    EXPECT_EQ(prior3.null_serve.rejects_from_null, 0);
+
+    std::remove(path.c_str());
+}
+
+// SERVE-EXACTNESS, expressed as the counter invariant: a required mining-window
+// tip takes EXACTLY one disposition, so window_open == null + real + fell_back
+// per type; the null-arm is counted as null ONLY on the floor tips and as real
+// wherever a verified commitment existed (it was never consulted there). Plus
+// the never-a-reject conjunct: submits from null-carrying templates > 0,
+// rejects == 0. Round-trips through the state file unchanged.
+TEST(DashServeGateCumulative, NullServeCountersLockServeExactness) {
+    QcNullServeCounters n;
+
+    // DKG-floor tips (phase-10 type-4, window-open type-2): the null was served.
+    for (int i = 0; i < 13; ++i) n.note(4, Disposition::NullServed);
+    n.note(2, Disposition::NullServed);
+
+    // A verified real commitment existed for the slot: the null-arm is NEVER
+    // consulted here (verified_for precedes null_evidence). Counted as REAL.
+    for (int i = 0; i < 5; ++i) n.note(4, Disposition::RealServed);
+    n.note(2, Disposition::RealServed);
+    n.note(2, Disposition::RealServed);
+
+    // Freshness unproven: the whole height fails closed to fallback (benign gap).
+    n.note(4, Disposition::FellBack);
+
+    // Block submissions from null-carrying templates — none rejected.
+    for (int i = 0; i < 8; ++i) n.note_submit(false);
+
+    // The dispositions are distinct and correctly bucketed.
+    EXPECT_EQ(n.null_served[4], 13);
+    EXPECT_EQ(n.null_served[2], 1);
+    EXPECT_EQ(n.real_served[4], 5);
+    EXPECT_EQ(n.real_served[2], 2);
+    EXPECT_EQ(n.fell_back[4], 1);
+
+    // THE INVARIANT: every window-open tip took exactly one disposition, so the
+    // null-arm can neither double-count nor fire on a real-quorum tip.
+    EXPECT_EQ(n.window_open[4], 13 + 5 + 1);
+    EXPECT_EQ(n.window_open[2], 1 + 2);
+    EXPECT_EQ(n.total_window_open(),
+              n.total_null_served() + n.total_real_served() + n.total_fell_back());
+
+    // Never-a-reject conjunct.
+    EXPECT_EQ(n.submits_from_null, 8);
+    EXPECT_EQ(n.rejects_from_null, 0);
+
+    // Survives persistence byte-for-byte (bump_restart=false to compare exactly).
+    const std::string path = na_temp_path("exact");
+    ServeGateCumulative c;
+    c.null_serve = n;
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(path, c));
+    ServeGateCumulative back =
+        dash::coin::load_serve_gate_state(path, /*bump_restart=*/false);
+    EXPECT_EQ(back.null_serve.null_served[4], 13);
+    EXPECT_EQ(back.null_serve.real_served[4], 5);
+    EXPECT_EQ(back.null_serve.fell_back[4], 1);
+    EXPECT_EQ(back.null_serve.window_open[2], 3);
+    EXPECT_EQ(back.null_serve.submits_from_null, 8);
+    EXPECT_EQ(back.null_serve.rejects_from_null, 0);
+    std::remove(path.c_str());
+}
+
+// A missing OR corrupt state file yields a clean zero (still counted as a
+// restart) — the soak file is a convenience, never a consensus input, so a bad
+// read must never wedge the node or invent totals.
+TEST(DashServeGateCumulative, MissingOrCorruptFileYieldsCleanZero) {
+    // Missing.
+    const std::string missing = na_temp_path("missing");
+    ServeGateCumulative m = dash::coin::load_serve_gate_state(missing);
+    EXPECT_EQ(m.restart_count, 1);
+    EXPECT_EQ(m.observed_sec, 0);
+    EXPECT_EQ(m.off_embedded_sec, 0);
+    EXPECT_TRUE(m.cause_totals.empty());
+    EXPECT_EQ(m.null_serve.total_window_open(), 0);
+
+    // Corrupt: half-written JSON must not throw, must reset to zero.
+    const std::string corrupt = na_temp_path("corrupt");
+    {
+        std::ofstream out(corrupt);
+        out << "{ \"observed_sec\": 999, this is not valid js";
+    }
+    ServeGateCumulative c = dash::coin::load_serve_gate_state(corrupt);
+    EXPECT_EQ(c.restart_count, 1);   // still counted
+    EXPECT_EQ(c.observed_sec, 0);    // NOT the 999 from the truncated file
+    EXPECT_TRUE(c.cause_totals.empty());
+    std::remove(corrupt.c_str());
+}
+
+// combine() = prior + live, and prior never absorbs the live part, so saving on
+// every roll-up tick is idempotent: two saves in one process from a growing
+// rollup REPLACE rather than add (20 s, not 10+20=30).
+TEST(DashServeGateCumulative, CombineIsReplaceNotAddWithinOneProcess) {
+    const std::string path = na_temp_path("replace");
+    ServeGateCumulative prior;  // frozen zero
+
+    ServeGateJournal j(1000000);
+    j.observe(false, "cause-x", 0);            // opens an off-embedded segment
+
+    // Tick 1 at t=10.
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(
+        path, dash::coin::combine(prior, j.rollup(10), {})));
+    // Tick 2 at t=20 — SAME frozen prior, larger live rollup.
+    ASSERT_TRUE(dash::coin::save_serve_gate_state_atomic(
+        path, dash::coin::combine(prior, j.rollup(20), {})));
+
+    ServeGateCumulative loaded =
+        dash::coin::load_serve_gate_state(path, /*bump_restart=*/false);
+    EXPECT_EQ(loaded.observed_sec, 20);        // replace, not 30
+    EXPECT_EQ(loaded.off_embedded_sec, 20);
+    EXPECT_EQ(loaded.cause_totals["cause-x"], 20);
+    std::remove(path.c_str());
+}
+
+// The operator log lines render the cumulative shape: denominator first, the
+// never-a-reject conjunct visible, per-type null/real breakout present.
+TEST(DashServeGateCumulative, LogLinesRenderCumulativeShape) {
+    ServeGateCumulative c;
+    c.restart_count = 3;
+    c.observed_sec = 200;
+    c.off_embedded_sec = 20;
+    c.cause_totals["qc-plan-underivable"] = 18;
+    c.null_serve.note(4, Disposition::NullServed);
+    c.null_serve.note(4, Disposition::RealServed);
+    c.null_serve.note_submit(false);
+
+    const std::string roll = dash::coin::cumulative_rollup_line(c);
+    EXPECT_NE(roll.find("[EMBED-GATE-ROLLUP-CUM]"), std::string::npos);
+    EXPECT_NE(roll.find("restarts=3"), std::string::npos);
+    EXPECT_NE(roll.find("observed=200s"), std::string::npos);
+    EXPECT_NE(roll.find("qc-plan-underivable=18s"), std::string::npos);
+
+    const std::string ns = dash::coin::qc_null_serve_line(c.null_serve);
+    EXPECT_NE(ns.find("[QC-NULL-SERVE]"), std::string::npos);
+    EXPECT_NE(ns.find("null=1"), std::string::npos);
+    EXPECT_NE(ns.find("real=1"), std::string::npos);
+    EXPECT_NE(ns.find("rejects=0"), std::string::npos);
+    EXPECT_NE(ns.find("type4:"), std::string::npos);
 }
 
 }  // namespace

--- a/test/test_dash_serve_gate_ledger.cpp
+++ b/test/test_dash_serve_gate_ledger.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// ServeGateLedger cross-restart never-a-reject accounting KAT.
+///
+/// THE DEFECT THIS PINS (critic, 2026-08-23): the EMBED-GATE roll-up and every
+/// ServeGateJournal counter are in-process members fed a process-monotonic
+/// steady_clock, so they WIPE on every restart. The dashd-cut acceptance gate
+/// is a CUMULATIVE never-a-reject claim spanning >=3 restarts ("the null-arm
+/// covered the 4.51% DKG floor, 0 rejects over N heights") — a claim the
+/// journal structurally cannot carry across a restart.
+///
+/// RED (without ServeGateLedger, or with a journal-style wipe): after a
+/// simulated restart every cumulative count reads 0 and the never-a-reject span
+/// resets, so the standing claim is unprovable.
+/// GREEN (with ServeGateLedger): counts survive save→load, epochs increments,
+/// the open-segment carry folds exactly once (no double-count), and a reject
+/// increments the reject counter AND breaks the never-a-reject span.
+///
+/// Pure-policy suite: the ledger takes caller-supplied monotonic seconds, no
+/// clock of its own; persistence is a real atomic tmp+rename round-trip through
+/// a temp file (the JSON companion), never a hand-rebuilt shape.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#include <impl/dash/coin/serve_gate_journal.hpp>
+#include <impl/dash/coin/serve_gate_ledger.hpp>
+#include <impl/dash/coin/serve_gate_ledger_json.hpp>
+
+using dash::coin::ServeGateJournal;
+using dash::coin::ServeGateLedger;
+using Arm = ServeGateLedger::Arm;
+
+namespace {
+
+std::string temp_ledger_path(const char* stem) {
+    auto p = std::filesystem::temp_directory_path() /
+             (std::string("c2pool_ledger_kat_") + stem + "_" +
+              std::to_string(::getpid()) + ".json");
+    std::filesystem::remove(p);
+    return p.string();
+}
+
+// A ledger banking the SAME Decision the journal returns must agree with the
+// journal's own closed-segment histogram to the second — that is the whole
+// point of feeding it Decision.prev_cause_sec rather than a re-derived number.
+TEST(DashServeGateLedger, LedgerAndJournalCannotDisagree) {
+    ServeGateJournal j(300);
+    ServeGateLedger  led;
+    const int64_t t0 = 1000;
+
+    // A 40 s qc-plan-underivable segment, then a 10 s dmn-stale segment, then
+    // resume. Feed every observation to both; bank the ledger from the journal
+    // Decision so they read the same closed-segment durations.
+    auto feed_decline = [&](const std::string& cause, int64_t t) {
+        auto d = j.observe(false, cause, t);
+        led.bank_serve(Arm::Fallback, cause, d, t);
+    };
+    auto feed_serve = [&](int64_t t) {
+        auto d = j.observe(true, "", t);
+        led.bank_serve(Arm::EmbeddedReal, "", d, t);
+    };
+
+    for (int64_t t = t0; t < t0 + 40; ++t) feed_decline("qc-plan-underivable", t);
+    for (int64_t t = t0 + 40; t < t0 + 50; ++t) feed_decline("dmn-stale", t);
+    feed_serve(t0 + 50);  // resume: closes the final (dmn-stale) segment
+
+    auto roll = j.rollup(t0 + 50);
+    const auto& T = led.totals();
+    // off_embedded matches the journal's closed-segment total.
+    EXPECT_EQ(T.off_embedded_sec, roll.off_embedded_sec);
+    EXPECT_EQ(T.per_cause_sec.at("qc-plan-underivable"), 40);
+    EXPECT_EQ(T.per_cause_sec.at("dmn-stale"), 10);
+    // observed_sec = wall clock spanned by the banked deltas (t0 .. t0+50).
+    EXPECT_EQ(T.observed_sec, 50);
+}
+
+// The load-bearing cross-restart test: counts survive save→load, epochs
+// increments, and the open-segment carry folds EXACTLY once.
+TEST(DashServeGateLedger, CrossRestartPersistsAndFoldsCarryOnce) {
+    const std::string path = temp_ledger_path("restart");
+    ServeGateJournal j(300);
+
+    // ── epoch 1 ──────────────────────────────────────────────────────────
+    ServeGateLedger led1;
+    led1.set_writer_commit("deadbeefcafe");
+    const int64_t t0 = 500;
+    // 20 s serving (embedded_real), banking observed_sec deltas.
+    for (int64_t t = t0; t < t0 + 20; ++t) {
+        auto d = j.observe(true, "", t);
+        led1.bank_serve(Arm::EmbeddedReal, "", d, t);
+    }
+    // Then decline into an OPEN qc-plan-underivable segment for 30 s, never
+    // resumed (the process is about to "crash").
+    for (int64_t t = t0 + 20; t < t0 + 50; ++t) {
+        auto d = j.observe(false, "qc-plan-underivable", t);
+        led1.bank_serve(Arm::Fallback, "qc-plan-underivable", d, t);
+    }
+    // A won embedded_real block at height 100 (extends the clean span).
+    led1.record_block_won(Arm::EmbeddedReal, 100);
+    led1.record_rpc_verdict(Arm::EmbeddedReal, 100, /*accepted=*/true, "");
+
+    // Flush: snapshot the open 30 s segment into carry, write-through.
+    led1.snapshot_carry_for_flush();
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_save(path, led1.totals()));
+
+    const auto T1 = led1.totals();
+    EXPECT_EQ(T1.serves_embedded_real, 20u);
+    EXPECT_EQ(T1.serves_fallback, 30u);
+    EXPECT_EQ(T1.off_embedded_sec, 0);         // segment still OPEN, not banked
+    EXPECT_EQ(T1.carry_sec, 29);               // open-segment partial in carry
+    EXPECT_EQ(T1.carry_cause, "qc-plan-underivable");
+    EXPECT_EQ(T1.epochs, 0u);                  // not loaded yet
+    EXPECT_EQ(T1.blocks_won_embedded_real, 1u);
+
+    // ── restart: epoch 2 ─────────────────────────────────────────────────
+    ServeGateLedger::Totals loaded;
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_load(path, loaded));
+    ServeGateLedger led2;
+    led2.load(loaded);
+    const auto& T2 = led2.totals();
+
+    // Counts SURVIVED the restart (the journal cannot do this).
+    EXPECT_EQ(T2.serves_embedded_real, 20u);
+    EXPECT_EQ(T2.serves_fallback, 30u);
+    EXPECT_EQ(T2.blocks_won_embedded_real, 1u);
+    EXPECT_EQ(T2.observed_sec, T1.observed_sec);        // wall clock preserved
+    EXPECT_EQ(T2.last_writer_commit, "deadbeefcafe");
+    // epochs incremented.
+    EXPECT_EQ(T2.epochs, 1u);
+    // Carry folded exactly once into the cumulative total, then cleared.
+    EXPECT_EQ(T2.off_embedded_sec, 29);
+    EXPECT_EQ(T2.per_cause_sec.at("qc-plan-underivable"), 29);
+    EXPECT_EQ(T2.carry_sec, 0);
+    EXPECT_TRUE(T2.carry_cause.empty());
+
+    // ── save again + load AGAIN: the carry must NOT fold a second time ────
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_save(path, led2.totals()));
+    ServeGateLedger::Totals loaded2;
+    ASSERT_TRUE(dash::coin::serve_gate_ledger_load(path, loaded2));
+    ServeGateLedger led3;
+    led3.load(loaded2);
+    const auto& T3 = led3.totals();
+    EXPECT_EQ(T3.off_embedded_sec, 29);                 // NOT 58 — no double-count
+    EXPECT_EQ(T3.per_cause_sec.at("qc-plan-underivable"), 29);
+    EXPECT_EQ(T3.epochs, 2u);                           // three lifetimes total
+
+    std::filesystem::remove(path);
+}
+
+// A reject increments the per-arm reject counter AND breaks the never-a-reject
+// span; the never_a_reject() cut gate flips false and stays false.
+TEST(DashServeGateLedger, RejectBreaksNeverARejectSpan) {
+    ServeGateLedger led;
+    EXPECT_TRUE(led.never_a_reject());
+    EXPECT_EQ(led.clean_span_heights(), 0u);
+
+    // Clean run: three embedded blocks accepted over heights 2000..2002.
+    for (uint64_t h = 2000; h <= 2002; ++h) {
+        led.record_block_won(Arm::EmbeddedReal, h);
+        led.record_rpc_verdict(Arm::EmbeddedReal, h, /*accepted=*/true, "");
+    }
+    EXPECT_TRUE(led.never_a_reject());
+    EXPECT_EQ(led.clean_span_heights(), 3u);            // 2000..2002 inclusive
+    EXPECT_EQ(led.totals().nr_total_rejects, 0u);
+
+    // A reject on an embedded_real block at 2003.
+    led.record_block_won(Arm::EmbeddedReal, 2003);
+    led.record_rpc_verdict(Arm::EmbeddedReal, 2003, /*accepted=*/false,
+                           "bad-cb-payee");
+    EXPECT_FALSE(led.never_a_reject());                 // hard gate tripped
+    EXPECT_EQ(led.totals().rpc_rejected_embedded_real, 1u);
+    EXPECT_EQ(led.totals().nr_total_rejects, 1u);
+    EXPECT_EQ(led.totals().nr_last_reject_height, 2003u);
+    EXPECT_EQ(led.totals().rpc_reject_reasons.at("bad-cb-payee"), 1u);
+    // Span reset by the reject.
+    EXPECT_EQ(led.clean_span_heights(), 0u);
+}
+
+// A validity-attributable orphan on an embedded arm is a SILENT reject: it
+// breaks the span too. A race orphan (validity_attributable=false) does not.
+TEST(DashServeGateLedger, ValidityOrphanBreaksSpanRaceOrphanDoesNot) {
+    ServeGateLedger led;
+    led.record_block_won(Arm::EmbeddedNull, 3000);
+    led.record_block_won(Arm::EmbeddedNull, 3001);
+    EXPECT_EQ(led.clean_span_heights(), 2u);
+
+    // Race orphan: disambiguated by the RPC verdict as NOT validity-caused.
+    led.record_orphan(Arm::EmbeddedNull, 3001, /*validity_attributable=*/false);
+    EXPECT_TRUE(led.never_a_reject());
+    EXPECT_EQ(led.clean_span_heights(), 2u);            // untouched
+
+    // Validity orphan: a silent reject on the null arm.
+    led.record_orphan(Arm::EmbeddedNull, 3001, /*validity_attributable=*/true);
+    EXPECT_FALSE(led.never_a_reject());
+    EXPECT_EQ(led.totals().orphaned_embedded_null, 1u);
+    EXPECT_EQ(led.clean_span_heights(), 0u);
+}
+
+// Null-arm first class: a null served where NO real quorum existed is the
+// correct DKG-floor case; a null served where a real quorum WAS available is
+// the defect the cut gate forbids (must stay 0).
+TEST(DashServeGateLedger, NullArmDkgFloorVsRealQuorumAvailable) {
+    ServeGateLedger led;
+    ServeGateJournal j(300);
+    auto d = j.observe(true, "", 10);  // a serving decision
+
+    // Correct: null over the DKG floor, no real quorum available.
+    led.bank_serve(Arm::EmbeddedNull, "", d, 10, /*real_quorum_available=*/false);
+    EXPECT_EQ(led.totals().serves_embedded_null, 1u);
+    EXPECT_EQ(led.totals().null_dkg_floor_tips_served, 1u);
+    EXPECT_EQ(led.totals().null_real_quorum_available_but_null_served, 0u);
+
+    // Defect: a null served while a real committed quorum existed.
+    led.bank_serve(Arm::EmbeddedNull, "", d, 11, /*real_quorum_available=*/true);
+    EXPECT_EQ(led.totals().null_dkg_floor_tips_served, 1u);
+    EXPECT_EQ(led.totals().null_real_quorum_available_but_null_served, 1u);
+}
+
+// observed_sec accumulates DELTAS, so it is monotone across a restart and never
+// depends on the absolute (process-monotonic) clock value. A second process
+// whose clock starts far lower must still ADD its wall clock, not reset.
+TEST(DashServeGateLedger, ObservedSecIsDeltaAccumulatedAcrossRestart) {
+    ServeGateJournal j(300);
+
+    ServeGateLedger a;
+    for (int64_t t = 9000; t < 9010; ++t)  // process A clock: high
+        a.bank_serve(Arm::EmbeddedReal, "", j.observe(true, "", t), t);
+    EXPECT_EQ(a.totals().observed_sec, 9);
+
+    // Restart: process B clock starts LOW (5). Deltas, not absolutes.
+    ServeGateLedger b;
+    b.load(a.totals());
+    EXPECT_EQ(b.totals().observed_sec, 9);              // carried forward
+    ServeGateJournal j2(300);
+    for (int64_t t = 5; t < 15; ++t)                    // 9 s more
+        b.bank_serve(Arm::EmbeddedReal, "", j2.observe(true, "", t), t);
+    EXPECT_EQ(b.totals().observed_sec, 18);             // 9 + 9, monotone
+}
+
+}  // namespace

--- a/test/test_dash_sml_resync_watchdog.cpp
+++ b/test/test_dash_sml_resync_watchdog.cpp
@@ -114,16 +114,21 @@ TEST(DashSmlResyncWatchdog, ReachingTheTipClearsEverything)
     EXPECT_EQ(w.attempts(), 0u);
 }
 
-// ── Bounded: backoff, then silence ──────────────────────────────────────────
+// ── Bounded: geometric backoff, then a CLAMPED perpetual retry ──────────────
 // The failure mode of a retry is hammering a peer that is already struggling,
-// so the cap is the safety property, not a nicety.
-TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenStopsAtTheCap)
+// so the interval must never collapse. But going SILENT forever is the OTHER
+// bug: an 18-min block gap never changes the (tip, sml) pair, so a hard stop at
+// max_attempts stranded the arm on the dashd fallback for the whole gap with
+// healthy peers idle. After max_attempts the interval is pinned at its cap and
+// the re-ask CONTINUES at that clamped cadence — bounded to ~1 request per cap
+// interval, but never giving up.
+TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenClampsAndKeepsRetrying)
 {
     SmlResyncWatchdog w(fast());
     const uint256 tip = blk(0x11), sml = blk(0x22);
     w.observe(tip, sml, 1000);
 
-    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());          // +20
+    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());          // +20  attempt 1
     EXPECT_FALSE(w.observe(tip, sml, 1059).has_value());         // needs +40
     ASSERT_TRUE(w.observe(tip, sml, 1060).has_value());          // attempt 2
     EXPECT_FALSE(w.observe(tip, sml, 1139).has_value());         // needs +80
@@ -131,12 +136,60 @@ TEST(DashSmlResyncWatchdog, BacksOffGeometricallyThenStopsAtTheCap)
     ASSERT_TRUE(third.has_value());
     EXPECT_EQ(third->attempt, 3u);
 
-    // Cap reached: from here we are silent and the next block does what it
-    // does today. A stuck peer therefore sees today's traffic plus at most
-    // max_attempts extra requests, ever.
-    EXPECT_FALSE(w.observe(tip, sml, 5000).has_value());
-    EXPECT_FALSE(w.observe(tip, sml, 99999).has_value());
-    EXPECT_EQ(w.attempts(), 3u);
+    // Cap reached (max_attempts=3): the interval is now CLAMPED at
+    // min_quiet * backoff^max_attempts = 20 * 2^3 = 160 s and stays there.
+    EXPECT_FALSE(w.observe(tip, sml, 1140 + 159).has_value())
+        << "inside the clamped interval nothing is re-sent";
+    auto fourth = w.observe(tip, sml, 1140 + 160);
+    ASSERT_TRUE(fourth.has_value())
+        << "past the clamped interval the re-ask CONTINUES — going silent "
+           "forever here is the measured 18-min fallback wedge";
+    EXPECT_EQ(fourth->attempt, 4u) << "attempts keep counting past the cap";
+
+    // ...and it keeps going, never faster than the clamped cadence.
+    EXPECT_FALSE(w.observe(tip, sml, 1140 + 160 + 159).has_value());
+    ASSERT_TRUE(w.observe(tip, sml, 1140 + 160 + 160).has_value());
+}
+
+// ── RED->GREEN: a wedged tip must NOT go silent forever ─────────────────────
+// The measured 1068 s wedge (hotel primary, 2026-08-23 03:39:40 -> ~03:58):
+// SmlResyncWatchdog fired attempts 1/3, 2/3, 3/3 and then went SILENT while the
+// chain sat on the SAME tip for ~18 min with 8 healthy peers idle — the arm
+// served the dashd fallback the entire time. The (tip, sml) pair never changed
+// (no new block), so the old hard stop at max_attempts never re-armed: the
+// armed-once-never-re-armed class (#1151 / #1162 / #103). This pins that past
+// the cap the re-ask CONTINUES at the clamped cadence, so an 18-min block gap
+// can recover a lost diff instead of wedging on it.
+//
+// RED on the pre-fix code: observe() returned std::nullopt for every call past
+// max_attempts, so the loop below counted ZERO re-asks during the wedge.
+TEST(DashSmlResyncWatchdog, WedgedTipIsReAskedPerpetuallyNotSilencedAtTheCap)
+{
+    SmlResyncWatchdog w(fast());
+    const uint256 tip = blk(0x11), sml = blk(0x22);
+
+    // Exhaust the geometric budget exactly as the hotel wedge did (1/3..3/3).
+    w.observe(tip, sml, 1000);
+    ASSERT_TRUE(w.observe(tip, sml, 1020).has_value());
+    ASSERT_TRUE(w.observe(tip, sml, 1060).has_value());
+    ASSERT_TRUE(w.observe(tip, sml, 1140).has_value());
+    ASSERT_GE(w.attempts(), 3u);
+
+    // Now the chain STALLS on this tip for 18 minutes. Poll the watchdog once a
+    // second — exactly like check_tip_body_overdue's high-cadence clock — and
+    // count the re-asks it emits. The pre-fix code emitted ZERO here.
+    const int64_t wedge_start = 1140;
+    int reasks_during_wedge = 0;
+    for (int64_t t = wedge_start + 1; t <= wedge_start + 18 * 60; ++t) {
+        if (w.observe(tip, sml, t).has_value()) ++reasks_during_wedge;
+    }
+
+    EXPECT_GT(reasks_during_wedge, 0)
+        << "the wedged tip must keep being re-asked — going silent forever here "
+           "is the measured 1068 s dashd-fallback wedge";
+    EXPECT_LE(reasks_during_wedge, (18 * 60) / 150)
+        << "but still bounded to ~one request per clamp interval, never a burst "
+           "against a peer that is already struggling";
 }
 
 // A new tip is a new situation: the previous budget described a lag that no
@@ -149,7 +202,8 @@ TEST(DashSmlResyncWatchdog, NewTipRestartsTheBudget)
     w.observe(blk(0x11), sml, 1020);
     w.observe(blk(0x11), sml, 1060);
     ASSERT_TRUE(w.observe(blk(0x11), sml, 1140).has_value());
-    EXPECT_FALSE(w.observe(blk(0x11), sml, 9000).has_value());   // capped
+    EXPECT_TRUE(w.observe(blk(0x11), sml, 9000).has_value())     // clamped, still re-asking
+        << "past the clamp the same stuck pair keeps being re-asked, not silenced";
 
     EXPECT_FALSE(w.observe(blk(0x44), sml, 9001).has_value());   // new tip: first sighting
     EXPECT_EQ(w.attempts(), 0u);

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2302,6 +2302,173 @@ TEST(DashStratumC1MainnetGate, GbtXcheckTxMerkleMatchServesEmbeddedUnchanged)
         << "a matching tx-merkleroot must NOT record a swap";
 }
 
+// =============================================================================
+// --embedded-tx-serve-own-set : SERVE OUR OWN VALID SET on a divergent-from-
+// dashd mempool selection, instead of the dashd-tx-merkle PARITY swap. The two
+// tests below are the load-bearing red->green through the work source:
+//
+//   * with the flag OFF the divergent set SWAPS to dashd (unchanged behaviour,
+//     proven by GbtXcheckServesDashdOnTxMerkleMismatch above);
+//   * with the flag ON and the validity-gate coupling satisfied, the SAME
+//     divergent set is served as EMBEDDED (this file);
+//   * with the flag ON but a validity probe bound and NOT yet open, it fail-
+//     closes to dashd -- the runtime guard against the already-mined / stale-
+//     UTXO-view class the internal-consistency referee cannot catch alone.
+// =============================================================================
+TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetServesEmbeddedOnConsistentTxDivergence)
+{
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x51;
+
+    // (0) Capture the EMBEDDED template (xcheck OFF): CbTx roots for dref to
+    // match, and the served tx set the flag-ON serve must reproduce byte-for-
+    // byte (serving OUR OWN set means the embedded body is untouched).
+    dash::coin::vendor::CCbTx emb_cb;
+    std::vector<uint256> emb_txids;
+    uint32_t emb_mempool_n = 0;
+    {
+        ::core::coin::UTXOViewCache utxo(nullptr);
+        auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+        auto never = []() -> dash::coin::DashWorkData { return {}; };
+        dash::stratum::DASHWorkSource ws(*cs, never, xcheck_submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
+        emb_txids     = t->m_tx_hashes;
+        emb_mempool_n = t->m_mempool_tx_count;
+    }
+    ASSERT_GT(emb_mempool_n, 0u)
+        << "fixture broken: no mempool txs served -> the m_mempool_tx_count>0"
+           " gate would skip the branch and this KAT would be vacuous";
+    const uint256 emb_txroot = dash::coin::compute_merkle_root(emb_txids);
+
+    // dashd fallback: SAME height + SAME CbTx roots (so only the tx axis
+    // diverges), DIFFERENT non-coinbase tx set.
+    std::vector<uint256> dref_txids(1);
+    dref_txids[0].SetHex(std::string(64, 'e'));
+    ASSERT_NE(emb_txroot, dash::coin::compute_merkle_root(dref_txids));
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.merkleRootMNList   = emb_cb.merkleRootMNList;
+        cb.merkleRootQuorums  = emb_cb.merkleRootQuorums;
+        cb.creditPoolBalance  = emb_cb.creditPoolBalance;
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        w.m_tx_hashes         = dref_txids;
+        w.m_mempool_tx_count  = 1;
+        return w;
+    };
+
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+    dash::stratum::DASHWorkSource ws(*cs, fallback, xcheck_submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+    // NO shadow-compare bound -> the validity-gate coupling is bypassed
+    // (pure-daemonless, operator-armed posture); the referee decides alone.
+    ws.set_tx_serve_own_set(true);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    // The served body is OUR OWN embedded set, NOT dashd's, despite the tx-
+    // merkle divergence.
+    EXPECT_EQ(t->m_tx_hashes, emb_txids)
+        << "own-set: a divergent-but-consistent embedded template is served"
+           " unchanged, not swapped for dashd's";
+    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), emb_txroot);
+    const auto st = ws.embedded_arm_status_json();
+    EXPECT_EQ(st.value("arm", std::string{}), "EMBEDDED")
+        << "the divergence must leave the embedded arm serving";
+    EXPECT_NE(st.value("no_work_reason", std::string{}), "gbt-xcheck-txmerkle-mismatch")
+        << "own-set must NOT record a parity swap";
+    EXPECT_GE(st.value("tx_serve_own_set_serves", (uint64_t)0), (uint64_t)1)
+        << "the referee must have actively served the divergent set as own";
+}
+
+TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetFailClosesWhenValidityGateNotOpen)
+{
+    uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
+    uint256 funding;  funding.begin()[0] = 0x51;
+
+    dash::coin::vendor::CCbTx emb_cb;
+    {
+        ::core::coin::UTXOViewCache utxo(nullptr);
+        auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+        auto never = []() -> dash::coin::DashWorkData { return {}; };
+        dash::stratum::DASHWorkSource ws(*cs, never, xcheck_submit,
+                                         core::stratum::StratumConfig{},
+                                         /*is_testnet=*/true);
+        ASSERT_FALSE(ws.get_current_work_template().empty());
+        auto t = ws.peek_template();
+        ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
+        ASSERT_GT(t->m_mempool_tx_count, 0u);
+    }
+
+    std::vector<uint256> dref_txids(1);
+    dref_txids[0].SetHex(std::string(64, 'e'));
+    const uint256 dref_txroot = dash::coin::compute_merkle_root(dref_txids);
+    auto fallback = [&]() -> dash::coin::DashWorkData {
+        dash::coin::DashWorkData w;
+        w.m_height         = kEmbeddedPrevHeight + 1;
+        w.m_previous_block = emb_prev;
+        w.m_bits           = 0x1e0ffff0u;
+        w.m_version        = static_cast<uint32_t>(kVersion);
+        w.m_curtime        = kCurtime;
+        dash::coin::vendor::CCbTx cb;
+        cb.nVersion           = dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE;
+        cb.nHeight            = static_cast<int32_t>(kEmbeddedPrevHeight + 1);
+        cb.merkleRootMNList   = emb_cb.merkleRootMNList;
+        cb.merkleRootQuorums  = emb_cb.merkleRootQuorums;
+        cb.creditPoolBalance  = emb_cb.creditPoolBalance;
+        w.m_coinbase_payload  = dash::coin::encode_cbtx(cb);
+        w.m_tx_hashes         = dref_txids;
+        w.m_mempool_tx_count  = 1;
+        return w;
+    };
+
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    auto cs = make_txmerkle_xcheck_cs(utxo, funding);
+    dash::stratum::DASHWorkSource ws(*cs, fallback, xcheck_submit,
+                                     core::stratum::StratumConfig{},
+                                     /*is_testnet=*/true);
+    ws.set_gbt_xcheck(true);
+    ws.set_tx_serve_own_set(true);
+
+    // Bind a shadow-compare with a testmempoolaccept oracle -> the mempool
+    // validity gate is ARMED but has accrued ZERO clean heights, so open() is
+    // false. The own-set path must therefore fail-close to dashd even though
+    // the embedded template is internally consistent: the runtime guard against
+    // serving a set the validity gate has not yet proven dashd-acceptable.
+    auto oracle = []() -> std::optional<dash::coin::DashWorkData> { return std::nullopt; };
+    auto accept = [](const std::string&) -> nlohmann::json { return nlohmann::json(); };
+    auto sc = std::make_shared<dash::coin::EmbeddedShadowCompare>(oracle, accept);
+    ws.set_shadow_compare(sc);
+
+    ASSERT_FALSE(ws.get_current_work_template().empty());
+    auto t = ws.peek_template();
+    ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
+    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), dref_txroot)
+        << "validity gate not open -> must serve dashd's body, not own";
+    const auto st = ws.embedded_arm_status_json();
+    EXPECT_EQ(st.value("arm", std::string{}), "dashd-fallback");
+    EXPECT_EQ(st.value("no_work_reason", std::string{}), "tx-serve-validity-gate-not-open")
+        << "the fail-close cause must name the un-open validity gate";
+    ws.set_shadow_compare(nullptr);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tip-transition fallback leak: on every new block the serve path re-sources
 // during the body-pending window and (correctly) gets the dashd fallback; the

--- a/test/test_dash_tx_serve_referee.cpp
+++ b/test/test_dash_tx_serve_referee.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// RED->GREEN KAT for the serve-time INTERNAL-CONSISTENCY referee
+// (tx_serve_referee.hpp) that replaces the dashd-tx-merkle PARITY backstop on
+// the --embedded-tx-serve-own-set path.
+//
+// The referee decides whether a divergent-from-dashd embedded template may be
+// served as OUR OWN valid set. It must:
+//   (serve) pass a template that is internally consistent -- coinbase fee-exact
+//           (coinbase_value == subsidy + Sum(fees) + superblock), every served
+//           mempool tx fee_fold_proven, no intra-set double-spend -- EVEN when
+//           its tx set (and hence tx-merkle-root) differs from dashd's.
+//   (fail)  fail-close to the dashd fallback when ANY of those does not hold:
+//           an over/under-claiming coinbase, an unproven tx, a double-spend, or
+//           an unstamped (unknown-provenance) template.
+//
+// Each fail-close case is load-bearing: flip the single field under test back
+// to its consistent value and the same template SERVES, proving the referee
+// reacts to that field and nothing else.
+
+#include <impl/dash/coin/tx_serve_referee.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <core/uint256.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using dash::coin::DashWorkData;
+using dash::coin::MutableTransaction;
+using dash::coin::Transaction;
+using dash::coin::tx_serve_internal_referee;
+
+// A one-output spend of outpoint (hash, idx). scriptPubKey/value are immaterial
+// to the referee (it reads vins for the double-spend fold and fees from
+// m_tx_fees), so keep it minimal and deterministic.
+MutableTransaction spend(const uint256& h, uint32_t idx)
+{
+    MutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash  = h;
+    tx.vin[0].prevout.index = idx;
+    tx.vout.resize(1);
+    tx.vout[0].value = 1000;
+    return tx;
+}
+
+uint256 h_of(uint8_t b)
+{
+    uint256 u;
+    u.begin()[0] = b;
+    return u;
+}
+
+// A minimally internally-consistent ARMED embedded template that carries one
+// mempool-sourced tx of fee `fee` spending outpoint (0x11:0). By construction
+// coinbase_value == subsidy(height) + fee + superblock, so the referee SERVES
+// it. Each negative test perturbs exactly ONE field.
+DashWorkData make_consistent(uint32_t height, uint64_t fee)
+{
+    DashWorkData w;
+    w.m_height = height;
+
+    MutableTransaction tx = spend(h_of(0x11), 0);
+    w.m_txs.push_back(Transaction(tx));
+    w.m_tx_hashes.push_back(h_of(0xaa));   // referee ignores hashes; realism only
+    w.m_tx_fees.push_back(fee);
+    w.m_mempool_tx_first_index = 0;
+    w.m_mempool_tx_count       = 1;
+
+    w.m_tx_serve_stamp.armed                       = true;
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+    w.m_tx_serve_stamp.superblock_total            = 0;
+
+    const uint64_t subsidy = static_cast<uint64_t>(
+        dash::coin::compute_dash_block_reward_post_v20(height));
+    w.m_coinbase_value = subsidy + fee;   // consistent
+    return w;
+}
+
+// A realistic post-checkpoint mainnet height (past V20 / MN_RR).
+constexpr uint32_t kH = 2'525'000;
+
+}  // namespace
+
+// ── SERVE: internally consistent, divergent-from-dashd is irrelevant ────────
+TEST(DashTxServeReferee, ServesOwnSetWhenInternallyConsistent)
+{
+    const DashWorkData w = make_consistent(kH, 10'000);
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_TRUE(v.serve_own_set) << v.detail;
+    EXPECT_TRUE(v.fail_cause.empty());
+}
+
+// ── SERVE: a funded superblock slice is accounted, not mistaken for over-claim
+TEST(DashTxServeReferee, ServesWithSuperblockSliceAccounted)
+{
+    DashWorkData w = make_consistent(kH, 7'500);
+    // Coinbase carries an additional treasury slice; the stamp records it, so
+    // coinbase_value == subsidy + fee + superblock still holds exactly.
+    w.m_tx_serve_stamp.superblock_total = 4'200'000;
+    w.m_coinbase_value += 4'200'000;
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_TRUE(v.serve_own_set) << v.detail;
+}
+
+// ── FAIL-CLOSE (a): coinbase over-claims fees (bad-cb-amount vector) ─────────
+TEST(DashTxServeReferee, FailClosesOnCoinbaseFeeOverclaim)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    w.m_coinbase_value += 1;   // one duff more than subsidy + fees
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-coinbase-inconsistent") << v.detail;
+
+    // Load-bearing: restore consistency and the SAME template serves.
+    w.m_coinbase_value -= 1;
+    EXPECT_TRUE(tx_serve_internal_referee(w).serve_own_set);
+}
+
+// ── FAIL-CLOSE (a): coinbase under-claims (per-tx fee vector corrupted) ──────
+TEST(DashTxServeReferee, FailClosesWhenFeeVectorDoesNotReconcileCoinbase)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    // The served body grew a tx-fee entry the coinbase never folded in.
+    w.m_tx_fees.push_back(5'000);
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-coinbase-inconsistent") << v.detail;
+}
+
+// ── FAIL-CLOSE (b): a served tx is not fee_fold_proven ──────────────────────
+TEST(DashTxServeReferee, FailClosesOnUnprovenFeeFold)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = false;
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-fee-fold-unproven") << v.detail;
+
+    // Load-bearing: re-prove and the SAME template serves.
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+    EXPECT_TRUE(tx_serve_internal_referee(w).serve_own_set);
+}
+
+// ── FAIL-CLOSE (c): two served txs spend the same outpoint ──────────────────
+TEST(DashTxServeReferee, FailClosesOnIntraSetDoubleSpend)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    // A SECOND served tx spends the SAME coin (0x11:0) as the first. Keep the
+    // coinbase and stamp consistent so ONLY the double-spend axis can fail.
+    MutableTransaction dup = spend(h_of(0x11), 0);
+    dup.vout[0].value = 500;
+    w.m_txs.push_back(Transaction(dup));
+    w.m_tx_hashes.push_back(h_of(0xbb));
+    w.m_tx_fees.push_back(500);
+    w.m_mempool_tx_count = 2;
+    const uint64_t subsidy = static_cast<uint64_t>(
+        dash::coin::compute_dash_block_reward_post_v20(kH));
+    w.m_coinbase_value = subsidy + 10'000 + 500;   // fee-consistent
+
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-double-spend") << v.detail;
+
+    // Load-bearing: point the duplicate at a DIFFERENT coin and it serves.
+    w.m_txs.back() = Transaction(spend(h_of(0x22), 0));
+    EXPECT_TRUE(tx_serve_internal_referee(w).serve_own_set);
+}
+
+// ── FAIL-CLOSE (pre): unstamped template (unknown provenance) ───────────────
+TEST(DashTxServeReferee, FailClosesOnUnstampedTemplate)
+{
+    DashWorkData w = make_consistent(kH, 10'000);
+    w.m_tx_serve_stamp.armed = false;   // not built by the serving path
+    const auto v = tx_serve_internal_referee(w);
+    EXPECT_FALSE(v.serve_own_set);
+    EXPECT_EQ(v.fail_cause, "tx-serve-unstamped") << v.detail;
+}


### PR DESCRIPTION
Combined landing of the 8 daemonless serve-path PRs (#1314 #1315 #1316 #1317 #1318 #1319 #1320 #1321), cherry-picked as single deltas onto master (which already carries the #154 + payee-desync equivalents), + a stale-test update completing #1315.

- Conflicts on combine were additive / test-registration only — NONE in consensus or reward logic.
- Full DASH suite green (580 tests) incl every new KAT; dry-start folded to live tip h=2526466, BLS=REAL, QC-NULL-ARM ARMED, no crash.
- All new behavior flags default OFF (dormant). --coin-rpc path unaffected.
- Same tree is byte-staged on the hotel money node (pkg 5c8c8037) for operator sudo-fire.

FOLLOW-UP (needs workflow scope): add test_dash_serve_gate_ledger to the two DASH ctest --target lists in .github/workflows/build.yml (lines ~208 and ~601) so CI builds+runs #1320s ledger KAT (verified 6/6 locally; the other new KATs fold into already-listed targets).

REVIEW FLAG: #1316 (quorumroot DKG-boundary classifier) carries an UNCONFIRMED reward-safety verdict; landed per operator directive, bounded on the node by the kept --coin-rpc fallback + unconditional root-xcheck.