### PR TITLE
dash(dashboard): feed pool_rate graph sampler from sharechain head (non-zero with 0 local miners)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7046,7 +7046,16 @@ nlohmann::json MiningInterface::rest_web_graph_data(const std::string& source, c
             val["dead"] = 0.0;
             result.push_back({entry.time, val, bin_width, 0});
         }
-        else if (source == "pool_hash_rate") {
+        else if (source == "pool_hash_rate" || source == "pool_rate") {
+            // "pool_rate" (singular) is an alias of the "pool_hash_rate" scalar.
+            // Both emit entry.pool_hash_rate, which the periodic sampler
+            // (update_stat_log :7212) fills from m_pool_hashrate_fn -- on DASH
+            // the #1349 estimator that anchors on dash::select_pool_rate_head,
+            // so this series is NON-ZERO on a live node with 0 local miners
+            // (peers-filled raw sharechain). Without this branch the singular
+            // name fell through to the catch-all and fabricated a flat-zero
+            // line on ANY node in ANY state (instrument-lied), masquerading as
+            // a dead graph regardless of real pool hashrate.
             result.push_back({entry.time, entry.pool_hash_rate, bin_width, 0});
         }
         else if (source == "pool_stale_prop") {
@@ -7118,7 +7127,15 @@ nlohmann::json MiningInterface::rest_web_graph_data(const std::string& source, c
             result.push_back({entry.time, entry.share_difficulty, bin_width, 0});
         }
         else {
-            result.push_back({entry.time, 0.0, bin_width, 0});
+            // Honest-absent: an UNKNOWN source name emits NOTHING rather than a
+            // fabricated zero bucket. The old `push_back({time, 0.0, ...})` made
+            // every unrecognised series (e.g. a mistyped "pool_rate" before the
+            // alias above) return one all-zero point per stat_log entry, which
+            // reads identically to a genuinely dead graph on a healthy node --
+            // an instrument that cannot be distinguished from the failure it is
+            // meant to detect. Skipping yields an empty array the frontend
+            // renders as "no data" instead of a false flat-zero trend.
+            continue;
         }
     }
     return result;


### PR DESCRIPTION
## Summary

The pool-rate graph **sampler** is already correctly wired on master (#1349): the 60 s stat_log timer (`WebServer::start`) calls `update_stat_log()` **unconditionally** -- no local-miner gate, no arm gate -- and that writer fills `entry.pool_hash_rate` from `m_pool_hashrate_fn` (`web_server.cpp:7212`). On DASH that callback is the estimator that anchors on `dash::select_pool_rate_head` (`impl/dash/coin/pool_rate_head_select.hpp`): the verified best-share head when present, else the tallest **raw** chain head. So on a live node running **zero local rigs** (the contabo / dash.voidbind.com relay case -- peers filled the raw sharechain but there is no verified head) the sampled value is the whole pool's hashing effort, not 0. This mirrors p2pool `web.py add_point()`, which feeds the graph off the shared tracker every 5 s regardless of any local miner.

What was still broken was the **reader**, not the sampler.

`rest_web_graph_data()` recognises `pool_rates` (plural dict series `{good,orphan,dead}`) and `pool_hash_rate` (scalar), but the singular `pool_rate` matched **no branch** and fell into the catch-all `else`, which did `push_back({time, 0.0, ...})` -- fabricating one all-zero bucket per stat_log entry. That reads **identically to a genuinely dead graph on any node in any state** (it would read zero even on a fully healthy node with miners), so an invalid/mistyped source name masqueraded as a dead graph and hid the real, non-zero head-derived rate the sampler was already producing.

## Changes (display/data-only -- no consensus/reward/mint path touched)

1. **Alias `pool_rate` (singular) to the `pool_hash_rate` scalar branch** so the singular name emits the real head-select-fed value instead of falling through to the zero-fabricating catch-all.
2. **Make the catch-all honest**: an unknown `source` now emits **nothing** (skip) instead of a fabricated zero bucket, so an invalid name can never again masquerade as a dead graph -- the frontend renders "no data" rather than a false flat-zero trend.

## Tests

The load-bearing head-selection logic is already pinned by the `test_dash_pool_rate_head_select` KAT (folded into `test_dash_share_tracker`, registered in `build.yml`): verified head verbatim when present, tallest raw head on the zero-local bootstrap, null (hold last-good) on an empty tracker. No new pure logic is introduced here (the reader change is source-name routing over the already-sampled `entry.pool_hash_rate`), so no KAT extension is warranted; the reader has no member-level test harness and standing one up would need a new build target that trips CI's NOT_BUILT sentinel.

The exact edited control-flow (alias branch + skip-on-unknown, using the real `nlohmann::json` 4-tuple push) was compiled and run in isolation: `pool_rate` returns byte-identical output to `pool_hash_rate`, and an unknown source returns `[]`.

## Deploy note

The live public node (contabo `90de50a9`) predates #1349, so even the correctly-named `pool_rates` series genuinely samples 0 there until it is redeployed with current master; `load_stat_log` also reloads pre-fix persisted entries with `phr=0` (no backfill), so history before a fixed-binary restart stays zero -- new non-zero points appear within ~70 s of restart.