### PR TITLE
dash(daemonless): PR-1 latency-aware peer scoring (passive, default-OFF)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -432,6 +432,17 @@ add_test(NAME coin_peer_rearm_kat COMMAND coin_peer_rearm_kat)
 add_executable(dash_arrival_instrumentation_kat dash_arrival_instrumentation_kat.cpp)
 add_test(NAME dash_arrival_instrumentation_kat COMMAND dash_arrival_instrumentation_kat)
 
+# -- KAT: PR-1 LATENCY-AWARE PEER SCORING (dashd-cut coin-P2P stack) --
+# Exercises the REAL dash::coin::DashPeerInfo::compute_score(): flag OFF is
+# byte-identical to master (latency term == 0), flag ON adds a bounded/clamped
+# tie-breaker so the faster deliverer ranks up. coin_peer_manager.hpp is a
+# header-only dash coin leaf; it needs the core lib for NetService + the JSON
+# header it includes. Built under -DC2POOL_DASH_BLS=ON; carries no BLS symbols.
+add_executable(dash_latency_scoring_kat dash_latency_scoring_kat.cpp)
+target_link_libraries(dash_latency_scoring_kat core ltc c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)
+target_link_libraries(dash_latency_scoring_kat nlohmann_json::nlohmann_json)
+add_test(NAME dash_latency_scoring_kat COMMAND dash_latency_scoring_kat)
+
 # Legacy applications have been archived to ../../archive/
 # - c2pool_legacy.cpp (original c2pool.cpp)
 # - c2pool_node_legacy.cpp (original c2pool_node.cpp)

