### PR TITLE
dash(daemonless): dashd-free self-validation on the serve path — unconditional referee + demote validity gate (rebased #1324)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -368,6 +368,30 @@ add_test(NAME dash_hdr_backfill_window_kat COMMAND dash_hdr_backfill_window_kat)
 # so CI's "Build tests" --target list actually compiles+runs it. A standalone
 # executable was never in the allowlist and became a NOT_BUILT/"Not Run" CTest
 # sentinel that red the suite (the #769 unregistered-KAT class).
+# KAT: DASHD-FREE self-validated own-set tx serving (successor to #1318). Pure
+# red/green over two header-only units with NO node and NO daemon: the
+# mempool-validity classifier (Window-1 dashd-ahead propagation -> demoted to
+# measurement, does not reset the clean run) and the serve-time internal-
+# consistency referee (own-state self-validation: coinbase fee-exact, no
+# intra-set double-spend, fee_fold_proven) that decides own-set serving with
+# ZERO dashd calls. Links the same DASH library set as c2pool-dash.
+add_executable(dash_tx_serve_self_validation_kat dash_tx_serve_self_validation_kat.cpp)
+target_link_libraries(dash_tx_serve_self_validation_kat
+    core pool sharechain
+    c2pool_node_enhanced
+    dash
+    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+    dash_x11
+    dash_rpc
+    dash_stratum
+    dash_block_replay
+    dash_bls_verify
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+)
+add_test(NAME dash_tx_serve_self_validation_kat COMMAND dash_tx_serve_self_validation_kat)
 
 # Windows: Boost.Asio requires Winsock libraries; /bigobj for large translation units
 if(WIN32)

--- a/src/c2pool/dash_tx_serve_self_validation_kat.cpp
+++ b/src/c2pool/dash_tx_serve_self_validation_kat.cpp
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT: DASHD-FREE self-validated own-set tx serving.
+//
+// Pins the two invariants the --coin-rpc cut relies on for tx-serving, both
+// exercised WITHOUT a live node or a daemon:
+//
+//   PART A — the mempool-validity CLASSIFIER (measurement, demoted from the
+//   serve gate). RED→GREEN for the h=2526495 incident class: a "missing-inputs"
+//   testmempoolaccept answer while dashd's probe-time tip is AHEAD of our serve
+//   parent is a Window-1 propagation artefact, NOT a defect. Before the fix it
+//   classified Invalid and RESET the clean run; after, it classifies
+//   PendingPropagation and the clean run is UNTOUCHED. The narrowing is proven:
+//   the SAME reject reason WITHOUT the dashd-ahead fact stays Invalid, and
+//   `bad-txns-inputs-missingorspent` stays Invalid even WITH the ahead fact.
+//
+//   PART B — the serve-time internal-consistency REFEREE (the self-validation
+//   the serve decision now depends on, making ZERO dashd calls). A template
+//   whose selected tx has an input spent by another selected tx (intra-set
+//   double-spend) is REFUSED by OUR OWN state; a clean template is SERVED. The
+//   referee is a pure function of the template — it runs identically whether or
+//   not a dashd is reachable, which is exactly what "serve with dashd
+//   unreachable" means.
+//
+// Header-only units: no RPC, no daemon, no I/O. A pure red/green pin.
+
+#include <impl/dash/coin/mempool_validity_gate.hpp>
+#include <impl/dash/coin/tx_serve_referee.hpp>
+#include <impl/dash/coin/subsidy.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/rpc_data.hpp>
+
+#include <core/uint256.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <string>
+
+using namespace dash::coin;
+
+static int g_fail = 0;
+#define CHECK(cond, msg)                                                        \
+    do {                                                                        \
+        if (!(cond)) { std::printf("  FAIL: %s\n", (msg)); ++g_fail; }          \
+        else         { std::printf("  ok:   %s\n", (msg)); }                    \
+    } while (0)
+
+// A single testmempoolaccept result object for one tx.
+static nlohmann::json reject(const std::string& reason)
+{
+    nlohmann::json j;
+    j["txid"]          = "deadbeef";
+    j["allowed"]       = false;
+    j["reject-reason"] = reason;
+    return j;
+}
+
+static void part_a_classifier()
+{
+    std::printf("[PART A] mempool-validity classifier (Window-1 propagation)\n");
+
+    // The incident class: missing-inputs while dashd is AHEAD of our serve
+    // parent. This is the tx the network confirmed in the very block our
+    // template competed for. GREEN: PendingPropagation, not a defect.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "8c4efd9c";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = true;
+        const auto r = classify_mempool_accept(tx, reject("missing-inputs"));
+        CHECK(r.verdict == MempoolAcceptVerdict::PendingPropagation,
+              "missing-inputs + dashd-ahead -> PendingPropagation (was Invalid)");
+    }
+
+    // The narrowing, direction 1: the SAME reject WITHOUT the ahead fact stays
+    // Invalid. The exemption is fact-gated, not reason-gated.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "no-skew";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = false;
+        const auto r = classify_mempool_accept(tx, reject("missing-inputs"));
+        CHECK(r.verdict == MempoolAcceptVerdict::Invalid,
+              "missing-inputs WITHOUT dashd-ahead -> stays Invalid");
+    }
+
+    // The narrowing, direction 2: the conflating reason is NEVER excused, even
+    // under the ahead skew. missingorspent conflates unknown-with-SPENT.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "spent";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = true;
+        const auto r = classify_mempool_accept(
+            tx, reject("bad-txns-inputs-missingorspent"));
+        CHECK(r.verdict == MempoolAcceptVerdict::Invalid,
+              "bad-txns-inputs-missingorspent + dashd-ahead -> STILL Invalid");
+    }
+
+    // Gate arithmetic: a PendingPropagation sample neither advances nor RESETS
+    // the clean run — the whole point of the demotion-to-measurement.
+    {
+        MempoolValidityGate g;
+
+        // h=100: one clean valid tx -> consecutive_clean advances to 1.
+        MempoolValiditySample s0; s0.height = 100; s0.probed = 1; s0.valid = 1;
+        g.apply(s0);
+        CHECK(g.consecutive_clean == 1, "clean height advances the run to 1");
+
+        // h=101: only a Window-1 pending-propagation tx. evidence_bearing()
+        // is false -> the run is UNTOUCHED (not advanced, not reset), and the
+        // class is counted separately so it stays measurable.
+        MempoolValiditySample s1; s1.height = 101; s1.probed = 1;
+        s1.pending_propagation = 1;
+        g.apply(s1);
+        CHECK(g.consecutive_clean == 1,
+              "pending-propagation-only height does NOT reset the run");
+        CHECK(g.txs_pending_propagation == 1,
+              "pending-propagation is counted (measurable, not hidden)");
+
+        // h=102: a valid tx AND a pending-propagation tx together -> the run
+        // advances (pending does not spoil an otherwise-clean height).
+        MempoolValiditySample s2; s2.height = 102; s2.probed = 2; s2.valid = 1;
+        s2.pending_propagation = 1;
+        g.apply(s2);
+        CHECK(g.consecutive_clean == 2,
+              "valid+pending height advances; pending does not reset");
+
+        // Contrast: a genuine Invalid DOES reset (the gate still catches real
+        // defects — the asymmetry is preserved).
+        MempoolValiditySample s3; s3.height = 103; s3.probed = 1; s3.invalid = 1;
+        MempoolAcceptResult bad; bad.txid = "x"; bad.reason = "bad-cb-amount";
+        bad.verdict = MempoolAcceptVerdict::Invalid; s3.invalids.push_back(bad);
+        g.apply(s3);
+        CHECK(g.consecutive_clean == 0, "a genuine Invalid still RESETS the run");
+    }
+}
+
+// Build a minimal armed embedded template. `dup_outpoint` makes the two
+// selected txs spend the SAME coin (intra-set double-spend); otherwise they
+// spend distinct coins.
+static DashWorkData make_template(bool dup_outpoint)
+{
+    DashWorkData w;
+    w.m_height = 2526494;                 // post-V20 mainnet height
+    w.m_mempool_tx_first_index = 0;
+    w.m_mempool_tx_count       = 2;
+
+    const uint64_t fee0 = 1000, fee1 = 2000;
+    w.m_tx_fees = { fee0, fee1 };
+
+    w.m_tx_serve_stamp.armed                       = true;
+    w.m_tx_serve_stamp.all_mempool_fee_fold_proven = true;
+    w.m_tx_serve_stamp.superblock_total            = 0;
+
+    const uint64_t subsidy = static_cast<uint64_t>(
+        compute_dash_block_reward_post_v20(w.m_height));
+    // Coinbase is fee-exact by construction (what the referee re-asserts).
+    w.m_coinbase_value = subsidy + fee0 + fee1;
+
+    auto make_tx = [](const uint256& h, uint32_t idx) {
+        MutableTransaction m;
+        TxIn in; in.prevout.hash = h; in.prevout.index = idx; in.sequence = 0;
+        m.vin.push_back(in);
+        return Transaction(m);
+    };
+
+    const uint256 coinA = uint256S(
+        "1111111111111111111111111111111111111111111111111111111111111111");
+    const uint256 coinB = uint256S(
+        "2222222222222222222222222222222222222222222222222222222222222222");
+
+    w.m_txs.push_back(make_tx(coinA, 0));
+    // Second tx: same outpoint (double-spend) or a distinct one.
+    w.m_txs.push_back(make_tx(dup_outpoint ? coinA : coinB, 0));
+    return w;
+}
+
+static void part_b_referee()
+{
+    std::printf("[PART B] serve-time internal-consistency referee (ZERO dashd)\n");
+
+    // Clean template -> SERVE OUR OWN SET. No dashd consulted anywhere in the
+    // call; the referee is a pure function of the template bytes.
+    {
+        const DashWorkData w = make_template(/*dup_outpoint=*/false);
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(v.serve_own_set,
+              "clean fee-exact non-conflicting template -> serve own set");
+    }
+
+    // Intra-set double-spend -> REFUSED by OUR OWN state (no dashd).
+    {
+        const DashWorkData w = make_template(/*dup_outpoint=*/true);
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(!v.serve_own_set && v.fail_cause == "tx-serve-double-spend",
+              "intra-set double-spend -> refused (tx-serve-double-spend)");
+    }
+
+    // Coinbase over-claim (the bad-cb-amount orphan vector) -> REFUSED by our
+    // own subsidy re-derivation.
+    {
+        DashWorkData w = make_template(/*dup_outpoint=*/false);
+        w.m_coinbase_value += 1;          // claim one duff too many
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(!v.serve_own_set && v.fail_cause == "tx-serve-coinbase-inconsistent",
+              "coinbase over-claim -> refused (tx-serve-coinbase-inconsistent)");
+    }
+
+    // Unstamped template (provenance) -> REFUSED.
+    {
+        DashWorkData w = make_template(/*dup_outpoint=*/false);
+        w.m_tx_serve_stamp.armed = false;
+        const TxServeRefereeVerdict v = tx_serve_internal_referee(w);
+        CHECK(!v.serve_own_set && v.fail_cause == "tx-serve-unstamped",
+              "unstamped template -> refused (tx-serve-unstamped)");
+    }
+}
+
+int main()
+{
+    std::printf("== dash_tx_serve_self_validation_kat ==\n");
+    part_a_classifier();
+    part_b_referee();
+    if (g_fail) {
+        std::printf("RESULT: FAIL (%d checks failed)\n", g_fail);
+        return 1;
+    }
+    std::printf("RESULT: PASS\n");
+    return 0;
+}

