### PR TITLE
Dashboard: render DASH PPLNS view + sharechain explorer PPLNS-on-hover (parity with LTC)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1701,13 +1701,36 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 mi->set_current_payouts_fn(current_pplns);
 
                 mi->set_sharechain_window_fn(
-                    [node_ptr, view_ctx, current_pplns]() -> nlohmann::json {
+                    [node_ptr, view_ctx, current_pplns, mi]() -> nlohmann::json {
                         auto cur = current_pplns();          // takes + releases the guard
                         auto guard = node_ptr->read_tracker();
                         if (!guard) return nlohmann::json::object();
                         auto w = dash::dashboard::build_window(*guard, view_ctx());
                         if (cur.is_object() && !cur.empty())
                             w["pplns_current"] = std::move(cur);
+                        // Per-share PPLNS overlay for the sharechain-explorer
+                        // hover — parity with LTC (main_ltc.cpp:3945-3951).
+                        // cache_pplns_at_tip() populates m_pplns_per_tip on
+                        // every DASH best-share change (through the
+                        // fire_share_tip_refresh -> trigger_work_refresh_debounced
+                        // -> execute_debounced_work_refresh pump, web_server.cpp:8686),
+                        // keyed by the SAME 16-hex short hash build_window emits
+                        // as each share's "h". Cache-hit only, exactly like LTC:
+                        // entries accumulate as tips advance; a share not yet
+                        // cached simply isn't in the map and the front-end
+                        // (dashboard.html getPPLNSForShare) falls back to
+                        // pplns_current. Read-only: no share bytes, coinbase,
+                        // payee or PPLNS math is touched here.
+                        if (mi && w.contains("shares") && w["shares"].is_array()) {
+                            nlohmann::json pplns_map = nlohmann::json::object();
+                            for (const auto& s : w["shares"]) {
+                                if (!s.contains("h")) continue;
+                                std::string sh = s["h"].get<std::string>();
+                                auto p = mi->get_pplns_for_tip(sh);
+                                if (!p.empty()) pplns_map[sh] = std::move(p);
+                            }
+                            if (!pplns_map.empty()) w["pplns"] = std::move(pplns_map);
+                        }
                         return w;
                     });
                 // The grid IS the sharechain — refresh it on tip change, not on
@@ -1715,10 +1738,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 mi->mark_last_cache_tip_driven();
 
                 mi->set_sharechain_delta_fn(
-                    [node_ptr, view_ctx](const std::string& since_hash) -> nlohmann::json {
+                    [node_ptr, view_ctx, mi](const std::string& since_hash) -> nlohmann::json {
                         auto guard = node_ptr->read_tracker();
                         if (!guard) return nlohmann::json::object();
-                        return dash::dashboard::build_delta(*guard, since_hash, view_ctx());
+                        auto d = dash::dashboard::build_delta(*guard, since_hash, view_ctx());
+                        // Per-share PPLNS overlay on the incremental path so a
+                        // client that stays connected keeps getting per-share
+                        // payout data for newly-arrived shares — parity with LTC
+                        // delta (main_ltc.cpp:4116-4122). Same m_pplns_per_tip
+                        // cache, same 16-hex "h" key, cache-hit only.
+                        if (mi && d.contains("shares") && d["shares"].is_array()) {
+                            nlohmann::json pplns_map = nlohmann::json::object();
+                            for (const auto& s : d["shares"]) {
+                                if (!s.contains("h")) continue;
+                                std::string sh = s["h"].get<std::string>();
+                                auto p = mi->get_pplns_for_tip(sh);
+                                if (!p.empty()) pplns_map[sh] = std::move(p);
+                            }
+                            if (!pplns_map.empty()) d["pplns"] = std::move(pplns_map);
+                        }
+                        return d;
                     });
 
                 // Individual share page + THE PPLNS VIEW FOR THAT SHARE.


### PR DESCRIPTION
## What

Completes the DASH dashboard PPLNS parity with LTC. Two things the operator reported as broken on the DASH pool:

1. **PPLNS view** (`#pplns-section` treemap) — renders on master via `/current_merged_payouts`, which `cache_pplns_at_tip()` already pumps on every DASH best-share change (through `fire_share_tip_refresh` -> `trigger_work_refresh_debounced` -> `execute_debounced_work_refresh`, `web_server.cpp:8686`). The live-symptom blank was a **stale binary** on the public node (predates the whole DASH dashboard-seam family); a master redeploy resolves it. No code change needed here.

2. **Sharechain explorer hover** — this PR. The DASH `/sharechain/window` and `/sharechain/delta` read-models attached only the pool-wide `pplns_current`, never a per-share `pplns[<short-hash>]` map, so the hover showed the *same* current split for every share. LTC has attached both since `main_ltc.cpp:3945-3951` (window) and `:4116-4122` (delta); DASH wired only the fallback.

## Fix

The per-share data was already present on DASH — `m_pplns_per_tip` is populated by `cache_pplns_at_tip()` on every best-share change, keyed by the same 16-hex short hash `build_window` emits as each share's `"h"`. Only the read-side merge into window/delta was missing. This PR mirrors the LTC merge exactly in `main_dash.cpp`'s `set_sharechain_window_fn` / `set_sharechain_delta_fn`: iterate the shares, and for each `"h"` with a cached entry, attach `get_pplns_for_tip("h")` under `result["pplns"]`.

- **Cache-hit only** (identical to LTC's live-arrival path): entries accumulate as tips advance; a share not yet cached is simply absent from the map and the front-end (`dashboard.html` `getPPLNSForShare`, line 6233) falls back to `pplns_current`.
- **No web-static change**: the front-end already consumes `data.pplns` (`dashboard.html:5187`) and `delta.pplns` (`:8961`) keyed by `share.h`; the value shape is identical to `pplns_current` / `/current_merged_payouts`, already parsed by `_parsePPLNS`.

## Safety / scope

Display/telemetry only — no share bytes, coinbase, payee, PPLNS math or won-block path touched. Per-coin isolation held: `src/c2pool/main_dash.cpp` only; LTC/BTC/DGB/BCH lanes untouched.

## Build

`c2pool-dash` target built clean from this branch (conan install + cmake + `cmake --build --target c2pool-dash`), exit 0, only pre-existing unrelated STL `-Wstringop-overread` warnings. `main_dash.cpp` is the sole TU for the target.

## Verify after deploy (real routes, not the 404 guesses)

- `/sharechain/window` — contains `pplns_current`, and a `pplns` map once shares have cycled as tips
- `/sharechain/delta?since=<hash>` — carries `pplns` for newly-arrived shares
- `/current_merged_payouts` — non-empty object after the first best-share change
- `/web/share/<hash>` — has `pplns` + `pplns_meta` (already on master, #1145)

Refs #57.