### PR TITLE
DGB: bind set_mint_share_fn (local-share mint seam) + #902 coinbase pool-tag/BIP34

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -45,6 +45,8 @@
 #include <impl/dgb/coin/mempool_ingest.hpp>
 #include <impl/dgb/stratum/work_source.hpp>
 #include <impl/dgb/coin/work_ref_hash.hpp>      // make_work_ref_hash_params (ref preimage SSOT)
+#include <impl/dgb/coin/coinbase_scriptsig.hpp>   // build_coinbase_scriptsig (BIP34 height + /c2pool-dgb/ tag, #902)
+#include <impl/dgb/run_loop_mint.hpp>              // parse_min_header_80 + create_local_share reference (#884/#294)
 #include <impl/dgb/conn_pplns_producer.hpp>        // make_conn_pplns_inputs (ref-hash bind SSOT)
 #include <impl/dgb/coin/pplns_weight_walk.hpp>   // compute_pplns_weight_walk (PPLNS step-1 SSOT)
 #include <core/target_utils.hpp>                 // chain::bits_to_target / target_to_average_attempts
@@ -74,6 +76,8 @@
 #include <atomic>
 #include <algorithm>
 #include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <optional>
 #include <string>
 #include <system_error>
@@ -820,7 +824,7 @@ int run_node(const core::CoinParams& params, bool testnet,
     {
         auto& pplns_tracker = p2p_node.tracker();
         work_source->set_pplns_inputs_fn(
-            [&pplns_tracker, &p2p_node, &params](
+            [&pplns_tracker, &p2p_node, &params, &header_chain](
                 const uint256& prev_share_hash,
                 const std::string& /*extranonce1_hex*/,
                 const std::vector<unsigned char>& payout_script,
@@ -923,6 +927,18 @@ int run_node(const core::CoinParams& params, bool testnet,
                     ? params.subsidy_func(absheight)
                     : 0;
 
+                // #902 -- production coinbase scriptSig: [BIP34 height push]
+                // [/c2pool-dgb/ tag]. Built from the coin block the next share
+                // sits on (header_chain.next_block_height()). Before this the
+                // scriptSig was EMPTY on the production path: no BIP34 height
+                // (=> bad-cb-height on any won block) and no pool tag. The SAME
+                // bytes feed BOTH the ref preimage (rin.coinbase_scriptSig, so
+                // the committed ref_hash matches) AND the emitted connection
+                // coinbase (ain.coinbase_script) -- a single SSOT so the two can
+                // never diverge and self-reject our own shares (#901 finding).
+                const std::vector<unsigned char> coinbase_scriptsig =
+                    dgb::coin::build_coinbase_scriptsig(header_chain.next_block_height());
+
                 // REF half -- assemble the ref preimage via the SSOT and hash it
                 // through the verifier primitive. V36/V35 split owned by
                 // compute_ref_hash_for_work().
@@ -930,6 +946,7 @@ int run_node(const core::CoinParams& params, bool testnet,
                 rin.share_version   = 36;
                 rin.desired_version = 36;
                 rin.prev_share      = prev_share_hash;
+                rin.coinbase_scriptSig = coinbase_scriptsig;  // #902: commit the BIP34+tag scriptSig
                 rin.share_nonce     = 0;            // share commitment nonce (not block)
                 rin.payout_script   = payout_script;
                 rin.subsidy         = subsidy;
@@ -956,10 +973,113 @@ int run_node(const core::CoinParams& params, bool testnet,
                 ain.total_weight    = walk.total_weight;
                 ain.subsidy         = subsidy;
                 ain.use_v36_pplns   = use_v36_pplns;
+                ain.coinbase_script = coinbase_scriptsig;  // #902: same BIP34+tag scriptSig as the ref preimage
                 ain.donation_script = dgb::PoolConfig::get_donation_script(/*share_version=*/36);
                 ain.ref_params      = dgb::coin::make_work_ref_hash_params(rin, params);
                 return dgb::make_conn_pplns_inputs(ain, params);
             });
+    }
+
+    // -- #884 sharechain WRITE path: bind the worker->mint seam ----------------
+    //
+    // Until now main_dgb never called set_mint_share_fn, so DGBWorkSource::
+    // try_mint_share() hit the null-fn branch (work_source.cpp) on EVERY share
+    // that met the share target -- a DGB node could relay peer shares but never
+    // record a locally-mined one, contributed zero hashrate to its own
+    // sharechain, and (the serious part, #888) its won blocks were invisible to
+    // every p2pool peer, which detect pool blocks by watching the sharechain for
+    // a share meeting the block target. broadcast_share / notify_local_share
+    // were zero-caller dead code. This binding lights that path up.
+    //
+    // The seam is invoked from mining_submit on the Stratum IO thread with ZERO
+    // locks held (asio handler -> process_message -> mining_submit -> mint), so
+    // taking the tracker lock here is safe. On the WonBlock arm the block is
+    // ALREADY dispatched before this runs (work_source.cpp), so nothing here can
+    // delay or endanger the block submit -- a decline only forfeits sharechain
+    // credit, never the block.
+    //
+    // Version pin (v36): the producer seam above freezes the connection coinbase
+    // at share_version=36 (make_conn_pplns_inputs hardcodes 36 / use_v36_pplns),
+    // so the mint MUST reconstruct at v36 too or the rebuilt gentx would not
+    // match the coinbase the miner hashed and create_local_share would decline.
+    // This is why we call create_local_share directly with 36 rather than the
+    // AutoRatchet adapter (dgb_select_mint_versions, run_loop_mint.hpp), whose
+    // baseline is 35 (auto_ratchet_wire.hpp) and would diverge from the producer.
+    // Aligning the producer onto the ratchet is a separate consensus decision.
+    // Every other field mirrors the producer exactly: donation=50, no merged
+    // addrs (standalone DGB parent), segwit_active=false (the producer emits a
+    // non-segwit coinbase), so the reconstruction is byte-identical when the
+    // sharechain tip has not moved between template build and submit; if it has,
+    // create_local_share returns null (a correctly-declined stale share).
+    {
+        work_source->set_mint_share_fn(
+            [&p2p_node, &params](
+                const dgb::stratum::DGBWorkSource::MintShareInputs& in) -> uint256
+            {
+                // in.coinbase_bytes is the coinbase scriptSig (BIP34 height +
+                // /c2pool-dgb/ tag) -- share.m_coinbase is the scriptSig, bounded
+                // 2..100B by share_init_verify, NOT the full coinbase tx.
+                auto min_header = dgb::parse_min_header_80(in.header_bytes);
+                if (!min_header) {
+                    LOG_WARNING << "[DGB-MINT] malformed 80-byte header -- share "
+                                   "NOT recorded (fail-closed)";
+                    return uint256();
+                }
+                BaseScript coinbase;
+                coinbase.m_data = in.coinbase_bytes;
+
+                // Exclusive tracker lock, non-blocking: defer to the next
+                // submission if the compute thread is mid-think() rather than
+                // block the Stratum IO thread. Released BEFORE broadcast_share /
+                // notify_local_share, which take their own locks / post to io.
+                std::unique_lock<std::shared_mutex> lk(
+                    p2p_node.tracker_mutex(), std::try_to_lock);
+                if (!lk.owns_lock()) {
+                    LOG_INFO << "[DGB-MINT] tracker busy -- share deferred "
+                                "(retry on next submission)";
+                    return uint256();
+                }
+
+                uint256 share_hash;
+                try {
+                    share_hash = dgb::create_local_share(
+                        p2p_node.tracker(), params, *min_header, coinbase,
+                        in.subsidy, in.prev_share, in.merkle_branches,
+                        in.payout_script,
+                        /*donation=*/50,
+                        std::vector<dgb::MergedAddressEntry>{},
+                        dgb::StaleInfo::none,
+                        /*segwit_active=*/false,  // producer emits non-segwit coinbase
+                        std::string{},            // witness_commitment_hex
+                        std::vector<unsigned char>{},  // message_data
+                        std::vector<unsigned char>{},  // actual_coinbase_bytes
+                        uint256(),                // witness_root
+                        0u, 0u,                   // override_max_bits / override_bits
+                        0u, uint128(), uint256(), 0u, uint256(),
+                        /*has_frozen=*/false,
+                        std::vector<uint256>{}, uint256(),
+                        std::vector<unsigned char>{},
+                        /*share_version=*/36, /*desired_version=*/36);
+                } catch (const std::exception& e) {
+                    LOG_WARNING << "[DGB-MINT] create_local_share threw: " << e.what();
+                    return uint256();
+                }
+
+                lk.unlock();
+
+                if (!share_hash.IsNull()) {
+                    p2p_node.broadcast_share(share_hash);
+                    p2p_node.notify_local_share(share_hash);
+                    LOG_INFO << "[DGB-MINT] share "
+                             << share_hash.GetHex().substr(0, 16)
+                             << " minted onto the sharechain + broadcast (prev="
+                             << in.prev_share.GetHex().substr(0, 16) << ")";
+                }
+                return share_hash;
+            });
+        std::cout << "[DGB] sharechain mint seam BOUND (set_mint_share_fn -> "
+                     "create_local_share v36 -> broadcast_share + "
+                     "notify_local_share)" << std::endl;
     }
 
     // -- --redistribute: node-local payout policy (Redistribute V2, #307) ------

--- a/src/impl/dgb/coin/coinbase_scriptsig.hpp
+++ b/src/impl/dgb/coin/coinbase_scriptsig.hpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ============================================================================
+// coinbase_scriptsig.hpp — SSOT for the DGB production coinbase scriptSig.
+//
+// The p2pool/c2pool per-connection coinbase carries a scriptSig of the form:
+//
+//     [BIP34 minimally-encoded height push][/c2pool-dgb/ pool-tag push]
+//
+// which is what every other lane already emits (LTC `/c2pool/`, BTC
+// `/c2pool-btc/`, BCH `/c2pool-bch/`, DASH `/P2Pool-DASH/c2pool/`). DGB was the
+// odd one out (#902): the production per-connection coinbase left the scriptSig
+// EMPTY because main_dgb never populated ConnPplnsAssemblyInputs::coinbase_script.
+// An empty scriptSig has no BIP34 height push, so a won DGB block is a
+// `bad-cb-height` rejection the moment the mint seam is bound (#884) and DGB
+// starts producing production coinbases. This header is the ONE place that
+// scriptSig is built, so the ref-preimage commitment (WorkRefHashInputs
+// ::coinbase_scriptSig) and the emitted connection coinbase (ConnPplnsAssembly
+// Inputs::coinbase_script) are populated from the SAME bytes and can never
+// diverge (a divergence would self-reject our own shares — the #901 finding).
+//
+// Pure: no tracker/chain handle, so it is directly KAT-able against a
+// hand-computed vector (see test/connection_coinbase_test.cpp).
+// ============================================================================
+
+#include <cstdint>
+#include <string_view>
+#include <vector>
+
+namespace dgb::coin
+{
+
+// The DGB pool tag stamped into the coinbase scriptSig. Mirrors the per-lane
+// convention (LTC `/c2pool/`, BTC `/c2pool-btc/`, BCH `/c2pool-bch/`).
+inline constexpr std::string_view DGB_POOL_TAG = "/c2pool-dgb/";
+
+// BIP34 minimally-encoded height push for the coinbase scriptSig.
+// Returns [OP_PUSHBYTES_n][n height bytes, little-endian], where n is the
+// smallest byte count that encodes the height with the high bit of the top
+// byte clear (script-integer sign-safety — a set high bit would be parsed as a
+// negative number). Byte-identical to btc::stratum::bip34_height_push.
+inline std::vector<unsigned char> bip34_height_push(uint32_t h)
+{
+    std::vector<unsigned char> enc;
+    uint32_t tmp = h;
+    while (tmp) {
+        enc.push_back(static_cast<unsigned char>(tmp & 0xff));
+        tmp >>= 8;
+    }
+    if (enc.empty())        enc.push_back(0);       // height 0 -> single 0x00
+    if (enc.back() & 0x80)  enc.push_back(0);       // sign-bit safety pad
+
+    std::vector<unsigned char> out;
+    out.reserve(1 + enc.size());
+    out.push_back(static_cast<unsigned char>(enc.size()));  // OP_PUSHBYTES_n
+    out.insert(out.end(), enc.begin(), enc.end());
+    return out;
+}
+
+// Build the full production coinbase scriptSig for the block at
+// `next_block_height` (the coin block the next share builds on top of, i.e.
+// dgb::coin::HeaderChain::next_block_height()). Layout:
+//   [BIP34 height push] || [1-byte push opcode = tag length] || DGB_POOL_TAG
+// The tag is a bare data push (opcode == length for 1..75 bytes), matching the
+// btc lane. Result is a valid coinbase scriptSig (well under the 100-byte
+// consensus cap and above the 2-byte floor share_init_verify enforces).
+inline std::vector<unsigned char> build_coinbase_scriptsig(uint32_t next_block_height)
+{
+    std::vector<unsigned char> s = bip34_height_push(next_block_height);
+    // Bare data push: for 1..75 bytes the push opcode IS the length.
+    if (!DGB_POOL_TAG.empty() && DGB_POOL_TAG.size() < 76) {
+        s.push_back(static_cast<unsigned char>(DGB_POOL_TAG.size()));
+        s.insert(s.end(), DGB_POOL_TAG.begin(), DGB_POOL_TAG.end());
+    }
+    return s;
+}
+
+} // namespace dgb::coin

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -103,6 +103,41 @@ inline uint256 merkle_pair(const uint256& left, const uint256& right) {
                 std::span<const uint8_t>(right.data(), 32));
 }
 
+// Extract the coinbase scriptSig from a reconstructed coinbase TRANSACTION.
+// The mint seam (create_local_share) stores the scriptSig in share.m_coinbase,
+// which share_init_verify bounds to 2..100 bytes -- so the mint MUST be handed
+// the scriptSig, NOT the full gentx. Coinbase tx layout (gentx_coinbase.hpp):
+//   version(4) | vin_count(1=0x01) | prev_hash(32) | prev_idx(4) |
+//   scriptSig(varint len + bytes) | sequence(4) | ...
+// so the scriptSig length varint sits at fixed offset 41. The 8-byte extranonce
+// lands in the OP_RETURN nonce slot near the tail (connection_coinbase.hpp),
+// never in the scriptSig, so the bytes recovered here are exactly the scriptSig
+// the producer froze at template time -- which is what keeps the mint's
+// recomputed ref_hash equal to the one the miner's coinbase committed to.
+inline std::vector<unsigned char>
+extract_coinbase_scriptsig(const std::vector<uint8_t>& coinbase_tx) {
+    constexpr size_t kScriptOffset = 4 + 1 + 32 + 4;  // = 41
+    if (coinbase_tx.size() < kScriptOffset + 1)
+        return {};  // truncated -> empty (fail-closed; mint declines on size<2)
+    size_t off = kScriptOffset;
+    uint64_t len = coinbase_tx[off++];
+    // A coinbase scriptSig is consensus-capped at 100 bytes, so its length is
+    // always a single-byte varint (< 0xfd). Handle the wider markers only to
+    // stay well-formed against a malformed buffer.
+    if (len == 0xfd) {
+        if (off + 2 > coinbase_tx.size()) return {};
+        len = static_cast<uint64_t>(coinbase_tx[off])
+            | (static_cast<uint64_t>(coinbase_tx[off + 1]) << 8);
+        off += 2;
+    } else if (len >= 0xfe) {
+        return {};  // implausible for a coinbase scriptSig -> fail-closed
+    }
+    if (off + len > coinbase_tx.size())
+        return {};  // length overruns the buffer -> fail-closed
+    return std::vector<unsigned char>(coinbase_tx.begin() + off,
+                                      coinbase_tx.begin() + off + len);
+}
+
 } // namespace
 
 DGBWorkSource::DGBWorkSource(c2pool::dgb::HeaderChain&     chain,
@@ -556,7 +591,13 @@ nlohmann::json DGBWorkSource::mining_submit(
                                     : "[DGB-STRATUM-SHARE]";
         MintShareInputs in;
         in.header_bytes    = header;
-        in.coinbase_bytes  = coinbase;
+        // #884/#902: hand the mint the coinbase SCRIPTSIG (share.m_coinbase is
+        // the scriptSig, bounded 2..100B by share_init_verify), extracted from
+        // the reconstructed coinbase tx -- NOT the full gentx `coinbase`, which
+        // is >100B and would make create_local_share throw "bad coinbase size".
+        // Recovering it from the tx (rather than re-deriving) guarantees it is
+        // byte-identical to the scriptSig the producer froze into the template.
+        in.coinbase_bytes  = extract_coinbase_scriptsig(coinbase);
         in.subsidy         = job->subsidy;
         in.prev_share      = job->prev_share_hash;
         in.merkle_branches = branch_hashes;

--- a/src/impl/dgb/test/connection_coinbase_test.cpp
+++ b/src/impl/dgb/test/connection_coinbase_test.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 #include <impl/dgb/coin/connection_coinbase.hpp>
+#include <impl/dgb/coin/coinbase_scriptsig.hpp>   // #902 build_coinbase_scriptsig KAT
 #include <impl/dgb/coin/last_txout_nonce.hpp>
 #include <c2pool/merged/merged_mining.hpp>  // core SSOT: build_auxpow_commitment
 
@@ -312,6 +313,47 @@ TEST(LastTxoutNonceSsot, DrawsAreDistinct) {
     std::set<uint64_t> seen;
     for (int i = 0; i < N; ++i) seen.insert(dgb::make_last_txout_nonce());
     EXPECT_EQ(seen.size(), static_cast<size_t>(N));
+}
+
+// ── #902 production coinbase scriptSig: BIP34 height push + /c2pool-dgb/ tag ──
+//
+// Pins dgb::coin::build_coinbase_scriptsig (coin/coinbase_scriptsig.hpp), the
+// SSOT main_dgb feeds into BOTH the ref preimage (WorkRefHashInputs
+// ::coinbase_scriptSig) and the emitted connection coinbase
+// (ConnPplnsAssemblyInputs::coinbase_script). Expected bytes are hand-computed:
+//   [OP_PUSHBYTES_n][height LE, sign-safe] || [len] || "/c2pool-dgb/"
+// so a byte drift on either the BIP34 encoding or the tag is caught before it
+// reaches a mainnet coinbase (an empty/short height push is a bad-cb-height
+// block loss -- exactly what #902 exists to stop).
+TEST(CoinbaseScriptSig, Bip34HeightPushMinimallyEncoded) {
+    using dgb::coin::bip34_height_push;
+    // 1 byte: height 1 -> push 1 byte 0x01.
+    EXPECT_EQ(tohex(bip34_height_push(1)), "0101");
+    // Sign-bit safety: 0x80 has the high bit set, so it needs a zero pad ->
+    // push 2 bytes 80 00 (NOT a bare 1-byte 0x80, which parses as negative).
+    EXPECT_EQ(tohex(bip34_height_push(0x80)), "028000");
+    // 21,000,000 = 0x01406F40 -> LE 40 6F 40 01, high byte 0x01 (bit clear) ->
+    // push 4 bytes.
+    EXPECT_EQ(tohex(bip34_height_push(21000000)), "04406f4001");
+}
+
+TEST(CoinbaseScriptSig, FullScriptSigPinsHeightAndTag) {
+    using dgb::coin::build_coinbase_scriptsig;
+    // "/c2pool-dgb/" = 12 bytes -> push opcode 0x0c, then the ASCII tag.
+    const std::string kTagHex = "0c2f6332706f6f6c2d6467622f";  // 0x0c || "/c2pool-dgb/"
+
+    // height 1: 01 01 || <tag>
+    EXPECT_EQ(tohex(build_coinbase_scriptsig(1)), "0101" + kTagHex);
+    // height 21,000,000: 04 40 6f 40 01 || <tag>
+    EXPECT_EQ(tohex(build_coinbase_scriptsig(21000000)), "04406f4001" + kTagHex);
+
+    // Structural invariants share_init_verify relies on: 2 <= size <= 100, and
+    // the tag is literally present as the trailing bytes.
+    auto s = build_coinbase_scriptsig(21000000);
+    EXPECT_GE(s.size(), size_t{2});
+    EXPECT_LE(s.size(), size_t{100});
+    std::string tail(s.end() - 12, s.end());
+    EXPECT_EQ(tail, "/c2pool-dgb/");
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

DRAFT — reward/mint path, holds for operator tap.

`main_dgb.cpp` never called `DGBWorkSource::set_mint_share_fn`, so `try_mint_share()` hit the null-fn branch on every share meeting the share target (#884). A DGB node could relay peer shares but never record a locally-mined one, contributed zero hashrate to its own sharechain, and — the serious part — its won blocks were **invisible to every p2pool peer**, which detect pool blocks by watching the sharechain for a share that meets the block target. `broadcast_share` / `notify_local_share` were zero-caller dead code.

Binding that seam lights up a coinbase scriptSig path that was empty (#902): no BIP34 height push (⇒ `bad-cb-height` on any won block) and no pool tag. Both are fixed here together, because #902 is masked while the seam is unbound and bites the instant it is bound.

## Changes

1. **`coin/coinbase_scriptsig.hpp` (new SSOT)** — `build_coinbase_scriptsig(height)` = `[BIP34 minimally-encoded height push] || [/c2pool-dgb/ pool tag]`. Mirrors the BTC lane's `bip34_height_push` + `POOL_TAG`.
2. **`main_dgb.cpp` `set_pplns_inputs_fn`** — feed that scriptSig into **both** the ref preimage (`WorkRefHashInputs::coinbase_scriptSig`) and the emitted connection coinbase (`ConnPplnsAssemblyInputs::coinbase_script`) from the **same** bytes, so the committed `ref_hash` and the actual coinbase can never diverge and self-reject our own shares (the #901 two-places-diverge failure mode).
3. **`main_dgb.cpp` `set_mint_share_fn`** — parse the 80-byte header, take the tracker exclusive lock (try, non-blocking, released before broadcast), call `create_local_share` at `share_version=36`, then `broadcast_share` + `notify_local_share`.
4. **`stratum/work_source.cpp` `mining_submit`** — hand the mint the coinbase **scriptSig** (`share.m_coinbase` is bounded 2..100 B by `share_init_verify`), extracted from the reconstructed coinbase tx, **not** the full gentx (which is >100 B and would make `create_local_share` throw *"bad coinbase size"*). Recovering it from the tx guarantees it is byte-identical to the scriptSig the producer froze.
5. **`test/connection_coinbase_test.cpp`** — KAT pinning the exact scriptSig bytes (BIP34 encoding + `/c2pool-dgb/`) for heights 1, `0x80`, 21,000,000. Folded into the already-allowlisted `dgb_connection_coinbase_test` target — no new executable, so no `NOT_BUILT` sentinel.

## Reward-path safety

- On the WonBlock arm the mint runs **after** the block is already dispatched, so a decline never endangers a block.
- `create_local_share` returns null (never an invalid share) when the reconstruction does not match the miner's header, so a sharechain tip that moved between template-build and submit yields a **correctly-declined stale share**, not a bad one.
- The mint takes the tracker exclusive lock non-blocking on the Stratum IO thread and releases it before `broadcast_share`/`notify_local_share` (which take their own locks).

## Decision point for review

The producer (`make_conn_pplns_inputs`) freezes the connection coinbase at **v36**, so the mint is pinned to v36 to reproduce it byte-for-byte. The `AutoRatchet` adapter (`dgb_select_mint_versions`, `run_loop_mint.hpp`) has a baseline of **35** and would produce a gentx that does not match the coinbase the miner hashed — so it is deliberately **not** used here. Aligning the producer onto the ratchet is a separate consensus decision.

## Verification

- `-DCOIN_DGB=ON` configure + build of the affected TUs (`dgb` object lib incl. `work_source.cpp`, `c2pool-dgb` incl. `main_dgb.cpp`) and the `dgb_connection_coinbase_test` target.
- New scriptSig KAT + standalone byte-logic check confirm: `build_coinbase_scriptsig(21000000)` = `04406f4001` + `0c` + `/c2pool-dgb/`; round-trip extraction from a coinbase tx recovers the exact scriptSig.

Refs #884 #902
