### PR TITLE
dash(daemonless): canonicalize opkey scheme at every E2d seed ingest so merkleRootMNList reproduces (#154 unseeded anchor)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6597,7 +6597,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                 // ROOT-COMMITTING fields -- SML authoritative.
                                 st.nVersion         = e.nVersion;
                                 st.nType            = e.nType;
-                                st.pubKeyOperator   = e.pubKeyOperator;
+                                // STORE CONTRACT: the DML engine stores the operator
+                                // key in CANONICAL BASIC encoding and re-encodes each
+                                // SML leaf per its own nVersion (to_sml_entry ->
+                                // opkey_for_leaf: legacy iff nVersion < BASIC_BLS).
+                                // The anchor SML carries the key in the scheme the
+                                // entry's nVersion dictates (legacy for the pre-v19
+                                // nVersion=1 entries), so canonicalize on ingest here
+                                // exactly as the fold_proupreg store sites do
+                                // (replay_fold_engine.hpp opkey_to_basic). Storing the
+                                // raw wire bytes lets a legacy-era leaf re-encode from
+                                // the wrong point -> merkleRootMNList diverges and the
+                                // seed self-check below UNSEEDS the engine (the
+                                // observed ff99366e != committed 2315e6df at h=2513000).
+                                st.pubKeyOperator   = dash::coin::vendor::opkey_to_basic(
+                                    e.pubKeyOperator,
+                                    e.nVersion < dash::coin::vendor::ProTxVersion::BASIC_BLS);
                                 st.keyIDVoting      = e.keyIDVoting;
                                 st.netInfo.ip       = e.netAddress;
                                 st.netInfo.port_be  = e.netPort;

--- a/src/impl/dash/coin/replay_prestate.hpp
+++ b/src/impl/dash/coin/replay_prestate.hpp
@@ -262,6 +262,16 @@ inline Prestate parse_prestate_text(const std::string& text)
         if (!d::u160_wire(f[7], st.keyIDOwner))  return fail("bad keyIDOwner" + at);
         if (!u16(8, "nVersion", st.nVersion)) return ps;
         if (!u16(9, "nType", st.nType))       return ps;
+        // STORE CONTRACT: the DML engine stores CANONICAL BASIC operator keys and
+        // re-encodes each SML leaf per its nVersion (to_sml_entry -> opkey_for_leaf).
+        // The prestate field is RAW WIRE bytes, encoded in the scheme the entry's
+        // nVersion dictates (legacy iff nVersion < BASIC_BLS); canonicalize on ingest
+        // here — same conversion the fold_proupreg store sites and the E2d anchor-SML
+        // seed apply — so legacy-era leaves hash the right bytes and the anchor root
+        // reproduces. Without this the seed self-check (seed_engine_from_prestate)
+        // fail-closes (reward-safe) and the engine never arms.
+        st.pubKeyOperator = vendor::opkey_to_basic(
+            st.pubKeyOperator, st.nVersion < vendor::ProTxVersion::BASIC_BLS);
         if (f[10] != "-" && !d::u160_wire(f[10], st.platformNodeID))
             return fail("bad platformNodeID" + at);
         if (!u16(11, "platformP2PPort", st.platformP2PPort))   return ps;

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -182,7 +182,8 @@ static std::vector<std::string> split_ws(const std::string& line)
     return out;
 }
 
