### PR TITLE
dash(daemonless): embedded getmnlistd slot tracker (fixed 10s re-ask, 3 boolean tiers, capability filter; flag default-OFF)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -474,6 +474,20 @@ add_test(NAME dash_proactive_rotation_kat COMMAND dash_proactive_rotation_kat)
 add_executable(dash_asn_diversity_kat dash_asn_diversity_kat.cpp)
 add_test(NAME dash_asn_diversity_kat COMMAND dash_asn_diversity_kat)
 
+# ── KAT: EMBEDDED getmnlistd SLOT TRACKER (dashd-cut coin-P2P stack, #154) ──
+# Locks the five gates the wiring depends on: (1) the <=K in-flight invariant
+# across a simulated rotation with fixed 10s per-slot timers (no backoff), (2)
+# late/duplicate reply => first content-addressed match wins, rest dropped, NO
+# strike, (3) expiry at 100s (10x) => ESCALATE not repeat, applied folds
+# untouched, (4) capability filter => an incapable old-proto peer never gets a
+# slot, (5) OFF-equivalence => flag default-OFF, tracker never consulted.
+# getmnlistd_tracker.hpp is pure policy (header-only, no node, no daemon,
+# standard library only), so this target links NOTHING and still exercises the
+# reward-safety contract the wiring depends on. Built under -DC2POOL_DASH_BLS=ON
+# like the rest of the dash suite; carries no BLS symbols.
+add_executable(dash_getmnlistd_tracker_kat dash_getmnlistd_tracker_kat.cpp)
+add_test(NAME dash_getmnlistd_tracker_kat COMMAND dash_getmnlistd_tracker_kat)
+
 # Legacy applications have been archived to ../../archive/
 # - c2pool_legacy.cpp (original c2pool.cpp)
 # - c2pool_node_legacy.cpp (original c2pool_node.cpp)

--- a/src/c2pool/dash_getmnlistd_tracker_kat.cpp
+++ b/src/c2pool/dash_getmnlistd_tracker_kat.cpp
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// KAT: EMBEDDED getmnlistd SLOT TRACKER (dashd-cut coin-P2P stack, task #154).
+//
+// Locks the five reward-safety / behaviour gates the wiring depends on:
+//
+//   (1) <=K IN-FLIGHT INVARIANT across a simulated rotation: slots retarget on
+//       their own 10s timer (fixed, no backoff); the outstanding set NEVER
+//       grows past K; a struck peer is benched until a FULL rotation, then the
+//       struck set is cleared (re-eligible).
+//   (2) LATE / DUPLICATE reply: the first content-addressed match wins (RACE
+//       satisfied), later copies are DropDuplicate, and NO strike is charged to
+//       a sibling genuinely asked this session; admission stays content-
+//       addressed (FreshDatumRaceInflight keyed by object identity, never peer).
+//   (3) EXPIRY mid-lane: at 100s (10x) the action is ESCALATE, never a repeated
+//       ask; applied folds are untouched (the tracker abandons a pending
+//       REQUEST, it never rewinds a fold).
+//   (4) CAPABILITY FILTER: an old-protocol peer that cannot serve GETMNLISTDIFF
+//       never receives a slot, no matter how it is otherwise scored.
+//   (5) OFF-EQUIVALENCE: the flag defaults OFF; toggling is exact; OFF => the
+//       tracker is never consulted (the re-ask path is byte-identical to
+//       master, which reads none of this machinery).
+//
+// Pure red/green over TWO header-only units (getmnlistd_tracker.hpp +
+// fresh_datum_race.hpp), NO node and NO daemon — builds under
+// -DC2POOL_DASH_BLS=ON without the c2pool-dash object graph, like PR-0/PR-2.
+
+#include <impl/dash/coin/getmnlistd_tracker.hpp>
+#include <impl/dash/coin/fresh_datum_race.hpp>
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using dash::coin::FreshDatumRaceInflight;
+using dash::coin::GetmnlistdCandidate;
+using dash::coin::GetmnlistdExpiryAction;
+using dash::coin::GetmnlistdSlotTracker;
+using dash::coin::GetmnlistdTier;
+using dash::coin::RaceReplyAction;
+using dash::coin::classify_getmnlistd_expiry;
+using dash::coin::getmnlistd_capable;
+
+static int g_fail = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond); ++g_fail; } } while (0)
+
+// A CAPABLE, serve-eligible candidate at the current DASH protocol version.
+static GetmnlistdCandidate cap(const std::string& key, const std::string& grp)
+{
+    GetmnlistdCandidate c;
+    c.key = key; c.netgroup = grp;
+    c.proto_version = 70230;      // >= kGetmnlistdServeProtoVersion (70214)
+    c.serve_eligible = true;
+    return c;
+}
+
+int main()
+{
+    // ── (5) OFF-EQUIVALENCE (checked first: the default state matters most) ──
+    // Default OFF; the wiring reads NONE of the machinery below while OFF, so an
+    // unflagged binary takes the identical wall-clock ladder path as master.
+    CHECK(dash::coin::embedded_getmnlistd_tracker_enabled() == false);
+    dash::coin::set_embedded_getmnlistd_tracker_enabled(true);
+    CHECK(dash::coin::embedded_getmnlistd_tracker_enabled() == true);
+    dash::coin::set_embedded_getmnlistd_tracker_enabled(false);
+    CHECK(dash::coin::embedded_getmnlistd_tracker_enabled() == false);   // restore OFF
+
+    // ── (4) CAPABILITY FILTER ───────────────────────────────────────────────
+    CHECK(getmnlistd_capable(70230) == true);
+    CHECK(getmnlistd_capable(70214) == true);    // exactly the serve floor
+    CHECK(getmnlistd_capable(70213) == false);   // one below -> cannot serve
+    CHECK(getmnlistd_capable(70000) == false);
+    CHECK(getmnlistd_capable(0)     == false);
+    {
+        // An old-proto peer with the HIGHEST notional preference never gets a
+        // slot; the one capable peer does.
+        GetmnlistdSlotTracker tr;
+        tr.configure(2);
+        GetmnlistdCandidate old = cap("old", "10.0"); old.proto_version = 70213; // incapable
+        GetmnlistdCandidate ok  = cap("ok",  "20.0");                            // capable
+        auto sent = tr.plan({old, ok}, /*now=*/0);
+        CHECK(sent.size() == 1);
+        CHECK(sent[0] == "ok");
+        CHECK(tr.holds("ok"));
+        CHECK(!tr.holds("old"));
+        CHECK(tr.in_flight() == 1);
+    }
+
+    // ── (1) <=K IN-FLIGHT INVARIANT ACROSS A ROTATION ───────────────────────
+    {
+        GetmnlistdSlotTracker tr;
+        tr.configure(2);                       // K = 2 slots
+        std::vector<GetmnlistdCandidate> pool = {
+            cap("a", "10.0"), cap("b", "20.0"), cap("c", "30.0"), cap("d", "40.0"),
+        };
+
+        // t=0: fill both slots. Never-asked (T2) peers, round-robin by key.
+        auto s0 = tr.plan(pool, 0);
+        CHECK(s0.size() == 2);
+        CHECK(tr.in_flight() == 2);
+        CHECK(tr.in_flight() <= tr.k());       // INVARIANT
+        // Two DISTINCT netgroups occupied.
+        CHECK(tr.holds(s0[0]) && tr.holds(s0[1]));
+
+        // t=5s: no slot has lapsed (< 10s). No new asks, still 2 in flight.
+        auto s5 = tr.plan(pool, 5000);
+        CHECK(s5.empty());
+        CHECK(tr.in_flight() == 2);
+
+        // t=10s: BOTH slots lapse -> struck + retargeted to the OTHER two peers.
+        // Set does NOT grow past K.
+        auto s10 = tr.plan(pool, 10000);
+        CHECK(s10.size() == 2);
+        CHECK(tr.in_flight() == 2);
+        CHECK(tr.in_flight() <= tr.k());       // INVARIANT held through retarget
+        // The two just-struck holders are NOT re-selected this rotation.
+        for (const auto& k : s10) { CHECK(k != s0[0]); CHECK(k != s0[1]); }
+        CHECK(tr.is_struck(s0[0]));
+        CHECK(tr.is_struck(s0[1]));
+
+        // t=20s: the second pair lapses too. Now EVERY capable peer is struck,
+        // so a FULL rotation has elapsed: the struck set clears (re-eligible)
+        // and we retarget onto the first pair again. Still <= K.
+        auto s20 = tr.plan(pool, 20000);
+        CHECK(s20.size() == 2);
+        CHECK(tr.in_flight() == 2);
+        CHECK(tr.in_flight() <= tr.k());       // INVARIANT held across rotation wrap
+    }
+
+    // ── (1b) NO BACKOFF: the interval is FIXED 10s per slot, not a growing
+    // ladder. Two consecutive lapses retarget at the SAME 10s cadence.
+    {
+        GetmnlistdSlotTracker tr;
+        tr.configure(1);
+        std::vector<GetmnlistdCandidate> pool = { cap("a", "10.0"), cap("b", "20.0") };
+        CHECK(tr.plan(pool, 0).size() == 1);           // slot filled at t=0
+        CHECK(tr.plan(pool, 9999).empty());            // 9.999s: not yet lapsed
+        CHECK(tr.plan(pool, 10000).size() == 1);       // 10.000s: retarget (fixed)
+        CHECK(tr.plan(pool, 19999).empty());           // next 9.999s: not lapsed
+        CHECK(tr.plan(pool, 20000).size() == 1);       // 10.000s later: retarget AGAIN
+        CHECK(tr.in_flight() == 1);
+    }
+
+    // ── (2) LATE / DUPLICATE reply => first wins, rest dropped, NO strike,
+    //         admission content-addressed ────────────────────────────────────
+    {
+        GetmnlistdSlotTracker tr;
+        tr.configure(2);
+        std::vector<GetmnlistdCandidate> pool = { cap("a", "10.0"), cap("b", "20.0") };
+        auto sent = tr.plan(pool, 0);
+        CHECK(sent.size() == 2);
+        const std::string winner = sent[0];
+        const std::string sibling = sent[1];
+
+        // Admission is CONTENT-ADDRESSED: the race is keyed by the object hash,
+        // never by peer identity. First strict-matcher pass flips satisfied.
+        FreshDatumRaceInflight<std::string> race;
+        race.arm("SNAPSHOT_HASH", 2);
+        CHECK(race.on_reply("SNAPSHOT_HASH", /*valid=*/true) == RaceReplyAction::Fold);
+        CHECK(race.satisfied());
+        // A late DUPLICATE from the sibling is dropped, NOT a second fold.
+        CHECK(race.on_reply("SNAPSHOT_HASH", true) == RaceReplyAction::DropDuplicate);
+        // A reply for a DIFFERENT object is NotArmed (peer identity is irrelevant
+        // to admission; only the object hash matters).
+        CHECK(race.on_reply("OTHER_HASH", true) == RaceReplyAction::NotArmed);
+
+        // Tracker side: the winner is marked T1 (answered) and the whole race is
+        // freed. The sibling that was genuinely asked this session is NOT struck
+        // — a late/duplicate copy earns no misbehaviour strike.
+        tr.note_answered(winner);
+        tr.win_race();
+        CHECK(tr.tier_of(winner) == GetmnlistdTier::Answered);   // T1
+        CHECK(!tr.is_struck(winner));
+        CHECK(!tr.is_struck(sibling));                            // NO strike on the sibling
+        CHECK(tr.asked(sibling));                                 // it WAS asked
+        CHECK(tr.tier_of(sibling) == GetmnlistdTier::Asked);      // T3 (asked, not answered) — not struck
+        CHECK(tr.in_flight() == 0);                               // race freed
+    }
+
+    // ── (2b) TIER PREFERENCE: an ANSWERED (T1) peer outranks a NEVER-ASKED (T2)
+    //         peer, which outranks an ASKED-not-answered (T3) peer. ───────────
+    {
+        GetmnlistdSlotTracker tr;
+        tr.configure(1);
+        // Prime session state: "ans" answered, "askd" was asked (not answered),
+        // "new" is untouched.
+        tr.note_answered("ans");     // T1
+        // Simulate "askd" having been asked: put it in a slot then strike-free
+        // via a lapse-free disconnect-less path — use plan with only askd, then
+        // free by winning a different object is awkward; instead assert tier
+        // directly after an ask by planning it into a slot and freeing it.
+        {
+            GetmnlistdCandidate only = cap("askd", "99.0");
+            auto s = tr.plan({only}, 0);
+            CHECK(s.size() == 1);
+            tr.win_race();           // asked, race won by someone else -> not struck
+            CHECK(tr.tier_of("askd") == GetmnlistdTier::Asked);   // T3
+        }
+        CHECK(tr.tier_of("ans") == GetmnlistdTier::Answered);     // T1
+        CHECK(tr.tier_of("brand-new") == GetmnlistdTier::NeverAsked); // T2
+
+        // Offer all three (distinct netgroups): T1 "ans" must be chosen first.
+        std::vector<GetmnlistdCandidate> pool = {
+            cap("askd", "99.0"), cap("brand-new", "88.0"), cap("ans", "77.0"),
+        };
+        auto pick = tr.plan(pool, 0);
+        CHECK(pick.size() == 1);
+        CHECK(pick[0] == "ans");     // T1 beats T2 beats T3
+    }
+
+    // ── (2c) DISCONNECT resets the T1 answered boolean (session-local only) ──
+    {
+        GetmnlistdSlotTracker tr;
+        tr.configure(1);
+        tr.note_answered("p");
+        CHECK(tr.answered("p"));
+        CHECK(tr.tier_of("p") == GetmnlistdTier::Answered);
+        tr.on_disconnect("p");
+        CHECK(!tr.answered("p"));
+        CHECK(!tr.asked("p"));
+        CHECK(tr.tier_of("p") == GetmnlistdTier::NeverAsked);   // back to T2 as if fresh
+    }
+
+    // ── (3) EXPIRY mid-lane => ESCALATE not repeat; applied folds untouched ──
+    {
+        // The tracker abandons a pending REQUEST; it never rewinds a fold. Model
+        // "applied folds" as an external counter the tracker cannot touch.
+        int applied_folds = 7;                 // folds already applied by the lane
+
+        GetmnlistdSlotTracker tr;
+        tr.configure(2);
+        std::vector<GetmnlistdCandidate> pool = { cap("a", "10.0"), cap("b", "20.0") };
+        auto sent = tr.plan(pool, 0);          // asks go out at t=0
+        CHECK(sent.size() == 2);
+
+        // Before 100s: WAIT (keep racing / retargeting on the 10s slot timer).
+        CHECK(classify_getmnlistd_expiry(50000, tr.oldest_asked_at(50000))
+              == GetmnlistdExpiryAction::Wait);
+
+        // At 100s: ESCALATE. The lane's response is peer-set churn / re-plan to
+        // a fresher target and route abandonment through remember_abandoned —
+        // NEVER a repeated identical ask, and NEVER a fold rewind.
+        CHECK(classify_getmnlistd_expiry(100000, tr.oldest_asked_at(100000))
+              == GetmnlistdExpiryAction::Escalate);
+        CHECK(classify_getmnlistd_expiry(150000, tr.oldest_asked_at(150000))
+              == GetmnlistdExpiryAction::Escalate);
+
+        // The applied-fold state the tracker "sees" is unchanged by expiry: the
+        // tracker exposes no mutator that could rewind it. It resets its own
+        // pending REQUEST slots and that is all.
+        tr.reset_slots();
+        CHECK(tr.in_flight() == 0);            // pending request abandoned
+        CHECK(applied_folds == 7);             // applied folds STAY applied
+
+        // No outstanding slot => never expired (oldest == now).
+        CHECK(classify_getmnlistd_expiry(999999, tr.oldest_asked_at(999999))
+              == GetmnlistdExpiryAction::Wait);
+    }
+
+    // ── (1c) INVARIANT under a bursty mixed drive (fuzz-ish deterministic) ──
+    {
+        GetmnlistdSlotTracker tr;
+        tr.configure(3);
+        std::vector<GetmnlistdCandidate> pool;
+        for (int i = 0; i < 8; ++i)
+            pool.push_back(cap("peer" + std::to_string(i),
+                               std::to_string(10 + i) + ".0"));
+        int64_t now = 0;
+        for (int step = 0; step < 40; ++step) {
+            now += 3000;                        // advance 3s each step
+            tr.plan(pool, now);
+            CHECK(tr.in_flight() <= tr.k());    // INVARIANT at EVERY step
+            CHECK(tr.in_flight() >= 0);
+            if (step % 7 == 0 && tr.in_flight() > 0) {
+                // A peer answers now and then; the race frees + marks T1.
+                // (Pick any held key deterministically.)
+                // Re-plan will refill on the next step.
+                tr.win_race();
+            }
+        }
+        CHECK(tr.in_flight() <= tr.k());
+    }
+
+    if (g_fail == 0) { std::printf("dash_getmnlistd_tracker_kat PASS\n"); return 0; }
+    std::printf("dash_getmnlistd_tracker_kat FAIL (%d)\n", g_fail);
+    return 1;
+}

