### PR TITLE
dash(daemonless): PR-4 coin-P2P ASN/geo diversity (optional racing tier)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -464,6 +464,15 @@ add_test(NAME dash_fresh_datum_race_kat COMMAND dash_fresh_datum_race_kat)
 # under -DC2POOL_DASH_BLS=ON like the rest of the dash suite; no BLS symbols.
 add_executable(dash_proactive_rotation_kat dash_proactive_rotation_kat.cpp)
 add_test(NAME dash_proactive_rotation_kat COMMAND dash_proactive_rotation_kat)
+# ── KAT: PR-4 ASN / GEO DIVERSITY (dashd-cut coin-P2P racing tier) ──
+# Locks the bundled ASN-prefix group assignment (peer_asn/peer_asn_group) and
+# the race-set diversity objective (enforce_asn_diversity: top-N span >= 2 ASNs).
+# asn_diversity.hpp is pure policy (header-only, no node, no daemon, boost::asio
+# address parsing only), so this target links NOTHING and still exercises the
+# schema --embedded-asn-diversity consumes. Built under -DC2POOL_DASH_BLS=ON like
+# the rest of the dash suite; it carries no BLS symbols.
+add_executable(dash_asn_diversity_kat dash_asn_diversity_kat.cpp)
+add_test(NAME dash_asn_diversity_kat COMMAND dash_asn_diversity_kat)
 
 # Legacy applications have been archived to ../../archive/
 # - c2pool_legacy.cpp (original c2pool.cpp)

