### PR TITLE
dash(daemonless): wall-clock re-ask a frozen ondemand/fold getmnlistd + expand outbound while it stalls

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6340,6 +6340,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     [cp](const uint256& block_hash) {
                         cp->send_getmnlistd_reask(uint256::ZERO, block_hash);
                     });
+                // WALL-CLOCK STALL SIGNAL (dashd TipMayBeStale ->
+                // SetTryNewOutboundPeer). The lane's watchdog tick raises this
+                // while a bridging getmnlistd is frozen unanswered so the pool
+                // expands its dial target past 8 and rotates the silent carrier
+                // — even when the header tip is itself stalled and the
+                // tip-driven re-ask never fires. Reward-safe: dial-count only.
+                mn_ckpt_lane->set_stateful_stall_fn(
+                    [cp](bool stalled) {
+                        cp->note_stateful_stall(stalled);
+                    });
                 // DEMUX (reward-critical): the reply comes back on the SAME
                 // mnlistdiff message the tip sync uses. Routed here it is
                 // consumed as historical and the LIVE tip SML is never

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -409,6 +409,18 @@ public:
     {
         m_reask_snapshot = std::move(fn);
     }
+    /// OPTIONAL. Wall-clock outbound STALL SIGNAL seam (dashd TipMayBeStale ->
+    /// SetTryNewOutboundPeer). watchdog_tick() calls this with TRUE while a
+    /// bridging getmnlistd has been outstanding past kStatefulStallGraceMs and
+    /// FALSE otherwise, so the coin-P2P pool raises its dial target to acquire
+    /// a peer that will answer and rotate off the silent one, then contracts
+    /// once the leg is served. Unwired, the lane behaves exactly as before: no
+    /// expansion signal. Pure connection management — no serve/arm/consensus
+    /// effect, the applied list is untouched.
+    void set_stateful_stall_fn(std::function<void(bool)> fn)
+    {
+        m_stateful_stall_fn = std::move(fn);
+    }
     void set_merkle_root_at_fn(MerkleRootAtFn fn)
     {
         m_merkle_root_at = std::move(fn);
@@ -563,6 +575,48 @@ public:
     void watchdog_tick()
     {
         const int64_t now = m_now();
+
+        // ── WALL-CLOCK STALL SIGNAL + RE-ASK (dashd CheckForStaleTipAnd
+        // EvictPeers parity). Runs on EVERY tick, OUTSIDE the log's due()
+        // cadence and independent of whether set_watchdog() was configured,
+        // because a frozen bridging getmnlistd must be recovered on wall clock:
+        // the tip-driven tick_pending_fold() re-ask never fires while the
+        // header tip is itself stalled, which is exactly the 2026-08-19
+        // single-peer freeze (waiting_for=ondemand-mnlist-reply, 1316 s, ONE
+        // ask to ONE peer, no rotation, pool pinned at 8/8). dashd never
+        // single-peer-wedges: it re-asks mnlistdiff from another peer on
+        // timeout and opens an extra OUTBOUND_FULL_RELAY when it falls behind.
+        //
+        // REWARD-SAFE: this only (a) tells the coin-P2P pool it is "behind" so
+        // it dials MORE and rotates the silent carrier, and (b) re-issues the
+        // SAME getmnlistd to a DIFFERENT peer through the rotate+demote seam. It
+        // never applies a list, never publishes, never changes m_snapshot_hash
+        // (a reply to any re-ask is matched by that unchanged hash and folded
+        // through the identical merkleRoot self-check + payee cross-check), and
+        // it acts only while a leg is genuinely outstanding.
+        // NB: m_snapshot_asked_at is set by begin_fold() (the ONLY site that
+        // sets m_snapshot_pending) at the moment the ask goes out, so
+        // m_snapshot_pending implies it is meaningful — no unset-sentinel guard
+        // (which would collide with a legitimate now==0 on a test clock).
+        const bool stateful_stalled =
+            m_snapshot_pending
+            && (now - m_snapshot_asked_at) >= kStatefulStallGraceMs;
+        if (m_stateful_stall_fn) m_stateful_stall_fn(stateful_stalled);
+        if (stateful_stalled && m_reask_snapshot
+            && now - m_last_wallclock_reask >= kStatefulReaskIntervalMs) {
+            m_last_wallclock_reask = now;
+            ++m_wallclock_reasks;
+            LOG_WARNING << "[MN-CKPT] wall-clock RE-ASK of the "
+                        << (m_ondemand_pending ? "ON-DEMAND " : "")
+                        << "masternode-list request at h=" << m_snapshot_height
+                        << " after " << ((now - m_snapshot_asked_at) / 1000)
+                        << "s of silence — rotating to a fresh peer and"
+                           " striking the silent carrier (dashd wall-clock"
+                           " mnlistdiff re-ask; does NOT wait for a tip"
+                           " change). wall_reasks=" << m_wallclock_reasks;
+            m_reask_snapshot(m_snapshot_hash);
+        }
+
         auto due = m_watchdog.due(now);
         if (!due) return;
         LOG_WARNING << "[LANE-WATCHDOG] lane=mn-ckpt state=" << state_name()
@@ -1384,6 +1438,9 @@ public:
     /// mismatch ever occurred — in which case every other number here is
     /// "never evaluated", NOT "evaluated and zero", and the reports say n/a.
     size_t   ondemand_folds()     const { return m_ondemand_folds; }
+    /// Wall-clock re-asks issued for a frozen bridging getmnlistd (telemetry;
+    /// also the KAT's green signal that the ondemand freeze now recovers).
+    size_t   wallclock_reasks()   const { return m_wallclock_reasks; }
     size_t   ondemand_excluded()  const { return m_ondemand_excluded; }
     /// Masternodes whose queue ORDERING (nPoSeRevivedHeight) an on-demand fold
     /// repaired — a ProUpServTx-revive this bridge applied with the ban
@@ -2797,6 +2854,12 @@ public:
                  << ") — replay PAUSED until it lands, so the cursor cannot"
                     " run past the height the list describes";
         m_request_snapshot(*hash);
+        // Start the wall-clock re-ask clock for this outstanding ask. dashd
+        // re-asks and rotates its sync peer on a wall-clock schedule, not on a
+        // new tip; watchdog_tick() reads these so a frozen leg recovers even
+        // while the header tip is itself stalled (the ondemand-mnlist freeze).
+        m_snapshot_asked_at    = m_now();
+        m_last_wallclock_reask = m_snapshot_asked_at;
         return true;
     }
 
@@ -3043,6 +3106,12 @@ public:
     /// costs the bridge its burst-proof mechanism for that interval.
     static constexpr uint32_t kFoldRetryPumps  = 3;
     static constexpr uint32_t kFoldGiveUpPumps = 12;
+    // dashd EXTRA_PEER_CHECK_INTERVAL (45 s): the WALL-CLOCK cadence on which a
+    // frozen bridging getmnlistd is declared stalled (so the outbound pool
+    // expands) and re-asked to a DIFFERENT peer. Independent of tip changes —
+    // the whole point of the port. watchdog_tick() enforces it.
+    static constexpr int64_t kStatefulStallGraceMs    = 45000;
+    static constexpr int64_t kStatefulReaskIntervalMs = 45000;
 
 private:
     /// Keep claiming a small ring of abandoned request hashes. Bounded: this
@@ -3858,6 +3927,9 @@ public:
         m_snapshot_hash    = uint256();
         m_snapshot_height  = 0;
         m_snapshot_waits   = 0;
+        m_snapshot_asked_at = 0;
+        m_last_wallclock_reask = 0;
+        m_wallclock_reasks = 0;
         m_abandoned_folds  = 0;
         m_abandoned.clear();
         // ── #1033 ON-DEMAND fold state. Every field the on-demand arm carries
@@ -4081,6 +4153,18 @@ public:
     bool      m_revive_probe_cap_hit{false};
     RequestSnapshotFn m_request_snapshot;
     RequestSnapshotFn m_reask_snapshot;   // optional rotate+demote re-ask seam
+    // ── WALL-CLOCK RE-ASK of a frozen fold/ondemand snapshot (dashd
+    // CheckForStaleTipAndEvictPeers parity). The tip-driven tick_pending_fold()
+    // re-ask stalls whenever the header tip stalls — precisely when a bridging
+    // getmnlistd most needs to rotate off a silent carrier (the 2026-08-19
+    // ondemand-mnlist single-peer freeze). watchdog_tick() reads these to
+    // re-ask on WALL CLOCK instead, and to raise the outbound stall signal so
+    // the coin-P2P pool dials past its base target while the leg is frozen.
+    // Peer-selection / dial-count only; the applied list is never touched.
+    int64_t  m_snapshot_asked_at{0};        // m_now() when the outstanding ask went out
+    int64_t  m_last_wallclock_reask{0};     // m_now() of the last wall-clock re-ask
+    size_t   m_wallclock_reasks{0};         // telemetry: wall-clock re-asks issued
+    std::function<void(bool)> m_stateful_stall_fn; // raise/clear outbound-behind
     MerkleRootAtFn    m_merkle_root_at;
     size_t   m_sml_recovery_cap{0}; // budget handed to the machine, mirrored
     size_t   m_registered{0};       // ADDS observed across the replay

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -730,6 +730,15 @@ private:
     // DIFFERENT carrier so it actually fans out.
     std::size_t  m_stateful_rr{0};
     std::string  m_last_stateful_peer;
+    // dashd TipMayBeStale/SetTryNewOutboundPeer analog for the STATEFUL leg: a
+    // bridging getmnlistd (fold / ondemand-mnlist) that the mn-ckpt lane has
+    // found outstanding past its wall-clock re-ask grace. While set,
+    // outbound_behind() is true so effective_max_peers() expands and refill/
+    // rotation dials past the base pool to reach a peer that will answer —
+    // exactly as dashd opens an extra OUTBOUND_FULL_RELAY when it falls behind.
+    // Set/cleared every lane watchdog tick via note_stateful_stall(), so it
+    // self-clears the moment the leg is served. Dial-count only.
+    bool         m_stateful_stall{false};
     // The peer select_block_peer() last sent a block getdata to, so
     // request_block_tracked() arms the watchdog against the peer actually
     // asked (not an unrelated primary).
@@ -1900,6 +1909,14 @@ public:
         send_getmnlistd_rotating(base_block_hash, block_hash);
     }
 
