### PR TITLE
dash(daemonless): PR-2 race the freshest datum to K distinct-netgroup carriers (flag/K default-OFF)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -442,6 +442,18 @@ add_executable(dash_latency_scoring_kat dash_latency_scoring_kat.cpp)
 target_link_libraries(dash_latency_scoring_kat core ltc c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage ltc_coin pool)
 target_link_libraries(dash_latency_scoring_kat nlohmann_json::nlohmann_json)
 add_test(NAME dash_latency_scoring_kat COMMAND dash_latency_scoring_kat)
+# ── KAT: PR-2 RACE THE FRESHEST DATUM (dashd-cut coin-P2P stack) ──
+# Locks (1) select_race_targets() naming the K fastest-scored CanServeBlocks
+# peers in DISTINCT netgroups (width<=1 == single carrier == today), and
+# (2) FreshDatumRaceInflight first-VALID-wins + single-flight dedup: the fold
+# self-check is licensed EXACTLY ONCE, duplicate racer copies are dropped, an
+# invalid copy with a sibling outstanding keeps racing, and the last racer
+# failing is fail-closed. fresh_datum_race.hpp is pure policy (header-only, no
+# node, no daemon, standard library only), so this target links NOTHING and
+# still exercises the reward-safety contract the wiring depends on. Built under
+# -DC2POOL_DASH_BLS=ON like the rest of the dash suite; carries no BLS symbols.
+add_executable(dash_fresh_datum_race_kat dash_fresh_datum_race_kat.cpp)
+add_test(NAME dash_fresh_datum_race_kat COMMAND dash_fresh_datum_race_kat)
 
 # Legacy applications have been archived to ../../archive/
 # - c2pool_legacy.cpp (original c2pool.cpp)