--- a/src/c2pool/dash_asn_diversity_kat.cpp
+++ b/src/c2pool/dash_asn_diversity_kat.cpp
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// KAT: PR-4 ASN / GEO DIVERSITY (dashd-cut coin-P2P racing tier).
+//
+// Locks the two invariants the --embedded-asn-diversity racing objective needs:
+//   (1) ASN GROUP ASSIGNMENT is correct — the bundled longest-prefix table
+//       maps representative provider IPs to the expected ASN bucket, and any
+//       address outside the table falls back to a /16 netgroup bucket
+//       ("ng:a.b") rather than collapsing every unknown into one bucket.
+//   (2) The RACE SET SPANS >= 2 ASNs — enforce_asn_diversity() reorders an
+//       already-score-ranked candidate list so the top `slots` entries span at
+//       least `min_asns` distinct buckets WHENEVER the pool allows it, is a
+//       no-op when the head is already diverse, and preserves score order when
+//       the pool cannot satisfy the objective (single-provider set).
+//
+// Pure red/green over ONE header-only unit, NO node and NO daemon. Header-only
+// so it builds under -DC2POOL_DASH_BLS=ON without the c2pool-dash object graph.
+
+#include <impl/dash/coin/asn_diversity.hpp>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using dash::coin::enforce_asn_diversity;
+using dash::coin::peer_asn;
+using dash::coin::peer_asn_group;
+using dash::coin::race_set_distinct_asns;
+using dash::coin::race_set_spans_min_asns;
+
+static int g_fail = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_fail; } } while (0)
+
+// A dial candidate stand-in: an endpoint host string carried in score order.
+struct Cand { std::string host; };
+
+static std::string group_of(const Cand& c) { return peer_asn_group(c.host); }
+
+int main()
+{
+    // ── (1) ASN GROUP ASSIGNMENT ─────────────────────────────────────────────
+    // Representative provider IPs resolve to the bundled ASN. These anchor the
+    // table: a regeneration that breaks one of these fails CI (see UPDATE PATH).
+    CHECK(peer_asn("109.161.57.3") == 51167);   // Contabo (hotel host /16)
+    CHECK(peer_asn("88.198.5.10")  == 24940);   // Hetzner
+    CHECK(peer_asn("159.65.1.1")   == 14061);   // DigitalOcean
+    CHECK(peer_asn("3.5.6.7")      == 16509);   // Amazon AWS (3.0.0.0/9)
+    CHECK(peer_asn("54.36.0.9")    == 16276);   // OVH (54.36.0.0/15)
+    CHECK(peer_asn("34.64.1.1")    == 396982);  // Google Cloud (34.64.0.0/10)
+    CHECK(peer_asn("45.32.9.9")    == 20473);   // Vultr/Choopa
+
+    // Group LABELS mirror the ASN, and unknowns fall back to a /16 netgroup
+    // bucket (NOT a single shared "unknown").
+    CHECK(peer_asn_group("109.161.57.3") == "AS51167");
+    CHECK(peer_asn_group("88.198.5.10")  == "AS24940");
+    CHECK(peer_asn("192.0.2.1")          == 0);          // TEST-NET-1: no ASN
+    CHECK(peer_asn_group("192.0.2.1")    == "ng:192.0"); // /16 fallback
+    CHECK(peer_asn_group("198.51.100.4") == "ng:198.51");// distinct fallback bucket
+    // Two unknowns on different /16s are DIFFERENT buckets (correct);
+    // two unknowns on the same /16 share a bucket (safe over-grouping).
+    CHECK(peer_asn_group("192.0.2.1")   != peer_asn_group("198.51.100.4"));
+    CHECK(peer_asn_group("192.0.2.1")   == peer_asn_group("192.0.2.99"));
+
+    // ── (2) RACE SET SPANS >= 2 ASNs ─────────────────────────────────────────
+    const int SLOTS = 2, MIN = 2;
+
+    // (2a) Head is all one provider; a second-provider candidate sits lower in
+    // score order. enforce must PROMOTE it so the top-2 span 2 ASNs.
+    {
+        std::vector<Cand> ranked = {
+            {"109.161.57.3"},  // Contabo   (best score)
+            {"109.161.58.9"},  // Contabo   (same ASN)
+            {"109.161.59.4"},  // Contabo   (same ASN)
+            {"88.198.5.10"},   // Hetzner   (the diversifier, lower score)
+        };
+        CHECK(!race_set_spans_min_asns(ranked, group_of, SLOTS, MIN)); // top-2 == 1 ASN
+        auto out = enforce_asn_diversity(ranked, group_of, SLOTS, MIN);
+        CHECK(out.size() == ranked.size());                            // nothing dropped
+        CHECK(race_set_spans_min_asns(out, group_of, SLOTS, MIN));     // objective met
+        CHECK(race_set_distinct_asns(out, group_of, SLOTS) == 2);
+        // Fast path keeps the best-scored peer; backup is the diversifier.
+        CHECK(out[0].host == "109.161.57.3");
+        CHECK(peer_asn(out[1].host) == 24940);                         // Hetzner promoted
+    }
+
+    // (2b) Head is ALREADY diverse: enforce is a strict no-op (byte-identical
+    // order), so the flag-on path costs nothing when the pool is already good.
+    {
+        std::vector<Cand> ranked = {
+            {"109.161.57.3"},  // Contabo
+            {"88.198.5.10"},   // Hetzner
+            {"159.65.1.1"},    // DigitalOcean
+        };
+        CHECK(race_set_spans_min_asns(ranked, group_of, SLOTS, MIN));
+        auto out = enforce_asn_diversity(ranked, group_of, SLOTS, MIN);
+        CHECK(out.size() == ranked.size());
+        for (std::size_t i = 0; i < ranked.size(); ++i)
+            CHECK(out[i].host == ranked[i].host);                      // order preserved
+    }
+
+    // (2c) Pool CANNOT satisfy diversity (single provider): enforce preserves
+    // score order and reports the honest span (1) — it never fabricates a peer.
+    {
+        std::vector<Cand> ranked = {
+            {"109.161.57.3"}, {"109.161.58.9"}, {"109.161.59.4"},
+        };
+        CHECK(!race_set_spans_min_asns(ranked, group_of, SLOTS, MIN));
+        auto out = enforce_asn_diversity(ranked, group_of, SLOTS, MIN);
+        CHECK(out.size() == ranked.size());
+        for (std::size_t i = 0; i < ranked.size(); ++i)
+            CHECK(out[i].host == ranked[i].host);                      // unchanged
+        CHECK(race_set_distinct_asns(out, group_of, SLOTS) == 1);
+    }
+
+    // (2d) Unknown-provider peers on distinct /16s DO count as diverse, so the
+    // racing objective works for peers outside the bundled table too.
+    {
+        std::vector<Cand> ranked = {
+            {"192.0.2.1"},     // ng:192.0
+            {"192.0.2.9"},     // ng:192.0 (same bucket)
+            {"198.51.100.4"},  // ng:198.51 (diversifier)
+        };
+        CHECK(!race_set_spans_min_asns(ranked, group_of, SLOTS, MIN));
+        auto out = enforce_asn_diversity(ranked, group_of, SLOTS, MIN);
+        CHECK(race_set_spans_min_asns(out, group_of, SLOTS, MIN));
+        CHECK(out[0].host == "192.0.2.1");                             // best kept
+        CHECK(peer_asn_group(out[1].host) == "ng:198.51");            // diversifier promoted
+    }
+
+    // (2e) Degenerate guards: min_asns<=1, empty, single-element => input as-is.
+    {
+        std::vector<Cand> ranked = {{"109.161.57.3"}, {"88.198.5.10"}};
+        auto a = enforce_asn_diversity(ranked, group_of, SLOTS, /*min*/1);
+        CHECK(a.size() == 2 && a[0].host == ranked[0].host && a[1].host == ranked[1].host);
+        std::vector<Cand> empty;
+        CHECK(enforce_asn_diversity(empty, group_of, SLOTS, MIN).empty());
+        std::vector<Cand> one = {{"109.161.57.3"}};
+        auto o = enforce_asn_diversity(one, group_of, SLOTS, MIN);
+        CHECK(o.size() == 1 && o[0].host == "109.161.57.3");
+    }
+
+    if (g_fail == 0) std::printf("dash_asn_diversity_kat: ALL PASS\n");
+    else             std::printf("dash_asn_diversity_kat: %d FAILURE(S)\n", g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -443,6 +443,7 @@ void print_banner(const char* argv0)
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
+        << "           [--embedded-asn-diversity]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--embedded-tx-serve-own-set]\n"
@@ -982,7 +983,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // candidate and sheds its slowest measured non-primary server so
              // the working set trends toward the fastest deliverers. Reward-safe
              // (connection-management only; every reply still self-checked).
-             bool embedded_proactive_rotate = false)
+             bool embedded_proactive_rotate = false,
+             // --embedded-asn-diversity (PR-4): DEFAULT OFF. When on, the coin
+             // peer manager reorders its already-scored, /16-group-diverse dial
+             // candidates so the fast path + its backup sit on INDEPENDENT ASNs
+             // (bundled ASN-prefix map; see asn_diversity.hpp). Pure reordering
+             // of THIS node's own dial targets — never changes WHAT is fetched
+             // or how a reply is verified. OFF => dial plan byte-identical to
+             // master.
+             bool embedded_asn_diversity = false)
 {
     namespace io = boost::asio;
 
@@ -2051,6 +2060,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             const uint16_t coin_port = testnet ? 19999 : 9999;
             dash::coin::DashPeerManagerConfig pm_cfg;
             pm_cfg.valid_ports = { coin_port };
+            // PR-4 (--embedded-asn-diversity, default OFF): when armed, the
+            // peer manager reorders its already-scored, /16-group-diverse dial
+            // candidates so the fast path + its backup sit on INDEPENDENT ASNs.
+            // OFF => the dial plan is byte-identical to master.
+            pm_cfg.asn_diversity = embedded_asn_diversity;
             // The manager BOUNDS the candidate set it hands back per call; with
             // the shipped default (3) it could never propose enough targets to
             // fill an 8-peer pool no matter how many peers it knew. Raise the
@@ -8913,6 +8927,7 @@ int main(int argc, char** argv)
     // window-open slots + template upgrade to the real commitment. DEFAULT
     // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
     bool embedded_null_arm = false;
+    bool embedded_asn_diversity = false;   // PR-4 (--embedded-asn-diversity): default OFF
     // --embedded-ingest-isdlock: arm the coin-P2P MSG_ISDLOCK pull (G4
     // conflict-tx-lock feed). DEFAULT OFF — off, no getdata for inv type 31
     // and the handler decodes-and-discards (wire + template behaviour
@@ -9049,6 +9064,10 @@ int main(int argc, char** argv)
                  && i + 1 < argc)
             dash::coin::set_fresh_datum_race_k(
                 static_cast<int>(std::strtol(argv[++i], nullptr, 10)));
