### PR TITLE
dash(daemonless): PR-3 LOW-RATE proactive coin-P2P peer rotation (flag default-OFF; stacks on PR-0)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -454,6 +454,16 @@ add_test(NAME dash_latency_scoring_kat COMMAND dash_latency_scoring_kat)
 # -DC2POOL_DASH_BLS=ON like the rest of the dash suite; carries no BLS symbols.
 add_executable(dash_fresh_datum_race_kat dash_fresh_datum_race_kat.cpp)
 add_test(NAME dash_fresh_datum_race_kat COMMAND dash_fresh_datum_race_kat)
+# ── KAT: PR-3 PROACTIVE PEER ROTATION policy (dashd-cut coin-P2P foundation) ──
+# Locks the proactive-rotation decision invariants — primary/protected-local
+# NEVER retired (#147), retirement picks the SLOWEST measured CanServeBlocks
+# server (#148), and the cadence is bounded (default-OFF => never). Runs over the
+# pure header proactive_rotation_policy.hpp (header-only, no node, no daemon,
+# standard library only), the EXACT logic the shipped maybe_proactive_rotate
+# calls, so this target links NOTHING and still exercises the real path. Built
+# under -DC2POOL_DASH_BLS=ON like the rest of the dash suite; no BLS symbols.
+add_executable(dash_proactive_rotation_kat dash_proactive_rotation_kat.cpp)
+add_test(NAME dash_proactive_rotation_kat COMMAND dash_proactive_rotation_kat)
 
 # Legacy applications have been archived to ../../archive/
 # - c2pool_legacy.cpp (original c2pool.cpp)

