### PR TITLE
dash(daemonless): self-validate served tx set from OUR OWN state — demote dashd validity gate to measurement

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -361,6 +361,31 @@ target_link_libraries(dash_hdr_backfill_window_kat
 )
 add_test(NAME dash_hdr_backfill_window_kat COMMAND dash_hdr_backfill_window_kat)
 
+# KAT: DASHD-FREE self-validated own-set tx serving (successor to #1318). Pure
+# red/green over two header-only units with NO node and NO daemon: the
+# mempool-validity classifier (Window-1 dashd-ahead propagation -> demoted to
+# measurement, does not reset the clean run) and the serve-time internal-
+# consistency referee (own-state self-validation: coinbase fee-exact, no
+# intra-set double-spend, fee_fold_proven) that decides own-set serving with
+# ZERO dashd calls. Links the same DASH library set as c2pool-dash.
+add_executable(dash_tx_serve_self_validation_kat dash_tx_serve_self_validation_kat.cpp)
+target_link_libraries(dash_tx_serve_self_validation_kat
+    core pool sharechain
+    c2pool_node_enhanced
+    dash
+    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+    dash_x11
+    dash_rpc
+    dash_stratum
+    dash_block_replay
+    dash_bls_verify
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+)
+add_test(NAME dash_tx_serve_self_validation_kat COMMAND dash_tx_serve_self_validation_kat)
+
 # Windows: Boost.Asio requires Winsock libraries; /bigobj for large translation units
 if(WIN32)
     target_link_libraries(c2pool ws2_32 mswsock bcrypt dbghelp)

