### PR TITLE
Dashboard: complete persistence roll — network-diff seed, per-miner ring rehydrate, real shares counters, DASH merged/checkpoint parity (G6-G9, #159)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -131,7 +131,8 @@
 #include <impl/dash/stratum/tip_refresh.hpp>   // dash::stratum::fire_share_tip_refresh — bump + notify_all + dashboard refresh
 #include <impl/dash/local_mint_ledger.hpp>     // dash::mint::LocalMintLedger — display-only local orphan/sibling gauge
 #include <impl/dash/share_messages.hpp>        // dash::validate_message_data — operator message-blob validation (EMIT side, mirrors main_ltc.cpp)
-#include <c2pool/storage/found_block_store.hpp>  // FoundBlockStore/Record + LevelDBStore (persistence, main_ltc parity)
+#include <c2pool/storage/found_block_store.hpp>  // FoundBlockStore/Record + LevelDBStore + MergedBlockStore (persistence, main_ltc parity)
+#include <c2pool/storage/the_checkpoint.hpp>   // TheCheckpointStore — #159 (G9) DASH parity wiring (inert until merged mining)
 #include <core/web_server.hpp>                 // core::WebServer — the EXISTING c2pool dashboard (same wiring main_ltc.cpp uses)
 #include <impl/dash/enhanced_node.hpp>         // dash::EnhancedDashNode — core::IMiningNode the WebServer ctor takes
 #include <impl/dash/share_messages.hpp>        // dash::unpack_share_messages — signed transitional-blob DISPLAY+VERIFY feed
@@ -1343,6 +1344,81 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 );
                 mi->load_persisted_found_blocks();
                 LOG_INFO << "[Pool] DASH found-block persistence enabled at " << fblk_db_path;
+
+                // #159 (G6): seed the network-difficulty series from the restored
+                // found-block rows so the long-horizon diff curve is rebuildable
+                // even from a wiped stat/.views file. Display-only, crash-safe.
+                mi->seed_netdiff_history_from_found_blocks();
+
+                // #159 (G9): DASH merged-block + THE-checkpoint parity wiring,
+                // mirrored from main_ltc.cpp and sharing the same found-blocks
+                // LevelDB. INERT until merged mining lands on DASH:
+                //   * MergedBlockStore has no DASH writer (its only writers are
+                //     LTC's DOGE paths), so it stays an empty store — merged-block
+                //     endpoints simply serve nothing.
+                //   * The checkpoint READ fns (latest/all/verify) are wired, but
+                //     the create_fn is deliberately LEFT UNSET (defaults to {}),
+                //     so no DASH THE-checkpoints are ever written. Core invokes
+                //     the create_fn on every found block, so wiring it live would
+                //     start writing immediately — that is a behaviour change, not
+                //     inert wiring, and is intentionally deferred until merged
+                //     mining (enabling it later is a one-line addition).
+                {
+                    auto mblk_store =
+                        std::make_shared<c2pool::storage::MergedBlockStore>(*fblk_leveldb);
+                    mi->set_merged_block_store(mblk_store);
+                    LOG_INFO << "[Pool] DASH merged block persistence enabled ("
+                             << mblk_store->count() << " stored, inert until merged mining)";
+
+                    auto the_store =
+                        std::make_shared<c2pool::storage::TheCheckpointStore>(*fblk_leveldb);
+                    mi->set_checkpoint_fns(
+                        [the_store]() -> nlohmann::json {
+                            for (const auto& chain : {"tDASH", "DASH"}) {
+                                auto cp = the_store->get_latest(chain);
+                                if (cp.has_value()) {
+                                    return nlohmann::json{
+                                        {"chain", cp->chain}, {"block_height", cp->block_height},
+                                        {"block_hash", cp->block_hash},
+                                        {"the_state_root", cp->the_state_root.GetHex()},
+                                        {"sharechain_height", cp->sharechain_height},
+                                        {"miner_count", cp->miner_count},
+                                        {"hashrate_class", cp->hashrate_class},
+                                        {"timestamp", cp->timestamp},
+                                        {"status", cp->status == 1 ? "verified" : "pending"}
+                                    };
+                                }
+                            }
+                            return nlohmann::json{{"status", "no checkpoints"}};
+                        },
+                        [the_store]() -> nlohmann::json {
+                            auto all = the_store->load_all();
+                            nlohmann::json arr = nlohmann::json::array();
+                            for (const auto& cp : all) {
+                                arr.push_back({
+                                    {"chain", cp.chain}, {"block_height", cp.block_height},
+                                    {"block_hash", cp.block_hash},
+                                    {"the_state_root", cp.the_state_root.GetHex()},
+                                    {"sharechain_height", cp.sharechain_height},
+                                    {"miner_count", cp.miner_count},
+                                    {"timestamp", cp.timestamp},
+                                    {"status", cp.status == 1 ? "verified" : (cp.status == 2 ? "mismatch" : "pending")}
+                                });
+                            }
+                            return arr;
+                        },
+                        [](const uint256&, uint32_t) -> bool { return true; }
+                        // create_fn intentionally omitted — see comment above.
+                    );
+                    // Startup housekeeping: prune checkpoints whose blocks were
+                    // orphaned (a no-op on the empty DASH store today).
+                    size_t pruned = the_store->prune_unverified();
+                    if (pruned > 0)
+                        LOG_INFO << "[THE] Pruned " << pruned
+                                 << " unverified DASH checkpoints from previous runs";
+                    LOG_INFO << "[THE] DASH checkpoint store: " << the_store->count()
+                             << " verified (read-only until merged mining)";
+                }
             } else {
                 LOG_WARNING << "[Pool] DASH found-block persistence DISABLED (LevelDB open failed at "
                             << fblk_db_path << ")";

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -2064,6 +2064,11 @@ int main(int argc, char* argv[]) {
                     mi->load_persisted_found_blocks();
                     LOG_INFO << "[Pool] Found block persistence enabled at " << fblk_db_path;
 
+                    // #159 (G6): seed the network-difficulty series from restored
+                    // found-block rows so the long-horizon diff curve is
+                    // rebuildable from a wiped stat/.views file. Display-only.
+                    mi->seed_netdiff_history_from_found_blocks();
+
                     // Merged block persistence (shares same LevelDB)
                     auto mblk_store = std::make_shared<c2pool::storage::MergedBlockStore>(*fblk_leveldb);
                     mi->set_merged_block_store(mblk_store);

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3732,6 +3732,79 @@ void MiningInterface::load_persisted_found_blocks()
     }
 }
 
