### PR TITLE
Dashboard: fix flat DASH pool-hashrate line + block trails (task #57 parity vs LTC)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1960,13 +1960,34 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // m_pool_hashrate_fn is read exclusively by web_server REST handlers.
             mi->set_pool_hashrate_fn([node_ptr]() -> double {
                 static double s_last_good = 0.0;
+                // ── STALENESS BOUND (#57 flat-plateau fix) ────────────────
+                // The last-good latch below is what keeps the graph smooth over
+                // transient tracker lock contention. Unbounded, it also turns a
+                // FROZEN estimator (e.g. a stuck verified-best election on a
+                // zero-local-mint relay) into a permanent flat rectangle: the
+                // value carried forward forever, zero variance for hours. Bound
+                // it -- if no fresh hr>0 has been produced for >10 min the latch
+                // is poisoned, so publish 0 and let update_stat_log BREAK the
+                // line instead of fabricating a plateau. Display-only.
+                static int64_t s_last_good_ts = 0;
+                const int64_t now_s =
+                    std::chrono::duration_cast<std::chrono::seconds>(
+                        std::chrono::steady_clock::now().time_since_epoch())
+                        .count();
+                constexpr int64_t kStaleSeconds = 600;  // 10 min
+                auto held = [&]() -> double {
+                    if (s_last_good_ts != 0 &&
+                        now_s - s_last_good_ts > kStaleSeconds)
+                        return 0.0;
+                    return s_last_good;
+                };
                 // Verified best-share head, queried WITHOUT the tracker guard
                 // held: best_share_hash()/elect_best_share takes the tracker
                 // lock itself, so nesting it under read_tracker() would
                 // recursively shared-lock the same mutex.
                 auto best = node_ptr->best_share_hash();
                 auto guard = node_ptr->read_tracker();
-                if (!guard) return s_last_good;
+                if (!guard) return held();
                 // ── ZERO-LOCAL-MINER / BOOTSTRAP FALLBACK ─────────────────
                 // With no local mint the VERIFIED chain has no heads, so
                 // best_share_hash() is null even though peers have filled the
@@ -1987,32 +2008,38 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 //
                 // Head selection is the pure dash::select_pool_rate_head SSOT
                 // (coin/pool_rate_head_select.hpp, KAT test_dash_pool_rate_head_select):
-                // verified head verbatim when present, else the tallest raw head.
+                // the verified head verbatim ONLY when present AND FRESH (not
+                // out-heighted by the raw tip); else the tallest raw head. Always
+                // gather the raw heads so the freshness check has the raw tip to
+                // compare the verified election against.
                 const bool best_in_chain =
                     !best.IsNull() && guard->chain.contains(best);
-                if (!best_in_chain) {
-                    std::vector<dash::RawChainHead> raw_heads;
-                    for (const auto& [head_hash, tail_hash] :
-                             guard->chain.get_heads()) {
-                        (void)tail_hash;
-                        raw_heads.push_back(
-                            {head_hash, static_cast<int32_t>(
-                                            guard->chain.get_height(head_hash))});
-                    }
-                    best = dash::select_pool_rate_head(uint256::ZERO, false,
-                                                       raw_heads);
+                const int32_t verified_height =
+                    best_in_chain
+                        ? static_cast<int32_t>(guard->chain.get_height(best))
+                        : -1;
+                std::vector<dash::RawChainHead> raw_heads;
+                for (const auto& [head_hash, tail_hash] :
+                         guard->chain.get_heads()) {
+                    (void)tail_hash;
+                    raw_heads.push_back(
+                        {head_hash, static_cast<int32_t>(
+                                        guard->chain.get_height(head_hash))});
                 }
+                best = dash::select_pool_rate_head(
+                    best_in_chain ? best : uint256::ZERO, best_in_chain,
+                    verified_height, raw_heads);
                 if (best.IsNull() || !guard->chain.contains(best))
-                    return s_last_good;
+                    return held();
                 int height = guard->chain.get_height(best);
-                if (height < 3) return s_last_good;
+                if (height < 3) return held();
                 const int display_lookbehind =
                     3600 / static_cast<int>(dash::SharechainConfig::share_period());
                 auto lookbehind = std::min(height - 1, display_lookbehind);
                 auto aps = guard->get_pool_attempts_per_second(best, lookbehind, false);
                 double hr = static_cast<double>(aps.GetLow64());
-                if (hr > 0) s_last_good = hr;
-                return s_last_good;
+                if (hr > 0) { s_last_good = hr; s_last_good_ts = now_s; }
+                return held();
             });
 
             // ── REAL best-share hash ──────────────────────────────────────
@@ -3943,10 +3970,32 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     auto think_timer = std::make_shared<io::steady_timer>(ioc);
     auto think_tick =
         std::make_shared<std::function<void(const boost::system::error_code&)>>();
-    *think_tick = [&p2p_node, think_timer, think_tick](
-                      const boost::system::error_code& ec) {
+    // ── #57 NETWORK-DIFFICULTY FEED (daemonless block-trail fix) ──────────
+    // The RPC work path (web_server.cpp refresh_work, ~1590) is the ONLY place
+    // the LTC family populates MiningInterface::m_network_difficulty; a
+    // daemonless DASH node never runs it, and set_coin_work_fn is only wired
+    // under --stratum, so on a zero-rig relay netdiff stays 0. That nulls the
+    // network_difficulty on every found-block row, which makes the dashboard's
+    // drawDiffRatioBars gate skip the LTC-style block trails and makes luck read
+    // '-'. Push the SERVED template's netdiff into the atomic on every think
+    // tick (unconditional, runs regardless of --stratum) so record_found_block's
+    // existing <=0 fallback stamps new rows, luck computes, trails draw and the
+    // netdiff graph comes alive -- no frontend change, coin-generic render path.
+    // Display/telemetry only; peek_template() is a non-fetching peek.
+    core::MiningInterface* netdiff_mi =
+        web_server ? web_server->get_mining_interface() : nullptr;
+    auto* netdiff_wsrc = work_source.get();
+    *think_tick = [&p2p_node, think_timer, think_tick, netdiff_mi,
+                   netdiff_wsrc](const boost::system::error_code& ec) {
         if (ec) return;   // cancelled at shutdown
         p2p_node.clean_tracker();
+        if (netdiff_mi && netdiff_wsrc) {
+            if (auto t = netdiff_wsrc->peek_template(); t && t->m_bits != 0) {
+                double nd = chain::target_to_difficulty(
+                    dash::coin::target_from_nbits(t->m_bits));
+                if (nd > 0.0) netdiff_mi->update_network_difficulty(nd, "tip");
+            }
+        }
         think_timer->expires_after(std::chrono::seconds(15));
         think_timer->async_wait(*think_tick);
     };

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -2985,8 +2985,8 @@ int main(int argc, char* argv[]) {
                         auto lookbehind = std::min(height - 1, display_lookbehind);
                         auto aps = guard->get_pool_attempts_per_second(best, lookbehind, false);
                         double hr = static_cast<double>(aps.GetLow64());
-                        if (hr > 0) s_last_good = hr;
-                        return s_last_good;
+                        if (hr > 0) { s_last_good = hr; s_last_good_ts = now_s; }
+                        return held();
                     });
                 // pool_hashrate is derived from the sharechain tip — move off
                 // the 1 Hz periodic timer onto the tip-change signal, same

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -2946,13 +2946,34 @@ int main(int argc, char* argv[]) {
                 web_server.get_mining_interface()->set_pool_hashrate_fn(
                     [&p2p_node]() -> double {
                         static double s_last_good = 0.0;
+                        // ── STALENESS BOUND (#57) ─────────────────────────
+                        // The last-good latch smooths transient tracker lock
+                        // contention, but unbounded it also turns a frozen
+                        // estimator into a permanent flat plateau (the DASH
+                        // dash.voidbind.com symptom). Bound it: if no fresh
+                        // hr>0 for >10 min, publish 0 so the chart breaks the
+                        // line instead of holding a stuck value forever.
+                        // Display-only; the retarget never reads this hook.
+                        static int64_t s_last_good_ts = 0;
+                        const int64_t now_s =
+                            std::chrono::duration_cast<std::chrono::seconds>(
+                                std::chrono::steady_clock::now()
+                                    .time_since_epoch())
+                                .count();
+                        constexpr int64_t kStaleSeconds = 600;  // 10 min
+                        auto held = [&]() -> double {
+                            if (s_last_good_ts != 0 &&
+                                now_s - s_last_good_ts > kStaleSeconds)
+                                return 0.0;
+                            return s_last_good;
+                        };
                         auto best = p2p_node->best_share_hash();
-                        if (best.IsNull()) return s_last_good;
+                        if (best.IsNull()) return held();
                         auto guard = p2p_node->read_tracker();
-                        if (!guard) return s_last_good;
-                        if (!guard->chain.contains(best)) return s_last_good;
+                        if (!guard) return held();
+                        if (!guard->chain.contains(best)) return held();
                         int height = guard->chain.get_height(best);
-                        if (height < 3) return s_last_good;
+                        if (height < 3) return held();
                         // DISPLAY LOOKBEHIND (#864): p2pool web.py get_global_stats()
                         // averages the gauge over ONE HOUR of shares --
                         // min(height, 3600//SHARE_PERIOD) -- not TARGET_LOOKBEHIND.

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7064,6 +7064,21 @@ void MiningInterface::add_netdiff_sample(double difficulty, const std::string& s
         m_netdiff_history.erase(m_netdiff_history.begin());
 }
 
+void MiningInterface::update_network_difficulty(double difficulty, const std::string& source)
+{
+    // Mirror of the refresh_work() network-difficulty commit (web_server.cpp
+    // ~1590) for coin-tip sources that never run refresh_work() (daemonless
+    // DASH). Store the atomic every consumer reads (/global_stats,
+    // record_found_block's netdiff fallback, attempts_to_block) and append a
+    // graph sample. add_netdiff_sample() already dedups & bounds the history.
+    if (difficulty <= 0.0) return;
+    m_network_difficulty.store(difficulty, std::memory_order_relaxed);
+    if (m_on_network_difficulty_fn) {
+        try { m_on_network_difficulty_fn(difficulty); } catch (...) {}
+    }
+    add_netdiff_sample(difficulty, source);
+}
+
 nlohmann::json MiningInterface::rest_network_difficulty()
 {
     nlohmann::json arr = nlohmann::json::array();

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1769,6 +1769,17 @@ public:
     double m_last_netdiff_sampled{0.0};  // dedup: skip if unchanged
     void add_netdiff_sample(double difficulty, const std::string& source);
 
+    // Push a live network difficulty into the cache atomic + the sample history
+    // from a coin-tip source that does NOT run refresh_work(). refresh_work()
+    // (the RPC/getblocktemplate work path, web_server.cpp ~1590) is the only
+    // place that populates m_network_difficulty on the LTC family; a daemonless
+    // DASH node never runs it, so netdiff stays 0 -> found-block rows carry a
+    // null network_difficulty -> the dashboard's drawDiffRatioBars gate skips
+    // the block trails, luck reads null, the netdiff graph is flat 0. This lets
+    // the embedded coin-tip follower feed the same atomic those consumers read.
+    // Display/telemetry only -- never drives coinbase or consensus. (#57)
+    void update_network_difficulty(double difficulty, const std::string& source);
+
     // ── Stratum worker session tracking ──────────────────────────────────
 public:
     using WorkerInfo = core::stratum::WorkerInfo;

--- a/src/impl/dash/coin/pool_rate_head_select.hpp
+++ b/src/impl/dash/coin/pool_rate_head_select.hpp
@@ -18,6 +18,20 @@
 // pool-rate graph then reads flat-zero even though peers have filled the RAW
 // sharechain with the whole pool's shares.
 //
+// SECOND PROBLEM (the FLAT PLATEAU, dash.voidbind.com 2026-08-27): on a zero-
+// local-mint relay the verified best-share election can be seeded ONCE (during
+// the initial hotel-sharechain backfill/verify) and then FREEZE -- peer-verified
+// shares update the verified set but never re-elect the head. Because that frozen
+// head is STILL CONTAINED in the raw chain window, the "present AND in chain"
+// guard kept trusting it verbatim, so the estimator recomputed the SAME value off
+// the SAME frozen anchor every sample and the pool-rate graph drew a perfectly
+// flat rectangle (921 bit-identical samples / 15.3 h observed live) even though
+// the raw sharechain tip provably kept advancing. The fix below stops trusting a
+// verified best that is merely in-chain: if the tallest RAW head is materially
+// taller (more than `stale_tolerance` shares) the verified election is stale, so
+// anchor on the advancing raw head instead. This is display/data only -- the
+// vardiff retarget never reads this hook (see below).
+//
 // p2pool has no such gate: web.py add_point() feeds the pool-rate graph every 5s
 // straight off tracker.get_height(best_share) / get_stale_counts over the shared
 // chain, independent of any local miner. This header restores that behaviour for
@@ -53,32 +67,53 @@ struct RawChainHead {
 // Choose the sharechain head to anchor the dashboard pool-rate estimator on.
 //
 //   1. If the verified best-share head is present (non-null AND still in the
-//      chain), use it verbatim -- behaviour is UNCHANGED whenever local mining
-//      seeds a verified head.
-//   2. Otherwise (zero-local-miner bootstrap: no verified head), fall back to the
-//      tallest RAW chain head. Ties keep the FIRST head seen at the maximum
-//      height (strictly-greater comparison), mirroring node.hpp
-//      advertised_best_share()'s `if (h > best_height)` walk.
-//   3. If there are no raw heads either (empty tracker), return null -- the
+//      chain) AND fresh -- i.e. no raw head out-heights it by more than
+//      `stale_tolerance` -- use it verbatim. Behaviour is UNCHANGED whenever a
+//      live-mining node re-elects its verified head every share.
+//   2. If the verified head is present-but-STALE (a raw head is more than
+//      `stale_tolerance` shares taller than it), the verified election has
+//      frozen: anchor on the tallest RAW head instead so the graph tracks the
+//      advancing chain rather than a frozen anchor.
+//   3. Otherwise (zero-local-miner bootstrap: no verified head, or it left the
+//      chain), fall back to the tallest RAW chain head. Ties keep the FIRST head
+//      seen at the maximum height (strictly-greater comparison), mirroring
+//      node.hpp advertised_best_share()'s `if (h > best_height)` walk.
+//   4. If there are no raw heads either (empty tracker), return null -- the
 //      caller then holds the last-good value rather than publishing a spurious 0.
+//
+// `stale_tolerance` is a small slack (default 2 shares) so ordinary one-share
+// lead/lag between the verified election and the raw tip does not flip the
+// anchor every sample; only a genuinely stuck election (many shares behind) does.
 inline uint256 select_pool_rate_head(const uint256& verified_best,
                                      bool verified_best_in_chain,
-                                     const std::vector<RawChainHead>& raw_heads)
+                                     int32_t verified_best_height,
+                                     const std::vector<RawChainHead>& raw_heads,
+                                     int32_t stale_tolerance = 2)
 {
-    if (!verified_best.IsNull() && verified_best_in_chain)
-        return verified_best;
-
-    uint256 best;              // null until a raw head is found
-    int32_t best_height = -1;
+    // Tallest raw head (and its height), by the same walk advertised_best_share
+    // uses. Null / height -1 when there are no usable raw heads.
+    uint256 raw_best;          // null until a raw head is found
+    int32_t raw_best_height = -1;
     for (const auto& head : raw_heads) {
         if (head.hash.IsNull())
             continue;
-        if (head.height > best_height) {
-            best_height = head.height;
-            best = head.hash;
+        if (head.height > raw_best_height) {
+            raw_best_height = head.height;
+            raw_best = head.hash;
         }
     }
-    return best;
+
+    if (!verified_best.IsNull() && verified_best_in_chain) {
+        // FRESHNESS: trust the verified election unless the raw tip has pulled
+        // materially ahead of it (frozen-election guard). When it has, the
+        // verified head is stale -- anchor on the advancing raw head.
+        if (!raw_best.IsNull() &&
+            raw_best_height > verified_best_height + stale_tolerance)
+            return raw_best;
+        return verified_best;
+    }
+
+    return raw_best;
 }
 
 }  // namespace dash

--- a/test/test_dash_pool_rate_head_select.cpp
+++ b/test/test_dash_pool_rate_head_select.cpp
@@ -12,9 +12,13 @@
 // Oracle (mirrors node.hpp advertised_best_share()'s raw-head walk + p2pool
 // web.py add_point() feeding the graph off the shared chain regardless of any
 // local miner):
-//   1. verified head present (non-null AND in chain) -> use it verbatim
-//   2. else -> tallest raw head, ties keep first-seen at max (h > best_height)
-//   3. no raw heads -> null (caller holds last-good, never a spurious 0)
+//   1. verified head present (non-null AND in chain) AND FRESH (the tallest raw
+//      head does not out-height it by more than stale_tolerance) -> verbatim
+//   2. verified head present but STALE (raw tip more than tolerance taller, i.e.
+//      the election froze) -> tallest raw head (the flat-plateau fix)
+//   3. else (no/absent verified head) -> tallest raw head, ties keep first-seen
+//      at max (h > best_height)
+//   4. no raw heads -> null (caller holds last-good, never a spurious 0)
 //
 // All expectations are hand-derived from that oracle, not produced by calling
 // the helper under test, so the KAT is non-circular.
@@ -44,54 +48,89 @@ uint256 h(uint32_t n) {
     return x;
 }
 
-// ---- (1) verified head present -> used verbatim -------------------------
+// ---- (1) verified head present + FRESH -> used verbatim -----------------
 
-TEST(DashPoolRateHead, VerifiedHeadUsedWhenPresent) {
-    // Verified head is non-null and in chain: returned as-is, raw heads ignored
-    // even if a raw head is taller.
+TEST(DashPoolRateHead, VerifiedHeadUsedWhenPresentAndFresh) {
+    // Verified head is non-null, in chain, and NOT out-heighted by the raw tip
+    // (its height 900 == the tallest raw head): returned as-is.
     std::vector<RawChainHead> raw = {{h(10), 500}, {h(11), 900}};
-    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/true, raw), h(7));
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/true,
+                                    /*verified_height=*/900, raw),
+              h(7));
+}
+
+TEST(DashPoolRateHead, VerifiedHeadWithinToleranceIsKept) {
+    // Raw tip only 2 shares taller than the verified election (899 vs the
+    // default tolerance 2): still within slack, so the verified head is kept.
+    std::vector<RawChainHead> raw = {{h(11), 901}};
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/true,
+                                    /*verified_height=*/899, raw),
+              h(7));
+}
+
+TEST(DashPoolRateHead, VerifiedTallerThanRawIsKept) {
+    // Verified election ahead of the raw heads: kept, never regressed to a
+    // shorter raw head.
+    std::vector<RawChainHead> raw = {{h(11), 800}};
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/true,
+                                    /*verified_height=*/1000, raw),
+              h(7));
+}
+
+// ---- (2) FROZEN verified election (the flat-plateau bug) ----------------
+
+TEST(DashPoolRateHead, StaleVerifiedOverriddenByTallerRaw) {
+    // THE dash.voidbind.com FLAT-PLATEAU CASE: the verified best-share election
+    // froze at height 100 while peers advanced the RAW chain to 900. 900 > 100+2
+    // so the verified head is stale -> anchor on the advancing raw head (h(11)),
+    // not the frozen verified head (h(7)). This is what unfreezes the graph.
+    std::vector<RawChainHead> raw = {{h(10), 500}, {h(11), 900}};
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/true,
+                                    /*verified_height=*/100, raw),
+              h(11));
 }
 
 TEST(DashPoolRateHead, VerifiedHeadNotInChainTriggersFallback) {
     // Non-null verified head but NOT in the chain (stale/pruned): fall back to
     // the tallest raw head.
     std::vector<RawChainHead> raw = {{h(10), 500}, {h(11), 900}};
-    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/false, raw), h(11));
+    EXPECT_EQ(select_pool_rate_head(h(7), /*in_chain=*/false,
+                                    /*verified_height=*/-1, raw),
+              h(11));
 }
 
