### PR TITLE
Dashboard: year-scale binned graph history (G4, #159)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,7 @@ set(source
     addr_store.hpp addr_store.cpp
     p2p_message_stats.hpp
     web_server.hpp web_server.cpp
+    graph_history.hpp graph_history.cpp
     http_session.cpp
     stratum_server.hpp stratum_server.cpp
     stratum_types.hpp

--- a/src/core/graph_history.cpp
+++ b/src/core/graph_history.cpp
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// graph_history.cpp — implementation of the p2pool graph.py binning port.
+// See graph_history.hpp for the design notes and the deliberate deviations.
+
+#include <core/graph_history.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace core {
+namespace graph {
+
+namespace {
+
+// _shift(x, shift, {}) restricted to shift >= 0 (the only case
+// _shift_bins_so_t_is_not_past_end ever produces): prepend `shift` empty bins
+// at the newest end (index 0) and drop the same number of the oldest bins.
+std::vector<Bin> shift_bins(const std::vector<Bin>& x, long shift) {
+    long n = static_cast<long>(x.size());
+    if (shift <= 0) return x;
+    if (shift >= n) return std::vector<Bin>(static_cast<size_t>(n));  // all empty
+    std::vector<Bin> out;
+    out.reserve(static_cast<size_t>(n));
+    out.resize(static_cast<size_t>(shift));  // `shift` empty bins
+    for (long i = 0; i < n - shift; ++i) out.push_back(x[static_cast<size_t>(i)]);
+    return out;
+}
+
+// _shift_bins_so_t_is_not_past_end
+void shift_so_t_not_past_end(std::vector<Bin>& bins, double& last_bin_end,
+                             double bin_width, double t) {
+    if (bin_width <= 0.0) return;
+    long shift = static_cast<long>(std::ceil((t - last_bin_end) / bin_width));
+    if (shift < 0) shift = 0;
+    if (shift > 0) {
+        bins = shift_bins(bins, shift);
+        last_bin_end = last_bin_end + shift * bin_width;
+    }
+}
+
+// combine_bins: union of keys, pairwise (total, count) addition.
+Bin combine_bins(const Bin& a, const Bin& b) {
+    Bin out = a;
+    for (const auto& kv : b) {
+        auto& slot = out[kv.first];  // value-inits to (0,0) on insert
+        slot.first += kv.second.first;
+        slot.second += kv.second.second;
+    }
+    return out;
+}
+
+}  // namespace
+
+Bin keep_largest(const Bin& in, int n, bool has_squash,
+                 const std::string& squash_key, bool is_gauge) {
+    // Fast path: nothing to trim.
+    if (static_cast<int>(in.size()) <= n) return in;
+
+    struct Item {
+        std::string key;
+        std::pair<double, double> val;
+    };
+    std::vector<Item> items;
+    items.reserve(in.size());
+    for (const auto& kv : in) items.push_back(Item{kv.first, kv.second});
+
+    // magnitude used for ordering: mean for gauges, total for rates.
+    auto mag = [&](const std::pair<double, double>& v) -> double {
+        if (is_gauge) return v.second != 0.0 ? v.first / v.second : 0.0;
+        return v.first;
+    };
+    // p2pool sorts by (k != squash_key, key(v)) reverse=True, i.e. the squash
+    // key is ranked LAST (its `k != squash_key` is False) and everything else
+    // by descending magnitude. std::stable_sort matches Python's stable sort.
+    std::stable_sort(items.begin(), items.end(),
+        [&](const Item& x, const Item& y) {
+            bool xs = has_squash && x.key != squash_key;
+            bool ys = has_squash && y.key != squash_key;
+            if (xs != ys) return xs > ys;      // non-squash keys first
+            return mag(x.val) > mag(y.val);    // then by descending magnitude
+        });
+
+    while (static_cast<int>(items.size()) > n) {
+        Item last = items.back();
+        items.pop_back();
+        if (has_squash && !items.empty()) {
+            // Merge the trimmed value into the new last item, RENAMING it to the
+            // squash key (p2pool: items[-1] = squash_key, add(items[-1][1], v)).
+            Item& tail = items.back();
+            tail.key = squash_key;
+            tail.val.first += last.val.first;
+            tail.val.second += last.val.second;
+        }
+    }
+
+    Bin out;
+    for (const auto& it : items) out[it.key] = it.val;
+    return out;
+}
+
+// ── DataView ────────────────────────────────────────────────────────────────
+
+void DataView::add_datum(const DataStreamDescription& ds, double t,
+                         std::map<std::string, double> value) {
+    if (!ds.multivalues) {
+        // Scalar streams arrive as {"null": scalar}; nothing to normalize.
+    } else if (ds.multivalue_undefined_means_0 && value.find("null") == value.end()) {
+        value["null"] = 0.0;  // null holds the sample counter
+    }
+
+    shift_so_t_not_past_end(bins, last_bin_end, desc.bin_width, t);
+
+    long bin = static_cast<long>(std::floor((last_bin_end - t) / desc.bin_width));
+    if (bin < 0) return;
+    if (bin < desc.bin_count) {
+        Bin add;
+        for (const auto& kv : value) add[kv.first] = {kv.second, 1.0};
+        Bin combined = combine_bins(bins[static_cast<size_t>(bin)], add);
+        bins[static_cast<size_t>(bin)] = keep_largest(
+            combined, ds.multivalues_keep, ds.has_squash_key,
+            ds.multivalues_squash_key, ds.is_gauge);
+    }
+}
+
+nlohmann::json DataView::get_data(const DataStreamDescription& ds, double t) const {
+    // Work on shifted copies so the read is const and non-mutating.
+    std::vector<Bin> b = bins;
+    double lbe = last_bin_end;
+    shift_so_t_not_past_end(b, lbe, desc.bin_width, t);
+
+    const double bw = desc.bin_width;
+
+    // Build ascending (oldest-first): p2pool enumerates newest-first (i=0 newest),
+    // so we walk i from bin_count-1 down to 0.
+    struct Point {
+        double center;
+        nlohmann::json val;
+        double width;
+        nlohmann::json def;
+        bool empty;
+    };
+    std::vector<Point> pts;
+    pts.reserve(b.size());
+
+    for (long i = desc.bin_count - 1; i >= 0; --i) {
+        const Bin& bin = b[static_cast<size_t>(i)];
+        double left = lbe - bw * (i + 1);
+        double right = std::min(t, lbe - bw * i);
+        double center = (left + right) / 2.0;
+        double width = right - left;
+
+        nlohmann::json val;
+        nlohmann::json def;
+        bool empty = bin.empty();
+
+        if (ds.is_gauge && ds.multivalue_undefined_means_0) {
+            double real_count = 0.0;
+            for (const auto& kv : bin) real_count = std::max(real_count, kv.second.second);
+            if (real_count == 0.0) {
+                val = nullptr;
+                empty = true;
+            } else {
+                val = nlohmann::json::object();
+                for (const auto& kv : bin) val[kv.first] = kv.second.first / real_count;
+            }
+            def = 0;
+        } else if (ds.is_gauge) {
+            val = nlohmann::json::object();
+            for (const auto& kv : bin) {
+                double c = kv.second.second;
+                val[kv.first] = c != 0.0 ? kv.second.first / c : 0.0;
+            }
+            def = nullptr;
+        } else {  // rate (not used by c2pool streams; ported for fidelity)
+            val = nlohmann::json::object();
+            for (const auto& kv : bin) {
+                val[kv.first] = width != 0.0 ? kv.second.first / width : 0.0;
+            }
+            def = 0;
+        }
+
+        if (!ds.multivalues) {
+            // Reduce to the scalar carried under "null".
+            if (val.is_null()) {
+                // keep null
+            } else if (val.contains("null")) {
+                nlohmann::json scalar = val["null"];  // copy before overwrite
+                val = std::move(scalar);
+            } else {
+                val = def;
+            }
+        } else if (val.is_object() && val.contains("null")) {
+            // Never leak the internal sample-counter key into a served dict:
+            // dashboard.html sums d[1]['null'] into DOA (renderHashrateGraph).
+            val.erase("null");
+        }
+
+        pts.push_back(Point{center, std::move(val), width, std::move(def), empty});
+    }
+
+    // Clip leading never-filled bins (oldest side) so the frontend never sees a
+    // run of nulls before real data begins — matches the flat path's behaviour
+    // of emitting only samples that exist.
+    size_t start = 0;
+    while (start < pts.size() && pts[start].empty) ++start;
+
+    nlohmann::json out = nlohmann::json::array();
+    for (size_t i = start; i < pts.size(); ++i) {
+        out.push_back(nlohmann::json::array({pts[i].center, pts[i].val,
+                                             pts[i].width, pts[i].def}));
+    }
+    return out;
+}
+
+nlohmann::json DataView::to_obj() const {
+    nlohmann::json o = nlohmann::json::object();
+    o["last_bin_end"] = last_bin_end;
+    o["bin_width"] = desc.bin_width;
+    nlohmann::json barr = nlohmann::json::array();
+    for (const auto& bin : bins) {
+        nlohmann::json bo = nlohmann::json::object();
+        for (const auto& kv : bin) {
+            bo[kv.first] = nlohmann::json::array({kv.second.first, kv.second.second});
+        }
+        barr.push_back(std::move(bo));
+    }
+    o["bins"] = std::move(barr);
+    return o;
+}
+
+// ── DataStream ───────────────────────────────────────────────────────────────
+
+void DataStream::add_multi(double t, const std::map<std::string, double>& value) {
+    for (auto& dv : dataviews) dv.second.add_datum(desc, t, value);
+}
+
+void DataStream::add_scalar(double t, double value) {
+    std::map<std::string, double> v{{"null", value}};
+    for (auto& dv : dataviews) dv.second.add_datum(desc, t, v);
+}
+
+DataView* DataStream::view(const std::string& name) {
+    for (auto& dv : dataviews)
+        if (dv.first == name) return &dv.second;
+    return nullptr;
+}
+const DataView* DataStream::view(const std::string& name) const {
+    for (const auto& dv : dataviews)
+        if (dv.first == name) return &dv.second;
+    return nullptr;
+}
+
+// ── HistoryDatabase ──────────────────────────────────────────────────────────
+
+HistoryDatabase HistoryDatabase::create(
+    const std::vector<std::pair<std::string, DataStreamDescription>>& descs) {
+    HistoryDatabase db;
+    for (const auto& sd : descs) {
+        DataStream ds;
+        ds.desc = sd.second;
+        for (const auto& dvd : sd.second.dataview_descriptions) {
+            std::vector<Bin> empty(static_cast<size_t>(dvd.second.bin_count));
+            ds.dataviews.emplace_back(dvd.first, DataView(dvd.second, 0.0, std::move(empty)));
+        }
+        db.datastreams.emplace_back(sd.first, std::move(ds));
+    }
+    return db;
+}
+
+HistoryDatabase HistoryDatabase::from_obj(
+    const std::vector<std::pair<std::string, DataStreamDescription>>& descs,
+    const nlohmann::json& obj, bool& needs_reseed) {
+    needs_reseed = false;
+    HistoryDatabase db;
+    for (const auto& sd : descs) {
+        DataStream ds;
+        ds.desc = sd.second;
+        const bool has_stream = obj.is_object() && obj.contains(sd.first)
+                                && obj[sd.first].is_object();
+        for (const auto& dvd : sd.second.dataview_descriptions) {
+            const DataViewDescription& geom = dvd.second;
+            bool loaded = false;
+            if (has_stream) {
+                const nlohmann::json& sdata = obj[sd.first];
+                if (sdata.contains(dvd.first) && sdata[dvd.first].is_object()) {
+                    const nlohmann::json& vd = sdata[dvd.first];
+                    // Geometry validation (review #2): a valid-JSON view with the
+                    // wrong bin_width or bin_count is NOT loadable as-is; discard
+                    // it and force a reseed rather than serving mismatched bins.
+                    const bool width_ok =
+                        vd.contains("bin_width") && vd["bin_width"].is_number()
+                        && std::fabs(vd["bin_width"].get<double>() - geom.bin_width)
+                               <= 1e-6 * std::max(1.0, geom.bin_width);
+                    const bool bins_ok =
+                        vd.contains("bins") && vd["bins"].is_array()
+                        && static_cast<int>(vd["bins"].size()) == geom.bin_count;
+                    if (width_ok && bins_ok) {
+                        std::vector<Bin> parsed;
+                        parsed.reserve(static_cast<size_t>(geom.bin_count));
+                        for (const auto& bo : vd["bins"]) {
+                            Bin bin;
+                            if (bo.is_object()) {
+                                for (auto it = bo.begin(); it != bo.end(); ++it) {
+                                    if (it.value().is_array() && it.value().size() == 2) {
+                                        bin[it.key()] = {it.value()[0].get<double>(),
+                                                         it.value()[1].get<double>()};
+                                    }
+                                }
+                            }
+                            parsed.push_back(std::move(bin));
+                        }
+                        double lbe = vd.value("last_bin_end", 0.0);
+                        ds.dataviews.emplace_back(dvd.first,
+                            DataView(geom, lbe, std::move(parsed)));
+                        loaded = true;
+                    }
+                }
+            }
+            if (!loaded) {
+                needs_reseed = true;
+                std::vector<Bin> empty(static_cast<size_t>(geom.bin_count));
+                ds.dataviews.emplace_back(dvd.first, DataView(geom, 0.0, std::move(empty)));
+            }
+        }
+        db.datastreams.emplace_back(sd.first, std::move(ds));
+    }
+    return db;
+}
+
+nlohmann::json HistoryDatabase::to_obj() const {
+    nlohmann::json o = nlohmann::json::object();
+    for (const auto& sd : datastreams) {
+        nlohmann::json so = nlohmann::json::object();
+        for (const auto& dv : sd.second.dataviews) {
+            so[dv.first] = dv.second.to_obj();
+        }
+        o[sd.first] = std::move(so);
+    }
+    return o;
+}
+
+DataStream* HistoryDatabase::stream(const std::string& name) {
+    for (auto& sd : datastreams)
+        if (sd.first == name) return &sd.second;
+    return nullptr;
+}
+const DataStream* HistoryDatabase::stream(const std::string& name) const {
+    for (const auto& sd : datastreams)
+        if (sd.first == name) return &sd.second;
+    return nullptr;
+}
+
+void HistoryDatabase::add_scalar(const std::string& name, double t, double value) {
+    if (auto* s = stream(name)) s->add_scalar(t, value);
+}
+void HistoryDatabase::add_multi(const std::string& name, double t,
+                                const std::map<std::string, double>& value) {
+    if (auto* s = stream(name)) s->add_multi(t, value);
+}
+
+}  // namespace graph
+}  // namespace core

