### PR TITLE
Dashboard: derive DASH PPLNS view from sharechain shares (pool-wide, no local miners)

### DIFF
--- a/src/impl/dash/dashboard_pplns.hpp
+++ b/src/impl/dash/dashboard_pplns.hpp
@@ -242,9 +242,33 @@ inline PplnsView pplns_payouts_for_share(ChainT& chain,
 }
 
 // ── Pool-wide convenience wrapper ───────────────────────────────────────────
-// "What would a block found RIGHT NOW pay?" — the live GBT template's reward
-// and masternode payment set, split over the window anchored on the node's
-// current best share. Finder fee omitted (see the header note).
+// "What would a block found RIGHT NOW pay?" — the pool-wide PPLNS split over the
+// window anchored on the node's current best share. Finder fee omitted (see the
+// header note).
+//
+// Two param sources, in strict precedence:
+//   1. LIVE TEMPLATE (preferred): the GBT template's reward + masternode payment
+//      set. This is the freshest possible answer — the exact split a block found
+//      now would pay — and is what a node WITH miners (a stratum session pumped
+//      the template cache) always takes.
+//   2. BEST-SHARE SNAPSHOT (fallback): when no template is cached — a fully
+//      daemonless node with ZERO local miners never pumps the template cache, so
+//      tmpl.peek() is permanently null there — derive the block params from the
+//      BEST SHARE's own recorded fields (m_subsidy, m_min_header.m_bits,
+//      m_packed_payments), exactly as pplns_payouts_for_share reads them for the
+//      per-share view. The window walk (pplns_weights_for) and the allocation
+//      (compute_dash_payouts) are identical; only the subsidy/bits/payee source
+//      differs. This is p2pool parity: get_expected_payouts (data.py:3273) takes
+//      subsidy + block_target as PARAMETERS and its only empty guard is a
+//      missing best share — there is no live-template coupling. The pool-wide
+//      PPLNS view therefore renders from the sharechain alone, with no local
+//      hashrate, which is the whole point of the dashboard on a bootstrap node.
+//
+// The snapshot subsidy/payees are the best SHARE's epoch, so on a reward-
+// reduction boundary or a masternode-payee rotation they lag the next block by
+// at most one federation share; acceptable for a DISPLAY view and never fed back
+// into any mint/coinbase path. Empty best share -> {} (the one legitimate p2pool
+// empty guard) is retained.
 template <typename ChainT>
 inline PplnsView pplns_payouts_current(ChainT& chain,
                                        const core::CoinParams& params,
@@ -252,12 +276,35 @@ inline PplnsView pplns_payouts_current(ChainT& chain,
                                        const TemplateSource& tmpl,
                                        bool testnet)
 {
-    auto t = tmpl.peek();
-    if (!t || t->m_coinbase_value == 0)
-        return {};   // no template -> no claim about what is owed
-    return pplns_payouts_at(chain, params, best_share_hash, t->m_bits,
-                            t->m_coinbase_value, t->m_packed_payments,
-                            uint160(), /*drop_finder_output=*/true, testnet);
+    // 1. Live template — the fresh, preferred source (nodes WITH miners).
+    if (auto t = tmpl.peek(); t && t->m_coinbase_value != 0)
+        return pplns_payouts_at(chain, params, best_share_hash, t->m_bits,
+                                t->m_coinbase_value, t->m_packed_payments,
+                                uint160(), /*drop_finder_output=*/true, testnet);
+
+    // 2. Best-share snapshot — no template cached (zero-local-miner node). Read
+    //    the block params the best share itself committed to and split over the
+    //    SAME window (anchored on best_share_hash). Read-only: the best share's
+    //    bytes are untouched; nothing here can change a served coinbase.
+    if (best_share_hash.IsNull() || !chain.contains(best_share_hash))
+        return {};   // empty sharechain — p2pool's one legitimate empty guard
+
+    uint32_t block_bits = 0;
+    uint64_t subsidy    = 0;
+    std::vector<dash::coin::PackedPayment> payments;
+    chain.get_share(best_share_hash).invoke([&](auto* obj) {
+        block_bits = obj->m_min_header.m_bits;
+        subsidy    = obj->m_subsidy;
+        payments.reserve(obj->m_packed_payments.size());
+        for (const auto& p : obj->m_packed_payments)
+            payments.push_back({p.m_payee, p.m_amount});
+    });
+    if (subsidy == 0)
+        return {};   // share carried no recorded reward — no honest claim
+
+    return pplns_payouts_at(chain, params, best_share_hash, block_bits, subsidy,
+                            payments, uint160(), /*drop_finder_output=*/true,
+                            testnet);
 }
 
 } // namespace dashboard

--- a/test/test_dash_dashboard_pplns.cpp
+++ b/test/test_dash_dashboard_pplns.cpp
@@ -260,37 +260,86 @@ TEST(DashDashboardPplns, PoolWideViewOmitsTheFinderFeeLikeLtcDoes)
     EXPECT_GT(sum_values(with_finder.payouts), sum_values(pool.payouts));
 }
 
