### PR TITLE
dash(daemonless): PR-C3 ConnectBlock fold-before-publish ordering (flag default-OFF, byte-identical master)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -992,7 +992,17 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // of THIS node's own dial targets — never changes WHAT is fetched
              // or how a reply is verified. OFF => dial plan byte-identical to
              // master.
-             bool embedded_asn_diversity = false)
+             bool embedded_asn_diversity = false,
+             // --embedded-connectblock-ordering (PR-C3): DEFAULT OFF. Port of
+             // dashcore ConnectBlock atomicity to the tip-publish seam
+             // (NodeCoinState::set_tip). When on, the arm refuses to publish a
+             // tip to the work source ahead of that tip block's body-derived
+             // credit-pool fold — closing the intra-node per-tip ordering
+             // window (#1154) that surfaces as creditpool/dmn/payee-stale.
+             // Ordering discipline ONLY (no derivation change); composes with
+             // the maintainer's body-first promotion gate. OFF => set_tip is
+             // byte-identical to master.
+             bool embedded_connectblock_ordering = false)
 {
     namespace io = boost::asio;
 
@@ -5643,6 +5653,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // advance. `creditpool-stale` then ceases to exist as a class in
         // normal operation; the ~1-2 s window is named `tip-body-pending`.
         maintainer->set_body_first_serve_tip(true);
+        // PR-C3 ConnectBlock ordering (default OFF): enforce fold-before-publish
+        // at the set_tip seam as a fail-closed backstop to the body-first
+        // promotion gate above. Only meaningful here, on the body-first arm.
+        node_coin_state.set_connectblock_ordering(embedded_connectblock_ordering);
+        std::cout << "[run] embedded ConnectBlock ordering (fold-before-publish): "
+                  << (embedded_connectblock_ordering
+                          ? "ENFORCED (--embedded-connectblock-ordering)"
+                          : "off (default; body-first promotion gate still orders "
+                            "the serve tip)")
+                  << "\n";
         // C-startup-invariant (gapless MN-list / daemonless re-seed): couple the
         // money-path freshness gates to body-first serving. The daemonless arm
         // sets body-first UNCONDITIONALLY one line up, so this can never
@@ -8940,6 +8960,7 @@ int main(int argc, char** argv)
     // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
     bool embedded_null_arm = false;
     bool embedded_asn_diversity = false;   // PR-4 (--embedded-asn-diversity): default OFF
+    bool embedded_connectblock_ordering = false;  // PR-C3 (--embedded-connectblock-ordering): default OFF
     // --embedded-ingest-isdlock: arm the coin-P2P MSG_ISDLOCK pull (G4
     // conflict-tx-lock feed). DEFAULT OFF — off, no getdata for inv type 31
     // and the handler decodes-and-discards (wire + template behaviour
@@ -9091,6 +9112,10 @@ int main(int argc, char** argv)
             embedded_asn_diversity = true;   // PR-4: require racing set to span >=2 ASNs
         else if (std::strcmp(argv[i], "--embedded-asn-diversity=false") == 0)
             embedded_asn_diversity = false;  // PR-4: explicit OFF (OFF-equivalence)
+        else if (std::strcmp(argv[i], "--embedded-connectblock-ordering") == 0)
+            embedded_connectblock_ordering = true;   // PR-C3: fold-before-publish at set_tip
+        else if (std::strcmp(argv[i], "--embedded-connectblock-ordering=false") == 0)
+            embedded_connectblock_ordering = false;  // PR-C3: explicit OFF (OFF-equivalence)
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
@@ -9436,7 +9461,8 @@ int main(int argc, char** argv)
                         embedded_ingest_isdlock,       // G4 isdlock feed
                         embedded_ingest_dstx,          // W5-B DSTX feed
                         embedded_proactive_rotate,    // PR-3 proactive rotation
-                        embedded_asn_diversity);       // PR-4 ASN diversity
+                        embedded_asn_diversity,        // PR-4 ASN diversity
+                        embedded_connectblock_ordering); // PR-C3 fold-before-publish
     }
     return run_selftest();
 }

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -455,6 +455,64 @@ public:
     /// Default OFF preserves the pre-CCbTx KAT/testnet posture byte-for-byte.
     void set_require_sml(bool v) { m_require_sml = v; }
 
