### PR TITLE
Sharechain: on restart, reorg to the network highest-work head instead of sticking to the persisted head

### DIFF
--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -1801,13 +1801,41 @@ void NodeImpl::run_think()
         // real work so no IO callbacks need the tracker lock.  Matches p2pool
         // where think() runs synchronously on the reactor during initial sync.
         bool bootstrap = m_tracker.verified.size() == 0;
+
+        // Restart-reorg: detect a genuine higher-work fork the warm-loaded node
+        // is stuck away from (see SupersedeHint). Skipped during bootstrap (empty
+        // start already downloads to 2*CL+10 under the unlimited budget). No-op
+        // on a healthy node whose persisted head already carries the most work.
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;  // bounded elevated per-tick verify
+        ltc::SupersedeHint supersede = bootstrap
+            ? ltc::SupersedeHint{}
+            : m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET);
+        m_supersede_hint = supersede;
+        uint256 prev_best_for_flip = m_best_share_hash;
+        if (supersede.active) {
+            LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                        << m_best_share_hash.GetHex().substr(0,16)
+                        << " incumbent_verified_h="
+                        << (m_tracker.verified.contains(m_best_share_hash)
+                            ? m_tracker.verified.get_height(m_best_share_hash) : -1)
+                        << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                        << " challenger_chain_h="
+                        << (m_tracker.chain.contains(supersede.target_head)
+                            ? m_tracker.chain.get_height(supersede.target_head) : -1)
+                        << " challenger_verified_h="
+                        << m_tracker.verified.get_acc_height(supersede.target_head)
+                        << " — challenger received work STRICTLY > incumbent verified work;"
+                        << " granting bounded elevated verify budget + 2*CL+10 backfill";
+        }
+
         LOG_INFO << "[ASYNC-THINK] compute: chain=" << m_tracker.chain.size()
                  << " verified=" << m_tracker.verified.size()
                  << " heads=" << m_tracker.chain.get_heads().size()
                  << " v_heads=" << m_tracker.verified.get_heads().size()
-                 << (bootstrap ? " BOOTSTRAP" : "");
+                 << (bootstrap ? " BOOTSTRAP" : "")
+                 << (supersede.active ? " SUPERSEDE" : "");
         auto think_t0 = std::chrono::steady_clock::now();
-        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap, supersede);
         think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - think_t0).count();
 
@@ -1821,6 +1849,25 @@ void NodeImpl::run_think()
         if (!result.best.IsNull()) {
             best_changed = (m_best_share_hash != result.best);
             m_best_share_hash = result.best;
+        }
+
+        // Restart-reorg: log the actual head flip once it happens, so the warm-
+        // restart soak can be verified from logs. The flip is driven ENTIRELY by
+        // the existing Phase-3 TailScore argmax — this only records it.
+        if (best_changed && supersede.active && !result.best.IsNull()) {
+            bool onto_challenger = false;
+            try {
+                onto_challenger =
+                    (m_tracker.chain.get_last(result.best) == supersede.target_segment_last);
+            } catch (...) {}
+            if (onto_challenger)
+                LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                            << prev_best_for_flip.GetHex().substr(0,16)
+                            << " new_best=" << result.best.GetHex().substr(0,16)
+                            << " new_verified_h="
+                            << (m_tracker.verified.contains(result.best)
+                                ? m_tracker.verified.get_height(result.best) : -1)
+                            << " — converged onto the network highest-work chain";
         }
 
         // Publish lock-free snapshot for all IO-thread consumers
@@ -2178,11 +2225,20 @@ void NodeImpl::clean_tracker()
             uint32_t bits = 0;
 
             bootstrap = m_tracker.verified.size() == 0;
+            // Restart-reorg hint (same detector as run_think). Recomputed here so
+            // the Step-2/Step-3 GC exemptions below act on a current view, and so
+            // Step-1 think() also advances the converging challenger.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? ltc::SupersedeHint{}
+                : m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET);
             LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
                      << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
-                     << (bootstrap ? " BOOTSTRAP" : "");
+                     << (bootstrap ? " BOOTSTRAP" : "")
+                     << (m_supersede_hint.active ? " SUPERSEDE" : "");
             auto think_t0 = std::chrono::steady_clock::now();
-            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                          m_supersede_hint);
             auto think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - think_t0).count();
 
@@ -2220,6 +2276,19 @@ void NodeImpl::clean_tracker()
 
                 // Guard 1: keep top-5 scored heads (p2pool node.py:363)
                 if (top5_set.count(head_hash)) continue;
+
+                // Guard 1b (restart-reorg): keep the converging challenger segment.
+                // Its verified height is below CHAIN_LENGTH so it is never in the
+                // top-5; without this exemption its partial verification would be
+                // eaten every ~300s and restarted forever — the original stuck-on-
+                // persisted-head latch in a different guise. Matched by segment id.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(head_hash) &&
+                            m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
 
                 // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
                 auto* idx = m_tracker.chain.get_index(head_hash);