--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -629,25 +629,32 @@ public:
         return j;
     }
 
-    /// Thread-safe readiness snapshot for the SERVE PATH (work_source.cpp).
-    /// TRUE only when a dashd testmempoolaccept oracle is bound AND the mempool
-    /// validity gate has accrued its sustained clean window (open()).
+    /// Thread-safe readiness snapshot. TRUE only when a dashd testmempoolaccept
+    /// oracle is bound AND the mempool validity gate has accrued its sustained
+    /// clean window (open()).
     ///
-    /// The tx-serve-own-set referee consults this so that serving OUR OWN valid
-    /// tx set -- dropping the dashd-tx-merkle PARITY backstop -- cannot begin
-    /// until the SELECTOR has been PROVEN dashd-acceptable over the window.
-    /// This is the direct runtime answer to the field finding at h=2526403:
-    /// our fee_fold_proven selection can still offer transactions dashd rejects
-    /// (the already-mined / stale-UTXO-view class), and the internal-
-    /// consistency referee shares a UTXO view with the selector, so it cannot
-    /// independently catch that class. Only dashd's external view (this gate,
-    /// or the parity backstop) can. Requiring open() here keeps the parity
-    /// backstop in force until the gate demonstrates the class is gone.
+    /// ══ DEMOTED TO A PRE-CUT CONFIDENCE MEASUREMENT ═════════════════════════
+    /// This was the serve BLOCKER for the tx-serve-own-set referee: own-set
+    /// serving could not begin until dashd's testmempoolaccept had been clean
+    /// over the window. That made dashd's external view a PERMANENT DEPENDENCY
+    /// of the serve decision — incompatible with the --coin-rpc cut, and, as
+    /// the h=2526495 incident proved, NOISY: it called "invalid" two txs the
+    /// network CONFIRMED in the very block our template competed for (the
+    /// Window-1 class the PendingPropagation classifier now recovers).
     ///
-    /// Returns false when no oracle is bound: the gate cannot be proven without
-    /// dashd, so it fail-closes. (A post-proof PURE-daemonless node runs with
-    /// no shadow-compare object at all; the caller bypasses the coupling only
-    /// when the probe is absent, never when it is present-but-empty.)
+    /// The serve decision no longer consults this. work_source.cpp SELF-
+    /// VALIDATES the served set from OUR OWN state — the internal-consistency
+    /// referee (tx_serve_referee.hpp: coinbase fee-exact, every tx
+    /// fee_fold_proven against our spent-aware UTXO view at build, no intra-set
+    /// double-spend) runs on EVERY armed embedded template, making ZERO dashd
+    /// calls, so it survives the cut unchanged. This function remains as a
+    /// CONFIDENCE COUNTER: pre-cut, with a probe bound, `open()` is EVIDENCE
+    /// that our self-validated set == dashd-clean over the window. It proves the
+    /// predicate; it does not gate the serve. Post-cut there is no shadow-
+    /// compare object and no probe — the measurement simply vanishes, and the
+    /// referee is unaffected.
+    ///
+    /// Returns false when no oracle is bound (measurement unavailable).
     bool validity_gate_open() const {
         std::lock_guard<std::mutex> lk(mu_);
         return static_cast<bool>(accept_) && validity_.open();
@@ -698,19 +705,12 @@ private:
             std::lock_guard<std::mutex> lk(mu_);
             counters_.apply(o);
         }
-        // TIP CONTEXT for the validity gate. dashd's getblocktemplate height is
-        // its NEXT block (tip+1); ours (served.m_height) is likewise our next
-        // block. dashd building a STRICTLY HIGHER block than us means dashd has
-        // already connected the block at our template's height (or beyond) while
-        // OUR tip is still its parent — the propagation Window 1 in which a tx
-        // dashd reports "txn-already-known" was mined in a block WE HAVE NOT YET
-        // CONNECTED. From our tip that tx is a valid unconfirmed tx and our
-        // template is a valid fork competitor, so the gate must not treat it as
-        // a staleness defect. When the oracle is absent we cannot tell, and pass
-        // false (conservative: already-known stays INVALID, gate stays CLOSED).
-        const bool dashd_ahead =
-            dashd.has_value() && dashd->m_height > served.m_height;
-        probe_validity(served, dashd_ahead);
+        // dashd's probe-time template height — the FACT the Window-1 classifier
+        // keys on. 0 when no oracle answered (the classifier then never treats
+        // any tx as dashd-ahead, so a missing-inputs stays Invalid: absent
+        // evidence of an ahead tip, we do not excuse the reject).
+        const uint32_t dashd_probe_height = dashd ? dashd->m_height : 0u;
+        probe_validity(served, dashd_probe_height);
     }
 
     /// THE MEMPOOL VALIDITY GATE, on the SAME worker thread as the oracle
@@ -721,9 +721,19 @@ private:
     ///
     /// This CANNOT change what is served. Its only outputs are log lines, the
     /// counters, and a readiness verdict on a DEFAULT-OFF flag.
