### PR TITLE
Dashboard: sharechain-derived pool leg + found_by on /recent_blocks (P1c)

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -2418,7 +2418,7 @@
             var label, color;
             if (by === 'this_node')            { label = 'This node'; color = '#00ff88'; }
             else if (by === 'sharechain_peer') { label = 'Pool peer'; color = '#00d4ff'; }
-            else                               { label = 'Unknown';   color = '#888888'; }
+            else                               { label = '—';         color = '#888888'; }
             var s = 'Found by: <b style="color:' + color + '">' + label + '</b><br/>';
             if (b && b.miner) {
                 var addr = String(b.miner);

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -2406,6 +2406,31 @@
             return d3.format('.2f')(d) + ' P';
         }
 
+        // Coin-generic finder attribution for a /recent_blocks row (#901).
+        // `found_by` is the pool-wide authorship the endpoint emits from its
+        // sharechain-derived pool leg:
+        //   this_node       -> our own template won the block
+        //   sharechain_peer -> another pool node's template won it
+        //   unknown/absent  -> a coin lane that has not labelled its find sites
+        // Display only: this reads the served value and never gates any logic.
+        function block_found_by_html(b) {
+            var by = b && b.found_by;
+            var label, color;
+            if (by === 'this_node')            { label = 'This node'; color = '#00ff88'; }
+            else if (by === 'sharechain_peer') { label = 'Pool peer'; color = '#00d4ff'; }
+            else                               { label = 'Unknown';   color = '#888888'; }
+            var s = 'Found by: <b style="color:' + color + '">' + label + '</b><br/>';
+            if (b && b.miner) {
+                var addr = String(b.miner);
+                var shortAddr = addr.length > 22
+                    ? addr.substr(0, 12) + '…' + addr.substr(addr.length - 6)
+                    : addr;
+                s += 'Miner: <b style="color:#c9c9e3" title="' + addr + '">'
+                   + shortAddr + '</b><br/>';
+            }
+            return s;
+        }
+
         // Format percentage with big integer + small decimal parts
         // Format percentage with big bold integer + smaller decimal
         function format_pct_fancy(pct) {
@@ -7833,6 +7858,7 @@
                                 else if (diffRatio >= 2) s += ' <span style="color:#00ff88">★</span>';
                                 s += '<br/>';
                             }
+                            s += block_found_by_html(b);
                             s += 'Status: <b style="color:' + (b.status === 'confirmed' ? '#00ff88' : '#ffc107') + '">' + (b.status || 'unknown') + '</b>';
                             return s;
                         }
@@ -7974,6 +8000,7 @@
                                 else if (diffRatio >= 2) s += ' <span style="color:#00ff88">★</span>';
                                 s += '<br/>';
                             }
+                            s += block_found_by_html(b);
                             s += 'Status: <b style="color:' + (b.status === 'confirmed' ? '#00ff88' : '#ffc107') + '">' + (b.status || 'unknown') + '</b>';
                             return s;
                         }
@@ -8516,6 +8543,7 @@
                                 else if (diffRatio >= 2) s += ' <span style="color:#00ff88">★</span>';
                                 s += '<br/>';
                             }
+                            s += block_found_by_html(b);
                             s += 'Status: <b style="color:' + (b.status === 'confirmed' ? '#00ff88' : '#ffc107') + '">' + (b.status || 'unknown') + '</b>';
                             return s;
                         }
@@ -8669,6 +8697,7 @@
                                 else if (diffRatio >= 2) s += ' <span style="color:#00ff88">★</span>';
                                 s += '<br/>';
                             }
+                            s += block_found_by_html(b);
                             s += 'Status: <b style="color:' + (b.status === 'confirmed' ? '#00ff88' : '#ffc107') + '">' + (b.status || 'unknown') + '</b>';
                             return s;
                         }

--- a/web-static/index.html
+++ b/web-static/index.html
@@ -450,6 +450,21 @@
                             if (block.status === 'orphaned') return '✗ Orphaned';
                             return '⏳ Pending';
                         });
+                    // Found by (coin-generic pool-wide authorship, #901):
+                    // this_node when our template won, sharechain_peer when
+                    // another pool node's minted share won. Display only.
+                    tr.append('td')
+                        .style('font-weight', 'bold')
+                        .style('color', function(block){
+                            if (block.found_by === 'this_node') return '#28a745';
+                            if (block.found_by === 'sharechain_peer') return '#0d6efd';
+                            return '#888';
+                        })
+                        .text(function(block){
+                            if (block.found_by === 'this_node') return 'This node';
+                            if (block.found_by === 'sharechain_peer') return 'Pool peer';
+                            return '—';
+                        });
                 });
                 
                 // Merged mining blocks
@@ -627,7 +642,7 @@
         <h2>Blocks found recently:</h2>
         <p>Note that blocks may have been orphaned from the P2Pool chain and so not be here.</p>
         <table border="1" id="blocks">