@@ -2283,6 +2352,21 @@ void NodeImpl::clean_tracker()
             auto tails_copy = m_tracker.chain.get_tails();
             for (auto& [tail_hash, head_hashes] : tails_copy)
             {
+                // Restart-reorg: never drop the tail of the converging challenger
+                // segment. An unrooted challenger needs its FULL ~2*CL depth to
+                // reach CHAIN_LENGTH verified shares; trimming its bottom mid-
+                // verification silently restarts convergence (looks like the
+                // original stickiness). The exemption lifts once it verifies to
+                // CHAIN_LENGTH and the hint deactivates, when normal drop-tails
+                // resumes. Matched by segment id (the shared missing-parent).
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(tail_hash) &&
+                            m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
+
                 int32_t min_height = 0;  // default 0 → skip if no valid heads
                 for (auto& hh : head_hashes) {
                     if (!m_tracker.chain.contains(hh)) continue;
@@ -2356,7 +2440,14 @@ void NodeImpl::clean_tracker()
             : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
         uint256 prev_block;
         uint32_t bits = 0;
-        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        // Restart-reorg: re-detect after pruning and pass the hint so the
+        // re-score also advances/flips onto the challenger.
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        m_supersede_hint = bootstrap
+            ? ltc::SupersedeHint{}
+            : m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET);
+        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                      m_supersede_hint);
         m_last_top5_heads = std::move(result.top5_heads);
         if (!result.best.IsNull()) {
             clean_best_changed = (m_best_share_hash != result.best);

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -191,6 +191,15 @@ protected:
     // to protect the best chains from head pruning (p2pool node.py:363).
     std::vector<uint256> m_last_top5_heads;
 
+    // Restart-reorg supersede hint from the last think()/clean cycle
+    // (ShareTracker::compute_supersede_hint). When active it names a genuine
+    // higher-work fork the node is converging onto after a warm restart; used
+    // by clean_tracker() to exempt the converging challenger segment from
+    // stale-head eating and tail-dropping so its verification is not thrown
+    // away and restarted every ~300s (which would re-create the original
+    // stuck-on-persisted-head latch). Inactive on a healthy node.
+    ltc::SupersedeHint m_supersede_hint;
+
     // Buffer of newly verified share hashes, flushed to LevelDB periodically
     std::vector<uint256> m_verified_flush_buf;
 

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -113,6 +113,47 @@ struct DecoratedData
     }
 };
 
+// ── Restart-reorg supersede hint ─────────────────────────────────────────
+// Computed by NodeImpl before each think() cycle (compute_supersede_hint()).
+//
+// Live evidence (contabo LTC, warm restart on the shared v36 sharechain): a
+// node that loads its persisted, fully-verified sharechain then peers with a
+// higher-work v36 network STICKS on the old head — [FORK-DIAG] heads=2
+// verified=12279 chain=20920 gap=8648 with best VERIFIED head frozen while the
+// node RECEIVES the higher-work chain to height 20920. The incumbent enjoys a
+// structural, permanent privilege: TailScore compares chain_len FIRST and
+// score() short-circuits to {verified_height,0} for any tail below CHAIN_LENGTH,
+// so a warm-loaded full-CL verified tail beats any challenger whose VERIFIED
+// height is still below CHAIN_LENGTH — and the challenger never verifies to
+// CHAIN_LENGTH because think() only ever extends an unrooted segment ~8 shares
+// deep and never backfills it to the ~2*CHAIN_LENGTH depth a CHAIN_LENGTH-tall
+// verified tail needs. A fresh re-seed only converges because an EMPTY start has
+// no incumbent and downloads to 2*CL+10 under the bootstrap budget.
+//
+// This hint makes the EXISTING think() argmax able to actually see the
+// challenger, mirroring p2pool's re-pick-best-after-download, WITHOUT adding a
+// reorg code path or weakening verified-only selection: when a chain head's
+// RECEIVED cumulative work is STRICTLY greater than the incumbent best's
+// VERIFIED work AND that head is a genuine fork (not an extension of the
+// incumbent) AND its verified height is still below CHAIN_LENGTH, think()
+// (a) deepens Phase-2 backfill for that segment to 2*CL+10 and (b) spends a
+// BOUNDED elevated verification budget on it through the ordinary Phase-2
+// attempt_verify loop. Over successive 5s ticks the challenger verifies to
+// CHAIN_LENGTH, the Phase-3 TailScore comparison flips on its own, and the head
+// moves. It NEVER bypasses attempt_verify, never scores unverified work, and is
+// a no-op when the incumbent already IS the best head (no strictly-higher-work
+// fork exists) — so a healthy node is unaffected.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;          // challenger chain head (highest received work)
+    uint256  target_segment_last;  // chain.get_last(target_head): its missing parent —
+                                   // the stable identity of the whole challenger segment
+    int      budget{0};            // bounded elevated per-tick verify budget for the segment
+    uint288  challenger_work;      // received cumulative work of the challenger (diagnostics)
+    uint288  incumbent_work;       // verified cumulative work of the incumbent best (diagnostics)
+};
+
 // --- Result types ---
 
 struct TrackerThinkResult
@@ -651,16 +692,73 @@ public:
         return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    // Returns an ACTIVE hint iff a genuine competing fork exists whose RECEIVED
+    // cumulative work is STRICTLY greater than the incumbent best's VERIFIED
+    // work and whose verified height is still below CHAIN_LENGTH. Pure read over
+    // chain + verified (no mutation); safe to call under the exclusive lock just
+    // before think(). Guardrails baked in here:
+    //   * strictly-greater only (incumbent_work < challenger_work) — a tie or
+    //     lower-work fork can never trigger;
+    //   * genuine-fork only (is_child_of(incumbent, head) skips extensions of
+    //     our own chain, so freshly-mined-but-unverified local shares that merely
+    //     extend the best head never masquerade as a challenger);
+    //   * verified-height < CHAIN_LENGTH only — once the challenger is full-length
+    //     verified the ordinary Phase-3 argmax owns the decision and the hint
+    //     deactivates (no perpetual trigger, no oscillation).
+    // No-op (inactive) when the incumbent best already carries the most work —
+    // the healthy single-head case.
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;  // bootstrap / no incumbent — bootstrap budget path applies
+        const auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+
+        uint256 best_ch;
+        uint288 best_ch_work;
+        bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            // Extension of our own best chain (not a fork) — the ordinary
+            // budgeted Phase-2 verifies it; never treat it as a challenger.
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) { /* concurrent trim — treat as fork candidate */ }
+            // Already a full-length verified chain — Phase-3 scoring handles it.
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+
+        if (found && incumbent_work < best_ch_work)  // STRICTLY higher received work
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
     // stratum isn't serving work — no IO needs the tracker lock.
     // Matches p2pool where think() runs synchronously on the reactor and
     // blocks everything else until verification completes.
