### PR TITLE
v36 ratchet: distinct-origin precondition before activation

### DIFF
--- a/src/impl/ltc/auto_ratchet.hpp
+++ b/src/impl/ltc/auto_ratchet.hpp
@@ -71,21 +71,21 @@ inline const char* ratchet_state_str(RatchetState s)
 // ---------------------------------------------------------------------------
 enum class RatchetBlocker : uint8_t
 {
-    NONE           = 0,  // all four conditions met — activation proceeds
-    WINDOW_FILL    = 1,  // (1) total < chain_length
-    VOTE_PCT       = 2,  // (2) vote_pct < ACTIVATION_THRESHOLD
-    TAIL_WORK      = 3,  // (3) oldest 10% carries < SWITCH_THRESHOLD% of WORK signalling
-    SELF_VOTE_ONLY = 4   // (4) distinct non-self YES-vote authors < MIN_DISTINCT_NONSELF_AUTHORS
+    NONE          = 0,  // all four conditions met — activation proceeds
+    WINDOW_FILL   = 1,  // (1) total < chain_length
+    VOTE_PCT      = 2,  // (2) vote_pct < ACTIVATION_THRESHOLD
+    TAIL_WORK     = 3,  // (3) oldest 10% carries < SWITCH_THRESHOLD% of WORK signalling
+    SINGLE_ORIGIN = 4   // (4) distinct YES-vote origins < MIN_DISTINCT_ORIGINS
 };
 
 inline const char* ratchet_blocker_str(RatchetBlocker b)
 {
     switch (b) {
-    case RatchetBlocker::NONE:           return "none";
-    case RatchetBlocker::WINDOW_FILL:    return "window-fill";
-    case RatchetBlocker::VOTE_PCT:       return "vote-pct";
-    case RatchetBlocker::TAIL_WORK:      return "tail-work";
-    case RatchetBlocker::SELF_VOTE_ONLY: return "self-vote-only";
+    case RatchetBlocker::NONE:          return "none";
+    case RatchetBlocker::WINDOW_FILL:   return "window-fill";
+    case RatchetBlocker::VOTE_PCT:      return "vote-pct";
+    case RatchetBlocker::TAIL_WORK:     return "tail-work";
+    case RatchetBlocker::SINGLE_ORIGIN: return "single-origin";
     }
     return "unknown";
 }
@@ -106,14 +106,30 @@ public:
     static constexpr int DEACTIVATION_THRESHOLD = 50;  // % below which to revert
     static constexpr int CONFIRMATION_MULTIPLIER = 2;  // confirm after 2x CHAIN_LENGTH
     static constexpr int SWITCH_THRESHOLD = 60;        // % required for format switch in validation
-    // Mode-2 self-vote guard (07-28): minimum number of DISTINCT non-self
-    // share authors whose YES-votes must back a 95% window before the ratchet
-    // may ACTIVATE. Closes the second false-activation mode — a pool mining
-    // ALONE driving its own desired_version to 95% and ratcheting itself into
-    // V36 with zero external consent. 1 = "at least one externally-originated
-    // yes-vote": the tightest bar that still permits the intended 2-node prod
-    // crossing (voidbind + G2 dest), while rejecting a 100%-self window.
-    static constexpr int MIN_DISTINCT_NONSELF_AUTHORS = 1;
+    // Distinct-origin precondition (#920, extends #930's mode-2 guard):
+    // minimum number of DISTINCT origins whose YES-votes must back a 95% window
+    // before the ratchet may ACTIVATE. An "origin" is the self node (all locally
+    // minted YES-votes collapse to ONE origin) plus each distinct non-self
+    // peer_addr among the received YES-votes.
+    //
+    // #930 required only >= 1 distinct NON-self author, which still let a window
+    // whose YES-votes ALL trace to a SINGLE origin activate the ratchet alone:
+    //   - a 100%-self window (contabo "72.25% on a ~100%-self window" incident)
+    //     — closed by #930; and
+    //   - a supermajority authored by ONE entity and injected through a SINGLE
+    //     peer connection, arriving with one non-self peer_addr — NOT closed by
+    //     #930, because one distinct non-self author cleared its bar of 1.
+    // Counting self as an origin and requiring >= 2 distinct origins closes BOTH:
+    // no single author/origin (local or one relay) can reach the threshold alone.
+    //
+    // 2 = the tightest bar that still permits the intended 2-node prod crossing
+    // (voidbind + G2 dest): each node sees its own YES-votes (self origin) plus
+    // the peer's relayed YES-votes (one non-self origin) = 2 distinct origins.
+    // LIMITATION (unchanged from #930): origins are counted by transient
+    // reception address, so a determined single operator holding N addresses can
+    // still simulate N origins. This raises the floor from 1 to 2; it is not a
+    // sybil-proof identity check.
+    static constexpr int MIN_DISTINCT_ORIGINS = 2;
 
     explicit AutoRatchet(const std::string& state_file_path = "",
                          int64_t target_version = 36)