--- a/src/c2pool/dash_proactive_rotation_kat.cpp
+++ b/src/c2pool/dash_proactive_rotation_kat.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// KAT: PR-3 PROACTIVE PEER ROTATION policy (dashd-cut coin-P2P, task #154 line).
+//
+// Locks the three invariants the shipped proactive rotation
+// (p2p_client.hpp maybe_proactive_rotate) relies on, over the pure decision
+// header proactive_rotation_policy.hpp — the EXACT code the client calls, so a
+// green KAT cannot diverge from the shipped path:
+//
+//   (1) PRIMARY IS NEVER RETIRED. m_primary and any protected-local peer (#147)
+//       are the latency reference; slowest_retirement_victim() must skip them
+//       even when they are the slowest measured peer in the set.
+//   (2) RETIREMENT PICKS THE SLOWEST. Among eligible CanServeBlocks (#148)
+//       peers with a measured TipBody delivery-latency EWMA, the victim is the
+//       one with the HIGHEST EWMA; ties resolve to the first (deterministic).
+//       Non-servers and peers with no measurement are never chosen.
+//   (3) CADENCE IS BOUNDED. proactive_due() is false while armed but inside the
+//       interval, true once a full interval has elapsed, and NEVER fires when
+//       the flag is OFF (byte-identical to master).
+//
+// Pure red/green over ONE header-only unit, NO node and NO daemon (mirrors the
+// PR-0 arrival KAT). Built under -DC2POOL_DASH_BLS=ON like the rest of the dash
+// suite; it carries no BLS symbols.
+
+#include <impl/dash/coin/proactive_rotation_policy.hpp>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using dash::coin::proactivepolicy::PeerLatencyView;
+using dash::coin::proactivepolicy::proactive_due;
+using dash::coin::proactivepolicy::slowest_retirement_victim;
+
+static int g_fail = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_fail; } } while (0)
+
+// A plain measured CanServeBlocks server (the common eligible case).
+static PeerLatencyView server(const std::string& key, int64_t ewma_ms) {
+    PeerLatencyView v;
+    v.key = key;
+    v.can_serve_blocks = true;
+    v.has_latency = ewma_ms >= 0;
+    v.ewma_ms = ewma_ms;
+    return v;
+}
+
+int main()
+{
+    // ── (1) PRIMARY / PROTECTED-LOCAL ARE NEVER RETIRED ──────────────────────
+    {
+        // The primary is the SLOWEST peer, yet it must never be the victim.
+        std::vector<PeerLatencyView> peers;
+        PeerLatencyView prim = server("primary", 9000);
+        prim.is_primary = true;
+        peers.push_back(prim);
+        peers.push_back(server("fast",  50));
+        peers.push_back(server("mid",  200));
+        const int v = slowest_retirement_victim(peers);
+        CHECK(v == 2);                       // "mid" (200) — the slowest NON-primary
+        CHECK(peers[v].key == "mid");
+    }
+    {
+        // A protected-local (loopback/LAN) peer, even slowest, is exempt (#147).
+        std::vector<PeerLatencyView> peers;
+        PeerLatencyView loc = server("local", 12000);
+        loc.is_protected_local = true;
+        peers.push_back(loc);
+        peers.push_back(server("remoteA", 300));
+        peers.push_back(server("remoteB", 700));
+        const int v = slowest_retirement_victim(peers);
+        CHECK(v == 2);                       // "remoteB" (700), not the local ref
+        CHECK(peers[v].key == "remoteB");
+    }
+    {
+        // Only the primary has a measurement — nothing else is eligible, so no
+        // victim (the primary is exempt and it is the only measured peer).
+        std::vector<PeerLatencyView> peers;
+        PeerLatencyView prim = server("primary", 5000);
+        prim.is_primary = true;
+        peers.push_back(prim);
+        peers.push_back(server("unmeasured", -1));   // no sample yet
+        CHECK(slowest_retirement_victim(peers) == -1);
+    }
+
+    // ── (2) RETIREMENT PICKS THE SLOWEST ─────────────────────────────────────
+    {
+        // Highest EWMA wins regardless of position.
+        std::vector<PeerLatencyView> peers;
+        peers.push_back(server("a", 120));
+        peers.push_back(server("b", 880));   // slowest
+        peers.push_back(server("c", 300));
+        const int v = slowest_retirement_victim(peers);
+        CHECK(v == 1);
+        CHECK(peers[v].key == "b");
+    }
+    {
+        // Ties resolve to the FIRST peer (deterministic).
+        std::vector<PeerLatencyView> peers;
+        peers.push_back(server("first",  500));
+        peers.push_back(server("second", 500));
+        const int v = slowest_retirement_victim(peers);
+        CHECK(v == 0);
+        CHECK(peers[v].key == "first");
+    }
+    {
+        // A NON-SERVER (#148) is never chosen even when it is slowest — proactive
+        // rotation operates ONLY among CanServeBlocks peers.
+        std::vector<PeerLatencyView> peers;
+        PeerLatencyView nonserver = server("nonserver", 9999);
+        nonserver.can_serve_blocks = false;
+        peers.push_back(nonserver);
+        peers.push_back(server("server", 400));
+        const int v = slowest_retirement_victim(peers);
+        CHECK(v == 1);
+        CHECK(peers[v].key == "server");
+    }
+    {
+        // A peer with no measurement is never chosen, even if it is the only
+        // non-primary server; a slower MEASURED server outranks it.
+        std::vector<PeerLatencyView> peers;
+        peers.push_back(server("measured",   250));
+        peers.push_back(server("unmeasured", -1));
+        const int v = slowest_retirement_victim(peers);
+        CHECK(v == 0);
+        CHECK(peers[v].key == "measured");
+    }
+    {
+        // Empty set / no eligible peer => -1 (the caller then does nothing).
+        std::vector<PeerLatencyView> empty;
+        CHECK(slowest_retirement_victim(empty) == -1);
+
+        std::vector<PeerLatencyView> all_unmeasured;
+        all_unmeasured.push_back(server("x", -1));
+        all_unmeasured.push_back(server("y", -1));
+        CHECK(slowest_retirement_victim(all_unmeasured) == -1);
+    }
+
+    // ── (3) CADENCE IS BOUNDED ───────────────────────────────────────────────
+    {
+        const int64_t interval = 300;
+        // Flag OFF => NEVER due, however much time has passed (byte-identical to
+        // master).
+        CHECK(!proactive_due(/*armed=*/false, /*now=*/1'000'000, /*last=*/0, interval));
+
+        // Armed, first fire (last==0): not due until a full interval elapses.
+        CHECK(!proactive_due(true, /*now=*/0,   /*last=*/0, interval));
+        CHECK(!proactive_due(true, /*now=*/299, /*last=*/0, interval));
+        CHECK( proactive_due(true, /*now=*/300, /*last=*/0, interval));
+        CHECK( proactive_due(true, /*now=*/900, /*last=*/0, interval));
+
+        // Armed, after a fire at t=1000: bounded to one per interval.
+        CHECK(!proactive_due(true, /*now=*/1000, /*last=*/1000, interval));
+        CHECK(!proactive_due(true, /*now=*/1299, /*last=*/1000, interval));
+        CHECK( proactive_due(true, /*now=*/1300, /*last=*/1000, interval));
+
+        // Non-positive interval never fires (defensive).
+        CHECK(!proactive_due(true, /*now=*/10'000, /*last=*/0, 0));
+        CHECK(!proactive_due(true, /*now=*/10'000, /*last=*/0, -5));
+    }
+
+    if (g_fail == 0) {
+        std::printf("dash_proactive_rotation_kat: ALL PASS\n");
+        return 0;
+    }
+    std::printf("dash_proactive_rotation_kat: %d CHECK(s) FAILED\n", g_fail);
+    return 1;
+}

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -449,6 +449,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
+        << "           [--embedded-proactive-rotate]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
         << "           [--pin-splice-xcheck-arm]  (let pins ride an xcheck-SWAPPED dashd template; default OFF)\n"
         << "           [--pin-splice-block-budget] (EXCLUDE a pin that pushes the template past the block size cap; default OFF)\n"
@@ -973,7 +974,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // byte-identical to master. Template EFFECT additionally
              // requires --embedded-serve-mempool-txs; the #1218
              // gbt-xcheck-txmerkle guard is untouched and stays the referee.
-             bool embedded_ingest_dstx = false)
+             bool embedded_ingest_dstx = false,
+             // --embedded-proactive-rotate (PR-3): arm the LOW-RATE proactive
+             // coin-P2P peer rotation. DEFAULT OFF => the coin client runs the
+             // stall-only rotation (#147/#148), byte-identical to master. ON, a
+             // healthy pool periodically probes one fresh CanServeBlocks
+             // candidate and sheds its slowest measured non-primary server so
+             // the working set trends toward the fastest deliverers. Reward-safe
+             // (connection-management only; every reply still self-checked).
+             bool embedded_proactive_rotate = false)
 {
     namespace io = boost::asio;
 
@@ -2028,6 +2037,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // object that can never be fetched. One peer made "we didn't hear it"
         // a guess; N peers make it evidence. See p2p_client.hpp.
         coin_p2p->set_max_peers(coin_p2p_peers);
+        // PR-3: arm the LOW-RATE proactive rotation when requested. Default OFF
+        // => the coin client keeps its stall-only rotation (byte-identical to
+        // master); the setter only flips a member bool.
+        coin_p2p->set_proactive_rotate_enabled(embedded_proactive_rotate);
 
         if (coin_p2p_discover_eff) {
             // ── Network-standalone arm: seed-discovered, SCORED, group-diverse
@@ -8910,6 +8923,10 @@ int main(int argc, char** argv)
     // pull + BLS-verified zero-fee admission with dashd's +0.1 COIN
     // prioritisation delta). DEFAULT OFF — wire and templates byte-identical.
     bool embedded_ingest_dstx = false;
+    // --embedded-proactive-rotate (PR-3): LOW-RATE proactive coin-P2P peer
+    // rotation. DEFAULT OFF — the coin client keeps its stall-only rotation,
+    // byte-identical to master.
+    bool embedded_proactive_rotate = false;
     std::string bestcl_policy = "freshness";   // --bestcl-policy: freshness (default, conservative proxy) | consensus-exact (dashcore's actual CheckCbTxBestChainlock rule)
     bool embedded_oracle_shadow = false;       // --embedded-oracle-shadow: per-block dashd cross-check (OBSERVE-only)
     bool embedded_shadow_compare = false;      // --embedded-shadow-compare: serve-vs-dashd template diff (OBSERVE-only, NOT a gate)
@@ -9036,6 +9053,8 @@ int main(int argc, char** argv)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
             embedded_ingest_dstx = true;      // W5-B CoinJoin DSTX feed
+        else if (std::strcmp(argv[i], "--embedded-proactive-rotate") == 0)
+            embedded_proactive_rotate = true; // PR-3 proactive peer rotation
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;
@@ -9365,7 +9384,8 @@ int main(int argc, char** argv)
                         embedded_null_arm,             // #127
                         embedded_accrue_asset_unlocks, // #143 Variant B
                         embedded_ingest_isdlock,       // G4 isdlock feed
-                        embedded_ingest_dstx);         // W5-B DSTX feed
+                        embedded_ingest_dstx,          // W5-B DSTX feed
+                        embedded_proactive_rotate);    // PR-3 proactive rotation
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -94,6 +94,7 @@
 #include <impl/dash/coin/arrival_timing.hpp>     // PR-0: per-peer per-datum-class delivery-latency EWMA (instrumentation only)
 #include <impl/dash/coin/fresh_datum_race.hpp>   // PR-2: fresh-datum race (K-way fan-out selector + single-flight dedup; flag/K default-OFF)
 #include <impl/dash/coin/coin_peer_manager.hpp> // PR-2: peer_network_group() for distinct-netgroup racing
+#include <impl/dash/coin/proactive_rotation_policy.hpp>  // PR-3: LOW-RATE proactive rotation decision helpers (pure, shared with the KAT)
 
 #include <algorithm>
 #include <chrono>
@@ -724,6 +725,11 @@ public:
     // analog) so refill_pool() draws a genuinely fresh candidate instead of
     // immediately re-dialing the non-server we just dropped.
     static constexpr int64_t OUTBOUND_ROTATE_COOLDOWN_SEC = 120;
+    // PR-3 proactive rotation cadence: a LOW rate (5 min) — far slower than
+    // the stall rotation (OUTBOUND_ROTATE_INTERVAL_SEC=20s). Bounds the
+    // proactive probe+shed so a HEALTHY pool trends toward the fastest
+    // deliverers without churning connections.
+    static constexpr int64_t PROACTIVE_ROTATE_INTERVAL_SEC = 300;
 
 private:
     dash::interfaces::Node* m_coin;
@@ -761,6 +767,14 @@ private:
     // Telemetry: how many demoted slot-holders we have rotated out for a fresh
     // archival dial (asserted by the KATs, surfaced in the pool-status log).
     uint64_t m_outbound_rotations{0};
+    // ── PR-3 proactive rotation (LOW-RATE, default OFF) ────────────────────
+    // When armed (--embedded-proactive-rotate), a HEALTHY pool periodically
+    // probes one fresh candidate and sheds its slowest measured non-primary
+    // server (maybe_proactive_rotate). OFF by default => on_pool_tick() runs the
+    // stall-only path, BYTE-IDENTICAL to master.
+    bool     m_proactive_rotate_enabled{false};
+    int64_t  m_last_proactive_rotate{0};
+    uint64_t m_proactive_rotations{0};
     // Round-robin cursor for the STATEFUL request legs (the mn-checkpoint
     // anchor->tip fold's getmnlistd snapshot). dashd picks a sync peer for a
     // mnlistdiff and ROTATES to another on stall rather than re-asking one slow
@@ -1438,6 +1452,11 @@ public:
     /// TEST-ONLY: master switch. Default ON; OFF restores the byte-identical
     /// pre-port frozen-full-pool behaviour (the RED arm of the acquisition KATs).
     void set_outbound_rotate_enabled_for_test(bool on) { m_outbound_rotate_enabled = on; }
+    /// PR-3: arm the LOW-RATE proactive rotation (--embedded-proactive-rotate).
+    /// Default OFF => byte-identical to master (stall-only rotation).
+    void set_proactive_rotate_enabled(bool on) { m_proactive_rotate_enabled = on; }
+    void set_proactive_rotate_enabled_for_test(bool on) { m_proactive_rotate_enabled = on; }
+    uint64_t proactive_rotations_for_test() const { return m_proactive_rotations; }
     /// TEST-ONLY: the dashd GetExtraFullOutboundCount-raised effective target.
     std::size_t effective_max_peers_for_test() const { return effective_max_peers(); }
     /// TEST-ONLY: behind on archival coverage (a demoted non-server holds a slot)?
@@ -2788,6 +2807,132 @@ private:
         refill_pool();                  // immediate redial; 30s loop is backstop
     }
 
+    /// PR-3: dial EXACTLY ONE fresh plan candidate (the proactive probe).
+    /// Unlike refill_pool() this ignores the effective target and dials a single
+    /// fresh address the pool does not already hold / dial / just rotated out,
+    /// so a HEALTHY pool can add one probe peer without a stall having raised the
+    /// target. Returns true iff a dial was issued. Reward-safe: a connection
+    /// only — the probe's replies flow through the identical fold self-checks.
+    bool dial_one_fresh_candidate(int64_t now)
+    {
+        if (!m_reconnect_enabled || m_dial_plan.empty()) return false;
+        prune_stale_dials(now);
+        const std::size_t n = m_dial_plan.size();
+        for (std::size_t i = 0; i < n; ++i)
+        {
+            const NetService target_addr = m_dial_plan.current();
+            m_dial_plan.advance();
+            const std::string key = target_addr.to_string();
+            if (holds_key(key) || m_dialing.count(key)) continue;
+            if (is_rotation_cooled(key, now)) continue;
+            m_dialing[key] = now;
+            LOG_INFO << "[" << m_chain_label << "] proactive probe dial " << key
+                     << " (pool " << m_pool.size() << "/" << m_max_peers
+                     << ", " << m_dialing.size() << " in flight)";
+            core::Factory<core::Client>::connect(target_addr);
+            return true;
+        }
+        return false;
+    }
+
+    // ── PR-3 proactive rotation (LOW-RATE, default OFF) ────────────────────
+    /// The proactive half of the acquisition loop, gated behind
+    /// --embedded-proactive-rotate. Even when NOT behind (no demoted slot-holder
+    /// and no stateful stall, so maybe_rotate_outbound() is a no-op), a healthy
+    /// pool that has latched on its frozen first-come set never discovers a
+    /// faster peer. Once per PROACTIVE_ROTATE_INTERVAL_SEC this:
+    ///   (1) PROBES — dials ONE fresh candidate if there is head-room under the
+    ///       hard cap, so its TipBody delivery-latency EWMA (PR-0 feed) starts
+    ///       filling on the next tip it answers; and
+    ///   (2) RETIRES — sheds the SLOWEST measured non-primary CanServeBlocks
+    ///       server, but ONLY when a genuine surplus remains afterwards (pool
+    ///       above the base target) and a fresh candidate exists to replace it.
+    /// m_primary and any protected-local peer (#147) are the latency reference
+    /// and are NEVER retired; selection operates ONLY among CanServeBlocks peers
+    /// (#148) and never promotes a non-server. Bounded by the cadence + the hard
+    /// cap. Default OFF => this whole method returns immediately, so
+    /// on_pool_tick() is byte-identical to master.
+    ///
+    /// Reward-safe (same class as #1329): only WHICH / HOW-MANY peers we fetch
+    /// from and WHEN we probe changes — never WHAT is fetched or derived. Every
+    /// reply still passes the identical merkle/payee/DIP-4/BLS self-checks;
+    /// worst case is one extra probe connection + one reconnect.
+    void maybe_proactive_rotate(int64_t now)
+    {
+        if (!proactivepolicy::proactive_due(m_proactive_rotate_enabled, now,
+                                            m_last_proactive_rotate,
+                                            PROACTIVE_ROTATE_INTERVAL_SEC))
+            return;
+
+        prune_rotation_cooldown(now);
+        bool acted = false;
+
+        // (1) PROBE one fresh candidate while there is head-room under the cap.
+        if (m_pool.size() + m_dialing.size() < POOL_PEERS_HARD_CAP
+            && has_fresh_dial_candidate(now))
+        {
+            acted = dial_one_fresh_candidate(now);
+        }
+
+        // (2) RETIRE the slowest measured non-primary server — only with a
+        // surplus over the base target AND a fresh candidate to replace it, so
+        // proactive rotation can never drop the pool below its healthy count.
+        if (m_pool.size() > m_max_peers && has_fresh_dial_candidate(now))
+        {
+            std::vector<proactivepolicy::PeerLatencyView> views;
+            views.reserve(m_pool.size());
+            for (const auto& up : m_pool)
+            {
+                PeerSession* p = up.get();
+                if (!p->handshake.complete()) continue;
+                if (is_rotation_cooled(p->key, now)) continue;
+                const AddrClass ac = classify_address(p->addr.address());
+                const auto& e = p->delivery.get(DatumClass::TipBody);
+                proactivepolicy::PeerLatencyView v;
+                v.key = p->key;
+                v.is_primary = (p == m_primary);
+                v.is_protected_local =
+                    (ac == AddrClass::loopback || ac == AddrClass::private_net);
+                v.can_serve_blocks = can_serve_blocks(p);
+                v.has_latency = e.has_sample();
+                v.ewma_ms = e.ewma_ms();
+                views.push_back(std::move(v));
+            }
+            const int idx = proactivepolicy::slowest_retirement_victim(views);
+            if (idx >= 0)
+            {
+                const std::string vkey = views[static_cast<std::size_t>(idx)].key;
+                PeerSession* victim = find_peer(vkey);
+                // Belt-and-suspenders: the primary is exempt in the selector,
+                // but never remove it here even if identity somehow shifted.
+                if (victim && victim != m_primary)
+                {
+                    LOG_INFO << "[" << m_chain_label << "] proactive rotation: "
+                                "retiring slowest server " << vkey
+                             << " (tip_body_ewma_ms="
+                             << views[static_cast<std::size_t>(idx)].ewma_ms
+                             << ") for a fresh archival probe (PR-3, reward-safe: "
+                                "connection-management only)";
+                    m_rotation_cooldown[vkey] = now + OUTBOUND_ROTATE_COOLDOWN_SEC;
+                    forgive_bulk_nonserver(vkey);
+                    remove_peer(victim, "proactive rotation: slowest measured "
+                                        "server shed for a fresh probe");
+                    refill_pool();   // immediate redial; 30s loop is backstop
+                    acted = true;
+                }
+            }
+        }
+
+        // Advance the cadence clock only when we actually acted, so a quiet
+        // interval (no fresh candidate, pool already at cap) re-checks next tick
+        // rather than silently burning the interval.
+        if (acted)
+        {
+            m_last_proactive_rotate = now;
+            ++m_proactive_rotations;
+        }
+    }
+
     /// Reclaim dial slots whose callback never came. Without this a Factory
     /// dial that neither connects nor fails (a black-holed SYN) would hold a
     /// pool slot for the life of the process and silently cap the pool.
@@ -2906,6 +3051,10 @@ private:
         // more and rotate the frozen full pool's worst non-server out for a
         // fresh archival candidate (connection-management only, reward-safe).
         maybe_rotate_outbound(now);
+        // PR-3: LOW-RATE proactive rotation — even a HEALTHY (not-behind) pool
+        // periodically probes a fresh candidate and sheds its slowest measured
+        // server. Default OFF => no-op (byte-identical to master).
+        maybe_proactive_rotate(now);
         maybe_log_pool_status(now);
     }
 

