### PR TITLE
BCH: dedicated readvertise_best_share() bypassing shared-hash dedup on re-advert

### DIFF
--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -1072,28 +1072,59 @@ uint256 NodeImpl::advertised_best_share()
     return uint256::ZERO;
 }
 
-// ROOT-2 re-advert. Unlike ltc/dgb (which have a dedicated readvertise that
-// bypasses the de-dup set), this delegates to broadcast_share, so the walk still
-// breaks on the first hash already in m_shared_share_hashes.
-//
-// Interaction with the F2 marking change: marking is now a strict SUBSET of what
-// the pre-fix code marked (only hashes a peer actually accepted). The walk breaks
-// later or in the same place, never earlier, so this re-advert re-pushes a
-// superset of what it used to — monotonically better, no regression. It is
-// strictly better in the case that motivated ROOT-2: head shares minted while no
-// peer was connected are no longer marked, so a peer that handshook during the
-// empty window now receives them. It does NOT fully close ROOT-2 here — head
-// shares already accepted by some OTHER peer stay marked and the walk still
-// breaks, exactly as before. Closing that needs the ltc/dgb-style de-dup-bypass
-// readvertise; pre-existing gap, out of scope for this change.
-void NodeImpl::readvertise_best()
+void NodeImpl::readvertise_best_share()
 {
-    if (m_peers.empty())
+    // ROOT-2 re-advertisement.  A peer that finished its version handshake
+    // while our verified chain was empty got a NULL best_share and never
+    // called download_shares(); broadcast_share() may not wake it either, because
+    // its walk breaks on the first hash already in m_shared_share_hashes.  Here
+    // we re-push the tip walk to every peer WITHOUT consulting the de-dup set.
+    // Advertise-only: never affects local work creation.
+    //
+    // This is the ltc/dgb-style de-dup-bypass re-advert (ltc/node.cpp,
+    // dgb/node.cpp).  The prior BCH readvertise_best() delegated to
+    // broadcast_share, whose walk breaks on the first hash already in
+    // m_shared_share_hashes, so a head share already accepted by some OTHER peer
+    // stayed masked and the re-advert never reached a freshly-handshook peer.
+    // Walking the head directly closes that gap.
+    uint256 head = advertised_best_share();
+    if (head.IsNull() || head == uint256::ZERO)
         return;
-    uint256 adv = advertised_best_share();
-    if (adv.IsNull() || adv == uint256::ZERO)
+
+    // Same try_to_lock discipline as broadcast_share (node.hpp:67): never block
+    // the IO thread on the tracker mutex.  If think() holds it now, the next
+    // trigger (best-change or the timer) retries.
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
         return;
-    broadcast_share(adv);
+
+    if (!m_chain->contains(head))
+        return;
+
+    std::vector<uint256> to_send;
+    int32_t height = m_chain->get_height(head);
+    int32_t walk = std::min(height, 5);
+    for (auto [hash, data] : m_chain->get_chain(head, walk)) {
+        if (m_rejected_share_hashes.count(hash))
+            continue; // never re-broadcast peer-rejected shares
+        to_send.push_back(hash);
+    }
+    if (to_send.empty())
+        return;
+
+    // Advertise-only path: deliberately ignores the de-dup set, so nothing is
+    // marked here.  Record only what was ACTUALLY written (F2) — a share the
+    // tx-completeness gate withheld must not be blamed for a later peer drop,
+    // which would mark it rejected and make the walk above `continue` past it
+    // forever.
+    auto now = std::chrono::steady_clock::now();
+    for (auto& [nonce, peer] : m_peers) {
+        std::vector<uint256> sent = send_shares(peer, to_send);
+        if (!sent.empty())
+            m_last_broadcast_to[peer->addr()] = {sent, now};
+    }
+    LOG_INFO << "[readvertise] re-pushed " << to_send.size()
+             << " head share(s) to " << m_peers.size() << " peer(s) (ROOT-2)";
 }
 
 void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_hash)