@@ -135,7 +151,7 @@ public:
     ///   3. tail-work       oldest 10% of the window carries >= SWITCH_THRESHOLD
     ///                      (60) percent of WORK signalling the target (WEIGHT,
     ///                      not head-count)
-    ///   4. self-vote-only  distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS
+    ///   4. single-origin   distinct_origins >= MIN_DISTINCT_ORIGINS
     ///
     /// Returns NONE when all four hold. `tail` is a tri-state: NOT_MEASURED is
     /// treated as blocking on (3), which is unreachable from the live caller
@@ -144,13 +160,13 @@ public:
     static RatchetBlocker first_unmet(bool full_window,
                                       int vote_pct,
                                       RatchetTail tail,
-                                      int distinct_nonself_authors)
+                                      int distinct_origins)
     {
         if (!full_window)                             return RatchetBlocker::WINDOW_FILL;
         if (vote_pct < ACTIVATION_THRESHOLD)          return RatchetBlocker::VOTE_PCT;
         if (tail != RatchetTail::PASS)                return RatchetBlocker::TAIL_WORK;
-        if (distinct_nonself_authors < MIN_DISTINCT_NONSELF_AUTHORS)
-            return RatchetBlocker::SELF_VOTE_ONLY;
+        if (distinct_origins < MIN_DISTINCT_ORIGINS)
+            return RatchetBlocker::SINGLE_ORIGIN;
         return RatchetBlocker::NONE;
     }
 
@@ -187,13 +203,16 @@ public:
         int32_t target_shares = 0;  // shares actually IN target format
         int32_t total = 0;
 
-        // Mode-2 self-vote guard: distinct NON-SELF origins among the YES-votes
-        // in the activation window. "self" reuses node.cpp's canonical is_local
+        // Distinct-origin precondition: distinct origins among the YES-votes in
+        // the activation window. "self" reuses node.cpp's canonical is_local
         // test — a locally minted share carries peer_addr == NetService{"0.0.0.0",0}
         // or the default NetService{}; a network share carries the relaying peer.
         // peer_addr is transient reception metadata, NOT part of the share hash,
         // so reading it here is consensus-neutral (see the ACTIVATE branch note).
+        // All local YES-votes collapse to ONE self origin; each distinct non-self
+        // peer_addr is one more. The gate below requires >= MIN_DISTINCT_ORIGINS.
         std::set<NetService> nonself_voting_authors;
+        bool self_yes_present = false;
 
         // OBSERVABILITY: depth (distance from the tip, 0 = tip) of the SHALLOWEST
         // — i.e. newest — share in the sample that does NOT signal the target.
@@ -210,7 +229,9 @@ public:
                     ++target_votes;
                     const bool is_local = (obj->peer_addr == NetService{"0.0.0.0", 0} ||
                                            obj->peer_addr == NetService{});
