### PR TITLE
Dashboard: /recent_blocks oracle-parity residual fields (explorer_url, block_reward, luck sample counts)

### DIFF
--- a/src/core/test/web_server_dashboard_data_test.cpp
+++ b/src/core/test/web_server_dashboard_data_test.cpp
@@ -825,3 +825,112 @@ TEST(DashboardData, GraphViewsTruncatedAndMissingSidecarTolerated)
     std::remove((path + ".views").c_str());
     std::remove((path + ".best.json").c_str());
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. /recent_blocks oracle-parity residual fields (#57)
+// ═══════════════════════════════════════════════════════════════════════════
+
+// The dashboard's miner view (miner.html) reads block.explorer_url and
+// block.block_reward directly, and other consumers expect the p2pool-dash
+// oracle's luck-provenance shape. Those fields were absent from the backend
+// until this change, so the links were dead and the reward column blank. The
+// values must be honest: block_reward in whole coins alongside the raw-duff
+// subsidy, a coin-generic explorer deep link, single-sample luck provenance,
+// and a first-row pool luck aggregate that never claims an accurate method
+// c2pool did not use.
+TEST(DashboardData, RecentBlocksCarriesOracleParityResidualFields)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    wire_dash_template(mi);
+
+    const std::string h1 =
+        "1111111111111111111111111111111111111111111111111111111111111111";
+    const std::string h2 =
+        "2222222222222222222222222222222222222222222222222222222222222222";
+    // Two blocks 2 s apart -> the newer row computes a luck (single-hashrate).
+    mi.record_found_block(2516911, uint256S(h1), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h1,
+                          0.0, 240228.0, 0.0, 0);
+    mi.record_found_block(2516914, uint256S(h2), 1785955174, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h2,
+                          0.0, 240228.0, 0.0, 0);
+
+    auto arr = mi.rest_recent_blocks();
+    auto blk = find_block(arr, h2);
+    ASSERT_TRUE(blk.is_object());
+
+    // block_reward: the template coinbasevalue (177109977 duff) in whole coins,
+    // present ALONGSIDE the untouched integer subsidy.
+    EXPECT_EQ(blk["subsidy"].get<uint64_t>(), 177109977u);
+    ASSERT_TRUE(blk["block_reward"].is_number());
+    EXPECT_DOUBLE_EQ(blk["block_reward"].get<double>(), 1.77109977);
+
+    // explorer_url: coin-generic DASH-first-class block deep link.
+    ASSERT_TRUE(blk["explorer_url"].is_string());
+    EXPECT_EQ(blk["explorer_url"].get<std::string>(),
+              "https://blockchair.com/dash/block/" + h2);
+
+    // from_history: recorded live this session, so false (never persisted).
+    ASSERT_TRUE(blk["from_history"].is_boolean());
+    EXPECT_FALSE(blk["from_history"].get<bool>());
+
+    // Single-sample luck provenance on a row that computed a luck.
+    EXPECT_TRUE(blk["luck_approximate"].get<bool>());
+    ASSERT_TRUE(blk["avg_hashrate_used"].is_number());
+    EXPECT_DOUBLE_EQ(blk["avg_hashrate_used"].get<double>(), 4294967296.0);
+    EXPECT_EQ(blk["hashrate_samples_used"].get<int>(), 1);
+    ASSERT_TRUE(blk["avg_difficulty_used"].is_number());
+    EXPECT_DOUBLE_EQ(blk["avg_difficulty_used"].get<double>(), 1.0);
+    EXPECT_EQ(blk["diff_samples_used"].get<int>(), 1);
+
+    // First-row pool luck aggregate: the array is newest-first, so arr[0] is
+    // h2 and carries the summary keys. One computed luck (50%), classified
+    // honestly as single_hashrate/approximate -- never accurate/simple_avg.
+    ASSERT_FALSE(arr.empty());
+    const auto& agg = arr[0];
+    ASSERT_TRUE(agg["pool_avg_luck"].is_number());
+    EXPECT_DOUBLE_EQ(agg["pool_avg_luck"].get<double>(), 50.0);
+    EXPECT_EQ(agg["blocks_for_luck"].get<uint64_t>(), 1u);
+    EXPECT_EQ(agg["single_hashrate_luck_count"].get<uint64_t>(), 1u);
+    EXPECT_EQ(agg["approximate_luck_count"].get<uint64_t>(), 1u);
+    EXPECT_EQ(agg["accurate_luck_count"].get<uint64_t>(), 0u);
+    EXPECT_EQ(agg["simple_avg_luck_count"].get<uint64_t>(), 0u);
+    EXPECT_EQ(agg["time_weighted_luck_count"].get<uint64_t>(), 0u);
+    EXPECT_TRUE(agg["luck_note"].is_string());
+}
+
+// Honest-null on the residual fields: an unmeasured row emits null, never a
+// fabricated 0 or a dead link. A single first block has no luck, so
+// luck_approximate is null and the pool aggregate reports zero contributors
+// with a null average.
+TEST(DashboardData, RecentBlocksResidualFieldsHonorHonestNull)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    // NO template wired and caller passes 0 subsidy: reward is unmeasured.
+    const std::string h =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    mi.record_found_block(2516911, uint256S(h), 1785955172, "DASH",
+                          "XoZcEFbqwnty5secW7HYjdQEZYfubMkURu", h,
+                          0.0, 0.0, 0.0, 0);
+
+    auto arr = mi.rest_recent_blocks();
+    auto blk = find_block(arr, h);
+    ASSERT_TRUE(blk.is_object());
+
+    EXPECT_TRUE(blk["block_reward"].is_null())
+        << "an unmeasured subsidy is null, never 0.0";
+    EXPECT_TRUE(blk["luck_approximate"].is_null())
+        << "no luck computed -> the approximate flag is null, not false";
+    EXPECT_TRUE(blk["avg_difficulty_used"].is_null());
+    EXPECT_EQ(blk["diff_samples_used"].get<int>(), 0);
+    // The explorer link is still a real DASH deep link (hash is known).
+    EXPECT_EQ(blk["explorer_url"].get<std::string>(),
+              "https://blockchair.com/dash/block/" + h);
+
+    ASSERT_FALSE(arr.empty());
+    EXPECT_TRUE(arr[0]["pool_avg_luck"].is_null());
+    EXPECT_EQ(arr[0]["blocks_for_luck"].get<uint64_t>(), 0u);
+    EXPECT_EQ(arr[0]["single_hashrate_luck_count"].get<uint64_t>(), 0u);
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2535,6 +2535,25 @@ nlohmann::json MiningInterface::rest_fee()
     return m_pool_fee_percent;
 }
 