+    /// ── PR-C3: dashd ConnectBlock atomicity at the tip-publish seam ──────────
+    /// dashcore's ConnectBlock (validation.cpp) updates the UTXO set + evo state
+    /// (DML, quorums, credit pool, ChainLocks) from the VALIDATED block body and
+    /// only THEN makes the new tip visible, so its getblocktemplate never sees a
+    /// tip at height N with a body-derived axis still at N-1. This arm advances
+    /// each axis on its own network round trip / local fold, so set_tip() — the
+    /// seam that publishes the tip to the work source (DASHWorkSource reads
+    /// m_prev_* through select_work()) — could in principle be poked with the
+    /// tip HEADER ahead of the tip BODY's credit-pool fold, opening the per-tip
+    /// intra-node-ordering window (#1154 / #102: ~47-80 ms/tip surviving replay)
+    /// that surfaces as the creditpool-stale / dmn-stale / payee-stale decline
+    /// family.
+    ///
+    /// When ARMED, set_tip() enforces the PUBLISH-LAST invariant defensively at
+    /// the seam itself: it REFUSES to advance the published tip to a block whose
+    /// reward-critical body-derived credit-pool seed is not yet folded AT that
+    /// block, leaving the previously-published (fully-folded) tip in place so
+    /// GBT keeps serving a tip it can stand behind. This is ORDERING DISCIPLINE
+    /// ONLY — no derivation changes, the same state is published, only AFTER the
+    /// fold rather than possibly before. It composes with (does not replace) the
+    /// CoinStateMaintainer body-first four-axis promotion gate
+    /// (maybe_promote_pending_tip): the maintainer already only calls set_tip
+    /// after that gate passes, so on the proven path this guard never fires; it
+    /// is the fail-closed backstop that catches a FUTURE wiring which pokes
+    /// set_tip without folding first (same spirit as
+    /// require_body_first_when_fresh_gated).
+    ///
+    /// DEFAULT OFF: set_tip() is byte-identical to the pre-C3 behaviour, so the
+    /// header-first / RPC-seed / KAT callers that legitimately publish before a
+    /// credit-pool fold are unaffected. Only meaningful on the body-first
+    /// (coin-P2P daemonless) arm, where main_dash arms it alongside body-first.
+    void set_connectblock_ordering(bool v) { m_connectblock_ordering = v; }
+    bool connectblock_ordering() const { return m_connectblock_ordering; }
+    /// How many set_tip() publications the ordering guard has deferred (a tip
+    /// whose body was not yet folded). Telemetry only; no serve/reward path
+    /// reads it. 0 on the proven body-first path (the maintainer never poses a
+    /// pre-fold tip); a non-zero value names a caller that violated the order.
+    uint64_t connectblock_ordering_deferrals() const {
+        return m_connectblock_ordering_deferrals;
+    }
+    /// The serve tip currently PUBLISHED to the work source (the values
+    /// select_work() builds a template on). Read-only observability, added
+    /// with PR-C3 so the fold-before-publish invariant is directly assertable
+    /// and so telemetry can print the live serve tip without provoking a build.
+    uint32_t published_tip_height() const { return m_prev_height; }
+    const uint256& published_tip_hash() const { return m_prev_hash; }
+    /// TRUE iff the reward-critical body-derived credit-pool seed is folded AT
+    /// the given tip block (hash AND its own height). This is the credit-pool
+    /// witness dashd's ConnectBlock advances inside the block connect; the
+    /// maintainer's four-axis promotion gate additionally proves the payee/SML
+    /// witnesses, which the seam guard need not re-derive (a stale payee/SML is
+    /// a REFUSE at the serve gate, never a wrong-amount block; a stale
+    /// creditPoolBalance is consensus-fatal, so it is the one the seam pins).
+    bool credit_pool_folded_at(uint32_t prev_height, const uint256& prev_hash) const {
+        return m_credit_pool_height == static_cast<int32_t>(prev_height)
+               && m_credit_pool_current_hash == prev_hash;
+    }
+
     /// Record the header-tip parameters and mark the bundle live. Call after
     /// the tip advances AND the MN list + mempool are seeded; until then the
     /// selector must route to the dashd fallback. curtime/version left 0 use