--- a/src/c2pool/dash_getmnlistd_tracker_kat.cpp
+++ b/src/c2pool/dash_getmnlistd_tracker_kat.cpp
@@ -358,6 +358,73 @@ int main()
         CHECK(dash::coin::embedded_getmnlistd_tracker_enabled() == false); // restored OFF
     }
 
+    // ── (7) k-inflight-live GATE: a member-sourcing reply for a DIFFERENT
+    //         target must NOT clear the K mn-checkpoint slots, must NOT trigger
+    //         a second wave of asks, and a reply for the TRACKED target MUST
+    //         still fire win_race (liveness). This models the p2p_client.hpp
+    //         mnlistdiff handler exactly: it gates note_answered()/win_race()
+    //         on reply_answers_active_target(), the SAME predicate the wire hook
+    //         calls, using the mn-checkpoint lane's pending fold target. ──────
+    {
+        const std::string T     = "TARGET_T_hash";      // the tracked fold target
+        const std::string OTHER = "MEMBER_WORK_hash";   // filter #1's own target
+
+        GetmnlistdSlotTracker tr;
+        tr.configure(3);                                 // K = 3 mn-ckpt slots
+        std::vector<GetmnlistdCandidate> pool = {
+            cap("a", "10.0"), cap("b", "20.0"), cap("c", "30.0"),
+        };
+        // The tracker holds K asks outstanding for target T (as reask_via_tracker
+        // does on the wire); the client has stamped the active target to T.
+        auto s0 = tr.plan(pool, 0);
+        CHECK(s0.size() == 3);
+        CHECK(tr.in_flight() == 3);
+        tr.set_active_target(T);
+        CHECK(tr.active_target() == T);
+
+        // A member-sourcing reply arrives: a full snapshot (base==ZERO) but for
+        // OTHER, not T. The demux would set the aggregate `consumed` true (the
+        // QuorumMemberSource filter claimed it), but the gate REFUSES it.
+        const bool member_reply_fires =
+            tr.reply_answers_active_target(/*base_is_null=*/true, OTHER);
+        CHECK(member_reply_fires == false);              // gate: NOT the tracked target
+        if (member_reply_fires) { tr.note_answered("a"); tr.win_race(); }  // (never taken)
+
+        // (1) the K slots are NOT cleared, (2) no peer was mis-marked T1.
+        CHECK(tr.in_flight() == 3);                      // slots intact
+        CHECK(!tr.answered("a") && !tr.answered("b") && !tr.answered("c"));
+
+        // (2) NO second wave: the next tick, still inside the fixed 10s window,
+        // emits nothing and the wire in-flight stays <= K (never grows to 2K).
+        auto s_next = tr.plan(pool, 5000);
+        CHECK(s_next.empty());
+        CHECK(tr.in_flight() == 3);
+        CHECK(tr.in_flight() <= tr.k());
+
+        // A base!=ZERO (delta / tip-sync) reply for T is also refused — only a
+        // full snapshot answers a fold.
+        CHECK(tr.reply_answers_active_target(/*base_is_null=*/false, T) == false);
+        CHECK(tr.in_flight() == 3);
+
+        // (3) LIVENESS: a genuine full-snapshot reply for the TRACKED target T
+        // fires the gate, so win_race clears the slots and the fold proceeds.
+        const bool tracked_reply_fires =
+            tr.reply_answers_active_target(/*base_is_null=*/true, T);
+        CHECK(tracked_reply_fires == true);              // gate: it IS the tracked target
+        if (tracked_reply_fires) { tr.note_answered("a"); tr.win_race(); }
+        CHECK(tr.in_flight() == 0);                      // slots cleared (no wedge)
+        CHECK(tr.tier_of("a") == GetmnlistdTier::Answered);   // answering peer -> T1
+
+        // With no active target (no fold pending) NO reply can win — the empty
+        // active_target short-circuits the gate.
+        GetmnlistdSlotTracker tr2;
+        tr2.configure(2);
+        tr2.plan({cap("x", "10.0"), cap("y", "20.0")}, 0);
+        CHECK(tr2.active_target().empty());
+        CHECK(tr2.reply_answers_active_target(true, T) == false);
+        CHECK(tr2.in_flight() == 2);                     // untouched
+    }
+
     if (g_fail == 0) { std::printf("dash_getmnlistd_tracker_kat PASS\n"); return 0; }
     std::printf("dash_getmnlistd_tracker_kat FAIL (%d)\n", g_fail);
     return 1;