+std::string MiningInterface::block_explorer_prefix() const
+{
+    // Operator override wins on every coin (same source rest_web_currency_info
+    // advertises as block_explorer_url_prefix), so a node configured for chainz
+    // or any other explorer links found blocks through it.
+    if (!m_custom_block_explorer.empty())
+        return m_custom_block_explorer;
+    switch (m_blockchain) {
+    case Blockchain::LITECOIN:
+        return m_testnet ? "https://blockchair.com/litecoin/testnet/block/"
+                         : "https://blockchair.com/litecoin/block/";
+    case Blockchain::BITCOIN:  return "https://blockchair.com/bitcoin/block/";
+    case Blockchain::DOGECOIN: return "https://blockchair.com/dogecoin/block/";
+    case Blockchain::DASH:     return "https://blockchair.com/dash/block/";
+    case Blockchain::DIGIBYTE: return "https://blockchair.com/digibyte/block/";
+    default:                   return "";   // unknown coin -> caller emits null
+    }
+}
+
 nlohmann::json MiningInterface::rest_recent_blocks()
 {
     static const char* status_str[] = {"pending", "confirmed", "orphaned", "stale"};
@@ -2565,6 +2584,24 @@ nlohmann::json MiningInterface::rest_recent_blocks()
         double d = chain::target_to_difficulty(h);   // diff1 / hash
         return d > 0.0 ? nlohmann::json(d) : nlohmann::json(nullptr);
     };