@@ -1719,7 +1750,7 @@ void NodeImpl::run_think()
                 // Root-2: re-advertise our new head.  A peer that handshook
                 // before we had a chain saw a ZERO advert and never issued
                 // download_shares -- re-announce so it pulls our shares now.
-                readvertise_best();
+                readvertise_best_share();
             } else if (result.best.IsNull()) {
                 LOG_WARNING << "[ASYNC-THINK] IO-phase: result.best is NULL — verified_tails="
                             << m_tracker.verified.get_tails().size()
@@ -1736,7 +1767,7 @@ void NodeImpl::run_think()
                 m_verified_was_empty = false;
                 if (!m_readvert_timer)
                     m_readvert_timer = std::make_unique<core::Timer>(m_context, false);
-                m_readvert_timer->start(10, [this]() { readvertise_best(); });
+                m_readvert_timer->start(10, [this]() { readvertise_best_share(); });
                 LOG_INFO << "[readvertise] verified chain populated — scheduled "
                             "10s re-advert (ROOT-2)";
             }
@@ -2255,7 +2286,7 @@ void NodeImpl::clean_tracker()
         if (clean_best_changed && m_on_best_share_changed) {
             LOG_INFO << "[CLEAN] IO-phase: work refresh (best changed)";
             m_on_best_share_changed();
-            readvertise_best();   // root-2: re-announce new head to peers
+            readvertise_best_share();   // root-2: re-announce new head to peers
         }
         drain_pending_adds();
         m_think_running.store(false);

--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -621,7 +621,10 @@ public:
     /// connected peers.  Invoked when think()/clean updates the best share so a
     /// peer that completed the version handshake before we had any shares (when
     /// our advert was ZERO) still learns our head and pulls via download_shares.
-    void readvertise_best();
+    /// Walks the head WITHOUT consulting the m_shared_share_hashes de-dup set
+    /// (ltc/dgb pattern), so a head share already accepted by another peer is
+    /// still re-pushed to a freshly-handshook one (ROOT-2, issue #885).
+    void readvertise_best_share();
 
     /// Start downloading shares from a peer, beginning at `target_hash`.
     /// Recursively fetches parents until the chain is connected or CHAIN_LENGTH reached.

--- a/src/impl/bch/test/broadcast_gate_test.cpp
+++ b/src/impl/bch/test/broadcast_gate_test.cpp
@@ -31,6 +31,7 @@
 // on the wire; share bytes, minting and payout are untouched.
 // ---------------------------------------------------------------------------
 
+#include <algorithm>
 #include <cstddef>
 #include <iostream>
 #include <map>
@@ -75,6 +76,21 @@ std::vector<uint256> walk(const std::vector<uint256>& chain_tip_first,
     for (const auto& hash : chain_tip_first) {
         if (marked.count(hash))
             break;
+        to_send.push_back(hash);
+    }
+    return to_send;
+}
+
+// The tip-first walk readvertise_best_share() performs (#885), verbatim in its
+// essentials: it does NOT consult the de-dup set, so a head share already in
+// m_shared_share_hashes is still re-pushed. It skips only peer-REJECTED hashes.
+std::vector<uint256> readvertise_walk(const std::vector<uint256>& chain_tip_first,
+                                      const std::set<uint256>& rejected)
+{
+    std::vector<uint256> to_send;
+    for (const auto& hash : chain_tip_first) {
+        if (rejected.count(hash))
+            continue;   // never re-broadcast a peer-rejected share
         to_send.push_back(hash);
     }
     return to_send;
@@ -200,6 +216,46 @@ int run_share_broadcast_gate_checks()
             check(marked.size() == 2u, "shipped ordering marks after a real send");
             check(walk(chain, marked).empty(), "shipped ordering then de-dups");
         }