-                    if (!is_local)
+                    if (is_local)
+                        self_yes_present = true;
+                    else
                         nonself_voting_authors.insert(obj->peer_addr);
                 }
                 else if (newest_nonsignal_depth < 0) {
@@ -243,8 +264,11 @@ public:
             RatchetTail tail_state = RatchetTail::NOT_MEASURED;
             int tail_pct = -1;          // -1 => not measured => printed as n/a
             int32_t eta_shares = -1;    // -1 => not computable => omitted
-            const int distinct_nonself_authors_obs =
-                static_cast<int>(nonself_voting_authors.size());
+            // Distinct origins = self (one origin if any local YES-vote) + each
+            // distinct non-self peer_addr among the YES-votes.
+            const int distinct_origins_obs =
+                static_cast<int>(nonself_voting_authors.size()) +
+                (self_yes_present ? 1 : 0);
 
             if (full_window && vote_pct >= ACTIVATION_THRESHOLD)
             {
@@ -281,14 +305,16 @@ public:
                 // Canonical: counts.get(VERSION,0) < sum(counts)*60//100
                 bool tail_ok = !(tail_target * uint32_t(100) < tail_total * uint32_t(SWITCH_THRESHOLD));
 
-                // --- Mode-2 self-vote guard (07-28) ------------------------
-                // Refuse to ACTIVATE on a self-authored window. The 07-14 guard
-                // closed mode 1 (absence counted as a vote); this closes mode 2:
-                // a pool mining ALONE can drive its own desired_version to 95%
-                // and ratchet itself into V36 with ZERO external consent (the
-                // contabo "72.25% on a ~100%-self window" incident). Require the
-                // 95% YES-votes to originate from >= MIN_DISTINCT_NONSELF_AUTHORS
-                // distinct non-self peers.
+                // --- Distinct-origin precondition (#920, extends #930) ------
+                // Refuse to ACTIVATE on a window whose YES-votes all trace to a
+                // SINGLE origin. #930's mode-2 guard closed the 100%-self case
+                // (the contabo "72.25% on a ~100%-self window" incident) by
+                // requiring >= 1 distinct NON-self author, but left the general
+                // hole open: a supermajority authored by ONE entity and injected
+                // through a SINGLE peer connection arrives with one non-self
+                // peer_addr and cleared that bar of 1. Count self as one origin
+                // and require >= MIN_DISTINCT_ORIGINS (2) distinct origins, so no
+                // single author/origin — local or one relay — activates alone.
                 //
                 // CONSENSUS-NEUTRAL: reads peer_addr (transient reception
                 // metadata, never serialized into the share hash) and only gates
@@ -299,10 +325,12 @@ public:
                 // mint, never change the validity or work of any existing share.
                 //
                 // FAIL-SAFE: after a restart mid-VOTING, reconstructed shares may
-                // carry an empty peer_addr and transiently understate external
-                // authors — that DELAYS activation, never causes a false one.
-                const int distinct_nonself_authors = static_cast<int>(nonself_voting_authors.size());
-                const bool multi_party = distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS;
+                // carry an empty peer_addr and transiently understate distinct
+                // origins — that DELAYS activation, never causes a false one.
+                const int distinct_origins =
+                    static_cast<int>(nonself_voting_authors.size()) +
+                    (self_yes_present ? 1 : 0);
+                const bool multi_origin = distinct_origins >= MIN_DISTINCT_ORIGINS;
 
                 // --- OBSERVABILITY ONLY from here to the `if (!tail_ok)` ------
                 tail_state = tail_ok ? RatchetTail::PASS : RatchetTail::FAIL;
@@ -350,7 +378,7 @@ public:
                 if (!tail_ok) {
                     // Don't transition yet — explained by the single line below.
                 }
-                else if (!multi_party) {
+                else if (!multi_origin) {
                     // Don't transition yet — explained by the single line below.
                 }
                 else
@@ -391,9 +419,9 @@ public:
             if (state_ == RatchetState::VOTING)
             {
                 const RatchetBlocker blocker = first_unmet(
-                    full_window, vote_pct, tail_state, distinct_nonself_authors_obs);
+                    full_window, vote_pct, tail_state, distinct_origins_obs);
                 log_voting_block(blocker, total, chain_length, vote_pct, tail_pct,
-                                 distinct_nonself_authors_obs, eta_shares);
+                                 distinct_origins_obs, eta_shares);
             }
         }
         else if (state_ == RatchetState::ACTIVATED)
