### PR TITLE
core(graph-store): frozen-estimator guard — never persist a bit-identical pool-rate plateau

### DIFF
--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -73,7 +73,14 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # idempotency, per-view geometry-mismatch reseed, and corrupt/missing
     # tolerance. Same fold-into-core_test reasoning as every TU here (a new
     # add_executable is the #769 "Not Run" trap).
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp graph_history_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp)
+    # web_server_frozen_pool_rate_guard_test.cpp: the frozen-estimator
+    # graph-store guard (dash.voidbind.com 48.96 TH/s rectangle). Pins the
+    # ingest cap (a bit-identical nonzero pool rate is recorded for at most
+    # kMaxIdenticalPoolRateRun samples, then honest-absent 0), verbatim
+    # recording of a live/varying estimator, and the load-time purge of
+    # pre-guard plateau runs plus their derived desired_versions. Same
+    # fold-into-core_test reasoning as every TU here.
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp web_server_frozen_pool_rate_guard_test.cpp graph_history_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/web_server_frozen_pool_rate_guard_test.cpp
+++ b/src/core/test/web_server_frozen_pool_rate_guard_test.cpp
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+#include <core/web_server.hpp>
+
+// ---------------------------------------------------------------------------
+// KATs for the frozen-estimator graph-store guard (dash.voidbind.com 48.96 TH/s
+// rectangle). A live pool-rate estimator recomputed every stat-log tick over a
+// sliding share window essentially never returns the same bit-identical
+// nonzero double for many consecutive ticks (empirical ceiling on live data:
+// 4). When an upstream latch freezes, the stuck value used to be recorded
+// verbatim for hours and PERSISTED into graph_db, so the plateau kept
+// rendering after the estimator itself was fixed and even across restarts.
+//
+// Two independent layers under test, both coin-generic in core::MiningInterface:
+//   1. INGEST guard (update_stat_log): after kMaxIdenticalPoolRateRun (10)
+//      consecutive bit-identical nonzero samples, record honest-absent 0.0
+//      so the graph breaks instead of extending a fabricated rectangle.
+//   2. LOAD sanitizer (load_stat_log): zero any persisted run LONGER than the
+//      ingest guard could ever write (pre-guard pollution), including the
+//      desired_versions series derived from the frozen value, and force the
+//      binned views to re-seed from the sanitized flat log.
+//
+// All of these FAIL WITHOUT THE FIX: pre-guard, every frozen sample is
+// recorded and reloaded verbatim.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// The literal frozen constant observed live (48.96 TH/s, whale-era estimate
+// latched by a stuck verified-best election on a zero-local-mint relay).
+constexpr double kFrozen = 48959943024877.0;
+
+// Matches MiningInterface::kMaxIdenticalPoolRateRun (private); the KATs pin
+// the behavioral contract — if the threshold changes, these numbers must too.
+constexpr int kMaxRun = 10;
+
+nlohmann::json read_stat_log(const std::string& path)
+{
+    std::ifstream f(path);
+    EXPECT_TRUE(static_cast<bool>(f)) << "stat-log file must exist: " << path;
+    std::string content((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    auto arr = nlohmann::json::parse(content);
+    EXPECT_TRUE(arr.is_array());
+    return arr;
+}
+
+struct TempStatDir {
+    std::filesystem::path dir;
+    TempStatDir(const char* name)
+    {
+        dir = std::filesystem::temp_directory_path() / name;
+        std::filesystem::remove_all(dir);
+        std::filesystem::create_directories(dir);
+    }
+    ~TempStatDir() { std::filesystem::remove_all(dir); }
+    std::string path(const char* leaf) const { return (dir / leaf).string(); }
+};
+
+}  // namespace
+
+// INGEST: a bit-identical nonzero estimator is recorded for at most kMaxRun
+// consecutive samples; every subsequent sample of the freeze is honest-absent
+// 0.0 (the graph BREAKS instead of extending the rectangle).
+TEST(FrozenPoolRateGuard, IngestZeroesAfterIdenticalRunThreshold) {
+    TempStatDir tmp("core_frozen_phr_ingest_kat");
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+    mi.set_stat_log_path(tmp.path("graph_db"));
+    mi.set_pool_hashrate_fn([]() { return kFrozen; });
+
+    const int kTicks = kMaxRun + 5;
+    for (int i = 0; i < kTicks; ++i) mi.update_stat_log();
+    mi.save_stat_log();
+
+    auto arr = read_stat_log(tmp.path("graph_db"));
+    ASSERT_EQ(arr.size(), static_cast<std::size_t>(kTicks));
+    for (int i = 0; i < kMaxRun; ++i)
+        EXPECT_EQ(arr[i]["phr"].get<double>(), kFrozen)
+            << "sample " << i << " is within the plausible identical run";
+    for (int i = kMaxRun; i < kTicks; ++i)
+        EXPECT_EQ(arr[i]["phr"].get<double>(), 0.0)
+            << "sample " << i << " must be honest-absent once the run is "
+               "implausibly long";
+}
+
+// INGEST: a live (varying) estimator is never touched — every sample recorded
+// verbatim, including immediately after a freeze ends.
+TEST(FrozenPoolRateGuard, IngestVaryingEstimatorRecordedVerbatim) {
+    TempStatDir tmp("core_frozen_phr_varying_kat");
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+    mi.set_stat_log_path(tmp.path("graph_db"));
+
+    // Phase 1: freeze long enough to trip the guard.
+    mi.set_pool_hashrate_fn([]() { return kFrozen; });
+    for (int i = 0; i < kMaxRun + 3; ++i) mi.update_stat_log();
+    // Phase 2: the estimator recovers and moves again.
+    double live = 8.5e12;
+    mi.set_pool_hashrate_fn([&live]() { return live += 1.0e9; });
+    const int kLiveTicks = 6;
+    for (int i = 0; i < kLiveTicks; ++i) mi.update_stat_log();
+    mi.save_stat_log();
+
+    auto arr = read_stat_log(tmp.path("graph_db"));
+    ASSERT_EQ(arr.size(), static_cast<std::size_t>(kMaxRun + 3 + kLiveTicks));
+    // Recovery: every post-freeze sample is nonzero and strictly increasing.
+    double prev = 0.0;
+    for (std::size_t i = kMaxRun + 3; i < arr.size(); ++i) {
+        const double v = arr[i]["phr"].get<double>();
+        EXPECT_GT(v, prev) << "recovered live samples must be recorded verbatim";
+        prev = v;
+    }
+}
+
+// LOAD: a persisted run longer than the ingest guard could ever write is
+// pre-guard pollution — zero it (and the desired_versions derived from it) on
+// load, while short legitimate runs and varying samples survive untouched.
+TEST(FrozenPoolRateGuard, LoadSanitizesLongFrozenRunAndDerivedVersions) {
+    TempStatDir tmp("core_frozen_phr_load_kat");
+    const std::string polluted = tmp.path("graph_db");
+    const std::string reload = tmp.path("graph_db.reload");
+
+    // Craft a polluted store: [4 varying] [12 frozen w/ dv] [4-run identical]
+    // [3 varying]. Only the 12-run is beyond what the ingest guard can write.
+    const double now = static_cast<double>(std::time(nullptr));
+    nlohmann::json arr = nlohmann::json::array();
+    double t = now - 3600.0;
+    auto push = [&](double phr, nlohmann::json dv) {
+        arr.push_back({{"t", t}, {"phr", phr}, {"dv", std::move(dv)}});
+        t += 60.0;
+    };
+    for (int i = 0; i < 4; ++i) push(7.0e12 + i * 1.0e10, {});
+    for (int i = 0; i < 12; ++i) push(kFrozen, {{"16", kFrozen}});
+    const double kShortRunVal = 6.5e12;
+    for (int i = 0; i < 4; ++i) push(kShortRunVal, {});
+    for (int i = 0; i < 3; ++i) push(8.0e12 + i * 1.0e10, {});
+    { std::ofstream f(polluted); f << arr.dump(); }
+
+    core::MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                             c2pool::address::Blockchain::LITECOIN);
+    mi.set_stat_log_path(polluted);
+    mi.load_stat_log();
+    // Re-flush to a second path to observe what was loaded (pattern of the
+    // B-STATS.944 shutdown KAT — no core-size getter is added for tests).
+    mi.set_stat_log_path(reload);
+    mi.save_stat_log();
+
+    auto out = read_stat_log(reload);
+    ASSERT_EQ(out.size(), arr.size());
+    for (int i = 0; i < 4; ++i)
+        EXPECT_NE(out[i]["phr"].get<double>(), 0.0) << "varying head survives";
+    for (int i = 4; i < 16; ++i) {
+        EXPECT_EQ(out[i]["phr"].get<double>(), 0.0)
+            << "frozen sample " << i << " must be purged on load";
+        EXPECT_EQ(out[i]["dv"]["16"].get<double>(), 0.0)
+            << "desired_versions derived from the frozen value must be purged";
+    }
+    for (int i = 16; i < 20; ++i)
+        EXPECT_EQ(out[i]["phr"].get<double>(), kShortRunVal)
+            << "a short identical run (<= threshold) is legitimate and kept";
+    for (int i = 20; i < 23; ++i)
+        EXPECT_NE(out[i]["phr"].get<double>(), 0.0) << "varying tail survives";
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -7496,6 +7496,33 @@ void MiningInterface::update_stat_log()
     // Pool hash rate — use p2pool-correct callback (safe, runs on ioc thread)
     entry.pool_hash_rate = m_pool_hashrate_fn ? m_pool_hashrate_fn() : 0.0;
 
+    // ── Frozen-estimator ingest guard (see header) ───────────────────────────
+    // Runs BEFORE desired_versions is derived below (dv[ver] = phr * pct), so
+    // zeroing a frozen sample here keeps the derived series clean too. The
+    // frozen 48.96 TH/s rectangle on dash.voidbind.com was exactly this: a
+    // stuck estimator value recorded verbatim for 15 h and persisted, still
+    // rendering after the estimator itself was fixed.
+    {
+        const double raw_phr = entry.pool_hash_rate;
+        if (raw_phr != 0.0 && raw_phr == m_phr_freeze_last) {
+            ++m_phr_freeze_run;
+        } else {
+            m_phr_freeze_last = raw_phr;
+            m_phr_freeze_run = 1;
+            m_phr_freeze_logged = false;
+        }
+        if (raw_phr != 0.0 && m_phr_freeze_run > kMaxIdenticalPoolRateRun) {
+            if (!m_phr_freeze_logged) {
+                LOG_WARNING << "[StatLog] pool_hash_rate frozen at " << raw_phr
+                            << " for " << m_phr_freeze_run
+                            << " consecutive samples — recording honest-absent 0"
+                               " until it moves (frozen-estimator guard)";
+                m_phr_freeze_logged = true;
+            }
+            entry.pool_hash_rate = 0.0;
+        }
+    }
+
     // Periodic network difficulty sample for graph
     double cur_diff = m_network_difficulty.load(std::memory_order_relaxed);
     if (cur_diff > 0)
@@ -8002,7 +8029,14 @@ void MiningInterface::load_graph_views()
     const auto descs = graph_stream_descriptions();
 
     bool do_full_seed = true;   // default: no usable sidecar → seed from flat
-    try {
+    if (m_flat_sanitized_on_load) {
+        // The flat log was purged of frozen-plateau runs on load; the sidecar
+        // bins were folded from the POLLUTED flat log and still carry the
+        // plateau, so adopting them would resurrect it on the long horizons.
+        // Discard the sidecar and re-seed everything from the clean flat log.
+        LOG_INFO << "[GraphViews] Flat log sanitized on load — discarding "
+                    "sidecar bins and re-seeding from the clean flat log";
+    } else try {
         std::ifstream f(path);
         if (f) {
             std::string content((std::istreambuf_iterator<char>(f)),
@@ -8132,6 +8166,40 @@ void MiningInterface::save_stat_log()
     save_graph_views();
 }
 
+std::size_t MiningInterface::sanitize_frozen_pool_rate_runs()
+{
+    // Caller holds m_stat_log_mutex. Zero pool_hash_rate across any run of
+    // MORE THAN kMaxIdenticalPoolRateRun consecutive bit-identical nonzero
+    // samples — the ingest guard caps new runs at exactly the threshold, so a
+    // longer persisted run can only be pre-guard frozen-estimator pollution
+    // (live data's legitimate identical-run ceiling is 4 at the 60 s cadence).
+    // desired_versions is derived from the frozen value (dv[ver] = phr * pct),
+    // so every numeric dv in a sanitized entry is fabricated too — zero it.
+    std::size_t changed = 0;
+    const std::size_t n = m_stat_log.size();
+    std::size_t i = 0;
+    while (i < n) {
+        const double v = m_stat_log[i].pool_hash_rate;
+        std::size_t j = i + 1;
+        if (v != 0.0) {
+            while (j < n && m_stat_log[j].pool_hash_rate == v) ++j;
+            if (j - i > static_cast<std::size_t>(kMaxIdenticalPoolRateRun)) {
+                for (std::size_t k = i; k < j; ++k) {
+                    auto& e = m_stat_log[k];
+                    e.pool_hash_rate = 0.0;
+                    if (e.desired_versions.is_object())
+                        for (auto& kv : e.desired_versions.items())
+                            if (kv.value().is_number())
+                                kv.value() = 0.0;
+                    ++changed;
+                }
+            }
+        }
+        i = j;
+    }
+    return changed;
+}
+
 void MiningInterface::load_stat_log()
 {
     if (m_stat_log_path.empty()) return;
@@ -8179,6 +8247,17 @@ void MiningInterface::load_stat_log()
             e.network_difficulty = j.value("nd", 0.0);
             e.share_difficulty = j.value("sd", 0.0);
             m_stat_log.push_back(std::move(e));
+        }
+        // ── Load-time frozen-run sanitizer (see header) ──────────────────────
+        // Self-heals stores polluted before the ingest guard existed: the guard
+        // caps NEW identical runs at exactly kMaxIdenticalPoolRateRun, so any
+        // longer persisted run can only be pre-guard pollution.
+        const std::size_t sanitized = sanitize_frozen_pool_rate_runs();
+        if (sanitized > 0) {
+            m_flat_sanitized_on_load = true;
+            LOG_WARNING << "[StatLog] Sanitized " << sanitized
+                        << " frozen pool_hash_rate samples on load "
+                           "(frozen-estimator plateau purge)";
         }
         LOG_INFO << "[StatLog] Loaded " << m_stat_log.size() << " entries from " << m_stat_log_path;
       } catch (const std::exception& ex) {

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1710,6 +1710,35 @@ private:
     std::vector<StatLogEntry> m_stat_log;
     mutable std::mutex m_stat_log_mutex;
     std::string m_stat_log_path;  // persistence file path (empty = no persistence)
+
+    // ── Frozen-estimator graph-store guard ───────────────────────────────────
+    // A live pool-rate estimator recomputed every 60 s tick over a sliding
+    // share window essentially never yields the same bit-identical nonzero
+    // double for many consecutive ticks (empirical ceiling on live data: 4).
+    // A long identical run means the estimator upstream is FROZEN (e.g. a
+    // stale latched anchor carried forward by a last-good latch); recording it
+    // bakes a fake flat plateau into the persisted graph_db that survives
+    // restarts — the estimator-side staleness bound stops NEW pollution but
+    // cannot clean what a frozen value already wrote. After
+    // kMaxIdenticalPoolRateRun consecutive bit-identical nonzero samples
+    // (~10 min at the 60 s cadence, matching the estimator-side 600 s
+    // staleness bound) the sample is recorded honest-absent 0.0 so the graph
+    // BREAKS instead of extending a fabricated rectangle. Display-only:
+    // nothing here feeds vardiff/consensus. Accessed only from the
+    // single-threaded stat-log timer (update_stat_log) and startup load.
+    static constexpr int kMaxIdenticalPoolRateRun = 10;
+    double m_phr_freeze_last{0.0};   // last RAW estimator value seen
+    int m_phr_freeze_run{0};         // consecutive bit-identical raw samples
+    bool m_phr_freeze_logged{false}; // one warning per freeze episode
+    // Load-time self-heal for stores polluted BEFORE the ingest guard existed:
+    // zero pool_hash_rate (and the desired_versions derived from it) across any
+    // persisted run longer than the ingest guard could ever write. Caller holds
+    // m_stat_log_mutex. Returns the number of entries sanitized.
+    std::size_t sanitize_frozen_pool_rate_runs();
+    // Set when the sanitizer changed entries; load_graph_views then discards
+    // the .views sidecar (its bins still carry the plateau) and re-seeds from
+    // the sanitized flat log.
+    bool m_flat_sanitized_on_load{false};
 public:
     /// Set persistence path for stat log (call before start)
     void set_stat_log_path(const std::string& path) { m_stat_log_path = path; }


### PR DESCRIPTION
## Problem

dash.voidbind.com's 1D Pool Hashrate chart kept rendering a frozen rectangular plateau at exactly 48.96 TH/s (`48959943024877` H/s) long after the estimator freeze itself was fixed in #1366. Root cause: the frozen value had been recorded verbatim into the stat log every 60 s tick for ~15 h and **persisted** into `graph_db` / `graph_db.views`, so the plateau survived the estimator fix and every restart. #1366 stopped NEW pollution; nothing cleaned what was already stored.

On-disk evidence (canary): 1705 samples with `phr == 48959943024877.0` in two runs (671 and 1034 consecutive samples), plus 1694 `dv` (desired_versions) values derived from it (`dv[ver] = phr * pct`).

## Fix — two coin-generic layers in `core::MiningInterface`

**1. Ingest guard (`update_stat_log`)** — a live estimator recomputed each tick over a sliding share window essentially never yields the same bit-identical nonzero double for many consecutive ticks (empirical ceiling on live canary data: 4). After `kMaxIdenticalPoolRateRun` (10, ~10 min at the 60 s cadence — matching the estimator-side 600 s staleness bound from #1366) consecutive bit-identical nonzero samples, the sample is recorded honest-absent `0.0` so the graph BREAKS instead of extending a fabricated rectangle. Placed before `desired_versions` is derived, so the derived series stays clean too. One warning log per freeze episode.

**2. Load-time sanitizer (`load_stat_log`)** — self-heals stores polluted before the guard existed: any persisted run LONGER than the ingest guard could ever write is zeroed (`pool_hash_rate` + the derived `desired_versions`), and the `.views` sidecar is discarded so the binned views re-seed from the sanitized flat log (the sidecar bins still carry the plateau otherwise).

Display-only: `m_pool_hashrate_fn` is read exclusively by web REST handlers; nothing here feeds vardiff/consensus.

## Tests (red on master, green with fix)

`core_test` KATs in `src/core/test/web_server_frozen_pool_rate_guard_test.cpp`:
- `IngestZeroesAfterIdenticalRunThreshold` — FAILS on master, passes with fix
- `IngestVaryingEstimatorRecordedVerbatim` — no-regression pin (passes both)
- `LoadSanitizesLongFrozenRunAndDerivedVersions` — FAILS on master, passes with fix; also pins that short legitimate identical runs (<= threshold) survive untouched

Full `core_test` suite: 195/195 pass with the fix (verified on the canary build host).

## Live state

The canary's polluted `graph_db`/`graph_db.views` were already purged manually (backups kept); this PR makes any node with a pre-guard polluted store self-heal on its next restart and prevents recurrence on every coin lane (DASH/LTC/BCH/BTC/DGB share this core path).
