### PR TITLE
dash(shadow-compare): NO-SAMPLES status, attempts counter and starvation heartbeat

### DIFF
--- a/src/impl/dash/coin/embedded_shadow_compare.hpp
+++ b/src/impl/dash/coin/embedded_shadow_compare.hpp
@@ -20,6 +20,17 @@
 /// have served looks like <X>". A [SHADOW] MISMATCH is DIAGNOSTIC EVIDENCE, not
 /// proof of a bad served block (see the SEMANTIC note below).
 ///
+/// ══ ZERO SAMPLES IS NOT A CLEAN RESULT ══════════════════════════════════════
+/// The probe is SERVE-TRIGGERED, so it measures nothing at all when nothing is
+/// served. In the August DASH soak that state lasted 12 h — no miner was on the
+/// node's stratum, on_serve never fired — and the honest a=0 was read by every
+/// consumer as "fine". Two things therefore report the state POSITIVELY rather
+/// than as an absence of output: an unconditional `shadow-attempts` count with a
+/// `status` of NO-SAMPLES/OK in the stats JSON, and a periodic
+/// `[SHADOW] HEARTBEAT ... status=NO-SAMPLES` line for log-scraping monitors
+/// that cannot be changed from this repo. Nothing measured is never nothing
+/// wrong.
+///
 /// ══ HOT-PATH DISCIPLINE (hard invariant) ════════════════════════════════════
 /// The dashd oracle fetch is ALWAYS off the miner-facing path. on_serve() only
 /// ENQUEUES a copy of the just-resolved template (coalescing to the newest) and