--- a/src/c2pool/dash_latency_scoring_kat.cpp
+++ b/src/c2pool/dash_latency_scoring_kat.cpp
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// KAT: PR-1 LATENCY-AWARE PEER SCORING (dashd-cut coin-P2P stack).
+//
+// Locks the two guarantees the reward-safety argument rests on, exercising the
+// REAL dash::coin::DashPeerInfo::compute_score() (not a re-implementation):
+//
+//   (1) FLAG DEFAULT-OFF => BYTE-IDENTICAL TO MASTER. With the flag off, a peer
+//       carrying arbitrary delivery-latency / ping-RTT samples scores EXACTLY
+//       what the same peer with no samples scores — the latency term is 0, so
+//       compute_score() reproduces master's value bit for bit. This is the
+//       whole default-OFF safety claim, asserted directly.
+//
+//   (2) FLAG ON => the faster deliverer RANKS UP, as a BOUNDED, CLAMPED
+//       tie-breaker. Two peers identical in every structural field but their
+//       measured latency: the faster one scores strictly higher. The term is
+//       monotonically decreasing in latency, clamped to +/-kLatencyScoreMax,
+//       and the source preference (tip_body > other delivery class > ping RTT)
+//       is exercised. The term NEVER changes eligibility — it is only ever
+//       added to an already-computed score, so it can only reorder preference
+//       within the eligible set.
+//
+// Header-only subject (coin_peer_manager.hpp is a dash coin leaf); links the
+// core lib for NetService. Built under -DC2POOL_DASH_BLS=ON like the dash suite.
+
+#include <impl/dash/coin/coin_peer_manager.hpp>
+
+#include <cstdio>
+
+using dash::coin::DashPeerInfo;
+using dash::coin::DatumClass;
+using dash::coin::peer_latency_score_enabled;
+using dash::coin::set_peer_latency_score_enabled;
+
+static int g_fail = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_fail; } } while (0)
+
+// A default coin-daemon-learned peer: the deterministic baseline the master
+// formula scores. No samples, no successes; every field left at its default so
+// two of them are guaranteed to score identically.
+static DashPeerInfo make_default_peer()
+{
+    DashPeerInfo p;
+    p.source = DashPeerInfo::Source::coind;
+    return p;
+}
+
+int main()
+{
+    // The emit flag must start OFF (the byte-identical-to-master guarantee).
+    CHECK(peer_latency_score_enabled() == false);
+
+    // ── MASTER BASELINE (flag OFF, no samples) ───────────────────────────────
+    const int master_score = make_default_peer().compute_score();
+
+    // ── (1) FLAG OFF => LATENCY IS INVISIBLE (byte-identical to master) ───────
+    {
+        DashPeerInfo fast = make_default_peer();
+        fast.record_delivery(DatumClass::TipBody, 5);      // very fast
+        fast.record_delivery(DatumClass::MnListDiff, 10);
+        fast.record_ping_rtt(3);
+        DashPeerInfo slow = make_default_peer();
+        slow.record_delivery(DatumClass::TipBody, 5000);   // very slow
+        slow.record_ping_rtt(9000);
+
+        // Samples recorded, flag OFF: term is 0 for both, score == master.
+        CHECK(fast.latency_score_term() == 0);
+        CHECK(slow.latency_score_term() == 0);
+        CHECK(fast.compute_score() == master_score);
+        CHECK(slow.compute_score() == master_score);
+        CHECK(fast.compute_score() == slow.compute_score());
+    }
+
+    // ── (2) FLAG ON => faster deliverer ranks up (bounded, clamped) ──────────
+    set_peer_latency_score_enabled(true);
+    CHECK(peer_latency_score_enabled() == true);
+
+    {
+        // Two peers identical but for tip_body delivery latency.
+        DashPeerInfo fast = make_default_peer();
+        fast.record_delivery(DatumClass::TipBody, 40);     // (200-40)*25/200 = 20
+        DashPeerInfo slow = make_default_peer();
+        slow.record_delivery(DatumClass::TipBody, 400);    // (200-400)*25/200 = -25
+
+        CHECK(fast.latency_score_term() == 20);
+        CHECK(slow.latency_score_term() == -25);
+        CHECK(fast.compute_score() == master_score + 20);
+        CHECK(slow.compute_score() == master_score - 25);
+        // The reward-safe claim: the faster deliverer ranks strictly up.
+        CHECK(fast.compute_score() > slow.compute_score());
+    }
+
+    // Exact term at the reference latency and the clamp boundaries.
+    {
+        DashPeerInfo ref = make_default_peer();
+        ref.record_delivery(DatumClass::TipBody, 200);     // exactly reference
+        CHECK(ref.latency_score_term() == 0);
+        CHECK(ref.compute_score() == master_score);        // neutral, == master
+
+        DashPeerInfo instant = make_default_peer();
+        instant.record_delivery(DatumClass::TipBody, 0);   // (200-0)*25/200 = 25
+        CHECK(instant.latency_score_term() == 25);         // = +max, not above
+
+        DashPeerInfo glacial = make_default_peer();
+        glacial.record_delivery(DatumClass::TipBody, 5000);// would be -600
+        CHECK(glacial.latency_score_term() == -25);        // clamped at -max
+    }
+
+    // No sample at all, flag ON: neutral term (never penalises the unmeasured).
+    {
+        DashPeerInfo blank = make_default_peer();
+        CHECK(blank.latency_score_term() == 0);
+        CHECK(blank.compute_score() == master_score);
+    }
+
+    // Source preference: tip_body > other delivery class > ping RTT.
+    {
+        // Only a non-tip delivery class measured => it is used.
+        DashPeerInfo mn_only = make_default_peer();
+        mn_only.record_delivery(DatumClass::MnListDiff, 100); // (200-100)*25/200 = 12
+        CHECK(mn_only.representative_latency_ms() == 100);
+        CHECK(mn_only.latency_score_term() == 12);
+
+        // Only ping RTT measured => it is the fallback.
+        DashPeerInfo ping_only = make_default_peer();
+        ping_only.record_ping_rtt(300);                       // (200-300)*25/200 = -12
+        CHECK(ping_only.representative_latency_ms() == 300);
+        CHECK(ping_only.latency_score_term() == -12);
+
+        // tip_body present alongside a SLOW mnlistdiff => tip_body wins.
+        DashPeerInfo tip_pref = make_default_peer();
+        tip_pref.record_delivery(DatumClass::TipBody, 50);
+        tip_pref.record_delivery(DatumClass::MnListDiff, 1000);
+        CHECK(tip_pref.representative_latency_ms() == 50);     // not 1000
+        CHECK(tip_pref.latency_score_term() == 18);            // (200-50)*25/200
+
+        // Fastest of several non-tip classes is chosen when tip is absent.
+        DashPeerInfo multi = make_default_peer();
+        multi.record_delivery(DatumClass::MnListDiff, 300);
+        multi.record_delivery(DatumClass::QrInfo, 120);
+        CHECK(multi.representative_latency_ms() == 120);       // min of the two
+    }
+
+    // Monotonicity across a latency sweep (faster is never scored worse).
+    {
+        int prev_term = 1000;  // above any possible term
+        for (int64_t lat = 0; lat <= 600; lat += 25) {
+            DashPeerInfo p = make_default_peer();
+            p.record_delivery(DatumClass::TipBody, lat);
+            const int t = p.latency_score_term();
+            CHECK(t <= prev_term);                    // non-increasing in latency
+            CHECK(t <= DashPeerInfo::kLatencyScoreMax);
+            CHECK(t >= -DashPeerInfo::kLatencyScoreMax);
+            prev_term = t;
+        }
+    }
+
+    // ── (3) FLAG OFF AGAIN => back to byte-identical to master ────────────────
+    set_peer_latency_score_enabled(false);
+    CHECK(peer_latency_score_enabled() == false);
+    {
+        DashPeerInfo fast = make_default_peer();
+        fast.record_delivery(DatumClass::TipBody, 1);
+        CHECK(fast.latency_score_term() == 0);
+        CHECK(fast.compute_score() == master_score);
+    }
+
+    if (g_fail == 0) { std::printf("dash_latency_scoring_kat PASS\n"); return 0; }
+    std::printf("dash_latency_scoring_kat FAIL (%d)\n", g_fail);
+    return 1;
+}