+    // supersede: restart-reorg hint (see SupersedeHint). Default-inactive, so
+    // every other coin/caller and the healthy-node path are byte-unchanged.
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& previous_block,
                              uint32_t bits,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
         // The timestamp is used to filter stale requests at return time.
@@ -901,6 +999,19 @@ public:
         // now, so budgeting is a safety net for cold starts only.
         constexpr int THINK_VERIFY_BUDGET = 100;
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
+        // Restart-reorg elevated budget (SupersedeHint): a BOUNDED extra pool
+        // that ONLY the challenger segment may draw from, after the normal
+        // budget is spent. Bounds the per-tick lock hold (ref #1343 serve-path
+        // contention) while still letting a strictly-higher-work fork verify to
+        // CHAIN_LENGTH over ~CL/budget ticks. Inactive → identical to before.
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active) {
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " segment_last=" << supersede.target_segment_last.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget
+                     << " challenger_work>" << "incumbent_work (strictly greater)";
+        }
         // NOTE: m_think_needs_continue is reset once at the top of think();
         // Phase 1 may have already requested a continuation, so do NOT clear
         // it here — either phase having remaining work must keep the loop going.
@@ -945,11 +1056,29 @@ public:
 
             auto [last_height, last_last_hash] = chain.get_height_and_last(last_hash);
 
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Matched by segment identity (the shared
+            // missing-parent), so it survives the frontier advancing tick to tick.
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+
             // Bounded backfill window: request as many shares as the chain is
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(PoolConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            // For an UNROOTED challenger segment a CHAIN_LENGTH-tall VERIFIED tail
+            // needs ~2*CL depth (each of the top CL shares needs CHAIN_LENGTH
+            // ancestors to pass attempt_verify's acc_height>=CL+1 guard on an
+            // unrooted chain). Target the fresh-bootstrap load depth 2*CL+10 so
+            // the segment can actually reach CHAIN_LENGTH verified shares — the
+            // core of the stuck-on-persisted-head bug. Rooted / non-challenger
+            // tails keep the original CL target (byte-unchanged).
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -981,10 +1110,16 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) {
+                    // Normal budget for everyone; the challenger segment may draw
+                    // from the bounded elevated pool AFTER the normal budget is
+                    // spent. A non-challenger head can never touch elevated_remaining.
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) {
                         m_think_needs_continue = true;
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
-                                 << " verifications, deferring remainder";
+                                 << " verifications, deferring remainder"
+                                 << (is_challenger ? " (challenger elevated pool spent)" : "");
                         break;
                     }
 
@@ -1058,7 +1193,10 @@ public:
                         break;
                     ++p2_verified_count;
                     if (!was_already_verified) {
-                        --budget_remaining;
+                        // Spend the normal budget first; only the challenger may
+                        // then draw from the bounded elevated pool.
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
                     }
                     // Throttled progress log: contabo freeze-diag (2026-05-24) caught
                     // this loop wedging the io_context for 2-7.5s at a time when emit
@@ -1075,8 +1213,18 @@ public:
                 }
             }
 
-            // Request more shares if verified chain is short
-            if (head_height < static_cast<int32_t>(PoolConfig::chain_length()) && !last_last_hash.IsNull())
+            // Request more shares if verified chain is short.
+            // Non-challenger: request until the MAIN chain reaches CHAIN_LENGTH
+            // (original behaviour). Challenger (restart-reorg): keep requesting
+            // parents until the segment reaches 2*CL+10 depth — the depth needed
+            // for a CHAIN_LENGTH-tall verified tail on an unrooted chain — so it
+            // is no longer pinned at ~CL+8 (the observed gap=8648 stuck state).
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(PoolConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 // Option A: check MAIN chain height (not verified height).
                 // If main chain is already in pruning zone, the unverified

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -746,6 +746,39 @@ public:
         return hint;
     }
 
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    // The challenger segment's VERIFIED frontier is short, so it sorts LOW in
+    // the work-descending Phase-2 head order. Left there, a shorter non-
+    // challenger verified head that outranks it by verified work can spend the
+    // whole normal per-tick verify budget first and trip the outer per-head
+    // budget gate, breaking the loop before the challenger's iteration is ever
+    // entered — so its bounded elevated pool is never drawn and the higher-work
+    // fork can never verify to CHAIN_LENGTH (the stuck-on-persisted-head bug).
+    // Moving the challenger-segment heads to the FRONT (stable_partition, so the
+    // work-descending order is preserved within each group) guarantees the
+    // challenger is reached every tick regardless of non-challenger contention.
+    // Challenger identity is the segment-last (shared missing parent), matched
+    // by chain.get_last so it survives the frontier advancing tick to tick —
+    // exactly the Phase-2 is_challenger test. Pure read over chain (get_last);
+    // no mutation, no PoW. Inactive supersede => predicate is always false =>
+    // stable_partition is a no-op and the healthy-node order is byte-identical.
+    // Returns the number of challenger heads moved to the front (priority prefix
+    // length). Selection (Phase 3/4 argmax) is untouched — this only orders the
+    // Phase-2 verify sweep so the challenger's elevated budget is actually drawn.
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active)
+            return 0;
+        auto is_challenger_head = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_challenger_head);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
@@ -1033,9 +1066,37 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;  // highest work first
             });