+void MiningInterface::seed_netdiff_history_from_found_blocks()
+{
+    // #159 (G6): p2pool keeps a block-sampled network-difficulty series seeded
+    // from block history at load. c2pool's found-block rows persist (ts,
+    // network_difficulty) after #1351, so the diff curve is reconstructable even
+    // from a wiped stat/.views file. Display-only; every step degrades to a
+    // no-op on missing/empty data and never throws out of the function.
+    try {
+        // Snapshot (ts, nd) under the blocks lock, then release it before taking
+        // any other lock (no nested lock-order coupling).
+        std::vector<std::pair<double, double>> samples;  // (ts, nd), ascending
+        {
+            std::lock_guard<std::mutex> lock(m_blocks_mutex);
+            samples.reserve(m_found_blocks.size());
+            for (const auto& b : m_found_blocks) {
+                const double ts = static_cast<double>(b.ts);
+                if (ts > 0.0 && b.network_difficulty > 0.0)
+                    samples.emplace_back(ts, b.network_difficulty);
+            }
+        }
+        if (samples.empty()) return;
+        std::sort(samples.begin(), samples.end(),
+                  [](const std::pair<double, double>& a,
+                     const std::pair<double, double>& b) {
+                      return a.first < b.first;
+                  });
+
+        // (1) Rebuild the volatile block-sampled series unconditionally — it is
+        // fully volatile (never persisted), so a wiped process starts empty and
+        // this is the only source until live add_netdiff_sample() calls append.
+        {
+            std::lock_guard<std::mutex> lock(m_netdiff_mutex);
+            std::vector<NetDiffSample> seeded;
+            seeded.reserve(samples.size() + m_netdiff_history.size());
+            for (const auto& s : samples)
+                seeded.push_back({s.first, s.second, "block-restore"});
+            // Defensive: preserve anything the live path already recorded
+            // (normally none this early in startup), restored samples first.
+            if (!m_netdiff_history.empty())
+                seeded.insert(seeded.end(), m_netdiff_history.begin(),
+                              m_netdiff_history.end());
+            if (seeded.size() > 2000)
+                seeded.erase(seeded.begin(), seeded.end() - 2000);
+            m_netdiff_history = std::move(seeded);
+        }
+
+        // (2) Fold pre-flat-window rows into the binned 'network_difficulty'
+        // stream — but ONLY when the views were freshly seeded this boot (so a
+        // healthy .views sidecar is never double-counted across restarts), and
+        // ONLY for rows older than the earliest flat stat_log entry (the dense
+        // 60s samples already cover the recent window). DataView::add_datum
+        // handles out-of-order/too-old timestamps safely, and the concurrent
+        // background flat-seed thread locks m_history_mutex per datum too.
+        if (!m_views_freshly_seeded.load(std::memory_order_acquire)) return;
+        double earliest_flat = 0.0;
+        {
+            std::lock_guard<std::mutex> lock(m_stat_log_mutex);
+            if (!m_stat_log.empty()) earliest_flat = m_stat_log.front().time;
+        }
+        {
+            std::lock_guard<std::mutex> hlock(m_history_mutex);
+            for (const auto& s : samples) {
+                if (earliest_flat > 0.0 && s.first >= earliest_flat) continue;
+                m_history.add_scalar("network_difficulty", s.first, s.second);
+            }
+        }
+        LOG_INFO << "[NetDiffSeed] Seeded network-difficulty series from "
+                 << samples.size() << " found-block row(s)";
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[NetDiffSeed] Failed: " << ex.what();
+    }
+}
+
 void MiningInterface::reverify_pending_found_blocks()
 {
     // Snapshot the pending hashes under the lock, then schedule outside it —
@@ -7258,6 +7331,12 @@ void MiningInterface::record_share_difficulty(double difficulty, const std::stri
     m_hashrate_ring.record(miner, difficulty,
         static_cast<int64_t>(std::time(nullptr)));
 
+    // #159 (G8): count accepted local shares for the per-interval 'shares'
+    // series that update_stat_log diffs into the /web/log graph. This is the
+    // per-accepted-share choke point (it already feeds the ring + best-diff);
+    // display/telemetry only, touches no share/consensus/reward path.
+    m_stat_shares_cum.fetch_add(1, std::memory_order_relaxed);
+
     // Snapshot the latest real share difficulty for the share-difficulty trend
     // line (fallback for coins whose sharechain stats omit min_difficulty).
     // This is the true vardiff target, not an approximation.
@@ -7333,6 +7412,7 @@ void MiningInterface::update_stat_log()
     // connected_miners = raw stratum TCP connections.
     entry.local_hash_rates = nlohmann::json::object();
     entry.local_dead_hash_rates = nlohmann::json::object();
+    uint64_t cur_stale_cum = 0;  // #159 (G8): cumulative per-worker stale count
     {
         auto workers = effective_stratum_workers();
         entry.connected_count = static_cast<int>(workers.size());  // raw TCP connections
@@ -7341,6 +7421,7 @@ void MiningInterface::update_stat_log()
             std::string combo = w.username;
             if (!w.worker_name.empty()) combo += "." + w.worker_name;
             worker_combos.insert(combo);
+            cur_stale_cum += w.stale;  // sum the same per-worker counters getstats sums
         }
         // Hash-rate series: source from the RateMonitor (windowed, p2pool-correct
         // get_local_rates), NOT the per-session WorkerInfo.hashrate estimate. The
@@ -7365,8 +7446,23 @@ void MiningInterface::update_stat_log()
         entry.worker_count = static_cast<int>(worker_combos.size());
     }
 
-    entry.shares = 0;
-    entry.stale_shares = 0;
+    // #159 (G8): real per-interval share / stale-share counters (were hardcoded
+    // to 0, persisting 31 days of a dead series). 'shares' diffs the cumulative
+    // accepted-share counter; 'stale_shares' diffs the summed per-worker stale
+    // counter. Both clamp to 0 because the cumulative sources can DROP between
+    // ticks (worker stale counts vanish when a stratum session unregisters).
+    // Deviation from p2pool (documented): p2pool's /web/log stores cumulative
+    // get_stale_counts values; c2pool's own frontend is the only consumer, so a
+    // per-interval delta is the more useful series here.
+    {
+        uint64_t cur_shares_cum = m_stat_shares_cum.load(std::memory_order_relaxed);
+        entry.shares = (cur_shares_cum >= m_stat_shares_prev)
+                           ? (cur_shares_cum - m_stat_shares_prev) : 0;
+        entry.stale_shares = (cur_stale_cum >= m_stat_stale_prev)
+                                 ? (cur_stale_cum - m_stat_stale_prev) : 0;
+        m_stat_shares_prev = cur_shares_cum;
+        m_stat_stale_prev = cur_stale_cum;
+    }
 
     // Current payout
     entry.current_payout = 0.0;
@@ -7849,6 +7945,12 @@ void MiningInterface::load_graph_views()
         do_full_seed = true;
     }
 
