### PR TITLE
dash(daemonless): PR-0 coin-P2P arrival instrumentation (off-embedded arrival/fold split + per-peer delivery-latency EWMA)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -422,6 +422,16 @@ target_link_libraries(coin_peer_rearm_kat c2pool_payout c2pool_merged_mining c2p
 target_link_libraries(coin_peer_rearm_kat nlohmann_json::nlohmann_json)
 add_test(NAME coin_peer_rearm_kat COMMAND coin_peer_rearm_kat)
 
+# ── KAT: PR-0 ARRIVAL INSTRUMENTATION schema (dashd-cut coin-P2P foundation) ──
+# Locks the OffEmbeddedWindow arrival/fold split invariant
+# (arrival_ms + fold_ms == window_ms) and the per-peer per-datum-class
+# DeliveryLatencyEwma update. arrival_timing.hpp is pure policy (header-only, no
+# node, no daemon, standard library only), so this target links NOTHING and
+# still exercises the schema the stacked coin-P2P PRs consume. Built under
+# -DC2POOL_DASH_BLS=ON like the rest of the dash suite; it carries no BLS symbols.
+add_executable(dash_arrival_instrumentation_kat dash_arrival_instrumentation_kat.cpp)
+add_test(NAME dash_arrival_instrumentation_kat COMMAND dash_arrival_instrumentation_kat)
+
 # Legacy applications have been archived to ../../archive/
 # - c2pool_legacy.cpp (original c2pool.cpp)
 # - c2pool_node_legacy.cpp (original c2pool_node.cpp)

--- a/src/c2pool/dash_arrival_instrumentation_kat.cpp
+++ b/src/c2pool/dash_arrival_instrumentation_kat.cpp
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// KAT: PR-0 ARRIVAL INSTRUMENTATION schema (dashd-cut coin-P2P foundation).
+//
+// Locks the two invariants the stacked coin-P2P PRs consume:
+//   (1) OffEmbeddedWindow's arrival/fold split partitions the window exactly:
+//         arrival_ms + fold_ms == window_ms       on every complete window,
+//       across synthetic windows with KNOWN t_open/t_data_arrived/
+//       t_fold_complete/t_resumed, including the boundary cases (zero-wire,
+//       zero-fold, single-instant window) and the order/duplicate guards.
+//   (2) DeliveryLatencyEwma's per-peer per-datum-class update follows the exact
+//       RTT-style sequence ewma += (sample - ewma)/8, seeded on the first
+//       sample, ignoring negative (unmatched) samples.
+//
+// Pure red/green over ONE header-only unit, NO node and NO daemon. Header-only
+// so it builds under -DC2POOL_DASH_BLS=ON without the c2pool-dash object graph.
+
+#include <impl/dash/coin/arrival_timing.hpp>
+
+#include <cstdio>
+#include <string>
+
+using dash::coin::DatumClass;
+using dash::coin::DeliveryLatencyEwma;
+using dash::coin::OffEmbeddedWindow;
+using dash::coin::PeerDeliveryLatency;
+
+static int g_fail = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_fail; } } while (0)
+
+// Build a complete window from four absolute monotonic-ms marks and assert the
+// split math holds and matches the expected component spans.
+static void check_window(int64_t open, int64_t arrived, int64_t fold_done,
+                         int64_t resumed,
+                         int64_t exp_arrival, int64_t exp_fold,
+                         int64_t exp_window)
+{
+    OffEmbeddedWindow w;
+    w.open(open);
+    CHECK(w.open_pending());
+    CHECK(!w.complete());
+    w.data_arrived(arrived);
+    w.fold_complete(fold_done);
+    w.resumed(resumed);
+
+    CHECK(w.complete());
+    CHECK(!w.open_pending());
+    CHECK(w.arrival_ms() == exp_arrival);
+    CHECK(w.fold_ms()    == exp_fold);
+    CHECK(w.window_ms()  == exp_window);
+    CHECK(w.derive_ms()  == fold_done - arrived);
+    // THE core invariant the emit and the stacked PRs rely on:
+    CHECK(w.arrival_ms() + w.fold_ms() == w.window_ms());
+    CHECK(w.split_consistent());
+}
+
+int main()
+{
+    // ── (1) WINDOW SPLIT MATH ────────────────────────────────────────────────
+    // Ordinary window: 40 ms on the wire, 60 ms folding, 100 ms total.
+    check_window(/*open*/1000, /*arrived*/1040, /*fold_done*/1075,
+                 /*resumed*/1100, /*arrival*/40, /*fold*/60, /*window*/100);
+    // Zero-wire (datum already in hand at open): all time is fold.
+    check_window(2000, 2000, 2010, 2050, 0, 50, 50);
+    // Zero-fold (resumed the instant the datum arrived): all time is arrival.
+    check_window(3000, 3080, 3080, 3080, 80, 0, 80);
+    // Single-instant window (everything at once): both spans zero, sum zero.
+    check_window(4000, 4000, 4000, 4000, 0, 0, 0);
+    // Large window that survives the sub-second tip round trip proportions
+    // measured on the hotel (issue #1154): 54 ms wire, rest fold.
+    check_window(5000, 5054, 5100, 5891, 54, 837, 891);
+
+    // ── ORDER / DUPLICATE GUARDS ─────────────────────────────────────────────
+    // A fresh open() resets a half-filled window (no stale boundary survives).
+    {
+        OffEmbeddedWindow w;
+        w.open(100); w.data_arrived(150);
+        w.open(200);                       // abandon + restart
+        CHECK(w.t_data_arrived == -1);
+        CHECK(w.arrival_ms() == -1);
+        CHECK(!w.complete());
+        w.data_arrived(260); w.resumed(300);
+        CHECK(w.arrival_ms() == 60);
+        CHECK(w.fold_ms()    == 40);
+        CHECK(w.arrival_ms() + w.fold_ms() == w.window_ms());
+    }
+    // data_arrived before open() is ignored; a duplicate reply cannot rewrite
+    // the banked arrival boundary; a duplicate resume cannot rewrite t_resumed.
+    {
+        OffEmbeddedWindow w;
+        w.data_arrived(50);                // no open yet -> ignored
+        CHECK(w.t_data_arrived == -1);
+        w.open(100);
+        w.data_arrived(140);
+        w.data_arrived(999);               // duplicate -> ignored (first wins)
+        CHECK(w.t_data_arrived == 140);
+        w.resumed(200);
+        w.resumed(777);                    // duplicate -> ignored (first wins)
+        CHECK(w.t_resumed == 200);
+        CHECK(w.arrival_ms() == 40);
+        CHECK(w.fold_ms()    == 60);
+    }
+    // An incomplete window reports -1 spans and is NOT split_consistent.
+    {
+        OffEmbeddedWindow w;
+        w.open(0); w.data_arrived(10);     // never resumed
+        CHECK(w.fold_ms() == -1);
+        CHECK(w.window_ms() == -1);
+        CHECK(!w.split_consistent());
+    }
+
+    // ── (2) PER-PEER PER-DATUM-CLASS DELIVERY-LATENCY EWMA ───────────────────
+    // Exact RTT-style sequence: seed, then ewma += (sample - ewma)/8.
+    {
+        DeliveryLatencyEwma e;
+        CHECK(!e.has_sample());
+        CHECK(e.ewma_ms() == -1);
+        e.observe(100);                    // seed
+        CHECK(e.has_sample());
+        CHECK(e.samples() == 1);
+        CHECK(e.ewma_ms() == 100);
+        CHECK(e.last_ms() == 100);
+        e.observe(180);                    // 100 + (180-100)/8 = 100 + 10 = 110
+        CHECK(e.ewma_ms() == 110);
+        CHECK(e.last_ms() == 180);
+        e.observe(180);                    // 110 + (180-110)/8 = 110 + 8 = 118
+        CHECK(e.ewma_ms() == 118);
+        e.observe(-5);                     // negative -> ignored entirely
+        CHECK(e.ewma_ms() == 118);
+        CHECK(e.samples() == 3);
+        e.observe(10);                     // 118 + (10-118)/8 = 118 + (-13) = 105
+        CHECK(e.ewma_ms() == 105);         // trunc-toward-zero: -108/8 = -13
+        CHECK(e.samples() == 4);
+    }
+    // A single fast sample seeds exactly; the EWMA never lags its only datum.
+    {
+        DeliveryLatencyEwma e;
+        e.observe(7);
+        CHECK(e.ewma_ms() == 7);
+    }
+
+    // ── PER-PEER HOLDER: the three classes are INDEPENDENT ───────────────────
+    {
+        PeerDeliveryLatency peer;
+        CHECK(!peer.has_any());
+        peer.observe(DatumClass::MnListDiff, 200);
+        peer.observe(DatumClass::MnListDiff, 200);   // 200 seed, stays 200
+        peer.observe(DatumClass::TipBody,    40);
+        peer.observe(DatumClass::QrInfo,     1000);
+        CHECK(peer.has_any());
+        CHECK(peer.ewma_ms(DatumClass::MnListDiff) == 200);
+        CHECK(peer.ewma_ms(DatumClass::TipBody)    == 40);
+        CHECK(peer.ewma_ms(DatumClass::QrInfo)     == 1000);
+        // A slow mnlistdiff does NOT move the tip_body average (independence).
+        peer.observe(DatumClass::MnListDiff, 360);   // 200 + (360-200)/8 = 220
+        CHECK(peer.ewma_ms(DatumClass::MnListDiff) == 220);
+        CHECK(peer.ewma_ms(DatumClass::TipBody)    == 40);
+        CHECK(peer.get(DatumClass::QrInfo).samples() == 1);
+    }
+
+    // Datum-class names are stable (the emit + grep contract).
+    CHECK(std::string(dash::coin::datum_class_name(DatumClass::TipBody))    == "tip_body");
+    CHECK(std::string(dash::coin::datum_class_name(DatumClass::MnListDiff)) == "mnlistdiff");
+    CHECK(std::string(dash::coin::datum_class_name(DatumClass::QrInfo))     == "qrinfo");
+
+    // Default-OFF emit flag (byte-identical-to-master guarantee).
+    CHECK(dash::coin::arrival_instr_enabled() == false);
+    dash::coin::set_arrival_instr_enabled(true);
+    CHECK(dash::coin::arrival_instr_enabled() == true);
+    dash::coin::set_arrival_instr_enabled(false);
+    CHECK(dash::coin::arrival_instr_enabled() == false);
+
+    if (g_fail == 0) { std::printf("dash_arrival_instrumentation_kat PASS\n"); return 0; }
+    std::printf("dash_arrival_instrumentation_kat FAIL (%d)\n", g_fail);
+    return 1;
+}