+        // Restart-reorg liveness: move challenger-segment heads to the FRONT of
+        // the work-descending order so a shorter non-challenger head that
+        // outranks the challenger by verified work can never spend the normal
+        // budget and trip the outer per-head gate before the challenger's
+        // iteration is entered (which would leave its elevated pool undrawn this
+        // tick — the starvation the fix closes). No-op when supersede is
+        // inactive: the healthy-node order is byte-identical.
+        prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) {
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Matched by segment identity (the shared
+            // missing-parent), so it survives the frontier advancing tick to tick.
+            // Hoisted above the per-head budget gate so the gate can be
+            // elevated-budget-aware (below).
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+
+            // Per-head budget gate. The normal budget bounds work per tick; only
+            // a challenger head may additionally draw the bounded elevated pool.
+            // Do NOT break while THIS head is a challenger that can still draw
+            // elevated budget — challengers are ordered first, so once a budget-
+            // spent non-challenger head is reached, no challenger remains behind
+            // it and stopping is correct. When supersede is inactive is_challenger
+            // is always false, so this reduces to the original `budget_remaining
+            // <= 0` break (healthy-node path byte-identical).
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
                 m_think_needs_continue = true;
                 break;
             }
@@ -1056,15 +1117,7 @@ public:
 
             auto [last_height, last_last_hash] = chain.get_height_and_last(last_hash);
 
-            // Restart-reorg: is this verified head the frontier of the challenger
-            // segment named by the hint? Matched by segment identity (the shared
-            // missing-parent), so it survives the frontier advancing tick to tick.
-            bool is_challenger = false;
-            if (supersede.active) {
-                try {
-                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
-                } catch (...) { is_challenger = false; }
-            }
+            // (is_challenger computed above, before the per-head budget gate.)
 
             // Bounded backfill window: request as many shares as the chain is
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # measurement that justifies it, and that an all-pass window logs no blocked
     # line and actually activates. Same folding rule: into the existing
     # allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/restart_reorg_supersede_test.cpp
+++ b/src/impl/ltc/test/restart_reorg_supersede_test.cpp
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Restart-reorg supersede detector -- KAT, exercised through LTC's REAL
+// ShareTracker API (ltc::ShareTracker::compute_supersede_hint).
+//
+// LIVE EVIDENCE this pins (contabo LTC, warm restart on the shared v36
+// sharechain): a node that loads its persisted, fully-verified sharechain then
+// peers with a higher-work v36 network STICKS on the old head --
+// [FORK-DIAG] heads=2 verified=12279 chain=20920 gap=8648 with the best VERIFIED
+// head frozen while the node RECEIVES the higher-work chain to height 20920. The
+// incumbent enjoys a structural, permanent privilege: TailScore compares
+// chain_len FIRST and score() short-circuits to {verified_height,0} below
+// CHAIN_LENGTH, so a warm-loaded full-CL verified tail beats any challenger whose
+// VERIFIED height is still short -- and the challenger never verifies to
+// CHAIN_LENGTH because think() never backfills the unrooted segment to the ~2*CL
+// depth a CHAIN_LENGTH-tall verified tail needs. A fresh re-seed only converges
+// because an EMPTY start has no incumbent.
+//
+// compute_supersede_hint is the visibility fix: it fires an ACTIVE hint iff a
+// GENUINE competing fork exists whose RECEIVED cumulative work is STRICTLY
+// greater than the incumbent best's VERIFIED work and whose verified height is
+// still below CHAIN_LENGTH. think() then deepens that segment's backfill to
+// 2*CL+10 and spends a bounded elevated verification budget on it, so it verifies
+// to CHAIN_LENGTH and the EXISTING Phase-3 TailScore argmax flips on its own.
+// This KAT drives the DECISION through the real chain/verified work accounting
+// (get_work over ShareIndex.work) -- the exact mechanism -- without needing real
+// PoW verification: the detector is a pure read over chain + verified.
+//
+// GUARDRAILS asserted here:
+//   * strictly-higher-work only  -> a lower-work or equal-work fork never fires;
+//   * genuine-fork only          -> an extension of the incumbent's own chain
+//                                   (freshly-mined-but-unverified local shares)
+//                                   never masquerades as a challenger;
+//   * no-op when incumbent is best (healthy single-head node) -> inactive;
+//   * no incumbent (bootstrap)   -> inactive.
+//
+// Folded into the EXISTING allowlisted `share_test` target (never a standalone
+// add_executable -- the #769 NOT_BUILT trap), so CI actually builds and runs it.
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <core/uint256.hpp>
+#include <impl/ltc/share.hpp>
+#include <impl/ltc/share_tracker.hpp>
+
+namespace {
+
+// Short hex tail -> uint256 (zero-padded), matching the LTC share_test hx()
+// convention used by the sibling chain_walk_window / desired_version tests.
+uint256 hx(const std::string& tail) {
+    uint256 v;
+    v.SetHex(std::string(64 - tail.size(), '0') + tail);
+    return v;
+}
+
+constexpr uint64_t kDv = 36;
+constexpr uint32_t kBits = 0x1e0fffff;  // uniform per-share work
+
+// Build a linear run of `count` uniform V36 shares into `tracker.chain`.
+//   root_prev : m_prev_hash of the DEEPEST share (share 0). Null -> rooted
+//               chain end (get_last == null); non-null-and-absent -> UNROOTED
+//               segment (get_last == root_prev), the challenger shape.
+//   salt      : disjoint hash space so independent runs never collide.
+// Returns the tip hash. Every share carries equal work, so total received work
+// is monotone in `count`.
+uint256 build_run(ltc::ShareTracker& tracker, int32_t count,
+                  const uint256& root_prev, size_t salt) {
+    uint256 prev = root_prev;
+    uint256 tip;
+    tip.SetNull();
+    for (int32_t i = 0; i < count; ++i) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%zx",
+                      static_cast<size_t>((salt << 20) + 0x5b70 + i));
+        uint256 h = hx(buf);
+        auto* sh = new ltc::MergedMiningShare();
+        sh->m_hash = h;
+        sh->m_prev_hash = prev;   // share 0 uses root_prev
+        sh->m_desired_version = kDv;
+        sh->m_bits = kBits;
+        sh->m_max_bits = kBits;
+        ltc::ShareType st;
+        st = sh;
+        tracker.add(st);
+        prev = h;
+        tip = h;
+    }
+    return tip;
+}
+
+// Mark a whole in-chain run [share 0 .. tip] as verified, as
+// load_persisted_shares() does (verified.add of the chain-owned share, ascending
+// so parent-before-child holds). Walks tip -> root via prev_hash.
+void mark_verified(ltc::ShareTracker& tracker, const uint256& tip) {
+    // Collect hashes tip->root, then add root->tip.
+    std::vector<uint256> chainward;
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    for (auto it = chainward.rbegin(); it != chainward.rend(); ++it) {
+        if (tracker.chain.contains(*it) && !tracker.verified.contains(*it)) {
+            auto& sv = tracker.chain.get_share(*it);
+            tracker.verified.add(sv);
+        }
+    }
+}
+
+constexpr int kBudget = 400;
+
+}  // namespace
+
+// --- Higher-work genuine fork -> ACTIVE, targeted at the challenger ----------
+TEST(LtcRestartReorgSupersede, HigherWorkForkActivates) {
+    ltc::ShareTracker t;
+    // Incumbent: rooted, fully verified, 30 shares.
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+    // Challenger: UNROOTED segment of 50 shares (more work than the incumbent),
+    // received but NOT verified. Its deepest share references an absent parent.
+    const uint256 missing_parent = hx("dead0001");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+
+    ASSERT_TRUE(t.verified.contains(inc_tip));
+    ASSERT_FALSE(t.verified.contains(ch_tip));
+    // Sanity: challenger received work strictly exceeds incumbent verified work.
+    EXPECT_TRUE(t.verified.get_work(inc_tip) < t.chain.get_work(ch_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_TRUE(hint.active);
+    EXPECT_EQ(hint.target_head, ch_tip);
+    EXPECT_EQ(hint.target_segment_last, missing_parent);  // segment identity
+    EXPECT_EQ(hint.budget, kBudget);
+    // Strictly-greater guard actually holds on the recorded works.
+    EXPECT_TRUE(hint.incumbent_work < hint.challenger_work);
+}
+
+// --- Lower-work fork -> INACTIVE (strictly-greater guard) --------------------
+TEST(LtcRestartReorgSupersede, LowerWorkForkStaysInactive) {
+    ltc::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    // Shorter unrooted fork: less received work than the incumbent's verified work.
+    const uint256 ch_tip = build_run(t, 10, hx("dead0002"), 2);
+
+    EXPECT_TRUE(t.chain.get_work(ch_tip) < t.verified.get_work(inc_tip));
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Equal-work fork -> INACTIVE (tie can never displace the head) ----------
+TEST(LtcRestartReorgSupersede, EqualWorkForkStaysInactive) {
+    ltc::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    // Same length -> identical total work (uniform per-share work).
+    const uint256 ch_tip = build_run(t, 30, hx("dead0003"), 2);
+
+    EXPECT_TRUE(t.chain.get_work(ch_tip) == t.verified.get_work(inc_tip));
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);  // requires STRICTLY greater
+}
+
+// --- Healthy single head -> INACTIVE (no-op when incumbent IS the best) ------
+TEST(LtcRestartReorgSupersede, HealthySingleHeadIsNoOp) {
+    ltc::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 40, uint256(), 1);
+    mark_verified(t, inc_tip);
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Own-chain extension (unverified) -> INACTIVE (genuine-fork guard) -------
+// Freshly-received-but-unverified shares that EXTEND the incumbent (higher
+// received work, same root) must NOT be treated as a challenger — they are the
+// node's own tip advancing, and the ordinary budgeted Phase-2 verifies them.
+TEST(LtcRestartReorgSupersede, OwnChainExtensionIsNotAChallenger) {
+    ltc::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    // 25 more shares built ON TOP of inc_tip, in-chain but unverified.
+    const uint256 ext_tip = build_run(t, 25, inc_tip /*extends incumbent*/, 2);
+
+    // Received work of the extension strictly exceeds the incumbent's verified
+    // work (it is 25 shares longer) — yet it is an extension, not a fork.
+    EXPECT_TRUE(t.verified.get_work(inc_tip) < t.chain.get_work(ext_tip));
+    EXPECT_TRUE(t.chain.is_child_of(inc_tip, ext_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);  // is_child_of guard excludes it
+}
+
+// --- No incumbent (bootstrap / empty verified) -> INACTIVE ------------------
+TEST(LtcRestartReorgSupersede, NoIncumbentIsInactive) {
+    ltc::ShareTracker t;
+    // Only an unrooted segment exists; nothing verified, no incumbent best.
+    const uint256 ch_tip = build_run(t, 50, hx("dead0004"), 2);
+    (void)ch_tip;
+    auto hint = t.compute_supersede_hint(uint256() /*null incumbent*/, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Backfill-depth target is the fresh-bootstrap load depth 2*CL+10 --------
+// The stuck state pinned the challenger segment at ~CL+8; the fix targets
+// 2*CL+10 so a CHAIN_LENGTH-tall verified tail is reachable on an unrooted chain.
+// This documents the invariant the think() Phase-2 want_depth uses.
+TEST(LtcRestartReorgSupersede, BackfillTargetIsTwiceChainLengthPlusTen) {
+    const int32_t CL = static_cast<int32_t>(ltc::PoolConfig::chain_length());
+    EXPECT_GT(CL, 0);
+    const int32_t challenger_target = 2 * CL + 10;
+    // Strictly deeper than the incumbent CL target — the whole point.
+    EXPECT_GT(challenger_target, CL);
+    // Matches the persisted-load depth (node.cpp keep_per_head = 2*CL + 10).
+    EXPECT_EQ(challenger_target, 2 * CL + 10);
+}

--- a/src/impl/ltc/test/restart_reorg_supersede_test.cpp
+++ b/src/impl/ltc/test/restart_reorg_supersede_test.cpp
@@ -36,9 +36,12 @@
 // Folded into the EXISTING allowlisted `share_test` target (never a standalone
 // add_executable -- the #769 NOT_BUILT trap), so CI actually builds and runs it.
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -112,7 +115,59 @@ void mark_verified(ltc::ShareTracker& tracker, const uint256& tip) {
     }
 }
 
+// Verify only the DEEPEST `n` shares of an in-chain run (root .. root+n-1),
+// ascending so parent-before-child holds — the partial "verified frontier" a
+// challenger segment has mid-catch-up. Returns the frontier verified head (the
+// shallowest verified share of the prefix), which is what verified.get_heads()
+// reports for the segment. n<=0 or n>=len verifies nothing extra beyond len.
+uint256 verify_deep_prefix(ltc::ShareTracker& tracker, const uint256& tip, int n) {
+    std::vector<uint256> chainward;  // tip -> root
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    const int sz = static_cast<int>(chainward.size());
+    if (n > sz) n = sz;
+    uint256 frontier;
+    for (int i = 0; i < n; ++i) {
+        const uint256& h = chainward[sz - 1 - i];  // root first (ascending)
+        if (tracker.chain.contains(h) && !tracker.verified.contains(h)) {
+            auto& sv = tracker.chain.get_share(h);
+            tracker.verified.add(sv);
+        }
+        frontier = h;  // last added = shallowest of the prefix = frontier head
+    }
+    return frontier;
+}
+
+// Faithful in-test model of think()'s Phase-2 OUTER per-head budget gate,
+// stepping an ordered head list. Worst case (the starvation driver): a
+// non-challenger head can spend the whole normal budget on its first turn.
+// `elevated_aware` selects the gate: false = the pre-fix `budget<=0` break;
+// true = the fix's `budget<=0 && !(is_challenger && elevated>0)` break.
+// Returns whether the challenger head's iteration is ENTERED (its elevated
+// budget becomes drawable this tick).
+bool challenger_iteration_entered(
+        const std::vector<uint256>& order, const uint256& challenger_head,
+        const std::function<bool(const uint256&)>& is_challenger,
+        int normal_budget, int elevated_budget, bool elevated_aware) {
+    int budget = normal_budget, elevated = elevated_budget;
+    for (const auto& h : order) {
+        const bool ch = is_challenger(h);
+        const bool brk = elevated_aware
+                             ? (budget <= 0 && !(ch && elevated > 0))
+                             : (budget <= 0);
+        if (brk) break;                       // outer loop terminates here
+        if (h == challenger_head) return true;  // challenger reached
+        if (!ch) budget = 0;                  // worst-case normal-budget spend
+    }
+    return false;
+}
+
 constexpr int kBudget = 400;
+constexpr int kNormalBudget = 100;  // THINK_VERIFY_BUDGET in think()
 
 }  // namespace
 
@@ -218,4 +273,142 @@ TEST(LtcRestartReorgSupersede, BackfillTargetIsTwiceChainLengthPlusTen) {
     EXPECT_GT(challenger_target, CL);
     // Matches the persisted-load depth (node.cpp keep_per_head = 2*CL + 10).
     EXPECT_EQ(challenger_target, 2 * CL + 10);
+}
+
+// --- STARVATION: a shorter, higher-verified-work non-challenger head must NOT
+//     starve the challenger's elevated budget within a think() tick -----------
+//
+// The liveness gap this pins: think() Phase-2 sorts VERIFIED heads by verified
+// work DESCENDING, then breaks the loop when the normal per-tick budget is
+// spent. The challenger's verified frontier is SHORT, so it sorts LOW; a shorter
+// non-challenger verified head that still outranks that short frontier can spend
+// the whole normal budget first and trip the outer break BEFORE the challenger's
+// iteration is ever entered — so the bounded elevated pool is never drawn that
+// tick, and m_think_needs_continue merely restarts the same starving sort order.
+// Property (a) "reorgs to the higher-work verified head after sync" then fails
+// under fork contention. The fix gives the challenger head budget PRIORITY:
+// prioritize_challenger_heads() moves the challenger-segment head(s) to the FRONT
+// (used verbatim by think()), and the outer gate is elevated-budget-aware. This
+// KAT drives the REAL chain/verified accounting and the REAL scheduling helper.
+TEST(LtcRestartReorgSupersede, ChallengerNotStarvedByShorterHigherWorkHead) {
+    ltc::ShareTracker t;
+
+    // Incumbent: rooted, fully verified, 30 shares (the warm-loaded head).
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+
+    // Non-challenger SIDE fork: rooted, fully verified, but SHORT (12 shares).
+    // Its verified work outranks the challenger's short frontier — the exact
+    // head that spends the normal budget first and would trip the break.
+    const uint256 nc_tip = build_run(t, 12, uint256() /*rooted, own root*/, 3);
+    mark_verified(t, nc_tip);
+
+    // Challenger: UNROOTED segment of 50 received shares (highest RECEIVED work),
+    // but only a SHORT verified frontier (deepest 3) — so it sorts LOW by
+    // verified work. Its segment identity is the shared missing parent.
+    const uint256 missing_parent = hx("dead0005");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+    const uint256 ch_frontier = verify_deep_prefix(t, ch_tip, 3);
+
+    // Sanity on the setup: all three are verified heads with the intended
+    // work ordering, and the challenger frontier carries the LEAST verified work.
+    ASSERT_TRUE(t.verified.contains(inc_tip));
+    ASSERT_TRUE(t.verified.contains(nc_tip));
+    ASSERT_TRUE(t.verified.contains(ch_frontier));
+    EXPECT_TRUE(t.verified.get_work(ch_frontier) < t.verified.get_work(nc_tip));
+    EXPECT_TRUE(t.verified.get_work(nc_tip)      < t.verified.get_work(inc_tip));
+
+    // The hint fires and names the challenger SEGMENT (by its missing parent),
+    // so the frontier head — deeper in the same segment — is is_challenger.
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    ASSERT_TRUE(hint.active);
+    EXPECT_EQ(hint.target_head, ch_tip);
+    EXPECT_EQ(hint.target_segment_last, missing_parent);
+    EXPECT_EQ(t.chain.get_last(ch_frontier), missing_parent);  // segment identity
+
+    // Build the Phase-2 head order EXACTLY as think() does: verified heads,
+    // sorted by verified work descending.
+    auto build_sorted = [&]() {
+        std::vector<std::pair<uint256, uint256>> v(
+            t.verified.get_heads().begin(), t.verified.get_heads().end());
+        std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+            auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+            auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+            return wa > wb;
+        });
+        return v;
+    };
+    auto index_of = [](const std::vector<std::pair<uint256, uint256>>& v,
+                       const uint256& h) -> int {
+        for (int i = 0; i < static_cast<int>(v.size()); ++i)
+            if (v[i].first == h) return i;
+        return -1;
+    };
+    auto is_ch = [&](const uint256& h) -> bool {
+        return t.chain.get_last(h) == hint.target_segment_last;
+    };
+
+    // PRE-fix order: the challenger frontier sorts AFTER the shorter
+    // non-challenger head — the starvation shape.
+    auto pre = build_sorted();
+    ASSERT_GE(index_of(pre, ch_frontier), 0);
+    ASSERT_GE(index_of(pre, nc_tip), 0);
+    EXPECT_GT(index_of(pre, ch_frontier), index_of(pre, nc_tip));
+    // And with the pre-fix `budget<=0` gate the challenger iteration is NEVER
+    // entered: a higher-work non-challenger spends the normal budget first.
+    std::vector<uint256> pre_order;
+    for (auto& hv : pre) pre_order.push_back(hv.first);
+    EXPECT_FALSE(challenger_iteration_entered(
+        pre_order, ch_frontier, is_ch, kNormalBudget, kBudget,
+        /*elevated_aware=*/false));
+
+    // FIX: prioritize the challenger segment to the front. Exactly one challenger
+    // head, and it lands ahead of the shorter non-challenger head.
+    auto post = build_sorted();
+    const size_t n_challengers = t.prioritize_challenger_heads(post, hint);
+    EXPECT_EQ(n_challengers, 1u);
+    EXPECT_EQ(index_of(post, ch_frontier), 0);
+    EXPECT_LT(index_of(post, ch_frontier), index_of(post, nc_tip));
+
+    // Post-fix order + elevated-aware gate: the challenger iteration IS entered,
+    // so its bounded elevated budget is drawn this tick — the head can advance
+    // toward CHAIN_LENGTH over successive ticks and Phase-3 flips on its own.
+    std::vector<uint256> post_order;
+    for (auto& hv : post) post_order.push_back(hv.first);
+    EXPECT_TRUE(challenger_iteration_entered(
+        post_order, ch_frontier, is_ch, kNormalBudget, kBudget,
+        /*elevated_aware=*/true));
+
+    // Per-tick bound is unchanged: normal budget + bounded elevated pool.
+    EXPECT_LE(kNormalBudget + kBudget, 500);
+}
+
+// --- Healthy node: prioritize is a NO-OP (order byte-identical) --------------
+// With no active supersede hint, prioritize_challenger_heads must not move a
+// single head — the healthy-node Phase-2 order stays exactly the sorted order.
+TEST(LtcRestartReorgSupersede, PrioritizeIsNoOpWhenInactive) {
+    ltc::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 side_tip = build_run(t, 12, uint256(), 3);
+    mark_verified(t, side_tip);
+
+    ltc::SupersedeHint inactive;  // active == false
+    ASSERT_FALSE(inactive.active);
+
+    std::vector<std::pair<uint256, uint256>> v(
+        t.verified.get_heads().begin(), t.verified.get_heads().end());
+    std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+        auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+        auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+        return wa > wb;
+    });
+    const auto before = v;
+    const size_t moved = t.prioritize_challenger_heads(v, inactive);
+    EXPECT_EQ(moved, 0u);
+    ASSERT_EQ(v.size(), before.size());
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v[i].first, before[i].first);
+        EXPECT_EQ(v[i].second, before[i].second);
+    }
 }