+    // #159 (G6): record whether the binned DB was seeded fresh this boot. When
+    // a healthy .views sidecar was adopted (do_full_seed == false), the
+    // found-block network_difficulty fold must be skipped so persisted gauge
+    // bins are never double-counted across restarts.
+    m_views_freshly_seeded.store(do_full_seed, std::memory_order_release);
+
     if (do_full_seed) {
         // Fresh, correctly-shaped empty views; seed on a background thread.
         {
@@ -7976,6 +8078,48 @@ void MiningInterface::load_stat_log()
         LOG_WARNING << "[StatLog] Load failed: " << ex.what();
       }
     }();
+
+    // #159 (G7): rehydrate the per-miner HashrateRing from the restored stat_log
+    // lhr (per-address H/s, 60s cadence) so the per-miner sparkline is not blank
+    // for ~1h after a restart. The ring stores raw shares; the aggregate rate it
+    // reports is sum(difficulty)*2^32/elapsed, so a 60s sample at rate `hps`
+    // reconstructs to a synthetic difficulty of hps*dt/2^32 — restoring both the
+    // aggregate number and the bucketed shape. Display-only; fully crash-safe
+    // (any parse issue on a single field is skipped, never throws out).
+    try {
+        std::vector<StatLogEntry> recent;
+        {
+            std::lock_guard<std::mutex> lock(m_stat_log_mutex);
+            const double cutoff =
+                static_cast<double>(std::time(nullptr)) - HashrateRing::kWindowSec;
+            for (const auto& e : m_stat_log)          // chronological (append order)
+                if (e.time > cutoff) recent.push_back(e);
+        }
+        double prev_t = 0.0;
+        for (const auto& e : recent) {
+            // dt to the previous sample, clamped to [1,300]s; default 60 for the
+            // first sample in the window (matches the update_stat_log cadence).
+            double dt = (prev_t > 0.0) ? (e.time - prev_t) : 60.0;
+            if (dt < 1.0) dt = 1.0;
+            if (dt > 300.0) dt = 300.0;
+            prev_t = e.time;
+            if (!e.local_hash_rates.is_object()) continue;
+            for (auto it = e.local_hash_rates.begin();
+                 it != e.local_hash_rates.end(); ++it) {
+                if (!it.value().is_number()) continue;
+                const double hps = it.value().get<double>();
+                if (!(hps > 0.0)) continue;
+                const double diff =
+                    hps * dt / HashrateRing::kHashesPerDifficultyShare;
+                if (diff > 0.0)
+                    m_hashrate_ring.record(it.key(), diff,
+                                           static_cast<int64_t>(e.time));
+            }
+        }
+    } catch (const std::exception& ex) {
+        LOG_WARNING << "[StatLog] Ring rehydrate failed: " << ex.what();
+    }
+
     load_best_share_all_time();
 
     // G4: load (or seed) the binned graph views. Runs AFTER the flat log is in

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -991,6 +991,16 @@ public:
     /// Load persisted found blocks from storage (call once after persistence is set)
     void load_persisted_found_blocks();
 