--- a/src/c2pool/dash_tx_serve_self_validation_kat.cpp
+++ b/src/c2pool/dash_tx_serve_self_validation_kat.cpp
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT: DASHD-FREE self-validated own-set tx serving.
+//
+// Pins the two invariants the --coin-rpc cut relies on for tx-serving, both
+// exercised WITHOUT a live node or a daemon:
+//
+//   PART A — the mempool-validity CLASSIFIER (measurement, demoted from the
+//   serve gate). RED→GREEN for the h=2526495 incident class: a "missing-inputs"
+//   testmempoolaccept answer while dashd's probe-time tip is AHEAD of our serve
+//   parent is a Window-1 propagation artefact, NOT a defect. Before the fix it
+//   classified Invalid and RESET the clean run; after, it classifies
+//   PendingPropagation and the clean run is UNTOUCHED. The narrowing is proven:
+//   the SAME reject reason WITHOUT the dashd-ahead fact stays Invalid, and
+//   `bad-txns-inputs-missingorspent` stays Invalid even WITH the ahead fact.
+//
+//   PART B — the serve-time internal-consistency REFEREE (the self-validation
+//   the serve decision now depends on, making ZERO dashd calls). A template
+//   whose selected tx has an input spent by another selected tx (intra-set
+//   double-spend) is REFUSED by OUR OWN state; a clean template is SERVED. The
+//   referee is a pure function of the template — it runs identically whether or
+//   not a dashd is reachable, which is exactly what "serve with dashd
+//   unreachable" means.
+//
+// Header-only units: no RPC, no daemon, no I/O. A pure red/green pin.
+
+#include <impl/dash/coin/mempool_validity_gate.hpp>
+#include <impl/dash/coin/tx_serve_referee.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/rpc_data.hpp>
+
+#include <core/uint256.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <string>
+
+using namespace dash::coin;
+
+static int g_fail = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) { std::printf("  FAIL: %s\n", (msg)); ++g_fail; }          \
+        else         { std::printf("  ok:   %s\n", (msg)); }                    \
+    } while (0)
+
+// A single testmempoolaccept result object for one tx.
+static nlohmann::json reject(const std::string& reason)
+{
+    nlohmann::json j;
+    j["txid"]          = "deadbeef";
+    j["allowed"]       = false;
+    j["reject-reason"] = reason;
+    return j;
+}
+
+static void part_a_classifier()
+{
+    std::printf("[PART A] mempool-validity classifier (Window-1 propagation)\n");
+
+    // The incident class: missing-inputs while dashd is AHEAD of our serve
+    // parent. This is the tx the network confirmed in the very block our
+    // template competed for. GREEN: PendingPropagation, not a defect.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "8c4efd9c";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = true;
+        const auto r = classify_mempool_accept(tx, reject("missing-inputs"));
+        CHECK(r.verdict == MempoolAcceptVerdict::PendingPropagation,
+              "missing-inputs + dashd-ahead -> PendingPropagation (was Invalid)");
+    }
+
+    // The narrowing, direction 1: the SAME reject WITHOUT the ahead fact stays
+    // Invalid. The exemption is fact-gated, not reason-gated.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "no-skew";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = false;
+        const auto r = classify_mempool_accept(tx, reject("missing-inputs"));
+        CHECK(r.verdict == MempoolAcceptVerdict::Invalid,
+              "missing-inputs WITHOUT dashd-ahead -> stays Invalid");
+    }
+
+    // The narrowing, direction 2: the conflating reason is NEVER excused, even
+    // under the ahead skew. missingorspent conflates unknown-with-SPENT.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "spent";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = true;
+        const auto r = classify_mempool_accept(
+            tx, reject("bad-txns-inputs-missingorspent"));
+        CHECK(r.verdict == MempoolAcceptVerdict::Invalid,
+              "bad-txns-inputs-missingorspent + dashd-ahead -> STILL Invalid");
+    }
+
+    // Gate arithmetic: a PendingPropagation sample neither advances nor RESETS
+    // the clean run — the whole point of the demotion-to-measurement.
+    {
+        MempoolValidityGate g;
+
+        // h=100: one clean valid tx -> consecutive_clean advances to 1.
+        MempoolValiditySample s0; s0.height = 100; s0.probed = 1; s0.valid = 1;
+        g.apply(s0);
+        CHECK(g.consecutive_clean == 1, "clean height advances the run to 1");
+
+        // h=101: only a Window-1 pending-propagation tx. evidence_bearing()
+        // is false -> the run is UNTOUCHED (not advanced, not reset), and the
+        // class is counted separately so it stays measurable.
+        MempoolValiditySample s1; s1.height = 101; s1.probed = 1;
+        s1.pending_propagation = 1;
+        g.apply(s1);
+        CHECK(g.consecutive_clean == 1,
+              "pending-propagation-only height does NOT reset the run");
+        CHECK(g.txs_pending_propagation == 1,
+              "pending-propagation is counted (measurable, not hidden)");
+
+        // h=102: a valid tx AND a pending-propagation tx together -> the run
+        // advances (pending does not spoil an otherwise-clean height).
+        MempoolValiditySample s2; s2.height = 102; s2.probed = 2; s2.valid = 1;
+        s2.pending_propagation = 1;
+        g.apply(s2);
+        CHECK(g.consecutive_clean == 2,
+              "valid+pending height advances; pending does not reset");
+
+        // Contrast: a genuine Invalid DOES reset (the gate still catches real
+        // defects — the asymmetry is preserved).
+        MempoolValiditySample s3; s3.height = 103; s3.probed = 1; s3.invalid = 1;
+        MempoolAcceptResult bad; bad.txid = "x"; bad.reason = "bad-cb-amount";
+        bad.verdict = MempoolAcceptVerdict::Invalid; s3.invalids.push_back(bad);
+        g.apply(s3);
+        CHECK(g.consecutive_clean == 0, "a genuine Invalid still RESETS the run");
+    }
+}
+
+// Build a minimal armed embedded template. `dup_outpoint` makes the two
+// selected txs spend the SAME coin (intra-set double-spend); otherwise they
+// spend distinct coins.
+static DashWorkData make_template(bool dup_outpoint)
+{
+    DashWorkData w;
+    w.m_height = 2526494;                 // post-V20 mainnet height
+    w.m_mempool_tx_first_index = 0;
+    w.m_mempool_tx_count       = 2;
+
+    const uint64_t fee0 = 1000, fee1 = 2000;
+    w.m_tx_fees = { fee0, fee1 };
+
+    w.m_tx_serve_stamp.armed                       = true;
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+    w.m_tx_serve_stamp.superblock_total            = 0;
+
+    const uint64_t subsidy = static_cast<uint64_t>(
+        compute_dash_block_reward_post_v20(w.m_height));
+    // Coinbase is fee-exact by construction (what the referee re-asserts).
+    w.m_coinbase_value = subsidy + fee0 + fee1;
+
+    auto make_tx = [](const uint256& h, uint32_t idx) {
+        MutableTransaction m;
+        TxIn in; in.prevout.hash = h; in.prevout.index = idx; in.sequence = 0;
+        m.vin.push_back(in);
+        return Transaction(m);
+    };
+
+    const uint256 coinA = uint256S(
+        "1111111111111111111111111111111111111111111111111111111111111111");
+    const uint256 coinB = uint256S(
+        "2222222222222222222222222222222222222222222222222222222222222222");
+
+    w.m_txs.push_back(make_tx(coinA, 0));
+    // Second tx: same outpoint (double-spend) or a distinct one.
+    w.m_txs.push_back(make_tx(dup_outpoint ? coinA : coinB, 0));
+    return w;
+}
+
+static void part_b_referee()
+{
+    std::printf("[PART B] serve-time internal-consistency referee (ZERO dashd)\n");
+
+    // Clean template -> SERVE OUR OWN SET. No dashd consulted anywhere in the
+    // call; the referee is a pure function of the template bytes.
+    {
+        const DashWorkData w = make_template(/*dup_outpoint=*/false);
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(v.serve_own_set,
+              "clean fee-exact non-conflicting template -> serve own set");
+    }
+
+    // Intra-set double-spend -> REFUSED by OUR OWN state (no dashd).
+    {
+        const DashWorkData w = make_template(/*dup_outpoint=*/true);
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(!v.serve_own_set && v.fail_cause == "tx-serve-double-spend",
+              "intra-set double-spend -> refused (tx-serve-double-spend)");
+    }
+
+    // Coinbase over-claim (the bad-cb-amount orphan vector) -> REFUSED by our
+    // own subsidy re-derivation.
+    {
+        DashWorkData w = make_template(/*dup_outpoint=*/false);
+        w.m_coinbase_value += 1;          // claim one duff too many
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(!v.serve_own_set && v.fail_cause == "tx-serve-coinbase-inconsistent",
+              "coinbase over-claim -> refused (tx-serve-coinbase-inconsistent)");
+    }
+
+    // Unstamped template (provenance) -> REFUSED.
+    {
+        DashWorkData w = make_template(/*dup_outpoint=*/false);
+        w.m_tx_serve_stamp.armed = false;
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(!v.serve_own_set && v.fail_cause == "tx-serve-unstamped",
+              "unstamped template -> refused (tx-serve-unstamped)");
+    }
+}
+
+int main()
+{
+    std::printf("== dash_tx_serve_self_validation_kat ==\n");
+    part_a_classifier();
+    part_b_referee();
+    if (g_fail) {
+        std::printf("RESULT: FAIL (%d checks failed)\n", g_fail);
+        return 1;
+    }
+    std::printf("RESULT: PASS\n");
+    return 0;
+}

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -629,25 +629,32 @@ public:
         return j;
     }
 
