### PR TITLE
dash(daemonless): PR-C1 — wire replay UTXO fold as LIVE serve-path input-pricing view (--embedded-fold-live, default OFF)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -449,6 +449,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-tx-serve-own-set]\n"
         << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
         << "           [--embedded-getmnlistd-tracker]\n"
+        << "           [--embedded-fold-live PATH]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--embedded-proactive-rotate]\n"
@@ -992,7 +993,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // of THIS node's own dial targets — never changes WHAT is fetched
              // or how a reply is verified. OFF => dial plan byte-identical to
              // master.
-             bool embedded_asn_diversity = false)
+             bool embedded_asn_diversity = false,
+             // --embedded-fold-live PATH (PR-C1): wire the full-history replay
+             // UTXO fold at PATH as the LIVE serve-path input-pricing view.
+             // EMPTY (flag absent) => fold never opened; mempool fee pricing +
+             // pin gate byte-identical to master. Non-empty => price mempool txs
+             // whose inputs predate the forward UTXO view from a set proven
+             // byte-equal to dashd (kernel/coinstats.cpp hash_serialized_2),
+             // marking them fee_fold_proven, and retire the gettxout/--coin-rpc
+             // pin lookup. Reward-safe: fold-exact fees, never overstated.
+             const std::string& fold_live_db = std::string())
 {
     namespace io = boost::asio;
 
@@ -2222,8 +2232,41 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // deliberately -- attach() hands the lane's UTXOViewCache pointer to the
     // bundle's Mempool (set_utxo), so the lane must outlive the mempool that
     // references it (reverse destruction order at scope exit).
+    // PR-C1 (embedded-fold-live): full-history replay UTXO fold opened as the
+    // LIVE serve-path input-pricing view. Declared BEFORE node_coin_state so it
+    // outlives the mempool that captures it (reverse destruction order); the
+    // lambdas below also capture a shared_ptr copy, so the fold survives as long
+    // as any wiring holds it. EMPTY fold_live_db (flag absent) => nothing opened,
+    // fee pricing + pin gate byte-identical to master. NOTE: populating this
+    // store to the tip (the 77G cold start) is task #154, a DEPLOY prereq -- an
+    // empty/partial store simply resolves fewer inputs (fail-closed to today's
+    // fee-unknown), never a wrong value.
+    std::shared_ptr<dash::coin::replay::ReplayUtxoFold> fold_live;
     dash::coin::UtxoLane utxo_lane;
     dash::coin::NodeCoinState node_coin_state;
+    if (!fold_live_db.empty()) {
+        fold_live = std::make_shared<dash::coin::replay::ReplayUtxoFold>();
+        if (!fold_live->open(fold_live_db)) {
+            std::cout << "[run] --embedded-fold-live: FAILED to open fold store "
+                      << fold_live_db << " -- fold view NOT wired (fees + pin "
+                         "gate byte-identical to master)\n";
+            fold_live.reset();
+        } else {
+            auto fp = fold_live;
+            node_coin_state.set_fold_coin_lookup(
+                [fp](const ::core::coin::Outpoint& op,
+                     ::core::coin::Coin& out) -> bool {
+                    return fp->get_coin(op, out) && !out.is_spent();
+                });
+            std::cout << "[run] embedded-fold-live ARMED: fold store "
+                      << fold_live_db << " resume_height="
+                      << fold_live->resume_height()
+                      << " -- mempool fee pricing reads the full-history UTXO "
+                         "fold (pre-window inputs now fee_fold_proven; byte-proven "
+                         "vs dashd hash_serialized_2). Populating to tip = task "
+                         "#154 (deploy prereq).\n";
+        }
+    }
 
     // ── Mempool-tx serving switch (--embedded-serve-mempool-txs) ────────────
     // DEFAULT OFF: embedded templates carry a coinbase-only body even once the
@@ -2378,7 +2421,24 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // an authoritative source, so fee==0 stays COMPUTED rather than
             // assumed, and an input neither source can resolve is still
             // refused. An unreachable daemon returns false — never a guess.
-            if (rpc) {
+            if (fold_live) {
+                // PR-C1: retire the gettxout/--coin-rpc pin lookup. The pin
+                // gate's second source is now the full-history replay UTXO fold
+                // (byte-proven vs dashd kernel/coinstats.cpp), so a pinned tx
+                // whose inputs predate the forward UTXO view is admitted from an
+                // authoritative daemonless set -- value + spentness exact, fee==0
+                // stays COMPUTED, an input the fold cannot resolve is still
+                // refused (never a guess).
+                auto fp = fold_live;
+                node_coin_state.set_pin_external_coin_lookup(
+                    [fp](const ::core::coin::Outpoint& op,
+                         ::core::coin::Coin& out) -> bool {
+                        return fp->get_coin(op, out) && !out.is_spent();
+                    });
+                std::cout << "[run] pin input lookup: embedded UTXO view + "
+                             "full-history replay fold second source "
+                             "(gettxout/--coin-rpc RETIRED by --embedded-fold-live)\n";
+            } else if (rpc) {
                 dash::coin::NodeRPC* rpc_raw = rpc.get();
                 node_coin_state.set_pin_external_coin_lookup(
                     [rpc_raw](const ::core::coin::Outpoint& op,
@@ -8940,6 +9000,10 @@ int main(int argc, char** argv)
     // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
     bool embedded_null_arm = false;
     bool embedded_asn_diversity = false;   // PR-4 (--embedded-asn-diversity): default OFF
+    // --embedded-fold-live PATH (PR-C1): full-history replay UTXO fold store
+    // wired as the LIVE serve-path input-pricing view. EMPTY (default) => OFF,
+    // byte-identical to master. See run_node / mempool.hpp set_fold_coin_lookup.
+    std::string embedded_fold_live_db;
     // --embedded-ingest-isdlock: arm the coin-P2P MSG_ISDLOCK pull (G4
     // conflict-tx-lock feed). DEFAULT OFF — off, no getdata for inv type 31
     // and the handler decodes-and-discards (wire + template behaviour
@@ -9091,6 +9155,8 @@ int main(int argc, char** argv)
             embedded_asn_diversity = true;   // PR-4: require racing set to span >=2 ASNs
         else if (std::strcmp(argv[i], "--embedded-asn-diversity=false") == 0)
             embedded_asn_diversity = false;  // PR-4: explicit OFF (OFF-equivalence)
+        else if (std::strcmp(argv[i], "--embedded-fold-live") == 0 && i + 1 < argc)
+            embedded_fold_live_db = argv[++i];  // PR-C1: fold store for live serve-path pricing
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
@@ -9436,7 +9502,8 @@ int main(int argc, char** argv)
                         embedded_ingest_isdlock,       // G4 isdlock feed
                         embedded_ingest_dstx,          // W5-B DSTX feed
                         embedded_proactive_rotate,    // PR-3 proactive rotation
-                        embedded_asn_diversity);       // PR-4 ASN diversity
+                        embedded_asn_diversity,        // PR-4 ASN diversity
+                        embedded_fold_live_db);        // PR-C1 embedded-fold-live
     }
     return run_selftest();
 }

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -64,6 +64,7 @@
 #include <impl/dash/coin/zmq_tip_notify.hpp> // dash::coin::TipHashDedup / ZmqHashblockSubscriber — dashd ZMQ hashblock INSTANT tip-notify (opt-in, hardening on the #770 poll)
 #include <impl/dash/coin/coin_p2p_magic.hpp>      // dash::coin::select_coin_p2p_magic — E5 --coin-p2p-magic override (regtest ARM A dial)
 #include <impl/dash/coin/node_coin_state.hpp>  // dash::coin::NodeCoinState (embedded work bundle)
+#include <impl/dash/coin/fold_live_controller.hpp>  // dash::coin::FoldLiveController (PR-C1 live tip-tracking fold)
 #include <impl/dash/coin/arm_resolution.hpp>   // dash::coin::resolve_embedded_arm (#738 arm decision, one place)
 #include <impl/dash/coin/embedded_startup_invariant.hpp>  // C-startup-invariant: embedded fresh-gate => body-first serve tip
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
@@ -449,7 +450,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-tx-serve-own-set]\n"
         << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
         << "           [--embedded-getmnlistd-tracker]\n"