-// ---- (2) zero-local-miner fallback: tallest raw head --------------------
+// ---- (3) zero-local-miner fallback: tallest raw head --------------------
 
 TEST(DashPoolRateHead, NullVerifiedPicksTallestRawHead) {
     // The bootstrap case: no verified head, peers filled the raw chain. Pick the
     // tallest raw head (900 > 500 > 100).
     std::vector<RawChainHead> raw = {{h(1), 100}, {h(2), 900}, {h(3), 500}};
-    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, raw), h(2));
+    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, -1, raw), h(2));
 }
 
 TEST(DashPoolRateHead, TieKeepsFirstSeenAtMaxHeight) {
     // Equal heights -> strictly-greater comparison keeps the FIRST at that max
     // (h(5), not h(9)), matching advertised_best_share()'s walk.
     std::vector<RawChainHead> raw = {{h(5), 800}, {h(9), 800}};
-    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, raw), h(5));
+    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, -1, raw), h(5));
 }
 
 TEST(DashPoolRateHead, NullHashRawHeadsAreSkipped) {
     // A null-hash raw head is not selectable even if it sorts "first".
     std::vector<RawChainHead> raw = {{uint256::ZERO, 999}, {h(4), 300}};
-    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, raw), h(4));
+    EXPECT_EQ(select_pool_rate_head(uint256::ZERO, false, -1, raw), h(4));
 }
 
