### PR TITLE
dash(sharechain): switch mainnet to c2pool's own sharechain identity

### DIFF
--- a/src/impl/dash/config_pool.hpp
+++ b/src/impl/dash/config_pool.hpp
@@ -80,8 +80,14 @@ struct SharechainConfig
     static uint32_t real_chain_length() { return is_testnet ? TESTNET_REAL_CHAIN_LENGTH : REAL_CHAIN_LENGTH; }
 
     // ISOLATION PRIMITIVES — per-coin AND per-instance, never unified cross-coin.
-    static inline const std::string IDENTIFIER_HEX         = "7242ef345e1bed6b";
-    static inline const std::string PREFIX_HEX             = "3b3e1286f446b891";
+    // 2026-08-25: c2pool moved to its OWN sharechain identity, distinct from the inherited legacy
+    // p2pool-dash chain. Identifier + prefix are the sharechain's network isolation keys — nodes
+    // with different values form disjoint sharechains and reject each other, so this cleanly
+    // separates the c2pool sharechain from the old p2pool one. Old values kept commented below.
+    //   OLD (legacy p2pool-dash identity):
+    //     IDENTIFIER_HEX = "7242ef345e1bed6b";  PREFIX_HEX = "3b3e1286f446b891";
+    static inline const std::string IDENTIFIER_HEX         = "ac2785363c0180b8";  // c2pool sharechain
+    static inline const std::string PREFIX_HEX             = "8d8516bac9edd280";  // c2pool sharechain
     static inline const std::string TESTNET_IDENTIFIER_HEX = "b6deb1e543fe2427";
     static inline const std::string TESTNET_PREFIX_HEX     = "198b644f6821e3b3";
 

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -1314,8 +1314,10 @@ TEST(DashConformanceNetworkParams, MainnetMatchesP2poolDashOracle) {
     EXPECT_EQ(dash::SharechainConfig::TARGET_LOOKBEHIND, 100u);
     EXPECT_EQ(dash::SharechainConfig::SPREAD, 10u);
     EXPECT_EQ(dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION, 1700u);
-    EXPECT_EQ(dash::SharechainConfig::identifier_hex(), std::string("7242ef345e1bed6b"));
-    EXPECT_EQ(dash::SharechainConfig::prefix_hex(),     std::string("3b3e1286f446b891"));
+    // 2026-08-25: mainnet uses c2pool's OWN sharechain identity (distinct from the legacy p2pool-dash
+    // chain). Testnet (below) still tracks the p2pool oracle. Old p2pool: 7242ef345e1bed6b / 3b3e1286f446b891.
+    EXPECT_EQ(dash::SharechainConfig::identifier_hex(), std::string("ac2785363c0180b8"));
+    EXPECT_EQ(dash::SharechainConfig::prefix_hex(),     std::string("8d8516bac9edd280"));
     uint256 expect_max;
     expect_max.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
     EXPECT_EQ(dash::SharechainConfig::max_target(), expect_max);    // 0xFFFF * 2**208

--- a/test/test_dash_poolnode_messages.cpp
+++ b/test/test_dash_poolnode_messages.cpp
@@ -202,7 +202,7 @@ TEST(DashConnectModePrefix, WirePrefix_NetAware_MainnetVsTestnet) {
     const bool saved = SharechainConfig::is_testnet;
 
     SharechainConfig::is_testnet = false;
-    EXPECT_EQ(SharechainConfig::prefix_hex(), std::string("3b3e1286f446b891"));
+    EXPECT_EQ(SharechainConfig::prefix_hex(), std::string("8d8516bac9edd280"));  // c2pool mainnet chain (was p2pool 3b3e1286f446b891)
     auto main_bytes = ParseHexBytes(SharechainConfig::prefix_hex());
     EXPECT_EQ(main_bytes.size(), size_t(8));
 

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -518,7 +518,7 @@ ProspectiveShareInfo fixture_f1_info() {
 }
 
 const char* F1_REF_STREAM_HEX =
-    "7242ef345e1bed6b"                                                  // IDENTIFIER
+    "ac2785363c0180b8"                                                  // IDENTIFIER
     "0000000000000000000000000000000000000000000000000000000000000000"  // prev None
     "0403010203"                                                        // coinbase VarStr
     "00"                                                                // inner payload None
@@ -539,7 +539,7 @@ const char* F1_REF_STREAM_HEX =
     "01000100010000000000000000000000";                                 // abswork LE (128)
 
 const char* F1_REF_HASH_HEX =
-    "ae9fd236e3de3647ce76bf2eb3172ad0ec51d3edba4b231b4b1e2d204771880b";
+    "6b97d93ff3b1adad8f4c4d1c0f2fb3cd99ee3ab92a90dd1f83c4faa1a9eaca7e";
 
 const char* F1_GENTX_HEX =
     "01000000"                                                          // version 1, type 0
@@ -550,12 +550,12 @@ const char* F1_GENTX_HEX =
     "00e1f50500000000" "066a04deadbeef"                                 // payment 100000000
     "00725d1700000000" "1976a91420cb5c22b1e4d5947e5c112c7696b51ad9af3c6188ac"  // donation 392000000
     "0000000000000000" "2a6a28"
-    "ae9fd236e3de3647ce76bf2eb3172ad0ec51d3edba4b231b4b1e2d204771880b"  // ref_hash
+    "6b97d93ff3b1adad8f4c4d1c0f2fb3cd99ee3ab92a90dd1f83c4faa1a9eaca7e"  // ref_hash
     "0102030405060708"                                                  // last_txout_nonce LE
     "00000000";                                                         // locktime
 
 const char* F1_TXID_HEX =
-    "4cf27aa8726d1df1af549cf905e1b747288dcca9a418f15d052ad45cc0d0b9a0";
+    "616583dd0f352b49ef69f04f2b947362bd4d4a9e29a3e7a02654fa095d1e2821";
 
 constexpr uint64_t F1_NONCE64 = 0x0807060504030201ull;
 
@@ -618,14 +618,14 @@ TEST(DashShareProducerGentx, F2PayloadGolden) {
 
     const uint256 ref_hash = dash::producer::compute_ref_hash(params, info);
     EXPECT_EQ(hex_of(ref_hash),
-              "e5efc58b08be49d7bc03b6f1731114d84068346817017465ce07e46c516196e1");
+              "011b11d0b71be8ab58e2c0bc10c0d0af5ca07a129d2a5879ce695c3db99056b9");
 
     auto gentx = dash::producer::build_gentx(
         info, dash::producer::CumulativeWeights{}, ref_hash, F1_NONCE64, params);
     EXPECT_EQ(gentx.bytes.size(), 194u);
     EXPECT_EQ(gentx.prefix_len, 145u);          // len - 5 (VarStr payload) - 44
     EXPECT_EQ(hex_of(gentx.txid),
-              "6835d59cfe4c564b06dc55b3d235fe201869a3aca3c1368eb295a831e8e36239");
+              "cd230eda4487e566d1ea587ff90eee094ef68672ff6c7a1348d92cfe394a68ea");
     // version int16 / type int16 (dash/data.py:97-98) + payload tail.
     ASSERT_GE(gentx.bytes.size(), 5u);
     EXPECT_EQ(gentx.bytes[0], 0x03); EXPECT_EQ(gentx.bytes[1], 0x00);


### PR DESCRIPTION
c2pool moves its DASH sharechain to its **own** network identity, distinct from the inherited legacy p2pool-dash chain. The identifier + prefix are the sharechain's network isolation keys — nodes with different values form disjoint sharechains and reject each other, cleanly separating the c2pool sharechain from the old p2pool one.

```
identifier: 7242ef345e1bed6b -> ac2785363c0180b8
prefix:     3b3e1286f446b891 -> 8d8516bac9edd280
```

- Old p2pool values kept **commented** in `config_pool.hpp` for provenance.
- **Testnet identity unchanged** (still tracks the p2pool oracle).
- Conformance (`test_dash_conformance`) + wire-prefix (`test_dash_poolnode_messages`) mainnet pins updated to the new values.
- Nodes on the new identity form the c2pool sharechain; old-chain nodes are cleanly separated.