### PR TITLE
dash(dashboard): derive pool hashrate from sharechain shares (populate graph with 0 local miners)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -60,6 +60,7 @@
 #include <impl/dash/coin/coin_peer_manager.hpp> // dash::coin::DashCoinPeerManager — DASH-ISOLATED scored/diverse peer discovery (--coin-p2p-discover; network-standalone gate)
 #include <impl/dash/coin/chain_seeds.hpp>  // dash::coin::dash_dns_seeds / dash_fixed_seeds — DASH mainnet/testnet seed bootstrap
 #include <impl/dash/coin/won_block_dispatch.hpp> // dash::coin::broadcast_won_block — S8 dual-path won-block dispatcher (embedded P2P primary + submitblock RPC backup)
+#include <impl/dash/coin/pool_rate_head_select.hpp> // dash::select_pool_rate_head — dashboard pool-rate head selection (verified head, else tallest raw head; zero-local-miner graph fix)
 #include <impl/dash/coin/reconstruct_won_block.hpp> // dash::coin::reconstruct_won_block — distributed won-block: rebuild full block from a won share for re-broadcast
 #include <impl/dash/coin/zmq_tip_notify.hpp> // dash::coin::TipHashDedup / ZmqHashblockSubscriber — dashd ZMQ hashblock INSTANT tip-notify (opt-in, hardening on the #770 poll)
 #include <impl/dash/coin/coin_p2p_magic.hpp>      // dash::coin::select_coin_p2p_magic — E5 --coin-p2p-magic override (regtest ARM A dial)