-    void probe_validity(const DashWorkData& w, bool dashd_ahead_of_serve_height) {
+    void probe_validity(const DashWorkData& w, uint32_t dashd_probe_height) {
         if (!accept_) return;
-        const auto set = mempool_probe_set(w);
+        auto set = mempool_probe_set(w);
+
+        // WINDOW-1 FACT. dashd's probe-time template height > our template
+        // height means dashd's tip is STRICTLY AHEAD of the serve parent this
+        // template was built on (our serve parent = w.m_height-1, dashd tip =
+        // dashd_probe_height-1). At that skew the classifier reclassifies a
+        // "missing-inputs" reject as PENDING-PROPAGATION (valid on our fork,
+        // stale probe) instead of a defect. A height comparison — never a
+        // reason-string inference. 0 when no oracle answered => never ahead.
+        const bool dashd_ahead = dashd_probe_height > w.m_height;
+        for (auto& t : set) t.dashd_ahead_of_serve_height = dashd_ahead;
 
         std::vector<nlohmann::json> answers;
         answers.reserve(set.size());
@@ -739,8 +749,7 @@ private:
             answers.push_back(std::move(a));
         }
 
-        const auto sample = mempool_validity_sample(w.m_height, set, answers,
-                                                    dashd_ahead_of_serve_height);
+        const auto sample = mempool_validity_sample(w.m_height, set, answers);
         std::lock_guard<std::mutex> lk(mu_);
         validity_.apply(sample);
         for (const auto& line : mempool_validity_log_lines(sample, validity_)) {

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -124,26 +124,8 @@ namespace coin {
 
 /// dashd's reject-reason for "I already hold this transaction", verbatim
 /// (Dash Core validation.cpp: TxValidationResult TX_CONFLICT,
-/// "txn-already-in-mempool"). The ONE unconditionally-exempted reason.
-/// Compared for EQUALITY.
+/// "txn-already-in-mempool"). The ONE exempted reason. Compared for EQUALITY.
 inline constexpr const char* kAlreadyInMempoolReason = "txn-already-in-mempool";
-
-/// dashd's reject-reason for "this transaction is ALREADY CONFIRMED in my
-/// active chain", verbatim (Dash Core MemPoolAccept::PreChecks: a tx whose
-/// outputs are already present as coins in dashd's UTXO view —
-/// `HaveCoin(COutPoint(hash, out))` — returns TX_CONFLICT "txn-already-known").
-/// This is a CONDITIONAL exemption, not an unconditional one: it is benign
-/// ONLY when the block that confirmed the tx is one WE HAVE NOT YET CONNECTED
-/// (propagation Window 1 — our tip is h-1, someone else mined h and dashd
-/// connected it before we did; from our tip the tx is a valid UNCONFIRMED tx
-/// and our template is a valid fork competitor at height h, never an orphan).
-/// It is a genuine DEFECT only when dashd sits on OUR parent (or behind) and
-/// still reports the tx confirmed — i.e. it was confirmed at or below OUR
-/// serve-tip while we still serve it (the intra-node eviction-lag class,
-/// "Window 2"). The caller supplies the tip context (classify_mempool_accept's
-/// `dashd_ahead_of_serve_height`), which alone decides which case applies.
-/// Compared for EQUALITY.
-inline constexpr const char* kAlreadyConfirmedReason = "txn-already-known";
 
 /// The ONE reject-reason that can mean ONLY "I do not know this input" — the
 /// answer a SINGLE-transaction probe gets for a child whose parent rides the
@@ -161,18 +143,22 @@ inline bool is_missing_or_spent_reason(const std::string& reason)
     return reason == "bad-txns-inputs-missingorspent";
 }
 
-/// Three-valued logic, plus the honest fourth state for "no answer".
+/// Three-valued logic, plus TWO honest "no verdict" states.
 /// Unprobed is NEVER counted as valid and NEVER counted as a defect: it is the
-/// absence of a measurement, and it advances nothing.
+/// absence of a measurement, and it advances nothing. PendingPropagation is the
+/// Window-1 analog (see the enumerator note): dashd's probe-time tip is AHEAD of
+/// the serve parent this template was built on, and a "missing-inputs" answer at
+/// that skew is the ahead-block having already spent/confirmed the very inputs
+/// (or txs) our still-valid fork template offered — a PROBE TIMING ARTEFACT, not
+/// a defect of the transaction. It, too, advances nothing and resets nothing.
 enum class MempoolAcceptVerdict : uint8_t {
     Valid,              // allowed == true
     AlreadyInMempool,   // allowed == false, reason == txn-already-in-mempool
-    ConfirmedAhead,     // reason == txn-already-known AND dashd is ahead of our
-                        // serve-tip -> benign propagation (Window 1). NOT a
-                        // defect and NOT evidence: it neither resets nor
-                        // advances the readiness run.
     Invalid,            // allowed == false, any other reason -> A DEFECT
-    Unprobed            // no answer, or an in-set-parent probe artefact
+    Unprobed,           // no answer, or an in-set-parent probe artefact
+    PendingPropagation  // missing-inputs at a dashd-AHEAD-of-serve-parent skew
+                        // (Window-1: valid on our fork; the probe is stale) —
+                        // NEVER a defect, NEVER counted valid, advances nothing
 };
 
 inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
@@ -180,8 +166,9 @@ inline const char* mempool_accept_verdict_name(MempoolAcceptVerdict v)
     switch (v) {
         case MempoolAcceptVerdict::Valid:            return "VALID";
         case MempoolAcceptVerdict::AlreadyInMempool: return "ALSO-VALID(already-in-mempool)";
-        case MempoolAcceptVerdict::ConfirmedAhead:   return "PROPAGATION(confirmed-in-not-yet-connected-block)";
         case MempoolAcceptVerdict::Invalid:          return "INVALID";
+        case MempoolAcceptVerdict::PendingPropagation:
+            return "PENDING-PROPAGATION(dashd-ahead-window-1)";
         default:                                     return "UNPROBED";
     }
 }
@@ -205,26 +192,30 @@ struct MempoolProbeTx {
     /// same probe set. Computed at template-build time from the real vins, not
     /// guessed from a reject string.
     bool        depends_on_in_set_parent{false};
+
+    /// TRUE when dashd's probe-time tip is STRICTLY AHEAD of the serve parent
+    /// this template was built on — a FACT (a height comparison: dashd's GBT
+    /// height > our template height), NOT an inference from any reject string.
+    /// The probe runs asynchronously on a worker thread; between the instant we
+    /// built the template at OUR tip and the instant dashd answered, dashd can
+    /// have connected one or more blocks. At that skew a "missing-inputs" answer
+    /// is the Window-1 propagation artefact: the ahead block already spent or
+    /// confirmed the very inputs (or the very txs) our still-valid fork template
+    /// offered, so dashd — probing against its newer view — cannot see them.
+    /// dashd's own testmempoolaccept detects the already-confirmed case only
+    /// best-effort (HaveCoinInCache over the tx OUTPUTS) and, once those outputs
+    /// are flushed or spent, falls through to the same "missing-inputs" string;
+    /// the field is how we recover the class dashd's string conflated. Set by
+    /// the probe caller (embedded_shadow_compare.hpp) from dashd's GBT height.
+    bool        dashd_ahead_of_serve_height{false};
 };
 
 /// PURE. dashd's testmempoolaccept answer for ONE transaction -> the verdict.
 /// `entry` is the single result object (`{"txid":..,"allowed":..,
 /// "reject-reason":..}`); a null/non-object entry means the probe produced no
 /// answer (RPC blip, daemon absent) and yields Unprobed.
-///
-/// `dashd_ahead_of_serve_height` is the sample-level tip context: TRUE when
-/// dashd's chain tip is STRICTLY AHEAD of the block WE built the probed
-/// template for (dashd's next-block height > our served height). It is
-/// consulted for EXACTLY ONE reason string — "txn-already-known" — to separate
-/// benign propagation (Window 1: dashd already connected a block we have not)
-/// from a genuine intra-node staleness defect (Window 2: dashd sits on our
-/// parent and still holds the tx confirmed at/below our serve-tip). It changes
-/// NOTHING for any other reason: every real reject stays a reject. Defaulting
-/// to FALSE preserves the pre-tip-context behaviour (already-known -> INVALID)
-/// for callers that cannot supply it — the conservative, gate-CLOSED direction.
 inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
-                                                   const nlohmann::json& entry,
-                                                   bool dashd_ahead_of_serve_height = false)
+                                                   const nlohmann::json& entry)
 {
     MempoolAcceptResult r;
     r.txid = tx.txid;
@@ -247,27 +238,6 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
     if (r.reason == kAlreadyInMempoolReason) {
         r.verdict = MempoolAcceptVerdict::AlreadyInMempool;
         return r;
-    }
-
-    // dashd says the tx is ALREADY CONFIRMED in its chain ("txn-already-known").
-    // Whether that is a defect depends ENTIRELY on WHICH block confirmed it,
-    // which the tip context decides (see kAlreadyConfirmedReason). dashd AHEAD
-    // of our serve-tip => it was confirmed in a block we have not connected =>
-    // benign propagation (Window 1): our template is a valid fork competitor at
-    // our height, so this must NOT reset the readiness run. dashd NOT ahead
-    // (on our parent, or behind) => confirmed at/below OUR serve-tip while we
-    // still serve it => a genuine current-tip staleness defect (Window 2) =>
-    // falls through to INVALID and resets, exactly as a served already-mined tx
-    // should. This is the ONLY reason whose disposition the tip context can
-    // change; the field-measured invalids were 23/23 this class, all Window 1.
-    if (r.reason == kAlreadyConfirmedReason) {
-        if (dashd_ahead_of_serve_height) {
-            r.verdict        = MempoolAcceptVerdict::ConfirmedAhead;
-            r.unprobed_cause = "confirmed-in-block-we-have-not-connected(propagation)";
-            return r;
-        }
-        // else: dashd on our parent or behind -> a real at/below-serve-tip
-        // defect; fall through to INVALID below.
     }
 
     // The ONLY excused rejection beyond the named one: a child probed alone
@@ -305,6 +275,43 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
         return r;
     }
 
