### PR TITLE
web: order recent-blocks list by chain height, not header ts

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3598,7 +3598,16 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
         if (blk.time_to_find > 0 && blk.expected_time > 0) {
             blk.luck = blk.expected_time / blk.time_to_find * 100.0;
         }
-        m_found_blocks.insert(m_found_blocks.begin(), blk);
+        // Keep found-blocks ordered newest-first by chain height (canonical
+        // chain order). Height is monotonic on-chain, so it is immune to the
+        // block-header timestamp skew that can reverse a same-day cluster
+        // relative to height; ts only breaks ties at equal height.
+        m_found_blocks.push_back(blk);
+        std::sort(m_found_blocks.begin(), m_found_blocks.end(),
+            [](const FoundBlock& a, const FoundBlock& b) {
+                if (a.height != b.height) return a.height > b.height;
+                return a.ts > b.ts;
+            });
     }
 
     // Persist to LevelDB (Layer +2 — never pruned)
@@ -3661,9 +3670,12 @@ void MiningInterface::load_persisted_found_blocks()
                 m_found_blocks.push_back(std::move(blk));
         }
 
-        // Sort newest first
+        // Sort newest-first by chain height (canonical, monotonic on-chain);
+        // ts only breaks ties. Sorting by ts alone reversed same-day clusters
+        // whose header timestamps disagree with height.
         std::sort(m_found_blocks.begin(), m_found_blocks.end(),
             [](const FoundBlock& a, const FoundBlock& b) {
+                if (a.height != b.height) return a.height > b.height;
                 return a.ts > b.ts;
             });
 

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -3958,7 +3958,7 @@
                 
                 // Store only 10 most recent blocks for table display
                 // (graph chart fetches recent_blocks separately and gets full history)
-                window.allBlocks = blocks.slice(0, 10);
+                window.allBlocks = blocks.slice().sort(function(a,b){var ha=(a.height!=null?a.height:a.number)||0,hb=(b.height!=null?b.height:b.number)||0;return hb-ha;}).slice(0, 10);
                 window.blocksDisplayCount = Math.min(10, window.allBlocks.length);
                 
                 // Function to render blocks
@@ -4135,7 +4135,7 @@
                 d3.select('#merged_blocks tbody').selectAll('tr').remove();
                 
                 // Store only 10 most recent merged blocks for table display
-                window.allMergedBlocks = blocks.slice(0, 10);
+                window.allMergedBlocks = blocks.slice().sort(function(a,b){var ha=(a.height!=null?a.height:a.number)||0,hb=(b.height!=null?b.height:b.number)||0;return hb-ha;}).slice(0, 10);
                 window.mergedBlocksDisplayCount = Math.min(10, window.allMergedBlocks.length);
                 
                 // Block explorer URLs for different merged mining chains


### PR DESCRIPTION
## What

Found-blocks / recent-blocks table was ordered newest-first by block-header **timestamp (ts)**. Header timestamps are not monotonic with height, so a same-day cluster of blocks whose headers disagree with height renders reverse-sorted relative to the rest of the list.

Reported by a hotel tenant on RES node 109.161.52.148 :8081 (build c2pool-dash-1209): the 2026-08-20 group showed heights 2525086 -> 2525051 -> 2525047 (descending) while the surrounding list read correctly. The blocks (h=2525047/2525051/2525068/2525086/2525133, won 2026-08-20) are correct on chain — only the display order was wrong.

## Root cause

Two insertion disciplines were never reconciled to one key:
- `record_found_block` (live) front-inserted in found-order.
- `load_persisted_found_blocks` (restart) sorted by `ts` only.

`ts` (header timestamp) is not monotonic with height; a tight same-day cluster sorts differently by ts than by height. The frontend applied no sort of its own (`blocks.slice(0, 10)`), so it faithfully rendered the inconsistent backend order.

## Fix (display-only, reward-safe)

In-memory API ordering only — no change to persistence, hashes, payouts, or block data.
- `record_found_block` (web_server.cpp): deterministic **height-descending** sort (ts tiebreak) replacing the blind front-insert.
- `load_persisted_found_blocks` (web_server.cpp): sort by height-descending (ts tiebreak) instead of ts alone — one canonical order for live + persisted blocks.
- `dashboard.html`: defensively sort both block tables (main + merged) by height before the top-10 slice, so the display stays consistent even against older binaries that still return ts-ordered data.

## Deploy note

Backend ordering is baked into the binary, so the hotel nodes (RES build 1209, PRI 37e95dd9) need a rebuild+redeploy to pick up the backend change — this is not a frontend static-swap of a newer frontend onto an older binary era. The frontend guard is additive and version-safe (`height`/`number` have long been present in `/recent_blocks`), so a targeted static application of just that guard could correct the hotel display ahead of a full cutover; deploy sequencing is the prod steward + integrator call.

For designated-reviewer review before CI; not for self-merge.