+        else if (std::strcmp(argv[i], "--embedded-asn-diversity") == 0)
+            embedded_asn_diversity = true;   // PR-4: require racing set to span >=2 ASNs
+        else if (std::strcmp(argv[i], "--embedded-asn-diversity=false") == 0)
+            embedded_asn_diversity = false;  // PR-4: explicit OFF (OFF-equivalence)
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
@@ -9385,7 +9404,8 @@ int main(int argc, char** argv)
                         embedded_accrue_asset_unlocks, // #143 Variant B
                         embedded_ingest_isdlock,       // G4 isdlock feed
                         embedded_ingest_dstx,          // W5-B DSTX feed
-                        embedded_proactive_rotate);    // PR-3 proactive rotation
+                        embedded_proactive_rotate,    // PR-3 proactive rotation
+                        embedded_asn_diversity);       // PR-4 ASN diversity
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/asn_diversity.hpp
+++ b/src/impl/dash/coin/asn_diversity.hpp
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// PR-4 ASN / GEO DIVERSITY (dashd-cut coin-P2P racing tier, task #154 line).
+///
+/// This header adds an AUTONOMOUS-SYSTEM (ASN) dimension on TOP of the existing
+/// /16 netgroup (peer_network_group in coin_peer_manager.hpp). Two peers can sit
+/// in different /16 groups yet still be the same physical failure domain — the
+/// same hosting provider, the same building, one BGP withdrawal away from
+/// vanishing together. A /16 is a routing-prefix proxy; an ASN is the operator.
+/// Requiring the fast path AND its backup to sit on INDEPENDENT ASNs is what
+/// makes the racing set survive a whole-provider outage, not just a single-host
+/// or single-/16 one.
+///
+/// It is pure policy exactly like arrival_timing.hpp: NO I/O, NO clock, NO coin
+/// state, header-only, standard library + one string in / string out. It folds
+/// into the allowlisted dash test targets and builds under
+/// -DC2POOL_DASH_BLS=ON carrying no BLS symbols.
+///
+/// ── REWARD SAFETY ─────────────────────────────────────────────────────────
+/// Nothing here derives, validates, or selects a DATUM. It answers exactly one
+/// question — "which independent-operator bucket does this IP belong to?" — and
+/// a second, pure-reordering question — "reorder these already-scored dial
+/// candidates so the top N span >= K distinct buckets". It changes only WHICH
+/// peers we dial and in WHICH order, never WHAT we ask them for nor how a reply
+/// is checked. Every reply still flows through the identical merkle/payee/DIP-4/
+/// BLS self-checks. Worst case = we dial a peer on a second provider we would
+/// otherwise have skipped. The consumer (coin_peer_manager) invokes this ONLY
+/// when --embedded-asn-diversity is armed; with the flag OFF the dial plan is
+/// byte-identical to master.
+///
+/// ── THE BUNDLED ASN MAP (main cost / risk — see PR body) ────────────────────
+/// peer_asn() resolves an IPv4 address to an ASN via a COMPACT, BUNDLED
+/// longest-prefix table (kAsnPrefixTable below). This table is the deliberate
+/// cost of the feature: it is a small, curated seed set covering the hosting
+/// providers that carry the bulk of public DASH P2P nodes (cloud + bare-metal
+/// VPS operators). It is NOT a full BGP routing table (~1M prefixes) — bundling
+/// that would bloat the binary and rot immediately. The design accepts that an
+/// address outside the table resolves to ASN 0 ("unknown"); such peers fall
+/// back to their /16 netgroup label so unknowns never all collapse into one
+/// bucket. That keeps the diversity guarantee conservative: we may treat two
+/// genuinely-independent unknown peers as diverse (correct) or, at worst, treat
+/// two same-/16 unknowns as one bucket (safe over-grouping).
+///
+/// UPDATE PATH (documented, intentionally manual):
+///   1. Pull the current prefix->ASN mapping for the target providers from a
+///      routing-data source, e.g. a Team Cymru / RIPEstat / bgp.tools dump, or
+///      `whois -h whois.cymru.com " -v <ip>"` per seed node.
+///   2. Regenerate kAsnPrefixTable rows as {ipv4_network, prefix_len, asn,
+///      "operator name"}. Keep them sorted for readability (lookup does not
+///      require sorting — it takes the LONGEST match by scan).
+///   3. Bump kAsnTableEpoch and rebuild. The KAT
+///      (dash_asn_diversity_kat.cpp) pins the assignment for a handful of
+///      representative rows, so a table edit that breaks an anchor row fails CI
+///      before it ships.
+/// The table is advisory routing metadata, not consensus data: a stale or wrong
+/// row can only mis-bucket a dial candidate, never mis-derive or mis-serve.
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <boost/asio/ip/address.hpp>
+#include <boost/system/error_code.hpp>
+
+namespace dash {
+namespace coin {
+
+// ─── Bundled compact ASN-prefix table ───────────────────────────────────────
+// One row per (IPv4 network, prefix length) -> ASN. Longest-prefix wins.
+// This is a CURATED SEED set (the providers that host the bulk of public DASH
+// P2P nodes), NOT a full routing table. See the UPDATE PATH note in the file
+// header for how to regenerate it. Adding/removing rows is the whole cost of
+// keeping this feature accurate over time.
+struct AsnPrefixRow
+{
+    uint32_t    network;    // IPv4 network address, host byte order
+    uint8_t     prefix_len; // 0..32
+    uint32_t    asn;        // autonomous system number (0 == unassigned/unknown)
+    const char* op_name;    // human-readable operator (diagnostics only)
+};
+
+// Bump when the table is regenerated (diagnostics / provenance only).
+inline constexpr uint32_t kAsnTableEpoch = 20260824u;
+
+// Helper: pack a dotted IPv4 literal into host-order uint32 at compile time so
+// the table below reads like addresses, not magic numbers.
+inline constexpr uint32_t ipv4(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
+{
+    return (static_cast<uint32_t>(a) << 24) | (static_cast<uint32_t>(b) << 16)
+         | (static_cast<uint32_t>(c) << 8)  |  static_cast<uint32_t>(d);
+}
+
+// Representative rows for the major DASH-node-hosting ASNs. Deliberately small.
+// (Prefixes chosen to be real, well-known allocations for each operator; extend
+//  per the UPDATE PATH. The feature does not require completeness — see header.)
+inline const std::array<AsnPrefixRow, 20>& asn_prefix_table()
+{
+    static const std::array<AsnPrefixRow, 20> kAsnPrefixTable = {{
+        // Amazon AWS (AS16509)
+        { ipv4(3,   0,   0, 0),  9, 16509, "Amazon AWS" },
+        { ipv4(52,  0,   0, 0),  8, 16509, "Amazon AWS" },
+        { ipv4(54,  0,   0, 0),  8, 16509, "Amazon AWS" },
+        // DigitalOcean (AS14061)
+        { ipv4(159, 65,  0, 0), 16, 14061, "DigitalOcean" },
+        { ipv4(165, 227, 0, 0), 16, 14061, "DigitalOcean" },
+        { ipv4(178, 62,  0, 0), 16, 14061, "DigitalOcean" },
+        // OVH (AS16276)
+        { ipv4(51,  38,  0, 0), 16, 16276, "OVH" },
+        { ipv4(54,  36,  0, 0), 15, 16276, "OVH" },
+        { ipv4(151, 80,  0, 0), 16, 16276, "OVH" },
+        // Hetzner (AS24940)
+        { ipv4(88,  198, 0, 0), 16, 24940, "Hetzner" },
+        { ipv4(95,  216, 0, 0), 15, 24940, "Hetzner" },
+        { ipv4(116, 202, 0, 0), 16, 24940, "Hetzner" },
+        // Vultr / Choopa (AS20473)
+        { ipv4(45,  32,  0, 0), 16, 20473, "Vultr/Choopa" },
+        { ipv4(66,  42,  0, 0), 16, 20473, "Vultr/Choopa" },
+        // Linode / Akamai (AS63949)
+        { ipv4(45,  33,  0, 0), 16, 63949, "Linode/Akamai" },
+        { ipv4(139, 162, 0, 0), 16, 63949, "Linode/Akamai" },
+        // Contabo (AS51167)
+        { ipv4(62,  171, 0, 0), 16, 51167, "Contabo" },
+        { ipv4(109, 161, 0, 0), 16, 51167, "Contabo" },
+        // M247 (AS9009)
+        { ipv4(37,  120, 0, 0), 16,  9009, "M247" },
+        // Google Cloud (AS396982)
+        { ipv4(34,  64,  0, 0), 10, 396982, "Google Cloud" },
+    }};
+    return kAsnPrefixTable;
+}
+
+// ─── IPv4 parse (host byte order); returns false for non-IPv4 inputs ─────────
+inline bool parse_ipv4_host_order(const std::string& ip, uint32_t& out)
+{
+    boost::system::error_code ec;
+    auto addr = boost::asio::ip::make_address(ip, ec);
+    if (ec) return false;
+    if (addr.is_v4()) {
+        out = addr.to_v4().to_uint();
+        return true;
+    }
+    if (addr.is_v6()) {
+        auto v6 = addr.to_v6();
+        if (v6.is_v4_mapped()) {
+            out = boost::asio::ip::make_address_v4(
+                      boost::asio::ip::v4_mapped, v6).to_uint();
+            return true;
+        }
+    }
+    return false; // native IPv6 (or unparseable) — no ASN in this table
+}
+
+// ─── ASN lookup: longest-prefix match over the bundled table ─────────────────
+// Returns 0 when the address is not IPv4 or matches no bundled prefix.
+inline uint32_t peer_asn(const std::string& ip)
+{
+    uint32_t host = 0;
+    if (!parse_ipv4_host_order(ip, host)) return 0;
+
+    uint32_t best_asn = 0;
+    int      best_len = -1;
+    for (const auto& row : asn_prefix_table()) {
+        // mask for prefix_len bits (guard shift-by-32 UB when len == 0)
+        uint32_t mask = (row.prefix_len == 0)
+                            ? 0u
+                            : (0xFFFFFFFFu << (32 - row.prefix_len));
+        if ((host & mask) == (row.network & mask)) {
+            if (static_cast<int>(row.prefix_len) > best_len) {
+                best_len = row.prefix_len;
+                best_asn = row.asn;
+            }
+        }
+    }
+    return best_asn;
+}
+
+// ─── ASN diversity bucket label ──────────────────────────────────────────────
+// The independent-failure-domain key for diversity accounting:
+//   * IPv4 with a bundled ASN  -> "AS<n>"
+//   * everything else (unknown ASN, native IPv6, unparseable) -> "ng:<group>"
+//     where <group> is a /16 IPv4 or /32 IPv6 netgroup-style fallback so that
+//     unknowns do NOT all collapse into a single bucket. Two unknowns on the
+//     same /16 are conservatively treated as one domain (safe over-grouping);
+//     two unknowns on different /16s count as diverse (correct).
+inline std::string asn_netgroup_fallback(const std::string& ip)
+{
+    boost::system::error_code ec;
+    auto addr = boost::asio::ip::make_address(ip, ec);
+    if (!ec && addr.is_v4()) {
+        auto b = addr.to_v4().to_bytes();
+        return std::to_string(b[0]) + "." + std::to_string(b[1]);
+    }
+    if (!ec && addr.is_v6()) {
+        auto v6 = addr.to_v6();
+        if (v6.is_v4_mapped()) {
+            auto b = boost::asio::ip::make_address_v4(
+                         boost::asio::ip::v4_mapped, v6).to_bytes();
+            return std::to_string(b[0]) + "." + std::to_string(b[1]);
+        }
+        auto b = v6.to_bytes();
+        char buf[12];
+        std::snprintf(buf, sizeof(buf), "%02x%02x:%02x%02x",
+                      b[0], b[1], b[2], b[3]);
+        return std::string(buf);
+    }
+    return ip; // unparseable: its own bucket
+}
+
+inline std::string peer_asn_group(const std::string& ip)
+{
+    uint32_t asn = peer_asn(ip);
+    if (asn != 0) return "AS" + std::to_string(asn);
+    return "ng:" + asn_netgroup_fallback(ip);
+}
+
+// ─── Race-set diversity objective (pure reordering) ──────────────────────────
+// Count the distinct ASN-diversity buckets spanned by the FIRST `slots` entries
+// of `ranked` (or the whole vector if it is shorter). `group_of` maps an entry
+// to its bucket label (typically peer_asn_group(host)).
+template <class T, class GetGroup>
+inline int race_set_distinct_asns(const std::vector<T>& ranked,
+                                  GetGroup group_of,
+                                  std::size_t slots)
+{
+    std::vector<std::string> seen;
+    std::size_t n = std::min(slots, ranked.size());
+    for (std::size_t i = 0; i < n; ++i) {
+        std::string g = group_of(ranked[i]);
+        bool dup = false;
+        for (auto& s : seen) if (s == g) { dup = true; break; }
+        if (!dup) seen.push_back(std::move(g));
+    }
+    return static_cast<int>(seen.size());
+}
+
+// TRUE iff the top `slots` of `ranked` already span >= min_asns distinct
+// buckets. A pure predicate over the current order.
+template <class T, class GetGroup>
+inline bool race_set_spans_min_asns(const std::vector<T>& ranked,
+                                    GetGroup group_of,
+                                    std::size_t slots,
+                                    int min_asns)
+{
+    return race_set_distinct_asns(ranked, group_of, slots) >= min_asns;
+}
+
+// Reorder an already-score-ranked candidate list (best-first) so that the top
+// `slots` entries span >= min_asns distinct ASN buckets WHEN the candidate pool
+// makes that possible, while otherwise preserving the incoming score order as
+// tightly as possible.
+//
+// Strategy (stable, greedy): walk the ranked list once, emitting the
+// best-scored candidate for each not-yet-represented bucket until either the
+// diversity target (min_asns buckets) is met or `slots` is filled; then append
+// every remaining candidate in original score order. This promotes at most
+// (min_asns - 1) lower-scored candidates ahead of same-bucket higher-scored
+// ones — the minimum reordering needed to hit the objective — and is a no-op
+// (returns the input order) when the top `slots` already satisfy it or when the
+// pool cannot satisfy it.
+//
+// PURE: it only reorders the caller's own candidates; it never fabricates,
+// drops, or alters an entry. The caller applies it ONLY under the flag.
+template <class T, class GetGroup>
+inline std::vector<T> enforce_asn_diversity(const std::vector<T>& ranked,
+                                            GetGroup group_of,
+                                            std::size_t slots,
+                                            int min_asns)
+{
+    if (min_asns <= 1 || slots == 0 || ranked.size() <= 1)
+        return ranked;
+    if (race_set_spans_min_asns(ranked, group_of, slots, min_asns))
+        return ranked; // already diverse — byte-identical to no-op
+
+    const std::size_t n = ranked.size();
+    std::vector<char> used(n, 0);
+    std::vector<T> out;
+    out.reserve(n);
+    std::vector<std::string> picked_groups;
+
+    // Pass 1: fill diversity slots — one representative per new bucket, in
+    // score order, until we hit min_asns buckets or run out of head slots.
+    for (std::size_t i = 0; i < n && out.size() < slots; ++i) {
+        if (static_cast<int>(picked_groups.size()) >= min_asns) break;
+        std::string g = group_of(ranked[i]);
+        bool have = false;
+        for (auto& pg : picked_groups) if (pg == g) { have = true; break; }
+        if (have) continue;
+        out.push_back(ranked[i]);
+        used[i] = 1;
+        picked_groups.push_back(std::move(g));
+    }
+
+    // Pass 2: append everything else in original score order.
+    for (std::size_t i = 0; i < n; ++i) {
+        if (used[i]) continue;
+        out.push_back(ranked[i]);
+    }
+    return out;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/coin_peer_manager.hpp
+++ b/src/impl/dash/coin/coin_peer_manager.hpp
@@ -60,6 +60,7 @@
 #include <core/dns_seeder.hpp>
 #include <core/coin_addrman.hpp>
 #include <impl/dash/coin/arrival_timing.hpp>   // PR-0: per-peer per-datum-class delivery-latency EWMA (instrumentation only)
+#include <impl/dash/coin/asn_diversity.hpp>    // PR-4: ASN/geo diversity buckets + race-set diversity objective (flag-gated)
 
 namespace dash {
 namespace coin {
@@ -345,6 +346,16 @@ struct DashPeerManagerConfig
     int         max_peers_per_group{4};         // max peers from same /16 (IPv4) or /32 (IPv6)
     int         max_new_peers_per_group{3};     // stricter limit for unverified (new) peers
     int         anchor_count{2};                // number of anchor connections to persist
+
+    // PR-4 ASN/GEO DIVERSITY (--embedded-asn-diversity). DEFAULT OFF => the dial
+    // plan is byte-identical to master. When on, get_peers_to_connect() applies
+    // enforce_asn_diversity() so the head of the returned candidate list (the
+    // fast path + its backup) spans >= min_race_asns INDEPENDENT ASN buckets
+    // when the candidate pool allows it. Pure reordering of already-scored,
+    // already /16-group-diverse candidates; never changes WHAT is fetched.
+    bool        asn_diversity{false};           // OFF => no behavioural change
+    int         asn_race_slots{2};              // head slots required to be ASN-diverse
+    int         min_race_asns{2};               // >= this many distinct ASNs across the head
 };
 
 // ─── DashCoinPeerManager ─────────────────────────────────────────────────────
@@ -573,6 +584,20 @@ public:
                 result.push_back(*ep);
                 connected_groups[grp]++;
             }
+        }
+
+        // PR-4 (--embedded-asn-diversity, default OFF): reorder the already
+        // score-sorted, /16-group-diverse result so the head (fast path + its
+        // backup) spans >= min_race_asns INDEPENDENT ASN buckets when the pool
+        // allows it. Pure reordering of THIS node's own dial candidates; it
+        // never adds, drops, or alters a target, and every fetched reply still
+        // flows through the identical self-checks. OFF => untouched order.
+        if (m_config.asn_diversity && result.size() > 1) {
+            result = enforce_asn_diversity(
+                result,
+                [](const PeerEndpoint& ep) { return peer_asn_group(ep.host()); },
+                static_cast<std::size_t>(m_config.asn_race_slots),
+                m_config.min_race_asns);
         }
         return result;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -328,6 +328,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_dependencies(test_dash_serve_gate_journal dash_latency_scoring_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_fresh_datum_race_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_proactive_rotation_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
+    add_dependencies(test_dash_serve_gate_journal dash_asn_diversity_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## PR-4 — Coin-P2P ASN / GEO diversity (optional racing tier)

Adds an **autonomous-system (ASN)** dimension on top of the existing `/16`
netgroup (`peer_network_group`) so the fresh/racing dial set can be required to
span **>= 2 INDEPENDENT ASNs**, not just distinct `/16` prefixes. Two peers in
different `/16`s can still sit on the same hosting provider — one BGP withdrawal
from vanishing together. Requiring the fast path **and** its backup to sit on
independent operators makes the racing set survive a whole-provider outage, not
just a single-host or single-`/16` one.

### What changed
- **New `src/impl/dash/coin/asn_diversity.hpp`** — pure policy, header-only, no
  node / no daemon, `boost::asio` address parsing only (same shape as PR-0's
  `arrival_timing.hpp`):
  - a **compact BUNDLED ASN-prefix table** (`kAsnPrefixTable`, longest-prefix
    match) covering the hosting providers that carry the bulk of public DASH P2P
    nodes. Addresses outside it resolve to ASN 0 and fall back to a `/16`
    netgroup bucket (`ng:a.b`) so unknowns never all collapse into one domain.
  - `peer_asn()` / `peer_asn_group()` bucket labels.
  - `enforce_asn_diversity()` — a **pure reordering** of an already
    score-ranked, already `/16`-group-diverse candidate list so the head spans
    `>= min_race_asns` distinct buckets when the pool allows it; a strict no-op
    when the head is already diverse or when the pool cannot satisfy it.
- **Flag-gated wiring, default OFF**: `DashPeerManagerConfig` gains
  `asn_diversity` / `asn_race_slots` / `min_race_asns`; `get_peers_to_connect()`
  applies `enforce_asn_diversity()` **only** when `asn_diversity` is set.
  `main_dash.cpp` adds `--embedded-asn-diversity` (plus the `=false`
  OFF-equivalence form) and threads it into `pm_cfg`.

### Flag
`--embedded-asn-diversity` — **default OFF**. With the flag off, the peer
manager never calls `enforce_asn_diversity()`, so the dial plan is
**byte-identical to master**.

### Reward-safety argument
Peer selection/rotation changes only **WHICH** peers we dial and in **WHICH
order** — this PR reorders **this node's own** already-scored dial candidates and
never fabricates, drops, or alters a target. It changes neither **WHAT** is
fetched from a peer nor how a reply is verified: every reply still flows through
the identical merkle / payee / DIP-4 / BLS self-checks (same class as PR-0 /
#1329). Worst case is an extra connection to a peer on a second provider we would
otherwise have skipped. With the flag OFF the behaviour is byte-identical to
master.

### Main cost / risk
The **bundled ASN-prefix map** is the deliberate cost of this feature. It is a
small, curated seed set — **not** a full BGP routing table (~1M prefixes), which
would bloat the binary and rot immediately. An address outside the table
resolves to ASN 0 and falls back to its `/16` bucket, which keeps the diversity
guarantee conservative (two same-`/16` unknowns are safely over-grouped as one
domain; two different-`/16` unknowns count as diverse). The table's **update
path is documented in the header**: pull prefix→ASN rows from a routing-data
source (Team Cymru / RIPEstat / bgp.tools), regenerate `kAsnPrefixTable`, bump
`kAsnTableEpoch`, rebuild. The map is advisory routing metadata, not consensus
data — a stale/wrong row can only mis-bucket a dial candidate, never mis-derive
or mis-serve.

### KAT
`src/c2pool/dash_asn_diversity_kat.cpp` (registered in ctest as
`dash_asn_diversity_kat`), header-only, built under `-DC2POOL_DASH_BLS=ON`:
- **group assignment correct** — representative provider IPs map to the expected
  ASN; unknown IPs fall back to `/16` buckets and distinct `/16`s stay distinct.
- **race set spans >= 2 ASNs** — promotion when the head is single-provider,
  strict no-op when the head is already diverse, and honest order-preserving
  `span == 1` when the pool is single-provider (never fabricates a peer).

Built and run locally under `-DC2POOL_DASH_BLS=ON`: `dash_asn_diversity_kat: ALL PASS`.

### Stack / merge order
Stacks on `dash/coinp2p-pr0-arrival-instrumentation`. Merge order is
**PR-0 → PR-1 → PR-2 → PR-3 → PR-4**; rebase this branch onto `master` after each
predecessor merges. This is the **optional** tier of the series. Opened as a
non-merged PR for review.