### PR DESCRIPTION
## Problem

A warm-restarted node that loads its persisted, fully-verified sharechain and then peers with a higher-work network **STICKS on the old head** and never reorgs onto the higher-work chain, even though it receives that chain in full.

### Live evidence (contabo LTC, shared v36 sharechain)

- After a plain restart (binary swap, data-dir preserved), the node loaded its persisted chain and froze:
  `[FORK-DIAG] heads=2 verified=12279 chain=20920 gap=8648`, best VERIFIED head frozen at `12272` while shares were RECEIVED up to `20920`; `[V36-GATE] sampling_signaling=0%`; `[AutoRatchet] "network is 100% old version"` spam. It was peered with the v36 network but did not reorg onto the higher-work chain.
- A **fresh re-seed** (wipe `sharechain_leveldb` + resync) adopted the v36 chain cleanly: single head, verified caught up to tip, `sampling_signaling=100%`, zero AutoRatchet spam.
- The re-seed only worked because an **empty** start has no incumbent to stick to. The durable fix must make a non-empty-start node converge too.

## Root cause

The persisted head enjoys a structural, permanent privilege: best-head selection can never see the challenger's work. `TailScore` compares `chain_len` FIRST and `score()` short-circuits to `{verified_height, 0}` below `CHAIN_LENGTH`, so a warm-loaded full-CL verified tail beats any challenger whose VERIFIED height is still below `CHAIN_LENGTH` — and the challenger never verifies to `CHAIN_LENGTH` because `think()` only extends an unrooted segment ~8 shares deep and never backfills it to the ~`2*CHAIN_LENGTH` depth a `CHAIN_LENGTH`-tall verified tail needs on an unrooted chain.

