### PR TITLE
dash(daemonless): wire --embedded-peer-latency-score CLI flag (PR-1 follow-up)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -9074,6 +9074,14 @@ int main(int argc, char** argv)
             embedded_ingest_dstx = true;      // W5-B CoinJoin DSTX feed
         else if (std::strcmp(argv[i], "--embedded-proactive-rotate") == 0)
             embedded_proactive_rotate = true; // PR-3 proactive peer rotation
+        // PR-1 LATENCY-AWARE PEER SCORING. Wire the CLI flag to the existing
+        // set_peer_latency_score_enabled() setter (coin_peer_manager.hpp). Default
+        // OFF => latency term = 0 => compute_score() byte-identical to master.
+        // Reward-safe: only reorders preference WITHIN the already-eligible set.
+        else if (std::strcmp(argv[i], "--embedded-peer-latency-score") == 0)
+            dash::coin::set_peer_latency_score_enabled(true);   // PR-1: latency tie-breaker ON
+        else if (std::strcmp(argv[i], "--embedded-peer-latency-score=false") == 0)
+            dash::coin::set_peer_latency_score_enabled(false);  // PR-1: explicit OFF
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;


### PR DESCRIPTION
PR-1 (coin-P2P latency-aware peer scoring) shipped `set_peer_latency_score_enabled()` / `peer_latency_score_enabled()` and consumed the flag inside `compute_score()`, but the `main_dash.cpp` arg-parse branch was never added — so `--embedded-peer-latency-score` was **unreachable** and the feature could not be armed in production. The standalone KAT calls the setter directly, so CI stayed green (the dead-flag gap is invisible to a test that never goes through argv).

**Fix:** add the arg-parse branch (and the `=false` form) calling the existing setter, mirroring the sibling `--embedded-proactive-rotate` / `--embedded-fresh-datum-race` flags.

**Reward-safety:** identical class to the merged PR-1. Default OFF is unchanged ⇒ latency term = 0 ⇒ `compute_score()` byte-identical to master when the flag is absent. When ON, it only reorders preference **within** the already-eligible peer set (never adds/removes an eligible peer); every reply still flows through the identical merkle/payee/DIP-4/BLS self-check.

**Why it matters now:** this flag is one of the coin-P2P freshness levers slated for the hotel canary. Without this wiring, arming it in the drop-in would be a silent no-op (unknown args are ignored, not fatal) — the canary would measure "latency scoring did nothing" when in truth it was never on.