### PR TITLE
Dashboard: persist found-blocks + hashrate history across restart (#159)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1303,6 +1303,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         rec.check_count = blk.check_count;
                         rec.confirmations = blk.confirmations;
                         rec.last_checked = static_cast<uint64_t>(std::time(nullptr));
+                        // #159: persist the dashboard-enrichment fields so a
+                        // restored row keeps miner/reward/difficulties/hashrate/
+                        // share-hash/authorship instead of a bare skeleton.
+                        rec.finder_address = blk.miner;
+                        rec.reward_satoshis = blk.subsidy;
+                        rec.network_difficulty = blk.network_difficulty;
+                        rec.share_difficulty = blk.share_difficulty;
+                        rec.pool_hashrate = blk.pool_hashrate;
+                        rec.share_hash = blk.share_hash;
+                        rec.authorship = static_cast<uint8_t>(blk.authorship);
                         return fblk_store->store(rec);
                     },
                     [fblk_store, fblk_leveldb]() -> std::vector<MI::FoundBlock> {
@@ -1318,6 +1328,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             blk.check_count = rec.check_count;
                             blk.chain = rec.chain;
                             blk.confirmations = rec.confirmations;
+                            // #159: restore enrichment (v1 records leave these at 0).
+                            blk.miner = rec.finder_address;
+                            blk.subsidy = rec.reward_satoshis;
+                            blk.network_difficulty = rec.network_difficulty;
+                            blk.share_difficulty = rec.share_difficulty;
+                            blk.pool_hashrate = rec.pool_hashrate;
+                            blk.share_hash = rec.share_hash;
+                            blk.authorship = static_cast<MI::BlockAuthorship>(rec.authorship);
                             result.push_back(std::move(blk));
                         }
                         return result;
@@ -8415,6 +8433,39 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                      "(daemonless header-chain verdict"
                   << (rpc ? " + dashd getblockheader fallback" : "")
                   << ")\n";
+
+        // #159 (G5): backfill network_difficulty + timestamp on restored found
+        // blocks from the embedded DASH header chain (parity with main_ltc.cpp).
+        // A v1 record — or any row recorded before the enrichment fields
+        // existed — carries network_difficulty=0, which is one of the two luck
+        // inputs; the exact value comes from the block header's nBits. Purely
+        // daemonless: reads only our own SPV header store, no dashd. Runs before
+        // the re-verify pass so the recomputed luck series uses the filled
+        // difficulty. backfill_block_fields internally re-derives the luck trend.
+        if (header_chain) {
+            auto* hc = header_chain.get();
+            cache_mi->backfill_block_fields(
+                [hc](const std::string& block_hash_hex) -> double {
+                    uint256 h;
+                    h.SetHex(block_hash_hex);
+                    auto e = hc->get_header(h);
+                    if (!e) return 0.0;
+                    return chain::target_to_difficulty(
+                        chain::bits_to_target(e->header.m_bits));
+                },
+                [hc](const std::string& block_hash_hex) -> uint32_t {
+                    uint256 h;
+                    h.SetHex(block_hash_hex);
+                    auto e = hc->get_header(h);
+                    return e ? e->header.m_timestamp : 0;
+                });
+        }
+
+        // #159 (G2): the verifier + io_context are now live, so drive a
+        // confirm/orphan pass over any found block that was still pending when
+        // this node last shut down. Without it a restored pending row never
+        // gets re-checked and stays "pending" on the dashboard forever.
+        cache_mi->reverify_pending_found_blocks();
     }
 
     // ════════════════════════════════════════════════════════════════════════

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -2024,6 +2024,15 @@ int main(int argc, char* argv[]) {
                             rec.check_count = blk.check_count;
                             rec.confirmations = blk.confirmations;
                             rec.last_checked = static_cast<uint64_t>(std::time(nullptr));
+                            // #159: persist dashboard-enrichment fields so a
+                            // restored row keeps its full detail after a restart.
+                            rec.finder_address = blk.miner;
+                            rec.reward_satoshis = blk.subsidy;
+                            rec.network_difficulty = blk.network_difficulty;
+                            rec.share_difficulty = blk.share_difficulty;
+                            rec.pool_hashrate = blk.pool_hashrate;
+                            rec.share_hash = blk.share_hash;
+                            rec.authorship = static_cast<uint8_t>(blk.authorship);
                             return fblk_store->store(rec);
                         },
                         [fblk_store, fblk_leveldb]() -> std::vector<MI::FoundBlock> {
@@ -2039,6 +2048,14 @@ int main(int argc, char* argv[]) {
                                 blk.check_count = rec.check_count;
                                 blk.chain = rec.chain;
                                 blk.confirmations = rec.confirmations;
+                                // #159: restore enrichment (v1 records => 0).
+                                blk.miner = rec.finder_address;
+                                blk.subsidy = rec.reward_satoshis;
+                                blk.network_difficulty = rec.network_difficulty;
+                                blk.share_difficulty = rec.share_difficulty;
+                                blk.pool_hashrate = rec.pool_hashrate;
+                                blk.share_hash = rec.share_hash;
+                                blk.authorship = static_cast<MI::BlockAuthorship>(rec.authorship);
                                 result.push_back(std::move(blk));
                             }
                             return result;
@@ -7131,6 +7148,12 @@ int main(int argc, char* argv[]) {
                         return entry ? entry->header.m_timestamp : 0;
                     });
             }
