### PR TITLE
Dashboard: decouple PPLNS view from the 1.1MB /sharechain/window fetch (task #57)

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -751,6 +751,23 @@
             0% { transform: translateX(-100%); }
             100% { transform: translateX(400%); }
         }
+        /* Visible failure state for a section that could not load its data
+           (e.g. the sharechain window fetch stalled/aborted). Replaces an
+           eternal "Loading..." with an error message + a manual retry. */
+        .section-loading.section-error {
+            color: var(--danger, #e5534b);
+        }
+        .section-loading .retry-btn {
+            display: inline-block;
+            margin-left: 8px;
+            padding: 2px 10px;
+            font-size: 0.85rem;
+            color: var(--primary);
+            background: transparent;
+            border: 1px solid var(--primary);
+            border-radius: 4px;
+            cursor: pointer;
+        }
 
         /* Shares Explorer */
         .shares-section {
@@ -2996,6 +3013,16 @@
             loadBroadcasterStats();
             loadMergedBroadcasterStats();
             loadShares();
+            // Trigger the PPLNS distribution treemap independently of the
+            // sharechain explorer. loadShares() -> defrag.load() fetches the
+            // ~1.1 MB /sharechain/window and only calls loadMainPPLNS() at the
+            // tail of that chain; a stalled window fetch (e.g. DPI throttling)
+            // would otherwise strand PPLNS at "Loading..." forever. The
+            // treemap's own source is the 426-byte /current_merged_payouts, so
+            // fetch it here on its own. renderMainPPLNS() replaces its grid
+            // wholesale, so the later in-chain call is idempotent (no
+            // double-render). Coin-generic — no per-coin branching.
+            loadMainPPLNS();
             document.getElementById('last-update').textContent = 'Last update: ' + new Date().toLocaleTimeString();
         });
         
@@ -5174,10 +5201,48 @@
                 }
             },
 
-            load: function() {
+            // Bounded retries before the explorer gives up. A stalled or
+            // aborted /sharechain/window (~1.1 MB; the first casualty under
+            // DPI throttling) used to strand the explorer — and, via the
+            // in-chain call at the tail of this function, the PPLNS treemap —
+            // at "Loading..." forever with no retry and no error shown.
+            _loadMaxRetries: 3,
+
+            load: function(_attempt) {
                 var self = this;
+                var attempt = _attempt || 0;
                 d3.json('../sharechain/window', function(data) {
-                    if (!data || !data.shares) return;
+                    if (!data || !data.shares) {
+                        var dl = document.getElementById('defrag-loading');
+                        if (attempt < self._loadMaxRetries) {
+                            // Transient: back off (1.5s, 3s, 4.5s) and retry so
+                            // a momentarily stalled fetch self-heals.
+                            if (dl) {
+                                dl.classList.remove('section-error');
+                                dl.innerHTML = 'Loading sharechain… retrying (' +
+                                    (attempt + 1) + '/' + self._loadMaxRetries + ')' +
+                                    '<div class="progress-track"><div class="progress-bar"></div></div>';
+                            }
+                            setTimeout(function() { self.load(attempt + 1); }, 1500 * (attempt + 1));
+                        } else if (dl) {
+                            // Exhausted retries: surface a visible error with a
+                            // manual retry instead of an eternal "Loading...".
+                            dl.classList.add('section-error');
+                            dl.innerHTML = 'Failed to load sharechain window.';
+                            var btn = document.createElement('button');
+                            btn.type = 'button';
+                            btn.className = 'retry-btn';
+                            btn.textContent = 'Retry';
+                            btn.addEventListener('click', function() {
+                                dl.classList.remove('section-error');
+                                dl.innerHTML = 'Loading sharechain…' +
+                                    '<div class="progress-track"><div class="progress-bar"></div></div>';
+                                self.load(0);
+                            });
+                            dl.appendChild(btn);
+                        }
+                        return;
+                    }
                     self.shares = data.shares;
                     self.myAddress = data.my_address || '';
                     self.windowSize = data.window_size || 8640;
@@ -8814,6 +8879,10 @@
                     loadPayouts();
                     loadPoolLuck();
                     loadShares();
+                    // Refresh the PPLNS treemap on its own 426-byte fetch,
+                    // not gated on the ~1.1 MB /sharechain/window that
+                    // loadShares() pulls (see page-init rationale).
+                    loadMainPPLNS();
                     loadBroadcasterStats();
                     loadMergedBroadcasterStats();
                     loadHashrateGraph();
@@ -8832,6 +8901,8 @@
             loadPayouts();
             loadPoolLuck();
             loadShares();
+            // Refresh the PPLNS treemap independently (see page-init rationale).
+            loadMainPPLNS();
             loadPeers();
             loadBroadcasterStats();
             loadMergedBroadcasterStats();


### PR DESCRIPTION
## DOM-proven root cause

The served dashboard page *does* render the PPLNS distribution cells once the big fetch completes — the backend and web-static are byte-correct. The visible "PPLNS view empty / stuck on Loading" is a **front-end coupling + silent-failure** defect, not a data defect:

- `loadMainPPLNS()` fetches the small (426 B) `../current_merged_payouts`, but its only call sites sit at the **tail of the sharechain-explorer chain**:
  `loadShares()` -> `defrag.load()` -> `d3.json('../sharechain/window')` [~1.1 MB] -> `render()` -> `updateStats()` -> `loadShareLinks()` -> `refreshPayoutsV36()` -> `loadMainPPLNS()`.
- `defrag.load()` had a **silent** `if (!data || !data.shares) return;`. A stalled or aborted 1.1 MB `/sharechain/window` (the first casualty under DPI throttling) strands **both** the explorer and PPLNS at "Loading..." forever — no retry, no error.
- Auto-Refresh and RealTime default **OFF**, so the chain runs exactly once. One stall = permanent strand.

## Fix (display-only, front-end only)

`web-static/dashboard.html` only. No C++/backend/served-JSON touched.

1. **Decouple the PPLNS trigger.** Call `loadMainPPLNS()` independently in the `currency_info` init fan-out (alongside `loadStats()`/`loadPayouts()`) and in both refresh paths (auto-refresh interval + `manualRefresh`), so the treemap's 426-byte fetch runs on its own and is not gated on the 1.1 MB window fetch completing. The existing in-chain calls are **kept** for tip-driven refresh. `renderMainPPLNS()` clears and rebuilds its grid wholesale, so the duplicate call is idempotent — no double-render.
2. **Surface the failure + self-heal.** Replace the silent return in `defrag.load()` with a bounded retry (up to 3, backoff 1.5s / 3s / 4.5s); on exhaustion, show a visible "Failed to load sharechain window" state with a manual **Retry** button instead of an eternal "Loading...".

## Properties

- **Display-only / front-end only** — a single file, `web-static/dashboard.html`.
- **Coin-generic** — works for DASH + LTC dashboards; no coin hardcoded.
- **Idempotent** — the independent + in-chain `loadMainPPLNS()` calls cannot double-render (grid is rebuilt each render).
- **No new dependencies.** Inline JS passes `node --check`.

Draft — not for merge.