-    /// Thread-safe readiness snapshot for the SERVE PATH (work_source.cpp).
-    /// TRUE only when a dashd testmempoolaccept oracle is bound AND the mempool
-    /// validity gate has accrued its sustained clean window (open()).
+    /// Thread-safe readiness snapshot. TRUE only when a dashd testmempoolaccept
+    /// oracle is bound AND the mempool validity gate has accrued its sustained
+    /// clean window (open()).
     ///
-    /// The tx-serve-own-set referee consults this so that serving OUR OWN valid
-    /// tx set -- dropping the dashd-tx-merkle PARITY backstop -- cannot begin
-    /// until the SELECTOR has been PROVEN dashd-acceptable over the window.
-    /// This is the direct runtime answer to the field finding at h=2526403:
-    /// our fee_fold_proven selection can still offer transactions dashd rejects
-    /// (the already-mined / stale-UTXO-view class), and the internal-
-    /// consistency referee shares a UTXO view with the selector, so it cannot
-    /// independently catch that class. Only dashd's external view (this gate,
-    /// or the parity backstop) can. Requiring open() here keeps the parity
-    /// backstop in force until the gate demonstrates the class is gone.
+    /// ══ DEMOTED TO A PRE-CUT CONFIDENCE MEASUREMENT ═════════════════════════
+    /// This was the serve BLOCKER for the tx-serve-own-set referee: own-set
+    /// serving could not begin until dashd's testmempoolaccept had been clean
+    /// over the window. That made dashd's external view a PERMANENT DEPENDENCY
+    /// of the serve decision — incompatible with the --coin-rpc cut, and, as
+    /// the h=2526495 incident proved, NOISY: it called "invalid" two txs the
+    /// network CONFIRMED in the very block our template competed for (the
+    /// Window-1 class the PendingPropagation classifier now recovers).
     ///
-    /// Returns false when no oracle is bound: the gate cannot be proven without
-    /// dashd, so it fail-closes. (A post-proof PURE-daemonless node runs with
-    /// no shadow-compare object at all; the caller bypasses the coupling only
-    /// when the probe is absent, never when it is present-but-empty.)
+    /// The serve decision no longer consults this. work_source.cpp SELF-
+    /// VALIDATES the served set from OUR OWN state — the internal-consistency
+    /// referee (tx_serve_referee.hpp: coinbase fee-exact, every tx
+    /// fee_fold_proven against our spent-aware UTXO view at build, no intra-set
+    /// double-spend) runs on EVERY armed embedded template, making ZERO dashd
+    /// calls, so it survives the cut unchanged. This function remains as a
+    /// CONFIDENCE COUNTER: pre-cut, with a probe bound, `open()` is EVIDENCE
+    /// that our self-validated set == dashd-clean over the window. It proves the
+    /// predicate; it does not gate the serve. Post-cut there is no shadow-
+    /// compare object and no probe — the measurement simply vanishes, and the
+    /// referee is unaffected.
+    ///
+    /// Returns false when no oracle is bound (measurement unavailable).
     bool validity_gate_open() const {
         std::lock_guard<std::mutex> lk(mu_);
         return static_cast<bool>(accept_) && validity_.open();
@@ -698,7 +705,12 @@ private:
             std::lock_guard<std::mutex> lk(mu_);
             counters_.apply(o);
         }