--- a/src/c2pool/dash_getmnlistd_tracker_kat.cpp
+++ b/src/c2pool/dash_getmnlistd_tracker_kat.cpp
@@ -39,6 +39,7 @@ using dash::coin::GetmnlistdTier;
 using dash::coin::RaceReplyAction;
 using dash::coin::classify_getmnlistd_expiry;
 using dash::coin::getmnlistd_capable;
+using dash::coin::getmnlistd_emit_eligible;
 
 static int g_fail = 0;
 #define CHECK(cond) do { if (!(cond)) { \
@@ -51,6 +52,18 @@ static GetmnlistdCandidate cap(const std::string& key, const std::string& grp)
     c.key = key; c.netgroup = grp;
     c.proto_version = 70230;      // >= kGetmnlistdServeProtoVersion (70214)
     c.serve_eligible = true;
+    return c;
+}
+
+// An INCAPABLE carrier: NODE_NETWORK serve-eligible (the race's own gate PASSES,
+// exactly like the real silent carriers) but proto < 70214 so it structurally
+// cannot serve GETMNLISTDIFF. It must never receive a slot on ANY emit path.
+static GetmnlistdCandidate incap(const std::string& key, const std::string& grp)
+{
+    GetmnlistdCandidate c;
+    c.key = key; c.netgroup = grp;
+    c.proto_version = 70213;      // one below the serve floor
+    c.serve_eligible = true;      // NODE_NETWORK proves nothing — still ineligible
     return c;
 }
 
@@ -279,6 +292,70 @@ int main()
             }
         }
         CHECK(tr.in_flight() <= tr.k());
+    }
+
+    // ── (6) INTEGRATION: the incapable peer is benched on EVERY emit path,
+    //         the tracker GOVERNS live selection (not dormant), and OFF is
+    //         byte-identical to master. ─────────────────────────────────────
+    //
+    // getmnlistd_emit_eligible() is the SINGLE predicate all THREE live emit
+    // sites gate a carrier through in p2p_client.hpp — the initial
+    // send_getmnlistd() to the pinned primary, the rotating next_stateful_peer()
+    // selection (used by send_getmnlistd_rotating and the reask rotating
+    // fallback), and, via getmnlistd_capable() inside plan(), the tracker-
+    // governed re-ask. Driving it here proves the SHIPPED selection, not a
+    // parallel model.
+    {
+        // ARMED: the incapable carrier is rejected on the initial + rotating
+        // paths (the predicate returns false), the capable one is accepted.
+        dash::coin::set_embedded_getmnlistd_tracker_enabled(true);
+        CHECK(getmnlistd_emit_eligible(70213) == false);   // initial/rotating: benched
+        CHECK(getmnlistd_emit_eligible(70214) == true);    // exactly the floor: served
+        CHECK(getmnlistd_emit_eligible(70230) == true);
+
+        // TRACKER GOVERNS the re-ask path: with an incapable peer present in the
+        // live projection, plan() NEVER hands it a slot on ANY rotation, and a
+        // capable peer IS selected (governance is live, not dormant).
+        GetmnlistdSlotTracker tr;
+        tr.configure(2);
+        std::vector<GetmnlistdCandidate> pool = {
+            incap("bad0", "10.0"), cap("good0", "20.0"),
+            incap("bad1", "30.0"), cap("good1", "40.0"),
+        };
+        bool selected_capable = false;
+        int64_t now = 0;
+        for (int step = 0; step < 30; ++step) {
+            auto sent = tr.plan(pool, now);
+            for (const auto& k : sent) {
+                CHECK(k != "bad0" && k != "bad1");   // incapable NEVER slotted
+                if (k == "good0" || k == "good1") selected_capable = true;
+            }
+            CHECK(!tr.holds("bad0"));
+            CHECK(!tr.holds("bad1"));
+            CHECK(tr.in_flight() <= tr.k());
+            now += 10000;   // lapse every slot each step -> full retarget churn
+        }
+        CHECK(selected_capable);                     // NOT dormant: it did select
+
+        // Only-incapable pool ARMED => plan selects NOTHING (correct: you cannot
+        // ask a peer that cannot serve; the lane waits / escalates at expiry).
+        GetmnlistdSlotTracker tr2;
+        tr2.configure(2);
+        std::vector<GetmnlistdCandidate> only_bad = {
+            incap("x", "10.0"), incap("y", "20.0"),
+        };
+        CHECK(tr2.plan(only_bad, 0).empty());
+        CHECK(tr2.in_flight() == 0);
+
+        // OFF-EQUIVALENCE: flag OFF => the predicate is ALWAYS true, so the
+        // initial + rotating emit sites select the incapable carrier EXACTLY as
+        // master would (no filtering, byte-identical), and the tracker is never
+        // consulted on the re-ask path.
+        dash::coin::set_embedded_getmnlistd_tracker_enabled(false);
+        CHECK(getmnlistd_emit_eligible(70213) == true);    // master: no filter
+        CHECK(getmnlistd_emit_eligible(0)     == true);
+        CHECK(getmnlistd_emit_eligible(70230) == true);
+        CHECK(dash::coin::embedded_getmnlistd_tracker_enabled() == false); // restored OFF
     }
 
     if (g_fail == 0) { std::printf("dash_getmnlistd_tracker_kat PASS\n"); return 0; }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6390,6 +6390,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     (const dash::coin::vendor::CSimplifiedMNListDiff& d) {
                         return mnl->on_historical_snapshot(d);
                     });
+                // #154 k-inflight-live: give the getmnlistd slot tracker THIS
+                // lane's currently-pending fold target so its slot bookkeeping
+                // (note_answered/win_race) fires ONLY on a reply that actually
+                // answers it — never on a member-sourcing reply for a different
+                // target, which the aggregate demux `consumed` flag cannot
+                // distinguish. Pending-hash read; reward-safety only, and the
+                // read is flag-guarded at the call site.
+                cp->set_active_fold_target_fn(
+                    [mnl = mn_ckpt_lane.get()]() -> std::string {
+                        return mnl->pending_snapshot_hash_hex();
+                    });
             }
             // The DIP-4 trust anchor: our own PoW-validated header's merkle
             // root. Without it a snapshot cannot be authenticated and the lane

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -448,6 +448,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
         << "           [--embedded-tx-serve-own-set]\n"
         << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
+        << "           [--embedded-getmnlistd-tracker]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--embedded-proactive-rotate]\n"
@@ -9064,6 +9065,17 @@ int main(int argc, char** argv)
                  && i + 1 < argc)
             dash::coin::set_fresh_datum_race_k(
                 static_cast<int>(std::strtol(argv[++i], nullptr, 10)));
+        // #154 getmnlistd SLOT TRACKER. Arms the fixed 10s per-slot re-ask with
+        // 3 boolean tiers + capability filter, replacing the growing wall-clock
+        // ladder for the MnListDiff class. Default OFF => the tracker is never
+        // consulted and the existing ladder runs verbatim (byte-identical to
+        // master). Reward-safe: only WHEN a slot retargets and FROM-WHOM the next
+        // getmnlistd goes changes; admission stays content-addressed
+        // (diff.blockHash == m_snapshot_hash), no fold is rewound.
+        else if (std::strcmp(argv[i], "--embedded-getmnlistd-tracker") == 0)
+            dash::coin::set_embedded_getmnlistd_tracker_enabled(true);
+        else if (std::strcmp(argv[i], "--embedded-getmnlistd-tracker=false") == 0)
+            dash::coin::set_embedded_getmnlistd_tracker_enabled(false);
         else if (std::strcmp(argv[i], "--embedded-asn-diversity") == 0)
             embedded_asn_diversity = true;   // PR-4: require racing set to span >=2 ASNs
         else if (std::strcmp(argv[i], "--embedded-asn-diversity=false") == 0)