--- a/src/impl/dash/coin/proactive_rotation_policy.hpp
+++ b/src/impl/dash/coin/proactive_rotation_policy.hpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// PR-3 proactive peer-rotation policy — pure, dependency-free decision helpers
+// shared by the coin P2P client (p2p_client.hpp maybe_proactive_rotate) and the
+// KAT (dash_proactive_rotation_kat.cpp). Kept free of any coin / boost / socket
+// / session dependency so BOTH the real call site AND the KAT link against the
+// EXACT same logic — no duplicated shadow implementation that could go green
+// while the shipped path regresses (the bulk_peer_policy.hpp precedent).
+//
+// WHAT this adds (dashd-cut coin-P2P, task #154 line, stacks on PR-0 arrival
+// instrumentation). The always-on stall rotation (#147/#148,
+// maybe_rotate_outbound) only cycles peers WHILE BEHIND — a demonstrated
+// deep-body non-server occupies a slot, or a fold getmnlistd is stalled. A
+// HEALTHY pool therefore latches on its frozen first-come set forever, even if
+// a member is the slowest deliverer in it. This policy is the LOW-RATE
+// proactive half: when armed, a healthy pool periodically probes one fresh
+// candidate and sheds its SLOWEST measured non-primary server, so the working
+// set trends toward the fastest deliverers.
+//
+// SAFETY (same class as #1329). This decides only WHICH / HOW-MANY peers we
+// fetch from and WHEN we probe — never WHAT is fetched or derived. Every reply
+// still flows through the identical merkle / payee / DIP-4 / BLS self-checks;
+// the worst case is one extra probe connection plus one reconnect on an
+// already-verified small object. m_primary and any protected-local peer (#147)
+// are the latency REFERENCE and are NEVER retirement-eligible; selection and
+// retirement operate ONLY among CanServeBlocks peers (#148).
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+namespace proactivepolicy {
+
+// A per-peer view for proactive-rotation retirement selection. Pure data: the
+// caller (CoinClient) fills it from its live PeerSession set, the KAT fills it
+// by hand, and BOTH run the identical selector below.
+struct PeerLatencyView {
+    std::string key;
+    bool     is_primary{false};          // #147: latency reference, NEVER retired
+    bool     is_protected_local{false};  // #147: loopback/LAN, NEVER retired
+    bool     can_serve_blocks{false};    // #148: only servers are in play
+    bool     has_latency{false};         // a TipBody delivery-latency sample exists
+    int64_t  ewma_ms{-1};                // smoothed TipBody delivery latency (PR-0)
+};
+
+// Cadence gate. Proactive rotation may fire at most once per interval; `armed`
+// false (flag default-OFF) => NEVER (byte-identical to master). A never-fired
+// clock (last_fire==0) becomes due once `now` has advanced one interval, the
+// same now-last>=interval convention the stall rotation uses. A non-positive
+// interval never fires (defensive).
+inline bool proactive_due(bool armed, std::int64_t now, std::int64_t last_fire,
+                          std::int64_t interval_sec) {
+    if (!armed) return false;
+    if (interval_sec <= 0) return false;
+    return now - last_fire >= interval_sec;
+}
+
+// Retirement victim: the SLOWEST (highest EWMA) eligible peer.
+//   eligible = can_serve_blocks (#148)
+//              AND NOT is_primary AND NOT is_protected_local (#147 exempt)
+//              AND has_latency AND ewma_ms >= 0
+// Returns the index into `peers`, or -1 when nothing is eligible. Ties resolve
+// to the FIRST such peer (stable / deterministic — the KAT locks it). The
+// caller's surplus guard decides whether it is SAFE to retire the returned
+// peer; this function only names the slowest.
+inline int slowest_retirement_victim(const std::vector<PeerLatencyView>& peers) {
+    int victim = -1;
+    std::int64_t worst = -1;
+    for (std::size_t i = 0; i < peers.size(); ++i) {
+        const PeerLatencyView& p = peers[i];
+        if (p.is_primary || p.is_protected_local) continue;  // #147 exempt
+        if (!p.can_serve_blocks) continue;                    // #148 servers only
+        if (!p.has_latency || p.ewma_ms < 0) continue;        // no measurement
+        if (victim < 0 || p.ewma_ms > worst) {
+            victim = static_cast<int>(i);
+            worst = p.ewma_ms;
+        }
+    }
+    return victim;
+}
+
+} // namespace proactivepolicy
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -327,6 +327,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_dependencies(test_dash_serve_gate_journal dash_arrival_instrumentation_kat)  # PR-0 coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_latency_scoring_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_fresh_datum_race_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
+    add_dependencies(test_dash_serve_gate_journal dash_proactive_rotation_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## PR-3 — Proactive coin-P2P peer rotation (LOW-RATE)

Extends the coin client's outbound rotation with a **LOW-RATE proactive cadence**. The always-on stall rotation (#147/#148, `maybe_rotate_outbound`) only cycles peers **while behind** — a demonstrated deep-body non-server holds a slot, or a fold `getmnlistd` is stalled. A **healthy** pool therefore latches on its frozen first-come set forever, even if a member is the slowest deliverer in it. This PR is the missing proactive half: even when NOT stalled, once per cadence a healthy pool probes one fresh candidate and sheds its slowest measured server so the working set trends toward the fastest deliverers.

### What it does (when armed)
Once per `PROACTIVE_ROTATE_INTERVAL_SEC` (300s, `on_pool_tick` -> `maybe_proactive_rotate`):
1. **PROBE** — dials **one** fresh `CanServeBlocks` candidate (`has_fresh_dial_candidate` + new `dial_one_fresh_candidate`) while there is head-room under `POOL_PEERS_HARD_CAP`, so its **TipBody delivery-latency EWMA (PR-0 feed)** starts filling on the next tip it answers.
2. **RETIRE** — sheds the **slowest measured non-primary `CanServeBlocks` server**, but ONLY with a genuine surplus over the base target (`m_pool.size() > m_max_peers`) AND a fresh replacement candidate, then `refill_pool()` redials.

`m_primary` and any **protected-local** peer (#147, loopback/private-LAN) are the latency **reference** and are **never** retired. Selection operates **only among `CanServeBlocks` peers** (#148) and never promotes a non-server. Bounded by the cadence + the hard cap.

### Reward-safety argument (must hold)
Same class as #1329. This changes only **WHICH / HOW-MANY** peers we fetch from and **WHEN** we probe — **never WHAT** is fetched or derived. Every reply still flows through the identical merkle / payee / DIP-4 / BLS self-checks. Worst case = one extra probe connection + one reconnect on an already-verified small object. Peer *identity* moves; block *validity* is untouched, no block is ever skipped.

### Flag (default-OFF => byte-identical to master)
`--embedded-proactive-rotate` (member `m_proactive_rotate_enabled{false}`, setter `set_proactive_rotate_enabled`). OFF => `maybe_proactive_rotate` returns immediately and `on_pool_tick` runs exactly the stall-only path — **byte-identical to master**. The cadence gate (`proactivepolicy::proactive_due`) also short-circuits on `armed==false`.

### Design note — pure policy header
The decision logic (cadence gate + slowest-victim selection) lives in a new pure, dependency-free header `src/impl/dash/coin/proactive_rotation_policy.hpp` (the `bulk_peer_policy.hpp` precedent), so the shipped client and the KAT link the **exact same code** — no shadow reimplementation that could go green while the client regresses.

### KAT
`dash_proactive_rotation_kat` (BLS=ON, header-only, links nothing — mirrors the PR-0 arrival KAT). Locks the three invariants:
- **primary / protected-local NEVER retired** (even when they are the slowest measured peer);
- **retirement picks the slowest** measured `CanServeBlocks` server (ties deterministic; non-servers and unmeasured peers never chosen);
- **cadence bounded** (not due inside the interval, due once a full interval elapses, and NEVER fires when the flag is OFF).

Proven green, and **RED-proven**: removing the #147 exemption fails exactly the primary-never-retired checks. Also verified that `main_dash.cpp` (which instantiates `CoinClient<dash::Config>`) compiles cleanly with the new template members + CLI wiring.

### Stack / merge order
`PR-0 -> PR-1 -> PR-2 -> PR-3 -> PR-4`. This PR **stacks on `dash/coinp2p-pr0-arrival-instrumentation`** (consumes its per-peer TipBody delivery-latency EWMA). Rebase onto `master` after each predecessor merges. **Do not merge out of order.**

Opened NON-merged (draft=false) for review.