+
+            // #159 (G2): re-verify any found block that was still pending at the
+            // last shutdown. The verify callback + io_context are wired above,
+            // so a restored pending row now gets confirm/orphan checks instead
+            // of staying "pending" on the dashboard forever.
+            web_server.get_mining_interface()->reverify_pending_found_blocks();
 
             // Load persisted merged blocks into mm_manager BEFORE block scan.
             {

--- a/src/c2pool/storage/found_block_store.hpp
+++ b/src/c2pool/storage/found_block_store.hpp
@@ -26,13 +26,26 @@ struct FoundBlockRecord {
     std::string finder_address;     // miner who found the block (if known)
     uint64_t    reward_satoshis{0}; // coinbase reward amount (if known)
     uint256     the_state_root;     // THE commitment embedded in coinbase scriptSig
+    // --- v2 dashboard-enrichment fields (issue #159) ---
+    // Persisted from the in-memory FoundBlock so a restored row keeps its
+    // difficulties, pool hashrate, winning-share hash and authorship instead of
+    // decaying to a bare skeleton after a restart. Doubles are stored as their
+    // IEEE-754 bit pattern (uint64) to match the existing little-endian memcpy
+    // read path — no dependency on operator<< double serialization.
+    double      network_difficulty{0.0}; // network difficulty at time of find
+    double      share_difficulty{0.0};   // winning share difficulty
+    double      pool_hashrate{0.0};      // pool hashrate at time of find
+    std::string share_hash;              // hash of the share that found the block
+    uint8_t     authorship{0};           // BlockAuthorship: 0=unknown, 1=peer, 2=this node
 
     // Serialize to bytes for LevelDB storage
     std::vector<uint8_t> serialize() const
     {
         PackStream ps;
-        // Version byte for future extensibility
-        uint8_t version = 1;
+        // Version byte. v2 appends the enrichment tail after the v1 body; a v1
+        // reader stops at reward_satoshis and a v2 reader that meets a v1 record
+        // simply leaves the new fields at their defaults (read-compat).
+        uint8_t version = 2;
         ps << version;
         // Chain as length-prefixed string
         uint8_t chain_len = static_cast<uint8_t>(std::min(chain.size(), size_t(255)));
@@ -57,6 +70,21 @@ struct FoundBlockRecord {
             ps.write(std::span<const std::byte>(
                 reinterpret_cast<const std::byte*>(finder_address.data()), addr_len));
         ps << reward_satoshis;
+        // --- v2 tail ---
+        auto put_double = [&ps](double d) {
+            uint64_t bits;
+            std::memcpy(&bits, &d, sizeof(bits));
+            ps << bits;
+        };
+        put_double(network_difficulty);
+        put_double(share_difficulty);
+        put_double(pool_hashrate);
+        uint8_t sh_len = static_cast<uint8_t>(std::min(share_hash.size(), size_t(255)));
+        ps << sh_len;
+        if (sh_len > 0)
+            ps.write(std::span<const std::byte>(
+                reinterpret_cast<const std::byte*>(share_hash.data()), sh_len));
+        ps << authorship;
 
         auto span = ps.get_span();
         return {reinterpret_cast<const uint8_t*>(span.data()),
@@ -95,7 +123,7 @@ struct FoundBlockRecord {
         };
 
         uint8_t version = read_u8();
-        if (version != 1) return rec; // unknown version
+        if (version != 1 && version != 2) return rec; // unknown version
 
         uint8_t chain_len = read_u8();
         rec.chain = read_str(chain_len);
@@ -110,6 +138,25 @@ struct FoundBlockRecord {
         uint8_t addr_len = read_u8();
         rec.finder_address = read_str(addr_len);
         rec.reward_satoshis = read_u64();
+
+        // --- v2 enrichment tail (absent on v1 records) ---
+        // Every read is bounds-checked (read_* return 0/"" past end), so a
+        // truncated or partially-written v2 record degrades to defaults for the
+        // missing fields rather than throwing — load stays crash-safe.
+        if (version >= 2) {
+            auto get_double = [&]() -> double {
+                uint64_t bits = read_u64();
+                double d;
+                std::memcpy(&d, &bits, sizeof(d));
+                return d;
+            };
+            rec.network_difficulty = get_double();
+            rec.share_difficulty = get_double();
+            rec.pool_hashrate = get_double();
+            uint8_t sh_len = read_u8();
+            rec.share_hash = read_str(sh_len);
+            rec.authorship = read_u8();
+        }
 
         return rec;
     }

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3645,6 +3645,39 @@ void MiningInterface::set_found_block_persistence(block_store_fn_t persist_fn, b
     m_load_blocks_fn = std::move(load_fn);
 }
 
+void MiningInterface::recompute_found_block_luck_locked()
+{
+    // CALLER HOLDS m_blocks_mutex. Reconstruct the DERIVED fields
+    // (time_to_find, expected_time, luck) that record_found_block computes at
+    // record time but that are NOT persisted, so a restored history keeps its
+    // luck trend instead of emitting null for every row. Only fills fields
+    // still at 0 — never clobbers a value that is already present. Inputs that
+    // are genuinely unknown (e.g. a v1 record with pool_hashrate==0) leave luck
+    // at 0, which rest_luck_stats renders as null rather than a fabricated 0%.
+    // The list is kept sorted newest-first by height, so the previous (older)
+    // block on the same chain is the NEXT same-chain element.
+    for (size_t i = 0; i < m_found_blocks.size(); ++i) {
+        auto& blk = m_found_blocks[i];
+        if (blk.time_to_find <= 0.0) {
+            for (size_t j = i + 1; j < m_found_blocks.size(); ++j) {
+                if (m_found_blocks[j].chain == blk.chain) {
+                    blk.time_to_find = static_cast<double>(blk.ts)
+                                     - static_cast<double>(m_found_blocks[j].ts);
+                    break;
+                }
+            }
+        }
+        if (blk.expected_time <= 0.0 && blk.network_difficulty > 0.0
+            && blk.pool_hashrate > 0.0) {
+            blk.expected_time =
+                blk.network_difficulty * 4294967296.0 / blk.pool_hashrate;
+        }
+        if (blk.luck <= 0.0 && blk.time_to_find > 0.0 && blk.expected_time > 0.0) {
+            blk.luck = blk.expected_time / blk.time_to_find * 100.0;
+        }
+    }
+}
+
 void MiningInterface::load_persisted_found_blocks()
 {
     if (!m_load_blocks_fn) return;
@@ -3679,11 +3712,33 @@ void MiningInterface::load_persisted_found_blocks()
                 return a.ts > b.ts;
             });
 
+        // #159 (G3): reconstruct the derived luck series for the restored rows.
+        recompute_found_block_luck_locked();
+
         LOG_INFO << "[Pool] Loaded " << blocks.size() << " found blocks from persistent storage";
     }
     catch (const std::exception& e) {
         LOG_WARNING << "[Pool] Failed to load found blocks: " << e.what();
     }
+}
+
+void MiningInterface::reverify_pending_found_blocks()
+{
+    // Snapshot the pending hashes under the lock, then schedule outside it —
+    // schedule_block_verification takes m_blocks_mutex itself.
+    std::vector<std::string> pending;
+    {
+        std::lock_guard<std::mutex> lock(m_blocks_mutex);
+        for (const auto& blk : m_found_blocks) {
+            if (blk.status == BlockStatus::pending && !blk.hash.empty())
+                pending.push_back(blk.hash);
+        }
+    }
+    if (pending.empty()) return;
+    for (const auto& hash : pending)
+        schedule_block_verification(hash);
+    LOG_INFO << "[Pool] Scheduled re-verification for " << pending.size()
+             << " restored pending found block(s)";
 }
 
 void MiningInterface::backfill_block_fields(block_diff_lookup_fn diff_fn, block_ts_lookup_fn ts_fn)
@@ -3706,6 +3761,10 @@ void MiningInterface::backfill_block_fields(block_diff_lookup_fn diff_fn, block_
         LOG_INFO << "[Pool] Backfilled network_difficulty on " << diff_filled << " found block(s)";
     if (ts_filled > 0)
         LOG_INFO << "[Pool] Backfilled timestamp on " << ts_filled << " found block(s)";
+    // #159 (G3/G5): a backfilled network_difficulty or timestamp is an input to
+    // the luck series, so recompute the derived fields now that they are known.
+    if (diff_filled > 0 || ts_filled > 0)
+        recompute_found_block_luck_locked();
 }
 
 void MiningInterface::set_merged_block_store(std::shared_ptr<void> store) { m_merged_block_store = std::move(store); }

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -989,11 +989,29 @@ public:
     /// Load persisted found blocks from storage (call once after persistence is set)
     void load_persisted_found_blocks();
 
+    /// #159 (G2): schedule confirm/orphan verification for every restored row
+    /// still marked pending. load_persisted_found_blocks() only rebuilds the
+    /// rows; without this a row that was pending at shutdown stays "pending"
+    /// forever because the live verification schedulers only fire on freshly
+    /// recorded blocks. Call once AFTER the block-verify callback and io_context
+    /// are wired. Safe to call with no verifier/io_context (it no-ops per row).
+    void reverify_pending_found_blocks();
+
     /// Backfill network_difficulty on loaded blocks using a block hash → difficulty lookup.
     /// Called after embedded header chain is available.
     using block_diff_lookup_fn = std::function<double(const std::string& block_hash)>;
     using block_ts_lookup_fn = std::function<uint32_t(const std::string& block_hash)>;
     void backfill_block_fields(block_diff_lookup_fn diff_fn, block_ts_lookup_fn ts_fn);
+
+private:
+    /// #159 (G3): recompute the DERIVED found-block fields (time_to_find,
+    /// expected_time, luck) that are never persisted, from the height-ordered
+    /// timestamps + network_difficulty + pool_hashrate that ARE restored. Only
+    /// fills fields still at 0 so it never clobbers a live-computed value.
+    /// CALLER MUST HOLD m_blocks_mutex. Coin-generic; run at load and again
+    /// after backfill_block_fields fills a previously-missing network_difficulty.
+    void recompute_found_block_luck_locked();
+public:
 
     /// Merged block persistence — opaque store pointer, cast in .cpp.
     void set_merged_block_store(std::shared_ptr<void> store);


### PR DESCRIPTION
Ports the missing dashboard historical-data persistence from p2pool into c2pool so the web dashboard survives a node restart with its found-block history intact. Coin-generic (DASH + LTC). Display/telemetry path only — no share, consensus, reward, mint or template path is touched, so this qualifies for the green+safe track rather than the consensus gate.

Closes the highest-visibility gaps from the #159 persistence audit.

## What now survives a restart

All persisted through the existing `FoundBlockStore` LevelDB (`<datadir>/<net>/found_blocks_db`), reusing the established load-on-start / persist-on-change lifecycle — no new storage engine.

- **Found-block enrichment (G1)** — miner / finder address, block reward, winning share hash, network difficulty, share difficulty, pool hashrate, and authorship (this-node vs sharechain-peer). Previously the persist/load lambdas filled only the skeleton (chain / height / hash / ts / status / confirmations), so every restored row lost its detail. `FoundBlockRecord` gains a **v2 tail**; `deserialize` stays **v1 read-compatible** (a v1 record leaves the new fields at their defaults), so upgrading a node never wipes existing found-block history.
- **Pending-row re-verification (G2)** — a row still `pending` at shutdown is now re-scheduled for confirm/orphan verification once the verify callback + io_context are live, instead of staying `pending` forever. New `MiningInterface::reverify_pending_found_blocks()`, wired on both lanes; safe no-op when no verifier/io_context is set.
- **Luck / time-to-find / expected-time (G3)** — these are derived and were never persisted, so `rest_luck_stats` emitted null luck for the whole restored history and the luck trend restarted empty. They are now recomputed at load from the restored height-ordered timestamps + network difficulty + pool hashrate, using the same formula as record time. Rows genuinely missing an input stay unknown (rendered `null`, never a fabricated 0%).
- **DASH network-difficulty backfill (G5)** — the DASH lane now wires `backfill_block_fields` against the embedded SPV header chain (parity with the LTC lane), so a restored row with `network_difficulty == 0` gets the exact value from the block header's `nBits` — daemonless, no dashd. A backfilled difficulty/timestamp re-triggers the luck recompute.

## Storage used

Existing `FoundBlockStore` (LevelDB, key prefix `fblk:`, never pruned). Record schema bumped v1 -> v2 with a bounds-checked, backward-read-compatible deserializer.

## Crash-safety

A missing store degrades to empty history; every field read in `deserialize` is bounds-checked, so a truncated or corrupt record degrades to defaults rather than throwing or crashing the web server.

## Build

Affected translation units compiled clean against the DASH build tree (Release, conan toolchain): `src/core/web_server.cpp`, `src/c2pool/main_dash.cpp`, `src/c2pool/main_ltc.cpp` — all exit 0.

## Scope notes

- v1 read-compat means an **upgrade** never loses history. A downgrade (old binary reading new v2 records) is not supported — standard for a schema bump.
- Not included here (larger, separately-reviewed): G4 year-scale binned graph history (stat_log is a flat 31-day window), and the LOW-priority items (G6 long-horizon network-diff series, G7 per-miner hashrate-ring warmup, G8 stat_log shares/stale hardcoded zeros, G9 dormant DASH merged/checkpoint-store wiring).

Refs #159.