--- a/src/c2pool/dash_fresh_datum_race_kat.cpp
+++ b/src/c2pool/dash_fresh_datum_race_kat.cpp
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// KAT: PR-2 RACE THE FRESHEST DATUM (dashd-cut coin-P2P stack).
+//
+// Locks the two invariants the racing wiring in p2p_client.hpp (the K-way send)
+// and mn_checkpoint_lane.hpp (the reply demux) rely on:
+//
+//   (1) select_race_targets() names the K fastest-scored CanServeBlocks peers in
+//       DISTINCT netgroups. width<=1 is single-carrier (today). Non-serving,
+//       non-eligible peers are never named; two peers in one /16 count once.
+//
+//   (2) FreshDatumRaceInflight enforces first-VALID-wins + single-flight dedup:
+//       TWO replies, one slow/invalid => the FIRST valid reply Folds (self-check
+//       licensed EXACTLY ONCE), the duplicate is DropDuplicate, an invalid copy
+//       with a sibling still outstanding is DropKeepRacing (NOT fail-closed),
+//       and the LAST racer failing is Exhausted (fail-closed, == today at K=1).
+//
+// Pure red/green over ONE header-only unit, NO node and NO daemon — builds under
+// -DC2POOL_DASH_BLS=ON without the c2pool-dash object graph, like PR-0's KAT.
+
+#include <impl/dash/coin/fresh_datum_race.hpp>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using dash::coin::FreshDatumRaceInflight;
+using dash::coin::RaceCandidate;
+using dash::coin::RaceReplyAction;
+using dash::coin::select_race_targets;
+
+static int g_fail = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_fail; } } while (0)
+
+static RaceCandidate cand(const std::string& key, const std::string& grp,
+                          int score, bool can_serve, bool eligible)
+{
+    RaceCandidate c;
+    c.key = key; c.netgroup = grp; c.score = score;
+    c.can_serve = can_serve; c.eligible = eligible;
+    return c;
+}
+
+int main()
+{
+    // ── (1) TARGET SELECTION ────────────────────────────────────────────────
+
+    // Flag/K defaults: OFF, K=2, width==1 while OFF (byte-identical to master).
+    CHECK(dash::coin::fresh_datum_race_enabled() == false);
+    CHECK(dash::coin::fresh_datum_race_k() == 2);
+    CHECK(dash::coin::fresh_datum_race_width() == 1);   // OFF => single carrier
+    dash::coin::set_fresh_datum_race_enabled(true);
+    CHECK(dash::coin::fresh_datum_race_width() == 2);   // ON  => K
+    dash::coin::set_fresh_datum_race_k(3);
+    CHECK(dash::coin::fresh_datum_race_width() == 3);
+    dash::coin::set_fresh_datum_race_k(0);              // floored at 1
+    CHECK(dash::coin::fresh_datum_race_k() == 1);
+    dash::coin::set_fresh_datum_race_enabled(false);
+    CHECK(dash::coin::fresh_datum_race_width() == 1);
+    dash::coin::set_fresh_datum_race_k(2);              // restore default
+
+    // A healthy pool: pick the top-K by score, one per netgroup.
+    {
+        std::vector<RaceCandidate> pool = {
+            cand("a1", "10.0", 100, true,  true),
+            cand("a2", "10.0",  90, true,  true),   // same group as a1 -> skipped
+            cand("b1", "20.0",  80, true,  true),
+            cand("c1", "30.0",  70, true,  true),
+        };
+        auto t2 = select_race_targets(pool, 2);
+        CHECK(t2.size() == 2);
+        CHECK(t2[0] == "a1");                 // best score
+        CHECK(t2[1] == "b1");                 // next DISTINCT group (a2 skipped)
+
+        auto t3 = select_race_targets(pool, 3);
+        CHECK(t3.size() == 3);
+        CHECK(t3[0] == "a1"); CHECK(t3[1] == "b1"); CHECK(t3[2] == "c1");
+
+        // width==1 is exactly today's single best carrier.
+        auto t1 = select_race_targets(pool, 1);
+        CHECK(t1.size() == 1);
+        CHECK(t1[0] == "a1");
+
+        // width==0 floors to 1 (never zero requests).
+        CHECK(select_race_targets(pool, 0).size() == 1);
+    }
+
+    // Non-serving / non-eligible carriers are never raced.
+    {
+        std::vector<RaceCandidate> pool = {
+            cand("hi",  "10.0", 200, false, true),   // NOT CanServeBlocks
+            cand("dem", "20.0", 190, true,  false),  // demoted/unhandshaked
+            cand("ok",  "30.0",  50, true,  true),   // the only real carrier
+        };
+        auto t = select_race_targets(pool, 3);
+        CHECK(t.size() == 1);
+        CHECK(t[0] == "ok");
+    }
+
+    // Distinct-netgroup cap: three high scorers in ONE /16 yield ONE target.
+    {
+        std::vector<RaceCandidate> pool = {
+            cand("s1", "42.42", 100, true, true),
+            cand("s2", "42.42",  99, true, true),
+            cand("s3", "42.42",  98, true, true),
+        };
+        auto t = select_race_targets(pool, 3);
+        CHECK(t.size() == 1);
+        CHECK(t[0] == "s1");
+    }
+
+    // Empty group string => the key is its own group (each raced separately).
+    {
+        std::vector<RaceCandidate> pool = {
+            cand("x", "", 10, true, true),
+            cand("y", "", 20, true, true),
+        };
+        auto t = select_race_targets(pool, 2);
+        CHECK(t.size() == 2);
+        CHECK(t[0] == "y");   // higher score first
+        CHECK(t[1] == "x");
+    }
+
+    // No eligible carrier => empty => caller keeps its single-carrier fallback.
+    {
+        std::vector<RaceCandidate> pool = { cand("bad", "1.1", 5, false, false) };
+        CHECK(select_race_targets(pool, 2).empty());
+        CHECK(select_race_targets({}, 2).empty());
+    }
+
+    // ── (2) FIRST-VALID-WINS + SINGLE-FLIGHT DEDUP ──────────────────────────
+
+    // THE HEADLINE KAT: two replies, one slow/invalid. First valid wins, the
+    // duplicate is discarded, the fold self-check is licensed EXACTLY ONCE.
+    {
+        FreshDatumRaceInflight<std::string> r;
+        r.arm("H", 2);                       // raced to 2 carriers
+        CHECK(r.have());
+        CHECK(!r.satisfied());
+        CHECK(r.outstanding() == 2);
+
+        // Carrier A answers first with a VALID (self-checked) copy -> Fold once.
+        int folds = 0;
+        auto a = r.on_reply("H", /*valid=*/true);
+        if (a == RaceReplyAction::Fold) ++folds;
+        CHECK(a == RaceReplyAction::Fold);
+        CHECK(r.satisfied());
+        CHECK(r.outstanding() == 1);         // B is still notionally in flight
+
+        // Carrier B's (slower) copy of the SAME object arrives -> duplicate.
+        auto b = r.on_reply("H", /*valid=*/true);
+        if (b == RaceReplyAction::Fold) ++folds;
+        CHECK(b == RaceReplyAction::DropDuplicate);
+
+        // Even a THIRD stray copy is a duplicate, never a second fold.
+        CHECK(r.on_reply("H", true) == RaceReplyAction::DropDuplicate);
+        CHECK(folds == 1);                    // self-check/fold ran EXACTLY once
+    }
+
+    // Variant: the SLOW one is the INVALID one, and it arrives FIRST. The
+    // invalid copy does NOT fail-close (a sibling is outstanding) and does NOT
+    // fold; the later valid copy wins. Self-check still folds exactly once.
+    {
+        FreshDatumRaceInflight<std::string> r;
+        r.arm("H", 2);
+        int folds = 0;
+
+        auto bad = r.on_reply("H", /*valid=*/false);   // garbage from a racer
+        CHECK(bad == RaceReplyAction::DropKeepRacing);  // wait, do not fail-close
+        CHECK(!r.satisfied());
+        CHECK(r.outstanding() == 1);
+
+        auto good = r.on_reply("H", /*valid=*/true);
+        if (good == RaceReplyAction::Fold) ++folds;
+        CHECK(good == RaceReplyAction::Fold);
+        CHECK(folds == 1);
+    }
+
+    // K==1 single-carrier: a valid reply folds; the SAME arm, when the one
+    // reply is invalid, is Exhausted immediately (fail-closed == today).
+    {
+        FreshDatumRaceInflight<std::string> r;
+        r.arm("H", 1);
+        CHECK(r.on_reply("H", true) == RaceReplyAction::Fold);
+    }
+    {
+        FreshDatumRaceInflight<std::string> r;
+        r.arm("H", 1);
+        CHECK(r.on_reply("H", false) == RaceReplyAction::Exhausted);
+        CHECK(!r.satisfied());
+    }
+
+    // ALL racers fail: each drop keeps racing until the LAST, which exhausts.
+    {
+        FreshDatumRaceInflight<std::string> r;
+        r.arm("H", 3);
+        CHECK(r.on_reply("H", false) == RaceReplyAction::DropKeepRacing);
+        CHECK(r.on_reply("H", false) == RaceReplyAction::DropKeepRacing);
+        CHECK(r.on_reply("H", false) == RaceReplyAction::Exhausted);
+    }
+
+    // A reply for an object we are NOT racing is NotArmed (handled as pre-PR-2).
+    {
+        FreshDatumRaceInflight<std::string> r;
+        CHECK(r.on_reply("H", true) == RaceReplyAction::NotArmed);   // never armed
+        r.arm("H", 2);
+        CHECK(r.on_reply("OTHER", true) == RaceReplyAction::NotArmed); // wrong key
+        // The armed race is untouched by the foreign reply.
+        CHECK(r.outstanding() == 2);
+        CHECK(!r.satisfied());
+    }
+
+    // clear() forgets the race entirely (a new begin_fold for a new height).
+    {
+        FreshDatumRaceInflight<std::string> r;
+        r.arm("H", 2);
+        r.on_reply("H", true);
+        r.clear();
+        CHECK(!r.have());
+        CHECK(r.on_reply("H", true) == RaceReplyAction::NotArmed);
+    }
+
+    // Works over an integer key too (the template is key-agnostic; the lane
+    // instantiates it on uint256).
+    {
+        FreshDatumRaceInflight<int> r;
+        r.arm(7, 2);
+        CHECK(r.on_reply(7, true) == RaceReplyAction::Fold);
+        CHECK(r.on_reply(7, true) == RaceReplyAction::DropDuplicate);
+        CHECK(r.on_reply(9, true) == RaceReplyAction::NotArmed);
+    }
+
+    if (g_fail == 0) { std::printf("dash_fresh_datum_race_kat PASS\n"); return 0; }
+    std::printf("dash_fresh_datum_race_kat FAIL (%d)\n", g_fail);
+    return 1;
+}

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -446,6 +446,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--embedded-tx-serve-own-set]\n"
+        << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--pin-local-tx-hex FILE]  (zero-fee self-mined tx, e.g. donation consolidation)\n"
@@ -9016,6 +9017,21 @@ int main(int argc, char** argv)
             embedded_null_arm = true;   // #127
         else if (std::strcmp(argv[i], "--embedded-null-arm=false") == 0)
             embedded_null_arm = false;  // #127: explicit OFF (OFF-equivalence)