-        << "           [--embedded-fold-live PATH]\n"
+        << "           [--embedded-fold-live PATH] [--embedded-fold-live-expect HASH]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--embedded-proactive-rotate]\n"
@@ -1002,7 +1003,13 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // byte-equal to dashd (kernel/coinstats.cpp hash_serialized_2),
              // marking them fee_fold_proven, and retire the gettxout/--coin-rpc
              // pin lookup. Reward-safe: fold-exact fees, never overstated.
-             const std::string& fold_live_db = std::string())
+             const std::string& fold_live_db = std::string(),
+             // --embedded-fold-live-expect HASH (PR-C1): the dashd
+             // hash_serialized_2 the fold store MUST verify to at open
+             // (at its cursor height) before it may feed any serving
+             // decision. EMPTY => the fold refuses to arm (fail-closed,
+             // byte-identical to master). See replay_utxo_fold.hpp:84-86.
+             const std::string& fold_live_expect = std::string())
 {
     namespace io = boost::asio;
 
@@ -2242,6 +2249,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // empty/partial store simply resolves fewer inputs (fail-closed to today's
     // fee-unknown), never a wrong value.
     std::shared_ptr<dash::coin::replay::ReplayUtxoFold> fold_live;
+    // PR-C1: the LIVE tip-tracking controller over the fold. Declared here (with
+    // fold_live) so both outlive node_coin_state / the mempool that reference the
+    // fold, and so the header-chain tip-changed callback can capture it by
+    // reference for the reorg-undo half (like PR-B's mined_commitment_index).
+    std::shared_ptr<dash::coin::FoldLiveController> fold_live_ctl;
+    // PR-C1 (remediation C): the tip-current gettxout/--coin-rpc pin lookup,
+    // built once below. When the fold is armed it becomes the pin's off-tip
+    // fallback rather than being retired; absent the fold it is the pin source.
+    std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)>
+        rpc_pin_lookup;
     dash::coin::UtxoLane utxo_lane;
     dash::coin::NodeCoinState node_coin_state;
     if (!fold_live_db.empty()) {
@@ -2251,20 +2268,46 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                       << fold_live_db << " -- fold view NOT wired (fees + pin "
                          "gate byte-identical to master)\n";
             fold_live.reset();
+        } else if (fold_live_expect.empty()) {
+            // (D) RUNTIME STORE VERIFY is MANDATORY. Without an expected
+            // hash_serialized_2 the store cannot be proven the right chain and
+            // uncorrupt, so it must not feed a serving decision -- refuse to arm
+            // (fail-closed; fees + pin gate byte-identical to master).
+            std::cout << "[run] --embedded-fold-live: refusing to arm WITHOUT "
+                         "--embedded-fold-live-expect <hash_serialized_2> -- the "
+                         "store cannot be verified (fees + pin gate byte-identical "
+                         "to master). Derive the expected hash with --replay-utxo-db "
+                      << fold_live_db << " --replay-utxo-hash.\n";
+            fold_live.reset();
         } else {
-            auto fp = fold_live;
-            node_coin_state.set_fold_coin_lookup(
-                [fp](const ::core::coin::Outpoint& op,
-                     ::core::coin::Coin& out) -> bool {
-                    return fp->get_coin(op, out) && !out.is_spent();
-                });
-            std::cout << "[run] embedded-fold-live ARMED: fold store "
-                      << fold_live_db << " resume_height="
-                      << fold_live->resume_height()
-                      << " -- mempool fee pricing reads the full-history UTXO "
-                         "fold (pre-window inputs now fee_fold_proven; byte-proven "
-                         "vs dashd hash_serialized_2). Populating to tip = task "
-                         "#154 (deploy prereq).\n";
+            // (D) Verify the store's dashd hash_serialized_2 at its cursor height
+            // BEFORE it feeds anything (same gate as --replay-utxo-expect). Any
+            // mismatch / scan error => refuse to arm.
+            std::cout << "[run] --embedded-fold-live: verifying store "
+                      << fold_live_db << " hash_serialized_2 at height "
+                      << fold_live->best_height()
+                      << " (full-set scan; a few minutes at mainnet tip)...\n";
+            auto res = fold_live->hash_serialized_2();
+            std::string want = fold_live_expect;
+            for (auto& c : want) c = static_cast<char>(std::tolower(c));
+            if (!res || res->hash.GetHex() != want) {
+                std::cout << "[run] --embedded-fold-live: store verify FAILED (got "
+                          << (res ? res->hash.GetHex()
+                                  : std::string("<scan-error: ") + fold_live->refusal() + ">")
+                          << " want " << want << ") -- fold view NOT wired (fees + "
+                             "pin gate byte-identical to master)\n";
+                fold_live.reset();
+            } else {
+                fold_live_ctl =
+                    std::make_shared<dash::coin::FoldLiveController>(fold_live);
+                std::cout << "[run] embedded-fold-live VERIFIED + ARMED: store "
+                          << fold_live_db << " hash_serialized_2=" << res->hash.GetHex()
+                          << " height=" << res->best_height
+                          << " -- LIVE tip-tracking fold. Advance-on-connect +"
+                             " reorg-undo wire below; consulted for input pricing /"
+                             " pin ONLY while caught up to the serve tip. Populating"
+                             " to tip = task #154 (deploy prereq).\n";
+            }
         }
     }
 
@@ -2421,26 +2464,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // an authoritative source, so fee==0 stays COMPUTED rather than
             // assumed, and an input neither source can resolve is still
             // refused. An unreachable daemon returns false — never a guess.
-            if (fold_live) {
-                // PR-C1: retire the gettxout/--coin-rpc pin lookup. The pin
-                // gate's second source is now the full-history replay UTXO fold
-                // (byte-proven vs dashd kernel/coinstats.cpp), so a pinned tx
-                // whose inputs predate the forward UTXO view is admitted from an
-                // authoritative daemonless set -- value + spentness exact, fee==0
-                // stays COMPUTED, an input the fold cannot resolve is still
-                // refused (never a guess).
-                auto fp = fold_live;
-                node_coin_state.set_pin_external_coin_lookup(
-                    [fp](const ::core::coin::Outpoint& op,
-                         ::core::coin::Coin& out) -> bool {
-                        return fp->get_coin(op, out) && !out.is_spent();
-                    });
-                std::cout << "[run] pin input lookup: embedded UTXO view + "
-                             "full-history replay fold second source "
-                             "(gettxout/--coin-rpc RETIRED by --embedded-fold-live)\n";
-            } else if (rpc) {
+            // PR-C1 (embedded-fold-live, remediation C): do NOT retire this
+            // tip-current gettxout/--coin-rpc pin lookup unconditionally. Build
+            // it into rpc_pin_lookup here; when the fold is armed it becomes the
+            // pin's FIRST source but ONLY while proven at tip (wired below, after
+            // the header chain exists), falling back to this live lookup off-tip.
+            // Absent the fold, this stays the pin's second source.
+            if (rpc) {
                 dash::coin::NodeRPC* rpc_raw = rpc.get();
-                node_coin_state.set_pin_external_coin_lookup(
+                rpc_pin_lookup =
                     [rpc_raw](const ::core::coin::Outpoint& op,
                               ::core::coin::Coin& out) -> bool {
                         try {
@@ -2481,7 +2513,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         } catch (const std::exception&) {
                             return false;
                         }
-                    });
+                    };
+                node_coin_state.set_pin_external_coin_lookup(rpc_pin_lookup);
                 std::cout << "[run] pin input lookup: embedded UTXO view + "
                              "coin-RPC second source (gettxout) ARMED\n";
             }
@@ -5552,6 +5585,53 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         coin_feed_subs.push_back(
             dash::coin::wire_full_block_ingest(coin_state, *header_chain));
 
