### PR TITLE
dash(dashboard): emit fork_switch on delta resync — explorer shares stop fading by age (#112)

### DIFF
--- a/src/impl/dash/dashboard_views.hpp
+++ b/src/impl/dash/dashboard_views.hpp
@@ -243,6 +243,19 @@ inline nlohmann::json build_window(TrackerT& tracker, const ViewContext& ctx)
 // ── Delta ───────────────────────────────────────────────────────────────────
 // Only the shares NEWER than `since_hash` (which the client already holds),
 // capped at ctx.delta_max_shares. Port of main_ltc.cpp:3946.
+//
+// FORK-SWITCH RESYNC (explorer SSE fade-by-age, task #112). The walk starts at
+// the current tallest head and stops when it reaches `since_hash`, the client's
+// held tip. When `since_hash` is NON-EMPTY yet the walk NEVER reaches it — the
+// client's tip was orphaned by a share-chain reorg, or the client fell more than
+// one window behind — the returned shares do NOT connect onto the client window.
+// The client (delta.ts §5.3 / realtime.ts applyDelta) already knows how to
+// handle this: `fork_switch:true` drops the stale window and rebuilds from the
+// authoritative set. The server simply never emitted the flag, so the client
+// instead prepended-and-deduped, keeping the orphaned shares forever while the
+// combined length crept past its cap — silently evicting the OLDEST good shares
+// and making them "fade out by age". Emitting the flag closes that hole. An
+// empty `since_hash` (cold client) is a legitimate full walk, never a fork.
 template <typename TrackerT>
 inline nlohmann::json build_delta(TrackerT& tracker, const std::string& since_hash,
                                   const ViewContext& ctx)
@@ -257,6 +270,7 @@ inline nlohmann::json build_delta(TrackerT& tracker, const std::string& since_ha
 
     nlohmann::json shares_arr = nlohmann::json::array();
     int count = 0;
+    bool found_since = false;
 
     if (!best.IsNull()) {
         const int walk = std::min(static_cast<int>(chain.get_height(best)),
@@ -266,8 +280,10 @@ inline nlohmann::json build_delta(TrackerT& tracker, const std::string& since_ha
                 (void)data;
                 const std::string full  = hash.GetHex();
                 const std::string short_h = full.substr(0, 16);
-                if (short_h == since_hash || full == since_hash)
+                if (short_h == since_hash || full == since_hash) {
+                    found_since = true;
                     break;   // reached what the client already has
+                }
                 shares_arr.push_back(share_cell(chain, verified, hash, count, ctx));
                 if (++count >= ctx.delta_max_shares) break;
             }
@@ -276,15 +292,21 @@ inline nlohmann::json build_delta(TrackerT& tracker, const std::string& since_ha
         }
     }
 
+    // The client held a tip we could not re-derive from the current best chain:
+    // signal a resync rather than let it splice a disconnected delta.
+    const bool fork_switch =
+        !since_hash.empty() && !best.IsNull() && !found_since;
+
     nlohmann::json blocks_arr = nlohmann::json::array();
     for (const auto& sh : ctx.found_block_short_hashes)
         blocks_arr.push_back(sh);
 
-    result["shares"] = std::move(shares_arr);
-    result["count"]  = count;
-    result["tip"]    = best.IsNull() ? "" : best.GetHex().substr(0, 16);
-    result["heads"]  = heads_array(chain);
-    result["blocks"] = std::move(blocks_arr);
+    result["shares"]      = std::move(shares_arr);
+    result["count"]       = count;
+    result["tip"]         = best.IsNull() ? "" : best.GetHex().substr(0, 16);
+    result["heads"]       = heads_array(chain);
+    result["blocks"]      = std::move(blocks_arr);
+    result["fork_switch"] = fork_switch;
     return result;
 }
 

--- a/test/test_dash_dashboard_views.cpp
+++ b/test/test_dash_dashboard_views.cpp
@@ -263,6 +263,40 @@ TEST(DashDashboardViews, DeltaHonoursItsSafetyCap)
     EXPECT_EQ(d["shares"].size(), 5u);
 }
 
+// ── KAT 4b: a `since` the walk can't re-derive resyncs, not silently drifts ──
+// Explorer SSE fade-by-age (task #112). When the client's held tip is orphaned
+// by a reorg (or the client is more than a window behind), walking back from the
+// current best never reaches `since_hash`. Emitting fork_switch tells the client
+// to rebuild from the authoritative set; without it the client spliced a
+// disconnected delta, kept the orphaned shares, and evicted good ones by cap.
+TEST(DashDashboardViews, DeltaSignalsForkSwitchWhenSinceIsNotOnTheBestChain)
+{
+    ChainHarness h(12);
+    auto ctx = h.ctx();
+
+    // Normal cases carry the flag explicitly false — never a spurious resync.
+    auto at_tip = dash::dashboard::build_delta(h.node.tracker(),
+                                               h.tip.GetHex().substr(0, 16), ctx);
+    ASSERT_TRUE(at_tip.contains("fork_switch"));
+    EXPECT_FALSE(at_tip["fork_switch"].get<bool>());
+
+    const std::string behind = view_hash(8).GetHex().substr(0, 16);
+    auto d_behind = dash::dashboard::build_delta(h.node.tracker(), behind, ctx);
+    EXPECT_FALSE(d_behind["fork_switch"].get<bool>());
+
+    // Cold client (empty since) is a legitimate full walk, not a fork.
+    auto cold = dash::dashboard::build_delta(h.node.tracker(), "", ctx);
+    EXPECT_FALSE(cold["fork_switch"].get<bool>());
+
+    // An orphaned / unknown tip the chain has never held -> resync. The walk
+    // still returns the current window so the client can rebuild from it.
+    const std::string orphan = view_hash(0x777).GetHex().substr(0, 16);
+    auto d_fork = dash::dashboard::build_delta(h.node.tracker(), orphan, ctx);
+    EXPECT_TRUE(d_fork["fork_switch"].get<bool>());
+    EXPECT_EQ(d_fork["count"].get<int>(), 12);
+    EXPECT_EQ(d_fork["shares"].size(), 12u);
+}
+
 // ── KAT 5: the individual share page ────────────────────────────────────────
 TEST(DashDashboardViews, ShareDetailAnswersForAShareInTheTracker)
 {


### PR DESCRIPTION
## Problem (integrator task #112)

Shares fade out of the sharechain explorer **by age** — the evicted set is wrong.

## Root cause

The explorer client (`web-static/sharechain-explorer/src/explorer/delta.ts` §5.3 + `realtime.ts` `applyDelta`) fully implements a **`fork_switch` resync**: on `fork_switch: true` it drops the stale window and rebuilds from the authoritative set. **The server's `build_delta` never emitted the flag.**

`build_delta` walks back from the current tallest head and stops when it reaches `since_hash` (the client's held tip). On a **sharechain reorg** — or when a client falls more than one window behind — `since_hash` is orphaned, so the walk never reaches it and the returned shares do **not** connect onto the client window. With no `fork_switch` signal, the client prepended-and-deduped them, kept the orphaned shares forever, and let the combined length creep past its cap — silently **evicting the oldest good shares**. That is the fade-by-age symptom.

## Fix

Emit `fork_switch: true` when `since_hash` is non-empty yet not re-derivable from the current best chain. An empty `since_hash` (cold client) is a legitimate full walk and never a fork — asserted explicitly.

- **Scope:** `src/impl/dash/dashboard_views.hpp` `build_delta` only (DASH).
- **Display-only / consensus-neutral:** the builder reads an already-locked tracker; nothing touches mint / payout / target / submission (empty diff-grep).
- **Test:** new binding KAT `DeltaSignalsForkSwitchWhenSinceIsNotOnTheBestChain`; asserts the flag is explicitly `false` on the at-tip / behind / cold paths. Full `DashDashboardViews.*` suite green (9/9) locally.

## Notes

- **Hotel redeploy required** to take effect — the served frontend already handles `fork_switch`; this is the server half that was missing. Version-coupled; coordinate with prod stewards.
- **LTC latent gap:** `main_ltc.cpp:3946` has the identical missing-`fork_switch` pattern. Left for a follow-up to keep this PR reward-safe and single-purpose.