### PR TITLE
qt(qpc): rebind embedded coin descriptor + tip stream on coin switch

### DIFF
--- a/ui/c2pool-qt/src/ApiClient.cpp
+++ b/ui/c2pool-qt/src/ApiClient.cpp
@@ -16,10 +16,15 @@ ApiClient::ApiClient(QObject* parent)
 
 void ApiClient::setBaseUrl(const QString& baseUrl)
 {
-    baseUrl_ = baseUrl.trimmed();
-    if (baseUrl_.endsWith('/')) {
-        baseUrl_.chop(1);
+    QString normalized = baseUrl.trimmed();
+    if (normalized.endsWith('/')) {
+        normalized.chop(1);
     }
+    if (normalized == baseUrl_) {
+        return;
+    }
+    baseUrl_ = normalized;
+    emit baseUrlChanged(baseUrl_);
 }
 
 QString ApiClient::baseUrl() const

--- a/ui/c2pool-qt/src/ApiClient.hpp
+++ b/ui/c2pool-qt/src/ApiClient.hpp
@@ -29,6 +29,14 @@ public:
 signals:
     void connectionStateChanged(const QString& state);
     void requestFailed(const QString& message);
+    /** Emitted when setBaseUrl() actually changes the target daemon
+     *  (e.g. an active-coin/profile switch). Consumers that hold a
+     *  long-lived connection keyed on the base URL — notably the
+     *  SharechainBridge SSE tip stream — reconnect against the new
+     *  daemon so a coin switch does not keep streaming the old coin's
+     *  tips. Request/response ops re-read baseUrl() per call and need
+     *  no signal. */
+    void baseUrlChanged(const QString& baseUrl);
 
 private:
     QString makeUrl(const QString& path) const;

--- a/ui/c2pool-qt/src/MainWindow.cpp
+++ b/ui/c2pool-qt/src/MainWindow.cpp
@@ -257,6 +257,18 @@ MainWindow::MainWindow(SettingsStore* settings, QWidget* parent)
                     baseUrlEdit_->setText(url);
                     api_.setBaseUrl(url);
                 }
+                // A profile switch can change the active coin. The
+                // embedded Explorer / PPLNS bundles read their
+                // CoinDescriptor from CoinBridge at boot only, so
+                // re-boot them here — after api_.setBaseUrl above so the
+                // reloaded pages open their SSE / fetches against the new
+                // coin's daemon. Without this a DASH<->LTC switch leaves
+                // the previous coin's version badges, address-explorer
+                // links and merged-chain rows showing. Display-only —
+                // no reward/consensus/template surface is touched.
+                sharechainPage_->reload();
+                pplnsPage_->reload();
+                miningPage_->reloadEmbed();
                 reloadProfileCombo();
                 statusLabel_->setText(tr("Profile: %1").arg(newActive));
                 refreshCurrentPage();

--- a/ui/c2pool-qt/src/PageMining.cpp
+++ b/ui/c2pool-qt/src/PageMining.cpp
@@ -100,6 +100,13 @@ PageMining::PageMining(QList<QObject*> embedBridges, QWidget* parent)
     connect(unbanButton_, &QPushButton::clicked, this, &PageMining::onUnbanMiner);
 }
 
+void PageMining::reloadEmbed()
+{
+    if (pplnsEmbed_ != nullptr) {
+        pplnsEmbed_->reload();
+    }
+}
+
 void PageMining::refresh(ApiClient* api)
 {
     api_ = api;

--- a/ui/c2pool-qt/src/PageMining.hpp
+++ b/ui/c2pool-qt/src/PageMining.hpp
@@ -34,6 +34,11 @@ public:
      *  PplnsBridge — no action needed here. */
     void refresh(ApiClient* api);
 
+    /** Re-boot the embedded PPLNS View surface so it re-reads the
+     *  active coin descriptor from CoinBridge on a profile/coin
+     *  switch. No-op when no embed was wired. GUI-only. */
+    void reloadEmbed();
+
 private slots:
     void onStartMining();
     void onStopMining();

--- a/ui/c2pool-qt/src/bridges/SharechainBridge.cpp
+++ b/ui/c2pool-qt/src/bridges/SharechainBridge.cpp
@@ -37,6 +37,15 @@ SharechainBridge::SharechainBridge(ApiClient* api, QObject* parent)
     reconnectTimer_ = new QTimer(this);
     reconnectTimer_->setSingleShot(true);
     connect(reconnectTimer_, &QTimer::timeout, this, &SharechainBridge::onReconnectTimer);
+    // A base-URL change means the active coin/daemon switched. The tip
+    // SSE socket is bound to whatever base URL was current at
+    // openStream() time, so reconnect it against the new daemon —
+    // otherwise both embedded views keep refetching off the previous
+    // coin's tip events until the old TCP connection happens to drop.
+    if (api_ != nullptr) {
+        connect(api_, &ApiClient::baseUrlChanged,
+                this, &SharechainBridge::restartStream);
+    }
 }
 
 SharechainBridge::~SharechainBridge()
