### PR TITLE
ci: per-binary zero-test floor (--no-tests=error) on every ctest leg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,9 @@ jobs:
       - name: Boost sentinel
         run: |
           cmake --build build_ci --target boost_sentinel -j8
-          ctest --test-dir build_ci -R '^boost_sentinel$' --output-on-failure
+          # --no-tests=error: the sentinel must actually RUN; if the target
+          # ever fails to register, an empty selection cannot pass as green.
+          ctest --test-dir build_ci -R '^boost_sentinel$' --output-on-failure --no-tests=error
 
       - name: Build
         # shell: bash => bash -o pipefail. WITHOUT it the default shell is
@@ -618,7 +620,10 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=0:check_initialization_order=1:strict_string_checks=1:abort_on_error=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
-        run: ctest --output-on-failure -j8 --exclude-regex "LiveTest\."
+        # --no-tests=error: per-binary zero-test floor. If the exclude ever
+        # swallows every case (or the tests fail to register), ctest REDs
+        # instead of greening over an empty run.
+        run: ctest --output-on-failure --no-tests=error -j8 --exclude-regex "LiveTest\."
 
       - name: Upload sanitizer test results on failure
         if: failure()
@@ -789,7 +794,10 @@ jobs:
 
       - name: Run BCH tests
         working-directory: build_bch
-        run: ctest --output-on-failure -j8 -R "^bch_"
+        # --no-tests=error: per-binary zero-test floor. A `-R "^bch_"` that
+        # selects nothing (targets renamed / failed to register) must RED,
+        # not green over an empty selection.
+        run: ctest --output-on-failure --no-tests=error -j8 -R "^bch_"
 
       - name: Upload test results on failure
         if: failure()
@@ -944,7 +952,10 @@ jobs:
         env:
           ASAN_OPTIONS: detect_leaks=0:check_initialization_order=1:strict_string_checks=1:abort_on_error=0
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=0
-        run: ctest --output-on-failure -j8 -R "^bch_"
+        # --no-tests=error: per-binary zero-test floor. A `-R "^bch_"` that
+        # selects nothing (targets renamed / failed to register) must RED,
+        # not green over an empty selection.
+        run: ctest --output-on-failure --no-tests=error -j8 -R "^bch_"
 
       - name: Upload sanitizer test results on failure
         if: failure()
@@ -1757,7 +1768,10 @@ jobs:
 
       - name: Run BLS KATs
         working-directory: build_dash_bls
-        run: ctest --output-on-failure -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS|DashChainLockVerify|DashIsdlockBls'
+        # --no-tests=error: per-binary zero-test floor. These KATs live behind
+        # #ifdef C2POOL_DASH_BLS, so a stub build makes the selector match zero
+        # -- RED here, belt to the explicit per-name assertion in the next step.
+        run: ctest --output-on-failure --no-tests=error -j8 -R 'DashBlsVerify|DashQuorumMembers|DashQuorumMemberSource|DashGovVoteBLS|DashChainLockVerify|DashIsdlockBls'
 
       # LEG 3: the BLS-ONLY cases actually ran. Each of these is inside
       # #ifdef C2POOL_DASH_BLS, so on a stub build they do not fail -- they


### PR DESCRIPTION
## Problem
The zero-test floor (a build that runs **0 tests must fail**, not fake-green) was enforced on only the primary `linux` leg — `scripts/ci/test_floor_guard.sh` + `--no-tests=error` on its `ctest`. Every **other per-binary test leg** ran a bare `ctest` with a `-R`/exclude selector and **no floor**. A selector that matches zero cases — targets renamed, failed to register, or compiled out behind an `#ifdef` — makes `ctest` exit 0, and the leg greens over an empty run. This is the exact hollow-green shape the repo has been bitten by before (unregistered KAT ⇒ 0 selected ⇒ green).

## Fix
Add `--no-tests=error` to every per-binary `ctest` invocation that runs tests:

| leg | selector | was |
|---|---|---|
| `linux-asan` | `--exclude-regex "LiveTest\."` | bare |
| `coin-bch` | `-R "^bch_"` | bare |
| `coin-bch-asan` | `-R "^bch_"` | bare |
| `linux-dash-bls` | `-R 'DashBlsVerify\|...'` (KATs behind `#ifdef C2POOL_DASH_BLS`) | bare |
| Boost sentinel | `-R '^boost_sentinel$'` | bare |

Now each leg **REDs** on a zero-test selection instead of greening.

## Safety
- **CI-config only**; no consensus/source code touched.
- **Strictly additive**: `--no-tests=error` changes behavior *only* when a leg would otherwise green over zero tests. Every leg here currently runs real tests, so green CI stays green.
- The `linux-dash-bls` leg keeps its explicit per-name "reported as run" assertion — this flag is the suspenders under that belt.
- `coin-dgb-auxdoge` is unchanged: it runs a `--help` smoke, not `ctest`, so there is no test run to floor.

Draft: ci-steward tracks. Complements the existing `test-floor-guard-honesty` tripwire, which proves the *guard* catches an empty junit; this PR makes the *runner itself* fail-loud on every binary.