+        // PR-2 FRESH-DATUM RACE (dashd-cut coin-P2P). Race the SINGLE freshest
+        // object (the fold snapshot's getmnlistd today) to K distinct-netgroup
+        // CanServeBlocks carriers and fold the first valid self-checked reply,
+        // deduping the rest. Default OFF; K default 2, K==1 == today. Reward-
+        // safe: only WHO/HOW-MANY is asked changes; every reply still flows
+        // through the identical DIP-4/merkle/payee self-check before it is
+        // believed, and exactly one fold is licensed.
+        else if (std::strcmp(argv[i], "--embedded-fresh-datum-race") == 0)
+            dash::coin::set_fresh_datum_race_enabled(true);
+        else if (std::strcmp(argv[i], "--embedded-fresh-datum-race=false") == 0)
+            dash::coin::set_fresh_datum_race_enabled(false);
+        else if (std::strcmp(argv[i], "--embedded-fresh-datum-race-k") == 0
+                 && i + 1 < argc)
+            dash::coin::set_fresh_datum_race_k(
+                static_cast<int>(std::strtol(argv[++i], nullptr, 10)));
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)

--- a/src/impl/dash/coin/fresh_datum_race.hpp
+++ b/src/impl/dash/coin/fresh_datum_race.hpp
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// PR-2 RACE THE FRESHEST DATUM (dashd-cut coin-P2P stack, task #154 line).
+///
+/// Header-only pure policy — NO I/O, NO clock, NO coin state, standard library
+/// only — exactly like arrival_timing.hpp (PR-0), so it folds into the
+/// allowlisted dash test targets and links NOTHING. It answers ONE question and
+/// enforces ONE reward-safety invariant.
+///
+/// THE LEVER. When the embedded arm falls off its template it waits on the
+/// SINGLE freshest object — the just-announced tip body, the mnlistdiff for the
+/// new fold base, or the qrinfo for a rotating quorum. Today that request goes
+/// to ONE carrier (rotate-on-stall, #1329) and the arm waits a whole wall-clock
+/// re-ask interval if that carrier is slow. select_race_targets() instead names
+/// the K fastest-scored CanServeBlocks peers in DISTINCT netgroups, so the SAME
+/// idempotent, self-checked request is issued in parallel and the arm resumes
+/// on whichever valid reply lands FIRST. K=1 reproduces today's single carrier
+/// EXACTLY. Bulk/historical fetch is untouched — this is the freshest-object
+/// path only.
+///
+/// THE REWARD-SAFETY INVARIANT, encoded in FreshDatumRaceInflight. Racing
+/// changes only WHEN and FROM-WHOM a datum arrives, never WHAT is derived:
+///
+///   * The winner is the FIRST reply that PASSES the identical DIP-4 / merkle /
+///     payee / BLS self-check the single-carrier path already runs. `valid` is
+///     that check's verdict; this policy never re-implements or weakens it.
+///   * The fold/apply is licensed EXACTLY ONCE (Fold), on that first valid
+///     reply. Every later copy of the same object — the K-1 slower racers — is
+///     a DropDuplicate: claimed and discarded so a past-dated snapshot can
+///     never leak to the live tip SML, and the expensive derive never re-runs.
+///   * A carrier whose copy FAILS the self-check does NOT fail-close the fold
+///     while a sibling is still outstanding (DropKeepRacing); it is dropped and
+///     we keep waiting. Only when the LAST outstanding racer has failed does the
+///     await go Exhausted — i.e. fail-closed exactly as the single-carrier path
+///     does today (K=1: one racer, one failure => Exhausted immediately).
+///   * A reply for an object we are not racing is NotArmed — the caller handles
+///     it exactly as before this policy existed.
+///
+/// Worst case is therefore extra connections/traffic on already-verified small
+/// objects. Flag default-OFF => the selector returns the single top peer and the
+/// inflight tracker is never armed, so an unflagged binary is byte-identical to
+/// master.
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FLAG + K CONFIG (default-OFF; K default 2, floored at 1)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// --embedded-fresh-datum-race arms the flag; the K count is a separate config.
+// Both live as function-local statics so the header stays dependency-free and a
+// KAT can drive them deterministically.
+
+inline bool& fresh_datum_race_flag_ref() { static bool f = false; return f; }
+inline bool  fresh_datum_race_enabled()  { return fresh_datum_race_flag_ref(); }
+inline void  set_fresh_datum_race_enabled(bool v) { fresh_datum_race_flag_ref() = v; }
+
+inline int& fresh_datum_race_k_ref() { static int k = 2; return k; }
+/// The configured fan-out width, floored at 1. K==1 is single-carrier (today).
+inline int  fresh_datum_race_k() { const int k = fresh_datum_race_k_ref(); return k < 1 ? 1 : k; }
+inline void set_fresh_datum_race_k(int k) { fresh_datum_race_k_ref() = k < 1 ? 1 : k; }
+
+/// The EFFECTIVE fan-out for THIS request: 1 unless the flag is armed, then K.
+/// Every caller sizes its race with this, so flag-OFF is single-carrier by
+/// construction and there is one place the two knobs combine.
+inline int fresh_datum_race_width()
+{
+    return fresh_datum_race_enabled() ? fresh_datum_race_k() : 1;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TARGET SELECTION — the K fastest-scored CanServeBlocks peers, distinct groups
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One candidate carrier, projected from a live PeerSession by the caller. This
+/// policy never touches a socket; it ranks the projection.
+struct RaceCandidate
+{
+    std::string key;        ///< the demux key (addr.to_string())
+    std::string netgroup;   ///< /16 IPv4 or /32 IPv6 group; empty => key is its own group
+    int         score{0};   ///< higher = better/faster (peer scorer or -EWMA)
+    bool        can_serve{false};  ///< dashd CanServeBlocks (NODE_NETWORK | LIMITED)
+    bool        eligible{false};   ///< handshaked AND not demoted
+};
+
+/// Rank candidates and return up to `width` peer KEYS to race the freshest
+/// object to:
+///   * keep only CanServeBlocks + eligible carriers (the same gate the bulk and
+///     stateful selectors apply — racing never asks a peer that cannot serve);
+///   * order by score DESC (fastest first), ties broken by key for determinism;
+///   * take at most ONE per netgroup (Sybil-resistant fan-out: two sockets in
+///     one /16 are one point of failure, not two independent races).
+/// width<=1 returns at most one key — today's single-carrier behaviour. An
+/// empty result means the caller falls back to its existing single-carrier send
+/// (no eligible peer to race), so racing can never REMOVE a request.
+inline std::vector<std::string>
+select_race_targets(std::vector<RaceCandidate> cands, int width)
+{
+    if (width < 1) width = 1;
+
+    std::vector<RaceCandidate> pool;
+    pool.reserve(cands.size());
+    for (auto& c : cands)
+        if (c.can_serve && c.eligible) pool.push_back(std::move(c));
+
+    std::stable_sort(pool.begin(), pool.end(),
+        [](const RaceCandidate& a, const RaceCandidate& b) {
+            if (a.score != b.score) return a.score > b.score;
+            return a.key < b.key;   // deterministic tie-break
+        });
+
+    std::vector<std::string> out;
+    std::set<std::string> groups_used;
+    for (auto& c : pool) {
+        if (static_cast<int>(out.size()) >= width) break;
+        const std::string grp = c.netgroup.empty() ? c.key : c.netgroup;
+        if (!groups_used.insert(grp).second) continue;  // group already raced
+        out.push_back(c.key);
+    }
+    return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SINGLE-FLIGHT DEDUP / FIRST-VALID-WINS — the reward-safety state machine
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// What the caller must do with a reply to a raced object.
+enum class RaceReplyAction
+{
+    NotArmed,        ///< no race for this key — handle exactly as pre-PR-2
+    Fold,            ///< first VALID reply — run the self-checked fold ONCE
+    DropDuplicate,   ///< a copy arriving after the race was already won — claim & drop
+    DropKeepRacing,  ///< this carrier's copy FAILED the self-check, siblings remain — claim & drop, stay pending
+    Exhausted        ///< the LAST outstanding racer failed — fail-closed, as today
+};
+
+/// Tracks ONE outstanding race for the freshest object, keyed by the object's
+/// identity (uint256 block hash in the lane; any equality-comparable, copyable
+/// key in a KAT). Not thread-aware: the lane touches it only on its single
+/// io_context thread, exactly like every other lane member.
+template <class Key>
+class FreshDatumRaceInflight
+{
+public:
+    /// Arm a race for `key` with `n` outstanding parallel requests (n>=1). n==1
+    /// is single-flight: one valid reply folds, one failure exhausts — today's
+    /// behaviour with no racing.
+    void arm(const Key& key, int n)
+    {
+        m_key         = key;
+        m_have        = true;
+        m_satisfied   = false;
+        m_outstanding = n < 1 ? 1 : n;
+    }
+
+    /// Forget the race (a fresh begin_fold for a different height, or a reset).
+    void clear()
+    {
+        m_have        = false;
+        m_satisfied   = false;
+        m_outstanding = 0;
+        m_key         = Key{};
+    }
+
+    bool have()        const { return m_have; }
+    bool satisfied()   const { return m_satisfied; }
+    int  outstanding() const { return m_outstanding; }
+    const Key& key()   const { return m_key; }
+
+    /// Classify a reply. `valid` is the verdict of the IDENTICAL self-check the
+    /// single-carrier path runs — this policy never weakens or re-runs it. See
+    /// RaceReplyAction for the contract. A reply whose key does not match the
+    /// armed race (or no race is armed) is NotArmed and the caller proceeds as
+    /// it did before PR-2.
+    RaceReplyAction on_reply(const Key& key, bool valid)
+    {
+        if (!m_have || !(key == m_key)) return RaceReplyAction::NotArmed;
+        if (m_satisfied) return RaceReplyAction::DropDuplicate;
+
+        if (m_outstanding > 0) --m_outstanding;
+
+        if (valid) {
+            m_satisfied = true;             // the race is won; later copies dup
+            return RaceReplyAction::Fold;   // license the fold EXACTLY once
+        }
+        // This carrier served an object that failed the self-check.
+        if (m_outstanding > 0) return RaceReplyAction::DropKeepRacing;
+        return RaceReplyAction::Exhausted;  // last racer failed -> fail-closed
+    }
+
+private:
+    Key  m_key{};
+    bool m_have{false};
+    bool m_satisfied{false};
+    int  m_outstanding{0};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -213,6 +213,7 @@
 #include <impl/dash/coin/historical_sml.hpp>   // authenticate_historical_snapshot
 #include <impl/dash/coin/lane_diag.hpp>        // ProgressReporter / StallWatchdog / MnSource
 #include <impl/dash/coin/arrival_timing.hpp>   // PR-0: OffEmbeddedWindow arrival/fold split (instrumentation only)
+#include <impl/dash/coin/fresh_datum_race.hpp>   // PR-2: fresh-datum race single-flight dedup / first-valid-wins (flag-gated)
 #include <impl/dash/coin/vendor/simplifiedmns.hpp>
 #include <impl/dash/coin/vendor/smldiff.hpp>    // CSimplifiedMNListDiff
 #include <impl/dash/coin/vendor/cbtx.hpp>       // CCbTx
@@ -616,6 +617,9 @@ public:
                            " mnlistdiff re-ask; does NOT wait for a tip"
                            " change). wall_reasks=" << m_wallclock_reasks;
             m_reask_snapshot(m_snapshot_hash);
+            // PR-2: a fresh fan-out attempt — reset the race budget for the new
+            // set of carriers this re-ask reaches (flag-gated width; 1==today).
+            m_fresh_race.arm(m_snapshot_hash, fresh_datum_race_width());
         }
 
         auto due = m_watchdog.due(now);
@@ -2865,6 +2869,14 @@ public:
         // moment the fold ask goes out. t_data_arrived/t_fold_complete/t_resumed
         // are stamped in on_historical_snapshot(). Pure timestamp; no behaviour.
         m_off_window.open(m_snapshot_asked_at);
+        // PR-2: arm the fresh-datum race for THIS snapshot so on_historical_
+        // snapshot() can dedup a K-way fan-out and keep racing past a single
+        // carrier's unauthenticated copy. Width is the flag-gated fan-out
+        // (1 when the flag is OFF => single-flight == today, and the tracker is
+        // read ONLY under fresh_datum_race_enabled(), so an unflagged binary is
+        // byte-identical to master). The client decides how many carriers it
+        // actually reaches; a shortfall is recovered by the wall-clock re-ask.
+        m_fresh_race.arm(m_snapshot_hash, fresh_datum_race_width());
         return true;
     }
 
@@ -3061,6 +3073,30 @@ public:
         vendor::CCbTx cbtx;
         auto sml = authenticate_historical_snapshot(
             diff, h, m_merkle_root_at, cbtx, "MN-CKPT");
+
+        // ── PR-2 FRESH-DATUM RACE reply classification (flag-gated) ──────────
+        // When the fold snapshot was raced to K carriers, K replies land for
+        // this same m_snapshot_hash. `sml.has_value()` is the verdict of the
+        // IDENTICAL DIP-4 self-check the single-carrier path runs — racing
+        // never weakens or re-runs it. A carrier that served an UNAUTHENTICATED
+        // copy does NOT fail-close the fold while a sibling racer is still
+        // outstanding; it is claimed and dropped and we keep awaiting a valid
+        // copy. Only when the last outstanding racer has failed (Exhausted, and
+        // K==1 => that is the very first failure => exactly as today) do we fall
+        // through to the identical fail_closed below.
+        if (fresh_datum_race_enabled() && m_fresh_race.have()) {
+            const auto act = m_fresh_race.on_reply(diff.blockHash, sml.has_value());
+            if (!sml && act == RaceReplyAction::DropKeepRacing) {
+                m_snapshot_pending = true;   // re-open: await a sibling racer
+                LOG_WARNING << "[MN-CKPT] a raced carrier served an"
+                               " UNAUTHENTICATED masternode list for h=" << h
+                            << " — claimed and DROPPED; still awaiting a valid"
+                               " copy from a sibling racer (fresh-datum race,"
+                               " fold NOT failed)";
+                return true;   // consumed our await; do NOT fail-close yet
+            }
+        }
+
         if (!sml) {
             m_ondemand_pending = false;
             fail_closed(
@@ -3074,6 +3110,13 @@ public:
                        : ""));
             return true;   // consumed: it matched our await
         }