@@ -503,7 +531,7 @@ private:
     void log_voting_block(RatchetBlocker blocker,
                           int32_t total, uint32_t chain_length,
                           int vote_pct, int tail_pct,
-                          int distinct_nonself_authors,
+                          int distinct_origins,
                           int32_t eta_shares)
     {
         if (blocker == RatchetBlocker::NONE) {
@@ -529,8 +557,8 @@ private:
         if (tail_pct < 0) line << "n/a";              // NOT measured — never "0"
         else              line << tail_pct << "%";
         line << " (need " << SWITCH_THRESHOLD << ")"
-             << " nonself_authors=" << distinct_nonself_authors
-             << " (need " << MIN_DISTINCT_NONSELF_AUTHORS << ")";
+             << " distinct_origins=" << distinct_origins
+             << " (need " << MIN_DISTINCT_ORIGINS << ")";
 
         // ETA is emitted ONLY for the tail guard, and only when derivable.
         if (blocker == RatchetBlocker::TAIL_WORK && eta_shares > 0) {

--- a/src/impl/ltc/test/auto_ratchet_blocked_by_test.cpp
+++ b/src/impl/ltc/test/auto_ratchet_blocked_by_test.cpp
@@ -16,7 +16,7 @@
 //   2  vote-pct        vote_pct >= ACTIVATION_THRESHOLD (95)
 //   3  tail-work       oldest 10% of the window carries >= SWITCH_THRESHOLD (60)
 //                      percent of WORK signalling the target (WEIGHT, not count)
-//   4  self-vote-only  distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS
+//   4  single-origin   distinct_origins >= MIN_DISTINCT_ORIGINS (2)
 //
 // Two layers, both driving REAL production code — no lifted oracle, no replica:
 //
@@ -107,19 +107,21 @@ TEST(LTC_RatchetBlockedBy, A_TailWorkIsNamedWhenTailGuardFails)
               RatchetBlocker::TAIL_WORK);
 }
 
-TEST(LTC_RatchetBlockedBy, A_SelfVoteOnlyIsNamedWhenWindowIsSelfAuthored)
+TEST(LTC_RatchetBlockedBy, A_SingleOriginIsNamedWhenWindowIsSingleOrigin)
 {
+    // Below the distinct-origin threshold — a window whose YES-votes all trace
+    // to one origin (0 or 1 distinct origins, < MIN_DISTINCT_ORIGINS=2).
     EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS,
-                                       AutoRatchet::MIN_DISTINCT_NONSELF_AUTHORS - 1),
-              RatchetBlocker::SELF_VOTE_ONLY);
-    EXPECT_STREQ(ltc::ratchet_blocker_str(RatchetBlocker::SELF_VOTE_ONLY), "self-vote-only");
+                                       AutoRatchet::MIN_DISTINCT_ORIGINS - 1),
+              RatchetBlocker::SINGLE_ORIGIN);
+    EXPECT_STREQ(ltc::ratchet_blocker_str(RatchetBlocker::SINGLE_ORIGIN), "single-origin");
 }
 
 TEST(LTC_RatchetBlockedBy, A_NoneWhenAllFourConditionsHold)
 {
     EXPECT_EQ(AutoRatchet::first_unmet(true, AutoRatchet::ACTIVATION_THRESHOLD,
                                        RatchetTail::PASS,
-                                       AutoRatchet::MIN_DISTINCT_NONSELF_AUTHORS),
+                                       AutoRatchet::MIN_DISTINCT_ORIGINS),
               RatchetBlocker::NONE);
 }
 