+    /// dashd SetTryNewOutboundPeer for the STATEFUL leg. The mn-ckpt lane's
+    /// wall-clock watchdog calls this TRUE while a bridging getmnlistd has been
+    /// unanswered past its grace and FALSE once it is served, raising/clearing
+    /// the outbound-behind expansion signal so the pool acquires a peer that
+    /// will answer instead of pinning at its base target on a silent carrier.
+    /// Reward-safe: dial-count only, the applied list is untouched.
+    void note_stateful_stall(bool stalled) { m_stateful_stall = stalled; }
+
     /// Send a getqrinfo (DIP-24 quorum-rotation-info request) — the ROTATED
     /// counterpart of send_getmnlistd above. An EMPTY baseBlockHashes asks for
     /// FULL (base=ZERO) mnlistdiffs at every cycle height, which is what the
@@ -2536,9 +2553,14 @@ private:
         return n;
     }
 
-    /// Behind on archival coverage ⇒ a demonstrated non-server occupies a slot.
+    /// Behind on archival coverage ⇒ a demonstrated non-server occupies a slot,
+    /// OR a bridging getmnlistd (fold / ondemand-mnlist) is stalled unanswered
+    /// (dashd opens an extra outbound in BOTH cases). The stall arm is what
+    /// makes a frozen ondemand-mnlist expand the pool without waiting for the
+    /// carrier to accumulate block-body strikes.
     bool outbound_behind() const