-static void parse_prestate_into(const char* text, PrestateFixture& fx)
+static void parse_prestate_into(const char* text, PrestateFixture& fx,
+                                bool canonicalize_opkeys = true)
 {
     std::istringstream is(text);
     std::string line;
@@ -220,6 +221,18 @@ static void parse_prestate_into(const char* text, PrestateFixture& fx)
         st.keyIDOwner         = u160_wire(f[7]);
         st.nVersion           = static_cast<uint16_t>(std::stoul(f[8]));
         st.nType              = static_cast<uint16_t>(std::stoul(f[9]));
+        // The fixture opkey field is RAW WIRE bytes (per-nVersion scheme). The DML
+        // engine's STORE CONTRACT is canonical BASIC (to_sml_entry re-encodes each
+        // leaf per nVersion via opkey_for_leaf), so canonicalize on ingest — exactly
+        // what the production wire-ingest boundaries do (main_dash.cpp anchor-SML
+        // seed, replay_prestate.hpp, fold_proupreg store sites). Seeding raw wire
+        // bytes makes a legacy-era (nVersion=1) leaf hash the wrong point and the
+        // seed self-check fails against the committed merkleRootMNList. The
+        // canonicalize_opkeys=false path exists ONLY to reproduce that failure in a
+        // regression-lock test.
+        if (canonicalize_opkeys)
+            st.pubKeyOperator = dash::coin::vendor::opkey_to_basic(
+                st.pubKeyOperator, st.nVersion < ProTxVersion::BASIC_BLS);
         st.platformNodeID     = (f[10] == "-") ? uint160{} : u160_wire(f[10]);
         st.platformP2PPort    = static_cast<uint16_t>(std::stoul(f[11]));
         st.platformHTTPPort   = static_cast<uint16_t>(std::stoul(f[12]));
@@ -383,6 +396,45 @@ TEST(DashReplayFoldReal, PrestateRootParity2516755)
     auto eng = seed_from_fixture(fx); // asserts root parity inside
     EXPECT_EQ(eng.size(), 2971u);
 }