@@ -135,8 +137,11 @@ TEST(LTC_RatchetBlockedBy, A_PrecedenceNamesTheFirstUnmetNotAList)
     EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::FAIL, 0),
               RatchetBlocker::TAIL_WORK);
     EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS, 0),
-              RatchetBlocker::SELF_VOTE_ONLY);
+              RatchetBlocker::SINGLE_ORIGIN);
+    // One distinct origin still fails the >= 2 bar (the #920 hole #930 left open).
     EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS, 1),
+              RatchetBlocker::SINGLE_ORIGIN);
+    EXPECT_EQ(AutoRatchet::first_unmet(true, 100, RatchetTail::PASS, 2),
               RatchetBlocker::NONE);
 }
 
@@ -186,6 +191,7 @@ struct ChainSpec
     int32_t count       = 0;
     int32_t old_prefix  = 0;    // number of oldest shares voting TARGET-1
     bool    external    = true; // give YES-voters a non-local peer_addr
+    int32_t ext_origins = 1;    // distinct non-self peer_addrs among YES-voters
 };
 
 // Build a resolved ltc::ShareTracker of uniform-work V36-format shares.
@@ -210,8 +216,14 @@ uint256 build_chain(ltc::ShareTracker& tracker, const ChainSpec& spec, size_t sa
                                         : static_cast<uint64_t>(TARGET_VERSION - 1);
         sh->m_bits     = 0x1e0ffff0;
         sh->m_max_bits = 0x1e0ffff0;
-        if (signals && spec.external)
-            sh->peer_addr = NetService{"203.0.113.7", 9333};
+        if (signals && spec.external) {
+            // Spread YES-voters across `ext_origins` distinct non-self addresses
+            // so a window can carry one origin (the #920 single-relay hole) or
+            // several (the genuine multi-party crossing).
+            const int32_t origins = spec.ext_origins > 0 ? spec.ext_origins : 1;
+            const int octet = 7 + static_cast<int>(i % origins);
+            sh->peer_addr = NetService{"203.0.113." + std::to_string(octet), 9333};
+        }
         ltc::ShareType st;
         st = sh;
         tracker.add(st);
@@ -314,11 +326,12 @@ TEST_F(RatchetExplainLine, B_TailWork_NamedWithMeasuredTailAndEta)
     EXPECT_EQ(ar.state(), RatchetState::VOTING);
 }
 