+    // WINDOW-1 PROPAGATION (the #1318 successor; the h=2526495 incident class).
+    // A "missing-inputs" answer while dashd's probe-time tip is STRICTLY AHEAD of
+    // the serve parent this template was built on is a PROBE-TIMING ARTEFACT, not
+    // a defect: dashd connected one or more blocks after we built, and that ahead
+    // block already spent/confirmed the inputs (or the txs themselves — both of
+    // the h=2526495 leak txs, 8c4efd9c… and 81109abf…, were CONFIRMED IN BLOCK
+    // 2526495 itself, the exact height our template competed for). Such a tx is
+    // VALID ON OUR FORK; dashd, probing against its newer view, cannot see it.
+    // The FACT is `dashd_ahead_of_serve_height` — a height comparison the caller
+    // supplies, never a string inference — so the exemption cannot widen on a
+    // reason alone. It is DELIBERATELY NARROW:
+    //
+    //   * Only "missing-inputs" qualifies. `bad-txns-inputs-missingorspent`
+    //     stays INVALID even under the ahead skew (see the note above): that
+    //     reason conflates unknown-with-SPENT in its own name and is the exact
+    //     bad-cb / double-spend loss vector; failing it toward a CLOSED gate on
+    //     ambiguous evidence is the direction a gate is allowed to be wrong in.
+    //   * It advances NOTHING and resets NOTHING — like Unprobed, it is the
+    //     absence of a usable measurement, not evidence in either direction. It
+    //     is counted separately (`pending_propagation`) so the class stays
+    //     visible and MEASURABLE (our-serve-parent vs dashd-tip skew), which is
+    //     precisely what a demoted-to-measurement gate needs to prove that OUR
+    //     self-validation verdict == dashd-clean once the skew resolves.
+    //
+    // Since this gate is a MEASUREMENT (it no longer decides what is served —
+    // work_source.cpp self-validates the served set from OUR OWN state), the
+    // cost of this classification is confidence accounting, never a served
+    // block: a genuine defect that happened to coincide with an ahead skew is
+    // caught by the serve-time internal-consistency referee (tx_serve_referee.
+    // hpp), which shares the selector's spent-aware UTXO view and runs on EVERY
+    // armed embedded template independent of dashd.
+    if (is_unknown_input_only_reason(r.reason) && tx.dashd_ahead_of_serve_height) {
+        r.verdict        = MempoolAcceptVerdict::PendingPropagation;
+        r.unprobed_cause = "dashd-ahead-of-serve-parent(window-1-propagation)";
+        return r;
+    }
+
     r.verdict = MempoolAcceptVerdict::Invalid;
     return r;
 }