--- a/src/impl/dash/coin/getmnlistd_tracker.hpp
+++ b/src/impl/dash/coin/getmnlistd_tracker.hpp
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// EMBEDDED getmnlistd SLOT TRACKER (dashd-cut coin-P2P stack, task #154 line).
+///
+/// Header-only pure policy — NO I/O, NO clock of its own, NO coin state,
+/// standard library only — exactly like arrival_timing.hpp (PR-0) and
+/// fresh_datum_race.hpp (PR-2), so it folds into the allowlisted dash test
+/// targets and links NOTHING. It answers TWO questions the wall-clock re-ask
+/// ladder answers badly, and it never touches WHAT is derived.
+///
+/// THE BUG BEING REMOVED. The stateful getmnlistd re-ask today is a SINGLE
+/// growing wall-clock interval (the "re-ask after N seconds, then longer"
+/// ladder). A slot that lands on a silent carrier is punished by GROWING the
+/// wait, so a structurally-incapable or merely-slow peer stretches the whole
+/// fold/ondemand-mnlist window. dashd does NOT grow the interval: it re-asks a
+/// stalled object on a FIXED per-class cadence (net_processing.cpp:1585-1599
+/// GetObjectInterval) and lets EXPIRY — not growth — bound the wait
+/// (:1601/:1614). It also refuses answer-rate scoring of peers
+/// (:6547-6551/:6552-6607): a peer that has served is preferred, but the
+/// preference is BOOLEAN and session-local, never a persistent numeric score.
+///
+/// THE PORT, in TWO composed structures that share ONE budget K:
+///
+///   * PARALLELISM is owned by the PR-2 fresh-datum race: K = fresh_datum_race
+///     _width() distinct-netgroup slots, first strict-matcher-passing reply
+///     wins, siblings cancel, late copies drop. This tracker does NOT re-own
+///     parallelism; it consumes the SAME K.
+///
+///   * TIME is owned HERE. Each of the K slots carries its OWN fixed 10s timer
+///     (kSlotIntervalMs). NO backoff. When a slot's 10s lapses with no answer
+///     it RETARGETS to the next candidate not currently holding a slot — the
+///     old ask is abandoned, a fresh candidate takes the slot, and the set
+///     NEVER grows past K. The bound on the whole wait is EXPIRY
+///     (kExpiryMs = 10x), whose action is ESCALATE (churn the peer set / signal
+///     the lane to re-plan to a fresher target), never "repeat the same ask to
+///     the same set" (a no-op).
+///
+/// CANDIDATE ORDERING is THREE BOOLEAN TIERS, round-robin within each — NOT a
+/// numeric answer-rate score (the scoring dashd refuses):
+///
+///   T1  outbound peers that ANSWERED >=1 getmnlistd THIS SESSION (boolean,
+///       reset on disconnect);
+///   T2  never-asked-this-session;
+///   T3  struck-this-rotation (re-eligible after a FULL rotation).
+///
+/// All three are SESSION-LOCAL. They never feed connection lifetime, addrman,
+/// or any cross-restart persistence — a disconnect erases a peer's tier state
+/// entirely.
+///
+/// THE CAPABILITY FILTER. A candidate is only eligible for a slot if it
+/// advertises a protocol version that can SERVE getmnlistd/GETMNLISTDIFF
+/// (kServeProtoVersion, DIP-4). NODE_NETWORK proves nothing — the silent
+/// carriers ARE NODE_NETWORK — so the filter is on the PROTOCOL VERSION (plus
+/// whatever service gate the race already applies), and a 10s slot therefore
+/// never lands on a structurally-incapable peer.
+///
+/// REWARD-SAFETY. This structure decides only WHEN a slot retargets and
+/// FROM-WHOM the next ask goes. It never admits a reply (admission stays
+/// content-addressed: diff.blockHash == m_snapshot_hash, the strict matcher,
+/// untouched — a peer-identity term is NEVER added to admission, that would
+/// break the K-race), never applies a list, never publishes, never rewinds a
+/// fold. A late or duplicate MNLISTDIFF from a peer genuinely asked this
+/// session for this (base,target) draws NO misbehaviour strike. Expiry abandons
+/// a pending REQUEST through the lane's EXISTING remember_abandoned() seam;
+/// applied folds stay applied.
+///
+/// FLAG default-OFF => the tracker is never consulted and the existing
+/// wall-clock ladder runs verbatim, so an unflagged binary is byte-identical to
+/// master.
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FLAG (default-OFF)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// --embedded-getmnlistd-tracker arms the slot tracker. Lives as a function-local
+// static so the header stays dependency-free and a KAT can drive it
+// deterministically. OFF => callers read NONE of the machinery below.
+
+inline bool& embedded_getmnlistd_tracker_flag_ref() { static bool f = false; return f; }
+inline bool  embedded_getmnlistd_tracker_enabled()  { return embedded_getmnlistd_tracker_flag_ref(); }
+inline void  set_embedded_getmnlistd_tracker_enabled(bool v) { embedded_getmnlistd_tracker_flag_ref() = v; }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CAPABILITY FILTER — protocol version that can serve getmnlistd/GETMNLISTDIFF
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// DIP-4 (deterministic masternode lists) introduced GETMNLISTDIFF/MNLISTDIFF at
+// Dash Core protocol version 70214 (LLMQS_PROTO_VERSION). A peer advertising an
+// older version cannot serve the object no matter what service bits it sets, so
+// it must never occupy a 10s slot.
+static constexpr uint32_t kGetmnlistdServeProtoVersion = 70214;
+
+/// TRUE iff a peer at this advertised protocol version can serve getmnlistd.
+inline bool getmnlistd_capable(uint32_t peer_proto_version)
+{
+    return peer_proto_version >= kGetmnlistdServeProtoVersion;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TIMING CONSTANTS — fixed per-slot interval, expiry at 10x (dashd parity)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// Per-slot re-ask cadence is FIXED (dashd GetObjectInterval; no growth). Expiry
+// — the bound on the whole wait — is 10x the slot interval; its action is
+// ESCALATE, never a repeated identical ask.
+static constexpr int64_t kGetmnlistdSlotIntervalMs = 10000;    // 10s per slot, FIXED
+static constexpr int64_t kGetmnlistdExpiryMs       = 100000;   // 100s = 10x -> ESCALATE
+
+/// The bound on the whole wait is EXPIRY, not interval growth. At expiry the
+/// lane must ESCALATE (peer-set churn / re-plan to a fresher target), never
+/// repeat the same ask to the same set (a no-op).
+enum class GetmnlistdExpiryAction
+{
+    Wait,       ///< the oldest outstanding ask is younger than expiry — keep racing
+    Escalate    ///< expiry reached — churn the peer set / signal the lane to re-plan
+};
+
+/// Classify the oldest outstanding ask against the 100s expiry.
+inline GetmnlistdExpiryAction
+classify_getmnlistd_expiry(int64_t now, int64_t first_asked_at)
+{
+    return (now - first_asked_at) >= kGetmnlistdExpiryMs
+               ? GetmnlistdExpiryAction::Escalate
+               : GetmnlistdExpiryAction::Wait;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CANDIDATE — projected from a live PeerSession by the caller
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// One candidate carrier for a getmnlistd slot. The caller projects this from a
+/// live session; the tracker owns the SESSION-LOCAL tier bookkeeping keyed by
+/// `key`, so only the immutable facts about the peer live here.
+struct GetmnlistdCandidate
+{
+    std::string key;                ///< the demux key (addr.to_string())
+    std::string netgroup;           ///< /16 IPv4 or /32 IPv6 group; empty => key is its own group
+    uint32_t    proto_version{0};   ///< advertised Dash Core protocol version
+    bool        serve_eligible{false}; ///< the race's own gate (handshaked, CanServeBlocks, not demoted)
+};
+
+/// The boolean tier a NON-in-flight, capable, non-struck candidate falls in.
+/// Lower ordinal = preferred. Struck peers are excluded from selection until a
+/// full rotation, then re-admitted (that is the T3 "re-eligible" transition).
+enum class GetmnlistdTier
+{
+    Answered   = 0,   ///< T1: answered >=1 getmnlistd this session
+    NeverAsked = 1,   ///< T2: never asked this session
+    Asked      = 2    ///< T3: asked-this-session, not (yet) answered
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SLOT TRACKER — K slots, each its own 10s timer; 3 boolean tiers, round-robin
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// LOAD-BEARING: the RACE (PR-2) owns PARALLELISM (K distinct-netgroup slots) and
+// this tracker owns TIME (each slot's own 10s timer; on lapse RETARGET). They
+// share ONE budget K, so the in-flight set never grows past K:
+//
+//   ASSERT INVARIANT: in_flight() <= K at every instant.
+//
+// Not thread-aware: the lane/client touches it only on its single io_context
+// thread, exactly like every other coin-P2P member.
+class GetmnlistdSlotTracker
+{
+public:
+    /// Configure the parallelism budget K (>=1). K == fresh_datum_race_width().
+    void configure(int k) { m_k = k < 1 ? 1 : k; }
+    int  k() const { return m_k; }
+
+    /// A slot currently occupied by an outstanding ask.
+    struct Slot
+    {
+        std::string key;         ///< the carrier the ask went to
+        std::string netgroup;    ///< its netgroup (distinct-netgroup enforcement)
+        int64_t     asked_at{0}; ///< m_now() when this slot's ask went out
+    };
+
+    int  in_flight() const { return static_cast<int>(m_slots.size()); }
+    bool holds(const std::string& key) const
+    {
+        for (const auto& s : m_slots) if (s.key == key) return true;
+        return false;
+    }
+
+    /// The oldest outstanding ask's timestamp (for the 100s expiry check). If no
+    /// slot is occupied, returns `now` (nothing outstanding => never expired).
+    int64_t oldest_asked_at(int64_t now) const
+    {
+        int64_t o = now;
+        bool have = false;
+        for (const auto& s : m_slots) {
+            if (!have || s.asked_at < o) { o = s.asked_at; have = true; }
+        }
+        return o;
+    }
+
+    /// Session-local disconnect: erase ALL tier state for `key` and free any
+    /// slot it holds. This is the ONLY lifetime coupling — a disconnect resets
+    /// the T1 "answered" boolean, exactly as the spec requires.
+    void on_disconnect(const std::string& key)
+    {
+        m_answered.erase(key);
+        m_asked.erase(key);
+        m_struck.erase(key);
+        m_last_selected_seq.erase(key);
+        free_slot(key);
+    }
+
+    /// A getmnlistd reply from `key` was admitted by the strict content-address
+    /// matcher (the RACE was won). Mark the carrier T1 (answered), and free the
+    /// slot it held. Sibling slots are freed by win_race() below — NOT struck:
+    /// they were genuinely asked, so a late/duplicate copy earns NO strike.
+    void note_answered(const std::string& key)
+    {
+        m_answered.insert(key);
+        m_asked.insert(key);
+        m_struck.erase(key);   // a peer that answered is not "struck this rotation"
+        free_slot(key);
+    }
+
+    /// The race is WON: free EVERY sibling slot without striking. A sibling that
+    /// was asked this session and did not win is neither T1 nor penalised — it
+    /// becomes T3 (asked-not-answered) on the next rotation, deprioritised but
+    /// not struck. Late copies from these siblings draw NO misbehaviour strike.
+    void win_race() { m_slots.clear(); }
+
+    /// Fill empty slots and RETARGET lapsed ones, up to K, from `cands`. Returns
+    /// the keys newly assigned a slot NOW (the caller sends getmnlistd to each).
+    /// Enforces, in order:
+    ///   * a lapsed slot (asked_at + 10s <= now) is STRUCK and freed BEFORE
+    ///     refilling — the old ask is abandoned, never re-grown;
+    ///   * only CAPABLE (proto >= serve version) + serve-eligible candidates are
+    ///     selectable — a 10s slot never lands on a structurally-incapable peer;
+    ///   * at most ONE slot per netgroup (the PR-2 Sybil-resistant fan-out);
+    ///   * tier order T1 > T2 > T3, round-robin (least-recently-selected) within
+    ///     a tier; struck peers are benched until a full rotation, then the whole
+    ///     struck set is cleared (re-eligible) and selection retries.
+    /// in_flight() is <= K on entry and on exit — the set never grows past K.
+    std::vector<std::string> plan(const std::vector<GetmnlistdCandidate>& cands,
+                                  int64_t now)
+    {
+        // (1) STRIKE + free any slot whose 10s timer has lapsed. Retarget, do
+        // NOT grow the wait: the old ask is abandoned.
+        for (size_t i = 0; i < m_slots.size();) {
+            if (now - m_slots[i].asked_at >= kGetmnlistdSlotIntervalMs) {
+                m_struck.insert(m_slots[i].key);
+                m_slots.erase(m_slots.begin() + i);
+            } else {
+                ++i;
+            }
+        }
+
+        std::vector<std::string> sent;
+        // netgroups already occupied by a live slot are off-limits.
+        std::set<std::string> groups_used;
+        for (const auto& s : m_slots)
+            groups_used.insert(s.netgroup.empty() ? s.key : s.netgroup);
+
+        // (2) FILL empty slots up to K.
+        bool cleared_rotation = false;
+        while (in_flight() < m_k) {
+            const GetmnlistdCandidate* pick = select_one(cands, groups_used);
+            if (!pick) {
+                // Nothing selectable. If the ONLY thing blocking us is that every
+                // remaining capable candidate is struck, a FULL rotation has
+                // elapsed: clear the struck set (T3 re-eligible) and retry ONCE.
+                if (!cleared_rotation && !m_struck.empty()
+                    && any_capable_but_all_struck(cands, groups_used)) {
+                    m_struck.clear();
+                    cleared_rotation = true;
+                    continue;
+                }
+                break;   // genuinely no eligible carrier — caller keeps waiting
+            }
+            const std::string grp = pick->netgroup.empty() ? pick->key : pick->netgroup;
+            groups_used.insert(grp);
+            m_slots.push_back(Slot{pick->key, grp, now});
+            m_asked.insert(pick->key);
+            m_last_selected_seq[pick->key] = ++m_seq;
+            sent.push_back(pick->key);
+        }
+        return sent;
+    }
+
+    /// The tier a candidate falls in, for tests and diagnostics. Only meaningful
+    /// for a capable, non-in-flight, non-struck candidate.
+    GetmnlistdTier tier_of(const std::string& key) const
+    {
+        if (m_answered.count(key)) return GetmnlistdTier::Answered;
+        if (!m_asked.count(key))   return GetmnlistdTier::NeverAsked;
+        return GetmnlistdTier::Asked;
+    }
+
+    bool is_struck(const std::string& key) const { return m_struck.count(key) != 0; }
+    bool answered(const std::string& key)  const { return m_answered.count(key) != 0; }
+    bool asked(const std::string& key)     const { return m_asked.count(key) != 0; }
+
+    /// Forget all outstanding slots (a fresh begin_fold for a new target). Tier
+    /// bookkeeping (answered/asked) survives — it is session-local, not
+    /// per-request — but the struck set is per-rotation, so it is cleared too.
+    void reset_slots()
+    {
+        m_slots.clear();
+        m_struck.clear();
+    }
+
+private:
+    void free_slot(const std::string& key)
+    {
+        for (size_t i = 0; i < m_slots.size(); ++i) {
+            if (m_slots[i].key == key) { m_slots.erase(m_slots.begin() + i); return; }
+        }
+    }
+
+    /// TRUE iff at least one capable, serve-eligible, distinct-netgroup, not-in-
+    /// flight candidate exists but EVERY such candidate is struck — i.e. the
+    /// rotation is complete and the struck set is the only thing left to try.
+    bool any_capable_but_all_struck(const std::vector<GetmnlistdCandidate>& cands,
+                                    const std::set<std::string>& groups_used) const
+    {
+        bool any = false;
+        for (const auto& c : cands) {
+            if (!selectable_ignoring_struck(c, groups_used)) continue;
+            any = true;
+            if (!m_struck.count(c.key)) return false;   // a non-struck option exists
+        }
+        return any;
+    }
+
+    /// A candidate is selectable (ignoring the struck bench) iff it is capable,
+    /// serve-eligible, not already holding a slot, and its netgroup is free.
+    bool selectable_ignoring_struck(const GetmnlistdCandidate& c,
+                                    const std::set<std::string>& groups_used) const
+    {
+        if (!c.serve_eligible) return false;
+        if (!getmnlistd_capable(c.proto_version)) return false;
+        if (holds(c.key)) return false;
+        const std::string grp = c.netgroup.empty() ? c.key : c.netgroup;
+        return groups_used.find(grp) == groups_used.end();
+    }
+
+    /// Pick the single best candidate: lowest tier, then round-robin
+    /// (least-recently-selected) within the tier, then key for determinism.
+    /// Struck candidates are excluded (benched until a full rotation).
+    const GetmnlistdCandidate* select_one(const std::vector<GetmnlistdCandidate>& cands,
+                                          const std::set<std::string>& groups_used) const
+    {
+        const GetmnlistdCandidate* best = nullptr;
+        int      best_tier = 1 << 30;
+        int64_t  best_seq  = 0;
+        for (const auto& c : cands) {
+            if (!selectable_ignoring_struck(c, groups_used)) continue;
+            if (m_struck.count(c.key)) continue;   // benched this rotation
+            const int t = static_cast<int>(tier_of(c.key));
+            int64_t seq = 0;
+            auto it = m_last_selected_seq.find(c.key);
+            if (it != m_last_selected_seq.end()) seq = it->second;
+            const bool better =
+                !best
+                || t < best_tier
+                || (t == best_tier && seq < best_seq)
+                || (t == best_tier && seq == best_seq && c.key < best->key);
+            if (better) { best = &c; best_tier = t; best_seq = seq; }
+        }
+        return best;
+    }
+
+    int m_k{1};
+    std::vector<Slot> m_slots;                       ///< occupied slots (<= K)
+    std::set<std::string> m_answered;                ///< T1 (session-local)
+    std::set<std::string> m_asked;                   ///< asked-this-session
+    std::set<std::string> m_struck;                  ///< struck-this-rotation
+    std::map<std::string, int64_t> m_last_selected_seq; ///< round-robin ordinal
+    int64_t m_seq{0};
+};
+
+}  // namespace coin
+}  // namespace dash

--- a/src/impl/dash/coin/getmnlistd_tracker.hpp
+++ b/src/impl/dash/coin/getmnlistd_tracker.hpp
@@ -107,6 +107,21 @@ inline bool getmnlistd_capable(uint32_t peer_proto_version)
     return peer_proto_version >= kGetmnlistdServeProtoVersion;
 }
 