@@ -134,6 +143,26 @@ void SharechainBridge::stopStream()
         stream_ = nullptr;
     }
     streamBuffer_.clear();
+}
+
+void SharechainBridge::restartStream()
+{
+    // Only act when a stream was actually requested; a switch made
+    // while no view is streaming needs nothing.
+    if (!streamRequested_) return;
+    if (reconnectTimer_ != nullptr) reconnectTimer_->stop();
+    if (stream_ != nullptr) {
+        stream_->abort();
+        stream_->deleteLater();
+        stream_ = nullptr;
+    }
+    streamBuffer_.clear();
+    reconnectAttempts_ = 0;
+    openStream();
+    // Tell the JS side to treat this as a reconnect so it refetches a
+    // fresh window rather than sending the old coin's delta cursor to
+    // the new coin's /sharechain/delta.
+    emit tipReconnected();
 }
 
 // ── Internals ────────────────────────────────────────────────────────

--- a/ui/c2pool-qt/src/bridges/SharechainBridge.hpp
+++ b/ui/c2pool-qt/src/bridges/SharechainBridge.hpp
@@ -86,6 +86,14 @@ private:
     /** Build the stream request + connect signals. Called both by
      *  startStream() and onReconnectTimer(). */
     void openStream();
+    /** Tear down the live SSE socket and immediately reopen it against
+     *  the current base URL. Wired to ApiClient::baseUrlChanged so an
+     *  active-coin/profile switch does not keep streaming the previous
+     *  coin's tips (the stream URL is fixed at openStream() time). A
+     *  no-op when no stream was requested. Emits tipReconnected so the
+     *  JS side re-syncs from a full window instead of a stale delta
+     *  cursor keyed to the old coin. */
+    void restartStream();
     /** Schedule the next reconnect attempt with exponential backoff. */
     void scheduleReconnect();
     /** Parse buffered SSE bytes; emit tipChanged for each complete

--- a/web-static/sharechain-explorer/dashboard-embed.html
+++ b/web-static/sharechain-explorer/dashboard-embed.html
@@ -150,23 +150,14 @@
     }
 
     // ── Boot: open QWebChannel, grab bridges, start the Explorer ────
-    function onChannelReady(channel) {
-      const bridge = channel.objects.sharechain;
-      if (!bridge) {
-        setStatus('no sharechain bridge', 'err');
-        log('error', 'QWebChannel did not expose sharechain');
-        return;
-      }
-      const transport = new QtTransport(bridge);
-      const coinBridge = channel.objects.coin;       // optional — step 9 adds
-      const myAddress = coinBridge && coinBridge.myAddress
-        ? coinBridge.myAddress
-        : undefined;
-
+    function startExplorer(transport, shareVersion) {
       const rt = createRealtime({
         canvas,
         transport,
-        userContext: { myAddress, shareVersion: 36 },
+        // shareVersion drives own-share classification/highlighting; it
+        // comes from the active coin's CoinDescriptor so the Explorer is
+        // coin-generic instead of pinned to a compile-time value.
+        userContext: { myAddress: undefined, shareVersion },
         containerWidth:  () => wrap.clientWidth,
         containerHeight: () => wrap.clientHeight,
         minCellSize: 4,   // default maxCellSize (120) kicks in
@@ -178,7 +169,7 @@
       });
       rt.start().then(() => {
         setStatus('connected');
-        log('info', 'Explorer started via QtTransport');
+        log('info', 'Explorer started via QtTransport', { shareVersion });
         window.__explorerQt = rt;
       }).catch((err) => {
         setStatus('failed to start', 'err');
@@ -188,6 +179,36 @@
       window.addEventListener('beforeunload', () => {
         try { rt.stop(); } catch {}
       });
+    }
+
+    function onChannelReady(channel) {
+      const bridge = channel.objects.sharechain;
+      if (!bridge) {
+        setStatus('no sharechain bridge', 'err');
+        log('error', 'QWebChannel did not expose sharechain');
+        return;
+      }
+      const transport = new QtTransport(bridge);
+      const coinBridge = channel.objects.coin;       // optional
+      const boot = (shareVersion) => {
+        const v = (typeof shareVersion === 'number' && shareVersion > 0)
+          ? shareVersion : 36;   // 36 = historical default
+        startExplorer(transport, v);
+      };
+      // Read the active coin's shareVersion from CoinBridge. QWebChannel
+      // invokables resolve asynchronously; fall back to the default when
+      // the bridge is absent or errors. A profile/coin switch re-boots
+      // this page (PageEmbedded::reload), so a boot-time read rebinds.
+      if (coinBridge && typeof coinBridge.currentCoinDescriptor === 'function') {
+        try {
+          coinBridge.currentCoinDescriptor(
+            (desc) => boot(desc && desc.shareVersion));
+        } catch (e) {
+          boot(undefined);
+        }
+      } else {
+        boot(undefined);
+      }
     }
 
     if (typeof QWebChannel !== 'function') {

--- a/web-static/sharechain-explorer/pplns-embed.html
+++ b/web-static/sharechain-explorer/pplns-embed.html
@@ -63,9 +63,14 @@
       descriptorForCoin,
     } from './dist/pplns-view.js';
 
-    // Coin identity for this node's dashboard. The Qt host injects
-    // window.__C2POOL_COIN__ from the node's config; a ?coin= query param is
-    // a manual override; absent both we fall back to LTC (historical default).
+    // Coin identity for this node's dashboard. Preference order:
+    //   1. the CoinBridge descriptor (channel.objects.coin) — the
+    //      authoritative active-coin/profile value under c2pool-qt,
+    //      resolved asynchronously in onChannelReady;
+    //   2. window.__C2POOL_COIN__ injected by a non-Qt host;
+    //   3. a ?coin= query-param override;
+    //   4. LTC (historical default).
+    // resolveCoin() covers 2–4; the bridge (1) is applied at boot.
     function resolveCoin() {
       if (typeof window.__C2POOL_COIN__ === 'string' && window.__C2POOL_COIN__) {
         return window.__C2POOL_COIN__;
@@ -75,6 +80,19 @@
         if (q) return q;
       } catch (e) { /* no location in some embed hosts */ }
       return 'LTC';
