### PR TITLE
dash(daemonless): classify txn-already-known under Window-1 ahead-skew as PendingPropagation (reward-safe fail-closed)

### DIFF
--- a/src/c2pool/dash_tx_serve_self_validation_kat.cpp
+++ b/src/c2pool/dash_tx_serve_self_validation_kat.cpp
@@ -97,6 +97,35 @@ static void part_a_classifier()
               "bad-txns-inputs-missingorspent + dashd-ahead -> STILL Invalid");
     }
 
+    // txn-already-known (validation.cpp:854, TX_CONFLICT, non-punishable per
+    // net_processing.cpp MaybePunishNodeForTx) while dashd is AHEAD of our serve
+    // parent: dashd found the tx's OWN outputs already in its UTXO set — it is
+    // CONFIRMED in the ahead block our still-valid fork template competed for
+    // (the h=2526495 class). GREEN: PendingPropagation, not a defect.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "81109abf";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = true;
+        const auto r = classify_mempool_accept(tx, reject("txn-already-known"));
+        CHECK(r.verdict == MempoolAcceptVerdict::PendingPropagation,
+              "txn-already-known + dashd-ahead -> PendingPropagation");
+    }
+
+    // REWARD-SAFE FAIL-CLOSED: the SAME reason WITHOUT the ahead fact means the
+    // tx is confirmed in OUR OWN ancestry — a real double-inclusion that would
+    // cost the block. It stays Invalid (and resets the clean run). Fact-gated,
+    // widened only in the one direction the tx is provably valid on our fork.
+    {
+        MempoolProbeTx tx;
+        tx.txid                        = "already-ours";
+        tx.depends_on_in_set_parent    = false;
+        tx.dashd_ahead_of_serve_height = false;
+        const auto r = classify_mempool_accept(tx, reject("txn-already-known"));
+        CHECK(r.verdict == MempoolAcceptVerdict::Invalid,
+              "txn-already-known WITHOUT dashd-ahead -> stays Invalid");
+    }
+
     // Gate arithmetic: a PendingPropagation sample neither advances nor RESETS
     // the clean run — the whole point of the demotion-to-measurement.
     {

--- a/src/impl/dash/coin/mempool_validity_gate.hpp
+++ b/src/impl/dash/coin/mempool_validity_gate.hpp
@@ -143,6 +143,20 @@ inline bool is_missing_or_spent_reason(const std::string& reason)
     return reason == "bad-txns-inputs-missingorspent";
 }
 
+/// dashd's reject-reason for "I already hold this transaction as a CONFIRMED
+/// tx on my own chain", verbatim (Dash Core validation.cpp:854: TX_CONFLICT,
+/// "txn-already-known"). It is returned when a HaveCoinInCache probe over the
+/// transaction's OWN outputs succeeds while an input HaveCoin fails: dashd is
+/// telling us the tx is ALREADY CONFIRMED in its UTXO set (its outputs exist),
+/// not that an input is unknown. It is non-punishable (net_processing.cpp
+/// MaybePunishNodeForTx: TX_CONFLICT falls to `break`, misbehaviour 0), exactly
+/// like the other propagation-class reasons. Compared for EQUALITY only — NO
+/// prefix matching, per this file's discipline.
+inline bool is_confirmed_tx_reason(const std::string& reason)
+{
+    return reason == "txn-already-known";
+}
+
 /// Three-valued logic, plus TWO honest "no verdict" states.
 /// Unprobed is NEVER counted as valid and NEVER counted as a defect: it is the
 /// absence of a measurement, and it advances nothing. PendingPropagation is the