+/// FLAG-GATED emit-site eligibility for a single getmnlistd carrier. EVERY live
+/// getmnlistd emit site — the initial send_getmnlistd() to the pinned primary,
+/// the rotating next_stateful_peer() selection, and the tracker-governed re-ask
+/// — gates a candidate carrier through EXACTLY this predicate, so a green KAT
+/// over it proves the shipped selection (it cannot diverge from the wire path).
+/// The slot tracker's plan() applies the same getmnlistd_capable() term
+/// internally. OFF (flag default) => ALWAYS true: every carrier passes and each
+/// emit site is byte-identical to master. ON => only a proto>=70214 carrier that
+/// can structurally serve GETMNLISTDIFF is eligible for the ask.
+inline bool getmnlistd_emit_eligible(uint32_t peer_proto_version)
+{
+    return !embedded_getmnlistd_tracker_enabled()
+           || getmnlistd_capable(peer_proto_version);
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // TIMING CONSTANTS — fixed per-slot interval, expiry at 10x (dashd parity)
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/impl/dash/coin/getmnlistd_tracker.hpp
+++ b/src/impl/dash/coin/getmnlistd_tracker.hpp
@@ -251,6 +251,43 @@ public:
     /// not struck. Late copies from these siblings draw NO misbehaviour strike.
     void win_race() { m_slots.clear(); }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // ACTIVE FOLD TARGET (k-inflight-live gate) — the (base=ZERO, target) block
+    // the mn-checkpoint lane is CURRENTLY folding. The mnlistdiff demux
+    // (historical_sml.hpp) is deliberately NOT short-circuiting, so its
+    // aggregate `consumed` flag is true whenever ANY historical filter claimed
+    // the reply — INCLUDING the QuorumMemberSource filter, which emits its OWN
+    // getmnlistd(base=ZERO, workHash) for a DIFFERENT target. Firing
+    // note_answered()/win_race() on that aggregate would clear all K mn-ckpt
+    // slots (and mis-mark the member-sourcing peer T1) on a reply that never
+    // answered the tracked target, leaving the K real asks outstanding while the
+    // next tick refills up to K MORE for the SAME target (up to 2K on the wire,
+    // and a repeat inside the fixed-10s guarantee). So the LIVE-wire hook gates
+    // on THIS target: a reply wins only when it is a full snapshot (base==ZERO)
+    // whose target hash equals the active fold target. The client stamps this
+    // from the lane's PENDING snapshot hash on each reply, so it always reflects
+    // the live target (never stale) — liveness is preserved: when the tracked
+    // target IS answered, it matches and win_race() still fires.
+    void set_active_target(const std::string& target_hash) { m_active_target = target_hash; }
+    void clear_active_target() { m_active_target.clear(); }
+    const std::string& active_target() const { return m_active_target; }
+
+    /// Reward-safe LIVE-wire gate for note_answered()/win_race(). TRUE iff a
+    /// demux-consumed historical reply GENUINELY answered the ACTIVE fold: a
+    /// full snapshot (base==ZERO) whose target hash equals active_target(). A
+    /// member-sourcing reply for a DIFFERENT target — or any reply while no fold
+    /// is active (empty active_target) — returns FALSE, so it can never clear
+    /// the K mn-checkpoint slots or mis-mark a peer. When the tracked target IS
+    /// answered it returns TRUE, so win_race() still fires and the fold proceeds
+    /// (the gate can never wedge a genuine answer).
+    bool reply_answers_active_target(bool reply_base_is_null,
+                                     const std::string& reply_target_hash) const
+    {
+        return !m_active_target.empty()
+            && reply_base_is_null
+            && reply_target_hash == m_active_target;
+    }
+
     /// Fill empty slots and RETARGET lapsed ones, up to K, from `cands`. Returns
     /// the keys newly assigned a slot NOW (the caller sends getmnlistd to each).
     /// Enforces, in order:
@@ -399,6 +436,7 @@ private:
     std::set<std::string> m_struck;                  ///< struck-this-rotation
     std::map<std::string, int64_t> m_last_selected_seq; ///< round-robin ordinal
     int64_t m_seq{0};
+    std::string m_active_target;   ///< k-inflight-live: active fold target (hex), "" => none
 };
 
 }  // namespace coin

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -411,6 +411,15 @@ public:
     {
         m_reask_snapshot = std::move(fn);
     }
