### PR TITLE
dash(replay): #154 — drive SML self-check merkle from O(k) block mutations (port dashd cache invariance)

### DIFF
--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -530,6 +530,18 @@ public:
         return sml.CalcMerkleRoot();
     }
 
+    /// Materialise the full SML entry vector from the held MN map — the O(n)
+    /// per-block cost the delta path avoids. Only the full-rebuild branches of
+    /// compute_sml_root_incremental() (cold fold, leaf-set change) call this.
+    std::vector<vendor::CSimplifiedMNListEntry> materialize_sml_entries() const
+    {
+        std::vector<vendor::CSimplifiedMNListEntry> ents;
+        ents.reserve(m_entries.size());
+        for (const auto& [protx, st] : m_entries)
+            ents.push_back(st.to_sml_entry(protx));
+        return ents;
+    }
+
     /// THE per-block hotspot, incrementalised (task #154). Same value as
     /// compute_sml_root() — byte-identical by construction — but reusing the
     /// leaf hashes and internal merkle nodes the block did not disturb, so a
@@ -543,11 +555,47 @@ public:
     /// the held list is replaced wholesale (seed()/load_snapshot() do this).
     uint256 compute_sml_root_incremental()
     {
-        std::vector<vendor::CSimplifiedMNListEntry> ents;
-        ents.reserve(m_entries.size());
-        for (const auto& [protx, st] : m_entries)
-            ents.push_back(st.to_sml_entry(protx));
-        const uint256 root = m_sml_cache.update(std::move(ents));
+        uint256 root;
+        if (!m_sml_cache.valid() || m_sml_structural) {
+            // Cold/first fold after (re)seed, or the leaf SET changed this block
+            // (ProReg add / collateral spend / collateral re-registration).
+            // Re-materialise the whole set ONCE and let update() rebuild — the
+            // rare case (adds/removes shift sorted positions). update() still
+            // reuses every unchanged leaf's cached hash.
+            root = m_sml_cache.update(materialize_sml_entries());
+        } else if (m_sml_touched.empty()) {
+            // THE OVERWHELMING MAJORITY: no SML-relevant field changed this
+            // block (payment rotation and PoSe-score decay bump ONLY the
+            // to_sml_entry-EXCLUDED nLastPaidHeight / nPoSePenalty). The root is
+            // definitionally unchanged — return the resident cached root with
+            // ZERO materialise, sort, diff, realloc or hashing. This is the
+            // dashd invariance (CalcCbTxMerkleRootMNList single-slot cache) the
+            // #1297 consolidation had, but paid for in full every block anyway.
+            root = m_sml_cache.root();
+        } else {
+            // A handful of value-only changes (confirmedHash crossings, ProUpServ
+            // / ProUpReg key & netInfo, PoSe ban/revive isValid flips). Build
+            // to_sml_entry for JUST those and patch them into the resident tree
+            // in place — O(k) materialise + O(k·log n) internal-node re-hash.
+            std::vector<vendor::CSimplifiedMNListEntry> changed;
+            changed.reserve(m_sml_touched.size());
+            for (const auto& protx : m_sml_touched) {
+                auto it = m_entries.find(protx);
+                if (it == m_entries.end()) continue;   // touched then removed ⇒
+                                                       // m_sml_structural set
+                                                       // (this branch unreached)
+                changed.push_back(it->second.to_sml_entry(protx));
+            }
+            auto delta = m_sml_cache.apply_value_changes(changed);
+            if (delta) {
+                root = *delta;
+            } else {
+                // Defensive: the delta could not be applied cleanly (a key was
+                // absent ⇒ the set actually changed). Fall back to the full
+                // rebuild so the self-check root is always exact.
+                root = m_sml_cache.update(materialize_sml_entries());
+            }
+        }
 #ifndef NDEBUG
         // Belt-and-suspenders in debug builds: the incremental root MUST equal
         // the naive full recompute at every block. (In release the fold's own
@@ -692,6 +740,10 @@ public:
             payee_script_pre = pst->scriptPayout.m_data;
         }
 