+        // ── PR-C1 (embedded-fold-live) LIVE tip-tracking wiring ──────────────
+        // Armed only when --embedded-fold-live opened + VERIFIED a store above.
+        // (A) ADVANCE half (dashd ConnectBlock): every connected block folds
+        //     forward, keeping fold_height tracking the serve tip. Same
+        //     block_connected feed as the UTXO/MN legs; a gap simply leaves the
+        //     fold behind tip (the guard then withholds). (B) the mempool
+        //     consults the fold for input pricing/viability ONLY while the fold
+        //     is caught up to the serve tip AND chain-identical, and (C) the pin
+        //     gate uses the fold at tip else the live rpc_pin_lookup.
+        if (fold_live_ctl) {
+            auto ctl = fold_live_ctl;
+            auto* hc = header_chain.get();
+            auto hash_at = [hc](uint32_t h) -> std::optional<uint256> {
+                if (auto e = hc->get_header_by_height(h)) return e->hash;
+                return std::nullopt;
+            };
+            coin_feed_subs.push_back(
+                coin_state.block_connected.subscribe(
+                    [ctl](const dash::interfaces::BlockConnected& bc) {
+                        ctl->on_block_connected(bc.block, bc.height);
+                    }));
+            node_coin_state.set_fold_coin_lookup(
+                [ctl, hc, hash_at](const ::core::coin::Outpoint& op,
+                                   ::core::coin::Coin& out) -> bool {
+                    return ctl->resolve_for_serve(op, out, hc->height(), hash_at);
+                });
+            node_coin_state.set_fold_at_tip_gate(
+                [ctl, hc, hash_at]() -> bool {
+                    return ctl->at_tip(hc->height(), hash_at);
+                });
+            node_coin_state.set_pin_external_coin_lookup(
+                [ctl, hc, hash_at, rpc_pin_lookup](
+                    const ::core::coin::Outpoint& op,
+                    ::core::coin::Coin& out) -> bool {
+                    // At tip: fold is the authoritative daemonless source.
+                    if (ctl->resolve_for_serve(op, out, hc->height(), hash_at))
+                        return true;
+                    // Off-tip: keep the live pin lookup (never a stale-fold guess).
+                    if (rpc_pin_lookup) return rpc_pin_lookup(op, out);
+                    return false;   // fail-closed
+                });
+            std::cout << "[run] embedded-fold-live wired to LIVE feed: "
+                         "advance-on-connect + reorg-undo + at-tip serving guard "
+                         "(fold consulted only while fold_height >= serve_tip and "
+                         "chain-identical; behind tip => fee-unknown = master)\n";
+        }
+
         // new_block(inv hash) -> pull the headers THEN the full block from the
         // peer. The getheaders-first ordering is the steady-state tip-follow
         // fix (E2c): dashd announces new blocks via inv (we never negotiate
@@ -5754,7 +5834,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // capture above): the index is constructed later in this function,
              // and on a reorg its symmetric UndoBlock half must roll the tip
              // back before the new branch is folded forward.
-             &mined_commitment_index]
+             &mined_commitment_index,
+             // PR-C1 (embedded-fold-live) UNDO half: by REFERENCE (same lifetime
+             // class as mined_commitment_index) -- on a reorg the fold's cursor
+             // must roll back to the fork point before the new branch is folded
+             // forward, or a stale coin would read UNSPENT.
+             &fold_live_ctl]
             (const uint256&, uint32_t, const uint256& new_tip, uint32_t new_height,
              bool was_reorg) {
                 // E2d bridge driver. Safe + REACHABLE here: HeaderChain fires
@@ -5824,6 +5909,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                        "the next contiguous fold";
                         mined_commitment_index->clear_for_cold_rebuild();
                     }
+                }
+                // PR-C1 (embedded-fold-live) UNDO half (dashd DisconnectBlock):
+                // roll the fold cursor down over the orphaned tail to the fork
+                // point using the retained block bodies, so a coin spent only on
+                // the ABANDONED branch is restored and no coin the new branch
+                // never spent reads spent. A reorg deeper than the retained
+                // window fails closed -- the fold is marked behind tip and the
+                // mempool withholds (fee-unknown = master) until it re-advances.
+                if (was_reorg && fold_live_ctl) {
+                    const bool ok = fold_live_ctl->handle_reorg(
+                        [hc](uint32_t q) -> std::optional<uint256> {
+                            if (auto e = hc->get_header_by_height(q)) return e->hash;
+                            return std::nullopt;
+                        });
+                    LOG_INFO << "[FOLD-LIVE] reorg to h=" << new_height
+                             << (ok ? " -> fold rolled back to the fork point"
+                                      " (tip-tracking preserved)"
+                                    : " -> fold could not roll back within the"
+                                      " retained window; withholding (fee-unknown)"
+                                      " until a fresh contiguous fold re-establishes"
+                                      " chain identity");
                 }
                 // SML axis: pull the mnlistdiff current AT the new tip. dashcore
                 // computes block (tip+1)'s CbTx merkleRootMNList/Quorums from the
@@ -9004,6 +9110,7 @@ int main(int argc, char** argv)
     // wired as the LIVE serve-path input-pricing view. EMPTY (default) => OFF,
     // byte-identical to master. See run_node / mempool.hpp set_fold_coin_lookup.
     std::string embedded_fold_live_db;
+    std::string embedded_fold_live_expect;   // PR-C1: --embedded-fold-live-expect (store verify)
     // --embedded-ingest-isdlock: arm the coin-P2P MSG_ISDLOCK pull (G4
     // conflict-tx-lock feed). DEFAULT OFF — off, no getdata for inv type 31
     // and the handler decodes-and-discards (wire + template behaviour
@@ -9157,6 +9264,8 @@ int main(int argc, char** argv)
             embedded_asn_diversity = false;  // PR-4: explicit OFF (OFF-equivalence)
         else if (std::strcmp(argv[i], "--embedded-fold-live") == 0 && i + 1 < argc)
             embedded_fold_live_db = argv[++i];  // PR-C1: fold store for live serve-path pricing
+        else if (std::strcmp(argv[i], "--embedded-fold-live-expect") == 0 && i + 1 < argc)
+            embedded_fold_live_expect = argv[++i];  // PR-C1: store hash_serialized_2 verify (D)
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
@@ -9503,7 +9612,8 @@ int main(int argc, char** argv)
                         embedded_ingest_dstx,          // W5-B DSTX feed
                         embedded_proactive_rotate,    // PR-3 proactive rotation
                         embedded_asn_diversity,        // PR-4 ASN diversity