+    /// #154 k-inflight-live: the CURRENTLY PENDING fold target (a base=ZERO
+    /// snapshot) as hex, or "" when no fold is pending. Read by the coin-P2P
+    /// client's getmnlistd-tracker hook to gate its slot bookkeeping on THIS
+    /// lane's own target, so a member-sourcing reply for a DIFFERENT target can
+    /// never clear the mn-checkpoint slots. Pure read; no behaviour.
+    std::string pending_snapshot_hash_hex() const
+    {
+        return m_snapshot_pending ? m_snapshot_hash.GetHex() : std::string();
+    }
     /// OPTIONAL. Wall-clock outbound STALL SIGNAL seam (dashd TipMayBeStale ->
     /// SetTryNewOutboundPeer). watchdog_tick() calls this with TRUE while a
     /// bridging getmnlistd has been outstanding past kStatefulStallGraceMs and

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1028,6 +1028,13 @@ private:
     // E2+ seams (callbacks, all optional)
     using AddrCallback = std::function<void(const std::vector<NetService>&)>;
     AddrCallback m_addr_callback;
+    /// #154 k-inflight-live gate: reads the mn-checkpoint lane's CURRENTLY
+    /// PENDING fold target (hex), or "" when no fold is pending. Wired by
+    /// main_dash to MnCheckpointLane::pending_snapshot_hash_hex(). Used ONLY to
+    /// gate the getmnlistd slot-tracker bookkeeping so a member-sourcing reply
+    /// for a different target cannot clear the mn-ckpt slots. Flag-guarded at
+    /// the call site; unset => the gate reads "" and the hook never fires.
+    std::function<std::string()> m_active_fold_target_fn;
     using PeerHeightCallback = std::function<void(uint32_t)>;
     PeerHeightCallback m_on_peer_height;
     using HandshakeCallback = std::function<void()>;
@@ -1496,6 +1503,10 @@ public:
     // ── E2+ seams ────────────────────────────────────────────────────────
     /// addr-message peer discovery feed.
     void set_addr_callback(AddrCallback cb) { m_addr_callback = std::move(cb); }
+    /// #154 k-inflight-live: wire the mn-checkpoint lane's pending-fold-target
+    /// accessor (see m_active_fold_target_fn). Reward-safety seam only.
+    void set_active_fold_target_fn(std::function<std::string()> fn)
+    { m_active_fold_target_fn = std::move(fn); }
     /// Peer's reported chain height (from its version message).
     void set_on_peer_height(PeerHeightCallback cb) { m_on_peer_height = std::move(cb); }
     /// Fired once per session when the version/verack handshake completes —
@@ -3955,6 +3966,17 @@ private:
         // the old block. Only tip-sync diffs fall through. The tip feed is
         // passed IN so it is structurally impossible to fire it on a consumed
         // reply (see HistoricalMnListDiffDemux::dispatch).
+        //
+        // #154 k-inflight-live: stamp the slot tracker's ACTIVE fold target from
+        // the mn-checkpoint lane's CURRENTLY PENDING snapshot hash BEFORE
+        // dispatch — dispatch runs on_historical_snapshot(), which clears the
+        // lane's pending flag, so a read AFTER would always be "". This is the
+        // reward-safety term the tracker bookkeeping is gated on below. OFF =>
+        // never read.
+        if (dash::coin::embedded_getmnlistd_tracker_enabled())
+            m_getmnlistd_tracker.set_active_target(
+                m_active_fold_target_fn ? m_active_fold_target_fn()
+                                        : std::string());
         const bool consumed = m_historical_mnlistdiff_demux.dispatch(
             msg->m_diff,
             [this](const vendor::CSimplifiedMNListDiff& d) {
@@ -3969,7 +3991,24 @@ private:
         // session-local) and free the whole race — a sibling that was genuinely
         // asked this session and lost the race draws NO strike (late/duplicate
         // copies are dropped, not penalised). OFF => the tracker is untouched.
-        if (dash::coin::embedded_getmnlistd_tracker_enabled() && consumed && m_active) {
+        //
+        // k-inflight-live GATE: `consumed` is the non-short-circuiting OR of
+        // ALL historical demux filters, so it is true even when only the
+        // QuorumMemberSource filter (which sourced its OWN getmnlistd for a
+        // DIFFERENT target) claimed the reply. Firing on `consumed` alone would
+        // clear all K mn-ckpt slots and mis-mark that member-sourcing peer T1,
+        // leaving the K real asks outstanding for the still-unanswered target
+        // (the next tick then refills up to K MORE — up to 2K on the wire, and a
+        // repeat inside the fixed-10s guarantee). So we additionally require the
+        // reply to ACTUALLY answer the tracker's active fold target: a full
+        // snapshot (base==ZERO) whose blockHash equals the pending target
+        // captured above. A member-sourcing reply for a different target can
+        // never satisfy this; a genuine answer to the tracked target always
+        // does (liveness: win_race still fires, slots clear, the fold proceeds).
+        if (dash::coin::embedded_getmnlistd_tracker_enabled() && consumed && m_active
+            && m_getmnlistd_tracker.reply_answers_active_target(
+                   msg->m_diff.baseBlockHash.IsNull(),
+                   msg->m_diff.blockHash.GetHex())) {
             m_getmnlistd_tracker.note_answered(m_active->key);
             m_getmnlistd_tracker.win_race();
         }

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -786,6 +786,16 @@ private:
     // DIFFERENT carrier so it actually fans out.
     std::size_t  m_stateful_rr{0};
     std::string  m_last_stateful_peer;
+    // #154 EMBEDDED getmnlistd SLOT TRACKER (flag default-OFF). Owns TIME for
+    // the live stateful re-ask: K slots (K = fresh_datum_race_width), each its
+    // OWN fixed 10s timer (no backoff), 3 boolean session-local tiers, the
+    // proto>=70214 capability filter, and the 100s expiry->ESCALATE bound. When
+    // --embedded-getmnlistd-tracker is ON it GOVERNS which capable carriers a
+    // re-ask reaches (reask_via_tracker below); OFF it is never consulted and
+    // the existing race+rotating ladder runs verbatim (byte-identical to
+    // master). Touched only on the single io_context thread, like every other
+    // member here.
+    dash::coin::GetmnlistdSlotTracker m_getmnlistd_tracker;
     // dashd TipMayBeStale/SetTryNewOutboundPeer analog for the STATEFUL leg: a
     // bridging getmnlistd (fold / ondemand-mnlist) that the mn-ckpt lane has
     // found outstanding past its wall-clock re-ask grace. While set,
@@ -1895,10 +1905,28 @@ public:
                         << " — the SML cannot advance until a peer is up";
             return;
         }
+        // #154 CAPABILITY FILTER on the initial ask (flag default-OFF). The
+        // pinned m_primary can be a proto<70214 peer structurally incapable of
+        // serving GETMNLISTDIFF (NODE_NETWORK proves nothing — the silent
+        // carriers ARE NODE_NETWORK). When the tracker is armed, rotate the ask
+        // onto a capable carrier instead of burning it on a peer that cannot
+        // answer; if none is capable, drop with a named cause. OFF => carrier is
+        // m_primary and every byte below is identical to master.
+        PeerSession* carrier = m_primary;
+        if (!dash::coin::getmnlistd_emit_eligible(m_primary->version)) {
+            carrier = next_stateful_peer();   // capability-filtered when armed
+            if (!carrier || !dash::coin::getmnlistd_emit_eligible(carrier->version)) {
+                LOG_WARNING << "[COIN-P2P] getmnlistd DROPPED (no getmnlistd-"
+                               "capable peer, proto>=70214):"
+                            << " base=" << base_block_hash.GetHex()
+                            << " target=" << block_hash.GetHex();
+                return;
+            }
+        }
         LOG_INFO << "[COIN-P2P] getmnlistd -> base=" << base_block_hash.GetHex()
                  << " target=" << block_hash.GetHex();
         auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
-        m_primary->write(msg);
+        carrier->write(msg);
     }
 
     /// Fold-snapshot variant of send_getmnlistd that ROTATES its carrier across
@@ -2045,6 +2073,19 @@ public:
         // server and expands/rotates the outbound set toward a real server.
         if (!m_last_stateful_peer.empty() && holds_key(m_last_stateful_peer))
             note_bulk_nonserver(m_last_stateful_peer);
+        // #154 TRACKER-GOVERNED re-ask (flag default-OFF). When armed, the slot
+        // tracker OWNS this re-ask: it applies the proto>=70214 capability
+        // filter, the <=K in-flight budget, the fixed 10s per-slot timer (no
+        // backoff) and the 3 boolean tiers, and it decides WHICH capable
+        // carriers get asked NOW. A slot still younger than 10s is left running
+        // (no new ask) so the tracker — not a growing wall-clock ladder — bounds
+        // the cadence; at 100s the oldest ask ESCALATES the outbound set. OFF =>
+        // the tracker is never consulted and the race+rotating ladder below runs
+        // verbatim (byte-identical to master).
+        if (dash::coin::embedded_getmnlistd_tracker_enabled()) {
+            reask_via_tracker(base_block_hash, block_hash);
+            return;
+        }
         // (B') PR-2: race the re-ask across K distinct-netgroup carriers so a
         // slow winner does not cost a whole wall-clock re-ask interval. Only
         // WHO/HOW-MANY changes; the reply is matched by the unchanged
@@ -2055,6 +2096,72 @@ public:
         // (B) rotate to a fresh archival carrier and send (never drops: the
         // rotating send falls back to any handshaked peer, then m_primary).
         send_getmnlistd_rotating(base_block_hash, block_hash);
+    }
+
+    /// #154: project the live pool into the slot tracker and let it GOVERN the
+    /// re-ask — capability filter (proto>=70214) + <=K slots + fixed 10s per-slot
+    /// timers (no backoff) + 3 boolean tiers + 100s expiry->ESCALATE. Returns the
+    /// number of getmnlistd messages actually written (0 => every slot is still
+    /// younger than 10s, or no capable carrier exists; either way the tracker has
+    /// decided no NEW ask is due). Reward-safe: only WHEN a slot retargets and
+    /// FROM-WHOM changes; the reply is matched by the unchanged m_snapshot_hash
+    /// and DIP-4 self-checked before it is folded, and no fold is rewound.
+    int reask_via_tracker(const uint256& base_block_hash, const uint256& block_hash)
+    {
+        m_getmnlistd_tracker.configure(dash::coin::fresh_datum_race_width());
+        const int64_t now = arrival_now_ms();
+        // 100s EXPIRY -> ESCALATE: the oldest outstanding ask has gone unanswered
+        // ~10x past the fixed cadence. Raise the stateful-stall signal so the
+        // acquisition pump expands the outbound set (dashd SetTryNewOutboundPeer)
+        // toward a fresher capable carrier. This ESCALATES the peer set; it never
+        // repeats an identical ask to the same set and never rewinds a fold.
+        const int64_t oldest = m_getmnlistd_tracker.oldest_asked_at(now);
+        if (dash::coin::classify_getmnlistd_expiry(now, oldest)
+                == dash::coin::GetmnlistdExpiryAction::Escalate)
+            m_stateful_stall = true;
+        auto cands = getmnlistd_candidates();
+        auto keys  = m_getmnlistd_tracker.plan(cands, now);
+        int sent = 0;
+        for (const auto& key : keys) {
+            PeerSession* p = nullptr;
+            for (const auto& up : m_pool) if (up->key == key) { p = up.get(); break; }
+            if (!p) continue;
+            m_last_stateful_peer = p->key;
+            auto msg = message_getmnlistd::make_raw(base_block_hash, block_hash);
+            p->write(msg);
+            p->note_request_sent(DatumClass::MnListDiff, now);
+            ++sent;
+        }
+        if (sent > 0)
+            LOG_INFO << "[COIN-P2P] getmnlistd(TRACKER x" << sent << ") -> "
+                     << sent << " capable slot-tracked carrier(s)"
+                        " (proto>=70214, fixed 10s per-slot, <=K in-flight),"
+                     << " base=" << base_block_hash.GetHex()
+                     << " target=" << block_hash.GetHex();
+        return sent;
+    }
+
+    /// #154: project every handshaked, serve-eligible peer into a slot-tracker
+    /// candidate. The tracker itself applies the capability filter (proto>=70214)
+    /// and the tier/slot/netgroup discipline — this is a pure projection, no
+    /// socket is touched. serve_eligible mirrors the race's own gate (handshaked,
+    /// CanServeBlocks, not bulk-demoted).
+    std::vector<dash::coin::GetmnlistdCandidate> getmnlistd_candidates() const
+    {
+        std::vector<dash::coin::GetmnlistdCandidate> out;
+        out.reserve(m_pool.size());
+        for (const auto& up : m_pool) {
+            const PeerSession* pp = up.get();
+            dash::coin::GetmnlistdCandidate c;
+            c.key            = pp->key;
+            c.netgroup       = dash::coin::peer_network_group(pp->addr.address());
+            c.proto_version  = pp->version;
+            c.serve_eligible = pp->handshake.complete()
+                               && can_serve_blocks(pp)
+                               && !bulk_demoted(pp->key);
+            out.push_back(std::move(c));
+        }
+        return out;
     }
 
     /// dashd SetTryNewOutboundPeer for the STATEFUL leg. The mn-ckpt lane's