+        // task #154 delta driver: this block's SML mutations start empty.
+        m_sml_touched.clear();
+        m_sml_structural = false;
+
         // ── Pass 1: confirmedHash (specialtxman.cpp:205-218) ────────────
         // Walks every MN, BANNED INCLUDED. Confirmation compares against
         // H−1 (the prev block's height), and the recorded hash is hash(H−1)
@@ -701,6 +753,7 @@ public:
             const int32_t confs = (H - 1) - st.nRegisteredHeight;
             if (confs >= m_cfg.gates.masternode_min_confirmations) {
                 st.UpdateConfirmedHash(protx, prev_hash);
+                sml_touch(protx);   // confirmedHash IS an SML field
                 ++r.confirmed;
             }
         }
@@ -1030,6 +1083,17 @@ private:
     // it only through compute_sml_root_incremental() in cursor order, and
     // reset() on any wholesale state replacement (seed/load_snapshot).
     vendor::IncrementalSmlMerkle m_sml_cache;
+    // task #154 delta driver. Which SML-relevant leaves the CURRENT block
+    // mutated in place (m_sml_touched) and whether the leaf SET changed —
+    // add/remove (m_sml_structural). Both are reset at the top of every
+    // fold_block and consumed once by compute_sml_root_incremental() so the
+    // self-check patches only the O(k) changed leaves instead of re-deriving
+    // the whole ~4900-entry set. A missed mark can only make the incremental
+    // root DISAGREE with the naive recompute, which the committed-root compare
+    // (and the debug assert) catches — fail-closed, never a wrong served root.
+    std::vector<uint256> m_sml_touched;
+    bool                 m_sml_structural{false};
+    void sml_touch(const uint256& protx) { m_sml_touched.push_back(protx); }
     std::map<bitcoin_family::coin::TxPrevOut, uint256, ReplayOutpointLess>
         m_collateral_index;
     uint64_t    m_total_registered_count{0};
@@ -1051,6 +1115,9 @@ private:
         if (it == m_entries.end()) return;
         m_collateral_index.erase(it->second.collateralOutpoint);
         m_entries.erase(it);
+        // Leaf SET changed (collateral spend / re-registration) — the
+        // incremental self-check must take the full-rebuild path this block.
+        m_sml_structural = true;
     }
 
     /// dashd CompareByLastPaid_GetHeight (deterministicmns.cpp:157-166),
@@ -1154,6 +1221,8 @@ private:
 
         m_collateral_index[st.collateralOutpoint] = proTxHash;
         m_entries[proTxHash] = std::move(st);
+        // A new leaf shifts sorted positions — full-rebuild path this block.
+        m_sml_structural = true;
         ++m_total_registered_count;
         ++r.registered;
         if (m_cfg.debug_logs) {
@@ -1208,6 +1277,8 @@ private:
                 }
             }
         }
+        // netInfo / platform ports / isValid(revive) are SML fields.
+        sml_touch(p.proTxHash);
         ++r.updated;
         return {};
     }
@@ -1258,6 +1329,9 @@ private:
         }
         st.keyIDVoting  = p.keyIDVoting;
         st.scriptPayout = p.scriptPayout;
+        // keyIDVoting is an SML field (and the operator-key-change branch above
+        // may have reset pubKeyOperator/netInfo + flipped isValid).
+        sml_touch(p.proTxHash);
         ++r.updated;
         return {};
     }
@@ -1280,6 +1354,8 @@ private:
         st.BanIfNotBanned(H);
         st.nRevocationReason = p.nReason;
         if (!was_banned) ++r.banned;
+        // Ban flips isValid + reset clears pubKeyOperator/netInfo — SML fields.
+        sml_touch(p.proTxHash);
         ++r.revoked;
         return {};
     }