-TEST_F(RatchetExplainLine, B_SelfVoteOnly_NamedOnAFullySelfAuthoredWindow)
+TEST_F(RatchetExplainLine, B_SingleOrigin_NamedOnAFullySelfAuthoredWindow)
 {
     // 100% YES by count AND by tail work, but every YES-vote is locally minted
-    // (default peer_addr), so the mode-2 guard holds. The tail WAS measured and
-    // passed, so it must report 100%, not `n/a`.
+    // (default peer_addr), so the window carries ONE origin (self) — below the
+    // distinct-origin bar of 2. The tail WAS measured and passed, so it must
+    // report 100%, not `n/a`. (This is the case #930 already closed.)
     ltc::ShareTracker tracker;
     ChainSpec spec; spec.count = 400; spec.old_prefix = 0; spec.external = false;
     auto tip = build_chain(tracker, spec, 4);
@@ -326,21 +339,45 @@ TEST_F(RatchetExplainLine, B_SelfVoteOnly_NamedOnAFullySelfAuthoredWindow)
     AutoRatchet ar("", TARGET_VERSION);
     const std::string out = evaluate(ar, tracker, tip);
 
-    EXPECT_NE(out.find("blocked-by=self-vote-only"), std::string::npos) << out;
+    EXPECT_NE(out.find("blocked-by=single-origin"), std::string::npos) << out;
     EXPECT_NE(out.find("vote=100% (need 95)"), std::string::npos) << out;
     EXPECT_NE(out.find("tail10%work=100% (need 60)"), std::string::npos) << out;
-    EXPECT_NE(out.find("nonself_authors=0 (need 1)"), std::string::npos) << out;
+    EXPECT_NE(out.find("distinct_origins=1 (need 2)"), std::string::npos) << out;
     EXPECT_EQ(out.find("eta_shares"), std::string::npos) << out;
+    EXPECT_EQ(ar.state(), RatchetState::VOTING);
+}
+
+TEST_F(RatchetExplainLine, B_SingleOrigin_NamedWhenAllYesVotesTraceToOneExternalPeer)
+{
+    // #920 CORE — the hole #930 left open. 100% YES by count AND by tail work,
+    // every YES-vote is EXTERNAL, but they all relay from a SINGLE non-self
+    // peer_addr. #930's bar of 1 distinct non-self author was cleared; the
+    // distinct-origin bar of 2 is NOT. A supermajority tracing to one origin
+    // must not ratchet the node into V36 alone.
+    ltc::ShareTracker tracker;
+    ChainSpec spec; spec.count = 400; spec.old_prefix = 0;
+    spec.external = true; spec.ext_origins = 1;   // one distinct external origin
+    auto tip = build_chain(tracker, spec, 8);
+
+    AutoRatchet ar("", TARGET_VERSION);
+    const std::string out = evaluate(ar, tracker, tip);
+
+    EXPECT_NE(out.find("blocked-by=single-origin"), std::string::npos) << out;
+    EXPECT_NE(out.find("vote=100% (need 95)"), std::string::npos) << out;
+    EXPECT_NE(out.find("tail10%work=100% (need 60)"), std::string::npos) << out;
+    EXPECT_NE(out.find("distinct_origins=1 (need 2)"), std::string::npos) << out;
     EXPECT_EQ(ar.state(), RatchetState::VOTING);
 }
 
 // --- NEGATIVE TWIN ---------------------------------------------------------
 TEST_F(RatchetExplainLine, B_AllFourPass_NoBlockedLineAndItActivates)
 {
-    // Same 400-share window, 100% YES, tail 100% by work, and the YES-votes
-    // carry an EXTERNAL peer_addr. All four conditions hold.
+    // Same 400-share window, 100% YES, tail 100% by work, and the YES-votes are
+    // spread across TWO distinct external origins. All four conditions hold —
+    // including the distinct-origin precondition (2 >= 2).
     ltc::ShareTracker tracker;
-    ChainSpec spec; spec.count = 400; spec.old_prefix = 0; spec.external = true;
+    ChainSpec spec; spec.count = 400; spec.old_prefix = 0;
+    spec.external = true; spec.ext_origins = 2;   // two distinct external origins
     auto tip = build_chain(tracker, spec, 5);
 
     AutoRatchet ar("", TARGET_VERSION);

--- a/src/impl/ltc/test/auto_ratchet_sim_test.cpp
+++ b/src/impl/ltc/test/auto_ratchet_sim_test.cpp
@@ -101,7 +101,7 @@ TEST(LTC_AutoRatchetSim, ThresholdsMatchCanonical)
     EXPECT_EQ(AutoRatchet::DEACTIVATION_THRESHOLD,  50);
     EXPECT_EQ(AutoRatchet::CONFIRMATION_MULTIPLIER,  2);
     EXPECT_EQ(AutoRatchet::SWITCH_THRESHOLD,        60);
-    EXPECT_EQ(AutoRatchet::MIN_DISTINCT_NONSELF_AUTHORS, 1);
+    EXPECT_EQ(AutoRatchet::MIN_DISTINCT_ORIGINS, 2);
 }
 
 // ---------------------------------------------------------------------------