@@ -1826,11 +1827,50 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // m_pool_hashrate_fn is read exclusively by web_server REST handlers.
             mi->set_pool_hashrate_fn([node_ptr]() -> double {
                 static double s_last_good = 0.0;
+                // Verified best-share head, queried WITHOUT the tracker guard
+                // held: best_share_hash()/elect_best_share takes the tracker
+                // lock itself, so nesting it under read_tracker() would
+                // recursively shared-lock the same mutex.
                 auto best = node_ptr->best_share_hash();
-                if (best.IsNull()) return s_last_good;
                 auto guard = node_ptr->read_tracker();
                 if (!guard) return s_last_good;
-                if (!guard->chain.contains(best)) return s_last_good;
+                // ── ZERO-LOCAL-MINER / BOOTSTRAP FALLBACK ─────────────────
+                // With no local mint the VERIFIED chain has no heads, so
+                // best_share_hash() is null even though peers have filled the
+                // RAW sharechain (the contabo / dash.voidbind.com relay case:
+                // a node carrying the whole pool's shares but running zero
+                // rigs). p2pool's pool-rate graph is fed unconditionally from
+                // the tracker every 5s regardless of local miners (web.py
+                // add_point / get_stale_counts), so mirror that: when there is
+                // no verified head, derive the pool hashrate from the tallest
+                // RAW chain head. This makes the pool-rate graph reflect the
+                // whole sharechain's hashing effort instead of reading 0.
+                //
+                // Display-only: m_pool_hashrate_fn is read exclusively by the
+                // web_server REST handlers (pool_hash_rate / pool_rates series
+                // and /global_stats). The vardiff retarget runs on the VERIFIED
+                // chain over TARGET_LOOKBEHIND (data.py:137,140) and never
+                // reads this hook, so consensus/reward are untouched.
+                //
+                // Head selection is the pure dash::select_pool_rate_head SSOT
+                // (coin/pool_rate_head_select.hpp, KAT test_dash_pool_rate_head_select):
+                // verified head verbatim when present, else the tallest raw head.
+                const bool best_in_chain =
+                    !best.IsNull() && guard->chain.contains(best);
+                if (!best_in_chain) {
+                    std::vector<dash::RawChainHead> raw_heads;
+                    for (const auto& [head_hash, tail_hash] :
+                             guard->chain.get_heads()) {
+                        (void)tail_hash;
+                        raw_heads.push_back(
+                            {head_hash, static_cast<int32_t>(
+                                            guard->chain.get_height(head_hash))});
+                    }
+                    best = dash::select_pool_rate_head(uint256::ZERO, false,
+                                                       raw_heads);
+                }
+                if (best.IsNull() || !guard->chain.contains(best))
+                    return s_last_good;
                 int height = guard->chain.get_height(best);
                 if (height < 3) return s_last_good;
                 const int display_lookbehind =

--- a/src/impl/dash/coin/pool_rate_head_select.hpp
+++ b/src/impl/dash/coin/pool_rate_head_select.hpp
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// SSOT for the DASH DASHBOARD POOL-RATE HEAD SELECTION -- the pure decision of
+// WHICH sharechain head the pool-hashrate estimator runs over when the dashboard
+// samples it.
+//
+// The estimator itself (ShareTracker::get_pool_attempts_per_second) is
+// unchanged: it sums the per-share work over a window and divides by the window
+// timespan -- p2pool data.py get_pool_attempts_per_second. What THIS header
+// fixes is the head it is anchored to.
+//
+// PROBLEM (contabo / dash.voidbind.com bootstrap): the dashboard hook previously
+// anchored the estimator on best_share_hash() -- the VERIFIED best-share head,
+// elected only over tracker.verified. On a node running ZERO local rigs the
+// verified chain has no heads (local mint is the only thing that seeds a verified
+// head), so best_share_hash() is null and the estimator short-circuits to 0. The
+// pool-rate graph then reads flat-zero even though peers have filled the RAW
+// sharechain with the whole pool's shares.
+//
+// p2pool has no such gate: web.py add_point() feeds the pool-rate graph every 5s
+// straight off tracker.get_height(best_share) / get_stale_counts over the shared
+// chain, independent of any local miner. This header restores that behaviour for
+// c2pool's dashboard: prefer the verified best-share head (unchanged when local
+// mining seeds it), and when it is absent fall back to the tallest RAW chain
+// head -- the same raw-head-by-height rule node.hpp advertised_best_share() uses
+// for its pre-sync head advert.
+//
+// Consensus/reward-NEUTRAL: the value produced here feeds ONLY the web_server
+// REST handlers (pool_hash_rate / pool_rates graph series and /global_stats).
+// The vardiff retarget runs on the VERIFIED chain over TARGET_LOOKBEHIND
+// (data.py:137,140) and never reads this hook. Display/data only.
+//
+// Pure function over already-collected inputs (the caller walks the tracker under
+// its read lock and hands the resolved verified head + the raw heads here), so a
+// KAT can pin the selection with no NodeImpl / ShareTracker / socket standup.
+// Per-coin isolation: dash/ only, header-only, additive.
+
+#include <cstdint>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace dash {
+
+// A raw sharechain head and its height, as read from ShareChain::get_heads() +
+// ShareChain::get_height() under the tracker read lock.
+struct RawChainHead {
+    uint256 hash;
+    int32_t height;
+};
+
+// Choose the sharechain head to anchor the dashboard pool-rate estimator on.
+//
+//   1. If the verified best-share head is present (non-null AND still in the
+//      chain), use it verbatim -- behaviour is UNCHANGED whenever local mining
+//      seeds a verified head.
+//   2. Otherwise (zero-local-miner bootstrap: no verified head), fall back to the
+//      tallest RAW chain head. Ties keep the FIRST head seen at the maximum
+//      height (strictly-greater comparison), mirroring node.hpp
+//      advertised_best_share()'s `if (h > best_height)` walk.
+//   3. If there are no raw heads either (empty tracker), return null -- the
+//      caller then holds the last-good value rather than publishing a spurious 0.
+inline uint256 select_pool_rate_head(const uint256& verified_best,
+                                     bool verified_best_in_chain,
+                                     const std::vector<RawChainHead>& raw_heads)
+{
+    if (!verified_best.IsNull() && verified_best_in_chain)
+        return verified_best;
+
+    uint256 best;              // null until a raw head is found
+    int32_t best_height = -1;
+    for (const auto& head : raw_heads) {
+        if (head.hash.IsNull())
+            continue;
+        if (head.height > best_height) {
+            best_height = head.height;
+            best = head.hash;
+        }
+    }
+    return best;
+}
+
+}  // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -341,7 +341,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     # weight ring buffer (compute_v36_weights), decay table, donation split,
     # window slides. PoW-independent consensus core; socket-free, chain-free.
     # Mirrors the test_dash_conformance link set.
-    add_executable(test_dash_share_tracker test_dash_share_tracker.cpp test_dash_share_remove_owns_data.cpp)
+    # test_dash_pool_rate_head_select.cpp: the dashboard pool-rate HEAD-SELECTION
+    # KAT (coin/pool_rate_head_select.hpp) -- verified best-share head verbatim
+    # when present, else the tallest RAW chain head so the pool-rate graph
+    # populates on a node running ZERO local miners (contabo/dash.voidbind.com
+    # bootstrap). FOLDED in as a second TU on this already-allowlisted target
+    # rather than a standalone executable: a fresh target would need a build.yml
+    # --target edit and would trip CI's NOT_BUILT sentinel until it had one
+    # (#143/#883/#893). Header-only pure function -- needs no extra link deps.
+    add_executable(test_dash_share_tracker test_dash_share_tracker.cpp test_dash_share_remove_owns_data.cpp test_dash_pool_rate_head_select.cpp)
     target_link_libraries(test_dash_share_tracker PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_pool_rate_head_select.cpp
+++ b/test/test_dash_pool_rate_head_select.cpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// dash::select_pool_rate_head -- dashboard pool-rate head-selection KAT.
+//
+// Pins coin/pool_rate_head_select.hpp: the pure decision of WHICH sharechain
+// head the dashboard pool-hashrate estimator anchors on. This is the load-
+// bearing new logic behind "populate the pool-rate graph with 0 local miners":
+// the estimator (get_pool_attempts_per_second) is unchanged; the fix is that
+// when the VERIFIED best-share head is absent (zero-local-miner bootstrap, the
+// contabo / dash.voidbind.com relay case) the estimator falls back to the
+// tallest RAW chain head instead of short-circuiting to 0.
+//
+// Oracle (mirrors node.hpp advertised_best_share()'s raw-head walk + p2pool
+// web.py add_point() feeding the graph off the shared chain regardless of any
+// local miner):
+//   1. verified head present (non-null AND in chain) -> use it verbatim
+//   2. else -> tallest raw head, ties keep first-seen at max (h > best_height)
+//   3. no raw heads -> null (caller holds last-good, never a spurious 0)
+//
+// All expectations are hand-derived from that oracle, not produced by calling
+// the helper under test, so the KAT is non-circular.
+//
+// FOLDED into the already-allowlisted test_dash_share_tracker target (a fresh
+// executable would need a build.yml --target edit and would otherwise trip CI's
+// NOT_BUILT sentinel, #143/#883/#893). The estimator arithmetic proper lives in
+// share_tracker.hpp; this header captures ONLY the head choice.
+
+#include <impl/dash/coin/pool_rate_head_select.hpp>
+
+#include <cstdio>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using dash::RawChainHead;
+using dash::select_pool_rate_head;
+
+// Distinct non-null test hashes: n encoded as a hex uint256.
+uint256 h(uint32_t n) {
+    char buf[9];
+    std::snprintf(buf, sizeof(buf), "%08x", n);
+    uint256 x;
+    x.SetHex(buf);
+    return x;
+}
+
+// ---- (1) verified head present -> used verbatim -------------------------
+
+TEST(DashPoolRateHead, VerifiedHeadUsedWhenPresent) {
+    // Verified head is non-null and in chain: returned as-is, raw heads ignored
+    // even if a raw head is taller.
+    std::vector<RawChainHead> raw = {{h(10), 500}, {h(11), 900}};
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/true, raw), h(7));
+}
+
+TEST(DashPoolRateHead, VerifiedHeadNotInChainTriggersFallback) {
+    // Non-null verified head but NOT in the chain (stale/pruned): fall back to
+    // the tallest raw head.
+    std::vector<RawChainHead> raw = {{h(10), 500}, {h(11), 900}};
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/false, raw), h(11));
+}
+
+// ---- (2) zero-local-miner fallback: tallest raw head --------------------
+
+TEST(DashPoolRateHead, NullVerifiedPicksTallestRawHead) {
+    // The bootstrap case: no verified head, peers filled the raw chain. Pick the
+    // tallest raw head (900 > 500 > 100).
+    std::vector<RawChainHead> raw = {{h(1), 100}, {h(2), 900}, {h(3), 500}};
+    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, raw), h(2));
+}
+
+TEST(DashPoolRateHead, TieKeepsFirstSeenAtMaxHeight) {
+    // Equal heights -> strictly-greater comparison keeps the FIRST at that max
+    // (h(5), not h(9)), matching advertised_best_share()'s walk.
+    std::vector<RawChainHead> raw = {{h(5), 800}, {h(9), 800}};
+    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, raw), h(5));
+}
+
+TEST(DashPoolRateHead, NullHashRawHeadsAreSkipped) {
+    // A null-hash raw head is not selectable even if it sorts "first".
+    std::vector<RawChainHead> raw = {{uint256::ZERO, 999}, {h(4), 300}};
+    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, raw), h(4));
+}
+
+// ---- (3) empty tracker -> null (caller holds last-good) -----------------
+
+TEST(DashPoolRateHead, NoHeadsReturnsNull) {
+    std::vector<RawChainHead> raw;
+    EXPECT_TRUE(select_pool_rate_head(uint256::ZERO, false, raw).IsNull());
+}
+
+TEST(DashPoolRateHead, NullVerifiedAndOnlyNullRawHeadsReturnsNull) {
+    std::vector<RawChainHead> raw = {{uint256::ZERO, 5}, {uint256::ZERO, 9}};
+    EXPECT_TRUE(select_pool_rate_head(uint256::ZERO, false, raw).IsNull());
+}
+
+}  // namespace