@@ -1369,6 +1445,9 @@ private:
         ++r.punished;
         if (!st.IsBanned() && st.nPoSePenalty >= max_penalty) {
             st.BanIfNotBanned(H);
+            // The ban flips isValid — the only SML-relevant effect of a punish
+            // (nPoSePenalty itself is EXCLUDED from to_sml_entry).
+            sml_touch(protx);
             ++r.banned;
             if (m_cfg.debug_logs) {
                 LOG_INFO << "[DML-FOLD] h=" << H << " MN "

--- a/src/impl/dash/coin/vendor/incremental_sml_merkle.hpp
+++ b/src/impl/dash/coin/vendor/incremental_sml_merkle.hpp
@@ -68,6 +68,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 #include <set>
 #include <utility>
 #include <vector>
@@ -75,6 +76,27 @@
 namespace dash {
 namespace coin {
 namespace vendor {
+
+// PERF/TEST SEAM (task #154 delta path). Counts the SML entries the incremental
+// path had to EXAMINE — materialize a CSimplifiedMNListEntry for, sort, and
+// byte-diff. This is the per-block O(n) cost the #1297 consolidation
+// reintroduced by re-deriving the WHOLE ~4900-entry set from the fold's MN map
+// every block (replay_fold_engine.hpp compute_sml_root_incremental → update()):
+// even a pure payment-rotation block, which changes NOTHING in the SML, paid a
+// full re-materialize + std::sort + full-set diff + full-cache realloc.
+//   * update()             bumps by entries.size()  — it re-sorts and re-diffs
+//                          the entire incoming set (cold build / leaf-set change).
+//   * apply_value_changes() bumps only by the number of leaves the block
+//                          actually mutated (the O(k) delta).
+//   * a quiet block bumps NEITHER — the fold engine returns the resident cached
+//     root without calling either path.
+// Same single-io-thread discipline as the sml_leaf/node_hash counters: plain
+// uint64, no atomics.
+inline uint64_t& sml_leaves_examined_count()
+{
+    static uint64_t n = 0;
+    return n;
+}
 
 class IncrementalSmlMerkle
 {
@@ -97,6 +119,10 @@ public:
     // for every input — see the header invariant.
     uint256 update(std::vector<CSimplifiedMNListEntry> entries)
     {
+        // The full path re-sorts and re-diffs the ENTIRE incoming set — the
+        // O(n) per-block cost the delta path (apply_value_changes) avoids.
+        sml_leaves_examined_count() += entries.size();
+
         // Same total order the naive path sorts by: dashcore's memcmp over the
         // raw proRegTxHash bytes (little-endian byte order). proRegTxHash is
         // unique per MN, so this is a strict total order → deterministic.
@@ -188,6 +214,59 @@ public:
             rebuild_tree();
         }
         m_valid = true;
+        return m_root;
+    }
+
+    // DELTA PATH (task #154). Apply in-place VALUE changes to a known-small set
+    // of already-present leaves, reusing the resident sorted leaf cache AND the
+    // cached tree — WITHOUT re-materialising, re-sorting, or re-diffing the full
+    // ~4900-entry set. `changed` carries the NEW SML entries for exactly the
+    // leaves the block mutated in place: same proRegTxHash → same sorted
+    // position, value-only fields moved (confirmedHash, netInfo, pubKeyOperator,
+    // keyIDVoting, isValid, nType, platform*). The leaf SET must be unchanged;
+    // adds / removes (which shift sorted positions) still go through update().
+    //
+    // Returns the new root, byte-identical to
+    //     CSimplifiedMNList(resulting_set).CalcMerkleRoot()
+    // by the same structural guarantee update() gives — identical CalcHash(),
+    // identical merkle_pair_hash(), identical memcmp leaf order. Returns
+    // std::nullopt when the delta cannot be applied safely (cache invalid / no
+    // tree / a key is not present ⇒ the set actually changed): the caller then
+    // falls back to update() so the self-check root is never approximate.
+    std::optional<uint256> apply_value_changes(
+        const std::vector<CSimplifiedMNListEntry>& changed)
+    {
+        if (!m_valid || m_leaves.empty() || m_levels.empty())
+            return std::nullopt;
+        if (m_levels[0].size() != m_leaves.size())
+            return std::nullopt;
+
+        // Only the touched leaves are examined — the O(k) win.
+        sml_leaves_examined_count() += changed.size();
+
+        std::vector<size_t> dirty;
+        dirty.reserve(changed.size());
+        for (const auto& e : changed) {
+            // lower_bound over the resident sorted leaf cache by proRegTxHash.
+            size_t lo = 0, hi = m_leaves.size();
+            while (lo < hi) {
+                const size_t mid = lo + (hi - lo) / 2;
+                if (keycmp(m_leaves[mid].key, e.proRegTxHash) < 0) lo = mid + 1;
+                else                                              hi = mid;
+            }
+            if (lo >= m_leaves.size()
+                || keycmp(m_leaves[lo].key, e.proRegTxHash) != 0) {
+                // Key absent ⇒ the leaf SET changed, not just a value. Bail so
+                // the caller rebuilds from the full set (fail-safe, never wrong).
+                return std::nullopt;
+            }
+            m_leaves[lo].entry = e;
+            m_leaves[lo].hash  = e.CalcHash();     // bumps sml_leaf_hash_count
+            m_levels[0][lo]    = m_leaves[lo].hash;
+            dirty.push_back(lo);
+        }
+        if (!dirty.empty())
+            recompute_paths(dirty);   // O(k·log n) internal nodes only
         return m_root;
     }
 

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -495,6 +495,47 @@ TEST(DashReplayFoldReal, Revive2516756ThenQuietSequence)
     EXPECT_EQ(eng.height(), 2516760u);
 }
 
+// task #154 delta path at the ENGINE level, on real mainnet bodies. The
+// self-check's incremental root recompute must NOT re-materialise + re-sort the
+// whole ~2971-entry SML on every block (the #1297 wall-clock regression). After
+// the one unavoidable warm-up rebuild, four real quiet bodies together examine
+// FEWER SML entries than a SINGLE full re-materialise — where the shipped code
+// examined 4*n. The folded roots stay byte-exact against the chain throughout,
+// so the speed-up costs nothing in correctness.
+TEST(DashReplayFoldReal, IncrementalSelfCheckAvoidsPerBlockFullRematerialize)
+{
+    auto fx  = parse_prestate(kDashReplayPrestate2516755);
+    auto eng = seed_from_fixture(fx);
+    const uint64_t n = eng.size();   // 2971
+
+    // Warm the cache: the first fold after a seed rebuilds from the full set
+    // (seed() dropped the diff base). This is the one unavoidable O(n).
+    ASSERT_TRUE(eng.fold_block(parse_block(kDashReplayBlock2516756), 2516756).ok);
+
+    // Four more real bodies. None registers or removes an MN (the leaf set is
+    // stable — the roots below prove it), so each takes the delta / cached-root
+    // path and examines only the leaves it actually mutated.
+    const char* seq[] = {kDashReplayBlock2516757, kDashReplayBlock2516758,
+                         kDashReplayBlock2516759, kDashReplayBlock2516760};
+    uint32_t h = 2516757;
+    const uint64_t ex0 = dash::coin::vendor::sml_leaves_examined_count();
+    for (const char* bh : seq) {
+        auto rr = eng.fold_block(parse_block(bh), h);
+        ASSERT_TRUE(rr.ok) << "h=" << h << ": " << rr.error;
+        // Byte-exact against the chain — the delta path never trades away
+        // correctness for speed.
+        EXPECT_EQ(rr.computed_root.GetHex(), kRoot2516756) << "h=" << h;
+        EXPECT_EQ(rr.registered, 0u) << "h=" << h;   // leaf set stable ⇒ non-structural
+        ++h;
+    }
+    const uint64_t examined =
+        dash::coin::vendor::sml_leaves_examined_count() - ex0;
+    EXPECT_LT(examined, n)
+        << "four blocks' delta self-check examined " << examined
+        << " SML entries — must be < one full re-materialise (n=" << n
+        << "); the shipped full path examined 4*n = " << (4 * n);
+}
+
 TEST(DashReplayFoldReal, OperatorSplitCarriedThroughFold)
 {
     auto fx  = parse_prestate(kDashReplayPrestate2516755);
@@ -1399,6 +1440,7 @@ TEST(DashReplayFoldSynthetic, SnapshotV3FailLoudPaths)
 using dash::coin::vendor::IncrementalSmlMerkle;
 using dash::coin::vendor::sml_leaf_hash_count;
 using dash::coin::vendor::sml_node_hash_count;
+using dash::coin::vendor::sml_leaves_examined_count;
 
 namespace {
 
@@ -1641,4 +1683,76 @@ TEST(DashReplayFoldIncrementalMerkle, RandomWalkAlwaysMatchesNaive)
             << "random-walk divergence at step " << stepno
             << " (op=" << op << ", size=" << state.size() << ")";
     }
+}
+
+// task #154 DELTA PATH — the fix for the #1297 wall-clock regression.
+//
+// The #1297 consolidation kept the LEAF-HASH reduction but paid a FULL per-block
+// re-materialise + std::sort + full-set diff + full-cache realloc on EVERY
+// block, including the pure-payment-rotation majority that change NOTHING in the
+// SML. apply_value_changes() drives the resident sorted cache from the O(k)
+// leaves a block actually mutated instead. This KAT proves the two things that
+// matter:
+//   (a) the delta root is BYTE-IDENTICAL to the naive full recompute (reward-
+//       safety — a fast-but-wrong root would serve a forked list); and
+//   (b) the delta path EXAMINES only the k changed leaves, where the full path
+//       (what shipped) examines all n — the O(n)→O(k) win, measured on the
+//       shared sml_leaves_examined_count() seam.
+TEST(DashReplayFoldIncrementalMerkle, DeltaPathByteIdenticalAndExaminesOnlyK)
+{
+    const uint32_t N = 300;
+    std::map<uint32_t, CSimplifiedMNListEntry> state;
+    for (uint32_t i = 0; i < N; ++i) state[i] = incmerkle_mk_entry(i, true);
+
+    auto entries_of = [&]() {
+        std::vector<CSimplifiedMNListEntry> v;
+        v.reserve(state.size());
+        for (const auto& [k, e] : state) { (void)k; v.push_back(e); }
+        return v;
+    };
+
+    IncrementalSmlMerkle cache;
+
+    // Cold build via the full path — examines all N once (unavoidable seed cost).
+    const uint64_t ex0 = sml_leaves_examined_count();
+    cache.update(entries_of());
+    EXPECT_EQ(sml_leaves_examined_count() - ex0, static_cast<uint64_t>(N))
+        << "cold build examines the whole set once";
+
+    // Mutate three leaves in place — value-only (confirmedHash / isValid), the
+    // set unchanged. This is the shape of a real change block.
+    state[10].confirmedHash = incmerkle_protx_of(900010);
+    state[20].isValid       = false;
+    state[30].confirmedHash = incmerkle_protx_of(900030);
+    const std::vector<CSimplifiedMNListEntry> changed =
+        { state[10], state[20], state[30] };
+
+    // (b) THE FULL PATH — what #1297 shipped — examines the WHOLE set again.
+    IncrementalSmlMerkle full_cache;
+    full_cache.update(entries_of());                 // its own cold build
+    const uint64_t exf0 = sml_leaves_examined_count();
+    const uint256 r_full = full_cache.update(entries_of());
+    const uint64_t full_examined = sml_leaves_examined_count() - exf0;
+    EXPECT_EQ(full_examined, static_cast<uint64_t>(N))
+        << "the shipped full path re-examines every leaf every block";
+
+    // (b) THE DELTA PATH examines ONLY the three changed leaves.
+    const uint64_t exd0 = sml_leaves_examined_count();
+    const std::optional<uint256> r_delta = cache.apply_value_changes(changed);
+    const uint64_t delta_examined = sml_leaves_examined_count() - exd0;
+    ASSERT_TRUE(r_delta.has_value()) << "a same-set value change must apply";
+    EXPECT_EQ(delta_examined, 3u) << "delta examines exactly the k changed leaves";
+    EXPECT_LT(delta_examined * 50, full_examined) << "O(k), not O(n)";
+
+    // (a) THE HARD INVARIANT — delta root == naive full recompute == full path.
+    const uint256 r_naive = CSimplifiedMNList(entries_of()).CalcMerkleRoot();
+    EXPECT_EQ(r_delta->GetHex(), r_naive.GetHex())
+        << "delta root diverged from the naive recompute — reward-path hazard";
+    EXPECT_EQ(r_full.GetHex(), r_naive.GetHex());
+
+    // FAIL-SAFE: a key not present ⇒ nullopt, so the fold falls back to the full
+    // rebuild and the self-check root is never approximate when the SET changed.
+    const std::vector<CSimplifiedMNListEntry> absent = { incmerkle_mk_entry(99999) };
+    EXPECT_FALSE(cache.apply_value_changes(absent).has_value())
+        << "an absent key must bail to the full-rebuild fallback";
 }


### PR DESCRIPTION
## #154 dashd-cut blocker: replay/cold-start speed to dashd-parity

**Root cause (CODE, decisive):** `compute_sml_root_incremental()` re-materialized the whole ~4900-entry SML from the MN map **every block** and fed `IncrementalSmlMerkle::update()`, which re-sorted + full-diffed + reallocated the entire leaf cache **every block** — even on the payment-rotation majority that change nothing in the SML. Measured ~1 blk/s (CPU-bound), the ~500x replay regression that gated the daemonless cold-start.

**Fix — port dashd's cache invariance.** dashd's `CalcCbTxMerkleRootMNList` (simplifiedmns.cpp) does a **cached full-recompute**: a single-slot cache returns the root with zero work when the SML projection is unchanged, and `CDeterministicMNList::UpdateMN` invalidates the SML cache **only if `to_sml_entry()` actually changed** (`to_sml_entry` carries no per-block-rotating field). This PR ports that invariance: the fold records which MNs a block mutated and drives a resident sorted cache —
- **quiet block** (no SML-relevant change) → return cached root, zero materialise/sort/diff/hash (this is the dashd port; it kills the regression);
- **value-only change** → `apply_value_changes()` patches just the k touched leaves in place, O(k) (a fenced optimization beyond dashd);
- **leaf-set change / cold fold** → the existing full rebuild (rare).

**Reward-safety (perf-only, fails closed).** `compute_sml_root()` stays the naive oracle; the block's committed cbTx `merkleRootMNList` byte-compare remains the final authority (mismatch → poison + reseed); `apply_value_changes()` returns `nullopt` on any doubt → caller falls back to full rebuild. A missed dirty-mark can only make the incremental root **disagree** (caught) — never silently serve a wrong root. Consensus output byte-identical; `--embedded-fold-checkscripts` untouched.

**Tests:** delta root byte-identical to an independently-constructed `CSimplifiedMNList::CalcMerkleRoot()` (real dashd naive path), examines k=3 vs n=300; random-walk fuzz matches naive; 4 real mainnet bodies byte-exact; `test_dash_mn_state` 129 passed / 1 skipped (corpus-gated). Independently adversarially verified: SAFE-TO-MERGE, no hole.