+
+    // #57 oracle parity: coin-generic block-explorer deep link (chainz-style),
+    // block reward in whole coins, luck-provenance sample counts, and a
+    // first-row pool luck aggregate. All DISPLAY-ONLY and honest-null (#942):
+    // an unmeasured value is null, never a fabricated 0.
+    const std::string explorer_prefix = block_explorer_prefix();
+    auto explorer_url = [&](const std::string& hash_hex) -> nlohmann::json {
+        if (explorer_prefix.empty() || hash_hex.empty())
+            return nlohmann::json(nullptr);
+        return nlohmann::json(explorer_prefix + hash_hex);
+    };
+    // Pool luck aggregate, accumulated over the rows as we build them. c2pool
+    // derives each block's luck from ONE network-difficulty and ONE pool-
+    // hashrate reading sampled at find time -- it does not interval-average
+    // between blocks the way the p2pool-dash oracle does -- so every computed
+    // luck is honestly the "single_hashrate" method and is approximate.
+    double luck_sum = 0.0;
+    uint64_t luck_count = 0;
 
     std::lock_guard<std::mutex> lock(m_blocks_mutex);
     for (const auto& b : m_found_blocks) {
@@ -2599,6 +2636,22 @@ nlohmann::json MiningInterface::rest_recent_blocks()
         auto num_or_null = [](double v) {
             return v > 0.0 ? nlohmann::json(v) : nlohmann::json(nullptr);
         };
+        // A luck value exists only on a row we hold locally that actually
+        // computed one (time_to_find>0 && luck>0). Those rows feed both the
+        // per-row luck_approximate flag and the first-row pool aggregate below.
+        const bool luck_present = have_local_record && b.luck > 0.0
+                                  && b.time_to_find > 0.0;
+        if (luck_present) { luck_sum += b.luck; ++luck_count; }
+        // block_reward: the raw-duff subsidy expressed in whole coins, kept
+        // ALONGSIDE the existing integer `subsidy` field. 1e8 base units per
+        // coin holds for every lane this build serves (DASH/LTC/DOGE/BTC/DGB).
+        nlohmann::json block_reward = b.subsidy != 0
+            ? nlohmann::json(static_cast<double>(b.subsidy) / 1e8)
+            : nlohmann::json(nullptr);
+        // Sample-count provenance. c2pool derives luck from ONE difficulty and
+        // ONE hashrate reading captured at find time, so the "average used" is
+        // that single value and the sample count is 1 when present, 0 when the
+        // input was never measured (honest-null, #942).
         arr.push_back({
             {"ts", b.ts},
             {"hash", b.hash},
@@ -2629,8 +2682,43 @@ nlohmann::json MiningInterface::rest_recent_blocks()
             {"expected_time", have_local_record ? num_or_null(b.expected_time) : nlohmann::json(nullptr)},
             {"time_to_find", have_local_record ? num_or_null(b.time_to_find) : nlohmann::json(nullptr)},
             {"luck", have_local_record ? num_or_null(b.luck) : nlohmann::json(nullptr)},
-            {"luck_method", method}
+            {"luck_method", method},
+            // #57 oracle-parity residual fields (all DISPLAY-ONLY, honest-null):
+            {"block_reward", block_reward},
+            {"explorer_url", explorer_url(b.hash)},
+            {"from_history", b.from_history},
+            // The luck value is a single-sample approximation whenever it
+            // exists; null (not false) when no luck was computed, so the UI
+            // renders '-' rather than claiming a precise measurement.
+            {"luck_approximate", luck_present ? nlohmann::json(true)
+                                              : nlohmann::json(nullptr)},
+            {"avg_hashrate_used", num_or_null(b.pool_hashrate)},
+            {"hashrate_samples_used", b.pool_hashrate > 0.0 ? 1 : 0},
+            {"avg_difficulty_used", num_or_null(b.network_difficulty)},
+            {"diff_samples_used", b.network_difficulty > 0.0 ? 1 : 0}
         });
+    }
+
+    // First-row pool luck aggregate (#57), mirroring the oracle shape: the
+    // summary keys ride on arr[0] so a consumer reads them without a second
+    // request. Every c2pool luck is the single-hashrate method (approximate),
+    // never the interval-averaged method the oracle labels accurate/simple_avg
+    // -- reporting it as anything else would fabricate a measurement we did not
+    // make. Empty counts and a null average when nothing was computed.
+    if (!arr.empty()) {
+        arr[0]["blocks_for_luck"]            = luck_count;
+        arr[0]["pool_avg_luck"]              = luck_count > 0
+            ? nlohmann::json(luck_sum / static_cast<double>(luck_count))
+            : nlohmann::json(nullptr);
+        arr[0]["accurate_luck_count"]        = 0;
+        arr[0]["approximate_luck_count"]     = luck_count;
+        arr[0]["time_weighted_luck_count"]   = 0;
+        arr[0]["simple_avg_luck_count"]      = 0;
+        arr[0]["single_hashrate_luck_count"] = luck_count;
+        arr[0]["luck_note"] =
+            "Luck derived from network difficulty and pool hashrate sampled at "
+            "block-find time (single sample per block, approximate; not "
+            "interval-averaged between blocks).";
     }
     return arr;
 }