@@ -317,20 +324,18 @@ struct MempoolValiditySample {
     size_t   already_in_mempool{0};
     size_t   invalid{0};
     size_t   unprobed{0};
-    /// Benign propagation (Window 1): dashd reported the tx already-CONFIRMED in
-    /// a block WE HAVE NOT YET CONNECTED. Neither a defect nor evidence — it is
-    /// counted here only so the log/JSON can say how much of the "already-known"
-    /// traffic was the propagation transient rather than a real staleness.
-    size_t   confirmed_ahead{0};
+    /// Window-1 propagation artefacts: dashd-ahead + missing-inputs. Neither
+    /// evidence of validity nor a defect — tracked so the skew class is visible.
+    size_t   pending_propagation{0};
     /// The defects, verbatim — txid + dashd's reason. These are what the
     /// refusal line prints.
     std::vector<MempoolAcceptResult> invalids;
 
     /// A height that actually OBSERVED validity. A height whose probe set was
-    /// empty, or whose every entry came back Unprobed / ConfirmedAhead,
-    /// observed nothing about CURRENT-TIP validity — a ConfirmedAhead answer is
-    /// dashd speaking from a NEWER tip than the one we probed for, so it is not
-    /// evidence either way (see the tip-context note on kAlreadyConfirmedReason).
+    /// empty, or whose every entry came back Unprobed / PendingPropagation,
+    /// observed nothing. PendingPropagation is EXCLUDED here for the same reason
+    /// Unprobed is: it is the absence of a usable measurement, so it must not
+    /// let a skew-only height count toward the clean window.
     bool evidence_bearing() const
     {
         return (valid + already_in_mempool + invalid) > 0;
@@ -341,18 +346,10 @@ struct MempoolValiditySample {
 /// PURE. Classify a whole probe set against the per-transaction answers.
 /// `answers[i]` is dashd's result object for `set[i]`; a shorter answers vector
 /// means the remaining entries got no answer (Unprobed), never a pass.
-///
-/// `dashd_ahead_of_serve_height` is the sample-level tip context threaded into
-/// each per-tx classification (see classify_mempool_accept). It ONLY affects
-/// the "txn-already-known" reason: dashd-ahead makes that a benign
-/// ConfirmedAhead (propagation Window 1, no reset), dashd-not-ahead keeps it a
-/// current-tip Invalid. Defaults FALSE so legacy/test callers get the pre-
-/// tip-context behaviour unchanged.
 inline MempoolValiditySample
 mempool_validity_sample(uint32_t height,
                         const std::vector<MempoolProbeTx>& set,
-                        const std::vector<nlohmann::json>& answers,
-                        bool dashd_ahead_of_serve_height = false)
+                        const std::vector<nlohmann::json>& answers)
 {
     MempoolValiditySample s;
     s.height = height;
@@ -360,15 +357,16 @@ mempool_validity_sample(uint32_t height,
     for (size_t i = 0; i < set.size(); ++i) {
         const nlohmann::json& a = (i < answers.size()) ? answers[i]
                                                        : nlohmann::json();
-        const MempoolAcceptResult r =
-            classify_mempool_accept(set[i], a, dashd_ahead_of_serve_height);
+        const MempoolAcceptResult r = classify_mempool_accept(set[i], a);
         switch (r.verdict) {
             case MempoolAcceptVerdict::Valid:            ++s.valid; break;
             case MempoolAcceptVerdict::AlreadyInMempool: ++s.already_in_mempool; break;
-            case MempoolAcceptVerdict::ConfirmedAhead:   ++s.confirmed_ahead; break;
             case MempoolAcceptVerdict::Invalid:
                 ++s.invalid;
                 s.invalids.push_back(r);
+                break;
+            case MempoolAcceptVerdict::PendingPropagation:
+                ++s.pending_propagation;
                 break;
             default:                                     ++s.unprobed; break;
         }
@@ -468,14 +466,14 @@ struct MempoolValidityGate {
     uint64_t txs_valid{0};
     uint64_t txs_already_in_mempool{0};
     uint64_t txs_unprobed{0};
-    /// Benign propagation transients (already-CONFIRMED in a block we have not
-    /// yet connected) seen over every applied sample. NOT defects, NOT
-    /// evidence — this counter exists so the operator can see how much of the
-    /// "already-known" traffic the tip context reclassified out of the invalid
-    /// bucket. A large value here with consecutive_clean advancing is the whole
-    /// point: propagation no longer stalls the readiness run.
-    uint64_t txs_confirmed_ahead{0};
     uint64_t repeat_txs_probed{0};
+
+    /// Window-1 propagation artefacts observed anywhere (dashd-ahead skew +
+    /// missing-inputs). Accrued on EVERY apply() regardless of disposition so
+    /// the skew class is fully visible; it advances nothing and resets nothing.
+    /// This is the demoted gate's CONFIDENCE evidence that the class dashd's
+    /// string conflated is benign and resolves as our tip catches up.
+    uint64_t txs_pending_propagation{0};
 
     /// DEFECTS ARE COUNTED WHEREVER THEY ARE OBSERVED — counted sample or
     /// repeat. See the asymmetry note at the top of this file.
@@ -495,6 +493,11 @@ struct MempoolValidityGate {
     {
         ++samples_seen;
 
+        // Window-1 propagation artefacts accrue unconditionally: they are
+        // measurement, not evidence, so they are counted before the evidence
+        // gate and never touch consecutive_clean in either direction.
+        txs_pending_propagation += s.pending_propagation;
+
         if (!s.evidence_bearing()) {
             // Neither advances nor resets — it is not evidence in either
             // direction. Said out loud so a long quiet stretch cannot be
@@ -502,9 +505,8 @@ struct MempoolValidityGate {
             // moved: a later probe of this same height that DOES find
             // transactions is the first evidence there, and must count.
             ++samples_without_evidence;
-            txs_unprobed        += s.unprobed;
-            txs_confirmed_ahead += s.confirmed_ahead;
-            last_disposition     = SampleDisposition::NoEvidence;
+            txs_unprobed     += s.unprobed;
+            last_disposition  = SampleDisposition::NoEvidence;
             return;
         }
 
@@ -538,7 +540,6 @@ struct MempoolValidityGate {
         txs_valid              += s.valid;
         txs_already_in_mempool += s.already_in_mempool;
         txs_unprobed           += s.unprobed;
-        txs_confirmed_ahead    += s.confirmed_ahead;
         last_disposition        = SampleDisposition::Counted;
 
         if (s.invalid > 0) return;        // already reset above
@@ -570,7 +571,7 @@ struct MempoolValidityGate {
         j["txs-already-in-mempool"]    = txs_already_in_mempool;
         j["txs-invalid"]               = txs_invalid;
         j["txs-unprobed"]              = txs_unprobed;
-        j["txs-confirmed-ahead-propagation"] = txs_confirmed_ahead;
+        j["txs-pending-propagation"]   = txs_pending_propagation;
         j["last-invalid-height"]       = last_invalid_height;
         j["last-invalid-txid"]         = last_invalid_txid;
         j["last-invalid-reason"]       = last_invalid_reason;
@@ -609,21 +610,16 @@ mempool_validity_log_lines(const MempoolValiditySample& s,
         + " valid="     + std::to_string(s.valid)
         + " already_in_mempool=" + std::to_string(s.already_in_mempool)
         + " invalid="   + std::to_string(s.invalid)
-        + " confirmed_ahead=" + std::to_string(s.confirmed_ahead)
         + " unprobed="  + std::to_string(s.unprobed)
+        + " pending_propagation=" + std::to_string(s.pending_propagation)
         + " clean_run=" + std::to_string(g.consecutive_clean) + "/"
         + std::to_string(g.required)
         + " heights_with_evidence=" + std::to_string(g.heights_with_evidence)
         + " sample=" + MempoolValidityGate::disposition_name(g.last_disposition)
         + " gate=" + (g.open() ? "OPEN" : "CLOSED");
     if (!s.evidence_bearing())
-        l += s.confirmed_ahead > 0
-             ? " (no-evidence: every probed tx is already CONFIRMED in a block we"
-               " have not yet connected — benign propagation Window 1, dashd is"
-               " ahead of the height we built for; the run neither advances nor"
-               " resets, and this is NOT a staleness defect)"
-             : " (no-evidence: nothing to probe at this height — the run neither"
-               " advances nor resets)";
+        l += " (no-evidence: nothing to probe at this height — the run neither"
+             " advances nor resets)";
     else if (g.last_disposition == MempoolValidityGate::SampleDisposition::RepeatHeight)
         l += " (repeat-height: h<=" + std::to_string(g.last_counted_height)
            + " is already banked — the probe fires ~5-6x per block, so this"

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -949,6 +949,11 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
             // tells the single splice point below which producer it is
             // serving -- and the 66-of-197 silent-miss class it closes.
             bool served_via_xcheck_swap = false;
+            // TRUE once the internal-consistency referee has run on this
+            // template (either the divergence branch below or the unconditional
+            // post-cut self-validation after this block). Prevents a redundant
+            // second referee pass on the same bytes.
+            bool embedded_self_validated = false;
             if (sel.source == coin::WorkSource::Embedded && gbt_xcheck_ && dashd_fallback_) {
                 coin::DashWorkData dref = dashd_fallback_();
                 coin::vendor::CCbTx emb_cb, dref_cb;
@@ -1207,13 +1212,33 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                         //   post-proof) the operator's arming of the flag is
                         //   the proof. Either way, failure fail-closes to
                         //   dashd -- safety is preserved on every branch.
-                        const bool gate_proven =
-                            !shadow_compare_ || shadow_compare_->validity_gate_open();
+                        // SELF-VALIDATION ONLY — the serve decision makes ZERO
+                        // dashd calls. The dashd testmempoolaccept validity gate
+                        // is DEMOTED to a pre-cut CONFIDENCE measurement
+                        // (validity_gate_measurement below): logged, never
+                        // gated. Own-set serving is decided SOLELY by the
+                        // internal-consistency referee over OUR OWN state
+                        // (every served tx fee_fold_proven vs our spent-aware
+                        // UTXO view at build, coinbase == subsidy+Σfee+superblock,
+                        // no intra-set double-spend) — the predicate that
+                        // survives the --coin-rpc cut. The already-mined /
+                        // stale-view class the gate used to backstop is a
+                        // Window-1 propagation artefact (dashd already connected
+                        // the block that spent/confirmed those inputs; the tx is
+                        // valid on OUR fork and dashd serves the same competing
+                        // set at the same instant) — unclosable without the
+                        // block, and NOT a defect the gate was right to punish.
                         coin::TxServeRefereeVerdict rv;
                         const bool serve_own =
-                            tx_serve_own_set_ && gate_proven
+                            tx_serve_own_set_
                             && (rv = coin::tx_serve_internal_referee(sel.work))
                                    .serve_own_set;
+                        embedded_self_validated = tx_serve_own_set_;
+                        // CONFIDENCE (pre-cut, observe-only): does our self-
+                        // validated verdict coincide with a dashd-clean window?
+                        // Recorded in the log; it decides nothing.
+                        const bool validity_gate_measurement =
+                            shadow_compare_ && shadow_compare_->validity_gate_open();
                         if (serve_own) {
                             // SERVE OUR OWN VALID SET. The dashd divergence is
                             // a SHADOW (diagnostic), not a fallback trigger.
@@ -1230,15 +1255,15 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                                         " a fallback trigger";
                             // sel stays Embedded â NO swap.
                         } else {
-                            // FAIL-CLOSE to dashd. Own-set OFF (legacy parity),
-                            // validity gate not yet proven-open, or the referee
-                            // refused an internal-consistency defect.
+                            // FAIL-CLOSE to dashd. Own-set OFF (legacy parity)
+                            // or the referee refused an internal-consistency
+                            // defect. The dashd validity gate no longer
+                            // participates (demoted to measurement), so it can
+                            // never be the cause here.
                             std::string cause =
                                 !tx_serve_own_set_
                                     ? std::string("gbt-xcheck-txmerkle-mismatch")
-                                    : (!gate_proven
-                                           ? std::string("tx-serve-validity-gate-not-open")
-                                           : rv.fail_cause);
+                                    : rv.fail_cause;
                             if (tx_serve_own_set_)
                                 tx_serve_own_set_failclose_.fetch_add(
                                     1, std::memory_order_relaxed);
@@ -1250,10 +1275,6 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                                         << " root=" << dref_txroot.GetHex().substr(0, 16)
                                         << " â serving dashd template (cause="
                                         << cause
-                                        << (tx_serve_own_set_ && !gate_proven
-                                                ? "; own-set armed but validity"
-                                                  " gate not open"
-                                                : "")
                                         << ")";
                             coin::DeclineReport xcheck;
                             xcheck.viable    = false;
@@ -1266,6 +1287,70 @@ void DASHWorkSource::resource_template_now(CoinStateArm arm) const
                             served_via_xcheck_swap = true;
                         }
                     }
+                }
+            }
+            // ── UNCONDITIONAL EMBEDDED SELF-VALIDATION (the cut-critical arm) ─
+            // The gbt-xcheck block above runs ONLY when a dashd RPC is armed AND
+            // the embedded selection DIVERGES from dashd's GBT. Post --coin-rpc
+            // cut there is no dashd to diverge from (gbt_xcheck_ && dashd_fallback_
+            // is false), so an armed embedded template would otherwise serve its
+            // mempool set with ZERO serve-time self-validation. This runs the
+            // internal-consistency referee on EVERY armed embedded template that
+            // carries mempool txs and has not already been refereed above,
+            // making ZERO dashd calls: coinbase == subsidy + Σfee + superblock,
+            // every served tx fee_fold_proven against our spent-aware UTXO view
+            // at build (the just-spent-input / missing-inputs class is caught
+            // HERE, by OUR OWN state, not by dashd), no intra-set double-spend.
+            // This is the self-validation the daemonless serve relies on.
+            //
+            // BYTE-NEUTRAL when --embedded-tx-serve-own-set is OFF (default):
+            // the referee is not consulted and the template serves exactly as
+            // before. Also inert when the template carries no mempool txs
+            // (coinbase-only bodies cannot orphan for a bad-txset reason).
+            //
+            // FAIL ACTION is dashd-FREE: refuse to serve the internally-
+            // inconsistent template (fail-closed to NoWork; the stratum holds
+            // the last good work and re-sources). We do NOT ask dashd and do NOT
+            // hand-strip a reward-critical coinbase at serve time — coinbase-only
+            // is a BUILD-time posture (embedded_gbt suppress_mempool_txs), never
+            // a serve-time edit. A referee failure here is a "cannot happen by
+            // construction" corruption signal (the builder selects only
+            // fee_fold_proven txs and sets the coinbase from the same subsidy
+            // function the referee re-derives), so refusing the block rather
+            // than mining a corrupt one is the only safe response.
+            if (tx_serve_own_set_
+                && !embedded_self_validated
+                && sel.source == coin::WorkSource::Embedded
+                && sel.work.m_mempool_tx_count > 0) {
+                const coin::TxServeRefereeVerdict rv =
+                    coin::tx_serve_internal_referee(sel.work);
+                if (rv.serve_own_set) {
+                    tx_serve_own_set_serves_.fetch_add(
+                        1, std::memory_order_relaxed);
+                    LOG_INFO << "[DASH-STRATUM] embedded self-validation OK at h="
+                             << sel.work.m_height
+                             << " txs=" << sel.work.m_tx_hashes.size()
+                             << " (" << rv.detail
+                             << ") — serving OWN valid set, ZERO dashd calls";
+                } else {
+                    tx_serve_own_set_failclose_.fetch_add(
+                        1, std::memory_order_relaxed);
+                    LOG_WARNING << "[DASH-STRATUM] embedded self-validation"
+                                   " REFUSED at h=" << sel.work.m_height
+                                << " cause=" << rv.fail_cause
+                                << " (" << rv.detail << ") — refusing to serve an"
+                                   " internally-inconsistent template (dashd-free"
+                                   " fail-close to no-work; last good work held)";
+                    coin::DeclineReport sv;
+                    sv.viable    = false;
+                    sv.cause     = "tx-serve-self-validation-refused:" + rv.fail_cause;
+                    sv.value     = std::to_string(sel.work.m_coinbase_value);
+                    sv.threshold = std::to_string(sel.work.m_mempool_tx_count)
+                                 + "-mempool-txs";
+                    sel.decline  = std::move(sv);
+                    // Fail-closed: make this template not-mineable so the store
+                    // below drops it and the stratum keeps the last good work.
+                    sel.work.m_bits = 0;
                 }
             }
             // ── THE SINGLE PIN SPLICE POINT ─────────────────────────────────

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -317,6 +317,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     )
     target_link_libraries(test_dash_serve_gate_journal PRIVATE c2pool_payout c2pool_hashrate c2pool_merged_mining)  # OBJECT-lib SCC direct-naming (#22/#39): core stratum/web_server TUs
     gtest_add_tests(test_dash_serve_gate_journal "" AUTO)
+    # Force-build the daemonless tx-serve self-validation KAT (defined in
+    # src/c2pool/CMakeLists.txt) whenever this target builds. That KAT exe is NOT in
+    # the fixed --target allowlist in .github/workflows/build.yml and we have no
+    # workflow scope to add it; test_dash_serve_gate_journal IS allowlisted in BOTH
+    # the Linux and AsAN CI jobs, so this dependency makes CI build the KAT and CTest
+    # find it instead of reporting it NOT_BUILT / Not Run.
+    add_dependencies(test_dash_serve_gate_journal dash_tx_serve_self_validation_kat)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on

--- a/test/test_dash_mempool_validity_gate.cpp
+++ b/test/test_dash_mempool_validity_gate.cpp
@@ -35,12 +35,16 @@ using namespace dash::coin;
 
 namespace {
 
-MempoolProbeTx tx(const std::string& id, bool depends = false)
+MempoolProbeTx tx(const std::string& id, bool depends = false,
+                  bool dashd_ahead = false)
 {
     MempoolProbeTx t;
     t.txid    = id;
     t.raw_hex = "0100000000";   // shape only; the daemon is the oracle here
-    t.depends_on_in_set_parent = depends;
+    t.depends_on_in_set_parent    = depends;
+    // The Window-1 propagation FACT is carried per-transaction now (a height
+    // comparison the caller supplies), not as a classify/sample parameter.
+    t.dashd_ahead_of_serve_height = dashd_ahead;
     return t;
 }
 
@@ -117,114 +121,119 @@ TEST(DashMempoolValidityGate, AnyOtherReasonIsInvalidAndCarriesItVerbatim) {
 TEST(DashMempoolValidityGate, NearMissReasonIsNotExempted) {
     // None of these is the exact "txn-already-in-mempool" name. Excusing them
     // would widen the gate by prefix-matching. "txn-already-known" is a REAL
-    // dashd reason (the tx is already CONFIRMED in dashd's chain), but WITHOUT
-    // tip context (the default here) we cannot tell benign propagation from a
-    // current-tip staleness defect, so the conservative reading is INVALID —
-    // exactly the pre-tip-context behaviour, and the gate-CLOSED direction.
-    // The tip-aware benign path is pinned separately below.
+    // dashd reason (the tx is already CONFIRMED in dashd's chain), but it is
+    // NOT the Window-1 propagation reason (that is "missing-inputs" under a
+    // dashd-ahead skew, pinned separately below) and it is not the exempted
+    // "txn-already-in-mempool" name, so its verdict is INVALID — the
+    // gate-CLOSED direction.
     for (const char* reason : {"txn-already-known",
                                "txn-already-in-mempool-ish",
                                "already-in-mempool"}) {
         const auto r = classify_mempool_accept(tx("dd"), refused("dd", reason));
         EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid)
-            << "reason=" << reason << " must NOT be exempted without tip context";
+            << "reason=" << reason << " is not the exempted name and is not the"
+               " Window-1 missing-inputs reason, so it must be INVALID";
     }
 }
 
-// ── 2b. THE PROPAGATION WINDOW: "txn-already-known" IS TIP-CONDITIONAL ───────
+// ── 2b. THE PROPAGATION WINDOW: "missing-inputs" IS TIP-CONDITIONAL ──────────
 //
-// FIELD MEASUREMENT (creditpool-arm + cert soaks, heights 2526398..2526404):
-// 23/23 of the live [MEMPOOL-VALIDITY] invalids were reason="txn-already-known"
-// and EVERY ONE was confirmed at EXACTLY the probe height — i.e. mined in the
-// very block our template competed for, while our tip was legitimately h-1.
-// That is benign propagation (Window 1): dashd connected block h before we did,
-// so it answers "already confirmed"; our template is a valid FORK COMPETITOR at
-// height h, never an orphan. The old gate reset the clean run on every one of
-// these, which is why clean_run was pinned at 0/576 forever. These KATs pin the
-// tip-context split that fixes it.
+// FIELD MEASUREMENT (creditpool-arm + cert soaks, the h=2526495 incident class):
+// the live [MEMPOOL-VALIDITY] Window-1 invalids were reason="missing-inputs"
+// answered while dashd's probe-time tip was STRICTLY AHEAD of the serve parent
+// this template was built on — dashd connected the ahead block before we did, so
+// that block had already spent/confirmed the very inputs (or txs) our still-valid
+// fork template offered, and dashd, probing against its newer view, could not see
+// them. That is benign propagation (Window 1): our template is a valid FORK
+// COMPETITOR at that height, never an orphan. The old gate reset the clean run on
+// every one of these, which is why clean_run was pinned at 0/576 forever. The FACT
+// that splits benign propagation from a genuine defect is the per-transaction
+// `dashd_ahead_of_serve_height` height comparison — never a string inference — so
+// the exemption cannot widen on a reason alone. These KATs pin that split.
 
 TEST(DashMempoolValidityGate, AlreadyKnownWithDashdAheadIsBenignPropagationNotInvalid) {
-    // dashd is AHEAD of the height we built for -> the tx was confirmed in a
-    // block WE HAVE NOT YET CONNECTED -> benign, not a defect.
+    // dashd is AHEAD of the height we built for and answers "missing-inputs" ->
+    // the ahead block already spent/confirmed our inputs -> benign, not a defect.
     const auto r = classify_mempool_accept(
-        tx("mined_elsewhere"), refused("mined_elsewhere", "txn-already-known"),
-        /*dashd_ahead_of_serve_height=*/true);
-    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::ConfirmedAhead);
+        tx("mined_elsewhere", /*depends=*/false, /*dashd_ahead=*/true),
+        refused("mined_elsewhere", "missing-inputs"));
+    EXPECT_EQ(r.verdict, MempoolAcceptVerdict::PendingPropagation);
 }
 
 TEST(DashMempoolValidityGate, AlreadyKnownWithDashdNotAheadIsStillAnInvalidDefect) {
-    // dashd sits on OUR parent (not ahead) and STILL reports the tx confirmed
-    // -> it was confirmed at/below our serve-tip while we serve it: a genuine
-    // current-tip staleness defect (Window 2). The gate MUST still catch this.
+    // dashd sits on OUR parent (not ahead) and STILL answers "missing-inputs"
+    // -> a genuine missing/at-tip input while we would serve it: a real defect
+    // (Window 2). Without the ahead FACT the gate MUST still catch this.
     const auto r = classify_mempool_accept(
-        tx("stale"), refused("stale", "txn-already-known"),
-        /*dashd_ahead_of_serve_height=*/false);
+        tx("stale", /*depends=*/false, /*dashd_ahead=*/false),
+        refused("stale", "missing-inputs"));
     EXPECT_EQ(r.verdict, MempoolAcceptVerdict::Invalid);
-    EXPECT_EQ(r.reason, "txn-already-known");
+    EXPECT_EQ(r.reason, "missing-inputs");
 }
 
 TEST(DashMempoolValidityGate, PropagationTransientDoesNotResetTheCleanRun) {
     // The whole point. A clean run in progress must SURVIVE a height whose only
-    // "invalids" are already-confirmed-in-a-block-we-haven't-connected txs.
+    // "invalids" are missing-inputs answered under a dashd-ahead skew.
     MempoolValidityGate g;
     feed_clean(g, 100);
     ASSERT_EQ(g.consecutive_clean, 100u);
 
-    // A propagation sample: 4 txs, all "txn-already-known", dashd AHEAD.
-    const std::vector<MempoolProbeTx> set{tx("p1"), tx("p2"), tx("p3"), tx("p4")};
+    // A propagation sample: 4 txs, all "missing-inputs", each dashd-AHEAD.
+    const std::vector<MempoolProbeTx> set{
+        tx("p1", false, true), tx("p2", false, true),
+        tx("p3", false, true), tx("p4", false, true)};
     const std::vector<nlohmann::json> ans{
-        refused("p1", "txn-already-known"), refused("p2", "txn-already-known"),
-        refused("p3", "txn-already-known"), refused("p4", "txn-already-known")};
-    const auto s = mempool_validity_sample(50000, set, ans,
-                                           /*dashd_ahead_of_serve_height=*/true);
-    // Not evidence, not a defect: 4 confirmed-ahead, 0 invalid.
-    EXPECT_EQ(s.confirmed_ahead, 4u);
+        refused("p1", "missing-inputs"), refused("p2", "missing-inputs"),
+        refused("p3", "missing-inputs"), refused("p4", "missing-inputs")};
+    const auto s = mempool_validity_sample(50000, set, ans);
+    // Not evidence, not a defect: 4 pending-propagation, 0 invalid.
+    EXPECT_EQ(s.pending_propagation, 4u);
     EXPECT_EQ(s.invalid, 0u);
     EXPECT_FALSE(s.evidence_bearing());
 
     g.apply(s);
     EXPECT_EQ(g.consecutive_clean, 100u) << "propagation Window 1 must NOT reset";
     EXPECT_EQ(g.txs_invalid, 0u);
-    EXPECT_EQ(g.txs_confirmed_ahead, 4u);
+    EXPECT_EQ(g.txs_pending_propagation, 4u);
 }
 
 TEST(DashMempoolValidityGate, TheSamePropagationSampleWithoutTipContextWouldHaveResetIt) {
-    // RED->GREEN CONTRAST. Feed the IDENTICAL already-known set the way the
-    // pre-fix gate saw it (no tip context => dashd_ahead=false): it classifies
+    // RED->GREEN CONTRAST. Feed the IDENTICAL missing-inputs set the way the
+    // pre-fix gate saw it (no ahead FACT => dashd_ahead=false): it classifies
     // as 4 INVALID and nukes a 100-height run to 0. This is the exact live
     // defect (clean_run stuck at 0/576). The only difference from the test above
-    // is the tip-context bit, which is what the fix threads through.
+    // is the per-tx ahead bit, which is what the fix threads through.
     MempoolValidityGate g;
     feed_clean(g, 100);
     ASSERT_EQ(g.consecutive_clean, 100u);
 
     const std::vector<MempoolProbeTx> set{tx("p1"), tx("p2"), tx("p3"), tx("p4")};
     const std::vector<nlohmann::json> ans{
-        refused("p1", "txn-already-known"), refused("p2", "txn-already-known"),
-        refused("p3", "txn-already-known"), refused("p4", "txn-already-known")};
-    const auto s = mempool_validity_sample(50000, set, ans,
-                                           /*dashd_ahead_of_serve_height=*/false);
+        refused("p1", "missing-inputs"), refused("p2", "missing-inputs"),
+        refused("p3", "missing-inputs"), refused("p4", "missing-inputs")};
+    const auto s = mempool_validity_sample(50000, set, ans);
     EXPECT_EQ(s.invalid, 4u);
-    EXPECT_EQ(s.confirmed_ahead, 0u);
+    EXPECT_EQ(s.pending_propagation, 0u);
 
     g.apply(s);
-    EXPECT_EQ(g.consecutive_clean, 0u) << "no tip context => conservative reset";
+    EXPECT_EQ(g.consecutive_clean, 0u) << "no ahead FACT => conservative reset";
     EXPECT_EQ(g.best_consecutive_clean, 100u);
 }
 
 TEST(DashMempoolValidityGate, PropagationDoesNotMaskAGenuineInvalidInTheSameSample) {
     // Belt: a sample carrying BOTH benign propagation AND a real defect still
-    // resets. The confirmed-ahead reclassification must never swallow a true
-    // invalid that shares the height.
+    // resets. The pending-propagation reclassification must never swallow a true
+    // invalid that shares the height. Note bad-txns-inputs-missingorspent stays
+    // INVALID even under the ahead skew — the conflating reason is never excused.
     MempoolValidityGate g;
     feed_clean(g, 100);
-    const std::vector<MempoolProbeTx> set{tx("ahead"), tx("realbad")};
+    const std::vector<MempoolProbeTx> set{
+        tx("ahead", false, true), tx("realbad", false, true)};
     const std::vector<nlohmann::json> ans{
-        refused("ahead", "txn-already-known"),
+        refused("ahead", "missing-inputs"),
         refused("realbad", "bad-txns-inputs-missingorspent")};
-    const auto s = mempool_validity_sample(50000, set, ans,
-                                           /*dashd_ahead_of_serve_height=*/true);
-    EXPECT_EQ(s.confirmed_ahead, 1u);
+    const auto s = mempool_validity_sample(50000, set, ans);
+    EXPECT_EQ(s.pending_propagation, 1u);
     EXPECT_EQ(s.invalid, 1u);
     g.apply(s);
     EXPECT_EQ(g.consecutive_clean, 0u) << "a real defect still resets";
@@ -236,14 +245,13 @@ TEST(DashMempoolValidityGate, AMixedValidAndPropagationHeightStillAdvances) {
     // even when the rest of the set is benign propagation.
     MempoolValidityGate g;
     feed_clean(g, 10);
-    const std::vector<MempoolProbeTx> set{tx("good"), tx("ahead")};
+    const std::vector<MempoolProbeTx> set{tx("good"), tx("ahead", false, true)};
     const std::vector<nlohmann::json> ans{
-        allowed_true("good"), refused("ahead", "txn-already-known")};
-    const auto s = mempool_validity_sample(60000, set, ans,
-                                           /*dashd_ahead_of_serve_height=*/true);
+        allowed_true("good"), refused("ahead", "missing-inputs")};
+    const auto s = mempool_validity_sample(60000, set, ans);
     EXPECT_TRUE(s.evidence_bearing());
     EXPECT_EQ(s.valid, 1u);
-    EXPECT_EQ(s.confirmed_ahead, 1u);
+    EXPECT_EQ(s.pending_propagation, 1u);
     g.apply(s);
     EXPECT_EQ(g.consecutive_clean, 11u);
 }

--- a/test/test_dash_stratum_work_source.cpp
+++ b/test/test_dash_stratum_work_source.cpp
@@ -2397,12 +2397,16 @@ TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetServesEmbeddedOnConsistentTxDiverg
         << "the referee must have actively served the divergent set as own";
 }
 
-TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetFailClosesWhenValidityGateNotOpen)
+TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetServesEmbeddedWhenValidityGateDemoted)
 {
     uint256 emb_prev; emb_prev.SetHex(kEmbeddedPrevHashHex);
     uint256 funding;  funding.begin()[0] = 0x51;
 
+    // Capture the EMBEDDED template (xcheck OFF): CbTx roots for the dashd
+    // fallback to match on the non-tx axes, and the served tx set (own-set
+    // serving must reproduce it byte-for-byte).
     dash::coin::vendor::CCbTx emb_cb;
+    std::vector<uint256> emb_txids;
     {
         ::core::coin::UTXOViewCache utxo(nullptr);
         auto cs = make_txmerkle_xcheck_cs(utxo, funding);
@@ -2415,11 +2419,16 @@ TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetFailClosesWhenValidityGateNotOpen)
         ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
         ASSERT_TRUE(dash::coin::vendor::parse_cbtx(t->m_coinbase_payload, emb_cb));
         ASSERT_GT(t->m_mempool_tx_count, 0u);
+        emb_txids = t->m_tx_hashes;
     }
+    const uint256 emb_txroot = dash::coin::compute_merkle_root(emb_txids);
 
     std::vector<uint256> dref_txids(1);
     dref_txids[0].SetHex(std::string(64, 'e'));
     const uint256 dref_txroot = dash::coin::compute_merkle_root(dref_txids);
+    ASSERT_NE(emb_txroot, dref_txroot)
+        << "fixture broken: embedded and dashd tx sets must diverge for this"
+           " test to discriminate own-set serving from a dashd swap";
     auto fallback = [&]() -> dash::coin::DashWorkData {
         dash::coin::DashWorkData w;
         w.m_height         = kEmbeddedPrevHeight + 1;
@@ -2447,11 +2456,21 @@ TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetFailClosesWhenValidityGateNotOpen)
     ws.set_gbt_xcheck(true);
     ws.set_tx_serve_own_set(true);
 
-    // Bind a shadow-compare with a testmempoolaccept oracle -> the mempool
-    // validity gate is ARMED but has accrued ZERO clean heights, so open() is
-    // false. The own-set path must therefore fail-close to dashd even though
-    // the embedded template is internally consistent: the runtime guard against
-    // serving a set the validity gate has not yet proven dashd-acceptable.
+    // PR #1325 DEMOTED the dashd testmempoolaccept validity gate OUT of the
+    // own-set serve decision: it is now a pre-cut CONFIDENCE measurement
+    // (logged, never gated), and the fail-close cause
+    // "tx-serve-validity-gate-not-open" was DELETED. Own-set serving is decided
+    // SOLELY by the internal-consistency referee over OUR OWN state (every
+    // served tx fee_fold_proven vs our spent-aware UTXO view, coinbase ==
+    // subsidy + sum(fee) + superblock, no intra-set double-spend) -- the
+    // predicate that survives the --coin-rpc cut, making ZERO dashd calls.
+    //
+    // We bind a shadow-compare whose validity gate is ARMED but has accrued
+    // ZERO clean heights (open()==false) -- the exact scenario that USED to
+    // fail-close to dashd. Under #1325 the internally-consistent embedded
+    // template is SERVED as EMBEDDED regardless: the un-open (demoted) gate can
+    // no longer force a dashd swap. This is the dashd-free serve intent -- the
+    // referee alone decides, and it passes here.
     auto oracle = []() -> std::optional<dash::coin::DashWorkData> { return std::nullopt; };
     auto accept = [](const std::string&) -> nlohmann::json { return nlohmann::json(); };
     auto sc = std::make_shared<dash::coin::EmbeddedShadowCompare>(oracle, accept);
@@ -2460,12 +2479,19 @@ TEST(DashStratumC1MainnetGate, GbtXcheckOwnSetFailClosesWhenValidityGateNotOpen)
     ASSERT_FALSE(ws.get_current_work_template().empty());
     auto t = ws.peek_template();
     ASSERT_TRUE(t && !t->m_coinbase_payload.empty());
-    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), dref_txroot)
-        << "validity gate not open -> must serve dashd's body, not own";
+    // The served body is OUR OWN embedded set, NOT dashd's, despite the un-open
+    // (demoted) validity gate.
+    EXPECT_EQ(dash::coin::compute_merkle_root(t->m_tx_hashes), emb_txroot)
+        << "demoted validity gate must NOT force a dashd swap: serve own set";
+    EXPECT_NE(dash::coin::compute_merkle_root(t->m_tx_hashes), dref_txroot)
+        << "the served set must be embedded, not dashd's fallback body";
     const auto st = ws.embedded_arm_status_json();