## Fix — mirror p2pool's re-pick-best-after-download

No new "reorg" code path, no weakening of verified-only selection. It makes the existing `think()` argmax able to actually *see* the challenger.

- **`ShareTracker::compute_supersede_hint()`** fires an active hint only when a GENUINE competing fork's **RECEIVED** cumulative work is **STRICTLY greater** than the incumbent best's **VERIFIED** work and its verified height is still below `CHAIN_LENGTH`.
- **`think()` Phase 2**, under an active hint: (a) deepens that segment's backfill target to `2*CL+10` (the fresh-bootstrap load depth), and (b) spends a **bounded** elevated verification budget (400/tick) on it **through the ordinary `attempt_verify` loop**. Over successive 5s ticks the challenger verifies to `CHAIN_LENGTH`, the **existing** Phase-3 `TailScore` argmax flips on its own, and `best_share_hash()` serves the new head.
- **`clean_tracker()`** exempts the converging challenger segment from stale-head eating and tail-dropping while the hint is active, so its partial verification isn't thrown away and restarted every ~300s (which would re-create the latch). The exemption lifts once it verifies to `CHAIN_LENGTH`.
- **`[SUPERSEDE]`** log lines mark the trigger and the actual head flip, so a warm-restart soak is verifiable from logs.

## Guardrails (every one from the plan)