-// ---- (3) empty tracker -> null (caller holds last-good) -----------------
+// ---- (4) empty tracker -> null (caller holds last-good) -----------------
 
 TEST(DashPoolRateHead, NoHeadsReturnsNull) {
     std::vector<RawChainHead> raw;
-    EXPECT_TRUE(select_pool_rate_head(uint256::ZERO, false, raw).IsNull());
+    EXPECT_TRUE(select_pool_rate_head(uint256::ZERO, false, -1, raw).IsNull());
 }
 
 TEST(DashPoolRateHead, NullVerifiedAndOnlyNullRawHeadsReturnsNull) {
     std::vector<RawChainHead> raw = {{uint256::ZERO, 5}, {uint256::ZERO, 9}};
-    EXPECT_TRUE(select_pool_rate_head(uint256::ZERO, false, raw).IsNull());
+    EXPECT_TRUE(select_pool_rate_head(uint256::ZERO, false, -1, raw).IsNull());
 }
 
 }  // namespace


### PR DESCRIPTION
## Live symptom

On **dash.voidbind.com** (the daemonless DASH canary) the dashboard "Pool Hashrate" chart shows a real, noisy ~8 TH/s line that at a point **JUMPS to a perfectly flat rectangular ~49 TH/s plateau** (zero variance for 15+ hours, carrying the Blocks diamonds), and the **Blocks diamonds render with no tails/trails** — the LTC reference dashboard draws a diff-ratio trail below each found-block marker; DASH does not. Both are the two `#57` LTC↔DASH parity gaps.