-            <tr><th>time</th><th>number</th><th>hash/explorer link</th><th>share</th><th>luck</th><th>status</th></tr>
+            <tr><th>time</th><th>number</th><th>hash/explorer link</th><th>share</th><th>luck</th><th>status</th><th>found by</th></tr>
         </table>
         
         <div id="merged_blocks_section" style="display:none;">

--- a/web-static/miners.html
+++ b/web-static/miners.html
@@ -553,6 +553,7 @@
                             <th>Block Height</th>
                             <th>Block Hash</th>
                             <th>Miner</th>
+                            <th title="Pool-wide finder attribution (#901): this node vs a sharechain peer">Found by</th>
                             <th>Luck</th>
                             <th>Status</th>
                         </tr>
@@ -1108,7 +1109,26 @@
                     minerLink.title = minerAddr;
                     tdMiner.appendChild(minerLink);
                     tr.appendChild(tdMiner);
-                    
+
+                    // Found by (coin-generic pool-wide authorship, #901).
+                    // Reads the endpoint's found_by field: this_node when our
+                    // template won, sharechain_peer when another pool node's
+                    // share (minted onto the sharechain) won. Display only.
+                    var tdFoundBy = document.createElement('td');
+                    tdFoundBy.style.fontWeight = 'bold';
+                    var fb = block.found_by;
+                    if (fb === 'this_node') {
+                        tdFoundBy.textContent = 'This node';
+                        tdFoundBy.style.color = '#28a745';
+                    } else if (fb === 'sharechain_peer') {
+                        tdFoundBy.textContent = 'Pool peer';
+                        tdFoundBy.style.color = '#0d6efd';
+                    } else {
+                        tdFoundBy.textContent = '—';
+                        tdFoundBy.style.color = '#888';
+                    }
+                    tr.appendChild(tdFoundBy);
+
                     // Luck
                     var tdLuck = document.createElement('td');
                     if (block.luck) {


### PR DESCRIPTION
## What (P1c, dashboard parity plan)

Dashboard lane **P1c** of `p2pool-dash/DASH_DASHBOARD_PLAN.md`. Makes the pool-wide, sharechain-derived block attribution on `/recent_blocks` **visible** in the dashboard.

## Scope note: the endpoint already carries the data

On master head (ad37fcf) the `/recent_blocks` endpoint (`MiningInterface::rest_recent_blocks()`, `src/core/web_server.cpp`) already:

- merges a **sharechain-derived pool leg** into the found-block store. Any participant's block-winning share, minted onto the sharechain (#888), is recorded via `record_found_block(..., BlockAuthorship::sharechain_peer)` (DASH: `src/impl/dash/dashboard_found_block.hpp` → `main_dash.cpp`; the local stratum win is recorded separately as `this_node`);
- emits a per-block **`found_by`** field: `this_node` / `sharechain_peer` / `unknown` (the #901 us-vs-pool split), alongside the legacy `found_locally` (have-a-local-record) flag;
- **dedups the merged result by block hash** — `record_found_block` keys on `(block hash, chain label)`, so a block that arrives on both the local-win arm and the sharechain arm appears exactly once, and authorship only ever climbs (a known finder is never downgraded).

What was missing was a **consumer**: no front-end view read `found_by`, so the served pool leg was invisible. This PR closes that gap.

## Change (front-end only, coin-generic)

- `web-static/dashboard.html`: shared `block_found_by_html()` helper adds a **Found by** line (plus the finder address) to all four block-diamond tooltips.
- `web-static/miners.html`: **Found by** column in the Pool Blocks table.
- `web-static/index.html`: **found by** column in the recent-blocks list.

Mapping is identical everywhere: `this_node` → "This node", `sharechain_peer` → "Pool peer", `unknown`/absent → "—". Works for every coin (DASH first-class); coins that do not label their find sites simply render "—".

## Display-only / consensus-neutral

These are `web-static/*` files served from disk (`--dashboard-dir`, default `web-static`) — no C++ TU is compiled and no binary changes. The change reads the already-served `found_by`/`miner` values and **gates no logic**. It touches **no** block validity, reward/coinbase, or template-building code. `/recent_blocks` remains fed exclusively by `record_found_block()`.

## Oracle validation

Validated the served shape against the live DASH oracle at `http://192.168.86.165:7903/recent_blocks` (p2pool-dash web.py). The shared per-row fields line up in name and type: `ts`, `hash`, `number`, `share`, `miner`, `pool_hashrate_at_find`, `network_difficulty`, `status`, `actual_hash_difficulty`, `luck`, `time_to_find`, `expected_time`, `luck_method`. `found_by` (and `found_locally`) are c2pool's **pool-wide extension** — the single-node oracle has no equivalent, so it is additive and does not disturb the shared shape.

## Not for merge

Draft. Display-only; review at leisure. Does not merge.