--- a/src/core/graph_history.hpp
+++ b/src/core/graph_history.hpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// graph_history.hpp — coin-generic binned history database.
+//
+// A faithful C++ port of p2pool's p2pool/util/graph.py
+// (DataViewDescription / DataView / DataStream / HistoryDatabase), used to back
+// the dashboard's long-horizon graph views (last_week / last_month / last_year)
+// with a bounded, fixed-point-count binned representation instead of the flat
+// per-sample stat log.
+//
+// Semantics preserved from p2pool:
+//   * bins hold {key: (total, count)}; bins[0] is the NEWEST bin;
+//   * shift-bins-so-t-is-not-past-end on both add and read;
+//   * keep_largest capping (with an optional squash key) for multivalue streams;
+//   * get_data emits [bin_center, value, width, default] 4-tuples, value being a
+//     scalar for scalar streams, a dict for multivalue streams, or null on an
+//     empty gauge bin.
+//
+// DELIBERATE DEVIATION FROM p2pool (reviewer-signed, see PR #159): every c2pool
+// stream is is_gauge=true. c2pool's StatLogEntry fields are pre-computed H/s
+// rates sampled at a fixed 60s cadence, unlike p2pool's raw per-event work
+// quantities. A bin therefore holds the MEAN of its samples (total/count).
+// p2pool's rate semantics (total/bin_width) would rescale every long-view
+// hashrate by a factor of bin_width and are intentionally NOT used for these
+// streams. get_data still ports the rate branch for fidelity/tests.
+//
+// Output ordering deviates from p2pool too: p2pool emits newest-bin-first; this
+// port emits ASCENDING in time (oldest first) to match c2pool's existing flat
+// graph path, and clips leading never-filled bins server-side so the frontend
+// never sees a run of nulls before real data begins.
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <map>
+#include <utility>
+
+#include <nlohmann/json.hpp>
+
+namespace core {
+namespace graph {
+
+// A bin maps a series key to (accumulated total, sample count).
+using Bin = std::map<std::string, std::pair<double, double>>;
+
+struct DataViewDescription {
+    int bin_count{0};
+    double bin_width{0.0};
+    DataViewDescription() = default;
+    DataViewDescription(int bins, double total_width)
+        : bin_count(bins), bin_width(bins > 0 ? total_width / bins : 0.0) {}
+};
+
+struct DataStreamDescription {
+    // Ordered (view-name, geometry) pairs. Order is stable so the served output
+    // and the persisted schema are deterministic.
+    std::vector<std::pair<std::string, DataViewDescription>> dataview_descriptions;
+    bool is_gauge{true};
+    bool multivalues{false};
+    int multivalues_keep{20};
+    bool has_squash_key{false};
+    std::string multivalues_squash_key;
+    bool multivalue_undefined_means_0{false};
+};
+
+// keep_largest: cap a bin to at most n keys, sorted by magnitude; when a squash
+// key is configured the trimmed keys are merged into it (p2pool exact). Exposed
+// for unit tests (ports p2pool test_graph.py::test_keep_largest).
+Bin keep_largest(const Bin& in, int n, bool has_squash,
+                 const std::string& squash_key, bool is_gauge);
+
+class DataView {
+public:
+    DataViewDescription desc;
+    double last_bin_end{0.0};
+    std::vector<Bin> bins;  // bins[0] == newest
+
+    DataView() = default;
+    DataView(const DataViewDescription& d, double lbe, std::vector<Bin> b)
+        : desc(d), last_bin_end(lbe), bins(std::move(b)) {}
+
+    // Fold one datum (t seconds, {key: value}) into the view.
+    void add_datum(const DataStreamDescription& ds, double t,
+                   std::map<std::string, double> value);
+
+    // Emit ascending [center, value, width, default] 4-tuples, leading empty
+    // (never-filled) bins clipped. Const: works on shifted copies.
+    nlohmann::json get_data(const DataStreamDescription& ds, double t) const;
+
+    nlohmann::json to_obj() const;
+};
+
+class DataStream {
+public:
+    DataStreamDescription desc;
+    std::vector<std::pair<std::string, DataView>> dataviews;  // by view name
+
+    DataStream() = default;
+
+    void add_multi(double t, const std::map<std::string, double>& value);
+    void add_scalar(double t, double value);
+
+    DataView* view(const std::string& name);
+    const DataView* view(const std::string& name) const;
+};
+
+class HistoryDatabase {
+public:
+    std::vector<std::pair<std::string, DataStream>> datastreams;
+
+    // Build an empty database from the schema.
+    static HistoryDatabase create(
+        const std::vector<std::pair<std::string, DataStreamDescription>>& descs);
+
+    // Build from a persisted to_obj() blob. Any view that is absent, has the
+    // wrong bin geometry, or fails to parse leaves an EMPTY DataView and sets
+    // needs_reseed=true so the caller can seed from the flat log instead of
+    // trusting a stale/mismatched view. Never returns a null view.
+    static HistoryDatabase from_obj(
+        const std::vector<std::pair<std::string, DataStreamDescription>>& descs,
+        const nlohmann::json& obj, bool& needs_reseed);
+
+    nlohmann::json to_obj() const;
+
+    DataStream* stream(const std::string& name);
+    const DataStream* stream(const std::string& name) const;
+
+    void add_scalar(const std::string& name, double t, double value);
+    void add_multi(const std::string& name, double t,
+                   const std::map<std::string, double>& value);
+};
+
+}  // namespace graph
+}  // namespace core

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -65,7 +65,15 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # honesty KATs (luck/netdiff-at-find, junk-row enrichment, block-value
     # split vs the accepted coinbase, fee units, last_block, best-share
     # persistence). Same fold-into-core_test reasoning as every TU here.
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp)
+    # graph_history_test.cpp: the G4 year-scale binned graph history (#159), a
+    # port of p2pool util/graph.py. Pins keep_largest (p2pool test_graph.py),
+    # the gauge-mean semantics (week/month/year == MEAN of samples, never
+    # total/bin_width — the deliberate deviation that would otherwise silently
+    # rescale every long-view hashrate), flat-log seed migration, watermark
+    # idempotency, per-view geometry-mismatch reseed, and corrupt/missing
+    # tolerance. Same fold-into-core_test reasoning as every TU here (a new
+    # add_executable is the #769 "Not Run" trap).
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp graph_history_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/graph_history_test.cpp
+++ b/src/core/test/graph_history_test.cpp
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// graph_history_test.cpp — G4 year-scale binned graph history (#159).
+//
+// Ports p2pool util/graph.py's own test (test_graph.py::test_keep_largest) and
+// pins the c2pool-specific invariants the design review made load-bearing:
+//   * GAUGE-MEAN semantics: a bin holds the MEAN (total/count) of its samples,
+//     NEVER total/bin_width — the deliberate deviation from p2pool's rate model
+//     that, if wrong, silently rescales every long-view hashrate;
+//   * served multivalue dicts never leak the internal 'null' sample-counter key
+//     (dashboard.html sums d[1]['null'] into DOA);
+//   * ascending output order with leading never-filled bins clipped;
+//   * to_obj/from_obj round-trip fidelity;
+//   * per-view GEOMETRY-MISMATCH -> needs_reseed (never a null view);
+//   * watermark-gated replay is idempotent (no double counting).
+
+#include <gtest/gtest.h>
+
+#include <core/graph_history.hpp>
+
+#include <string>
+#include <vector>
+
+using core::graph::Bin;
+using core::graph::DataStreamDescription;
+using core::graph::DataViewDescription;
+using core::graph::HistoryDatabase;
+using core::graph::keep_largest;
+
+namespace {
+
+// A one-view schema for focused semantics tests.
+std::vector<std::pair<std::string, DataStreamDescription>>
+one_view_schema(int bin_count, double total_width, bool multivalues,
+                bool undefined0, int keep, bool squash)
+{
+    DataViewDescription v(bin_count, total_width);
+    DataStreamDescription d;
+    d.dataview_descriptions = {{"last_hour", v}};
+    d.is_gauge = true;
+    d.multivalues = multivalues;
+    d.multivalue_undefined_means_0 = undefined0;
+    d.multivalues_keep = keep;
+    if (squash) { d.has_squash_key = true; d.multivalues_squash_key = "other"; }
+    return {{"s", d}};
+}
+
+double last_scalar(const nlohmann::json& arr)
+{
+    EXPECT_TRUE(arr.is_array());
+    EXPECT_FALSE(arr.empty());
+    return arr.back()[1].get<double>();
+}
+
+}  // namespace
+
+// ── p2pool test_graph.py::test_keep_largest, ported ──────────────────────────
+TEST(GraphHistory, KeepLargestPortsP2poolTest)
+{
+    // b = dict(a=1, b=3, c=5, d=7, e=9); represented as (total, count=1) so the
+    // gauge magnitude (total/count) equals the p2pool scalar.
+    Bin b = {{"a", {1, 1}}, {"b", {3, 1}}, {"c", {5, 1}},
+             {"d", {7, 1}}, {"e", {9, 1}}};
+
+    // keep_largest(3, 'squashed')(b) == {'squashed': 9, 'd': 7, 'e': 9}
+    Bin r1 = keep_largest(b, 3, /*has_squash=*/true, "squashed", /*is_gauge=*/true);
+    ASSERT_EQ(r1.size(), 3u);
+    EXPECT_DOUBLE_EQ(r1["e"].first, 9);
+    EXPECT_DOUBLE_EQ(r1["d"].first, 7);
+    ASSERT_TRUE(r1.count("squashed"));
+    EXPECT_DOUBLE_EQ(r1["squashed"].first, 9);  // 5 + 3 + 1
+
+    // keep_largest(3)(b) == {'c': 5, 'd': 7, 'e': 9}
+    Bin r2 = keep_largest(b, 3, /*has_squash=*/false, "", /*is_gauge=*/true);
+    ASSERT_EQ(r2.size(), 3u);
+    EXPECT_DOUBLE_EQ(r2["c"].first, 5);
+    EXPECT_DOUBLE_EQ(r2["d"].first, 7);
+    EXPECT_DOUBLE_EQ(r2["e"].first, 9);
+    EXPECT_FALSE(r2.count("a"));
+    EXPECT_FALSE(r2.count("b"));
+}
+
+// ── GAUGE-MEAN: a bin is the MEAN of its samples, never total/bin_width ───────
+TEST(GraphHistory, ScalarBinIsMeanNotRate)
+{
+    auto db = HistoryDatabase::create(
+        one_view_schema(10, 10000.0 /*bin_width=1000*/, false, false, 20, false));
+
+    // First add establishes last_bin_end=11000; subsequent adds with t < that
+    // land in the SAME newest bin so we can check the mean of {100,200,300}.
+    db.add_scalar("s", 10500, 100);
+    db.add_scalar("s", 10600, 200);
+    db.add_scalar("s", 10700, 300);
+
+    auto data = db.stream("s")->view("last_hour")->get_data(
+        db.stream("s")->desc, 10700);
+    // Newest point == arithmetic mean, distinct from total/bin_width(=0.6) and
+    // total/width. This is the pin that locks the is_gauge deviation.
+    EXPECT_NEAR(last_scalar(data), 200.0, 1e-9);
+}
+
+// ── multivalue undefined_means_0 (pool_rates shape) mean + no 'null' leak ─────
+TEST(GraphHistory, MultivalueMeanAndNoNullLeak)
+{
+    auto db = HistoryDatabase::create(
+        one_view_schema(10, 10000.0, true, /*undefined0=*/true, 20, false));
+
+    db.add_multi("s", 10500, {{"good", 100}, {"orphan", 10}, {"dead", 0}});
+    db.add_multi("s", 10600, {{"good", 300}, {"orphan", 30}, {"dead", 0}});
+
+    auto data = db.stream("s")->view("last_hour")->get_data(
+        db.stream("s")->desc, 10600);
+    ASSERT_FALSE(data.empty());
+    const auto& val = data.back()[1];
+    ASSERT_TRUE(val.is_object());
+    // Means: good=(100+300)/2=200, orphan=(10+30)/2=20.
+    EXPECT_NEAR(val["good"].get<double>(), 200.0, 1e-9);
+    EXPECT_NEAR(val["orphan"].get<double>(), 20.0, 1e-9);
+    // The internal sample-counter key must NOT reach the served dict, or
+    // dashboard.html renderHashrateGraph would sum it into DOA.
+    EXPECT_FALSE(val.contains("null"));
+}
+
+// ── ascending order + leading never-filled bins clipped ──────────────────────
+TEST(GraphHistory, AscendingAndLeadingEmptyClipped)
+{
+    auto db = HistoryDatabase::create(
+        one_view_schema(10, 10000.0, false, false, 20, false));
+    db.add_scalar("s", 10500, 42);
+
+    auto data = db.stream("s")->view("last_hour")->get_data(
+        db.stream("s")->desc, 10500);
+    // Only filled bins remain (the 9 older empty bins are clipped), and the
+    // single point carries the value.
+    ASSERT_EQ(data.size(), 1u);
+    EXPECT_NEAR(data[0][1].get<double>(), 42.0, 1e-9);
+
+    // Timestamps ascending across a multi-bin case.
+    auto db2 = HistoryDatabase::create(
+        one_view_schema(10, 100.0 /*bin_width=10*/, false, false, 20, false));
+    db2.add_scalar("s", 1000, 1);
+    db2.add_scalar("s", 1015, 2);
+    db2.add_scalar("s", 1035, 3);
+    auto d2 = db2.stream("s")->view("last_hour")->get_data(db2.stream("s")->desc, 1035);
+    ASSERT_GE(d2.size(), 2u);
+    for (size_t i = 1; i < d2.size(); ++i)
+        EXPECT_LE(d2[i - 1][0].get<double>(), d2[i][0].get<double>());
+}
+
+// ── to_obj / from_obj round-trip fidelity ────────────────────────────────────
+TEST(GraphHistory, PersistenceRoundTrip)
+{
+    auto schema = one_view_schema(10, 10000.0, true, false, 200, true);
+    auto db = HistoryDatabase::create(schema);
+    db.add_multi("s", 10500, {{"XaddrA", 100}, {"XaddrB", 50}});
+    db.add_multi("s", 10600, {{"XaddrA", 200}, {"XaddrB", 60}});
+
+    nlohmann::json obj = db.to_obj();
+    bool needs_reseed = true;
+    auto db2 = HistoryDatabase::from_obj(schema, obj, needs_reseed);
+    EXPECT_FALSE(needs_reseed);
+    // Same served output before and after a save/load cycle.
+    auto a = db.stream("s")->view("last_hour")->get_data(db.stream("s")->desc, 10600);
+    auto b = db2.stream("s")->view("last_hour")->get_data(db2.stream("s")->desc, 10600);
+    EXPECT_EQ(a, b);
+}
+
+// ── per-view GEOMETRY MISMATCH -> reseed, never a null/mismatched view ────────
+TEST(GraphHistory, GeometryMismatchForcesReseed)
+{
+    auto schema10 = one_view_schema(10, 10000.0, false, false, 20, false);
+    auto db = HistoryDatabase::create(schema10);
+    db.add_scalar("s", 10500, 7);
+    nlohmann::json obj = db.to_obj();
+
+    // A future config changed bin_count 10 -> 20: the stored view is valid JSON
+    // but the WRONG geometry. It must be discarded (needs_reseed) and rebuilt
+    // empty at the compiled geometry, never loaded as-is and never null.
+    auto schema20 = one_view_schema(20, 10000.0, false, false, 20, false);
+    bool needs_reseed = false;
+    auto db2 = HistoryDatabase::from_obj(schema20, obj, needs_reseed);
+    EXPECT_TRUE(needs_reseed);
+    const auto* dv = db2.stream("s")->view("last_hour");
+    ASSERT_NE(dv, nullptr);
+    EXPECT_EQ(dv->bins.size(), 20u);  // compiled geometry, all empty
+    for (const auto& bin : dv->bins) EXPECT_TRUE(bin.empty());
+}
+
+// ── missing stream in stored obj -> reseed ───────────────────────────────────
+TEST(GraphHistory, MissingStreamForcesReseed)
+{
+    auto schema = one_view_schema(10, 10000.0, false, false, 20, false);
+    nlohmann::json empty_obj = nlohmann::json::object();  // nothing stored
+    bool needs_reseed = false;
+    auto db = HistoryDatabase::from_obj(schema, empty_obj, needs_reseed);
+    EXPECT_TRUE(needs_reseed);
+    // Still yields a usable, correctly-shaped empty DB (never null).
+    ASSERT_NE(db.stream("s"), nullptr);
+    ASSERT_NE(db.stream("s")->view("last_hour"), nullptr);
+    EXPECT_EQ(db.stream("s")->view("last_hour")->bins.size(), 10u);
+}
+
+// ── watermark-gated replay is idempotent (no double counting) ─────────────────
+TEST(GraphHistory, WatermarkReplayIsIdempotent)
+{
+    auto schema = one_view_schema(10, 10000.0, false, false, 20, false);
+    auto db = HistoryDatabase::create(schema);
+
+    struct Sample { double t; double v; };
+    std::vector<Sample> flat = {{10500, 100}, {10600, 200}, {10700, 300}};
+    for (auto& s : flat) db.add_scalar("s", s.t, s.v);
+    double watermark = flat.back().t;
+
+    nlohmann::json obj = db.to_obj();
+    bool needs_reseed = true;
+    auto reloaded = HistoryDatabase::from_obj(schema, obj, needs_reseed);
+    ASSERT_FALSE(needs_reseed);
+
+    // Simulate the load-time incremental replay: only entries strictly newer
+    // than the watermark are re-added. With watermark == last, nothing replays,
+    // so the served output is byte-identical to the pre-save output.
+    for (auto& s : flat)
+        if (s.t > watermark) reloaded.add_scalar("s", s.t, s.v);
+
+    auto a = db.stream("s")->view("last_hour")->get_data(db.stream("s")->desc, 10700);
+    auto b = reloaded.stream("s")->view("last_hour")->get_data(
+        reloaded.stream("s")->desc, 10700);
+    EXPECT_EQ(a, b);
+    // And the mean at the newest bin is unchanged (200 == mean of 100/200/300
+    // when all three share the newest bin window).
+    EXPECT_NEAR(last_scalar(b), 200.0, 1e-9);
+}