@@ -2432,7 +2539,7 @@ private:
     PeerSession* next_stateful_peer()
     {
         const std::size_t n = m_pool.size();
-        if (n == 0) return m_primary;
+        if (n == 0) return getmnlistd_capable_fallback(m_primary);
         for (int pass = 0; pass < 3; ++pass)
         {
             for (std::size_t i = 0; i < n; ++i)
@@ -2440,12 +2547,31 @@ private:
                 PeerSession* p = m_pool[(m_stateful_rr + i) % n].get();
                 if (!p->handshake.complete()) continue;
                 if (pass < 2 && !bulk_eligible(p)) continue;
+                // #154 CAPABILITY FILTER (flag default-OFF): a getmnlistd slot
+                // must never land on a peer whose advertised proto cannot serve
+                // GETMNLISTDIFF (>=70214). getmnlistd_emit_eligible() is the SAME
+                // predicate the initial send_getmnlistd() and the KAT drive. OFF
+                // => it is always true, this continue is never taken, and the
+                // selection is byte-identical to master.
+                if (!dash::coin::getmnlistd_emit_eligible(p->version)) continue;
                 if (pass == 0 && p->key == m_last_stateful_peer) continue;
                 m_stateful_rr = (m_stateful_rr + i + 1) % n;
                 return p;
             }
         }
-        return m_primary;
+        return getmnlistd_capable_fallback(m_primary);
+    }
+
+    /// #154: the final m_primary fallback of the stateful selectors must itself
+    /// respect the capability filter when the tracker is armed — otherwise the
+    /// "no eligible peer" fallback would re-introduce the very incapable carrier
+    /// the filter just excluded. OFF (or a capable primary) => returns the
+    /// pointer unchanged, byte-identical to master.
+    PeerSession* getmnlistd_capable_fallback(PeerSession* p) const
+    {
+        if (p && !dash::coin::getmnlistd_emit_eligible(p->version))
+            return nullptr;
+        return p;
     }
 
     /// dashd mapBlocksInFlight bound: MAX_BLOCKS_IN_TRANSIT_PER_PEER across
@@ -2566,6 +2692,11 @@ private:
 
         if (m_active == p) m_active = nullptr;
         if (was_primary) m_primary = nullptr;
+        // #154: a disconnect erases the peer's session-local tier state and
+        // frees any getmnlistd slot it held (the T1 "answered" boolean resets on
+        // disconnect, exactly as the spec requires). No-op unless the tracker was
+        // ever consulted; harmless when the flag is OFF.
+        m_getmnlistd_tracker.on_disconnect(key);
 
         // Erase LAST: the unique_ptr destructor tears the Connection (and its
         // socket) down, so nothing may hold p afterwards.
@@ -3832,6 +3963,15 @@ private:
         if (consumed) {
             LOG_INFO << "[" << m_chain_label << "] mnlistdiff consumed as "
                         "HISTORICAL (tip SML untouched)";
+        }
+        // #154: a HISTORICAL mnlistdiff is the stateful getmnlistd leg the slot
+        // tracker governs. When armed, mark the answering carrier T1 (answered,
+        // session-local) and free the whole race — a sibling that was genuinely
+        // asked this session and lost the race draws NO strike (late/duplicate
+        // copies are dropped, not penalised). OFF => the tracker is untouched.
+        if (dash::coin::embedded_getmnlistd_tracker_enabled() && consumed && m_active) {
+            m_getmnlistd_tracker.note_answered(m_active->key);
+            m_getmnlistd_tracker.win_race();
         }
     }
 

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -93,6 +93,7 @@
 #include <impl/dash/coin/bulk_peer_policy.hpp>   // #154 select_bulk_eligible_keys (LEVER 1 pure logic)
 #include <impl/dash/coin/arrival_timing.hpp>     // PR-0: per-peer per-datum-class delivery-latency EWMA (instrumentation only)
 #include <impl/dash/coin/fresh_datum_race.hpp>   // PR-2: fresh-datum race (K-way fan-out selector + single-flight dedup; flag/K default-OFF)
+#include <impl/dash/coin/getmnlistd_tracker.hpp> // #154: getmnlistd slot tracker (fixed 10s per-slot re-ask, 3 boolean tiers, capability filter; flag default-OFF)
 #include <impl/dash/coin/coin_peer_manager.hpp> // PR-2: peer_network_group() for distinct-netgroup racing
 #include <impl/dash/coin/proactive_rotation_policy.hpp>  // PR-3: LOW-RATE proactive rotation decision helpers (pure, shared with the KAT)
 
@@ -1978,7 +1979,20 @@ public:
             c.key       = pp->key;
             c.netgroup  = dash::coin::peer_network_group(pp->addr.address());
             c.can_serve = can_serve_blocks(pp);