--- a/src/impl/dash/coin/coin_peer_manager.hpp
+++ b/src/impl/dash/coin/coin_peer_manager.hpp
@@ -97,6 +97,28 @@ inline std::string peer_network_group(const std::string& ip)
 }
 
 // ─── Peer info tracked per endpoint ──────────────────────────────────────────
+// PR-1 LATENCY-AWARE PEER SCORING (default-OFF flag).
+// When OFF, DashPeerInfo::latency_score_term() returns exactly 0, so
+// compute_score() is byte-identical to master. A process-wide relaxed
+// atomic set once at startup from --embedded-peer-latency-score and read on
+// the peer-selection thread. Arming it only reorders preference WITHIN the
+// already-eligible peer set (eligibility is decided by can_retry / group
+// caps / is_protected, never by this term); it can never add or remove an
+// eligible peer, fetch anything, or change what is derived.
+inline std::atomic<bool>& peer_latency_score_flag()
+{
+    static std::atomic<bool> g{false};
+    return g;
+}
+inline bool peer_latency_score_enabled()
+{
+    return peer_latency_score_flag().load(std::memory_order_relaxed);
+}
+inline void set_peer_latency_score_enabled(bool on)
+{
+    peer_latency_score_flag().store(on, std::memory_order_relaxed);
+}
+
 struct DashPeerInfo
 {
     enum class Source { coind, addr_crawl, manual, dns_seed, fixed_seed };
@@ -137,6 +159,66 @@ struct DashPeerInfo
     void record_delivery(DatumClass cls, int64_t latency_ms)
     {
         delivery_latency.observe(cls, latency_ms);
+    }
+
+    // PR-1 LATENCY-AWARE SCORING. A second latency source: the PeerLiveness
+    // ping/pong round-trip time (PeerLiveness measures it per peer). It is a
+    // datum-class-agnostic responsiveness signal used as the FALLBACK when the
+    // peer has not yet answered a real fetch (tip_body / mnlistdiff / qrinfo).
+    // Pure EWMA record, same class as delivery_latency; never gates anything.
+    DeliveryLatencyEwma ping_rtt;
+
+    // Feed one observed ping->pong RTT (monotonic ms) for THIS peer.
+    void record_ping_rtt(int64_t rtt_ms)
+    {
+        ping_rtt.observe(rtt_ms);
+    }
+
+    // Read accessors (telemetry / scoring input). -1 before any sample.
+    int64_t delivery_ewma_ms(DatumClass cls) const { return delivery_latency.ewma_ms(cls); }
+    int64_t ping_rtt_ewma_ms() const { return ping_rtt.ewma_ms(); }
+
+    // The single latency figure the scorer consults, in ms, or -1 if this peer
+    // has produced NO latency sample at all (=> neutral term). Preference:
+    //   1. tip_body delivery EWMA  — the live-serve datum peer selection is
+    //      ultimately optimizing the delivery of;
+    //   2. else the fastest other measured delivery class (mnlistdiff/qrinfo);
+    //   3. else the PeerLiveness ping RTT.
+    int64_t representative_latency_ms() const
+    {
+        const int64_t tip = delivery_latency.ewma_ms(DatumClass::TipBody);
+        if (tip >= 0) return tip;
+        int64_t best = -1;
+        for (size_t i = 0; i < static_cast<size_t>(DatumClass::Count); ++i) {
+            const int64_t e = delivery_latency.get(static_cast<DatumClass>(i)).ewma_ms();
+            if (e >= 0 && (best < 0 || e < best)) best = e;
+        }
+        if (best >= 0) return best;
+        return ping_rtt.ewma_ms();
+    }
+
+    // Bounds for the latency tie-breaker. Deliberately SMALLER in magnitude
+    // than the structural score signals (source +/-50, in_tried +50, age
+    // +/-50) so latency reorders peers WITHIN a preference tier rather than
+    // promoting a daemon-learned peer over an addr-crawl one on speed alone.
+    static constexpr int     kLatencyScoreMax = 25;   // clamp magnitude (points)
+    static constexpr int64_t kLatencyRefMs    = 200;  // term == 0 at this latency
+
+    // Bounded, clamped latency tie-breaker (points added to compute_score()).
+    //   OFF, or no latency sample      => 0  (byte-identical to master)
+    //   faster than kLatencyRefMs      => positive, up to +kLatencyScoreMax
+    //   slower than kLatencyRefMs      => negative, down to -kLatencyScoreMax
+    // Monotonically DECREASING in latency, so the faster deliverer ranks up.
+    // Integer arithmetic only (deterministic; the KAT locks the exact values).
+    int latency_score_term() const
+    {
+        if (!peer_latency_score_enabled()) return 0;
+        const int64_t lat = representative_latency_ms();
+        if (lat < 0) return 0;
+        int64_t term = (kLatencyRefMs - lat) * kLatencyScoreMax / kLatencyRefMs;
+        if (term >  kLatencyScoreMax) term =  kLatencyScoreMax;
+        if (term < -kLatencyScoreMax) term = -kLatencyScoreMax;
+        return static_cast<int>(term);
     }
 
     std::string key() const { return address.to_string(); }
@@ -231,6 +313,13 @@ struct DashPeerInfo
             if (std::chrono::duration_cast<std::chrono::hours>(uptime).count() < 1)
                 s += 20;
         }