--- a/src/core/test/web_server_dashboard_data_test.cpp
+++ b/src/core/test/web_server_dashboard_data_test.cpp
@@ -26,6 +26,9 @@
 
 #include <cstdio>
 #include <string>
+#include <chrono>
+#include <fstream>
+#include <thread>
 
 using core::MiningInterface;
 
@@ -627,4 +630,198 @@ TEST(FoundBlockAuthorship, EnrichmentRaisesAuthorshipAndNeverLowersIt)
     EXPECT_EQ(find_block(mi.rest_recent_blocks(), h2)["found_by"].get<std::string>(),
               "this_node")
         << "a later, less informed call must not downgrade a known finder";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. G4: year-scale binned graph history (#159)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// These extend the persistence round-trip (case 6) to the new <path>.views
+// sidecar: a clean save/reload serves the long horizons from the bins, the
+// pool_rates served dict keeps its exact {good,orphan,dead} shape with no
+// leaked 'null' counter, and a missing / corrupt / truncated sidecar degrades
+// to the flat fallback without ever crashing load or startup.
+
+namespace {
+
+// Poll until the binned views finish loading/seeding (background thread), with
+// a generous bound so slow CI never flakes. Returns true if ready in time.
+bool wait_views_ready(const MiningInterface& mi, int timeout_ms = 5000)
+{
+    for (int waited = 0; waited < timeout_ms; waited += 20) {
+        if (mi.graph_views_ready()) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    return mi.graph_views_ready();
+}
+
+// The week view's bin width == 604800/300 == 2016 s; the flat path hardcodes
+// 300.0 for d[2]. Reading the width tells us WHICH path served the request.
+constexpr double kWeekBinWidth = 604800.0 / 300.0;  // 2016.0
+
+}  // namespace
+
+TEST(DashboardData, GraphViewsSidecarRoundTrip)
+{
+    const std::string path = "/tmp/c2pool_test_g4_views.json";
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+
+    {
+        MiningInterface mi(false, nullptr, c2pool::address::Blockchain::DASH);
+        mi.set_pool_hashrate_fn([]() { return 1234.0; });
+        mi.set_stat_log_path(path);
+        mi.load_stat_log();               // empty flat -> schema built + seeded
+        ASSERT_TRUE(wait_views_ready(mi));
+        for (int i = 0; i < 5; ++i) mi.update_stat_log();  // fan into the bins
+        mi.save_stat_log();               // writes flat FIRST, then .views
+    }
+
+    // The sidecar exists on disk.
+    { std::ifstream f(path + ".views"); ASSERT_TRUE(f.good()); }
+
+    // Reload: a clean load must adopt the bins (no reseed) and serve week from
+    // them — provable by the bin width in d[2].
+    MiningInterface mi2(false, nullptr, c2pool::address::Blockchain::DASH);
+    mi2.set_stat_log_path(path);
+    mi2.load_stat_log();
+    ASSERT_TRUE(wait_views_ready(mi2));
+
+    auto week = mi2.rest_web_graph_data("pool_hash_rate", "last_week");
+    ASSERT_TRUE(week.is_array());
+    ASSERT_FALSE(week.empty());
+    // The bin path's newest bin is partial, so its width is < the full 2016 s
+    // bin width but is NEVER the flat path's hardcoded 300.0 — that difference
+    // is the proof the request was answered from the bins.
+    const double wk_w = week.back()[2].get<double>();
+    EXPECT_NE(wk_w, 300.0) << "week must be served from the bins, not the flat 300s path";
+    EXPECT_GT(wk_w, 0.0);
+    EXPECT_LE(wk_w, kWeekBinWidth + 1e-6);
+
+    // last_hour stays on the flat path (unchanged), width == 300.
+    auto hour = mi2.rest_web_graph_data("pool_hash_rate", "last_hour");
+    ASSERT_TRUE(hour.is_array());
+    if (!hour.empty())
+        EXPECT_NEAR(hour.back()[2].get<double>(), 300.0, 1e-6)
+            << "last_hour must keep the flat path unchanged";
+
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+}
+
+// The served pool_rates dict keeps EXACTLY {good,orphan,dead}; the internal
+// 'null' sample-counter key must never leak (dashboard.html sums d[1]['null']
+// into DOA — review-mandated served-dict hygiene).
+TEST(DashboardData, GraphViewsPoolRatesServedShapeHasNoNullKey)
+{
+    const std::string path = "/tmp/c2pool_test_g4_poolrates.json";
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+
+    MiningInterface mi(false, nullptr, c2pool::address::Blockchain::DASH);
+    mi.set_pool_hashrate_fn([]() { return 5000.0; });
+    mi.set_stat_log_path(path);
+    mi.load_stat_log();
+    ASSERT_TRUE(wait_views_ready(mi));
+    for (int i = 0; i < 4; ++i) mi.update_stat_log();
+
+    auto week = mi.rest_web_graph_data("pool_rates", "last_week");
+    ASSERT_TRUE(week.is_array());
+    ASSERT_FALSE(week.empty());
+    const double wk_w = week.back()[2].get<double>();
+    EXPECT_NE(wk_w, 300.0);            // from bins, not the flat 300s path
+    EXPECT_LE(wk_w, kWeekBinWidth + 1e-6);
+    const auto& val = week.back()[1];
+    ASSERT_TRUE(val.is_object());
+    EXPECT_TRUE(val.contains("good"));
+    EXPECT_TRUE(val.contains("orphan"));
+    EXPECT_TRUE(val.contains("dead"));
+    EXPECT_FALSE(val.contains("null")) << "the sample-counter key must not leak";
+
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+}
+
+// A corrupt sidecar must NOT crash load_stat_log and must NOT block the flat
+// file from loading; the node degrades to reseed-from-flat and keeps serving.
+TEST(DashboardData, GraphViewsCorruptSidecarDegradesToFlatSeed)
+{
+    const std::string path = "/tmp/c2pool_test_g4_corrupt.json";
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+
+    // First, produce a valid flat log with a few entries.
+    {
+        MiningInterface mi(false, nullptr, c2pool::address::Blockchain::DASH);
+        mi.set_pool_hashrate_fn([]() { return 42.0; });
+        mi.set_stat_log_path(path);
+        mi.load_stat_log();
+        ASSERT_TRUE(wait_views_ready(mi));
+        for (int i = 0; i < 3; ++i) mi.update_stat_log();
+        mi.save_stat_log();
+    }
+    // Now corrupt the sidecar (valid flat file still present).
+    { std::ofstream f(path + ".views", std::ios::trunc); f << "{ this is not json"; }
+
+    MiningInterface mi2(false, nullptr, c2pool::address::Blockchain::DASH);
+    mi2.set_stat_log_path(path);
+    ASSERT_NO_THROW(mi2.load_stat_log());   // must not crash on the corrupt file
+    ASSERT_TRUE(wait_views_ready(mi2));     // seeded from the flat log instead
+    // Still serves week (from the reseeded bins).
+    auto week = mi2.rest_web_graph_data("pool_hash_rate", "last_week");
+    EXPECT_TRUE(week.is_array());
+
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+}
+
+// A truncated sidecar (partial JSON) is tolerated the same way; and a totally
+// absent sidecar on an existing flat log is the ordinary upgrade path.
+TEST(DashboardData, GraphViewsTruncatedAndMissingSidecarTolerated)
+{
+    const std::string path = "/tmp/c2pool_test_g4_trunc.json";
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
+
+    {
+        MiningInterface mi(false, nullptr, c2pool::address::Blockchain::DASH);
+        mi.set_pool_hashrate_fn([]() { return 7.0; });
+        mi.set_stat_log_path(path);
+        mi.load_stat_log();
+        ASSERT_TRUE(wait_views_ready(mi));
+        for (int i = 0; i < 3; ++i) mi.update_stat_log();
+        mi.save_stat_log();
+    }
+    // Truncate the sidecar to a partial object.
+    {
+        std::ifstream in(path + ".views");
+        std::string s((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+        std::ofstream out(path + ".views", std::ios::trunc);
+        out << s.substr(0, s.size() / 2);   // half a JSON document
+    }
+    MiningInterface mi2(false, nullptr, c2pool::address::Blockchain::DASH);
+    mi2.set_stat_log_path(path);
+    ASSERT_NO_THROW(mi2.load_stat_log());
+    EXPECT_TRUE(wait_views_ready(mi2));
+
+    // Absent sidecar: the classic first-boot-after-upgrade path. The flat 31d
+    // history seeds the week/month/year views.
+    std::remove((path + ".views").c_str());
+    MiningInterface mi3(false, nullptr, c2pool::address::Blockchain::DASH);
+    mi3.set_stat_log_path(path);
+    ASSERT_NO_THROW(mi3.load_stat_log());
+    EXPECT_TRUE(wait_views_ready(mi3));
+    auto year = mi3.rest_web_graph_data("pool_hash_rate", "last_year");
+    EXPECT_TRUE(year.is_array());   // seeded from the flat log, serves
+
+    std::remove(path.c_str());
+    std::remove((path + ".views").c_str());
+    std::remove((path + ".best.json").c_str());
 }

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -62,6 +62,16 @@ MiningInterface::MiningInterface(bool testnet, std::shared_ptr<IMiningNode> node
     setup_methods();
 }
 
+MiningInterface::~MiningInterface()
+{
+    // Stop and join the background graph-view seed thread (if it is still
+    // replaying the flat log). Never blocks shutdown for long: the flag is
+    // checked between entries.
+    m_views_seed_stop.store(true, std::memory_order_relaxed);
+    if (m_views_seed_thread.joinable())
+        m_views_seed_thread.join();
+}
+
 void MiningInterface::setup_methods()
 {
     // Core mining methods - explicitly cast to MethodHandle
@@ -7083,6 +7093,19 @@ nlohmann::json MiningInterface::rest_web_graph_data(const std::string& source, c
     // data_to_lines() in graphs.html parses this format.
     nlohmann::json result = nlohmann::json::array();
 
+    // G4 dispatch: the long horizons (week/month/year) answer from the binned
+    // history DB when it is ready, dropping the payload from thousands of flat
+    // samples to ~300 bin points. last_hour/last_day stay on the flat path
+    // below unchanged. If the binned view is not ready yet (still seeding) or is
+    // empty, fall through to the flat path — never worse than today.
+    if ((view == "last_week" || view == "last_month" || view == "last_year")
+        && m_views_ready.load(std::memory_order_acquire)) {
+        nlohmann::json binned = graph_view_data(source, view);
+        if (binned.is_array() && !binned.empty())
+            return binned;
+        // else: fall through to the flat path (honest-absent / not-yet-filled)
+    }
+
     std::lock_guard<std::mutex> lock(m_stat_log_mutex);
     auto now = std::time(nullptr);
     double window = 3600.0;
@@ -7544,6 +7567,300 @@ void MiningInterface::update_stat_log()
         while (!m_stat_log.empty() && m_stat_log.front().time < cutoff)
             m_stat_log.erase(m_stat_log.begin());
     }
+
+    // G4: fan the fresh entry into the binned history DB (last_week/month/year).
+    // Done AFTER releasing m_stat_log_mutex so the two locks never couple. The
+    // history DB has its own mutex. One datum per 60s tick — no new timer.
+    {
+        std::lock_guard<std::mutex> hlock(m_history_mutex);
+        feed_history_entry(entry);
+        m_views_watermark = entry.time;
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// G4: year-scale binned graph history (p2pool util/graph.py port)
+// ════════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+// nlohmann {key: number} object -> std::map<string,double>, skipping non-numbers.
+std::map<std::string, double> json_obj_to_map(const nlohmann::json& j)
+{
+    std::map<std::string, double> out;
+    if (j.is_object())
+        for (auto it = j.begin(); it != j.end(); ++it)
+            if (it.value().is_number())
+                out[it.key()] = it.value().get<double>();
+    return out;
+}
+
+double json_obj_sum(const nlohmann::json& j)
+{
+    double s = 0.0;
+    if (j.is_object())
+        for (auto& [k, v] : j.items())
+            if (v.is_number()) s += v.get<double>();
+    return s;
+}
+
+}  // namespace
+
+std::vector<std::pair<std::string, core::graph::DataStreamDescription>>
+MiningInterface::graph_stream_descriptions()
+{
+    using core::graph::DataViewDescription;
+    using core::graph::DataStreamDescription;
+
+    // The five p2pool horizons. last_hour/last_day are maintained in the DB for
+    // completeness but SERVED from the flat log; last_week/month/year are served
+    // from these bins. last_year = 365.25d / 300 bins (p2pool-exact).
+    const std::vector<std::pair<std::string, DataViewDescription>> views = {
+        {"last_hour",  DataViewDescription(150, 60.0 * 60.0)},
+        {"last_day",   DataViewDescription(300, 60.0 * 60.0 * 24.0)},
+        {"last_week",  DataViewDescription(300, 60.0 * 60.0 * 24.0 * 7.0)},
+        {"last_month", DataViewDescription(300, 60.0 * 60.0 * 24.0 * 30.0)},
+        {"last_year",  DataViewDescription(300, 60.0 * 60.0 * 24.0 * 365.25)},
+    };
+
+    // Every c2pool stream is a GAUGE (deliberate deviation from p2pool — the
+    // datums are pre-computed H/s rates sampled at 60s, so a bin holds their
+    // MEAN, not total/bin_width). See graph_history.hpp.
+    auto scalar = [&]() {
+        DataStreamDescription d;
+        d.dataview_descriptions = views;
+        d.is_gauge = true;
+        d.multivalues = false;
+        return d;
+    };
+    // Per-address multivalue streams are capped (review #1): p2pool's
+    // multivalues_keep=10000 makes month/year unbounded on a large pool. Cap at
+    // 200 keys with an "other" squash key. The per-address YEAR payout story
+    // (open question #14) is DEFERRED — it would reinflate exactly this bound.
+    auto multi = [&](bool undefined0, bool capped) {
+        DataStreamDescription d;
+        d.dataview_descriptions = views;
+        d.is_gauge = true;
+        d.multivalues = true;
+        d.multivalue_undefined_means_0 = undefined0;
+        if (capped) {
+            d.multivalues_keep = 200;
+            d.has_squash_key = true;
+            d.multivalues_squash_key = "other";
+        } else {
+            d.multivalues_keep = 20;  // fixed-key streams (peers, traffic): 2 keys
+        }
+        return d;
+    };
+
+    return {
+        {"pool_rates",              multi(/*undefined0=*/true,  /*capped=*/false)},
+        {"pool_hash_rate",          scalar()},
+        {"pool_stale_prop",         scalar()},
+        {"local_hash_rate",         scalar()},
+        {"local_dead_hash_rate",    scalar()},
+        {"local_share_hash_rates",  multi(true,  true)},
+        {"miner_hash_rates",        multi(false, true)},
+        {"miner_dead_hash_rates",   multi(false, true)},
+        {"current_payout",          scalar()},
+        {"current_payouts",         multi(false, true)},
+        {"merged_current_payouts",  multi(false, true)},
+        {"peers",                   multi(false, false)},
+        {"desired_version_rates",   multi(true,  true)},
+        {"worker_count",            scalar()},
+        {"unique_miner_count",      scalar()},
+        {"connected_miners",        scalar()},
+        {"traffic_rate",            multi(false, false)},
+        {"getwork_latency",         scalar()},
+        {"memory_usage",            scalar()},
+        {"network_difficulty",      scalar()},
+        {"share_difficulty",        scalar()},
+    };
+}
+
+void MiningInterface::feed_history_entry(const StatLogEntry& e)
+{
+    // Caller holds m_history_mutex.
+    const double t = e.time;
+
+    // pool_rates — SAME derivation the flat path uses at rest_web_graph_data:
+    // good = phr*(1-stale), orphan = phr*stale, dead = 0.
+    m_history.add_multi("pool_rates", t, {
+        {"good",   e.pool_hash_rate * (1.0 - e.pool_stale_prop)},
+        {"orphan", e.pool_hash_rate * e.pool_stale_prop},
+        {"dead",   0.0},
+    });
+
+    m_history.add_scalar("pool_hash_rate",       t, e.pool_hash_rate);
+    m_history.add_scalar("pool_stale_prop",      t, e.pool_stale_prop);
+    m_history.add_scalar("local_hash_rate",      t, json_obj_sum(e.local_hash_rates));
+    m_history.add_scalar("local_dead_hash_rate", t, json_obj_sum(e.local_dead_hash_rates));
+
+    m_history.add_multi("local_share_hash_rates", t, json_obj_to_map(e.local_hash_rates));
+    m_history.add_multi("miner_hash_rates",       t, json_obj_to_map(e.local_hash_rates));
+    m_history.add_multi("miner_dead_hash_rates",  t, json_obj_to_map(e.local_dead_hash_rates));
+
+    m_history.add_scalar("current_payout",        t, e.current_payout);
+    m_history.add_multi("current_payouts",        t, json_obj_to_map(e.current_payouts));
+    m_history.add_multi("merged_current_payouts", t, json_obj_to_map(e.merged_current_payouts));
+    m_history.add_multi("peers",                  t, json_obj_to_map(e.peers));
+    m_history.add_multi("desired_version_rates",  t, json_obj_to_map(e.desired_versions));
+
+    m_history.add_scalar("worker_count",       t, static_cast<double>(e.worker_count));
+    m_history.add_scalar("unique_miner_count", t, static_cast<double>(e.miner_count));
+    m_history.add_scalar("connected_miners",   t, static_cast<double>(e.connected_count));
+    m_history.add_multi ("traffic_rate",       t, json_obj_to_map(e.traffic));
+    m_history.add_scalar("getwork_latency",    t, e.work_latency);
+    m_history.add_scalar("memory_usage",       t, e.memory_usage);
+    m_history.add_scalar("network_difficulty", t, e.network_difficulty);
+    m_history.add_scalar("share_difficulty",   t, e.share_difficulty);
+}
+
+nlohmann::json MiningInterface::graph_view_data(const std::string& source,
+                                                const std::string& view)
+{
+    // "pool_rate" (singular) is an alias of the "pool_hash_rate" scalar, kept
+    // for wire compatibility exactly as the flat path does.
+    const std::string src = (source == "pool_rate") ? "pool_hash_rate" : source;
+    std::lock_guard<std::mutex> hlock(m_history_mutex);
+    const auto* stream = m_history.stream(src);
+    if (!stream) return nlohmann::json::array();  // honest-absent unknown source
+    const auto* dv = stream->view(view);
+    if (!dv) return nlohmann::json::array();
+    return dv->get_data(stream->desc, static_cast<double>(std::time(nullptr)));
+}
+
+void MiningInterface::save_graph_views()
+{
+    const std::string path = graph_views_path();
+    if (path.empty()) return;
+    try {
+        nlohmann::json out;
+        {
+            std::lock_guard<std::mutex> hlock(m_history_mutex);
+            // Only persist once the views carry data — a half-seeded DB would
+            // store a watermark ahead of its bins and mislead the next replay.
+            if (!m_views_ready.load(std::memory_order_acquire)) return;
+            out["version"] = 1;
+            out["watermark"] = m_views_watermark;
+            out["data"] = m_history.to_obj();
+        }
+        const std::string tmp = path + ".new";
+        { std::ofstream f(tmp, std::ios::trunc); f << out.dump(); }
+        std::filesystem::rename(tmp, path);
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[GraphViews] Save failed: " << ex.what();
+    }
+}
+
+void MiningInterface::seed_graph_views_from_flat()
+{
+    // Replay the WHOLE flat log into empty views (the upgrade / corrupt-recovery
+    // path). Runs on a background thread so a live money node never blocks
+    // startup on the ~44k-entry x ~21-stream replay; week/month/year answer from
+    // the flat fallback until this completes. Any throw leaves the views empty
+    // (m_views_ready stays false) → permanent flat fallback, which is safe.
+    try {
+        std::vector<StatLogEntry> snapshot;
+        {
+            std::lock_guard<std::mutex> lock(m_stat_log_mutex);
+            snapshot = m_stat_log;   // chronological (append order)
+        }
+        double last_t = 0.0;
+        for (const auto& e : snapshot) {
+            if (m_views_seed_stop.load(std::memory_order_relaxed)) return;
+            std::lock_guard<std::mutex> hlock(m_history_mutex);
+            feed_history_entry(e);
+            last_t = e.time;
+        }
+        {
+            std::lock_guard<std::mutex> hlock(m_history_mutex);
+            if (last_t > m_views_watermark) m_views_watermark = last_t;
+        }
+        m_views_ready.store(true, std::memory_order_release);
+        LOG_INFO << "[GraphViews] Seeded binned views from " << snapshot.size()
+                 << " flat entries";
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[GraphViews] Seed failed (serving long views from flat "
+                       "fallback): " << ex.what();
+    }
+}
+
+void MiningInterface::load_graph_views()
+{
+    // Fully guarded (review #4): ANY failure — missing / parse error / version
+    // mismatch / geometry mismatch — degrades to seed-from-flat, and if seeding
+    // itself throws the views stay empty and week/month/year serve from the flat
+    // fallback. Never aborts load_stat_log, never crashes startup.
+    const std::string path = graph_views_path();
+    if (path.empty()) return;
+
+    // Always (re)build the schema so the compiled geometry is authoritative.
+    const auto descs = graph_stream_descriptions();
+
+    bool do_full_seed = true;   // default: no usable sidecar → seed from flat
+    try {
+        std::ifstream f(path);
+        if (f) {
+            std::string content((std::istreambuf_iterator<char>(f)),
+                                std::istreambuf_iterator<char>());
+            if (!content.empty()) {
+                auto obj = nlohmann::json::parse(content);  // throws on corrupt
+                int version = obj.is_object() ? obj.value("version", 0) : 0;
+                if (version == 1 && obj.contains("data")) {
+                    bool needs_reseed = false;
+                    auto db = core::graph::HistoryDatabase::from_obj(
+                        descs, obj["data"], needs_reseed);
+                    if (!needs_reseed) {
+                        // Clean load: adopt the bins, then incrementally replay
+                        // the flat tail strictly newer than the stored watermark
+                        // (covers a crash between the flat and .views saves).
+                        double watermark = obj.value("watermark", 0.0);
+                        std::vector<StatLogEntry> tail;
+                        {
+                            std::lock_guard<std::mutex> lock(m_stat_log_mutex);
+                            for (const auto& e : m_stat_log)
+                                if (e.time > watermark) tail.push_back(e);
+                        }
+                        {
+                            std::lock_guard<std::mutex> hlock(m_history_mutex);
+                            m_history = std::move(db);
+                            m_views_watermark = watermark;
+                            for (const auto& e : tail) {
+                                feed_history_entry(e);
+                                if (e.time > m_views_watermark)
+                                    m_views_watermark = e.time;
+                            }
+                        }
+                        m_views_ready.store(true, std::memory_order_release);
+                        do_full_seed = false;
+                        LOG_INFO << "[GraphViews] Loaded bins (watermark "
+                                 << static_cast<long long>(watermark) << ", replayed "
+                                 << tail.size() << " tail entries)";
+                    }
+                    // needs_reseed (missing view / wrong geometry) falls through
+                    // to the full seed below with fresh, correctly-shaped views.
+                }
+            }
+        }
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[GraphViews] Sidecar load failed, seeding from flat: "
+                    << ex.what();
+        do_full_seed = true;
+    }
+
+    if (do_full_seed) {
+        // Fresh, correctly-shaped empty views; seed on a background thread.
+        {
+            std::lock_guard<std::mutex> hlock(m_history_mutex);
+            m_history = core::graph::HistoryDatabase::create(descs);
+            m_views_watermark = 0.0;
+        }
+        m_views_ready.store(false, std::memory_order_release);
+        if (m_views_seed_thread.joinable()) m_views_seed_thread.join();
+        m_views_seed_stop.store(false, std::memory_order_relaxed);
+        m_views_seed_thread = std::thread([this]() { seed_graph_views_from_flat(); });
+    }
 }
 
 void MiningInterface::save_stat_log()
@@ -7598,12 +7915,23 @@ void MiningInterface::save_stat_log()
     } catch (const std::exception& ex) {
         LOG_WARNING << "[StatLog] Save failed: " << ex.what();
     }
+
+    // G4: persist the binned views AFTER the flat file (review-mandated order).
+    // The stored watermark can then never exceed the flat file's newest entry,
+    // so the strict t>watermark replay on load is provably double-count-free and
+    // the crash window is bounded to flat-newer-than-views (absorbed by replay).
+    save_graph_views();
 }
 
 void MiningInterface::load_stat_log()
 {
     if (m_stat_log_path.empty()) return;
-    try {
+    // Flat-log load is wrapped in an IIFE so its early returns (missing/empty/
+    // malformed file) skip ONLY the flat parse — load_best_share_all_time and
+    // load_graph_views below must always run, including on a first boot where no
+    // flat file exists yet (that is exactly when the views seed themselves).
+    [&]() {
+      try {
         std::ifstream f(m_stat_log_path);
         if (!f) return;
         std::string content((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
@@ -7644,10 +7972,17 @@ void MiningInterface::load_stat_log()
             m_stat_log.push_back(std::move(e));
         }
         LOG_INFO << "[StatLog] Loaded " << m_stat_log.size() << " entries from " << m_stat_log_path;
-    } catch (const std::exception& ex) {
+      } catch (const std::exception& ex) {
         LOG_WARNING << "[StatLog] Load failed: " << ex.what();
-    }
+      }
+    }();
     load_best_share_all_time();
+
+    // G4: load (or seed) the binned graph views. Runs AFTER the flat log is in
+    // memory so the seed/replay migration can read m_stat_log. Fully guarded:
+    // any failure degrades to serving week/month/year from the flat fallback and
+    // never aborts load_stat_log or crashes startup.
+    load_graph_views();
 }
 
 // ── ALL-TIME best share: survives restarts ──────────────────────────────

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -34,6 +34,7 @@
 #include <c2pool/payout/payout_manager.hpp>
 #include <c2pool/hashrate/tracker.hpp>
 #include <core/address_utils.hpp>
+#include <core/graph_history.hpp>
 
 // Forward declaration for merged mining integration
 namespace c2pool { namespace merged { class MergedMiningManager; } }
@@ -124,6 +125,7 @@ class MiningInterface : public jsonrpccxx::JsonRpc2Server,
 {
 public:
     MiningInterface(bool testnet = false, std::shared_ptr<IMiningNode> node = nullptr, Blockchain blockchain = Blockchain::LITECOIN);
+    ~MiningInterface();
 
     // Core mining methods that miners expect
     nlohmann::json getwork(const std::string& request_id = "");
@@ -1684,7 +1686,46 @@ public:
     void save_stat_log();
     /// Load stat log from disk. Called once at startup.
     void load_stat_log();
+    /// True once the binned graph views are loaded/seeded and answering the
+    /// long horizons. Until then week/month/year serve from the flat fallback.
+    bool graph_views_ready() const { return m_views_ready.load(std::memory_order_acquire); }
 private:
+    // ── G4: year-scale binned graph history (p2pool graph.py port) ───────────
+    // A coin-generic binned history DB (core::graph) that backs the long-horizon
+    // graph views (last_week / last_month / last_year). last_hour / last_day are
+    // still served from the flat m_stat_log above — the 60s samples are denser
+    // than useful there and binning would only introduce null gaps. Fed one
+    // datum per 60s update_stat_log tick; persisted to <stat_log_path>.views on
+    // the existing save cadence; seeded from the flat log on first upgrade.
+    core::graph::HistoryDatabase m_history;
+    mutable std::mutex m_history_mutex;
+    // Guards the crossover: while false, week/month/year fall back to the flat
+    // path (never worse than today). Set true once bins are loaded/seeded.
+    std::atomic<bool> m_views_ready{false};
+    // Background seed thread (used when the .views file is absent/corrupt/geometry-
+    // mismatched and all views must be replayed from the flat log). Joined in the
+    // destructor. Long views answer from the flat fallback until it completes.
+    std::thread m_views_seed_thread;
+    std::atomic<bool> m_views_seed_stop{false};
+    double m_views_watermark{0.0};  // last binned datum time (persisted)
+
+    std::string graph_views_path() const {
+        return m_stat_log_path.empty() ? std::string()
+                                       : m_stat_log_path + ".views";
+    }
+    // The stream schema (~21 streams). Coin-generic; identical for every coin.
+    static std::vector<std::pair<std::string, core::graph::DataStreamDescription>>
+        graph_stream_descriptions();
+    // Fold one flat StatLogEntry into every binned stream. Caller holds
+    // m_history_mutex.
+    void feed_history_entry(const StatLogEntry& e);
+    // Serve one long view from the bins ([] if unknown source / empty).
+    nlohmann::json graph_view_data(const std::string& source, const std::string& view);
+    // Persistence + one-time seed/replay migration for the .views sidecar.
+    void save_graph_views();
+    void load_graph_views();   // called at the tail of load_stat_log
+    void seed_graph_views_from_flat();  // background replay of the whole flat log
+public:
 
     // Network difficulty history for /network_difficulty
     struct NetDiffSample { double ts; double difficulty; std::string source; };


### PR DESCRIPTION
## Summary

Ports p2pool's `util/graph.py` binning to a new coin-generic core module
(`core::graph` — `HistoryDatabase` / `DataStream` / `DataView`) that backs the
dashboard's long-horizon graphs. The flat per-sample stat log stays for the
short horizons; the long horizons move to fixed 300-bin views, and a real
year-scale retention is added.

Refs #159.

## View / bin layout

| view        | bins | bin width | served from |
|-------------|------|-----------|-------------|
| `last_hour` | 150  | 24 s      | flat stat log (unchanged) |
| `last_day`  | 300  | 288 s     | flat stat log (unchanged) |
| `last_week` | 300  | 2016 s    | **bins** (10080 → ~300 points) |
| `last_month`| 300  | 8640 s    | **bins** (44640 → ~300 points) |
| `last_year` | 300  | 105192 s (365.25 d / 300) | **bins** — new real year retention |

`rest_web_graph_data` is a hybrid dispatcher: `last_hour`/`last_day` keep
today's flat path byte-for-byte; `last_week`/`last_month`/`last_year` answer
from the bins and fall back to the flat path whenever a binned view is empty or
not yet ready — never worse than today.

The DB is fed one datum per existing 60 s `update_stat_log` tick (~21 streams),
under its own mutex, with no new timer and no lock coupling to the stat-log
mutex.

### Gauge-mean deviation (reviewer-signed)

Every stream is `is_gauge=true`: a bin holds the **mean** of its samples
(`total/count`). This is a deliberate deviation from p2pool's rate model
(`total/bin_width`), justified because c2pool's `StatLogEntry` fields are
pre-computed H/s rates sampled at a fixed 60 s cadence — the rate model would
rescale every long-view hashrate by a factor of `bin_width`. A golden test
pins this (week/month/year value == mean of the flat samples).

## Migration behavior for an existing flat 31-day `graph_db`

`load_stat_log()` runs first, unchanged: the current flat 31-day `graph_db` is
accepted exactly as today and is **never** rewritten, truncated, or deleted.
Then the new sibling `<stat_log_path>.views` is handled:

- **present, version-ok, geometry-ok** → load the bins, then replay only flat
  entries strictly newer than the stored watermark (covers a crash between the
  two saves; strict `>` prevents double counting);
- **missing / corrupt / truncated / version-mismatched / per-view
  geometry-mismatched** → seed all views by replaying the flat log. This is the
  upgrade path: an existing 31-day flat history appears in the
  week/month/year views on the first boot after deploy, and the year view grows
  from there. The seed runs on a background thread, so a live node never blocks
  startup; long views serve from the flat fallback until it completes, and any
  seed failure leaves the views empty (permanent flat fallback — safe).

The `.views` write happens **after** the flat file on the existing 100 s save
cadence, so the stored watermark can never exceed the flat file's newest entry.

## Retained horizon

The flat `graph_db` keeps its **31-day** window and save format untouched
(shrinking it is a separate, later, config-gated decision). The binned views
retain **week / month / year (365.25 d)**. Rollback to an old binary is safe:
it ignores `.views` and keeps writing the flat file; on re-upgrade the watermark
replay re-absorbs the gap (bounded by the 31-day flat window).

## Frontend compatibility

Wire shape frozen: `GET /web/graph_data/<source>/last_<view>` still returns
`[timestamp, value, width, default]` 4-tuples — scalar for scalar sources, a
dict for plural sources (`pool_rates {good,orphan,dead}`), null on empty gauge
bins. Endpoint paths, the `last_hour..last_year` names, the 1H/1D/1W/1M/1Y
selector, all source names and the `pool_rate` alias are untouched; only the
point count and the width value change for week/month/year, neither of which is
part of the contract. Points are emitted ascending in time and leading
never-filled bins are clipped. The internal `null` sample-counter key is never
leaked into a served dict (the renderer sums `d[1]['null']` into DOA).
Per-address multivalue streams are capped at 200 keys with an `other` squash key
to bound month/year file size on a large pool.

## Coin-generic

Everything lives in core `MiningInterface`, wired by every `main_<coin>` via
`set_stat_log_path`. DASH and LTC need zero per-coin code.

## Tests / build

- `src/core/test/graph_history_test.cpp`: p2pool `test_graph.py::test_keep_largest`
  port, gauge-mean semantics, ascending + leading-clip, `to_obj`/`from_obj`
  round-trip, per-view geometry-mismatch reseed, missing-stream reseed,
  watermark idempotency.
- `web_server_dashboard_data_test.cpp`: `.views` round-trip, served-dict hygiene
  (`pool_rates` shape, no `null` leak), corrupt / truncated / missing sidecar
  tolerance.
- `core` (incl. `web_server.cpp`, `graph_history.cpp`), `core_test`,
  `c2pool-dash` and `c2pool-ltc` all build clean; the full 190-case `core_test`
  suite passes.

Draft — do not merge.