@@ -239,44 +239,55 @@ TEST(LTC_AutoRatchetSim, C4_FreshNodeMintsBaselineOnBootstrap)
 }
 
 // ---------------------------------------------------------------------------
-// C5 — mode-2 self-vote guard (07-28). Closes the SECOND false-activation mode
-// (the 07-14 guard closed the first, absence-as-vote): a pool mining ALONE can
-// drive its own desired_version to 95% and ratchet itself into V36 with ZERO
-// external consent (the contabo "72.25% on a ~100%-self window" incident). The
-// live guard (auto_ratchet.hpp ACTIVATE branch) additionally requires
-//   distinct_nonself_authors >= MIN_DISTINCT_NONSELF_AUTHORS
-// where a non-self author is a YES-voting share whose peer_addr is not local.
-// Inline replica (same discipline as inline_tail_ok for the work gate) so the
-// KAT pins the guard WITHOUT building an 8640-share tracker.
+// C5 — distinct-origin precondition (#920, extends #930's mode-2 guard). The
+// mode-2 guard closed the 100%-self case (a pool mining ALONE ratcheting itself
+// into V36 with ZERO external consent — the contabo "72.25% on a ~100%-self
+// window" incident) by requiring >= 1 distinct NON-self author. #920 closes the
+// GENERAL hole it left: a supermajority authored by ONE entity and injected
+// through a SINGLE peer arrives with one non-self peer_addr and cleared that bar
+// of 1. The live guard (auto_ratchet.hpp ACTIVATE branch) now requires
+//   distinct_origins >= MIN_DISTINCT_ORIGINS
+// where distinct_origins = self (one origin if any local YES-vote) + each
+// distinct non-self peer_addr among the YES-votes. Inline replica (same
+// discipline as inline_tail_ok for the work gate) so the KAT pins the guard
+// WITHOUT building an 8640-share tracker.
 // ---------------------------------------------------------------------------
 namespace {
 bool effective_activation_guarded(int votes, int total,
                                   const uint288& w_target, const uint288& w_total,
-                                  int distinct_nonself_authors)
+                                  int distinct_origins)
 {
     return effective_activation(votes, total, w_target, w_total) &&
-           distinct_nonself_authors >= AutoRatchet::MIN_DISTINCT_NONSELF_AUTHORS;
+           distinct_origins >= AutoRatchet::MIN_DISTINCT_ORIGINS;
 }
 } // namespace
 
 TEST(LTC_AutoRatchetSim, C5_SelfAuthoredWindowDoesNotActivate)
 {
     // 100% self-authored: every YES-vote was locally minted, so the window
-    // carries ZERO distinct non-self origins. The count gate (95%) and the
-    // work gate (100%) BOTH fire, yet the ratchet must hold.
+    // carries ONE origin (self) and no non-self origin. The count gate (95%) and
+    // the work gate (100%) BOTH fire, yet the ratchet must hold: 1 < 2.
     EXPECT_TRUE (effective_activation(100, 100, uint288(100), uint288(100)));
-    EXPECT_FALSE(effective_activation_guarded(100, 100, uint288(100), uint288(100), /*non-self*/ 0));
+    EXPECT_FALSE(effective_activation_guarded(100, 100, uint288(100), uint288(100), /*origins*/ 1));
+}
+
+TEST(LTC_AutoRatchetSim, C5_SingleExternalOriginDoesNotActivate)
+{
+    // #920 CORE: a supermajority that all traces to a SINGLE origin — e.g. one
+    // entity injecting through one peer, or a lone self miner — must NOT ratchet
+    // alone. One distinct origin cleared #930's bar of 1; it fails the >= 2 bar.
+    EXPECT_FALSE(effective_activation_guarded(100, 100, uint288(100), uint288(100), /*origins*/ 1));
 }
 
 TEST(LTC_AutoRatchetSim, C5_MixedWindowActivates)
 {
-    // Mixed window at >= threshold WITH external consent: >= 1 distinct non-self
-    // origin backs the 95%/60% window, so activation is permitted. This is the
-    // intended 2-node prod crossing (voidbind + G2 dest) shape.
-    EXPECT_TRUE(effective_activation_guarded(95, 100, uint288(95), uint288(100), /*non-self*/ 1));
-    EXPECT_TRUE(effective_activation_guarded(100, 100, uint288(100), uint288(100), /*non-self*/ 3));
+    // >= 2 distinct origins back the 95%/60% window, so activation is permitted.
+    // This is the intended 2-node prod crossing (voidbind + G2 dest) shape: each
+    // node sees its own YES-votes (self origin) plus the peer's (one non-self).
+    EXPECT_TRUE(effective_activation_guarded(95, 100, uint288(95), uint288(100), /*origins*/ 2));
+    EXPECT_TRUE(effective_activation_guarded(100, 100, uint288(100), uint288(100), /*origins*/ 4));
 
-    // Guard is orthogonal to the work gate: external consent cannot rescue a
+    // Guard is orthogonal to the work gate: multiple origins cannot rescue a
     // window that fails the 60%-by-work accept gate (mint<->accept coupling).
-    EXPECT_FALSE(effective_activation_guarded(95, 100, uint288(1), uint288(100), /*non-self*/ 5));
+    EXPECT_FALSE(effective_activation_guarded(95, 100, uint288(1), uint288(100), /*origins*/ 6));
 }