### PR DESCRIPTION
## Problem

The dashboard pool-rate hook (`m_pool_hashrate_fn`, `main_dash.cpp`) anchored the p2pool `get_pool_attempts_per_second` estimator on `best_share_hash()` — the **verified** best-share head, elected only over `tracker.verified`. On a node running **zero local rigs** the verified chain has no heads (local mint is the only thing that seeds a verified head), so the hook short-circuited to 0 and the `pool_hash_rate` / `pool_rates` graph series read flat-zero — even though peers had already filled the **raw** sharechain with the whole pool's shares.

This is exactly the contabo / **dash.voidbind.com** bootstrap case: a node carrying the entire pool's sharechain but running no miners of its own shows an empty pool-hashrate graph.

## Fix (mirror p2pool)

p2pool has no such gate: `web.py add_point()` feeds the pool-rate graph every 5 s straight off the shared tracker, independent of any local miner. This PR mirrors that: when there is no verified head, the estimator falls back to the **tallest raw chain head** — the same raw-head-by-height rule `node.hpp advertised_best_share()` already uses for its pre-sync head advert — and runs the **unchanged** `Σ target_to_average_attempts(share.target) / (t_near − t_far)` estimator over it.

Formula (unchanged, `ShareTracker::get_pool_attempts_per_second`):