-                        embedded_fold_live_db);        // PR-C1 embedded-fold-live
+                        embedded_fold_live_db,         // PR-C1 embedded-fold-live
+                        embedded_fold_live_expect);    // PR-C1 store-verify hash
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/fold_live_controller.hpp
+++ b/src/impl/dash/coin/fold_live_controller.hpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DASH daemonless — LIVE tip-tracking controller for the full-history replay
+// UTXO fold (PR-C1, --embedded-fold-live).
+//
+// The replay UTXO fold (replay_utxo_fold.hpp) is a strict left fold of the
+// whole chain into a dashd-equivalent coin set, gate-proven byte-equal to
+// dashd's `gettxoutsetinfo hash_serialized_2`. Opened alone it is a SNAPSHOT
+// frozen at its resume cursor R: a coin unspent at R but spent on-chain in
+// (R, tip] would still read UNSPENT, which — if that stale answer priced a
+// mempool tx — could select a double-spend of an already-confirmed input and
+// lose a block. dashd never has this problem because its CCoinsViewCache is
+// kept AT the tip: ConnectBlock applies each connected block (spending inputs,
+// adding outputs) and DisconnectBlock undoes on a reorg.
+//
+// This controller ports exactly those two halves onto the fold so it becomes a
+// true tip-tracking view, and adds a fail-closed serving guard:
+//
+//   * ADVANCE (dashd ConnectBlock): on_block_connected() applies each connected
+//     block to the fold in ascending, no-gap order, advancing R toward the tip.
+//     It also retains the block body in a bounded ring so the undo half can key
+//     the spent-coin restore, exactly like dashd hands DisconnectBlock the block
+//     it is undoing.
+//
+//   * UNDO (dashd DisconnectBlock): handle_reorg() walks the fold cursor down
+//     over every orphaned tip block — using the retained body — until the fork
+//     point (the first height whose switched-chain hash already matches the
+//     fold's block there). A reorg deeper than the retained window fails closed
+//     (marks the view stranded) rather than leaving a wrong coin unspent. This
+//     mirrors PR-B's MinedCommitmentIndex connect+undo halves.
+//
+//   * AT-TIP SERVING GUARD (belt-and-suspenders): at_tip() answers true ONLY
+//     when the fold is caught up to the serve tip AND its tip block is the one
+//     on the served chain at that height. The mempool consults the fold for
+//     pricing/viability ONLY when this holds; behind tip (cold start, a gap in
+//     the live feed, mid-reorg, or a stranded view) it withholds, which is
+//     byte-identical to master's fee-unknown exclusion — never a bad block.
+//
+// One std::mutex serialises every fold touch (advance / undo / serve-path read)
+// so the io-thread block feed and any serve-path reader cannot tear the fold's
+// in-memory overlay. Constructed only under --embedded-fold-live; absent, the
+// fold is never opened and this class is never instantiated — the fee path and
+// pin gate are byte-identical to master.
+
+#include "block.hpp"                 // BlockType / BlockHeaderType
+#include "replay_utxo_fold.hpp"      // dash::coin::replay::ReplayUtxoFold
+
+#include <impl/dash/crypto/hash_x11.hpp>
+
+#include <core/coin/utxo.hpp>        // core::coin::Coin / Outpoint
+#include <core/pack.hpp>
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace dash {
+namespace coin {
+
+class FoldLiveController {
+public:
+    using Coin       = ::core::coin::Coin;
+    using Outpoint   = ::core::coin::Outpoint;
+    using ReplayFold = ::dash::coin::replay::ReplayUtxoFold;
+    // Canonical (served-chain) block hash at a height — supplied by the caller
+    // from the header chain. std::nullopt when the height is not indexed.
+    using HashAtFn   = std::function<std::optional<uint256>(uint32_t)>;
+
+    explicit FoldLiveController(std::shared_ptr<ReplayFold> fold)
+        : m_fold(std::move(fold))
+    {
+        // Retain at most one undo window of block bodies (bounded, same window
+        // the fold keeps its undo records over): a reorg deeper than this is
+        // handled fail-closed, not by unbounded body retention.
+        if (m_fold) m_body_ring_cap = m_fold->undo_window();
+    }
+
+    // ── ADVANCE (dashd ConnectBlock) ───────────────────────────────────────
+    // Apply one connected block to the fold, tracking the tip. Idempotent
+    // redelivery and out-of-order/gap deliveries are handled by the fold's own
+    // strict in-order contract (a gap is REFUSED and the fold simply stays
+    // behind tip, which the serving guard treats as "not caught up"). Returns
+    // whatever the fold returned (true = advanced or idempotently acked).
+    bool on_block_connected(const BlockType& block, uint32_t height)
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        if (!m_fold) return false;
+        const uint256 hash = block_identity(block);
+        const bool ok = m_fold->on_replay_block(height, hash, block);
+        // Retain the body only for the height the fold now actually sits at, so
+        // the undo half has the exact block it must disconnect.
+        if (ok && m_fold->have_cursor() && m_fold->best_height() == height) {
+            m_bodies[height] = block;
+            prune_bodies_locked();
+        }
+        return ok;
+    }
+
+    // ── UNDO (dashd DisconnectBlock) ───────────────────────────────────────
+    // Roll the fold cursor down over the orphaned tail to the fork point.
+    // `canonical_hash_at` returns the switched chain's hash at a height. Returns
+    // true when the fold tip is consistent with the switched chain afterwards;
+    // false (and latches "stranded") when a body outside the retained window
+    // would be needed — the serving guard then withholds until a restart /
+    // fresh contiguous fold re-establishes chain identity. Never leaves a coin
+    // wrongly unspent (fail-closed, the over-withholding direction).
+    bool handle_reorg(const HashAtFn& canonical_hash_at)
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        if (!m_fold || !m_fold->have_cursor()) return false;
+        while (m_fold->best_height() > 0) {
+            const uint32_t h = m_fold->best_height();
+            const auto want = canonical_hash_at(h);
+            if (want && *want == m_fold->best_hash())
+                return true;  // fold tip already on the switched chain
+            auto it = m_bodies.find(h);
+            if (it == m_bodies.end() || !m_fold->disconnect_tip(it->second)) {
+                m_reorg_stranded = true;  // fail-closed
+                return false;
+            }
+            m_bodies.erase(it);
+        }
+        return true;
+    }
+
+    // ── AT-TIP SERVING GUARD (remediation B) ───────────────────────────────
+    // The fold may feed a pricing/viability decision ONLY when it is caught up
+    // to `serve_tip` AND its tip block is the served chain's block at that
+    // height. Any other state (behind tip, mid-reorg, stranded) => false.
+    bool at_tip(uint32_t serve_tip, const HashAtFn& canonical_hash_at) const
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        return at_tip_locked(serve_tip, canonical_hash_at);
+    }
+
+    // Serve-path coin lookup, self-guarded by at_tip. Returns true and fills
+    // `out` only when the fold is at tip AND holds the coin unspent. This is
+    // the function handed to the mempool (fold-input pricing) and, at tip, to
+    // the pin gate. Off-tip it returns false, which the mempool reads as
+    // fee-unknown (byte-identical to master).
+    bool resolve_for_serve(const Outpoint& op, Coin& out,
+                           uint32_t serve_tip,
+                           const HashAtFn& canonical_hash_at) const
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        if (!at_tip_locked(serve_tip, canonical_hash_at)) return false;
+        return m_fold->get_coin(op, out) && !out.is_spent();
+    }
+
+    std::shared_ptr<ReplayFold> fold() const { return m_fold; }
+    bool reorg_stranded() const
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        return m_reorg_stranded;
+    }
+    uint32_t best_height() const
+    {
+        std::lock_guard<std::mutex> lk(m_mu);
+        return (m_fold && m_fold->have_cursor()) ? m_fold->best_height() : 0;
+    }
+
+private:
+    bool at_tip_locked(uint32_t serve_tip, const HashAtFn& canonical_hash_at) const
+    {
+        if (!m_fold || !m_fold->have_cursor() || m_reorg_stranded) return false;
+        const uint32_t fh = m_fold->best_height();
+        if (fh < serve_tip) return false;              // not caught up
+        const auto want = canonical_hash_at(fh);
+        return want.has_value() && *want == m_fold->best_hash();  // chain identity
+    }
+
+    static uint256 block_identity(const BlockType& block)
+    {
+        auto packed = ::pack(static_cast<const BlockHeaderType&>(block));
+        return ::dash::crypto::hash_x11(packed.get_span());
+    }
+
+    void prune_bodies_locked()
+    {
+        // std::map is height-ordered; drop the lowest heights past the cap.
+        while (m_bodies.size() > m_body_ring_cap && !m_bodies.empty())
+            m_bodies.erase(m_bodies.begin());
+    }
+
+    mutable std::mutex             m_mu;
+    std::shared_ptr<ReplayFold>    m_fold;
+    std::map<uint32_t, BlockType>  m_bodies;             // retained undo bodies
+    std::size_t                    m_body_ring_cap = 100;
+    bool                           m_reorg_stranded = false;
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -368,6 +368,21 @@ public:
     }
     bool has_fold_coin_lookup() const { return static_cast<bool>(m_fold_coin_lookup); }
 
+    /// PR-C1 (embedded-fold-live) AT-TIP SERVING GUARD. The fold is a true
+    /// tip-tracking view only while its cursor is caught up to the serve tip and
+    /// chain-identical (FoldLiveController::at_tip). This predicate carries that
+    /// answer into the mempool: the fold-input pricing/viability sources below
+    /// are consulted ONLY when the gate is UNSET (no guard wired -- unit tests)
+    /// or reports true. When it reports false (cold start, a gap in the live
+    /// block feed, mid-reorg, or a stranded view) the fold is treated as absent
+    /// and the tx stays fee-unknown -- byte-identical to master's exclusion, so
+    /// a coin the fold has not yet advanced past can never price a template.
+    void set_fold_at_tip_gate(std::function<bool()> fn)
+    {
+        m_fold_at_tip_gate = std::move(fn);
+    }
+    bool has_fold_at_tip_gate() const { return static_cast<bool>(m_fold_at_tip_gate); }
+
     PinnedTxGate pinned_tx_admissible(const MutableTransaction& tx,
                                       uint32_t next_height) const {
         // SIZE FIRST. It is the cheapest check and the only one whose failure
@@ -1327,17 +1342,20 @@ public:
                                                   vin.prevout.index);
                         ::core::coin::Coin coin;
                         bool have = utxo->get_coin(op, coin);