-    EXPECT_EQ(st.value("arm", std::string{}), "dashd-fallback");
-    EXPECT_EQ(st.value("no_work_reason", std::string{}), "tx-serve-validity-gate-not-open")
-        << "the fail-close cause must name the un-open validity gate";
+    EXPECT_EQ(st.value("arm", std::string{}), "EMBEDDED")
+        << "referee-pass with a demoted gate leaves the embedded arm serving";
+    EXPECT_EQ(st.value("no_work_reason", std::string{}), "")
+        << "no fail-close: the demoted validity gate records no cause";
+    EXPECT_GE(st.value("tx_serve_own_set_serves", (uint64_t)0), (uint64_t)1)
+        << "the referee must have actively served the divergent set as own";
     ws.set_shadow_compare(nullptr);
 }
 


### PR DESCRIPTION
**Cut-critical.** Makes the embedded serve path self-validate the served tx set from OUR OWN state with ZERO dashd calls — the piece the `--coin-rpc` cut needs. Rebased clean onto master (`6e0318cf8`, post-#1322) as a single delta; supersedes #1324 (which was stacked on #1314's pre-#1322 branch).

Three pieces, all behind `--embedded-tx-serve-own-set` (default OFF = byte-identical):
1. **DEMOTE dashd gate** out of the serve decision — was `tx_serve_own_set_ && gate_proven && referee`, now `tx_serve_own_set_ && referee`. `validity_gate_open()` kept only as a logged pre-cut measurement.
2. **UNCONDITIONAL self-validation referee** on the embedded serve path. Previously the internal-consistency referee ran ONLY inside the `gbt_xcheck_ && dashd_fallback_` divergence branch, so post-cut (rpc==null) an armed template served with zero serve-time self-validation. Now runs on every armed embedded template with tx_count>0, ZERO dashd calls; fail action is dashd-free (refuse → hold-last-good).
3. **PendingPropagation classifier** (successor to #1318): `missing-inputs` under `dashd_ahead_of_serve_height` = Window-1 propagation, resets/advances nothing. Narrowing-strict: same reject WITHOUT the height fact stays Invalid; `bad-txns-inputs-missingorspent` never excused.

**Evidence:** at block 2526495 the two txs the old gate called "missing-inputs" were confirmed IN block 2526495 itself — our selection was correct; dashd's testmempoolaccept mislabeled already-confirmed as missing-inputs.

**Verification (191):** `dash_tx_serve_self_validation_kat` 12/12 PASS; red proven by hand (guarding the classifier branch → incident assertion fails EXIT=1; reverted → 12/12). Referee is a pure function of `DashWorkData` (no RPC in serve or refuse path).

**Residual (documented, not a cut-blocker):** own state does not run `CheckInputScripts`; relies on the sole-ingestion-path (relay-only) invariant — holds for the `--coin-rpc` cut, breaks at T3.1 miner injection (#157).