### PR DESCRIPTION
## Summary

Extends #930's mode-2 self-vote guard into the general **distinct-origin precondition** for the v36 AutoRatchet (LTC lane). The ratchet must not activate on version signals that all trace to a **single** author/origin.

Refs #920 #930

## The hole #930 left open

`VOTING -> ACTIVATED` had a fourth gate (from #930) requiring `>= 1` distinct **non-self** voting author. That closed the 100%-self case (the contabo "72.25% on a ~100%-self window" incident) but not the general one: a supermajority authored by **one** entity and injected through a **single** peer connection arrives with one non-self `peer_addr` and clears a bar of 1. A single origin still ratcheted the node into V36 alone.

## Change

- Count the **self** node as one origin (all locally minted YES-votes collapse to a single origin) **plus** each distinct non-self `peer_addr` among the YES-votes.
- Require `distinct_origins >= MIN_DISTINCT_ORIGINS` (**2**) before activation.
- Closes both single-origin shapes — a fully self-authored window **and** a supermajority relayed from one peer — while still permitting the intended 2-node prod crossing (each node sees self origin + the peer's one non-self origin = 2).
- Blocker `SELF_VOTE_ONLY -> SINGLE_ORIGIN` (log token `self-vote-only -> single-origin`); explain-line field `nonself_authors -> distinct_origins`.

## Consensus surface

**CONSENSUS-SENSITIVE** — ratchet activation gates when this node starts minting V36. Consensus-neutral in the same sense as #930: reads only `peer_addr` (transient reception metadata, never serialized into the share hash); the accept/validity path keys `v36_active` off the share's own version, not the ratchet state, so a stricter activation can only DELAY our own mint, never change the validity or work of any existing share. **Kept DRAFT for operator tap.**

Limitation (unchanged from #930): origins are counted by reception address, so a single operator with N addresses can still simulate N origins. This raises the floor from 1 to 2; it is not a sybil-proof identity check.

## Tests

Folded into the allowlisted `share_test` target (no new `add_executable`, no NOT_BUILT trap).

- `first_unmet` precedence KATs updated for the `>= 2` bar.
- **New** end-to-end KAT `B_SingleOrigin_NamedWhenAllYesVotesTraceToOneExternalPeer` — a full 95%/60% window whose YES-votes all relay from one external peer is refused (`blocked-by=single-origin`, `distinct_origins=1 (need 2)`).
- Activation twin now spans two distinct external origins.
- `build_ci --target share_test` builds clean; **94/94 share_test pass** (32 ratchet/AutoRatchet cases green).