-                        if (!have && m_fold_coin_lookup) {
+                        if (!have) {
                             // PR-C1 (embedded-fold-live): the input predates the
                             // forward view; resolve it from the full-history
                             // replay UTXO fold (byte-proven vs dashd
                             // kernel/coinstats.cpp) so a fold-PRICED tx is also
-                            // SELECTABLE end-to-end. The fold's Coin carries
-                            // height+coinbase, so the G3 maturity check below
-                            // stays dashd-exact. EMPTY unless --embedded-fold-live
-                            // armed it => byte-identical to master (the tx is
-                            // simply not selected, as today).
-                            have = m_fold_coin_lookup(op, coin) && !coin.is_spent();
+                            // SELECTABLE end-to-end. fold_resolve consults the
+                            // fold ONLY while it is caught up to the serve tip and
+                            // chain-identical (at-tip guard), and only if the coin
+                            // is present + unspent there -- so an input the fold
+                            // has advanced past reads MISSING, not stale-unspent.
+                            // The fold's Coin carries height+coinbase, so the G3
+                            // maturity check below stays dashd-exact. Off-tip /
+                            // flag-off => byte-identical to master (not selected).
+                            have = fold_resolve(op, coin);
                         }
                         if (!have) {
                             // Stale input: not a selected parent, and neither the
@@ -1513,6 +1531,23 @@ private:
     // set_external_coin_lookup). Set once at wiring time, before any template
     // build, and never mutated afterwards — the gate reads it on the template
     // path where m_utxo is already read lock-free.
+    // PR-C1 (embedded-fold-live): a fold read is LIVE only when a lookup is
+    // wired AND the at-tip gate (if any) is satisfied. Unset gate => consult
+    // (preserves the flag-off / unit-test path). fold_resolve additionally
+    // demands the coin be present and unspent in the fold, so an input the fold
+    // has already advanced past (spent in (R, tip]) resolves false and the tx
+    // is priced fee-unknown / withheld -- never a stale UNSPENT answer.
+    bool fold_active() const
+    {
+        return static_cast<bool>(m_fold_coin_lookup)
+               && (!m_fold_at_tip_gate || m_fold_at_tip_gate());
+    }
+    bool fold_resolve(const ::core::coin::Outpoint& op,
+                      ::core::coin::Coin& out) const
+    {
+        return fold_active() && m_fold_coin_lookup(op, out) && !out.is_spent();
+    }
+
     std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)>
                                                       m_external_coin_lookup;
 
@@ -1526,6 +1561,11 @@ private:
     // predate the forward view become fee_fold_proven instead of fee-unknown.
     std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)>
                                                       m_fold_coin_lookup;
+
+    // PR-C1 (embedded-fold-live) at-tip serving guard predicate (see
+    // set_fold_at_tip_gate). EMPTY on master / when the flag is off (fold_active
+    // then depends only on m_fold_coin_lookup, itself empty => never consulted).
+    std::function<bool()>                             m_fold_at_tip_gate;
 
     /// G1: gather `txid` plus every UNSELECTED in-mempool ancestor into
     /// `out`, parents strictly before children (post-order DFS). `seen`
@@ -1848,9 +1888,9 @@ private:
             // master. When wired, the coin comes from a set proven byte-equal to
             // dashd (kernel/coinstats.cpp hash_serialized_2), so the fee stays
             // fold-EXACT (never overstated) and the tx earns fee_fold_proven below.
-            if (m_fold_coin_lookup) {
+            {
                 ::core::coin::Coin fc;
-                if (m_fold_coin_lookup(op, fc) && !fc.is_spent()) {
+                if (fold_resolve(op, fc)) {
                     in_sum += static_cast<uint64_t>(fc.value);
                     continue;
                 }

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -354,6 +354,20 @@ public:
     }
     bool has_external_coin_lookup() const { return static_cast<bool>(m_external_coin_lookup); }
 
+    /// PR-C1 (embedded-fold-live): wire the full-history replay UTXO fold as the
+    /// LIVE serve-path input-pricing source. Consulted by compute_fee_locked ONLY
+    /// after the forward UTXO view and every in-pool parent miss -- so a tx whose
+    /// inputs predate the forward view (was permanently fee-unknown, template-
+    /// excluded) is priced from a set proven byte-equal to dashd's and becomes
+    /// fee_fold_proven. Set once at wiring time (before any template build).
+    /// Unset (default) => byte-identical to master.
+    void set_fold_coin_lookup(
+        std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)> fn)
+    {
+        m_fold_coin_lookup = std::move(fn);
+    }
+    bool has_fold_coin_lookup() const { return static_cast<bool>(m_fold_coin_lookup); }
+
     PinnedTxGate pinned_tx_admissible(const MutableTransaction& tx,
                                       uint32_t next_height) const {
         // SIZE FIRST. It is the cheapest check and the only one whose failure
@@ -1312,8 +1326,22 @@ public:
                         ::core::coin::Outpoint op(vin.prevout.hash,
                                                   vin.prevout.index);
                         ::core::coin::Coin coin;
-                        if (!utxo->get_coin(op, coin)) {
-                            // Stale input: neither selected-parent nor UTXO.
+                        bool have = utxo->get_coin(op, coin);
+                        if (!have && m_fold_coin_lookup) {
+                            // PR-C1 (embedded-fold-live): the input predates the
+                            // forward view; resolve it from the full-history
+                            // replay UTXO fold (byte-proven vs dashd
+                            // kernel/coinstats.cpp) so a fold-PRICED tx is also
+                            // SELECTABLE end-to-end. The fold's Coin carries
+                            // height+coinbase, so the G3 maturity check below
+                            // stays dashd-exact. EMPTY unless --embedded-fold-live
+                            // armed it => byte-identical to master (the tx is
+                            // simply not selected, as today).
+                            have = m_fold_coin_lookup(op, coin) && !coin.is_spent();
+                        }
+                        if (!have) {
+                            // Stale input: not a selected parent, and neither the
+                            // forward UTXO view nor (when armed) the fold has it.
                             ok = false;
                             break;
                         }
@@ -1487,6 +1515,17 @@ private:
     // path where m_utxo is already read lock-free.
     std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)>
                                                       m_external_coin_lookup;
+
+    // PR-C1 (embedded-fold-live): full-history replay UTXO fold view, wired as
+    // the LIVE serve-path last-source for input pricing when --embedded-fold-live
+    // is armed. EMPTY on master and whenever the flag is off, so every read of it
+    // below is skipped and fee pricing is byte-identical. When set (main_dash.cpp)
+    // it is ReplayUtxoFold::get_coin -- a set byte-proven equal to dashd's
+    // (kernel/coinstats.cpp hash_serialized_2), so a coin it resolves keeps the
+    // computed fee fold-EXACT (never overstated) and lets a tx whose inputs
+    // predate the forward view become fee_fold_proven instead of fee-unknown.
+    std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)>
+                                                      m_fold_coin_lookup;
 
     /// G1: gather `txid` plus every UNSELECTED in-mempool ancestor into
     /// `out`, parents strictly before children (post-order DFS). `seen`
@@ -1799,6 +1838,22 @@ private:
                 in_sum += static_cast<uint64_t>(
                     pit->second.tx.vout[vin.prevout.index].value);
                 continue;
+            }
+            // PR-C1 (embedded-fold-live): the forward-from-start UTXO view and
+            // every in-pool parent missed this prevout -- on master that is a
+            // permanent fee-unknown (the pre-window-input class, ~20/34 of the
+            // tx-merkle divergence). Consult the full-history replay UTXO fold as
+            // the authoritative last source. EMPTY unless --embedded-fold-live
+            // armed it => this clause is skipped and pricing is byte-identical to
+            // master. When wired, the coin comes from a set proven byte-equal to
+            // dashd (kernel/coinstats.cpp hash_serialized_2), so the fee stays
+            // fold-EXACT (never overstated) and the tx earns fee_fold_proven below.
+            if (m_fold_coin_lookup) {
+                ::core::coin::Coin fc;
+                if (m_fold_coin_lookup(op, fc) && !fc.is_spent()) {
+                    in_sum += static_cast<uint64_t>(fc.value);
+                    continue;
+                }
             }
             entry.fee_known = false;
             entry.fee_fold_proven = false;

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -654,6 +654,16 @@ public:
         m_mempool.set_fold_coin_lookup(std::move(fn));
     }
 
+    /// PR-C1 (embedded-fold-live) AT-TIP SERVING GUARD forwarder. Carries the
+    /// FoldLiveController::at_tip answer (fold caught up to the serve tip AND
+    /// chain-identical) into the mempool, which consults the fold ONLY while it
+    /// holds. Behind tip / mid-reorg / stranded => the mempool withholds
+    /// (byte-identical to master). Unset (default) => no guard, fold never wired.
+    void set_fold_at_tip_gate(std::function<bool()> fn)
+    {
+        m_mempool.set_fold_at_tip_gate(std::move(fn));
+    }
+
     /// Superblock-height guard. On a Dash superblock height the coinbase MUST
     /// pay the governance/treasury (superblock) outputs; the embedded template
     /// does not compute those, so emitting a normal coinbase there is a

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -638,6 +638,22 @@ public:
         m_mempool.set_external_coin_lookup(std::move(fn));
     }
 