+
+        // PR-2: the race is won. Remember the folded hash so the K-1 slower
+        // duplicate racer copies are claimed & dropped by the is_abandoned
+        // guard above — a past-dated snapshot can never reach the live tip SML.
+        // Bounded ring (kAbandonedRing); a no-op when racing is off (with one
+        // carrier there is never a duplicate to drop).
+        if (fresh_datum_race_enabled()) remember_abandoned(m_snapshot_hash);
 
         if (on_demand) { finish_ondemand_fold(*sml, h); return true; }
 
@@ -3977,6 +4020,7 @@ public:
         m_wallclock_reasks = 0;
         m_abandoned_folds  = 0;
         m_abandoned.clear();
+        m_fresh_race.clear();   // PR-2: forget any in-flight fresh-datum race
         // ── #1033 ON-DEMAND fold state. Every field the on-demand arm carries
         // across a bridge, reset for the next one. The one-shot-ish latches
         // are the dangerous half again: m_ondemand_cap_hit unreset makes a
@@ -4198,6 +4242,12 @@ public:
     bool      m_revive_probe_cap_hit{false};
     RequestSnapshotFn m_request_snapshot;
     RequestSnapshotFn m_reask_snapshot;   // optional rotate+demote re-ask seam
+    // PR-2 FRESH-DATUM RACE single-flight tracker (flag-gated). Keyed by the
+    // snapshot hash; armed by begin_fold() and the wall-clock re-ask; READ only
+    // when fresh_datum_race_enabled(). Enforces first-valid-wins + dedup so a
+    // K-way fan-out of the fold snapshot folds EXACTLY ONCE and the losing
+    // carriers' copies never reach the live tip SML.
+    FreshDatumRaceInflight<uint256> m_fresh_race;
     // ── WALL-CLOCK RE-ASK of a frozen fold/ondemand snapshot (dashd
     // CheckForStaleTipAndEvictPeers parity). The tip-driven tick_pending_fold()
     // re-ask stalls whenever the header tip stalls — precisely when a bridging

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -92,6 +92,8 @@
 #include <impl/dash/coin/historical_sml.hpp>    // HistoricalMnListDiffDemux (reward-critical tip/historical split)
 #include <impl/dash/coin/bulk_peer_policy.hpp>   // #154 select_bulk_eligible_keys (LEVER 1 pure logic)
 #include <impl/dash/coin/arrival_timing.hpp>     // PR-0: per-peer per-datum-class delivery-latency EWMA (instrumentation only)