-    { return m_outbound_rotate_enabled && pool_demoted_count() > 0; }
+    { return m_outbound_rotate_enabled
+             && (pool_demoted_count() > 0 || m_stateful_stall); }
 
     /// dashd GetExtraFullOutboundCount analog: the dial target, RAISED while we
     /// are behind so refill dials MORE fresh candidates to reach archival

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -1504,6 +1504,61 @@ TEST(DashStatefulFold, fold_getmnlistd_never_wedges_when_only_pruned_peers_exist
                            "archival peer exists (fallback to the handshaked pool)";
 }
 
+// (STATEFUL-STALL B) THE DIRECT EXPANSION SIGNAL (2026-08-19 ondemand freeze).
+// (STATEFUL-STALL A) below demotes the carrier via TWO re-asks landing on the
+// SAME peer — which reaches BULK_NONSERVER_STRIKE_MAX only when the pool has a
+// SINGLE eligible carrier. On the live ondemand-mnlist freeze the re-asks
+// ROTATE across many peers, so no single carrier ever accumulates two strikes
+// and the block-body demotion tally stays EMPTY even after 22 minutes frozen.
+// The mn-ckpt lane's wall-clock watchdog therefore signals the stall DIRECTLY
+// (dashd TipMayBeStale -> SetTryNewOutboundPeer): note_stateful_stall(true)
+// raises outbound_behind() with ZERO demoted peers, so the pool dials past its
+// base target and rotates onto a peer that will answer. It self-clears the
+// moment the leg is served. RED contrast: pre-port, outbound_behind() read
+// ONLY the demotion tally, so a rotation-spread getmnlistd stall was invisible
+// and the pool stayed frozen at 8.
+TEST(DashStatefulFold, a_frozen_bridging_getmnlistd_expands_outbound_directly)
+{
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(8);
+
+    std::vector<NetService> plan;
+    for (int i = 1; i <= 8; ++i) plan.push_back(PoolRig::peer_addr(i));
+    rig.client.connect(plan);
+    for (int i = 1; i <= 8; ++i) rig.handshake_services(i, SVC_FULL);
+    ASSERT_EQ(rig.client.connected_peer_count(), 8u);
+
+    // Fresh archival candidates the frozen set never reached.
+    rig.client.update_dial_targets({PoolRig::peer_addr(9), PoolRig::peer_addr(10)});
+
+    // Healthy AND with NO demoted peer: (STATEFUL-STALL A)'s demotion path
+    // cannot be what expands here — the tally is empty.
+    EXPECT_FALSE(rig.client.outbound_behind_for_test());
+    EXPECT_EQ(rig.client.effective_max_peers_for_test(), 8u);
+
+    // The lane's wall-clock watchdog found a bridging getmnlistd frozen and
+    // raised the direct stall signal. Expansion engages with ZERO strikes.
+    rig.client.note_stateful_stall(true);
+    EXPECT_TRUE(rig.client.outbound_behind_for_test())
+        << "a frozen ondemand-mnlist must expand the pool WITHOUT waiting for a "
+           "carrier to accumulate block-body strikes";
+    EXPECT_EQ(rig.client.effective_max_peers_for_test(), 10u)
+        << "a frozen stateful leg must raise the dial target directly";
+
+    // A pool tick dials the extra fresh archival outbound (dashd extra outbound).
+    rig.run_seconds(1);
+    EXPECT_GE(rig.client.dialing_count(), 1u)
+        << "behind on a frozen stateful leg, the pool must acquire a fresh peer";
+
+    // The (rotated) peer answers => the lane clears the signal => the pool
+    // contracts back to its base target (dashd stops opening extras on recovery).
+    rig.client.note_stateful_stall(false);
+    EXPECT_FALSE(rig.client.outbound_behind_for_test());
+    EXPECT_EQ(rig.client.effective_max_peers_for_test(), 8u)
+        << "once the leg is served the expansion signal must drop, not latch";
+}
+
 // (STATEFUL-STALL A) THE EXPANSION HALF, DRIVEN BY A STATEFUL STALL.
 // The live A/B (wf w8cr3yepg) proved the acquisition ROTATION fired but the
 // effective_max_peers EXPANSION never engaged: the near-tip window was