@@ -3709,8 +3797,12 @@ void MiningInterface::load_persisted_found_blocks()
                     break;
                 }
             }
-            if (!exists)
+            if (!exists) {
+                // Provenance for the dashboard (#57): a block that arrives via
+                // the load path is, by definition, from persisted history.
+                blk.from_history = true;
                 m_found_blocks.push_back(std::move(blk));
+            }
         }
 
         // Sort newest-first by chain height (canonical, monotonic on-chain);

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -154,6 +154,10 @@ public:
     nlohmann::json rest_users();
     nlohmann::json rest_fee();
     nlohmann::json rest_recent_blocks();
+    // Coin-generic block-explorer URL prefix (block deep link, DASH first-class).
+    // Honors an operator custom explorer, else the per-coin default; empty when
+    // the coin is unknown so callers emit null rather than a wrong-coin link.
+    std::string block_explorer_prefix() const;
 
     // THE checkpoint endpoints
     nlohmann::json rest_checkpoint();    // latest verified checkpoint
@@ -817,6 +821,12 @@ public:
         // and the log states it in words. Unlabelled stays `unknown`, which
         // the log reports as unknown rather than guessing.
         BlockAuthorship authorship{BlockAuthorship::unknown};
+        // Provenance for the dashboard (#57 oracle parity). true when this row
+        // was restored from persistent storage at startup rather than recorded
+        // live this session. DISPLAY-ONLY, never persisted (a restored row is
+        // by definition from history), so it stays last in the struct and out
+        // of every positional aggregate-init above.
+        bool from_history{false};
     };
 
     // Block acceptance verification: schedule async checks at +10s, +30s, +120s.


### PR DESCRIPTION
## What

Adds the residual fields the P1c locate found MISSING on `/recent_blocks`
versus the live DASH oracle (`:7903/recent_blocks`), so dashboard views
built to the oracle shape render correctly against a c2pool backend.

The miner view (`web-static/miner.html`) already reads `block.explorer_url`
and `block.block_reward` directly (lines ~1006/1016), so those links and the
reward column were dead until the backend emitted them.

### Per-row (`MiningInterface::rest_recent_blocks`)
- **`block_reward`** — raw-duff `subsidy` expressed in whole coins, kept
  ALONGSIDE the untouched integer `subsidy` (1e8 base units per coin).
- **`explorer_url`** — coin-generic block deep link from the same source
  `rest_web_currency_info` advertises (operator custom override, else per-coin
  default; DASH first-class). Unknown coin -> null, never a wrong-coin link.
- **`from_history`** — true only for rows restored from persistence at startup.
- **`luck_approximate`**, **`avg_hashrate_used`/`hashrate_samples_used`**,
  **`avg_difficulty_used`/`diff_samples_used`** — single-sample luck
  provenance. c2pool derives luck from ONE difficulty and ONE hashrate reading
  at find time (not interval-averaged), so the sample count is 1 when present,
  0 when never measured.

### First-row pool aggregate (keys ride on `arr[0]`, mirroring the oracle)
- **`pool_avg_luck`** + `blocks_for_luck`, and the luck-count breakdown
  (`accurate`/`approximate`/`time_weighted`/`simple_avg`/`single_hashrate`)
  with a `luck_note`. Every c2pool luck is the `single_hashrate` method and is
  approximate; it is never reported as accurate/simple_avg — that would
  fabricate a measurement c2pool did not make.

## Honesty
DISPLAY-ONLY, consensus-neutral, coin-generic. Honors the honest-null rule
(#942): an unmeasured value is `null`, never a fabricated `0`.

## Tests
Two KATs added to the allowlisted `core_test` target
(`web_server_dashboard_data_test.cpp`): the populated shape and the
honest-null shape. Full `DashboardData.*` suite: 20/20 green (conan-debug,
GCC 13).

Refs task #57. Draft — do not merge.