@@ -306,9 +320,30 @@ inline MempoolAcceptResult classify_mempool_accept(const MempoolProbeTx& tx,
     // caught by the serve-time internal-consistency referee (tx_serve_referee.
     // hpp), which shares the selector's spent-aware UTXO view and runs on EVERY
     // armed embedded template independent of dashd.
-    if (is_unknown_input_only_reason(r.reason) && tx.dashd_ahead_of_serve_height) {
+    //
+    // The SAME Window-1 logic covers dashd's "txn-already-known" reason under
+    // the ahead skew. That reason (validation.cpp:854) means dashd found the
+    // transaction's OWN outputs already in its UTXO set: the tx is CONFIRMED on
+    // dashd's chain. When dashd's probe-time tip is STRICTLY AHEAD of our serve
+    // parent, that confirmation lives in the ahead block(s) our still-valid fork
+    // template competed for — the tx is VALID ON OUR FORK, and dashd, probing
+    // against its newer view, reports it as already-confirmed. This is the proven
+    // h=2526495 class (both leak txs were CONFIRMED IN BLOCK 2526495 itself). Like
+    // the missing-inputs arm it is FACT-gated on `dashd_ahead_of_serve_height`,
+    // never on the reason alone, and it advances NOTHING and resets NOTHING.
+    //
+    // REWARD-SAFE FAIL-CLOSED: WITHOUT the ahead skew, "txn-already-known" means
+    // the tx is confirmed in OUR OWN ancestry — a genuine double-inclusion that
+    // would cost the block — so it falls through to Invalid below and RESETS the
+    // clean run, flagging a selector/ingest eviction miss. The gate is only ever
+    // widened in the one direction (ahead skew) where the tx is provably valid on
+    // our fork; on ambiguous or non-skewed evidence it stays CLOSED.
+    if ((is_unknown_input_only_reason(r.reason) || is_confirmed_tx_reason(r.reason))
+        && tx.dashd_ahead_of_serve_height) {
         r.verdict        = MempoolAcceptVerdict::PendingPropagation;
-        r.unprobed_cause = "dashd-ahead-of-serve-parent(window-1-propagation)";
+        r.unprobed_cause = is_confirmed_tx_reason(r.reason)
+            ? "confirmed-in-dashd-ahead-block(window-1)"
+            : "dashd-ahead-of-serve-parent(window-1-propagation)";
         return r;
     }
 


### PR DESCRIPTION
## What

Widen the daemonless mempool-validity gate so dashd `txn-already-known` under a Window-1 ahead-skew is classified `PendingPropagation` (a measurement artefact), not `Invalid`. Port-from-dashd, exact.

## Why (dashd citations)

When `testmempoolaccept` probes a transaction whose inputs are not in dashd's view, Dash Core first asks "are the inputs missing because I already have this tx?" by looking up the transaction's OWN outputs in the coins cache:

```
// validation.cpp:849-858
if (!m_view.HaveCoin(txin.prevout)) {
    // Are inputs missing because we already have the tx?
    for (size_t out = 0; out < tx.vout.size(); out++) {
        if (coins_cache.HaveCoinInCache(COutPoint(hash, out))) {
            return state.Invalid(TxValidationResult::TX_CONFLICT, "txn-already-known");
        }
    }
    return state.Invalid(TxValidationResult::TX_MISSING_INPUTS, "bad-txns-inputs-missingorspent");
}
```

So `txn-already-known` (validation.cpp:850-855) means **"this transaction is already CONFIRMED in my UTXO set"** — its outputs exist. It is **non-punishable**: `MaybePunishNodeForTx` routes `TX_CONFLICT` to `break` (misbehaviour 0), i.e. dashd itself treats it as conflicting-but-not-invalid policy data, not review:

```
// net_processing.cpp:1988-2011  MaybePunishNodeForTx
case TxValidationResult::TX_CONSENSUS: { Misbehaving(nodeid, 100); return true; }
// Conflicting (but not necessarily invalid) data or different policy:
...
case TxValidationResult::TX_MISSING_INPUTS:
case TxValidationResult::TX_CONFLICT:      // <- txn-already-known lands here
...
    break;   // misbehaviour 0
```

Under the Window-1 skew (dashd's probe-time tip STRICTLY AHEAD of the serve parent this template was built on), that confirmation lives in the ahead block(s) our still-valid fork template competed for — the proven **h=2526495** class, where both leak txs (`8c4efd9c…`, `81109abf…`) were confirmed **in block 2526495 itself**, the exact height our template competed for. The tx is **VALID ON OUR FORK**; dashd, probing against its newer view, simply already mined it. Before this change it classified `Invalid` and **reset the clean run** — the exact false negative the Window-1 arm exists to prevent, just reached through dashd's second reject string.

## Fix

- Add `inline bool is_confirmed_tx_reason(const std::string& r){ return r=="txn-already-known"; }` — verbatim equality, NO prefix matching, per the file's discipline.
- Widen the fact-gated Window-1 branch to `(is_unknown_input_only_reason(r.reason) || is_confirmed_tx_reason(r.reason)) && tx.dashd_ahead_of_serve_height` => `PendingPropagation`, `unprobed_cause = "confirmed-in-dashd-ahead-block(window-1)"` for the confirmed sub-case. Advances nothing, resets nothing, counted separately (`pending_propagation`) so the skew class stays measurable.

## Reward-safety (fail-closed)

The widening is gated on the **ahead-skew FACT** — `dashd_ahead_of_serve_height`, a height comparison the caller supplies — **never** on the reason string alone.

- **WITHOUT the skew**, `txn-already-known` means the tx is confirmed in **OUR OWN ancestry**: a genuine double-inclusion that would cost the block. It falls through to `Invalid` **and resets `consecutive_clean = 0`**, flagging a selector/ingest eviction miss.
- `bad-txns-inputs-missingorspent` stays `Invalid` even under the skew (unchanged) — it conflates unknown-with-SPENT in its own name.

The gate is only ever widened in the one direction the tx is provably valid on our fork; on ambiguous or non-skewed evidence it fails toward a **CLOSED** gate.

## KAT

Two new rows in `src/c2pool/dash_tx_serve_self_validation_kat.cpp`:

- `(txn-already-known, dashd_ahead=true)` => `PendingPropagation`
- `(txn-already-known, dashd_ahead=false)` => `Invalid`

Built + run **green under BLS=ON**:

```
ok:   txn-already-known + dashd-ahead -> PendingPropagation
ok:   txn-already-known WITHOUT dashd-ahead -> stays Invalid
...
RESULT: PASS
```

The KAT is already CI-anchored via `add_dependencies(test_dash_serve_gate_journal dash_tx_serve_self_validation_kat)` in `test/CMakeLists.txt`, so it builds in CI (not fake-green).