+    }
+
+    // The CoinBridge descriptor's `symbol` is the chain name
+    // (e.g. "litecoin", "dash"); map it to the ticker the PPLNS
+    // descriptor registry keys on. Unknown chains fall through to the
+    // raw value — descriptorForCoin() upper-cases and falls back to LTC.
+    const CHAIN_TO_TICKER = {
+      litecoin: 'LTC', bitcoin: 'BTC', dogecoin: 'DOGE',
+      digibyte: 'DGB', dash: 'DASH', bitcoincash: 'BCH',
+    };
+    function symbolFromDescriptor(desc) {
+      if (!desc || typeof desc.symbol !== 'string' || !desc.symbol) return null;
+      return CHAIN_TO_TICKER[desc.symbol.toLowerCase()] || desc.symbol;
     }
 
     const statusEl = document.getElementById('status');
@@ -162,39 +180,62 @@
     }
 
     // ── Boot ─────────────────────────────────────────────────────────
+    function startPplnsView(transport, coinSymbol) {
+      const ctrl = PplnsView.init({
+        container: tree,
+        transport,
+        coin: descriptorForCoin(coinSymbol),
+        showVersionBadge: true,
+        showHashrate: true,
+        showMerged: true,
+      });
+      ctrl.on('ready', () => {
+        setStatus('connected');
+        log('info', 'PPLNS View started via QtPplnsTransport',
+            { coin: coinSymbol });
+      });
+      ctrl.on('error', (err) => {
+        setStatus('error', 'err');
+        log('error', err.message || String(err), { type: err.type });
+      });
+      window.__pplnsQt = ctrl;
+      window.addEventListener('beforeunload', () => {
+        try { ctrl.destroy(); } catch {}
+      });
+    }
+
     function onChannelReady(channel) {
       const pplnsBridge = channel.objects.pplns;
       const shareBridge = channel.objects.sharechain;
+      const coinBridge  = channel.objects.coin;
       if (!pplnsBridge) {
         setStatus('no pplns bridge', 'err');
         log('error', 'QWebChannel did not expose pplns');
         return;
       }
       const transport = new QtPplnsTransport(pplnsBridge, shareBridge);
-      try {
-        const ctrl = PplnsView.init({
-          container: tree,
-          transport,
-          coin: descriptorForCoin(resolveCoin()),
-          showVersionBadge: true,
-          showHashrate: true,
-          showMerged: true,
-        });
-        ctrl.on('ready', () => {
-          setStatus('connected');
-          log('info', 'PPLNS View started via QtPplnsTransport');
-        });
-        ctrl.on('error', (err) => {
-          setStatus('error', 'err');
-          log('error', err.message || String(err), { type: err.type });
-        });
-        window.__pplnsQt = ctrl;
-        window.addEventListener('beforeunload', () => {
-          try { ctrl.destroy(); } catch {}
-        });
-      } catch (err) {
-        setStatus('failed to start', 'err');
-        log('error', String(err && err.message ? err.message : err));
+      const boot = (symbol) => {
+        try {
+          startPplnsView(transport, symbol || resolveCoin());
+        } catch (err) {
+          setStatus('failed to start', 'err');
+          log('error', String(err && err.message ? err.message : err));
+        }
+      };
+      // Prefer the authoritative active-coin descriptor from CoinBridge.
+      // QWebChannel invokables resolve asynchronously; fall back to
+      // resolveCoin() when the bridge is absent (non-Qt host) or errors.
+      // A profile/coin switch re-boots this page (PageEmbedded::reload),
+      // so reading the descriptor at boot is sufficient to rebind — no
+      // separate coinChanged handler is needed.
+      if (coinBridge && typeof coinBridge.currentCoinDescriptor === 'function') {
+        try {
+          coinBridge.currentCoinDescriptor((desc) => boot(symbolFromDescriptor(desc)));
+        } catch (e) {
+          boot(null);
+        }
+      } else {
+        boot(null);
       }
     }
 


### PR DESCRIPTION
## QP-C — coin-switch rebind for the c2pool-qt embedded pages

**Scope: GUI/display only.** No reward / coinbase / consensus / template code is touched.

The Control Panel embeds `pplns-embed.html` + `dashboard-embed.html` into PageMining / PageEmbedded over QWebChannel. The multi-coin backend seams were merged (#1001, #1145, #1144, #1190) but the Qt host never fed the active coin through to the embedded pages, so a **DASH<->LTC profile switch left the previous coin's data showing**. This PR wires the missing half.

### Gaps closed

1. **PPLNS page pinned to LTC.** `pplns-embed.html` booted with `descriptorForCoin('LTC')` unconditionally — the Qt host never injects `window.__C2POOL_COIN__` and the qrc URL has no `?coin=`, so a DASH profile rendered LTC version badges, LTC address-explorer links and a DOGE merged column. It now reads `CoinBridge.currentCoinDescriptor()` at boot and maps the chain name to the registry ticker (`dash`->`DASH`, `litecoin`->`LTC`).

2. **`coinChanged` emitted but unconsumed.** Rather than add a live JS handler (which would race the base-URL repoint on profile switch), `MainWindow` re-boots the three embedded surfaces (`sharechainPage_`, `pplnsPage_`, PageMining's embed) via `PageEmbedded::reload()` on `profileChanged`, **after** `api_.setBaseUrl()`. The reloaded pages re-read the descriptor and hit the new coin's daemon.

3. **Explorer hardcodes.** `dashboard-embed.html` hardcoded `userContext.shareVersion:36` and read a non-existent `coinBridge.myAddress`. It now takes `shareVersion` from the descriptor (fallback 36) and drops the dead `myAddress` read.

4. **Stale SSE on switch.** The `SharechainBridge` tip stream was bound to the base URL current at `openStream()` time and never reconnected on a coin switch. `ApiClient` now emits `baseUrlChanged` when the target daemon actually changes; `SharechainBridge` reconnects the stream against the new base and emits `tipReconnected` so the JS re-syncs from a full window instead of sending the old coin's delta cursor to the new coin.

### Verification
- `c2pool-qt` builds clean (Qt6 + WebEngine; the `explorer_bundle` qrc rebuilds with the HTML edits).
- DASH descriptor path checked against the live pool at `192.168.86.165` — `/current_payouts` returns **X-prefixed** mainnet addresses, matching the dash `p2pkh` version-76 descriptor the fix now selects (previously these would have been linked to blockchair litecoin + shown a DOGE column).

Draft — not for merge; review by maintainer.