--- a/src/impl/dash/coin/arrival_timing.hpp
+++ b/src/impl/dash/coin/arrival_timing.hpp
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// PR-0 ARRIVAL INSTRUMENTATION (dashd-cut coin-P2P foundation, task #154 line).
+///
+/// This header is the SCHEMA the coin-P2P racing/selection PRs (PR-1..PR-4)
+/// build on. It is pure policy: NO I/O, NO clock of its own (every caller
+/// passes monotonic milliseconds), NO coin state, header-only so it folds into
+/// the allowlisted dash test targets exactly like serve_gate_journal.hpp.
+///
+/// It answers two questions that the existing serve-gate journal cannot,
+/// because the journal times in WHOLE SECONDS on the serve path and cannot see
+/// WHY a window was long:
+///
+///   (1) When the embedded arm falls off its template into an off-embedded
+///       window (a fold / re-seed round trip), how much of that window was
+///       spent WAITING FOR THE DATUM ON THE WIRE (arrival) versus DERIVING it
+///       once it arrived (fold)?  A 4-second window that was 3.9 s of network
+///       silence and 0.1 s of fold is a peer-selection problem; the same 4 s
+///       that was 0.1 s wire and 3.9 s fold is a derivation problem. The
+///       count- and second-only journal reads them identically — the same
+///       class of trap the #119 per-cause-TIME work already fought.
+///
+///       OffEmbeddedWindow stamps the four boundary timestamps
+///       t_open / t_data_arrived / t_fold_complete / t_resumed and partitions
+///       the window into EXACTLY two spans that sum to the whole:
+///           arrival_ms = t_data_arrived - t_open      (wire wait)
+///           fold_ms    = t_resumed      - t_data_arrived (derive + resume)
+///       so arrival_ms + fold_ms == window_ms by construction. t_fold_complete
+///       is an intermediate marker WITHIN fold_ms (derivation done, before the
+///       serve path resumed) carried for the finer 3-way view; it never breaks
+///       the 2-way invariant.
+///
+///   (2) Per PEER and per DATUM CLASS (tip body / mnlistdiff / qrinfo), what is
+///       the delivery latency between the request we sent and the reply we got,
+///       smoothed so one slow round trip does not dominate?  DeliveryLatencyEwma
+///       is a classic RTT-style exponential moving average (alpha = 1/8), the
+///       measurement a later PR's peer scorer would consult to prefer the
+///       carrier that actually answers fastest.
+///
+/// REWARD SAFETY. Nothing here selects a peer, fetches, or derives anything. It
+/// records timestamps and computes moving averages. The emit of these fields on
+/// the live log is gated behind a default-OFF flag (arrival_instr_enabled()) so
+/// an unflagged binary is byte-identical to master. Worst case with the flag ON
+/// is extra log fields; the values never gate a decision in this PR.
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace dash {
+namespace coin {
+
+// ─── Datum classes whose per-peer delivery latency the coin-P2P lane measures ─
+// Ordinals are STABLE (they index PeerDeliveryLatency::by_class); append only.
+enum class DatumClass : uint8_t {
+    TipBody    = 0,   // block body fetched by getdata (the live-tip serve input)
+    MnListDiff = 1,   // getmnlistd -> mnlistdiff (the fold snapshot)
+    QrInfo     = 2,   // getqrinfo -> qrinfo (rotated-quorum bootstrap)
+    Count      = 3
+};
+
+inline const char* datum_class_name(DatumClass c) {
+    switch (c) {
+        case DatumClass::TipBody:    return "tip_body";
+        case DatumClass::MnListDiff: return "mnlistdiff";
+        case DatumClass::QrInfo:     return "qrinfo";
+        default:                     return "?";
+    }
+}
+
+// ─── The default-OFF instrumentation emit flag ───────────────────────────────
+// Gates ONLY the NEW log fields these instruments feed. OFF => byte-identical
+// to master. Recording (the timestamp/EWMA member writes) is invisible and
+// always runs; only the emit is flagged. A process-wide relaxed atomic — set
+// once at startup from a CLI flag, read on the serve/dispatch threads.
+inline std::atomic<bool>& arrival_instr_flag() {
+    static std::atomic<bool> g{false};
+    return g;
+}
+inline bool arrival_instr_enabled() {
+    return arrival_instr_flag().load(std::memory_order_relaxed);
+}
+inline void set_arrival_instr_enabled(bool on) {
+    arrival_instr_flag().store(on, std::memory_order_relaxed);
+}
+
+// ─── One off-embedded window's four boundary timestamps + the arrival/fold split
+// All times are monotonic milliseconds supplied by the caller. -1 = unstamped.
+struct OffEmbeddedWindow {
+    int64_t t_open{-1};          // arm fell off the embedded template / ask sent
+    int64_t t_data_arrived{-1};  // the datum (reply) arrived on the wire
+    int64_t t_fold_complete{-1}; // derivation from the datum finished
+    int64_t t_resumed{-1};       // the arm resumed serving the embedded template
+
+    void reset() { t_open = t_data_arrived = t_fold_complete = t_resumed = -1; }
+
+    // Idempotent-ish stampers: open() starts a fresh window; the later marks
+    // record the FIRST time they are reached within the window and are ignored
+    // out of order, so a duplicate reply or a spurious resume cannot rewrite a
+    // boundary already banked.
+    void open(int64_t now)          { reset(); t_open = now; }
+    void data_arrived(int64_t now)  { if (t_open >= 0 && t_data_arrived < 0)  t_data_arrived  = now; }
+    void fold_complete(int64_t now) { if (t_data_arrived >= 0 && t_fold_complete < 0) t_fold_complete = now; }
+    void resumed(int64_t now)       { if (t_open >= 0 && t_resumed < 0)       t_resumed       = now; }
+
+    bool open_pending() const { return t_open >= 0 && t_resumed < 0; }
+    bool complete()     const { return t_open >= 0 && t_data_arrived >= 0 && t_resumed >= 0; }
+
+    // Wire-wait span: open -> data arrived. -1 until the datum has arrived.
+    int64_t arrival_ms() const {
+        return (t_open >= 0 && t_data_arrived >= 0) ? t_data_arrived - t_open : -1;
+    }
+    // Derive+resume span: data arrived -> resumed. -1 until resumed.
+    int64_t fold_ms() const {
+        return (t_data_arrived >= 0 && t_resumed >= 0) ? t_resumed - t_data_arrived : -1;
+    }
+    // Derivation sub-span WITHIN fold_ms: data arrived -> fold complete.
+    int64_t derive_ms() const {
+        return (t_data_arrived >= 0 && t_fold_complete >= 0) ? t_fold_complete - t_data_arrived : -1;
+    }
+    // Full window: open -> resumed. -1 until resumed.
+    int64_t window_ms() const {
+        return (t_open >= 0 && t_resumed >= 0) ? t_resumed - t_open : -1;
+    }
+    // The invariant the KAT locks and the emit relies on: on a complete window
+    // the two spans partition the whole with no gap and no overlap.
+    bool split_consistent() const {
+        return complete() && (arrival_ms() + fold_ms() == window_ms());
+    }
+};
+
+// ─── Per-peer, per-datum-class delivery-latency EWMA ─────────────────────────
+// Classic RTT smoother: seed on the first sample, then
+//     ewma <- ewma + (sample - ewma) / kInvAlpha      (alpha = 1/kInvAlpha)
+// Integer division truncates toward zero (deterministic; the KAT asserts the
+// exact sequence). Negative samples (an unmatched reply / missing request
+// stamp) are ignored so a bogus latency never poisons the average.
+class DeliveryLatencyEwma {
+public:
+    static constexpr int64_t kInvAlpha = 8;  // alpha = 1/8
+
+    void observe(int64_t sample_ms) {
+        if (sample_ms < 0) return;
+        m_last_ms = sample_ms;
+        ++m_samples;
+        if (m_ewma_ms < 0) { m_ewma_ms = sample_ms; return; }  // seed exactly
+        m_ewma_ms += (sample_ms - m_ewma_ms) / kInvAlpha;
+    }
+
+    int64_t  ewma_ms()   const { return m_ewma_ms; }  // -1 before any sample
+    int64_t  last_ms()   const { return m_last_ms; }  // -1 before any sample
+    uint64_t samples()   const { return m_samples; }
+    bool     has_sample() const { return m_samples > 0; }
+
+private:
+    int64_t  m_ewma_ms{-1};
+    int64_t  m_last_ms{-1};
+    uint64_t m_samples{0};
+};
+
+// A peer holds one EWMA per datum class. Embedded in the peer/session object;
+// pure recording, zero behaviour.
+struct PeerDeliveryLatency {
+    std::array<DeliveryLatencyEwma, static_cast<size_t>(DatumClass::Count)> by_class{};
+
+    void observe(DatumClass c, int64_t sample_ms) {
+        const size_t i = static_cast<size_t>(c);
+        if (i < by_class.size()) by_class[i].observe(sample_ms);
+    }
+    const DeliveryLatencyEwma& get(DatumClass c) const {
+        return by_class[static_cast<size_t>(c)];
+    }
+    int64_t ewma_ms(DatumClass c) const { return get(c).ewma_ms(); }
+    int64_t last_ms(DatumClass c) const { return get(c).last_ms(); }
+    bool    has_any() const {
+        for (const auto& e : by_class) if (e.has_sample()) return true;
+        return false;
+    }
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/coin_peer_manager.hpp
+++ b/src/impl/dash/coin/coin_peer_manager.hpp
@@ -59,6 +59,7 @@
 #include <core/netaddress.hpp>
 #include <core/dns_seeder.hpp>
 #include <core/coin_addrman.hpp>
+#include <impl/dash/coin/arrival_timing.hpp>   // PR-0: per-peer per-datum-class delivery-latency EWMA (instrumentation only)
 
 namespace dash {
 namespace coin {
@@ -123,6 +124,20 @@ struct DashPeerInfo
     int                 broadcast_failures{0};
     int                 connection_successes{0};
     int                 blocks_relayed{0};
+
+    // PR-0 ARRIVAL INSTRUMENTATION (record-only): per-datum-class delivery
+    // latency EWMA (tip_body / mnlistdiff / qrinfo) for THIS peer. A later
+    // coin-P2P PR's scorer would consult record_delivery()'s smoothed value to
+    // prefer the carrier that actually answers fastest; in THIS PR it is pure
+    // telemetry — compute_score() does NOT read it, so selection is unchanged.
+    PeerDeliveryLatency delivery_latency;
+
+    // Feed one observed request->reply latency (monotonic ms) for a datum class.
+    // Pure EWMA update; never touches score/backoff/eligibility.
+    void record_delivery(DatumClass cls, int64_t latency_ms)
+    {
+        delivery_latency.observe(cls, latency_ms);
+    }
 
     std::string key() const { return address.to_string(); }
 

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -212,6 +212,7 @@
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/historical_sml.hpp>   // authenticate_historical_snapshot
 #include <impl/dash/coin/lane_diag.hpp>        // ProgressReporter / StallWatchdog / MnSource
+#include <impl/dash/coin/arrival_timing.hpp>   // PR-0: OffEmbeddedWindow arrival/fold split (instrumentation only)
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
 #include <impl/dash/coin/vendor/smldiff.hpp>    // CSimplifiedMNListDiff
 #include <impl/dash/coin/vendor/cbtx.hpp>       // CCbTx
@@ -2860,6 +2861,10 @@ public:
         // while the header tip is itself stalled (the ondemand-mnlist freeze).
         m_snapshot_asked_at    = m_now();
         m_last_wallclock_reask = m_snapshot_asked_at;
+        // PR-0 instrumentation (record-only): the off-embedded window opens the
+        // moment the fold ask goes out. t_data_arrived/t_fold_complete/t_resumed
+        // are stamped in on_historical_snapshot(). Pure timestamp; no behaviour.
+        m_off_window.open(m_snapshot_asked_at);
         return true;
     }
 
@@ -3046,6 +3051,10 @@ public:
         }
 
         m_snapshot_pending = false;
+        // PR-0 instrumentation (record-only): the fold datum arrived on the
+        // wire. Closes the arrival span opened by begin_fold(); ignored if no
+        // window is open. Pure timestamp; the derived list is untouched.
+        m_off_window.data_arrived(m_now());
         const uint32_t h = m_snapshot_height;
         const bool on_demand = m_ondemand_pending;
 
@@ -3069,7 +3078,17 @@ public:
         if (on_demand) { finish_ondemand_fold(*sml, h); return true; }
 
         apply_fold(*sml, h);
+        // PR-0 instrumentation (record-only): derivation from the datum is done.
+        m_off_window.fold_complete(m_now());
         if (m_state != State::Bridging) return true;
+
+        // PR-0 instrumentation (record-only): the arm resumes the embedded
+        // template here — the window closes. emit_off_window_seg() prints the
+        // arrival/fold split ONLY when the default-OFF flag is armed, so an
+        // unflagged binary is byte-identical to master. No behaviour change:
+        // this is a timestamp read and a conditional log line.
+        m_off_window.resumed(m_now());
+        emit_off_window_seg(h);
 
         // Resume: the cursor is exactly at h, so the next block is h+1.
         if (m_tip_height) {
@@ -3087,6 +3106,14 @@ public:
 
     bool snapshot_pending() const { return m_snapshot_pending; }
     uint32_t folds_applied() const { return m_folds; }
+
+    /// PR-0 ARRIVAL INSTRUMENTATION (read-only). The four boundary timestamps
+    /// and the arrival/fold split of the MOST RECENT off-embedded fold window
+    /// (the getmnlistd ask -> reply -> derive -> resume round trip). A serve-
+    /// path consumer (the [EMBED-GATE-SEG]/[EMBED-GATE-ROLLUP] emit) reads this
+    /// to split off-embedded time into wire-wait vs derivation. Never gates a
+    /// decision; pure telemetry.
+    const OffEmbeddedWindow& off_embedded_window() const { return m_off_window; }
     /// LIFETIME totals across the whole span from the anchor, i.e. including
     /// whatever a previous process contributed before a resume.
     ///
@@ -3114,6 +3141,24 @@ public:
     static constexpr int64_t kStatefulReaskIntervalMs = 45000;
 
 private:
+    /// PR-0 ARRIVAL INSTRUMENTATION emit (record-only when the flag is OFF).
+    /// Prints the completed off-embedded window's arrival/fold split on the
+    /// greppable [EMBED-GATE-SEG] tag so an operator can separate wire-wait from
+    /// derivation without hand-pairing lines. Gated on the default-OFF
+    /// arrival_instr_enabled() flag: an unflagged binary emits NOTHING here and
+    /// is byte-identical to master. Reads timestamps only; never gates anything.
+    void emit_off_window_seg(uint32_t height) const
+    {
+        if (!arrival_instr_enabled()) return;
+        if (!m_off_window.split_consistent()) return;
+        LOG_WARNING << "[EMBED-GATE-SEG] h=" << height
+                    << " cause=mn-ckpt-fold"
+                    << " arrival_ms=" << m_off_window.arrival_ms()
+                    << " fold_ms="    << m_off_window.fold_ms()
+                    << " derive_ms="  << m_off_window.derive_ms()
+                    << " window_ms="  << m_off_window.window_ms();
+    }
+
     /// Keep claiming a small ring of abandoned request hashes. Bounded: this
     /// is a leak-proof guard, not a history.
     static constexpr size_t kAbandonedRing = 16;
@@ -4162,6 +4207,10 @@ public:
     // the coin-P2P pool dials past its base target while the leg is frozen.
     // Peer-selection / dial-count only; the applied list is never touched.
     int64_t  m_snapshot_asked_at{0};        // m_now() when the outstanding ask went out
+    // PR-0 ARRIVAL INSTRUMENTATION (record-only): the four boundary timestamps
+    // and arrival/fold split of the most recent off-embedded fold window. Pure
+    // telemetry — never read by a gate, never touches the derived list.
+    OffEmbeddedWindow m_off_window;
     int64_t  m_last_wallclock_reask{0};     // m_now() of the last wall-clock re-ask
     size_t   m_wallclock_reasks{0};         // telemetry: wall-clock re-asks issued
     std::function<void(bool)> m_stateful_stall_fn; // raise/clear outbound-behind

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -91,6 +91,7 @@
 #include <impl/dash/coin/governance_object.hpp> // govobject_hash / govvote_signature_hash (dashcore-exact digests)
 #include <impl/dash/coin/historical_sml.hpp>    // HistoricalMnListDiffDemux (reward-critical tip/historical split)
 #include <impl/dash/coin/bulk_peer_policy.hpp>   // #154 select_bulk_eligible_keys (LEVER 1 pure logic)
+#include <impl/dash/coin/arrival_timing.hpp>     // PR-0: per-peer per-datum-class delivery-latency EWMA (instrumentation only)
 
 #include <algorithm>
 #include <chrono>
@@ -531,6 +532,34 @@ struct PeerSession
     // stop us issuing N getdata", and on "did the won block reach every peer".
     uint64_t msgs_sent{0};
 
+    // PR-0 ARRIVAL INSTRUMENTATION (record-only). Per-datum-class request-sent
+    // timestamp (monotonic ms; -1 = none outstanding) and the smoothed
+    // delivery-latency EWMA. note_request_sent() stamps when we ask THIS peer;
+    // note_reply_received() closes the latency when the matching reply lands on
+    // THIS peer and returns it (or -1 if there was no outstanding request of
+    // that class — e.g. a rotated fold whose reply came from a different peer).
+    // Pure telemetry: nothing here gates selection, fetch, or derivation.
+    std::array<int64_t, static_cast<size_t>(DatumClass::Count)> req_sent_at_ms{
+        {-1, -1, -1}};
+    PeerDeliveryLatency delivery;
+
+    void note_request_sent(DatumClass cls, int64_t now_ms)
+    {
+        req_sent_at_ms[static_cast<size_t>(cls)] = now_ms;
+    }
+    // Returns the observed latency (ms), or -1 when no request of this class was
+    // outstanding on this peer. Updates the per-class EWMA on a real match.
+    int64_t note_reply_received(DatumClass cls, int64_t now_ms)
+    {
+        const size_t i = static_cast<size_t>(cls);
+        const int64_t sent = req_sent_at_ms[i];
+        if (sent < 0 || now_ms < sent) return -1;
+        req_sent_at_ms[i] = -1;
+        const int64_t latency = now_ms - sent;
+        delivery.observe(cls, latency);
+        return latency;
+    }
+
     int64_t age_sec() const
     {
         return std::chrono::duration_cast<std::chrono::seconds>(
@@ -543,6 +572,16 @@ struct PeerSession
         if (conn) conn->write(rmsg);
     }
 };
+
+// PR-0 ARRIVAL INSTRUMENTATION: monotonic milliseconds for delivery-latency
+// stamps. Independent of the liveness clock; used only to time request->reply
+// round trips for telemetry. Never gates behaviour.
+inline int64_t arrival_now_ms()
+{
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
 
 #define ADD_P2P_HANDLER(name)\
     void handle(std::unique_ptr<dash::coin::p2p::message_##name> msg)
@@ -1761,6 +1800,9 @@ public:
         auto msg = message_getdata::make_raw(
             {inventory_type(inventory_type::block, block_hash)});
         p->write(msg);
+        // PR-0 instrumentation (record-only): stamp the tip/body getdata on the
+        // chosen carrier so the block reply can be timed. Pure telemetry.
+        p->note_request_sent(DatumClass::TipBody, arrival_now_ms());
         return true;
     }
 
@@ -1865,6 +1907,9 @@ public:
                  << " target=" << block_hash.GetHex();
         auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
         p->write(msg);
+        // PR-0 instrumentation (record-only): stamp the mnlistdiff ask on this
+        // carrier so the matching reply can be timed. Pure telemetry.
+        p->note_request_sent(DatumClass::MnListDiff, arrival_now_ms());
     }
 
     /// TIMEOUT RE-ASK of the STATEFUL getmnlistd leg — the recovery half of
@@ -1930,6 +1975,9 @@ public:
         auto msg = message_getqrinfo::make_raw(base_block_hashes,
                                                block_request_hash, extra_share);
         m_primary->write(msg);
+        // PR-0 instrumentation (record-only): stamp the qrinfo ask so the reply
+        // can be timed. Pure telemetry.
+        m_primary->note_request_sent(DatumClass::QrInfo, arrival_now_ms());
     }
 
     /// Send a govsync (MNGOVERNANCESYNC) — E-SUPERBLOCK governance-object sync
@@ -2934,6 +2982,25 @@ private:
                  << " body_stall_evictions=" << m_body_stall_evictions;
     }
 
+    // ── PR-0 ARRIVAL INSTRUMENTATION (record-only) ────────────────────────
+    // Close the delivery-latency clock for `cls` on the peer that answered
+    // (m_active during dispatch), update its per-class EWMA, and — only when the
+    // default-OFF flag is armed — emit the per-peer latency on [COIN-P2P]. When
+    // the flag is OFF this still records into the peer's EWMA (invisible) and
+    // emits nothing, so the log is byte-identical to master. Never gates the
+    // handler; a reply with no matching outstanding request is a silent no-op.
+    void record_delivery_latency(DatumClass cls)
+    {
+        if (!m_active) return;
+        const int64_t lat = m_active->note_reply_received(cls, arrival_now_ms());
+        if (lat < 0 || !arrival_instr_enabled()) return;
+        LOG_INFO << "[COIN-P2P] delivery peer=" << m_active->key
+                 << " datum=" << datum_class_name(cls)
+                 << " delivery_latency_ms=" << lat
+                 << " ewma_ms=" << m_active->delivery.ewma_ms(cls)
+                 << " samples=" << m_active->delivery.get(cls).samples();
+    }
+
     // ── handshake ────────────────────────────────────────────────────────
 
     ADD_P2P_HANDLER(version)
@@ -3207,6 +3274,10 @@ private:
 
     ADD_P2P_HANDLER(block)
     {
+        // PR-0 instrumentation (record-only): time the tip/body delivery on the
+        // peer that answered. Pure telemetry; the block is verified identically
+        // downstream. The emit is gated on the default-OFF flag.
+        record_delivery_latency(DatumClass::TipBody);
         // E2a: BlockType now deserializes the full body (header + tx set), so
         // msg->m_block carries the transactions the ingest legs consume
         // (MnStateMachine::apply_block special txs, UTXO connect_block). The
@@ -3495,6 +3566,10 @@ private:
 
     ADD_P2P_HANDLER(mnlistdiff)
     {
+        // PR-0 instrumentation (record-only): time the mnlistdiff delivery on
+        // the peer that answered. Pure telemetry; the diff is authenticated
+        // identically downstream. The emit is gated on the default-OFF flag.
+        record_delivery_latency(DatumClass::MnListDiff);
         // SML/quorum snapshot. message_mnlistdiff already fully deserialized the
         // wire form into msg->m_diff (a vendor::CSimplifiedMNListDiff, see
         // p2p_messages.hpp) — apply_diff + the QuorumTail parser + the CCbTx
@@ -3529,6 +3604,10 @@ private:
 
     ADD_P2P_HANDLER(qrinfo)
     {
+        // PR-0 instrumentation (record-only): time the qrinfo delivery on the
+        // peer that answered. Pure telemetry; the reply is verified identically
+        // downstream. The emit is gated on the default-OFF flag.
+        record_delivery_latency(DatumClass::QrInfo);
         // DIP-24 quorum rotation info. Decoded HERE (not in the codec) so a
         // malformed reply is a local, logged refusal rather than a stream
         // exception on the coin connection — see p2p_messages.hpp.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -324,6 +324,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # the Linux and AsAN CI jobs, so this dependency makes CI build the KAT and CTest
     # find it instead of reporting it NOT_BUILT / Not Run.
     add_dependencies(test_dash_serve_gate_journal dash_tx_serve_self_validation_kat)
+    add_dependencies(test_dash_serve_gate_journal dash_arrival_instrumentation_kat)  # PR-0 coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## PR-0 — Coin-P2P arrival instrumentation (foundation)

First of a stacked series (PR-0 → PR-1 → PR-2 → PR-3 → PR-4) building peer racing/selection for the daemonless coin-P2P lane. **This PR is instrumentation ONLY — zero behavior change, zero reward risk.** It measures where off-embedded time goes and how fast each peer answers, so the later selection PRs have a signal to act on.

### What it adds
- **`src/impl/dash/coin/arrival_timing.hpp`** (new, header-only, pure policy — the SCHEMA the stacked PRs consume):
  - `OffEmbeddedWindow` — the four boundary timestamps `t_open` / `t_data_arrived` / `t_fold_complete` / `t_resumed`, partitioning an off-embedded window into `arrival_ms` (wire wait) + `fold_ms` (derive+resume) `== window_ms`. `t_fold_complete` is an intermediate marker inside `fold_ms` (`derive_ms`).
  - `DeliveryLatencyEwma` / `PeerDeliveryLatency` — per-peer, per-datum-class (`tip_body` / `mnlistdiff` / `qrinfo`) RTT-style EWMA, `alpha = 1/8`.
  - `arrival_instr_enabled()` / `set_arrival_instr_enabled()` — the default-OFF emit flag.
- **`mn_checkpoint_lane.hpp`** — stamps the four window boundaries on the real fold path (`begin_fold` ask → `on_historical_snapshot` reply → `apply_fold` → resume) and emits the arrival/fold split on the existing greppable **`[EMBED-GATE-SEG]`** tag when the flag is armed. `off_embedded_window()` exposes the window read-only.
- **`coin_peer_manager.hpp`** (`DashPeerInfo`) — per-peer `PeerDeliveryLatency` member + `record_delivery()`. `compute_score()` does **not** read it — selection is unchanged.
- **`p2p_client.hpp`** (`PeerSession`) — request-sent stamps at the `getmnlistd` / `getqrinfo` / block-body `getdata` sends, reply-received timing in the `mnlistdiff` / `qrinfo` / `block` handlers, per-peer EWMA update, and a flag-gated **`[COIN-P2P] delivery … delivery_latency_ms=…`** emit.

### Schema (for the stacked PRs)
```
namespace dash::coin
enum class DatumClass : uint8_t { TipBody=0, MnListDiff=1, QrInfo=2, Count=3 }
struct OffEmbeddedWindow { t_open, t_data_arrived, t_fold_complete, t_resumed;
                           arrival_ms(), fold_ms(), derive_ms(), window_ms(),
                           split_consistent() }   // arrival_ms + fold_ms == window_ms
class  DeliveryLatencyEwma { observe(int64_t ms); ewma_ms(); last_ms(); samples() }  // ewma += (s-ewma)/8
struct PeerDeliveryLatency { observe(DatumClass,ms); ewma_ms(DatumClass); get(DatumClass) }
bool arrival_instr_enabled();  void set_arrival_instr_enabled(bool);   // default OFF
```
New emitted fields: `[EMBED-GATE-SEG] … arrival_ms= fold_ms= derive_ms= window_ms=` (per fold window) and `[COIN-P2P] delivery … delivery_latency_ms= ewma_ms= samples=` (per peer, per datum class).

### Reward-safety argument
Peer selection / rotation / racing is untouched: nothing here changes **WHEN** or **FROM-WHOM** a datum is requested, nor **WHAT** is fetched or derived. The instruments record timestamps and moving averages only; `compute_score()` does not consult the EWMA, and the checkpoint lane's applied list / payee set are never read or written by this code. Every reply still flows through the identical merkle / payee / DIP-4 / BLS self-checks (same class as #1329). Worst case with the flag ON is extra log fields on already-verified small objects. **Flag default-OFF ⇒ byte-identical to master** (no new log lines; the EWMA/timestamp member writes are invisible).

### Flag
`arrival_instr_enabled()` (namespace `dash::coin`), **default OFF**.

### KAT
`dash_arrival_instrumentation_kat` (built with `-DC2POOL_DASH_BLS=ON`) asserts:
- the split math `arrival_ms + fold_ms == window_ms` across ordinary / zero-wire / zero-fold / single-instant windows, plus the open-reset and duplicate-boundary guards and the incomplete-window `-1` behavior;
- the exact per-peer per-datum-class EWMA update sequence (seed, `+= (s-ewma)/8`, negative-sample rejection, trunc-toward-zero) and datum-class independence.

Header-only (no node, no daemon), so it builds without the `c2pool-dash` object graph. **Built + run green under BLS=ON**; the three edited headers additionally verified via `-fsyntax-only` of `main_dash.cpp` and the dash `work_source.cpp` TU under the real BLS=ON compile flags.

### Scope note ([EMBED-GATE-ROLLUP])
The per-window arrival/fold split rides the `[EMBED-GATE-SEG]` tag on the fold path (where the four timestamps actually live). Threading a *cumulative* arrival/fold split into the work-source `[EMBED-GATE-ROLLUP]` line was deliberately deferred: it would require a `work_source → MnCheckpointLane` provider whose capture would outlive the lane at shutdown (reverse-declaration teardown → use-after-free). `off_embedded_window()` is the lifetime-safe seam for a later, correctly-scoped hook.

### Stack / merge order
PR-0 → PR-1 → PR-2 → PR-3 → PR-4. Rebase each successor onto master after its predecessor merges. **Do not merge** — review-gated.