-        probe_validity(served);
+        // dashd's probe-time template height — the FACT the Window-1 classifier
+        // keys on. 0 when no oracle answered (the classifier then never treats
+        // any tx as dashd-ahead, so a missing-inputs stays Invalid: absent
+        // evidence of an ahead tip, we do not excuse the reject).
+        const uint32_t dashd_probe_height = dashd ? dashd->m_height : 0u;
+        probe_validity(served, dashd_probe_height);
     }
 
     /// THE MEMPOOL VALIDITY GATE, on the SAME worker thread as the oracle
@@ -709,9 +721,19 @@ private:
     ///
     /// This CANNOT change what is served. Its only outputs are log lines, the
     /// counters, and a readiness verdict on a DEFAULT-OFF flag.
-    void probe_validity(const DashWorkData& w) {
+    void probe_validity(const DashWorkData& w, uint32_t dashd_probe_height) {
         if (!accept_) return;
-        const auto set = mempool_probe_set(w);
+        auto set = mempool_probe_set(w);
+
+        // WINDOW-1 FACT. dashd's probe-time template height > our template
+        // height means dashd's tip is STRICTLY AHEAD of the serve parent this
+        // template was built on (our serve parent = w.m_height-1, dashd tip =
+        // dashd_probe_height-1). At that skew the classifier reclassifies a
+        // "missing-inputs" reject as PENDING-PROPAGATION (valid on our fork,
+        // stale probe) instead of a defect. A height comparison — never a
+        // reason-string inference. 0 when no oracle answered => never ahead.
+        const bool dashd_ahead = dashd_probe_height > w.m_height;
+        for (auto& t : set) t.dashd_ahead_of_serve_height = dashd_ahead;
 
         std::vector<nlohmann::json> answers;
         answers.reserve(set.size());

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -143,14 +143,22 @@ inline bool is_missing_or_spent_reason(const std::string& reason)
     return reason == "bad-txns-inputs-missingorspent";
 }
 
-/// Three-valued logic, plus the honest fourth state for "no answer".
+/// Three-valued logic, plus TWO honest "no verdict" states.
 /// Unprobed is NEVER counted as valid and NEVER counted as a defect: it is the
-/// absence of a measurement, and it advances nothing.
+/// absence of a measurement, and it advances nothing. PendingPropagation is the
+/// Window-1 analog (see the enumerator note): dashd's probe-time tip is AHEAD of
+/// the serve parent this template was built on, and a "missing-inputs" answer at
+/// that skew is the ahead-block having already spent/confirmed the very inputs
+/// (or txs) our still-valid fork template offered — a PROBE TIMING ARTEFACT, not
+/// a defect of the transaction. It, too, advances nothing and resets nothing.
 enum class MempoolAcceptVerdict : uint8_t {
     Valid,              // allowed == true
     AlreadyInMempool,   // allowed == false, reason == txn-already-in-mempool
     Invalid,            // allowed == false, any other reason -> A DEFECT
-    Unprobed            // no answer, or an in-set-parent probe artefact
+    Unprobed,           // no answer, or an in-set-parent probe artefact
+    PendingPropagation  // missing-inputs at a dashd-AHEAD-of-serve-parent skew
+                        // (Window-1: valid on our fork; the probe is stale) —
+                        // NEVER a defect, NEVER counted valid, advances nothing
 };
 
 inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
@@ -159,6 +167,8 @@ inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
         case MempoolAcceptVerdict::Valid:            return "VALID";
         case MempoolAcceptVerdict::AlreadyInMempool: return "ALSO-VALID(already-in-mempool)";
         case MempoolAcceptVerdict::Invalid:          return "INVALID";
+        case MempoolAcceptVerdict::PendingPropagation:
+            return "PENDING-PROPAGATION(dashd-ahead-window-1)";
         default:                                     return "UNPROBED";
     }
 }