-            c.eligible  = pp->handshake.complete() && !bulk_demoted(pp->key);
+            // #154 getmnlistd SLOT TRACKER capability gate (flag default-OFF).
+            // When the tracker is armed AND we are ranking the MnListDiff class,
+            // a peer whose advertised protocol version cannot serve GETMNLISTDIFF
+            // is made INELIGIBLE so a raced slot never lands on a structurally-
+            // incapable carrier (NODE_NETWORK proves nothing; the silent carriers
+            // ARE NODE_NETWORK). OFF => the extra term is `true` and this line is
+            // byte-identical to master. Only WHO is asked changes; admission stays
+            // content-addressed (diff.blockHash == m_snapshot_hash), never peer.
+            const bool mnlistd_capable =
+                !(dash::coin::embedded_getmnlistd_tracker_enabled()
+                  && cls == DatumClass::MnListDiff)
+                || dash::coin::getmnlistd_capable(pp->version);
+            c.eligible  = pp->handshake.complete() && !bulk_demoted(pp->key)
+                          && mnlistd_capable;
             const int64_t e = pp->delivery.ewma_ms(cls);
             c.score     = (e < 0) ? 0
                         : (e > 1000000 ? -1000000 : static_cast<int>(1000000 - e));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -329,6 +329,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_dependencies(test_dash_serve_gate_journal dash_fresh_datum_race_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_proactive_rotation_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_asn_diversity_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
+    add_dependencies(test_dash_serve_gate_journal dash_getmnlistd_tracker_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## Embedded getmnlistd slot tracker (dashd-cut coin-P2P stack, #154)

Flag-gated **non-merged** port of dashd`s fixed-interval object re-request onto the daemonless coin-P2P `getmnlistd` path, replacing the growing wall-clock re-ask ladder. Composes with the merged **PR-2 fresh-datum race**.

### Reward-safety (WHEN / FROM-WHOM only)
- Decides only **WHEN** a slot retargets and **FROM-WHOM** the next `getmnlistd` goes. Never admits a reply, applies a list, publishes, or rewinds a fold.
- Admission stays **content-addressed** self-check: `diff.blockHash == m_snapshot_hash` (the strict matcher, `mn_checkpoint_lane.hpp` ~2497/2957/3049). **No peer-identity term is ever added to admission** (that would break the K-race).
- A late/duplicate `MNLISTDIFF` from a peer genuinely asked this session for this `(base,target)` draws **NO** misbehaviour strike.
- Expiry abandons a pending **REQUEST** through the existing `remember_abandoned(m_snapshot_hash)` seam (`mn_checkpoint_lane.hpp` 2910/2943); **applied folds stay applied**.
- **Flag `--embedded-getmnlistd-tracker`, default-OFF => byte-identical to master.** OFF, the tracker is never consulted and the existing wall-clock ladder runs verbatim; the one added `race_candidates` term collapses to `true`, and the arg-parse only flips a function-local static.

### Design (spec + review) + the 5 gates
1. **Interval = 10s FIXED, per-slot, NO backoff.** The growing 10-40s ladder is the bug removed. dashd uses fixed per-class intervals (`GetObjectInterval`, `net_processing.cpp:1585-1599`); the bound is EXPIRY (`:1601`/`:1614`), not growth.
2. **Ordering = 3 BOOLEAN tiers, round-robin within each** (T1 answered-this-session / T2 never-asked / T3 struck-this-rotation, re-eligible after a full rotation) -- **not** the answer-rate numeric score dashd refuses (`:6547-6551`/`:6552-6607`). Session-local only; a disconnect erases a peer`s tier state. Never feeds connection lifetime / addrman / cross-restart persistence.
3. **Race + tracker = ONE structure sharing ONE budget K.** Race owns PARALLELISM (K = `fresh_datum_race_width`, distinct netgroups); tracker owns TIME (each slot its own 10s timer; on lapse RETARGET -- old ask abandoned, next candidate not currently holding a slot; set never grows past K). **ASSERT invariant: `<=K` getmnlistd in-flight per `(base,target)` at any instant.** First strict-matcher reply wins; siblings cancel; late replies silently dropped.
4. **Expiry = 100s (10x). Action = ESCALATE not repeat** (same ask to same set = no-op): trigger peer-set churn / signal the lane to re-plan to a fresher target.
5. **Capability filter:** candidate eligible only if advertised protocol-version `>=` the getmnlistd/GETMNLISTDIFF serve floor (70214, LLMQS_PROTO_VERSION / DIP-4). `NODE_NETWORK` proves nothing -- the silent carriers ARE `NODE_NETWORK` -- so a 10s slot never lands on a structurally-incapable peer.

**KAT `dash_getmnlistd_tracker_kat`** locks all five: (1) `<=K` in-flight across a simulated rotation (+ no-backoff + bursty fuzz); (2) late/dup => first content-addressed match wins (`FreshDatumRaceInflight` keyed by object hash, `Fold` then `DropDuplicate`), rest dropped, sibling NOT struck; (3) expiry mid-lane => `Escalate`, applied-fold counter untouched, lane re-plans not rewinds; (4) capability filter benches the incapable old-proto peer; (5) OFF-equivalence (default OFF, exact toggle). **Green under `-DC2POOL_DASH_BLS=ON`.** Registered on the build.yml-allowlisted `test_dash_serve_gate_journal` anchor (`add_dependencies`) so CI actually builds it -- the NOT_BUILT fake-green guard.

### Honest scope note -- this is a DESIGN port
dashd builds its SML **locally** and never *requests* a `mnlistdiff`; `getmnlistd` is a **c2pool-daemonless-only** path. The cited dashd mechanism (fixed re-ask cadence, expiry-bounded, answer-rate-scoring refused) is the *policy* being ported, not a like-for-like code path.

**90%-simpler alternative considered:** a cold-start-only one-shot fan-out to all capable candidates (no per-slot timers, no tiers, no rotation). Rejected as the default because it re-dials the whole capable set on every cold bridge and gives up the steady-state near-tip retarget behaviour, but it is the fallback if the tracker`s bookkeeping ever proves too subtle to maintain.

### ARM gate
Hotel soak **time-to-first-fold-after-restart < 30s** (vs the 1-17 min the growing ladder produces on a silent-carrier-heavy peer set). Not armed by this PR.

### Verification performed
- KAT built + run under BLS=ON: `dash_getmnlistd_tracker_kat PASS` (exit 0).
- Full `c2pool-dash` binary built (BLS=ON, dashbls verify enabled); `strings` confirms `--embedded-getmnlistd-tracker` / `=false` / usage line are compiled in, and `--help` prints the flag -- **not a dead flag** (the prior setter-without-arg-parse trap is avoided).

dashd citations: `net_processing.cpp:1585-1599` (GetObjectInterval fixed cadence), `:1601`/`:1614` (expiry bounds the wait), `:6547-6551`/`:6552-6607` (answer-rate scoring refused).



---

## UPDATE (0022eff4f): tracker is now LIVE-wired on ALL FOUR emit sites

The initial commit added the structure + capability filter but (a follow-up review found) enforced the filter at ONLY ONE of four getmnlistd emit sites and NEVER instantiated the tracker in any runtime path. Both holes are now closed, still entirely behind `--embedded-getmnlistd-tracker` (default-OFF).

### (A) Capability filter (proto >= 70214) on ALL FOUR emit sites
One shared predicate `getmnlistd_emit_eligible(proto)` = `!flag || proto>=70214` — every site AND the KAT gate through it, so a green KAT proves the shipped selection:
- **`send_getmnlistd()` initial ask** — if the pinned `m_primary` is incapable, rotate to a capable carrier, else drop with a named cause (`getmnlistd DROPPED (no getmnlistd-capable peer, proto>=70214)`).
- **`next_stateful_peer()`** (the rotating selection used by `send_getmnlistd_rotating` **and** the `send_getmnlistd_reask` rotating fallback) — skips incapable carriers; the final `m_primary` fallback returns `nullptr` rather than re-introduce an incapable carrier.
- **`race_candidates()`** — already gated (unchanged).
- **`send_getmnlistd_reask()`** rotating fallback inherits the filter through `next_stateful_peer`.

### (B) Tracker INSTANTIATED and GOVERNING live selection
`GetmnlistdSlotTracker m_getmnlistd_tracker` now lives in the CoinClient. The live wall-clock re-ask (`mn_checkpoint_lane::watchdog_tick` -> `m_reask_snapshot` -> `send_getmnlistd_reask`) routes through `reask_via_tracker()` when armed: it projects the live pool into candidates and lets `plan()` GOVERN which capable carriers are asked NOW — capability filter + `<=K` in-flight + fixed 10s per-slot timer (no backoff) + 3 boolean session-local tiers + 100s expiry->ESCALATE (raises the stateful-stall/outbound-expansion signal; never a repeated identical ask, never a fold rewind). A historical `mnlistdiff` reply marks the answering carrier T1 and frees the whole race (no strike on genuinely-asked siblings); a disconnect erases session-local tier state. The strict content-addressed matcher (`diff.blockHash == m_snapshot_hash`) and `remember_abandoned` seam are untouched.

### Liveness + OFF-equivalence proof
- **KAT green**: `dash_getmnlistd_tracker_kat PASS` (BLS=ON) — now includes section (6) INTEGRATION: with an incapable (proto 70213, NODE_NETWORK serve-eligible) peer present it drives the shared emit-site predicate + the tracker across a full slot rotation and asserts (1) the incapable peer NEVER gets a slot on ANY path, (2) a capable peer IS selected (governance live, not dormant), (3) an only-incapable pool selects nothing, (4) OFF => predicate always-true so initial/rotating sites select exactly as master and the tracker is never consulted.
- **OFF-equivalence**: `getmnlistd_emit_eligible` collapses to `true` when the flag is OFF, so every emit site takes the master path verbatim; the `reask_via_tracker` branch and the reply-hook are behind `embedded_getmnlistd_tracker_enabled()`. The only always-run addition is `on_disconnect()` on a never-populated tracker — a pure no-op (no I/O, no logging, no wire effect).
- **Full binary built** (BLS=ON, Release): `main_dash.cpp` + `mn_checkpoint_lane.hpp` + `p2p_client.hpp` compile and link into `c2pool-dash`; binary strings confirm `--embedded-getmnlistd-tracker`, `getmnlistd(TRACKER x`, and the capability-drop path are live.
- CI-fix `add_dependencies(test_dash_serve_gate_journal dash_getmnlistd_tracker_kat)` retained.