@@ -463,6 +521,16 @@ public:
                  uint32_t bits_for_next, uint32_t mtp_at_tip,
                  uint8_t address_version, uint8_t address_p2sh_version,
                  uint32_t curtime = 0, uint32_t version = 0) {
+        // PR-C3 ConnectBlock ordering (default OFF): refuse to publish a tip
+        // ahead of its body-derived credit-pool fold. prev_height==0 (genesis /
+        // uninitialised) is exempt — there is no prior block to fold. Fail
+        // CLOSED: leave the previously-published, fully-folded tip in place so
+        // the work source never serves a tip whose derived state is stale.
+        if (m_connectblock_ordering && prev_height != 0
+            && !credit_pool_folded_at(prev_height, prev_hash)) {
+            ++m_connectblock_ordering_deferrals;
+            return;
+        }
         // D2: prev_height/prev_hash are inputs of the confirmation-pass
         // projection (confirmations = prev_height - reg_height; confirmedHash
         // = prev_hash), so a tip move invalidates the memoized projected root.
@@ -1905,6 +1973,10 @@ private:
     uint32_t m_curtime{0};
     uint32_t m_version{0};
     bool     m_populated{false};
+    // PR-C3 ConnectBlock fold-before-publish ordering (default OFF; armed on
+    // the body-first daemonless arm). See set_connectblock_ordering().
+    bool     m_connectblock_ordering{false};
+    uint64_t m_connectblock_ordering_deferrals{0};
 };
 
 } // namespace coin

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1239,8 +1239,17 @@ if (BUILD_TESTING AND GTest_FOUND)
     # contiguous fold; the unrepairable-gap fail-closed floor (wipe + demote +
     # re-seed ask) unchanged; and the consumer half of the G7 split (below-tip
     # seed catch-up / refusal-to-arm). Links leveldb via core.