--- a/test/test_dash_lane_diag.cpp
+++ b/test/test_dash_lane_diag.cpp
@@ -309,6 +309,114 @@ TEST(DashLaneDiag, WatchdogStaysSilentOnAnUnstartedLane)
     EXPECT_EQ(rig.lane.cursor_height(), kDiagAnchorHeight);
 }
 
+// ═══════════════════════════════════════════════════════════════════════════
+// 3b. THE ONDEMAND-MNLIST FREEZE KAT (2026-08-19). A bridging getmnlistd that
+//     goes unanswered must RE-ASK A DIFFERENT PEER and raise the outbound
+//     stall signal on WALL CLOCK — WITHOUT waiting for a tip change. dashd
+//     re-asks mnlistdiff from another peer on timeout and opens an extra
+//     outbound when behind; our tip-driven tick_pending_fold() re-ask cannot,
+//     because a 1.38M-block-behind fold sees no new tip while it is frozen
+//     (live: waiting_for=ondemand-mnlist-reply, 1316 s, ONE ask, ONE peer,
+//     pool pinned at 8/8).
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+/// WatchdogRig plus the rotate+demote RE-ASK seam and the outbound STALL
+/// SIGNAL seam the fix drives from wall clock.
+struct OndemandReaskRig
+{
+    MnCheckpointLane lane;
+    std::map<uint32_t, uint256> headers;
+    uint32_t tip{0};
+    int64_t  now{0};
+    int first_asks{0};
+    int reasks{0};
+    bool last_stall{false};
+
+    OndemandReaskRig()
+    {
+        lane.set_clock_fn([this] { return now; });
+        lane.set_tip_height_fn([this] { return tip; });
+        lane.set_header_hash_at_fn(
+            [this](uint32_t h) -> std::optional<uint256> {
+                auto it = headers.find(h);
+                if (it == headers.end()) return std::nullopt;
+                return it->second;
+            });
+        lane.set_publish_fn(
+            [](std::vector<std::pair<uint256, MNState>>, uint32_t) {});
+        lane.set_request_block_fn([](uint32_t) { return true; });
+        lane.set_request_snapshot_fn([this](const uint256&) { ++first_asks; });
+        // Production wires this to send_getmnlistd_reask (strike the silent
+        // carrier + rotate to a fresh eligible peer). Here we observe only that
+        // the lane DROVE it — the peer rotation itself is proven in
+        // test_dash_coin_p2p_pool.cpp.
+        lane.set_reask_snapshot_fn([this](const uint256&) { ++reasks; });
+        // The outbound expansion signal (dashd SetTryNewOutboundPeer).
+        lane.set_stateful_stall_fn([this](bool s) { last_stall = s; });
+        lane.set_merkle_root_at_fn(
+            [](const uint256&) -> std::optional<uint256> { return std::nullopt; });
+    }
+};
+
+} // namespace
+
+TEST(DashLaneDiag, FrozenOndemandMnlistReasksAnotherPeerAndExpandsOnWallClock)
+{
+    OndemandReaskRig rig;
+    auto cp = diag_checkpoint();
+    rig.headers[kDiagAnchorHeight] = cp.blockhash;
+    rig.tip = kDiagAnchorHeight + 50;
+    rig.lane.arm(cp);
+
+    // Nothing outstanding yet: a wall-clock tick, even far past the grace, must
+    // NOT declare the pool behind. The stall signal is CONDITIONAL, not latched.
+    rig.now = MnCheckpointLane::kStatefulStallGraceMs * 10;
+    rig.lane.watchdog_tick();
+    EXPECT_FALSE(rig.last_stall);
+    rig.now = 0;
+
+    // Park on the anchor fold: ONE getmnlistd out, replay PAUSED — the exact
+    // shape the live freeze was stuck in.
+    rig.lane.pump();
+    ASSERT_TRUE(rig.lane.snapshot_pending());
+    ASSERT_EQ(rig.first_asks, 1);
+    ASSERT_EQ(rig.reasks, 0);
+
+    // THE FREEZE: the header tip never advances (a fold 1.38M blocks behind
+    // sees no new tip), so pump() is NEVER CALLED again — pump() is driven by
+    // HeaderChain::on_tip_changed, and there is no tip change while the leg is
+    // frozen. tick_pending_fold() therefore never runs, so its own tip-counted
+    // re-ask (kFoldRetryPumps) and give-up (kFoldGiveUpPumps) cannot fire. This
+    // is the exact live shape: ONE ask, ONE peer, no rotation, forever. Only
+    // the wall clock moves from here — nothing calls pump().
+    ASSERT_EQ(rig.reasks, 0);
+
+    // Below the grace: not yet stalled.
+    rig.now = MnCheckpointLane::kStatefulStallGraceMs - 1;
+    rig.lane.watchdog_tick();
+    EXPECT_FALSE(rig.last_stall);
+    EXPECT_EQ(rig.reasks, 0);
+
+    // Past the grace: THE FIX. Wall clock alone re-asks a fresh peer AND raises
+    // the outbound-behind stall signal — no tip change involved.
+    rig.now = MnCheckpointLane::kStatefulStallGraceMs;
+    rig.lane.watchdog_tick();
+    EXPECT_TRUE(rig.last_stall)
+        << "a frozen ondemand-mnlist must signal BEHIND so the pool dials past 8";
+    EXPECT_EQ(rig.reasks, 1)
+        << "a frozen ondemand-mnlist must re-ask on wall clock, not on a tip";
+    EXPECT_EQ(rig.lane.wallclock_reasks(), 1u);
+
+    // Still frozen one interval later: it keeps rotating (dashd re-asks another
+    // peer each cycle), not one-shot.
+    rig.now += MnCheckpointLane::kStatefulReaskIntervalMs;
+    rig.lane.watchdog_tick();
+    EXPECT_EQ(rig.reasks, 2);
+    EXPECT_TRUE(rig.last_stall);
+}
+
 TEST(DashLaneDiag, ColdStartIsTheDefaultAndIsStated)
 {
     WatchdogRig rig;


### PR DESCRIPTION
## What

Ports the one canary-lineage operational commit (`bd74154cc`) that keeps a **bridging `getmnlistd` (fold snapshot / on-demand PoSe fold)** from wedging a single silent peer. Availability-only — **no derivation/root/payee logic changes**.

Today the *only* re-ask path (`tick_pending_fold`, `kFoldRetryPumps`) is counted in `pump()` drives, and `pump()` is driven by `HeaderChain::on_tip_changed`. A fold running far behind the tip sees a new tip only every few minutes, so every frozen/stalled `getmnlistd` reply on a slow WAN path costs minutes and the pool stays pinned at 8/8 on the silent carrier. On hotel-primary this collapsed the E2d fresh-anchor fold from ~28 blk/s to **~0.3 blk/s (eta 3h12m)** even though correctness held (applied=785 payee_ok=785 **diverged=0**).

dashd never single-peer-wedges: `CheckForStaleTipAndEvictPeers` runs on a **45s wall-clock** schedule (`EXTRA_PEER_CHECK_INTERVAL`), opens an extra `OUTBOUND_FULL_RELAY` when behind (`SetTryNewOutboundPeer` / `GetExtraFullOutboundCount`), and rotates the stalest peer (`EvictExtraOutboundPeers`) — all independent of any new tip. This port copies those conditions and constants.

## Exact hunks ported (5 files, +281/-2, straight cherry-pick — applied clean, zero conflicts)

- **`src/impl/dash/coin/mn_checkpoint_lane.hpp`**
  - `set_stateful_stall_fn(std::function<void(bool)>)` seam
  - `watchdog_tick()` (already a 30s wall-clock timer): computes `stateful_stalled = m_snapshot_pending && (now - m_snapshot_asked_at) >= 45s` on **every** tick, publishes it via `m_stateful_stall_fn(bool)`, and (>=45s since last) re-asks via the **existing** `m_reask_snapshot(m_snapshot_hash)` rotate+demote seam — `m_snapshot_hash` **unchanged**
  - `m_snapshot_asked_at` / `m_last_wallclock_reask` stamped at the single `m_request_snapshot(*hash)` ask site in `begin_fold`
  - constants `kStatefulStallGraceMs=45000` / `kStatefulReaskIntervalMs=45000`; `wallclock_reasks()` telemetry; field resets
- **`src/impl/dash/coin/p2p_client.hpp`**
  - `bool m_stateful_stall` + `note_stateful_stall(bool)`
  - `outbound_behind()` → `m_outbound_rotate_enabled && (pool_demoted_count() > 0 || m_stateful_stall)` — raises `effective_max_peers()` (dial past base pool 8→10) and drives rotation; self-clears next tick once served
- **`src/c2pool/main_dash.cpp`** — one 10-line wiring block after the existing `set_reask_snapshot_fn` wiring: `mn_ckpt_lane->set_stateful_stall_fn([cp](bool s){ cp->note_stateful_stall(s); })`
- **`test/test_dash_lane_diag.cpp`** + **`test/test_dash_coin_p2p_pool.cpp`** — the two KATs (red on base, green here)

## Reward-safety

Re-ask **timing** (45s wall-clock, tip-independent) and peer **selection / dial-count** only. `m_snapshot_hash` is never changed, so any re-ask reply is matched by the unchanged hash and folded through the **identical** `merkleRoot` self-check + payee cross-check + DIP-4 verification + poison fail-closed. The applied mnlistdiff, the served template and the MN-list derivation are byte-identical. PORT class, non-consensus, non-reward.

## Proof

**KATs (BLS=ON build):** both green with the port —
- `DashLaneDiag.FrozenOndemandMnlistReasksAnotherPeerAndExpandsOnWallClock` — parked fold, no tip change: `wall_reasks=1`, `wall_reasks=2` fire on the wall-clock watchdog alone and keep rotating each interval.
- `DashStatefulFold.a_frozen_bridging_getmnlistd_expands_outbound_directly` — stall signal expands the pool from 8 to dialing 9/10 with ZERO demoted peers, contracts when served.

**Live cold daemonless fold (workstation-191, BLS=REAL):** fresh cold data-dir, `--embedded-no-dashd-mn-seed` + observe-only `--coin-rpc` (oracle-shadow) + `--coin-p2p-connect 192.168.86.165:9999`, no dashd MN seed.
- Anchor h=2522504 → live tip h=2526789, **replayed 4285 blocks in ~25s**, sustained **250–626 blk/s** (avg ~170 blk/s) — vs the 0.3 blk/s / 3h WAN-stall baseline.
- `applied=4285 payee_ok=4285 **diverged=0**`
- `bridge COMPLETE: published 2985 masternodes as-of h=2526789`
- `[EMBED-STATUS] arm=would-serve … populated=1 have_tip=1 have_mn=1 mn_source=mn-ckpt **mn_daemonless=1** mn_entries=2985 payee_cursor=2526789/2526789 sml=ok bridge=published`
- `wall-clock RE-ASK` fired **0** times on the fast LAN peer — the new path stays dormant when nothing stalls (no extra traffic, no regression when healthy). The stall-recovery mechanism itself is exercised by the two KATs; the residual live proof of WAN-stall recovery is the hotel fold-rate measurement.

## Stacking

Branch is cut off `dash/e2d-fresh-anchor-2522504-opkey` (43faf85), which is `origin/master` + **#1328** (fresh h=2522504 anchor + E2d opkey fix). This PR therefore **includes / stacks on #1328** — the diff shows both commits. Land after #1328, or rebase onto master once #1328 merges. Only the top commit (`1a7b4455b`) is this port.

**Do not merge — operator-gated.**