+
+#ifdef C2POOL_DASH_BLS
+// Regression lock for the #154 seed-side opkey scheme bug (this PR): the DML
+// engine's store contract is CANONICAL BASIC operator keys — to_sml_entry
+// re-encodes each SML leaf per its own nVersion (opkey_for_leaf: legacy iff
+// nVersion < BASIC_BLS). Seeding the RAW WIRE bytes (legacy-encoded for the
+// pre-v19 nVersion=1 entries, 1784 of 2971 at this height) makes those leaves
+// hash the wrong point, so compute_sml_root() DIVERGES from the committed
+// merkleRootMNList. The production wire-ingest boundaries (main_dash.cpp
+// anchor-SML seed, replay_prestate.hpp) canonicalize on ingest — when they do,
+// the root reproduces BY CONSTRUCTION and the anchor seed self-check passes
+// (fail-CLOSED preserved: a seed that cannot reproduce the root unseeds).
+// Guarded on C2POOL_DASH_BLS because opkey_to_basic is an identity no-op
+// without a BLS backend, so raw == canonical and both reproduce the root
+// (this is exactly why the defect was invisible to the BLS-OFF CI jobs).
+TEST(DashReplayFoldReal, SeedRawWireOpkeyDivergesCanonicalReproducesRoot2516755)
+{
+    uint256 anchor;
+    // RAW WIRE seed (canonicalize_opkeys=false) MUST NOT reproduce the root.
+    PrestateFixture raw;
+    parse_prestate_into(kDashReplayPrestate2516755, raw,
+                        /*canonicalize_opkeys=*/false);
+    anchor.SetHex(raw.blockhash_display);
+    FoldConfig cfg;
+    cfg.enabled = true;
+    DmlFoldEngine eng_raw(cfg);
+    eng_raw.seed(raw.entries, raw.entries.size(), raw.height, anchor,
+                 raw.network);
+    EXPECT_NE(eng_raw.compute_sml_root().GetHex(), raw.mnroot_display)
+        << "raw-wire opkey seed unexpectedly reproduced the committed root — "
+           "the store contract or the fixture's legacy-scheme mix changed";
+
+    // CANONICAL seed (the production wire-ingest path) MUST reproduce the root.
+    auto fx = parse_prestate(kDashReplayPrestate2516755);
+    DmlFoldEngine eng_can(cfg);
+    eng_can.seed(fx.entries, fx.entries.size(), fx.height, anchor, fx.network);
+    EXPECT_EQ(eng_can.compute_sml_root().GetHex(), fx.mnroot_display);
+}
+#endif // C2POOL_DASH_BLS
 
 TEST(DashReplayFoldReal, Revive2516756ThenQuietSequence)
 {

--- a/test/test_dash_replay_payee_publish.cpp
+++ b/test/test_dash_replay_payee_publish.cpp
@@ -157,6 +157,17 @@ PpPrestate pp_parse_prestate(const char* text)
         st.keyIDOwner       = pp_u160_wire(f[7]);
         st.nVersion         = static_cast<uint16_t>(std::stoul(f[8]));
         st.nType            = static_cast<uint16_t>(std::stoul(f[9]));
+        // STORE CONTRACT: the DML engine stores canonical BASIC operator keys and
+        // re-encodes each SML leaf per its nVersion (to_sml_entry -> opkey_for_leaf).
+        // The fixture opkey field is RAW WIRE bytes (per-nVersion scheme), so
+        // canonicalize on ingest — exactly what the production wire-ingest boundaries
+        // (main_dash.cpp anchor-SML seed, replay_prestate.hpp) do. Without this a
+        // legacy-era (nVersion=1) leaf hashes the wrong point and the anchor seed
+        // self-check diverges from the committed merkleRootMNList under a real BLS
+        // backend (identity no-op when BLS is OFF).
+        st.pubKeyOperator   = dash::coin::vendor::opkey_to_basic(
+            st.pubKeyOperator,
+            st.nVersion < dash::coin::vendor::ProTxVersion::BASIC_BLS);
         st.platformNodeID   = (f[10] == "-") ? uint160{} : pp_u160_wire(f[10]);
         st.platformP2PPort  = static_cast<uint16_t>(std::stoul(f[11]));
         st.platformHTTPPort = static_cast<uint16_t>(std::stoul(f[12]));


### PR DESCRIPTION
## What this fixes (#154) — engine derivation, NOT a stale checkpoint

The daemonless E2d DML fold engine derives `merkleRootMNList` over the deterministic MN set (the payee/consensus surface). Its **store contract is CANONICAL BASIC operator keys**: `to_sml_entry` re-encodes each SML leaf per its own `nVersion` (`opkey_for_leaf`: legacy iff `nVersion < BASIC_BLS`). The `fold_proupreg` store sites already canonicalize on ingest (`opkey_to_basic`), but the **seed ingest boundaries stored the raw wire operator key verbatim**.

The SML/prestate wire encodes each operator key in the scheme the entry `nVersion` dictates (legacy for the pre-v19 `nVersion=1` entries). Stored raw, a legacy-era leaf re-encodes from the *wrong point* → the seeded set fails its own committed-root self-check → the engine is left **UNSEEDED (fail-closed, reward-safe)** and the daemonless payee axis never populates.

This is exactly the shipped-checkpoint symptom in the field: the compiled anchor at `h=2513000` carries raw dashd-snapshot (legacy) opkeys; under the basic-store leaf convention the full-state anchor-SML seed self-checks to `ff99366e…` instead of the committed `2315e6df…`, so the bridge never arms (`mn_entries=0`).

**Classification: (B) engine-derivation fix. The `.inc` checkpoint is byte-correct and is NOT touched.**

## The fix

Apply `opkey_to_basic(wire, nVersion < BASIC_BLS)` on ingest at every wire boundary that seeds the engine — matching the existing `fold_proupreg` convention and dashd itself (which stores a G1 *point* and serializes per entry `nVersion`):

- `src/c2pool/main_dash.cpp` — the E2d full-state anchor-SML seed lambda (the production daemonless path).
- `src/impl/dash/coin/replay_prestate.hpp` — `parse_prestate_text`, the shared `--replay` anchor parser reused by `seed_engine_from_prestate`, `test_dash_replay_run`, `test_dash_replay_quorum_seam`, and the `getmnlistdiff` seed hatch (`load_and_validate_mnlist_seed`).

Test-fixture ingest boundaries get the same conversion (the fixtures are documented RAW WIRE bytes): `test_dash_replay_fold.cpp` and `test_dash_replay_payee_publish.cpp`.

## Fail-CLOSED preserved

The seed self-check (`compute_sml_root() == committed merkleRootMNList`) is **unchanged**. A seed that cannot reproduce the committed root still unseeds and every caller falls through to the network path — a wrong payee can never be minted. Under `C2POOL_DASH_BLS=OFF` the change is byte-identical: `opkey_to_basic` is an identity no-op without a BLS backend, so the default build is unaffected.

## Byte-parity proof vs the dashd oracle

With the fix the engine reproduces the chain-committed `merkleRootMNList` at every real-mainnet KAT height. Verified vs `getblock` cbTx at the oracle (`192.168.86.165:9998`):

| height | engine `compute_sml_root()` (after fix) | oracle committed | before fix |
|---|---|---|---|
| 2516755 | `3687f8f3…de75360f` | `3687f8f3…de75360f` ✅ | `880ca5c4…` ✗ |

All six `DashReplayFoldReal` KATs + the `DashReplayPayeePublish` real-block projections (2516411 / 2516755 / 2516756 / 2516955 / 2516956) go **red on master (BLS=ON) → green with the fix**.

## Tests

- Fixed the fold/replay + payee-publish KATs to canonicalize at the fixture ingest boundary (they seed RAW WIRE bytes).
- **New regression lock** `DashReplayFoldReal.SeedRawWireOpkeyDivergesCanonicalReproducesRoot2516755`: proves raw-wire seeding **diverges** and canonical seeding **reproduces** the committed root (guarded on `C2POOL_DASH_BLS`; a no-op under BLS-OFF, which is why this class was invisible to the default CI).

Local verification on the real-BLS build (workstation-191, gcc-13):
- `test_dash_mn_state` BLS=ON: **128 passed, 1 env-skipped, 0 failed** (was 6+14 failing on clean master).
- `test_dash_mn_state` BLS=OFF: **127 passed, 1 env-skipped, 0 failed** (unchanged).
- `c2pool-dash` BLS=ON links clean.

## CI follow-up (NOT in this PR — needs a `workflow`-scoped push)

The `linux-dash-bls` job never built `test_dash_mn_state`, so the production-config fold engine had **zero** BLS coverage — exactly how a seed-side scheme regression shipped green. This PR could not carry the workflow edit (OAuth token lacks `workflow` scope). Apply this to `.github/workflows/build.yml`:

```diff
       - name: Build c2pool-dash + BLS KATs
         run: |
           cmake --build build_dash_bls \
             --target c2pool-dash \
                      test_dash_bls_verify test_dash_quorum_members \
                      test_dash_quorum_member_source test_dash_govvote_bls \
                      test_dash_chainlock_verify test_dash_isdlock test_dash_dstx \
+                     test_dash_mn_state \
             -j8
```
```yaml
      # add after "Run BLS KATs":
      - name: Run DASH replay-fold + MN-state KATs under real BLS
        working-directory: build_dash_bls
        run: |
          ./test/test_dash_mn_state --gtest_filter=DashReplayFoldReal.* \
            | tee replay_fold_bls.log
          log="$(cat replay_fold_bls.log)"; missing=0
          for t in \
            DashReplayFoldReal.PrestateRootParity2516755 \
            DashReplayFoldReal.SeedRawWireOpkeyDivergesCanonicalReproducesRoot2516755 \
            DashReplayFoldReal.SnapshotV3RoundTripAndResumeOnRealState
          do case "$log" in *"OK ] $t"*) echo "  ok   $t";; *) echo "  MISS $t"; missing=1;; esac; done
          [ "$missing" -eq 0 ] || { echo "::error::DASH replay-fold KATs did not run under real BLS"; exit 1; }
```

## Merge posture

Consensus path — **do NOT merge** without operator review. No runtime dashd dependency is added; the oracle was used only to generate/verify the byte-match.