@@ -182,6 +192,22 @@ struct MempoolProbeTx {
     /// same probe set. Computed at template-build time from the real vins, not
     /// guessed from a reject string.
     bool        depends_on_in_set_parent{false};
+
+    /// TRUE when dashd's probe-time tip is STRICTLY AHEAD of the serve parent
+    /// this template was built on — a FACT (a height comparison: dashd's GBT
+    /// height > our template height), NOT an inference from any reject string.
+    /// The probe runs asynchronously on a worker thread; between the instant we
+    /// built the template at OUR tip and the instant dashd answered, dashd can
+    /// have connected one or more blocks. At that skew a "missing-inputs" answer
+    /// is the Window-1 propagation artefact: the ahead block already spent or
+    /// confirmed the very inputs (or the very txs) our still-valid fork template
+    /// offered, so dashd — probing against its newer view — cannot see them.
+    /// dashd's own testmempoolaccept detects the already-confirmed case only
+    /// best-effort (HaveCoinInCache over the tx OUTPUTS) and, once those outputs
+    /// are flushed or spent, falls through to the same "missing-inputs" string;
+    /// the field is how we recover the class dashd's string conflated. Set by
+    /// the probe caller (embedded_shadow_compare.hpp) from dashd's GBT height.
+    bool        dashd_ahead_of_serve_height{false};
 };
 
 /// PURE. dashd's testmempoolaccept answer for ONE transaction -> the verdict.
@@ -249,6 +275,43 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
         return r;
     }
 
+    // WINDOW-1 PROPAGATION (the #1318 successor; the h=2526495 incident class).
+    // A "missing-inputs" answer while dashd's probe-time tip is STRICTLY AHEAD of
+    // the serve parent this template was built on is a PROBE-TIMING ARTEFACT, not
+    // a defect: dashd connected one or more blocks after we built, and that ahead
+    // block already spent/confirmed the inputs (or the txs themselves — both of
+    // the h=2526495 leak txs, 8c4efd9c… and 81109abf…, were CONFIRMED IN BLOCK
+    // 2526495 itself, the exact height our template competed for). Such a tx is
+    // VALID ON OUR FORK; dashd, probing against its newer view, cannot see it.
+    // The FACT is `dashd_ahead_of_serve_height` — a height comparison the caller
+    // supplies, never a string inference — so the exemption cannot widen on a
+    // reason alone. It is DELIBERATELY NARROW:
+    //
+    //   * Only "missing-inputs" qualifies. `bad-txns-inputs-missingorspent`
+    //     stays INVALID even under the ahead skew (see the note above): that
+    //     reason conflates unknown-with-SPENT in its own name and is the exact
+    //     bad-cb / double-spend loss vector; failing it toward a CLOSED gate on
+    //     ambiguous evidence is the direction a gate is allowed to be wrong in.
+    //   * It advances NOTHING and resets NOTHING — like Unprobed, it is the
+    //     absence of a usable measurement, not evidence in either direction. It
+    //     is counted separately (`pending_propagation`) so the class stays
+    //     visible and MEASURABLE (our-serve-parent vs dashd-tip skew), which is
+    //     precisely what a demoted-to-measurement gate needs to prove that OUR
+    //     self-validation verdict == dashd-clean once the skew resolves.
+    //
+    // Since this gate is a MEASUREMENT (it no longer decides what is served —
+    // work_source.cpp self-validates the served set from OUR OWN state), the
+    // cost of this classification is confidence accounting, never a served
+    // block: a genuine defect that happened to coincide with an ahead skew is
+    // caught by the serve-time internal-consistency referee (tx_serve_referee.
+    // hpp), which shares the selector's spent-aware UTXO view and runs on EVERY
+    // armed embedded template independent of dashd.
+    if (is_unknown_input_only_reason(r.reason) && tx.dashd_ahead_of_serve_height) {
+        r.verdict        = MempoolAcceptVerdict::PendingPropagation;
+        r.unprobed_cause = "dashd-ahead-of-serve-parent(window-1-propagation)";
+        return r;
+    }
+
     r.verdict = MempoolAcceptVerdict::Invalid;
     return r;
 }