-// ── KAT 5: an unbound template source yields nothing, not a guess ───────────
-TEST(DashDashboardPplns, UnboundTemplateSourceYieldsAnHonestEmpty)
+// ── KAT 5: no template -> the pool-wide view falls back to the best share ────
+// This is the fix. On a fully daemonless node with ZERO local miners nothing
+// ever pumps the work-source template cache (the stratum work-serving paths are
+// the only producers), so TemplateSource::peek() is permanently null there and
+// the pool-wide /current_payouts, /current_merged_payouts and /pplns/current
+// used to render `{}` over a full sharechain window. p2pool has no such coupling
+// (get_expected_payouts takes subsidy as a parameter, data.py:3273), so the
+// pool-wide split must derive from the sharechain alone. It now snapshots the
+// block params off the BEST SHARE's own recorded fields.
+TEST(DashDashboardPplns, NoTemplateFallsBackToBestShareSnapshot)
 {
     PplnsHarness h(40);
-    dash::dashboard::TemplateSource tmpl;   // never bound
-
+    dash::dashboard::TemplateSource tmpl;   // never bound — the zero-miner node
     EXPECT_EQ(tmpl.peek(), nullptr);
-    auto v = dash::dashboard::pplns_payouts_current(
-        h.node.tracker().chain, h.params, h.tip, tmpl, /*testnet=*/false);
-    EXPECT_FALSE(v.ok);
-    EXPECT_TRUE(v.payouts.empty())
-        << "no template must mean no claim about what is owed";
 
-    // Bound -> answers. This is the whole difference between the shipped
-    // behaviour and this change.
+    auto snap = dash::dashboard::pplns_payouts_current(
+        h.node.tracker().chain, h.params, h.tip, tmpl, /*testnet=*/false);
+
+    ASSERT_TRUE(snap.ok) << "a full sharechain with no live template must still "
+                            "render the pool-wide split — this is the zero-miner "
+                            "dashboard, and {} here IS the bug";
+    EXPECT_FALSE(snap.payouts.empty());
+
+    // The snapshot uses the best SHARE's own recorded reward decomposition
+    // (subsidy, masternode + burn payments), NOT a fabricated one.
+    EXPECT_EQ(snap.subsidy,        P_SUBSIDY);
+    EXPECT_EQ(snap.payments_total, P_MN_PAY + P_BURN_PAY);
+    EXPECT_EQ(snap.worker_payout,  P_SUBSIDY - P_MN_PAY - P_BURN_PAY);
+
+    // Pool-wide contract, identical to the live-template path: masternode payee
+    // excluded, finder placeholder dropped, three miners split ~98% of the
+    // worker payout (the missing 2% is the unknown finder's reserve).
+    EXPECT_FALSE(snap.payouts.contains(p_addr(0xc0)));
+    EXPECT_FALSE(snap.payouts.contains(
+        core::script_to_address(dash::pubkey_hash_to_script2(uint160()), "", 76, 16)));
+    EXPECT_GE(snap.recipients, 3);
+    const double worker = static_cast<double>(snap.worker_payout) / 1e8;
+    EXPECT_NEAR(sum_values(snap.payouts), worker * 0.98, worker * 0.001);
+
+    // Every rendered key is a DASH address, never a Bitcoin '1'.
+    for (const auto& [addr, amt] : snap.payouts.items()) {
+        (void)amt;
+        EXPECT_TRUE(!addr.empty() && (addr[0] == 'X' || addr[0] == '7'))
+            << "non-DASH address rendering: " << addr;
+    }
+
+    // A LIVE template takes strict precedence over the snapshot: bind one whose
+    // reward differs (single masternode payment, no burn) and the view switches
+    // to it — nodes WITH miners are unchanged by this fallback.
     auto wd = std::make_shared<dash::coin::DashWorkData>();
-    wd->m_coinbase_value = P_SUBSIDY;
-    wd->m_bits           = P_BLOCK_BITS;
+    wd->m_coinbase_value  = P_SUBSIDY;
+    wd->m_bits            = P_BLOCK_BITS;
     wd->m_packed_payments = {{p_addr(0xc0), P_MN_PAY}};
     tmpl.bind([wd]() -> std::shared_ptr<const dash::coin::DashWorkData> { return wd; });
 
-    auto v2 = dash::dashboard::pplns_payouts_current(
+    auto live = dash::dashboard::pplns_payouts_current(
         h.node.tracker().chain, h.params, h.tip, tmpl, false);
-    ASSERT_TRUE(v2.ok);
-    EXPECT_EQ(v2.worker_payout, P_SUBSIDY - P_MN_PAY);
-    EXPECT_GE(v2.recipients, 3);
+    ASSERT_TRUE(live.ok);
+    EXPECT_EQ(live.worker_payout, P_SUBSIDY - P_MN_PAY)
+        << "a bound template must win over the best-share snapshot";
+}
 
-    // NEGATIVE CONTROL: this is what /current_payouts served before — an
-    // object that passes every "is it valid JSON" check and renders nothing.
-    const nlohmann::json shipped = nlohmann::json::object();
-    EXPECT_TRUE(shipped.is_object());
-    EXPECT_TRUE(shipped.empty());
-    EXPECT_FALSE(v2.payouts.empty());
+// ── KAT 6: an empty sharechain still yields nothing (p2pool's one guard) ─────
+// The fallback must NOT invent payouts when there is no share to snapshot — the
+// post-restart empty-chain case stays `{}` exactly as get_expected_payouts does.
+TEST(DashDashboardPplns, NoTemplateAndNoSharesStaysEmpty)
+{
+    // A single genesis share: present, but too short for a window (no
+    // grandparent), so pplns_weights_for misses — the snapshot must degrade to
+    // empty, never a fabricated row.
+    PplnsHarness cold(1);
+    dash::dashboard::TemplateSource tmpl;   // never bound
+    auto v = dash::dashboard::pplns_payouts_current(
+        cold.node.tracker().chain, cold.params, cold.tip, tmpl, /*testnet=*/false);
+    EXPECT_FALSE(v.ok);
+    EXPECT_TRUE(v.payouts.empty());
+
+    // A null best-share hash (a genuinely empty chain) is the same honest empty.
+    auto none = dash::dashboard::pplns_payouts_current(
+        cold.node.tracker().chain, cold.params, uint256::ZERO, tmpl, false);
+    EXPECT_FALSE(none.ok);
+    EXPECT_TRUE(none.payouts.empty());
 }


### PR DESCRIPTION
## Summary

The pool-wide PPLNS dashboard view — `/current_payouts`, `/current_merged_payouts` and `/pplns/current` — rendered empty (`{}`) on a fully daemonless DASH node with **zero local miners**, even while the node held a full federation sharechain window. This is the symptom seen on the public bootstrap/proposal node (dash.voidbind.com): healthy, synced, sharechain populated, but the PPLNS treemap drew nothing.

Refs #57 (LTC↔DASH dashboard parity audit — "PPLNS view empty").

## Root cause

`dash::dashboard::pplns_payouts_current` returned `{}` whenever the live GBT template was absent (`TemplateSource::peek()` null or `m_coinbase_value == 0`). On a node with **no stratum sessions**, nothing ever pumps the work-source template cache — the stratum work-serving paths are its only producers — so `peek()` is permanently null there and the whole pool-wide view fell closed.

The sharechain window walk (`dash::mint::pplns_weights_for`) and the allocator (`dash::coinbase::compute_dash_payouts`) were **already pool-wide and miner-independent**. Only the block-params source (subsidy / bits / masternode payments) was coupled to the live template.

This diverges from:
- **p2pool**, whose `get_expected_payouts` (`data.py`) takes `subsidy` and `block_target` as *parameters* and guards only on an empty sharechain — no live-template coupling; and
- the **LTC lane**, whose unconditional `refresh_work` keeps the view populated at zero local hashrate.

## Fix (display-only)

When no template is cached, derive the block params from the **best share's own recorded fields** (`m_subsidy`, `m_min_header.m_bits`, `m_packed_payments`) — exactly the fields `pplns_payouts_for_share` already reads for the per-share view — and split them over the same window anchored on the best share. Precedence is strict:

1. **Live template** (preferred): a node *with* miners is byte-for-byte unchanged.
2. **Best-share snapshot** (fallback): engages only when `peek()` is null — the zero-miner node.

The one legitimate p2pool empty guard is retained: an empty / too-short sharechain still yields `{}`.

The snapshot's subsidy/payees are the best share's epoch, so on a reward-reduction boundary or a masternode-payee rotation they lag the next block by at most one federation share — acceptable for a display view, and never fed back into any mint path.

## What now populates

With this change, on a zero-miner node holding federation shares:
- `/current_payouts` — pool-wide worker split (best-share snapshot), read live via `m_current_payouts_fn`.
- `/current_merged_payouts` and `/pplns/current` — populated from the same source through `cache_pplns_at_tip → compute_current_merged_payouts`, which already fires on every best-share change on the DASH lane (`set_on_best_share_changed → fire_share_tip_refresh → trigger_work_refresh_debounced`), so the cache refreshes as remote federation shares arrive. No new trigger wiring was required.

## Safety

- **No reward/consensus/mint/template/coinbase path is touched.** The change lives entirely in the dashboard read-model (`dashboard_pplns.hpp`) and only *reads* share fields. The served block's coinbase payout is byte-identical to before.
- Crash-safe: empty / short window degrades to a well-formed empty response.
- Masternode / platform / superblock payments stay excluded (consensus outputs, not pool payouts); the finder-fee placeholder is dropped exactly as the live-template path does.

## Tests

`test/test_dash_dashboard_pplns.cpp`:
- Rewrote KAT 5 (`NoTemplateFallsBackToBestShareSnapshot`): a full sharechain with no live template now yields the pool-wide split, matching the best share's own reward decomposition, dropping the finder placeholder, rendering DASH addresses; and a bound template wins over the snapshot.
- Added KAT 6 (`NoTemplateAndNoSharesStaysEmpty`): an empty / genesis-only chain, and a null best-share hash, both stay `{}`.

All 6 `DashDashboardPplns` KATs pass (`test_dash_node`, Release build).

## Not merging

Draft. Display-only, but requesting review before merge.