+    /// PR-C1 (embedded-fold-live): wire the full-history replay UTXO fold as the
+    /// LIVE serve-path input-pricing source (main_dash.cpp, under
+    /// --embedded-fold-live). Forwarded to the mempool, which consults it in
+    /// compute_fee_locked ONLY after the forward UTXO view and every in-pool
+    /// parent miss -- so a mempool tx whose inputs predate the forward view (was
+    /// permanently fee-unknown and template-excluded) is priced from a set proven
+    /// byte-equal to dashd's and becomes fee_fold_proven. The pin gate's own
+    /// second-source seam (set_pin_external_coin_lookup) is separately pointed at
+    /// the same fold, retiring the gettxout/--coin-rpc pin lookup. Unset
+    /// (default) => viability + fee pricing are byte-identical to master.
+    void set_fold_coin_lookup(
+        std::function<bool(const ::core::coin::Outpoint&, ::core::coin::Coin&)> fn)
+    {
+        m_mempool.set_fold_coin_lookup(std::move(fn));
+    }
+
     /// Superblock-height guard. On a Dash superblock height the coinbase MUST
     /// pay the governance/treasury (superblock) outputs; the embedded template
     /// does not compute those, so emitting a normal coinbase there is a

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -1938,3 +1938,78 @@ TEST(DashMempool, MnhfSignalUnpriceableIsFailClosed)
         << "fail-closed: an unpriceable EHF signal is WITHHELD from the template";
     EXPECT_EQ(total_fees, 0u);
 }