+    # Third TU (PR-C3): test_dash_connectblock_ordering.cpp — the ConnectBlock
+    # fold-before-publish ordering guard at the NodeCoinState::set_tip seam
+    # (flag default-OFF, byte-identical master when off). Folded into this
+    # ALREADY-ALLOWLISTED target rather than a fresh add_executable so it is
+    # actually built + run in CI: a new target absent from the build.yml
+    # --target list is the #143 NOT_BUILT sentinel that "passes" by never
+    # being compiled. It is header-only over node_coin_state.hpp, so it adds no
+    # link deps beyond this target's existing set.
     add_executable(test_dash_coin_state_maintainer test_dash_coin_state_maintainer.cpp
-                   test_dash_mn_gap_repair.cpp)
+                   test_dash_mn_gap_repair.cpp
+                   test_dash_connectblock_ordering.cpp)
     target_link_libraries(test_dash_coin_state_maintainer PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_connectblock_ordering.cpp
+++ b/test/test_dash_connectblock_ordering.cpp
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// PR-C3 — ConnectBlock fold-before-publish ordering KAT.
+///
+/// dashcore's ConnectBlock (validation.cpp) updates the UTXO set + evo state
+/// (credit pool, DML, quorums, ChainLocks) from the VALIDATED block body and
+/// only THEN makes the new tip visible, so its getblocktemplate never observes
+/// a tip at height N with a body-derived axis still at N-1. c2pool's embedded
+/// arm advances each axis on its own round trip / local fold, so the seam that
+/// publishes the tip to the work source — NodeCoinState::set_tip(), read by
+/// DASHWorkSource through select_work() — could be poked with the tip HEADER
+/// ahead of the tip BODY's credit-pool fold. That is the intra-node per-tip
+/// ordering window measured in issue #1154 (~47-80 ms/tip surviving replay),
+/// which surfaces as the creditpool-stale / dmn-stale / payee-stale decline
+/// family.
+///
+/// These cases pin the ported invariant at the seam itself:
+///   * DEFAULT OFF — set_tip publishes immediately, byte-identical to master,
+///     even with no credit-pool fold (the header-first / RPC-seed / KAT path).
+///   * ARMED — set_tip REFUSES to publish a tip whose credit-pool seed is not
+///     folded AT that block (fold-before-publish), and the previously
+///     published, fully-folded tip is retained (fail-closed, no stale window).
+///   * ARMED — once the body folds (set_credit_pool at the tip), the SAME
+///     set_tip publishes: the derived state is folded BEFORE the tip goes live.
+///   * genesis (prev_height==0) is exempt — no prior block body to fold.
+///
+/// Reward-safety: the guard only ever REFUSES to advance to a not-yet-folded
+/// tip; it never changes any derived value. Off, it is inert.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/node_coin_state.hpp>
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+
+using dash::coin::NodeCoinState;
+
+namespace {
+
+constexpr uint8_t  ADDR_VER = 76;   // DASH mainnet P2PKH
+constexpr uint8_t  P2SH_VER = 16;
+constexpr uint32_t BITS     = 0x1a0abcde;
+constexpr uint32_t MTP      = 1'700'000'000;
+
+uint256 raw256(uint8_t base) {
+    uint256 h;
+    std::array<uint8_t, 32> p{};
+    for (size_t i = 0; i < 32; ++i) p[i] = static_cast<uint8_t>(base + i);
+    std::memcpy(h.data(), p.data(), 32);
+    return h;
+}
+
+// Publish tip at (height, hash) through the seam the work source reads.
+void publish_tip(NodeCoinState& st, uint32_t height, const uint256& hash) {
+    st.set_tip(height, hash, BITS, MTP, ADDR_VER, P2SH_VER);
+}
+
+// Fold the tip block's body-derived credit-pool seed AT (height, hash) — the
+// reward-critical witness that dashd's ConnectBlock advances inside the connect.
+void fold_body(NodeCoinState& st, uint32_t height, const uint256& hash) {
+    st.set_credit_pool(/*balance=*/123456, hash, static_cast<int32_t>(height));
+}
+
+} // namespace
+
+// OFF-equivalence: default flag off, no fold — set_tip publishes immediately,
+// exactly as master does. This is what keeps every existing caller (header-
+// first, RPC seed, the #673 direct-poke KAT) byte-identical.
+TEST(DashConnectBlockOrdering, OffPublishesWithoutFold) {
+    NodeCoinState st;
+    ASSERT_FALSE(st.connectblock_ordering());
+
+    const uint256 tipH = raw256(0x40);
+    publish_tip(st, 2'500'000, tipH);
+
+    EXPECT_TRUE(st.populated());
+    EXPECT_EQ(st.published_tip_height(), 2'500'000u);
+    EXPECT_EQ(st.published_tip_hash(), tipH);
+    EXPECT_EQ(st.connectblock_ordering_deferrals(), 0u);
+}
+
+// ARMED: a tip whose body is not yet folded is REFUSED. No serve slot moves
+// (populated stays false, prev_height stays 0) — the work source never sees a
+// tip ahead of its derived state.
+TEST(DashConnectBlockOrdering, ArmedRefusesTipAheadOfFold) {
+    NodeCoinState st;
+    st.set_connectblock_ordering(true);
+
+    const uint256 tipH = raw256(0x40);
+    ASSERT_FALSE(st.credit_pool_folded_at(2'500'000, tipH));
+
+    publish_tip(st, 2'500'000, tipH);
+
+    EXPECT_FALSE(st.populated());
+    EXPECT_EQ(st.published_tip_height(), 0u);
+    EXPECT_EQ(st.connectblock_ordering_deferrals(), 1u);
+}
+
+// ARMED: once the body folds AT the tip, the SAME publish succeeds — the
+// derived state is folded BEFORE the tip is published (the ported invariant).
+TEST(DashConnectBlockOrdering, ArmedPublishesAfterFold) {
+    NodeCoinState st;
+    st.set_connectblock_ordering(true);
+
+    const uint256 tipH = raw256(0x40);
+
+    // Pre-fold poke is refused ...
+    publish_tip(st, 2'500'000, tipH);
+    ASSERT_FALSE(st.populated());
+    ASSERT_EQ(st.connectblock_ordering_deferrals(), 1u);
+
+    // ... fold the tip body's credit-pool seed, then publish: now it rides.
+    fold_body(st, 2'500'000, tipH);
+    ASSERT_TRUE(st.credit_pool_folded_at(2'500'000, tipH));
+    publish_tip(st, 2'500'000, tipH);
+
+    EXPECT_TRUE(st.populated());
+    EXPECT_EQ(st.published_tip_height(), 2'500'000u);
+    EXPECT_EQ(st.published_tip_hash(), tipH);
+    // No new deferral on the successful publish.
+    EXPECT_EQ(st.connectblock_ordering_deferrals(), 1u);
+}
+
+// ARMED: a stale header-tip advance (body of H not folded) is refused while a
+// PREVIOUS fully-folded tip (H-1) is already live — the previous tip is
+// retained (fail-closed), not clobbered, so the arm keeps serving a tip it can
+// stand behind through the propagation window. Promotion resumes once H folds.
+TEST(DashConnectBlockOrdering, ArmedRetainsPreviousFoldedTip) {
+    NodeCoinState st;
+    st.set_connectblock_ordering(true);
+
+    const uint256 tipA = raw256(0x10);   // H-1
+    const uint256 tipB = raw256(0x80);   // H
+
+    // Fold + publish H-1.
+    fold_body(st, 2'499'999, tipA);
+    publish_tip(st, 2'499'999, tipA);
+    ASSERT_TRUE(st.populated());
+    ASSERT_EQ(st.published_tip_height(), 2'499'999u);
+
+    // Header tip H arrives; its body is not folded yet. Refused, previous
+    // tip retained.
+    publish_tip(st, 2'500'000, tipB);
+    EXPECT_TRUE(st.populated());                 // still live on H-1
+    EXPECT_EQ(st.published_tip_height(), 2'499'999u);     // NOT advanced to H
+    EXPECT_EQ(st.published_tip_hash(), tipA);
+    EXPECT_EQ(st.connectblock_ordering_deferrals(), 1u);
+
+    // H's body folds -> the same advance now publishes.
+    fold_body(st, 2'500'000, tipB);
+    publish_tip(st, 2'500'000, tipB);
+    EXPECT_TRUE(st.populated());
+    EXPECT_EQ(st.published_tip_height(), 2'500'000u);
+    EXPECT_EQ(st.published_tip_hash(), tipB);
+    EXPECT_EQ(st.connectblock_ordering_deferrals(), 1u);
+}
+
+// Genesis carve-out: prev_height==0 has no prior block body to fold, so the
+// guard is exempt and the publish rides (mirrors the maintainer's ZERO
+// carve-outs; prevents a cold-node deadlock).
+TEST(DashConnectBlockOrdering, ArmedGenesisExempt) {
+    NodeCoinState st;
+    st.set_connectblock_ordering(true);
+
+    const uint256 zero = uint256::ZERO;
+    publish_tip(st, 0, zero);
+
+    EXPECT_TRUE(st.populated());
+    EXPECT_EQ(st.connectblock_ordering_deferrals(), 0u);
+}


### PR DESCRIPTION
## PR-C3 — ConnectBlock fold-before-publish ordering (dormant defense-in-depth)

Adds `--embedded-connectblock-ordering` (default OFF, byte-identical to master when absent). When armed on the body-first coin-P2P arm, `NodeCoinState::set_tip()` refuses to advance the published serve-tip to a block whose credit-pool axis is not yet folded (early-return, no derived-state write — strictly more fail-closed than master).

### Scope correction (measured, not claimed)
Review of the wired path shows the per-tip creditpool/payee/dmn-SML publish window is **already closed** by the pre-existing 4-axis `maybe_promote_pending_tip` -> `promote_serve_tip` machinery (header + credit-pool-seed + payee-cursor + SML-currency all proven current at the promoted block before `republish()->set_tip`). On that path `connectblock_ordering_deferrals == 0` — this guard never fires. It is therefore a **dormant defense-in-depth backstop on the credit-pool axis**, not the mechanism that closes the window.

The one residual — the serve tip promoting ahead of the quorum-folded state (`emit-qc-*`) — is caught fail-closed at emit time (no wrong quorum root is ever emitted) and is the known qc-availability propagation floor, addressed by the MinedCommitmentIndex arming + null-arm, not by fold-ordering. This PR does not close it.

### Safety
- Flag OFF => byte-identical to master (single guarded early-return, `m_connectblock_ordering` default false; new members read by no other logic). Proven by KAT `OffPublishesWithoutFold` + untouched 65/65 maintainer + 109/109 node_coin_state suites.
- When armed: only ever REFUSES to advance to a not-yet-folded tip (retains the prior fully-folded tip). No derived value is ever changed — reward-safe ordering discipline only. Re-run on every maintainer event + independent `check_tip_body_overdue` demote => cannot wedge.
- KAT (5 cases) folded into the allowlisted `test_dash_coin_state_maintainer` target (no NOT_BUILT fake-green).

Reward-safe, dormant, off the dashd-cut critical path.