@@ -261,12 +324,18 @@ struct MempoolValiditySample {
     size_t   already_in_mempool{0};
     size_t   invalid{0};
     size_t   unprobed{0};
+    /// Window-1 propagation artefacts: dashd-ahead + missing-inputs. Neither
+    /// evidence of validity nor a defect — tracked so the skew class is visible.
+    size_t   pending_propagation{0};
     /// The defects, verbatim — txid + dashd's reason. These are what the
     /// refusal line prints.
     std::vector<MempoolAcceptResult> invalids;
 
     /// A height that actually OBSERVED validity. A height whose probe set was
-    /// empty, or whose every entry came back Unprobed, observed nothing.
+    /// empty, or whose every entry came back Unprobed / PendingPropagation,
+    /// observed nothing. PendingPropagation is EXCLUDED here for the same reason
+    /// Unprobed is: it is the absence of a usable measurement, so it must not
+    /// let a skew-only height count toward the clean window.
     bool evidence_bearing() const
     {
         return (valid + already_in_mempool + invalid) > 0;
@@ -295,6 +364,9 @@ mempool_validity_sample(uint32_t height,
             case MempoolAcceptVerdict::Invalid:
                 ++s.invalid;
                 s.invalids.push_back(r);
+                break;
+            case MempoolAcceptVerdict::PendingPropagation:
+                ++s.pending_propagation;
                 break;
             default:                                     ++s.unprobed; break;
         }
@@ -396,6 +468,13 @@ struct MempoolValidityGate {
     uint64_t txs_unprobed{0};
     uint64_t repeat_txs_probed{0};
 
+    /// Window-1 propagation artefacts observed anywhere (dashd-ahead skew +
+    /// missing-inputs). Accrued on EVERY apply() regardless of disposition so
+    /// the skew class is fully visible; it advances nothing and resets nothing.
+    /// This is the demoted gate's CONFIDENCE evidence that the class dashd's
+    /// string conflated is benign and resolves as our tip catches up.
+    uint64_t txs_pending_propagation{0};
+
     /// DEFECTS ARE COUNTED WHEREVER THEY ARE OBSERVED — counted sample or
     /// repeat. See the asymmetry note at the top of this file.
     uint64_t txs_invalid{0};
@@ -413,6 +492,11 @@ struct MempoolValidityGate {
     void apply(const MempoolValiditySample& s)
     {
         ++samples_seen;
+
+        // Window-1 propagation artefacts accrue unconditionally: they are
+        // measurement, not evidence, so they are counted before the evidence
+        // gate and never touch consecutive_clean in either direction.
+        txs_pending_propagation += s.pending_propagation;
 
         if (!s.evidence_bearing()) {
             // Neither advances nor resets — it is not evidence in either
@@ -487,6 +571,7 @@ struct MempoolValidityGate {
         j["txs-already-in-mempool"]    = txs_already_in_mempool;
         j["txs-invalid"]               = txs_invalid;
         j["txs-unprobed"]              = txs_unprobed;
+        j["txs-pending-propagation"]   = txs_pending_propagation;
         j["last-invalid-height"]       = last_invalid_height;
         j["last-invalid-txid"]         = last_invalid_txid;
         j["last-invalid-reason"]       = last_invalid_reason;
@@ -526,6 +611,7 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " already_in_mempool=" + std::to_string(s.already_in_mempool)
         + " invalid="   + std::to_string(s.invalid)
         + " unprobed="  + std::to_string(s.unprobed)
+        + " pending_propagation=" + std::to_string(s.pending_propagation)
         + " clean_run=" + std::to_string(g.consecutive_clean) + "/"
         + std::to_string(g.required)
         + " heights_with_evidence=" + std::to_string(g.heights_with_evidence)

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -947,6 +947,11 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
             // tells the single splice point below which producer it is
             // serving -- and the 66-of-197 silent-miss class it closes.
             bool served_via_xcheck_swap = false;
+            // TRUE once the internal-consistency referee has run on this
+            // template (either the divergence branch below or the unconditional
+            // post-cut self-validation after this block). Prevents a redundant
+            // second referee pass on the same bytes.
+            bool embedded_self_validated = false;
             if (sel.source == coin::WorkSource::Embedded && gbt_xcheck_ && dashd_fallback_) {
                 coin::DashWorkData dref = dashd_fallback_();
                 coin::vendor::CCbTx emb_cb, dref_cb;
@@ -1150,13 +1155,33 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                         //   post-proof) the operator's arming of the flag is
                         //   the proof. Either way, failure fail-closes to
                         //   dashd -- safety is preserved on every branch.
-                        const bool gate_proven =
-                            !shadow_compare_ || shadow_compare_->validity_gate_open();
+                        // SELF-VALIDATION ONLY — the serve decision makes ZERO
+                        // dashd calls. The dashd testmempoolaccept validity gate
+                        // is DEMOTED to a pre-cut CONFIDENCE measurement
+                        // (validity_gate_measurement below): logged, never
+                        // gated. Own-set serving is decided SOLELY by the
+                        // internal-consistency referee over OUR OWN state
+                        // (every served tx fee_fold_proven vs our spent-aware
+                        // UTXO view at build, coinbase == subsidy+Σfee+superblock,
+                        // no intra-set double-spend) — the predicate that
+                        // survives the --coin-rpc cut. The already-mined /
+                        // stale-view class the gate used to backstop is a
+                        // Window-1 propagation artefact (dashd already connected
+                        // the block that spent/confirmed those inputs; the tx is
+                        // valid on OUR fork and dashd serves the same competing
+                        // set at the same instant) — unclosable without the
+                        // block, and NOT a defect the gate was right to punish.
                         coin::TxServeRefereeVerdict rv;
                         const bool serve_own =
-                            tx_serve_own_set_ && gate_proven
+                            tx_serve_own_set_
                             && (rv = coin::tx_serve_internal_referee(sel.work))
                                    .serve_own_set;
+                        embedded_self_validated = tx_serve_own_set_;
+                        // CONFIDENCE (pre-cut, observe-only): does our self-
+                        // validated verdict coincide with a dashd-clean window?
+                        // Recorded in the log; it decides nothing.
+                        const bool validity_gate_measurement =
+                            shadow_compare_ && shadow_compare_->validity_gate_open();
                         if (serve_own) {
                             // SERVE OUR OWN VALID SET. The dashd divergence is
                             // a SHADOW (diagnostic), not a fallback trigger.
@@ -1173,15 +1198,15 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                                         " a fallback trigger";
                             // sel stays Embedded â NO swap.
                         } else {
-                            // FAIL-CLOSE to dashd. Own-set OFF (legacy parity),
-                            // validity gate not yet proven-open, or the referee
-                            // refused an internal-consistency defect.
+                            // FAIL-CLOSE to dashd. Own-set OFF (legacy parity)
+                            // or the referee refused an internal-consistency
+                            // defect. The dashd validity gate no longer
+                            // participates (demoted to measurement), so it can
+                            // never be the cause here.
                             std::string cause =
                                 !tx_serve_own_set_
                                     ? std::string("gbt-xcheck-txmerkle-mismatch")
-                                    : (!gate_proven
-                                           ? std::string("tx-serve-validity-gate-not-open")
-                                           : rv.fail_cause);
+                                    : rv.fail_cause;
                             if (tx_serve_own_set_)
                                 tx_serve_own_set_failclose_.fetch_add(
                                     1, std::memory_order_relaxed);
@@ -1193,10 +1218,6 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                                         << " root=" << dref_txroot.GetHex().substr(0, 16)
                                         << " â serving dashd template (cause="
                                         << cause
-                                        << (tx_serve_own_set_ && !gate_proven
-                                                ? "; own-set armed but validity"
-                                                  " gate not open"
-                                                : "")
                                         << ")";
                             coin::DeclineReport xcheck;
                             xcheck.viable    = false;
@@ -1209,6 +1230,70 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                             served_via_xcheck_swap = true;
                         }
                     }
+                }
+            }
+            // ── UNCONDITIONAL EMBEDDED SELF-VALIDATION (the cut-critical arm) ─
+            // The gbt-xcheck block above runs ONLY when a dashd RPC is armed AND
+            // the embedded selection DIVERGES from dashd's GBT. Post --coin-rpc
+            // cut there is no dashd to diverge from (gbt_xcheck_ && dashd_fallback_
+            // is false), so an armed embedded template would otherwise serve its
+            // mempool set with ZERO serve-time self-validation. This runs the
+            // internal-consistency referee on EVERY armed embedded template that
+            // carries mempool txs and has not already been refereed above,
+            // making ZERO dashd calls: coinbase == subsidy + Σfee + superblock,
+            // every served tx fee_fold_proven against our spent-aware UTXO view
+            // at build (the just-spent-input / missing-inputs class is caught
+            // HERE, by OUR OWN state, not by dashd), no intra-set double-spend.
+            // This is the self-validation the daemonless serve relies on.
+            //
+            // BYTE-NEUTRAL when --embedded-tx-serve-own-set is OFF (default):
+            // the referee is not consulted and the template serves exactly as
+            // before. Also inert when the template carries no mempool txs
+            // (coinbase-only bodies cannot orphan for a bad-txset reason).
+            //
+            // FAIL ACTION is dashd-FREE: refuse to serve the internally-
+            // inconsistent template (fail-closed to NoWork; the stratum holds
+            // the last good work and re-sources). We do NOT ask dashd and do NOT
+            // hand-strip a reward-critical coinbase at serve time — coinbase-only
+            // is a BUILD-time posture (embedded_gbt suppress_mempool_txs), never
+            // a serve-time edit. A referee failure here is a "cannot happen by
+            // construction" corruption signal (the builder selects only
+            // fee_fold_proven txs and sets the coinbase from the same subsidy
+            // function the referee re-derives), so refusing the block rather
+            // than mining a corrupt one is the only safe response.
+            if (tx_serve_own_set_
+                && !embedded_self_validated
+                && sel.source == coin::WorkSource::Embedded
+                && sel.work.m_mempool_tx_count > 0) {
+                const coin::TxServeRefereeVerdict rv =
+                    coin::tx_serve_internal_referee(sel.work);
+                if (rv.serve_own_set) {
+                    tx_serve_own_set_serves_.fetch_add(
+                        1, std::memory_order_relaxed);
+                    LOG_INFO << "[DASH-STRATUM] embedded self-validation OK at h="
+                             << sel.work.m_height
+                             << " txs=" << sel.work.m_tx_hashes.size()
+                             << " (" << rv.detail
+                             << ") — serving OWN valid set, ZERO dashd calls";
+                } else {
+                    tx_serve_own_set_failclose_.fetch_add(
+                        1, std::memory_order_relaxed);
+                    LOG_WARNING << "[DASH-STRATUM] embedded self-validation"
+                                   " REFUSED at h=" << sel.work.m_height
+                                << " cause=" << rv.fail_cause
+                                << " (" << rv.detail << ") — refusing to serve an"
+                                   " internally-inconsistent template (dashd-free"
+                                   " fail-close to no-work; last good work held)";
+                    coin::DeclineReport sv;
+                    sv.viable    = false;
+                    sv.cause     = "tx-serve-self-validation-refused:" + rv.fail_cause;
+                    sv.value     = std::to_string(sel.work.m_coinbase_value);
+                    sv.threshold = std::to_string(sel.work.m_mempool_tx_count)
+                                 + "-mempool-txs";
+                    sel.decline  = std::move(sv);
+                    // Fail-closed: make this template not-mineable so the store
+                    // below drops it and the stratum keeps the last good work.
+                    sel.work.m_bits = 0;
                 }
             }
             // ── THE SINGLE PIN SPLICE POINT ─────────────────────────────────


### PR DESCRIPTION
## DASHD-FREE self-validated own-set tx serving

Successor to the tx-serve referee (#1314) and to the validity-gate window-1 work (#1318). Makes the **serve decision self-sufficient for the `--coin-rpc` cut**: deciding *what* to serve now makes **zero dashd calls**. All behind the existing `--embedded-tx-serve-own-set` flag — **default OFF is byte-identical**.

### What changed
1. **Demote the dashd testmempoolaccept validity gate out of the serve decision.** Own-set serving previously required `validity_gate_open()` (576 clean testmempoolaccept heights) — a *permanent* dependency on dashd's external view. The serve decision now depends **solely on the internal-consistency referee over our own state** (coinbase == subsidy + Σfee + superblock; every served tx `fee_fold_proven` against our spent-aware UTXO view at build; no intra-set double-spend). `validity_gate_open()` remains a **pre-cut confidence measurement** (logged, never gated); post-cut it simply vanishes.
2. **Run the referee unconditionally on the embedded serve path.** It used to live only inside the `gbt_xcheck_ && dashd_fallback_` divergence branch, so post-cut (rpc==null) an armed template served with *zero* serve-time self-validation. It now runs on every armed embedded template carrying mempool txs, making zero dashd calls. Fail action is **dashd-free**: refuse the internally-inconsistent template (fail-closed to no-work; last good work held) — never ask dashd, never hand-strip a reward-critical coinbase at serve time.
3. **Classifier successor to #1318 (the h=2526495 incident class).** `missing-inputs` while dashd's probe-time tip is *strictly ahead* of our serve parent is a **Window-1 propagation artefact**, not a defect — both leaked txs at 2526495 were confirmed *in block 2526495 itself*, the exact height our template competed for; valid on our fork. `classify` now emits `PendingPropagation` (advances nothing, resets nothing, counted separately so the skew stays measurable) instead of `Invalid`, keyed on a **fact** (`dashd_ahead_of_serve_height`, a height comparison from dashd's GBT height) never a reason-string. Narrowing is strict: same reject **without** the ahead fact stays `Invalid`; `bad-txns-inputs-missingorspent` stays `Invalid` even under the skew.

### Residual (stated, not hidden)
Own state validates UTXO-spentness / no-double-spend / coinbase fee-exactness / topology / maturity / islock / already-confirmed — but **not tx scripts/signatures** (c2pool ports no `CheckInputScripts`). The reliance is the **sole-ingestion-path invariant**: every pooled tx arrived only via dashd-peer relay (full script checks ran there) and we never mutate bytes. That invariant **survives the `--coin-rpc` cut** (coin-P2P peers remain full nodes; `testmempoolaccept` was never the script check). It **breaks at T3.1 miner tx-injection (#157)** — script validation becomes mandatory there, a T3.1 gate, not a cut gate.

### Test — `dash_tx_serve_self_validation_kat` (no node, no daemon)
- **PART A (classifier, red→green):** `missing-inputs`+dashd-ahead → `PendingPropagation` (was `Invalid`); same without the fact stays `Invalid`; `missingorspent` stays `Invalid`; a PendingPropagation-only height does **not** reset the clean run; a genuine `Invalid` still does.
- **PART B (referee, zero dashd):** serves our own valid set; refuses double-spend / coinbase over-claim / unstamped template — a pure function of the template.

Verified **red** (incident assertion fails with the new branch disabled) → **green** (12/12). `c2pool-dash` links clean on the 191 build.

### Rollout
Serve/reward path. **Default OFF, operator-gated. Do NOT merge and do NOT restart the money node without the operator's tap.** Base is `integrator/tx-serve-own-valid-set` (#1314); review this delta on top of the referee.