@@ -78,6 +89,8 @@
 #include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -283,6 +296,22 @@ struct ShadowOutcome {
 /// monitor/dashboard can read, plus a per-field breakdown keyed
 /// "shadow-mismatch-<field>".
 struct ShadowCounters {
+    /// EVERY processed sample, unconditionally — the DENOMINATOR the verdict
+    /// tallies below are numerators of.
+    ///
+    /// ⚠ THE AUGUST DASH SOAK LESSON. Without this field a reader of the
+    /// counters cannot tell "the probe measured and found nothing wrong" from
+    /// "the probe measured NOTHING". Both render as all-zeros: the verdict
+    /// tallies are each conditional (a non-served Mismatch carrying only
+    /// non-commitment field diffs bumps no top-level counter at all), so
+    /// zero-everywhere was a reachable state under real traffic as well as
+    /// under total starvation. During the soak the embedded shadow-compare
+    /// produced zero samples for 12 h — no miner was on the node's stratum, so
+    /// the serve path never fired and on_serve was never called — and every
+    /// consumer read the honest a=0 as "fine". Zero attempts means NOTHING WAS
+    /// MEASURED; it is never a health claim. Same reasoning as the ABSENT-not-0
+    /// `behind` field in serve_staleness.hpp.
+    uint64_t shadow_attempts{0};
     uint64_t shadow_match{0};
     uint64_t shadow_no_oracle{0};
     uint64_t shadow_served_mismatch{0};
@@ -293,6 +322,10 @@ struct ShadowCounters {
     std::map<std::string, uint64_t> shadow_mismatch_by_field;   // field -> count
 
     void apply(const ShadowOutcome& o) {
+        // Unconditional, and deliberately BEFORE the switch: this counts
+        // MEASUREMENTS, not verdicts. Every kind — including the ones that
+        // bump nothing else — advances it.
+        shadow_attempts++;
         switch (o.kind) {
         case ShadowOutcome::Kind::NoOracle: shadow_no_oracle++; break;
         case ShadowOutcome::Kind::Match:    shadow_match++;     break;
@@ -312,6 +345,7 @@ struct ShadowCounters {
     }
     nlohmann::json to_json() const {
         nlohmann::json j;
+        j["shadow-attempts"]        = shadow_attempts;
         j["shadow-match"]           = shadow_match;
         j["shadow-no-oracle"]       = shadow_no_oracle;
         j["shadow-served-mismatch"] = shadow_served_mismatch;
@@ -607,6 +641,11 @@ public:
     /// samples serves; a skipped intermediate is a coverage gap, never a wrong
     /// count). Safe to call whether the resolved arm was Embedded or fallback.
     void on_serve(WorkSource source, const DashWorkData& served) {
+        // Counted BEFORE the coalescing store, so it tallies serves OFFERED,
+        // not serves that survived coalescing: an enqueue count that shrank
+        // with the queue could not distinguish "no serve arrived" from "serves
+        // arrived and were merged".
+        serves_enqueued_.fetch_add(1, std::memory_order_relaxed);
         {
             std::lock_guard<std::mutex> lk(q_mu_);
             pending_ = std::make_pair(source, served);   // copy
@@ -619,6 +658,22 @@ public:
         nlohmann::json j = counters_.to_json();
         j["mode"] = "embedded-shadow-compare";
         j["note"] = "diagnostic only — NOT a serve gate";
+        // THE ZERO-ATTEMPTS GUARD. A consumer must not have to know that the
+        // verdict tallies are conditional in order to avoid reading an
+        // all-zero counter block as good news. Zero attempts is reported as a
+        // named STATE, not as a set of zeros: nothing was measured, which is
+        // never the same claim as nothing is wrong (August DASH soak — see
+        // ShadowCounters::shadow_attempts).
+        j["status"] = counters_.shadow_attempts ? "OK" : "NO-SAMPLES";
+        // How many serves REACHED the probe, which the attempts count cannot
+        // tell you: enqueue and processing are distinct stages (on_serve
+        // coalesces to the newest pending job). serves-enqueued == 0 with the
+        // probe armed is serve STARVATION — nothing was handed to us — while a
+        // non-zero enqueue count against zero attempts would instead point at
+        // the worker. That distinction is the whole 12 h diagnosis.
+        j["shadow-serves-enqueued"] =
+            serves_enqueued_.load(std::memory_order_relaxed);
+        j["armed-since-s"] = armed_since_s();
         // The serve-FLAG readiness verdict. Still not a serve gate: it decides
         // whether --embedded-serve-mempool-txs MAY be armed, never what is
         // served at this instant.
@@ -662,20 +717,83 @@ public:
 
 private:
     void worker_loop() {
+        auto last_heartbeat = std::chrono::steady_clock::now();
         for (;;) {
             std::pair<WorkSource, DashWorkData> job;
+            bool have_job = false;
             {
                 std::unique_lock<std::mutex> lk(q_mu_);
-                q_cv_.wait(lk, [this] { return stop_ || pending_.has_value(); });
+                // wait_FOR, not wait: the heartbeat below must still fire when
+                // nothing is ever enqueued — which is exactly the state it
+                // exists to make visible. A timed wake with no job is the
+                // normal case on a starved node, not an error.
+                q_cv_.wait_for(lk, kHeartbeatInterval,
+                               [this] { return stop_ || pending_.has_value(); });
                 if (stop_ && !pending_.has_value()) return;
-                job = std::move(*pending_);
-                pending_.reset();
+                if (pending_.has_value()) {
+                    job = std::move(*pending_);
+                    pending_.reset();
+                    have_job = true;
+                }
             }
-            try { process(job.first, job.second); }
-            catch (const std::exception& e) {
-                LOG_WARNING << "[SHADOW] worker exception: " << e.what();
+            if (have_job) {
+                try { process(job.first, job.second); }
+                catch (const std::exception& e) {
+                    LOG_WARNING << "[SHADOW] worker exception: " << e.what();
+                }
+            }
+            const auto now = std::chrono::steady_clock::now();
+            if (now - last_heartbeat >= kHeartbeatInterval) {
+                last_heartbeat = now;
+                log_heartbeat();
             }
         }
+    }
+
+    /// The LOG-STREAM half of the zero-attempts guard, and the half that
+    /// matters to a monitor nobody in this repo can change.
+    ///
+    /// stats_json() only answers something that ASKS. The external soak
+    /// guardian log-scrapes [SHADOW] lines, and a starved probe emits no
+    /// [SHADOW] line at all — an absence indistinguishable from a healthy,
+    /// quiet node. This line is emitted on a fixed cadence whether or not
+    /// anything was sampled, so starvation acquires a POSITIVE signature in
+    /// the log stream (`status=NO-SAMPLES`) instead of being expressed as
+    /// silence. Nothing outside this process has to change to see it.
+    void log_heartbeat() const {
+        uint64_t attempts = 0;
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            attempts = counters_.shadow_attempts;
+        }
+        const uint64_t enqueued = serves_enqueued_.load(std::memory_order_relaxed);
+        std::string l = "[SHADOW] HEARTBEAT armed_since="
+                      + std::to_string(armed_since_s())
+                      + "s serves_enqueued=" + std::to_string(enqueued)
+                      + " samples=" + std::to_string(attempts)
+                      + " status=" + (attempts ? "OK" : "NO-SAMPLES");
+        if (attempts == 0) {
+            // Which stage is starved is the whole diagnosis, so the line says
+            // it rather than leaving the reader to infer it from two numbers.
+            l += enqueued == 0
+                     ? " — no serve has reached the probe: SERVE STARVATION"
+                       " (nothing is asking this node for a template — e.g. no"
+                       " miner on the stratum). NOTHING WAS MEASURED; this is"
+                       " not a clean result"
+                     : " — serves reached the probe but no sample completed."
+                       " NOTHING WAS MEASURED; this is not a clean result";
+            LOG_WARNING << l;
+        } else {
+            LOG_INFO << l;
+        }
+    }
+
+    /// Wall-clock seconds since the probe was ARMED. An age, not a timestamp:
+    /// "armed 43200 s ago with 0 samples" survives a log paste, an absolute
+    /// steady-clock reading does not (same reasoning as serve_staleness.hpp).
+    int64_t armed_since_s() const {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+                   std::chrono::steady_clock::now() - armed_at_).count();
     }
 
     void process(WorkSource source, const DashWorkData& served) {
@@ -758,8 +876,19 @@ private:
         }
     }
 
+    /// Heartbeat cadence. Deliberately the same 300 s as ServeGateJournal's
+    /// stuck-arm heartbeat (serve_gate_journal.hpp) — slow enough to cost
+    /// nothing, dense enough that ANY window of the journal names the state.
+    static constexpr std::chrono::seconds kHeartbeatInterval{300};
+
     OracleFn oracle_;
     AcceptFn accept_;
+
+    /// Armed at construction; both are read outside mu_ (an age and an atomic
+    /// tally), so a heartbeat never contends with the compare path.
+    const std::chrono::steady_clock::time_point armed_at_{
+        std::chrono::steady_clock::now()};
+    std::atomic<uint64_t> serves_enqueued_{0};
 
     mutable std::mutex mu_;          // guards counters_ + validity_
     ShadowCounters     counters_;

--- a/test/test_dash_embedded_shadow_compare.cpp
+++ b/test/test_dash_embedded_shadow_compare.cpp
@@ -711,3 +711,88 @@ TEST(DashShadowCompare, CandidateOursOnlyIsMeasuredAndReportedInformational) {
     EXPECT_FALSE(has_line_with(o.log_lines,
                                "do NOT enable --embedded-serve-mempool-txs"));
 }
+
+// ═════════════════════════════════════════════════════════════════════════
+// ZERO SAMPLES IS NOT A CLEAN RESULT — the August DASH soak guard.
+//
+// The probe is serve-triggered, so it measures nothing when nothing is
+// served. On the soak that lasted 12 h (no miner on the node's stratum, so
+// the serve path never fired and on_serve was never called) and the honest
+// a=0 was read by every consumer as "fine". These pin the two surfaces that
+// make the state report itself POSITIVELY: an unconditional attempts count,
+// and a named status that says NOTHING WAS MEASURED rather than a block of
+// zeros that reads like health.
+// ═════════════════════════════════════════════════════════════════════════
+
+// Every processed sample advances shadow_attempts — including the verdict
+// that advances NO other top-level counter. A non-served Mismatch whose only
+// divergence is a non-commitment field bumps shadow_mismatch_by_field and
+// nothing else, so before this counter existed the tallies could read
+// all-zero under real traffic, not merely under starvation.
+TEST(DashShadowCompare, AttemptsCountsEverySampleIncludingCounterlessVerdicts) {
+    auto emb_cb  = make_cbtx(2500000, /*mn_seed=*/1, /*q_seed=*/100);
+    auto dref_cb = make_cbtx(2500001, /*mn_seed=*/1, /*q_seed=*/100);
+    auto emb  = make_wd(2500000, emb_cb,  "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    // Fallback arm + a non-commitment (cbtx_height) divergence only.
+    auto dref = make_wd(2500000, dref_cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+
+    const auto o = shadow_evaluate(WorkSource::DashdFallback, emb, dref);
+    ASSERT_EQ(o.kind, ShadowOutcome::Kind::Mismatch);
+    EXPECT_FALSE(o.served_mismatch);
+
+    ShadowCounters c;
+    EXPECT_EQ(c.shadow_attempts, 0u);
+    c.apply(o);
+    // The top-level verdict tallies are all still zero — which is exactly the
+    // reading that must not be mistaken for "the probe never ran".
+    EXPECT_EQ(c.shadow_match, 0u);
+    EXPECT_EQ(c.shadow_no_oracle, 0u);
+    EXPECT_EQ(c.shadow_served_mismatch, 0u);
+    EXPECT_EQ(c.shadow_match_modulo_mempool_protx, 0u);
+    EXPECT_EQ(c.shadow_attempts, 1u);
+    EXPECT_EQ(c.to_json()["shadow-attempts"], 1u);
+}
+
+// A fresh probe that has been handed nothing reports NO-SAMPLES, not OK: an
+// all-zero counter block is a statement about MEASUREMENT, never about health.
+TEST(DashShadowCompare, FreshProbeWithNoSamplesReportsNoSamplesStatus) {
+    EmbeddedShadowCompare probe(
+        []() -> std::optional<DashWorkData> { return std::nullopt; });
+
+    const auto j = probe.stats_json();
+    EXPECT_EQ(j["status"], "NO-SAMPLES");
+    EXPECT_EQ(j["shadow-attempts"], 0u);
+    // Zero serves REACHED the probe: the starvation signature (nothing asked
+    // this node for a template) as distinct from a stuck worker.
+    EXPECT_EQ(j["shadow-serves-enqueued"], 0u);
+}
+
+// One processed sample flips the status to OK and the attempts count off zero
+// — the other half of the guard: NO-SAMPLES must be a transient of an unused
+// probe, not a permanent label.
+TEST(DashShadowCompare, StatusFlipsToOkAfterOneProcessedSample) {
+    auto cb     = make_cbtx(2500000);
+    auto served = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+    auto dref   = make_wd(2500000, cb, "yMNaddrAAAAAAAAAAAAAAAAAAAAA");
+
+    EmbeddedShadowCompare probe(
+        [dref]() -> std::optional<DashWorkData> { return dref; });
+    ASSERT_EQ(probe.stats_json()["status"], "NO-SAMPLES");
+
+    probe.on_serve(WorkSource::Embedded, served);
+
+    bool fired = false;
+    for (int i = 0; i < 200 && !fired; ++i) {
+        if (probe.stats_json().value("shadow-attempts", 0u) >= 1u) fired = true;
+        else std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(fired);
+
+    const auto j = probe.stats_json();
+    EXPECT_EQ(j["status"], "OK");
+    EXPECT_GE(j["shadow-attempts"].get<uint64_t>(), 1u);
+    EXPECT_GE(j["shadow-serves-enqueued"].get<uint64_t>(), 1u);
+    // The sample itself matched — status is about measurement having HAPPENED,
+    // and is reported alongside the verdict tallies, never instead of them.
+    EXPECT_EQ(j["shadow-match"], 1u);
+}


### PR DESCRIPTION
## Zero samples is not a clean result

During the August DASH soak the embedded shadow-compare
(`src/impl/dash/coin/embedded_shadow_compare.hpp`, the observe-only
embedded-vs-dashd block-template diagnostic) reported **a=0 comparisons for
12 hours** and every consumer read that as "fine". It was not a health
signal: it meant **nothing had been measured at all**.

Root cause of the zero: serve starvation. The probe is *serve*-triggered —
`DASHWorkSource` hands each just-resolved template to
`shadow_compare_->on_serve(...)` at `src/impl/dash/stratum/work_source.cpp`
(the enqueue-only call site in the template-sourcing block). No miner was
connected to the soak node's stratum, so no template was ever served, so
`on_serve` never fired and the worker never processed a sample. The oracle
was armed and healthy the whole time; it simply had nothing to look at.

The post-incident commentary already landed
(`src/impl/dash/coin/serve_staleness.hpp` §(d), which names the shadow
oracle's a=0 as one of the five detectors that were blind by construction,
and the matching `behind`-is-ABSENT-not-0 note in
`work_source.cpp::serve_staleness_json`). The **guard itself never did**.
This PR is that guard.

## What changes

All of it is instrumentation. Nothing here reads, selects, delays, or alters
a served template — the diagnostic's "NOT a serve gate" contract is
untouched, and the pure `shadow_evaluate()` comparison layer is not modified
at all.

1. **`shadow_attempts`, an unconditional counter** on `ShadowCounters`,
   bumped at the top of `apply()` for every processed sample and exported as
   `shadow-attempts`. There was previously no field bumped on *every* sample:
   the verdict tallies are each conditional, and a non-served `Mismatch`
   carrying only non-commitment field diffs bumps no top-level counter at
   all. So an all-zero counter block was reachable under real traffic, not
   only under starvation — attempts is the denominator that was missing.

2. **`status` in `stats_json()`**: `"NO-SAMPLES"` when `shadow_attempts == 0`,
   `"OK"` otherwise. A consumer should not have to know which tallies are
   conditional in order to avoid reading zeros as good news. Same discipline
   as the existing ABSENT-not-0 `behind` field.

3. **`shadow-serves-enqueued` and `armed-since-s`** alongside it. Enqueue and
   processing are distinct stages (`on_serve` coalesces to the newest pending
   job), and the distinction is the entire diagnosis: `serves-enqueued == 0`
   with the probe armed is *serve starvation — nothing asked this node for a
   template*, whereas a non-zero enqueue count against zero attempts would
   point at the worker instead.

4. **A periodic `[SHADOW] HEARTBEAT` line**, emitted from the worker thread
   on a 300 s cadence — the same interval as `ServeGateJournal`'s stuck-arm
   heartbeat in `src/impl/dash/coin/serve_gate_journal.hpp`, so the two
   diagnostics keep one cadence. The worker's `q_cv_.wait` becomes
   `wait_for`, so the line still fires when nothing is ever enqueued, which
   is precisely the state it exists to make visible:

   ```
   [SHADOW] HEARTBEAT armed_since=43200s serves_enqueued=0 samples=0 status=NO-SAMPLES — no serve has reached the probe: SERVE STARVATION (nothing is asking this node for a template — e.g. no miner on the stratum). NOTHING WAS MEASURED; this is not a clean result
   ```

   Logged at WARNING while `samples == 0`, INFO once sampling starts. Grammar
   matches the existing `[SHADOW]` lines (`key=value`, space-separated).

### Why the heartbeat, and not just the JSON

The external soak guardian that watches this probe **lives outside this
repository** and log-scrapes `[SHADOW]` lines; its location is being chased
separately and it cannot be fixed from here. A starved probe emits no
`[SHADOW]` line at all, and that absence is indistinguishable from a healthy,
quiet node — which is exactly how 12 h of nothing passed for 12 h of fine.
The heartbeat gives starvation a **positive signature in the log stream**, so
the existing scraper sees it with no change on its side. `stats_json()` only
answers something that asks; the log is what was actually being watched.

## Tests

Extended `test/test_dash_embedded_shadow_compare.cpp` (the hermetic
shadow-compare KAT suite, which already rides the `test_dash_embedded_gbt`
target — that target is in the build.yml "Build tests" `--target` allowlist
and a standalone one would be a NOT_BUILT sentinel, per issue #769 on the
push bot lacking `workflow` scope), with three cases:

* `AttemptsCountsEverySampleIncludingCounterlessVerdicts` — the regression
  proper: a non-served `Mismatch` whose only divergence is a non-commitment
  field leaves every top-level verdict tally at zero, and `shadow_attempts`
  still reads 1.
* `FreshProbeWithNoSamplesReportsNoSamplesStatus` — a fresh probe handed
  nothing reports `status=NO-SAMPLES`, `shadow-attempts=0`,
  `shadow-serves-enqueued=0`.
* `StatusFlipsToOkAfterOneProcessedSample` — after one processed sample the
  status flips to `OK` with `shadow-attempts >= 1`, so NO-SAMPLES is a
  transient of an unused probe and not a permanent label.

Built and run locally as the targeted `test_dash_embedded_gbt` target: green.

## Not in scope

The guardian script itself (out of repo) and the separate proposal that the
guardian FAIL rather than pass on `attempts == 0`. This PR only makes the
node state the truth in both surfaces the guardian can read.