+    /// #159 (G6): rebuild the network-difficulty series from persisted
+    /// found-block rows so the long-horizon diff curve is reconstructable even
+    /// after a wiped stat/.views file. Rebuilds the volatile block-sampled
+    /// m_netdiff_history unconditionally, and folds pre-flat-window rows into
+    /// the binned 'network_difficulty' stream ONLY when the views were freshly
+    /// seeded this boot (idempotent across restarts with a healthy .views
+    /// sidecar). Display-only; crash-safe (empty/missing source degrades to a
+    /// no-op). Call AFTER load_persisted_found_blocks so the rows are in memory.
+    void seed_netdiff_history_from_found_blocks();
+
     /// #159 (G2): schedule confirm/orphan verification for every restored row
     /// still marked pending. load_persisted_found_blocks() only rebuilds the
     /// rows; without this a row that was pending at shutdown stays "pending"
@@ -1650,6 +1660,17 @@ private:
     // share-difficulty trend line. 0 == no shares seen yet (honest-absent).
     std::atomic<double> m_recent_share_difficulty{0.0};
 
+    // #159 (G8): cumulative count of accepted local shares, incremented once
+    // per accepted share in record_share_difficulty. update_stat_log diffs it
+    // against m_stat_shares_prev to fill the per-interval 'shares' series that
+    // was previously hardcoded to 0 (dead p2pool-compatible /web/log graph).
+    // Display/telemetry only — never read by any share/consensus/reward path.
+    std::atomic<uint64_t> m_stat_shares_cum{0};
+    // Prev-cumulative snapshots for the per-interval diff (only touched from
+    // update_stat_log, which runs single-threaded on the stat-log timer).
+    uint64_t m_stat_shares_prev{0};
+    uint64_t m_stat_stale_prev{0};
+
     // Stat log for /web/log JSON endpoint (rolling 24h window)
     struct StatLogEntry {
         double time;
@@ -1702,6 +1723,10 @@ private:
     // Guards the crossover: while false, week/month/year fall back to the flat
     // path (never worse than today). Set true once bins are loaded/seeded.
     std::atomic<bool> m_views_ready{false};
+    // #159 (G6): true when load_graph_views seeded the binned DB fresh this boot
+    // (no usable .views sidecar). Gates the found-block network_difficulty fold
+    // so a healthy sidecar is never double-counted across restarts.
+    std::atomic<bool> m_views_freshly_seeded{false};
     // Background seed thread (used when the .views file is absent/corrupt/geometry-
     // mismatched and all views must be replayed from the flat log). Joined in the
     // destructor. Long views answer from the flat fallback until it completes.


### PR DESCRIPTION
Completes the four LOW-priority dashboard persistence/parity gaps from the #159 plan, on top of #1351 (found_block_store persistence), #1352 (per-share PPLNS), and #1353 (binned graph history). All changes are display/telemetry only -- no share, consensus, reward, mint, or template path is touched. Every load/rehydrate/seed degrades to empty on a missing/corrupt source and never crashes. Persistence formats are backward/forward compatible (no wipe of existing hotel/voidbind data).

## G6 -- Long-horizon network-difficulty series, rebuildable from found blocks
p2pool keeps a block-sampled network-difficulty series seeded from block history at load. c2pool only had the volatile `m_netdiff_history` (wiped every restart) and the flat 31-day `nd` field, so the year-scale diff curve could not survive a wiped stat/.views file. New `seed_netdiff_history_from_found_blocks()`:
- sorts the restored found-block rows ascending, filtered to `ts>0 && network_difficulty>0`;
- **unconditionally** rebuilds `m_netdiff_history` from them (fully volatile, so safe -- live `add_netdiff_sample()` appends afterwards);
- folds `(ts, nd)` into the #1353 binned `network_difficulty` stream **only** when the views were freshly seeded this boot (new `m_views_freshly_seeded` guard, so a healthy `.views` sidecar is never double-counted across restarts) and **only** for rows older than the earliest flat stat_log entry (the dense 60s samples already cover the recent window).

Called from both mains right after `load_persisted_found_blocks()` -- the load order is `load_stat_log` (which runs `load_graph_views` + the background seed thread) **before** `load_persisted_found_blocks`, so the seed must live where the rows are actually in memory. Concurrency is safe: both `m_history` writers hold `m_history_mutex` per datum and `DataView::add_datum` tolerates out-of-order / too-old timestamps.

## G7 -- Per-miner HashrateRing rehydrate
The ring was volatile: ~1h per-miner sparkline warmup after every restart. `load_stat_log` now rehydrates the ring from the restored stat_log `lhr` entries (per-address H/s, 60s cadence). A 60s sample at rate `hps` reconstructs to a synthetic difficulty of `hps*dt/2^32` (dt clamped to [1,300]s), restoring both the aggregate number and the bucketed sparkline shape at t+0.

## G8 -- Real shares / stale_shares counters
`stat_log` `shares`/`stale_shares` were hardcoded to 0 -- 31 days of a dead p2pool-compatible `/web/log` series. Now:
- `shares` diffs a cumulative accepted-share counter incremented once per accepted share in `record_share_difficulty`;
- `stale_shares` diffs the summed per-worker `stale` counter (the same per-worker counters `getstats` sums).

Both clamp to 0 because the cumulative sources can drop when a stratum session unregisters. Per-interval (documented deviation from p2pool's cumulative `get_stale_counts` -- c2pool's own frontend is the only consumer, so a per-interval delta is the more useful series).

## G9 -- DASH MergedBlockStore + TheCheckpointStore parity wiring (INERT)
Mirrors the LTC wiring into `main_dash.cpp`, sharing the found-blocks LevelDB. Stays inert until merged mining lands:
- `MergedBlockStore` has no DASH writer (its only writers are LTC's DOGE paths), so it serves an empty store;
- the checkpoint **read** fns are wired (`get_latest` over `{tDASH, DASH}` / `load_all` / `verify`), but the **create_fn is deliberately left unset** (defaults to `{}`) so no DASH THE-checkpoints are ever written. Core invokes `create_fn` on every found block, so wiring it live would be a behavior change, not inert wiring -- deferred until merged mining (enabling it later is a one-line addition, and is arguably desirable THE-parity on its own).

## Build / test
`core`, `core_test`, `c2pool-dash`, `c2pool-ltc` all compile clean (Linux/GCC-13, Conan Release). `core_test` 190/190 pass (includes graph_history + web_server dashboard suites).

Refs #159. Draft -- do not merge.