+
+
+// ─── PR-C1: embedded-fold-live — pre-window input pricing ────────────────────
+//
+// The LIVE serve path prices mempool txs against a forward-from-start
+// UTXOViewCache, so a tx whose inputs predate the height this node started at
+// is ABSENT from that view and stays permanently fee-unknown (the ~20/34
+// pre-window-input class of the tx-merkle divergence). PR-C1 wires the
+// full-history replay UTXO fold (byte-proven vs dashd kernel/coinstats.cpp
+// hash_serialized_2) as the authoritative last source via
+// Mempool::set_fold_coin_lookup: such a tx is now priced fold-EXACT and marked
+// fee_fold_proven, so the template selector includes it. With NO fold lookup
+// wired (default / master) the SAME tx stays fee-unknown and is withheld —
+// OFF-equivalence is byte-identical to master.
+
+TEST(DashMempool, FeeFoldLiveResolvesPreWindowInput)
+{
+    UTXOViewCache utxo(nullptr);      // forward view EMPTY: the input predates it
+    Mempool mp; mp.set_utxo(&utxo);
+
+    const uint256 prev = mint_hash(90'110);   // NOT added to the forward view
+    // The full-history fold KNOWS this coin (value 100000, mature non-coinbase).
+    mp.set_fold_coin_lookup(
+        [prev](const Outpoint& op, Coin& out) -> bool {
+            if (op.txid == prev && op.index == 0) {
+                out = Coin(100'000, {}, /*height=*/1, /*cb=*/false);
+                return true;
+            }
+            return false;
+        });
+    ASSERT_TRUE(mp.has_fold_coin_lookup());
+
+    auto tx = make_spend(prev, 0, /*out=*/90'000, /*salt=*/90'110);  // fee 10'000
+    ASSERT_TRUE(mp.add_tx(tx));
+
+    auto e = mp.get_entry(dash_txid(tx));
+    ASSERT_TRUE(e.has_value());
+    EXPECT_TRUE(e->fee_known)
+        << "pre-window input priced from the full-history fold view";
+    EXPECT_TRUE(e->fee_fold_proven)
+        << "pre-window input is now fold-PROVEN (RED on master: fee-unknown)";
+    EXPECT_EQ(e->fee, 10'000u)
+        << "fee = 100000 - 90000, fold-EXACT (never overstated)";
+
+    auto [sel, total_fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    ASSERT_EQ(sel.size(), 1u)
+        << "a fold-proven tx is SELECTABLE for the template";
+    EXPECT_EQ(sel[0].fee, 10'000u);
+    EXPECT_EQ(total_fees, 10'000u);
+}
+
+TEST(DashMempool, FeeFoldLiveOffIsFeeUnknownByteIdentical)
+{
+    // OFF-equivalence: with NO fold lookup wired (default / master), the SAME
+    // pre-window-input tx stays fee-unknown and is WITHHELD from the template.
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+    ASSERT_FALSE(mp.has_fold_coin_lookup());
+
+    const uint256 prev = mint_hash(90'111);   // absent from the forward view
+    auto tx = make_spend(prev, 0, /*out=*/90'000, /*salt=*/90'111);
+    ASSERT_TRUE(mp.add_tx(tx));
+
+    auto e = mp.get_entry(dash_txid(tx));
+    ASSERT_TRUE(e.has_value());
+    EXPECT_FALSE(e->fee_known)
+        << "no fold view wired => pre-window input unpriceable (master behaviour)";
+    EXPECT_FALSE(e->fee_fold_proven);
+
+    auto [sel, total_fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_TRUE(sel.empty())
+        << "fail-closed: without the fold view the tx is WITHHELD "
+           "(byte-identical to master's exclusion discipline)";
+    EXPECT_EQ(total_fees, 0u);
+}

--- a/test/test_dash_mempool.cpp
+++ b/test/test_dash_mempool.cpp
@@ -2013,3 +2013,109 @@ TEST(DashMempool, FeeFoldLiveOffIsFeeUnknownByteIdentical)
            "(byte-identical to master's exclusion discipline)";
     EXPECT_EQ(total_fees, 0u);
 }
+
+
+// ─── PR-C1: embedded-fold-live — AT-TIP SERVING GUARD (remediation B) ────────
+//
+// The fold is a true tip-tracking view only while its cursor is caught up to
+// the serve tip and chain-identical (FoldLiveController::at_tip). The mempool
+// carries that answer through set_fold_at_tip_gate and consults the fold ONLY
+// when the gate is satisfied. Behind tip (cold start, a gap in the live block
+// feed, mid-reorg, a stranded view) the fold is treated as absent and the tx
+// stays fee-unknown — byte-identical to master's exclusion, so a coin the fold
+// has NOT yet advanced past can never price a template.
+
+TEST(DashMempool, FeeFoldLiveGuardBehindTipWithholds)
+{
+    UTXOViewCache utxo(nullptr);            // forward view empty: input predates it
+    Mempool mp; mp.set_utxo(&utxo);
+
+    const uint256 prev = mint_hash(90'112);
+    // The fold KNOWS the coin (it WOULD price the tx) ...
+    mp.set_fold_coin_lookup(
+        [prev](const Outpoint& op, Coin& out) -> bool {
+            if (op.txid == prev && op.index == 0) {
+                out = Coin(100'000, {}, /*height=*/1, /*cb=*/false);
+                return true;
+            }
+            return false;
+        });
+    // ... but the at-tip gate reports the fold BEHIND the serve tip.
+    mp.set_fold_at_tip_gate([]() -> bool { return false; });
+    ASSERT_TRUE(mp.has_fold_at_tip_gate());
+
+    auto tx = make_spend(prev, 0, /*out=*/90'000, /*salt=*/90'112);
+    ASSERT_TRUE(mp.add_tx(tx));
+
+    auto e = mp.get_entry(dash_txid(tx));
+    ASSERT_TRUE(e.has_value());
+    EXPECT_FALSE(e->fee_known)
+        << "fold behind tip => NOT consulted (master fee-unknown behaviour)";
+    EXPECT_FALSE(e->fee_fold_proven);
+
+    auto [sel, total_fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_TRUE(sel.empty())
+        << "withheld byte-identical to master's exclusion when the fold is not "
+           "caught up to the tip";
+    EXPECT_EQ(total_fees, 0u);
+
+    // Same coin lookup, gate flipped to AT-TIP: now it prices — proving it is
+    // the GUARD, not the lookup, that withheld above.
+    UTXOViewCache utxo2(nullptr);
+    Mempool mp2; mp2.set_utxo(&utxo2);
+    mp2.set_fold_coin_lookup(
+        [prev](const Outpoint& op, Coin& out) -> bool {
+            if (op.txid == prev && op.index == 0) {
+                out = Coin(100'000, {}, /*height=*/1, /*cb=*/false);
+                return true;
+            }
+            return false;
+        });
+    mp2.set_fold_at_tip_gate([]() -> bool { return true; });
+    auto tx2 = make_spend(prev, 0, /*out=*/90'000, /*salt=*/90'112);
+    ASSERT_TRUE(mp2.add_tx(tx2));
+    auto e2 = mp2.get_entry(dash_txid(tx2));
+    ASSERT_TRUE(e2.has_value());
+    EXPECT_TRUE(e2->fee_known)     << "at tip => fold priced the pre-window input";
+    EXPECT_TRUE(e2->fee_fold_proven);
+    EXPECT_EQ(e2->fee, 10'000u);
+}
+
+// ─── PR-C1: embedded-fold-live — double-spend of an ON-CHAIN-SPENT input ─────
+//
+// The core of the frozen-snapshot hole: a tx that double-spends a pre-window
+// coin already spent on-chain must NOT be priced fee_fold_proven / selected —
+// dashd's tip-current cache would refuse the input. With the ADVANCE half
+// wired, the fold has folded past the block that spent the coin, so its
+// get_coin now reports the coin MISSING (erased on spend). The fold is AT TIP
+// here (caught up + chain-identical), so the guard does NOT withhold — it is
+// the fold's own advanced state that refuses the input, exactly like dashd.
+
+TEST(DashMempool, FeeFoldLiveOnChainSpentInputNotPricedNotSelected)
+{
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+
+    const uint256 prev = mint_hash(90'113);
+    // The advanced fold (caught up to tip) has already spent `prev` in (R, tip],
+    // so it reads MISSING — precisely what apply-on-connect produces.
+    mp.set_fold_coin_lookup(
+        [](const Outpoint&, Coin&) -> bool { return false; });
+    mp.set_fold_at_tip_gate([]() -> bool { return true; });  // caught up + identical
+
+    auto tx = make_spend(prev, 0, /*out=*/90'000, /*salt=*/90'113);  // double-spend
+    ASSERT_TRUE(mp.add_tx(tx));
+
+    auto e = mp.get_entry(dash_txid(tx));
+    ASSERT_TRUE(e.has_value());
+    EXPECT_FALSE(e->fee_known)
+        << "an on-chain-spent input is unpriceable from the advanced fold";
+    EXPECT_FALSE(e->fee_fold_proven)
+        << "NOT fold-proven => the template selector excludes it (no block loss)";
+
+    auto [sel, total_fees] = mp.get_sorted_txs_with_fees(1u << 20);
+    EXPECT_TRUE(sel.empty())
+        << "a double-spend of an already-confirmed pre-window coin is NOT "
+           "selected — dashd's tip cache would refuse the same input";
+    EXPECT_EQ(total_fees, 0u);
+}

--- a/test/test_dash_replay_utxo_fold.cpp
+++ b/test/test_dash_replay_utxo_fold.cpp
@@ -34,6 +34,7 @@
 
 #include <impl/dash/coin/replay_bulk_fetch.hpp>  // W2 (merged): IReplayBlockConsumer
 #include <impl/dash/coin/replay_utxo_fold.hpp>
+#include <impl/dash/coin/fold_live_controller.hpp>  // PR-C1 LIVE tip-tracking controller
 
 #include <core/hash.hpp>
 #include <core/uint256.hpp>
@@ -700,6 +701,171 @@ TEST(ReplayUtxoFoldTest, EmptySetHashIsHashBlockOnly)
     EXPECT_EQ(res->coins, 0u);
     std::vector<uint8_t> pre(ghash.data(), ghash.data() + 32);
     EXPECT_EQ(res->hash.GetHex(), ::Hash(pre).GetHex());
+}
+
+
+// ─── PR-C1: embedded-fold-live — LIVE tip-tracking controller ────────────────
+//
+// FoldLiveController ports dashd's ConnectBlock (advance-on-connect) and
+// DisconnectBlock (undo-on-reorg) onto the replay UTXO fold, plus the at-tip
+// serving guard. These KATs prove the mechanism the --embedded-fold-live serve
+// wiring depends on, on small synthetic chains.
+
+using dash::coin::FoldLiveController;
+
+// (a) ADVANCE: a pre-window coin unspent at the resume cursor R reads SPENT
+// once the fold has advanced over the block that spent it in (R, tip] — the
+// frozen-snapshot hole, closed. On master (no advance) the same read stays
+// UNSPENT forever.
+TEST(FoldLiveController, AdvanceSpendsPreWindowCoinReadsSpent)
+{
+    TmpDir dir;
+    auto fold = std::make_shared<ReplayUtxoFold>();
+    ASSERT_TRUE(fold->open(dir.sub("db")));
+
+    // h1: a coinbase mints coin A — the "pre-window" coin (present at R=1).
+    auto cb1 = make_coinbase(1, {{100000, p2pkh(0xAA)}});
+    const uint256 A = dash_txid(cb1);
+    ASSERT_TRUE(fold->on_replay_block(1, fake_block_hash(1), make_block({cb1})));
+
+    FoldLiveController ctl(fold);
+    {   // At R, coin A is UNSPENT.
+        ::core::coin::Coin c;
+        EXPECT_TRUE(fold->get_coin(::core::coin::Outpoint(A, 0), c));
+    }
+
+    // h2 arrives on the LIVE feed and spends A. The controller advances the fold.
+    auto cb2   = make_coinbase(2, {{5000, p2pkh(0xBB)}});
+    auto spend = make_spend({{A, 0}}, {{90000, p2pkh(0xCC)}});
+    ASSERT_TRUE(ctl.on_block_connected(make_block({cb2, spend}), 2));
+    EXPECT_EQ(fold->best_height(), 2u);
+
+    {   // After the advance, A reads SPENT (was UNSPENT at R).
+        ::core::coin::Coin c;
+        EXPECT_FALSE(fold->get_coin(::core::coin::Outpoint(A, 0), c))
+            << "advance-on-connect spent the pre-window coin (frozen-snapshot "
+               "hole closed)";
+    }
+}
+
+// at_tip guard: false while behind the serve tip or when the fold's tip block
+// is not the served chain's block at that height; true only when caught up AND
+// chain-identical.
+TEST(FoldLiveController, AtTipGuardTracksCursorAndChainIdentity)
+{
+    TmpDir dir;
+    auto fold = std::make_shared<ReplayUtxoFold>();
+    ASSERT_TRUE(fold->open(dir.sub("db")));
+    auto cb1 = make_coinbase(1, {{100000, p2pkh(0x11)}});
+    ASSERT_TRUE(fold->on_replay_block(1, fake_block_hash(1), make_block({cb1})));
+
+    FoldLiveController ctl(fold);
+    auto hash_at_ok = [&](uint32_t h) -> std::optional<uint256> {
+        if (h == 1) return fold->best_hash();
+        return std::nullopt;
+    };
+    EXPECT_FALSE(ctl.at_tip(2, hash_at_ok)) << "behind tip (serve_tip=2 > fold h=1)";
+    EXPECT_TRUE(ctl.at_tip(1, hash_at_ok))  << "caught up + chain-identical";
+
+    auto hash_at_fork = [&](uint32_t h) -> std::optional<uint256> {
+        if (h == 1) return fake_block_hash(999);   // reorged away from the fold's block
+        return std::nullopt;
+    };
+    EXPECT_FALSE(ctl.at_tip(1, hash_at_fork)) << "chain hash mismatch at fold tip";
+}
+
+// UNDO: a reorg that abandons the branch on which coin A was spent must restore
+// A (dashd DisconnectBlock), walking the fold cursor down to the fork point.
+TEST(FoldLiveController, ReorgUndoRestoresCoinSpentOnlyOnOrphanedBranch)
+{
+    TmpDir dir;
+    auto fold = std::make_shared<ReplayUtxoFold>();
+    ASSERT_TRUE(fold->open(dir.sub("db")));
+
+    auto cb1 = make_coinbase(1, {{100000, p2pkh(0xAA)}});
+    const uint256 A = dash_txid(cb1);
+    ASSERT_TRUE(fold->on_replay_block(1, fake_block_hash(1), make_block({cb1})));
+
+    FoldLiveController ctl(fold);
+    // h2 on the (soon-orphaned) branch spends A. Controller retains the body.
+    auto cb2   = make_coinbase(2, {{1, p2pkh(0xBB)}});
+    auto spend = make_spend({{A, 0}}, {{90000, p2pkh(0xCC)}});
+    ASSERT_TRUE(ctl.on_block_connected(make_block({cb2, spend}), 2));
+    {
+        ::core::coin::Coin c;
+        EXPECT_FALSE(fold->get_coin(::core::coin::Outpoint(A, 0), c));  // spent on orphan
+    }
+
+    // Switched chain: h1 hash matches (fork point), h2 differs (new branch).
+    auto canonical = [&](uint32_t h) -> std::optional<uint256> {
+        if (h == 1) return fake_block_hash(1);
+        if (h == 2) return fake_block_hash(0xBEEF);   // != orphan h2 identity
+        return std::nullopt;
+    };
+    EXPECT_TRUE(ctl.handle_reorg(canonical));
+    EXPECT_EQ(fold->best_height(), 1u) << "cursor rolled back to the fork point";
+    {
+        ::core::coin::Coin c;
+        EXPECT_TRUE(fold->get_coin(::core::coin::Outpoint(A, 0), c))
+            << "coin spent only on the orphaned branch is restored";
+    }
+    EXPECT_FALSE(ctl.reorg_stranded());
+}
+
+// UNDO fail-closed: a reorg deeper than the retained body window cannot roll
+// back exactly, so the controller latches "stranded" and at_tip withholds —
+// the over-withholding (never phantom-unspent) direction.
+TEST(FoldLiveController, ReorgDeeperThanRetainedBodiesFailsClosed)
+{
+    TmpDir dir;
+    auto fold = std::make_shared<ReplayUtxoFold>();
+    ASSERT_TRUE(fold->open(dir.sub("db")));
+    auto cb1 = make_coinbase(1, {{100000, p2pkh(0x11)}});
+    ASSERT_TRUE(fold->on_replay_block(1, fake_block_hash(1), make_block({cb1})));
+    auto cb2 = make_coinbase(2, {{100000, p2pkh(0x22)}});
+    ASSERT_TRUE(fold->on_replay_block(2, fake_block_hash(2), make_block({cb2})));
+
+    // Controller built AFTER h2 folded => it retains NO body for h2 (the undo
+    // half needs the disconnected block body). A reorg at/below h2 fails closed.
+    FoldLiveController ctl(fold);
+    auto canonical = [&](uint32_t h) -> std::optional<uint256> {
+        if (h == 1) return fake_block_hash(1);
+        if (h == 2) return fake_block_hash(0xBEEF);   // orphaned
+        return std::nullopt;
+    };
+    EXPECT_FALSE(ctl.handle_reorg(canonical)) << "no retained body => cannot undo";
+    EXPECT_TRUE(ctl.reorg_stranded());
+    // Stranded => at_tip withholds even though the cursor height still >= tip.
+    auto hash_at = [&](uint32_t h) -> std::optional<uint256> {
+        if (h == 2) return fold->best_hash();
+        return std::nullopt;
+    };
+    EXPECT_FALSE(ctl.at_tip(2, hash_at)) << "stranded fold is not consulted";
+}
+
+// (d) STORE VERIFY: the set hash is cursor-specific, so the arm gate (equality
+// vs the expected hash_serialized_2) refuses a store at the wrong height or a
+// corrupt/foreign expect — the mechanism run_node uses to refuse to arm.
+TEST(ReplayUtxoStoreVerify, HashIsCursorSpecificSoWrongCursorRefusesArm)
+{
+    TmpDir dir;
+    ReplayUtxoFold fold;
+    ASSERT_TRUE(fold.open(dir.sub("db")));
+    auto cb1 = make_coinbase(1, {{100000, p2pkh(0x01)}});
+    ASSERT_TRUE(fold.on_replay_block(1, fake_block_hash(1), make_block({cb1})));
+    auto hA = fold.hash_serialized_2();
+    ASSERT_TRUE(hA.has_value());
+
+    auto cb2 = make_coinbase(2, {{50000, p2pkh(0x02)}});
+    ASSERT_TRUE(fold.on_replay_block(2, fake_block_hash(2), make_block({cb2})));
+    auto hB = fold.hash_serialized_2();
+    ASSERT_TRUE(hB.has_value());
+
+    EXPECT_NE(hA->hash.GetHex(), hB->hash.GetHex())
+        << "hash_serialized_2 is cursor-specific: an expect for the earlier "
+           "cursor no longer verifies once the store advanced => refuse to arm";
+    EXPECT_NE(hB->hash.GetHex(), std::string(64, '0'))
+        << "a corrupt/absent (all-zero) expect never matches a real store hash";
 }
 
 }  // namespace


### PR DESCRIPTION
## PR-C1 — `--embedded-fold-live`: a true tip-tracking UTXO view (default OFF)

Wires the full-history replay UTXO fold as the LIVE serve-path input-pricing
view, so a mempool tx whose inputs predate this node's forward UTXO view (the
pre-window-input class, permanently fee-unknown / template-excluded on master)
is priced from a set proven byte-equal to dashd (`gettxoutsetinfo
hash_serialized_2`, `kernel/coinstats.cpp`) and becomes `fee_fold_proven`.

The fold is now kept **at the serve tip** and only consulted when it is,
matching how dashd keeps its `CCoinsViewCache` current.

### What this update adds

**Advance half (dashd `ConnectBlock`).** `FoldLiveController::on_block_connected`
applies each connected block to the fold on the same `block_connected` feed the
UTXO / MN legs use, advancing the fold's cursor forward toward the tip (spending
inputs, adding outputs). A coin unspent at the resume cursor `R` but spent
on-chain in `(R, tip]` now reads **spent** from the fold, instead of the stale
UNSPENT a frozen snapshot returned.

**Undo half (dashd `DisconnectBlock`).** `FoldLiveController::handle_reorg`,
driven from the header-chain tip-changed callback, walks the fold cursor down
over the orphaned tail to the fork point using a bounded ring of retained block
bodies, restoring inputs the abandoned branch spent. A reorg deeper than the
retained window fails closed (the view is marked behind tip). This mirrors the
connect + undo halves wired for the mined-commitment index (PR-B).

**At-tip serving guard.** The mempool consults the fold for pricing / viability
**only** while `fold_height >= serve_tip` **and** the fold's tip block is the
served chain's block at that height (`set_fold_at_tip_gate`). Behind tip — cold
start, a gap in the live block feed, mid-reorg, or a stranded view — it
withholds, which is byte-identical to master's fee-unknown exclusion, so a coin
the fold has not yet advanced past can never price a template.

**Pin gate.** The fold does **not** retire the tip-current `gettxout` /
`--coin-rpc` pin lookup unconditionally: it becomes the pin's first source only
while proven at tip, falling back to the live lookup off-tip (fail-closed when
neither is available).

**Runtime store verification.** `--embedded-fold-live-expect <hash_serialized_2>`
is now required. On open, the store's hash is verified against it at its cursor
height (the same path as `--replay-utxo-expect`) before it feeds any serving
decision; a wrong / corrupt / wrong-chain store refuses to arm and the node
falls back to master behaviour.

One mutex serialises every fold touch (advance / undo / serve-path read) so the
io-thread block feed and any serve-path reader cannot tear the in-memory
overlay.

### Reward-safety

Fold-resolved fees are exact (never overstated); an input the fold cannot
resolve stays fee-unknown → template-excluded. With the flag default-OFF the
fold is never opened and both fee pricing and the pin gate are byte-identical to
master.

### Flags

```
--embedded-fold-live PATH                 open the fold store as the live view
--embedded-fold-live-expect HASH          required: hash_serialized_2 the store
                                          must verify to before it may arm
```

### Tests (BLS=ON, all green)

- advance flips a pre-window coin UNSPENT → SPENT once the fold folds past the
  block that spent it;
- the guard withholds (fee-unknown, byte-identical to master) when the fold is
  behind tip, and prices the same input once at tip;
- a double-spend of an on-chain-spent pre-window coin is not priced
  `fee_fold_proven` and not selected;
- a wrong-cursor / corrupt (all-zero) expected hash refuses to arm;
- reorg-undo restores a coin spent only on the orphaned branch, and fails
  closed past the retained body window.

Build + full `test_dash_mempool` suite (105 tests) green.