+#include <impl/dash/coin/fresh_datum_race.hpp>   // PR-2: fresh-datum race (K-way fan-out selector + single-flight dedup; flag/K default-OFF)
+#include <impl/dash/coin/coin_peer_manager.hpp> // PR-2: peer_network_group() for distinct-netgroup racing
 
 #include <algorithm>
 #include <chrono>
@@ -1941,6 +1943,67 @@ public:
     /// still DIP-4 client-verified against the block's own cbTx commitment
     /// before they are believed; and a peer that later delivers a body clears
     /// its strike (forgive_bulk_nonserver on the ingest path).
+    // PR-2 FRESH-DATUM RACE (flag/K default-OFF). Project the live pool into
+    // ranked RaceCandidates for a datum class: only CanServeBlocks + handshaked
+    // + non-demoted carriers are eligible (the SAME gate the stateful/bulk
+    // selectors apply), scored so a lower measured delivery-latency EWMA (PR-0)
+    // ranks higher and an unmeasured peer sits neutral (so it still gets raced
+    // and gathers a measurement). Pure projection — no socket is touched here.
+    std::vector<dash::coin::RaceCandidate> race_candidates(DatumClass cls) const
+    {
+        std::vector<dash::coin::RaceCandidate> out;
+        out.reserve(m_pool.size());
+        for (const auto& up : m_pool) {
+            const PeerSession* pp = up.get();
+            dash::coin::RaceCandidate c;
+            c.key       = pp->key;
+            c.netgroup  = dash::coin::peer_network_group(pp->addr.address());
+            c.can_serve = can_serve_blocks(pp);
+            c.eligible  = pp->handshake.complete() && !bulk_demoted(pp->key);
+            const int64_t e = pp->delivery.ewma_ms(cls);
+            c.score     = (e < 0) ? 0
+                        : (e > 1000000 ? -1000000 : static_cast<int>(1000000 - e));
+            out.push_back(std::move(c));
+        }
+        return out;
+    }
+
+    // Fan the SAME idempotent getmnlistd out to the K fastest-scored
+    // CanServeBlocks carriers in DISTINCT netgroups and let the first valid
+    // self-checked reply win (the lane's on_historical_snapshot dedups the
+    // rest). Returns the number of carriers actually asked (0 => caller must
+    // fall back to its single-carrier send; racing never REMOVES a request).
+    // Reward-safe: this only changes FROM-WHOM and HOW-MANY; every reply still
+    // flows through the identical DIP-4/merkle/payee self-check before it is
+    // believed, and exactly one fold is licensed.
+    int race_getmnlistd(const uint256& base_block_hash, const uint256& block_hash)
+    {
+        const int width = dash::coin::fresh_datum_race_width();
+        if (width <= 1) return 0;   // flag OFF or K==1 -> single carrier (today)
+        auto targets = dash::coin::select_race_targets(
+            race_candidates(DatumClass::MnListDiff), width);
+        if (targets.size() < 2) return 0;   // <2 distinct-group carriers -> today
+        int sent = 0;
+        for (const auto& key : targets) {
+            PeerSession* p = nullptr;
+            for (const auto& up : m_pool) if (up->key == key) { p = up.get(); break; }
+            if (!p) continue;
+            auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
+            p->write(msg);
+            // PR-0 instrumentation (record-only): time each carrier's leg.
+            p->note_request_sent(DatumClass::MnListDiff, arrival_now_ms());
+            ++sent;
+        }
+        if (sent > 0)
+            LOG_INFO << "[COIN-P2P] getmnlistd(RACE x" << sent << ") -> "
+                     << targets.size() << " distinct-netgroup carriers,"
+                     << " base=" << base_block_hash.GetHex()
+                     << " target=" << block_hash.GetHex()
+                     << " — first valid self-checked reply wins, the rest are"
+                        " deduped";
+        return sent;
+    }
+
     void send_getmnlistd_reask(const uint256& base_block_hash,
                                const uint256& block_hash)
     {
@@ -1949,6 +2012,13 @@ public:
         // server and expands/rotates the outbound set toward a real server.
         if (!m_last_stateful_peer.empty() && holds_key(m_last_stateful_peer))
             note_bulk_nonserver(m_last_stateful_peer);
+        // (B') PR-2: race the re-ask across K distinct-netgroup carriers so a
+        // slow winner does not cost a whole wall-clock re-ask interval. Only
+        // WHO/HOW-MANY changes; the reply is matched by the unchanged
+        // m_snapshot_hash and DIP-4 self-checked before it is folded. Flag OFF
+        // or K==1 or <2 carriers => race_getmnlistd() returns 0 and we take the
+        // identical single rotating carrier below (byte-identical to master).
+        if (race_getmnlistd(base_block_hash, block_hash) > 0) return;
         // (B) rotate to a fresh archival carrier and send (never drops: the
         // rotating send falls back to any handshaked peer, then m_primary).
         send_getmnlistd_rotating(base_block_hash, block_hash);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -326,6 +326,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_dependencies(test_dash_serve_gate_journal dash_tx_serve_self_validation_kat)
     add_dependencies(test_dash_serve_gate_journal dash_arrival_instrumentation_kat)  # PR-0 coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_latency_scoring_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
+    add_dependencies(test_dash_serve_gate_journal dash_fresh_datum_race_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## PR-2 — Race the freshest datum

Second stacked PR of the coin-P2P peer racing/selection series (PR-0..PR-4). **Stacks on `dash/coinp2p-pr0-arrival-instrumentation`** (PR-0) — it reuses PR-0's per-peer per-datum-class delivery-latency EWMA to score carriers. The PR is opened against `master`, so until PR-0 merges this diff also contains PR-0's commit; review only the PR-2 commit (`fc12a752`).

### The lever
When the embedded arm falls off its template it waits on the SINGLE freshest object — the fold snapshot's `getmnlistd` (the just-announced tip body / mnlistdiff for the new base / qrinfo for a rotating quorum). Today that request goes to ONE carrier (rotate-on-stall, #1329) and the arm waits a whole wall-clock re-ask interval if that carrier is slow. This races that ONE idempotent request to the **K fastest-scored `CanServeBlocks` peers in DISTINCT netgroups** and resumes on whichever valid, self-checked reply lands first; the K-1 losers are deduped. Bulk/historical fetch keeps its `inv->getdata` fan-in collapse **UNTOUCHED**.

Wired FIRST onto the #1329 `set_reask_snapshot_fn` re-ask path — it already re-issues an idempotent, self-checked request keyed by the unchanged `m_snapshot_hash`.

### Reward safety (must hold)
Racing changes only **WHEN and FROM-WHOM** a datum arrives and **HOW MANY** carriers are asked — **never WHAT** is fetched or derived. Every reply still flows through the identical `authenticate_historical_snapshot` merkle / payee / DIP-4 / BLS self-check before it is believed (same class as #1329). The fold is licensed **EXACTLY ONCE**; a carrier whose copy fails the self-check does NOT fail-close while a sibling racer is still outstanding (it is claimed and dropped, we keep waiting); the winning hash is remembered so the slower duplicate copies are claimed and dropped by the existing `is_abandoned` guard and can never reach the live tip SML. Worst case = extra connections/traffic on already-verified small objects.

### Flag (default-OFF => byte-identical to master)
`--embedded-fresh-datum-race` (default **OFF**); `K` via `--embedded-fresh-datum-race-k` (default **2**, floored at 1). `fresh_datum_race_width()` returns **1** while OFF, and the inflight tracker is READ only under `fresh_datum_race_enabled()`, so an unflagged binary is byte-identical to master. **K==1 => exactly today's single-carrier behaviour.** No new wire messages — reuses `getmnlistd`.

### KAT
`dash_fresh_datum_race_kat` (built + run under `-DC2POOL_DASH_BLS=ON`, PASS). Pure red/green over the header-only policy — no node, no daemon. Locks:
- `select_race_targets()` names the K fastest-scored `CanServeBlocks` peers in DISTINCT netgroups; non-serving/demoted excluded; two peers in one /16 count once; `width<=1` == single carrier.
- `FreshDatumRaceInflight`: **two replies, one slow/invalid => first valid wins, duplicate discarded, self-check/fold licensed EXACTLY ONCE**; invalid-with-sibling keeps racing; last racer failing is fail-closed (== K==1 == today).

### Stack / merge order
PR-0 -> PR-1 -> PR-2 -> PR-3 -> PR-4. Rebase onto master after each predecessor merges. **Do not merge before PR-0.**