+
+        // PR-1 LATENCY-AWARE SCORING (default-OFF): bounded, clamped
+        // tie-breaker that prefers the peer answering our requests fastest.
+        // OFF => term is exactly 0 => byte-identical to master. It only
+        // reorders preference within the already-eligible set; it never
+        // gates eligibility (is_protected returned 999999 above, untouched).
+        s += latency_score_term();
 
         return s;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -325,6 +325,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # find it instead of reporting it NOT_BUILT / Not Run.
     add_dependencies(test_dash_serve_gate_journal dash_tx_serve_self_validation_kat)
     add_dependencies(test_dash_serve_gate_journal dash_arrival_instrumentation_kat)  # PR-0 coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
+    add_dependencies(test_dash_serve_gate_journal dash_latency_scoring_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## PR-1 — Latency-aware peer scoring (passive, default-OFF)

Second step of the coin-P2P peer racing/selection stack. Turns the per-peer,
per-datum-class delivery-latency EWMA that **PR-0** records into a **bounded,
clamped tie-breaker** inside `DashPeerInfo::compute_score()`, so the embedded
DASH arm can prefer the peer that has actually been answering our requests
fastest. Passive: it only reorders preference — it never changes who is dialed
for eligibility, what is fetched, or what is derived.

### What it adds (`src/impl/dash/coin/coin_peer_manager.hpp` only)
- `peer_latency_score_enabled()` / `set_peer_latency_score_enabled()` — a
  process-wide, **default-OFF** flag (armed by `--embedded-peer-latency-score`).
  OFF ⇒ `latency_score_term() == 0` ⇒ `compute_score()` is **byte-identical to
  master**.
- `DashPeerInfo::ping_rtt` (a PeerLiveness-RTT sink) + `record_ping_rtt()` — a
  datum-class-agnostic responsiveness EWMA used as the fallback signal.
- accessors `delivery_ewma_ms()` / `ping_rtt_ewma_ms()` and
  `representative_latency_ms()` — the single latency figure the scorer reads,
  preferring the **tip_body** delivery EWMA (the live-serve datum), then the
  fastest other measured delivery class, then the PeerLiveness ping RTT; `-1`
  (⇒ neutral) when the peer has produced no sample at all.
- `latency_score_term()`: integer, deterministic, **monotonically decreasing in
  latency**, **clamped to ±`kLatencyScoreMax` (25)**, zero at `kLatencyRefMs`
  (200). Folded into `compute_score()`'s final return **after** the
  `is_protected` early return, so the pinned local node (score 999999, #147) is
  untouched.

### Reward-safety argument
The latency term is only ever **added to an already-computed score**.
Eligibility (`can_retry` / network-group caps / `is_protected`) is decided
elsewhere and never consults latency, so the term can only **reorder preference
within the already-eligible set** — it can never add or remove an eligible peer,
fetch anything, or change what is derived. Peer selection/rotation changes only
*when* and *from-whom* a datum is requested, never *what* is fetched or derived;
every reply still flows through the identical merkle / payee / DIP-4 / BLS
self-checks (same class as #1329). Worst case is a differently-ordered dial
preference among peers already deemed dialable — extra connections/traffic on
already-verified small objects at most. The magnitude cap (25) is deliberately
smaller than the structural signals (source ±50, `in_tried` +50, age ±50) so
latency breaks ties **within** a preference tier rather than promoting a
daemon-learned peer over an addr-crawl one on speed alone.

**Flag:** `--embedded-peer-latency-score`
(`dash::coin::peer_latency_score_enabled`), default **OFF** ⇒ byte-identical to
master.

### KAT
`dash_latency_scoring_kat` (built with `-DC2POOL_DASH_BLS=ON`) exercises the
**real** `DashPeerInfo::compute_score()`:
- flag-OFF is byte-identical to master even with arbitrary latency samples
  present (term `== 0`);
- flag-ON makes the faster deliverer rank **strictly up**;
- exact term values at the reference latency and both clamp boundaries;
- the `tip_body > other-class > ping-RTT` source preference;
- monotonicity across a latency sweep; and
- the neutral (no-sample) term.

Locally: `dash_latency_scoring_kat PASS` (and PR-0's
`dash_arrival_instrumentation_kat` still PASS — shared header intact).

### Stack / merge order
`PR-0 → PR-1 → PR-2 → PR-3 → PR-4`. This branch is **stacked on
`dash/coinp2p-pr0-arrival-instrumentation`** (its diff vs master includes PR-0's
commit); rebase onto master after PR-0 merges. The session→record feed routing
(delivery + PeerLiveness RTT wired from `p2p_client` into the peer record) and
the racing that consumes this ranking land in the later selection PRs; PR-1
supplies the scorer + sinks so those PRs only wire the feed.

**Do not merge** — review only.