+    }
+
+    // -- #885: readvertise_best_share re-pushes a head share the de-dup set
+    //          would otherwise mask, where broadcast_share's walk breaks --------
+    // A peer that handshook while our verified chain was empty never called
+    // download_shares(); it must be re-served the tip. But the tip's parents
+    // were already accepted by an EARLIER peer, so they sit in m_shared_share_hashes.
+    // broadcast_share's walk breaks on the first such hash and never reaches the
+    // tip; readvertise_best_share ignores the de-dup set and re-pushes the window.
+    {
+        const std::vector<uint256> chain{S3, S2, S1};   // S3 is the tip
+        const std::set<uint256> marked{S2, S1};         // parents already shared
+
+        // broadcast_share delegate (pre-#885 readvertise_best): breaks at S2,
+        // so the tip S3 is re-pushed but nothing behind it — and if the TIP
+        // itself were already marked the walk would yield NOTHING.
+        const std::set<uint256> marked_incl_tip{S3, S2, S1};
+        check(walk(chain, marked_incl_tip).empty(),
+              "#885 broadcast_share walk strands an all-marked head (documents the gap)");
+        check(walk(chain, marked).size() == 1u,
+              "#885 broadcast_share walk breaks on the first shared parent");
+
+        // readvertise_best_share (the fix): de-dup set is ignored entirely, so
+        // the full tip window is re-pushed regardless of prior sharing.
+        const std::set<uint256> no_rejects;
+        auto readv = readvertise_walk(chain, no_rejects);
+        check(readv.size() == 3u,
+              "#885 readvertise walk re-pushes the whole window ignoring the de-dup set");
+        if (readv.size() == 3u) {
+            check(readv[0] == S3, "#885 readvertise walk starts at the tip");
+            check(readv[2] == S1, "#885 readvertise walk reaches the shared parents");
+        }
+
+        // ...but a peer-REJECTED share is still never re-broadcast.
+        const std::set<uint256> rejected{S2};
+        auto readv_rej = readvertise_walk(chain, rejected);
+        check(readv_rej.size() == 2u,
+              "#885 readvertise walk still skips a peer-rejected share");
+        check(std::find(readv_rej.begin(), readv_rej.end(), S2) == readv_rej.end(),
+              "#885 readvertise walk excludes the rejected hash");
     }
 
     if (g_failures == 0)


### PR DESCRIPTION
## Summary

Closes the ROOT-2 re-advertise gap on the BCH lane (issue #885).

`bch/node.cpp`'s ROOT-2 re-advertisement (`readvertise_best`) delegated to `broadcast_share`, whose tip-walk **breaks on the first hash already in the `m_shared_share_hashes` dedup set**. A head share already accepted by an earlier peer stayed masked, so a peer that finished its version handshake while our verified chain was empty (advert == ZERO, never issued `download_shares`) was never re-served the head.

This ports the extant **ltc/dgb** pattern (`ltc/node.cpp`, `dgb/node.cpp`): a dedicated **`readvertise_best_share()`** that walks the advertised head directly **without consulting the dedup set**, so the full tip window is re-pushed regardless of prior sharing.

## What changed

- `src/impl/bch/node.hpp` — `readvertise_best()` → `readvertise_best_share()` (doc updated).
- `src/impl/bch/node.cpp` — new body walks the head, ignoring `m_shared_share_hashes`; still:
  - skips peer-rejected shares (`m_rejected_share_hashes`),
  - records only what each peer actually accepted (F2, `m_last_broadcast_to`),
  - keeps the `try_to_lock` discipline on `m_tracker_mutex` (never blocks the IO thread),
  - remains **advertise-only** — local work creation / minting / payout untouched.
- Three internal callers (run_think best-change, the one-shot 10s re-advert timer, `clean_tracker` best-change) updated.
- `src/impl/bch/test/broadcast_gate_test.cpp` — **#885 KAT** added, riding the already-allowlisted `bch_embedded_block_broadcast_test` target (no new CMake target → avoids the NOT_BUILT sentinel trap): contrasts the dedup-breaking walk vs the dedup-bypass walk, pins that the latter re-pushes the whole window yet still excludes a peer-rejected hash.

## Scope

p2p re-advertise plumbing. Not consensus / share-validity / reward-coinbase / template building. #880 (mark-only-what-was-sent) is already merged and does **not** close this.

Refs: #885