- **Verified-only mining preserved** — selection stays the existing argmax over VERIFIED tails/heads; the hint only widens verification BUDGET and backfill DEPTH. It never bypasses `attempt_verify`, never scores unverified work, and the `acc_height >= CL+1` unrooted guard and all PoW checks are untouched.
- **Strictly-higher-work only** — the trigger requires received work strictly greater than the incumbent verified best; adoption itself only happens through the existing strict `TailScore` comparison. A tie or lower-work chain can never displace the head.
- **No oscillation** — `TailScore` is a deterministic pure function and verification is monotone (verified set only grows), so the ranking flips at most once per direction; `clean_tracker` then prunes the losing stale tail.
- **Bounded work per tick** — elevated verification is capped (400 shares/think), backfill by the existing `to_get` batching; no full-chain re-verification per tick. `think_ms` must be watched in soak (tracker-lock contention is a known serve-path sensitivity, ref #1343).
- **Invalid chains cannot win** — a fake-high-work advertisement only spends the bounded budget; `attempt_verify` fails the bad shares, the existing ban path punishes the peer, and the incumbent is never released until the challenger is fully verified to `CL` and strictly ahead.
- **Genuine-fork only / no-op on healthy nodes** — `is_child_of` excludes our own unverified chain extension; when the persisted head already IS the best head the hint stays inactive, so a healthy node is byte-unchanged.
- **Consensus-sensitive change: no auto-merge.** This is which-chain-the-node-mines-on logic (money risk). Needs review + a live **warm-restart soak on contabo** (binary swap with preserved data-dir on the shared LTC sharechain) proving single-head convergence, `sampling_signaling=100%`, zero AutoRatchet "100% old" spam — before any fleet/hotel deploy.

## Scope

Coin-generic head-selection core; wired for LTC (#71). `think()` gains a default-inactive `SupersedeHint` parameter, so btc/dgb/dash callers and the healthy-node path are byte-unchanged.

## Tests

- New KAT `src/impl/ltc/test/restart_reorg_supersede_test.cpp` (7 cases, folded into the allowlisted `share_test`): higher-work fork activates + targets the challenger; lower-work and equal-work stay inactive; healthy single head is a no-op; own-chain extension is not a challenger; no incumbent is inactive; backfill target is `2*CL+10`.
- Local: `share_test` **90/90** (includes the `auto_ratchet_*` suites), `core_test` **190/190** (includes `chain_test`).

## Do not merge

This needs soak. Draft until the contabo warm-restart convergence run is captured.

Refs #71.