```
pool_attempts_per_second = get_delta(near, far).work / max(1, ts[near] − ts[far])
                         = ( Σ_{shares in window} 2^256/(share.target+1) ) / Δt
```

window = last `min(height−1, 3600/SHARE_PERIOD)` shares (~180 on DASH). Only the **head** the window is anchored on changed; the arithmetic is identical.

Head selection is lifted into a pure SSOT `dash::select_pool_rate_head` (`src/impl/dash/coin/pool_rate_head_select.hpp`):
1. verified head present (non-null AND in chain) → used verbatim (**behaviour unchanged when local mining seeds a verified head**);
2. else → tallest raw head (ties keep first-seen at max height, matching `advertised_best_share`);
3. no raw heads → null (caller holds the last-good value, never a spurious 0).

## Scope / safety

- **Display/data only.** `m_pool_hashrate_fn` is read exclusively by the `web_server` REST handlers (`pool_hash_rate` / `pool_rates` graph series and `/global_stats`).
- The vardiff **retarget** runs on the **verified** chain over `TARGET_LOOKBEHIND` and never reads this hook — **consensus/reward paths untouched.**
- No mint/consensus code changed. DASH-scoped (`src/impl/dash/`, `src/c2pool/main_dash.cpp`).
- graph_data JSON shape unchanged: `[[ts, value, span, stddev], ...]`.

## Test

`test_dash_pool_rate_head_select.cpp` — 7 oracle-derived KAT cases for `select_pool_rate_head` (verified verbatim, stale-verified fallback, tallest-raw pick, tie keeps first, null-hash skip, empty→null). Folded into the already-allowlisted `test_dash_share_tracker` target (a fresh target would trip CI's `NOT_BUILT` sentinel).

## Build

The pure head-select header compiled clean at C++20 and a standalone driver exercising all KAT cases ran green (`ALL_PASS`). The `main_dash.cpp` wiring uses only accessors already exercised verbatim by `node.hpp advertised_best_share()` and the pre-existing lambda (`guard->chain.get_heads()/get_height()/contains()`). The full `main_dash.cpp` TU was not compiled in this environment (heavy cmake/boost/secp/gtest fetch).

**Draft** — not for merge; opened for review + CI.