The operator confirms real pool hashrate is ~8 TH/s (largest miner left), so the flat 49 TH/s plateau contradicts reality — it is a data artifact, not real hashrate.

## Root cause — both are DASH-daemonless *data-feed* gaps upstream of a shared, correct frontend

The render path (`web-static/dashboard.html`) is already coin-generic and correct. `drawDiffRatioBars` gates purely on the data fields (`network_difficulty`), and the pool-rate series is drawn from whatever the backend serves. **No frontend change is needed or made.**

**Defect 1 — flat plateau (the backend series is served flat).** The pool-hashrate hook anchors the p2pool estimator on the *verified best-share election*. On a zero-local-mint relay that election can be seeded once during the initial hotel-sharechain backfill and then **freeze**, while the raw sharechain tip keeps advancing. Because the frozen head is still *contained* in the raw chain window, `dash::select_pool_rate_head` kept trusting it verbatim ("present AND in chain"), so the estimator recomputed the **bit-identical** value every 60 s sample — a flat rectangle baked into the served series (and it also contaminated `/global_stats pool_hash_rate` and every found block's `pool_hashrate_at_find`).

**Defect 2 — missing block trails (network difficulty is never fed on the daemonless path).** `drawDiffRatioBars` draws a block's trail only when its row carries `network_difficulty > 0`. That atomic is populated **solely** by the RPC `refresh_work()` path, which a daemonless node never runs (and `set_coin_work_fn` is only wired under `--stratum`). So netdiff stays `0`, every found-block row records a **null** `network_difficulty`, the trail gate fails, and luck reads `-`.

## Fix (display / telemetry only — never touches coinbase, consensus, or the reward/vardiff retarget)

Defect 1:
- **Head freshness** in `dash::select_pool_rate_head`: stop trusting a verified best that is merely in-chain — compare its height against the tallest raw head and anchor on the advancing raw head when the raw tip is more than a small tolerance (2 shares) taller. This alone unfreezes the graph. The pure-function KAT (`test_dash_pool_rate_head_select`) gains the frozen-election case plus within-tolerance / verified-taller cases.
- **Staleness bound** on the last-good latch in both the DASH and LTC pool-hashrate hooks: timestamp the last fresh sample; if none for >10 min, publish `0` so the chart **breaks the line** instead of holding a stuck value forever.

Defect 2:
- New public `MiningInterface::update_network_difficulty(diff, source)` helper (mirror of the `refresh_work()` netdiff commit), pushed from the **unconditional** think tick in `main_dash.cpp` using the served template's `nBits`. Once the atomic is live, `record_found_block`'s existing `<=0` fallback stamps new rows, luck computes, `drawDiffRatioBars` draws the trails, and the netdiff graph series comes alive — DASH now uses the **same coin-generic render path** as LTC.

## touches_backend: **yes**

The flat plateau is proven to be a *served-flat* series (backend), so the fix is backend, kept minimal and reward-safe — the hashrate/netdiff feeds are telemetry read exclusively by the web REST handlers; the vardiff retarget runs on the verified chain over `TARGET_LOOKBEHIND` and never reads these hooks.

## Verification
- `dash::select_pool_rate_head` logic validated by a standalone driver over all branches incl. the frozen-election case (verified 100 vs raw 900 → anchors on the advancing raw head).
- No JS changed (render path untouched).

Draft — do not merge.