### PR TITLE
Peer-found blocks invisible on dashboard: carry share PoW across threads (LTC/BTC/DGB/BCH)

### DIFF
--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -4331,10 +4331,15 @@ int main(int argc, char* argv[]) {
                              << " miner=" << miner_addr.substr(0,16)
                              << " height=" << height;
 
+                    // sharechain_peer: this hook fires for ANY verified share
+                    // meeting the block target. For our own find the submit
+                    // path records this_node and authorship only climbs, so
+                    // labelling peer here can never downgrade a local record.
                     mi->record_found_block(
                         height, block_hash, s->m_min_header.m_timestamp,
                         is_testnet ? "tLTC" : "LTC",
-                        miner_addr, share_hash.GetHex(), net_diff, share_diff, pool_hr, 0);
+                        miner_addr, share_hash.GetHex(), net_diff, share_diff, pool_hr, 0,
+                        core::MiningInterface::BlockAuthorship::sharechain_peer);
                     mi->schedule_block_verification(block_hash.GetHex());
                 });
             };

--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -392,6 +392,13 @@ void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
                     {
                         share.ACTION({
                             obj->m_hash = share_init_verify(*obj, true);
+                            // Carry the PoW result WITH the share: the
+                            // thread_local scratch set here (verify pool)
+                            // is invisible to the compute thread that runs
+                            // attempt_verify() later. Without this, peer
+                            // shares meeting the block target were never
+                            // reported (block-found + merged callbacks).
+                            obj->m_pow_hash = g_last_pow_hash;
                         });
                     }
                     catch (const std::exception&)

--- a/src/impl/bch/share_check.hpp
+++ b/src/impl/bch/share_check.hpp
@@ -491,6 +491,14 @@ inline thread_local uint256 g_last_pow_hash;  // SHA256d hash of the share heade
 template <typename ShareT>
 uint256 share_init_verify(const ShareT& share, bool check_pow = true)
 {
+    // Reset the per-thread scratch UNCONDITIONALLY so a check_pow=false call
+    // can never leave a STALE pow_hash/is_block from a previously verified
+    // share on this thread. Callers must treat a null g_last_pow_hash after
+    // this call as "PoW not computed here" and fall back to the value carried
+    // on the share (m_pow_hash) or the chain index.
+    g_last_init_is_block = false;
+    g_last_pow_hash = uint256();
+
     // --- Basic validation ---
     if (share.m_coinbase.size() < 2 || share.m_coinbase.size() > 100)
         throw std::invalid_argument("bad coinbase size");
@@ -3241,6 +3249,9 @@ uint256 create_local_share(
                 // Expected: most stratum pseudoshares don't meet share target
                 return uint256();
             }
+            // Carry the PoW result on the share itself (transient field) so
+            // attempt_verify() can run block/merged detection on any thread.
+            share.m_pow_hash = pow_hash;
             LOG_INFO << "[Pool] REAL SHARE CREATED! pow=" << pow_hash.GetHex().substr(0, 16)
                      << " target=" << target.GetHex().substr(0, 16)
                      << " diff=" << chain::target_to_difficulty(target);

--- a/src/impl/bch/share_tracker.hpp
+++ b/src/impl/bch/share_tracker.hpp
@@ -502,16 +502,33 @@ public:
         // Success — clear any previous fail count.
         m_verify_fail_count.erase(share_hash);
 
-        // Cache the SHA256d pow_hash on the index (restart block-scan reuse —
-        // avoids recomputing SHA256d). g_last_pow_hash is set by share_init_verify
-        // (share_check.hpp). BCH PoW is SHA256d (same family as btc).
-        if (!g_last_pow_hash.IsNull()) {
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->pow_hash = g_last_pow_hash;
-        }
+        // Resolve this share's PoW hash WITHOUT trusting thread_locals across
+        // threads. Priority:
+        //   1. m_pow_hash carried on the share — set during phase-1 reception
+        //      (verify pool) or local creation; survives thread hops;
+        //   2. g_last_pow_hash IF verify_share() above just recomputed PoW on
+        //      THIS thread (share_init_verify resets it on entry, so non-null
+        //      here always refers to THIS share);
+        //   3. idx->pow_hash cached from LevelDB metadata at startup load.
+        // The old code read only the thread_local: phase-1 PoW runs on
+        // verify-pool workers while attempt_verify runs on the compute thread,
+        // so peer shares that met the block target NEVER fired m_on_block_found
+        // (or the merged check) — peer-found blocks were invisible to the
+        // found-blocks store and the dashboard.
+        auto& share_var = chain.get_share(share_hash);
+        auto* idx = chain.get_index(share_hash);
+        uint256 pow_hash;
+        share_var.invoke([&](auto* s) { pow_hash = s->m_pow_hash; });
+        if (pow_hash.IsNull())
+            pow_hash = g_last_pow_hash;
+        if (pow_hash.IsNull() && idx)
+            pow_hash = idx->pow_hash;
+
+        // Cache pow_hash on the index (for restart block scan — avoids recomputing PoW)
+        if (idx && !pow_hash.IsNull())
+            idx->pow_hash = pow_hash;
 
         // Promote into the verified SubsetTracker.
-        auto& share_var = chain.get_share(share_hash);
         if (!verified.contains(share_hash))
             verified.add(share_var);
 
@@ -519,16 +536,22 @@ public:
         if (m_on_share_verified)
             m_on_share_verified(share_hash);
 
-        // Block detection: share_init_verify flags a block solution when the
-        // share's SHA256d pow meets the BCH parent block target. Mirrors p2pool
-        // tracker.verified.added watcher (node.py). BCH standalone-parent: NO
-        // merged DOGE-target leg here.
-        if (m_on_block_found && g_last_init_is_block) {
-            g_last_init_is_block = false;
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->is_block_solution = true;
-            m_on_block_found(share_hash);
+        // Block detection: derive from the share's PoW hash vs the BLOCK target
+        // (min_header.m_bits from GBT — far harder than the share target), not
+        // from a cross-thread flag. Matches p2pool's tracker.verified.added
+        // watcher (node.py:289) — detects blocks from ANY pool participant.
+        if (m_on_block_found && !pow_hash.IsNull()) {
+            bool is_block = false;
+            share_var.invoke([&](auto* s) {
+                uint256 block_target = chain::bits_to_target(s->m_min_header.m_bits);
+                is_block = !block_target.IsNull() && pow_hash <= block_target;
+            });
+            if (is_block) {
+                if (idx) idx->is_block_solution = true;
+                m_on_block_found(share_hash);
+            }
         }
+        // BCH standalone-parent: NO merged DOGE-target leg here.
 
         // Report share difficulty for the best-share dashboard tracking.
         if (m_on_share_difficulty) {

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -392,6 +392,13 @@ void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
                     {
                         share.ACTION({
                             obj->m_hash = share_init_verify(*obj, true);
+                            // Carry the PoW result WITH the share: the
+                            // thread_local scratch set here (verify pool)
+                            // is invisible to the compute thread that runs
+                            // attempt_verify() later. Without this, peer
+                            // shares meeting the block target were never
+                            // reported (block-found + merged callbacks).
+                            obj->m_pow_hash = g_last_pow_hash;
                         });
                     }
                     catch (const std::exception&)

--- a/src/impl/btc/share_check.hpp
+++ b/src/impl/btc/share_check.hpp
@@ -478,6 +478,14 @@ inline thread_local uint256 g_last_pow_hash;  // scrypt hash of the share header
 template <typename ShareT>
 uint256 share_init_verify(const ShareT& share, bool check_pow = true)
 {
+    // Reset the per-thread scratch UNCONDITIONALLY so a check_pow=false call
+    // can never leave a STALE pow_hash/is_block from a previously verified
+    // share on this thread. Callers must treat a null g_last_pow_hash after
+    // this call as "PoW not computed here" and fall back to the value carried
+    // on the share (m_pow_hash) or the chain index.
+    g_last_init_is_block = false;
+    g_last_pow_hash = uint256();
+
     // --- Basic validation ---
     if (share.m_coinbase.size() < 2 || share.m_coinbase.size() > 100)
         throw std::invalid_argument("bad coinbase size");
@@ -3199,6 +3207,9 @@ uint256 create_local_share(
                 // Expected: most stratum pseudoshares don't meet share target
                 return uint256();
             }
+            // Carry the PoW result on the share itself (transient field) so
+            // attempt_verify() can run block/merged detection on any thread.
+            share.m_pow_hash = pow_hash;
             LOG_INFO << "[Pool] REAL SHARE CREATED! pow=" << pow_hash.GetHex().substr(0, 16)
                      << " target=" << target.GetHex().substr(0, 16)
                      << " diff=" << chain::target_to_difficulty(target);

--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -516,14 +516,33 @@ public:
         // Success — clear any previous fail count
         m_verify_fail_count.erase(share_hash);
 
-        // Cache pow_hash on the index (for restart block scan — avoids recomputing scrypt)
-        if (!g_last_pow_hash.IsNull()) {
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->pow_hash = g_last_pow_hash;
-        }
+        // Resolve this share's PoW hash WITHOUT trusting thread_locals across
+        // threads. Priority:
+        //   1. m_pow_hash carried on the share — set during phase-1 reception
+        //      (verify pool) or local creation; survives thread hops;
+        //   2. g_last_pow_hash IF verify_share() above just recomputed PoW on
+        //      THIS thread (share_init_verify resets it on entry, so non-null
+        //      here always refers to THIS share);
+        //   3. idx->pow_hash cached from LevelDB metadata at startup load.
+        // The old code read only the thread_local: phase-1 PoW runs on
+        // verify-pool workers while attempt_verify runs on the compute thread,
+        // so peer shares that met the block target NEVER fired m_on_block_found
+        // (or the merged check) — peer-found blocks were invisible to the
+        // found-blocks store and the dashboard.
+        auto& share_var = chain.get_share(share_hash);
+        auto* idx = chain.get_index(share_hash);
+        uint256 pow_hash;
+        share_var.invoke([&](auto* s) { pow_hash = s->m_pow_hash; });
+        if (pow_hash.IsNull())
+            pow_hash = g_last_pow_hash;
+        if (pow_hash.IsNull() && idx)
+            pow_hash = idx->pow_hash;
+
+        // Cache pow_hash on the index (for restart block scan — avoids recomputing PoW)
+        if (idx && !pow_hash.IsNull())
+            idx->pow_hash = pow_hash;
 
         // Add to verified chain
-        auto& share_var = chain.get_share(share_hash);
         if (!verified.contains(share_hash))
             verified.add(share_var);
 
@@ -531,13 +550,20 @@ public:
         if (m_on_share_verified)
             m_on_share_verified(share_hash);
 
-        // Block detection: if share_init_verify flagged this share as a block solution,
-        // fire the callback. Matches p2pool's tracker.verified.added watcher (node.py:289).
-        if (m_on_block_found && g_last_init_is_block) {
-            g_last_init_is_block = false;
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->is_block_solution = true;
-            m_on_block_found(share_hash);
+        // Block detection: derive from the share's PoW hash vs the BLOCK target
+        // (min_header.m_bits from GBT — far harder than the share target), not
+        // from a cross-thread flag. Matches p2pool's tracker.verified.added
+        // watcher (node.py:289) — detects blocks from ANY pool participant.
+        if (m_on_block_found && !pow_hash.IsNull()) {
+            bool is_block = false;
+            share_var.invoke([&](auto* s) {
+                uint256 block_target = chain::bits_to_target(s->m_min_header.m_bits);
+                is_block = !block_target.IsNull() && pow_hash <= block_target;
+            });
+            if (is_block) {
+                if (idx) idx->is_block_solution = true;
+                m_on_block_found(share_hash);
+            }
         }
 
         // Report share difficulty for best-share dashboard tracking
@@ -557,9 +583,10 @@ public:
 
         // Merged block detection: check ALL verified shares against DOGE target.
         // A share can meet the DOGE target without meeting the LTC target
-        // (DOGE difficulty is much lower). The pow_hash was cached by share_init_verify.
-        if (m_on_merged_block_check && !g_last_pow_hash.IsNull()) {
-            m_on_merged_block_check(share_hash, g_last_pow_hash);
+        // (DOGE difficulty is much lower). Uses the resolved pow_hash above —
+        // NOT the thread_local, which is unset on the compute thread.
+        if (m_on_merged_block_check && !pow_hash.IsNull()) {
+            m_on_merged_block_check(share_hash, pow_hash);
         }
 
         // Naughty propagation: if parent is naughty, increment (up to 6 generations)

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -398,6 +398,13 @@ void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
                     {
                         share.ACTION({
                             obj->m_hash = share_init_verify(*obj, *m_tracker.m_params, true);
+                            // Carry the PoW result WITH the share: the
+                            // thread_local scratch set here (verify pool)
+                            // is invisible to the compute thread that runs
+                            // attempt_verify() later. Without this, peer
+                            // shares meeting the block target were never
+                            // reported (block-found + merged callbacks).
+                            obj->m_pow_hash = g_last_pow_hash;
                         });
                     }
                     catch (const std::exception&)

--- a/src/impl/dgb/share_check.hpp
+++ b/src/impl/dgb/share_check.hpp
@@ -498,6 +498,14 @@ inline thread_local uint256 g_last_pow_hash;  // scrypt hash of the share header
 template <typename ShareT>
 uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, bool check_pow = true)
 {
+    // Reset the per-thread scratch UNCONDITIONALLY so a check_pow=false call
+    // can never leave a STALE pow_hash/is_block from a previously verified
+    // share on this thread. Callers must treat a null g_last_pow_hash after
+    // this call as "PoW not computed here" and fall back to the value carried
+    // on the share (m_pow_hash) or the chain index.
+    g_last_init_is_block = false;
+    g_last_pow_hash = uint256();
+
     // --- Basic validation ---
     if (share.m_coinbase.size() < 2 || share.m_coinbase.size() > 100)
         throw std::invalid_argument("bad coinbase size");
@@ -2994,6 +3002,9 @@ uint256 create_local_share(
                 // Expected: most stratum pseudoshares don't meet share target
                 return uint256();
             }
+            // Carry the PoW result on the share itself (transient field) so
+            // attempt_verify() can run block/merged detection on any thread.
+            share.m_pow_hash = pow_hash;
             LOG_INFO << "[Pool] REAL SHARE CREATED! pow=" << pow_hash.GetHex().substr(0, 16)
                      << " target=" << target.GetHex().substr(0, 16)
                      << " diff=" << chain::target_to_difficulty(target);

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -520,14 +520,33 @@ public:
         // Success — clear any previous fail count
         m_verify_fail_count.erase(share_hash);
 
-        // Cache pow_hash on the index (for restart block scan — avoids recomputing scrypt)
-        if (!g_last_pow_hash.IsNull()) {
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->pow_hash = g_last_pow_hash;
-        }
+        // Resolve this share's PoW hash WITHOUT trusting thread_locals across
+        // threads. Priority:
+        //   1. m_pow_hash carried on the share — set during phase-1 reception
+        //      (verify pool) or local creation; survives thread hops;
+        //   2. g_last_pow_hash IF verify_share() above just recomputed PoW on
+        //      THIS thread (share_init_verify resets it on entry, so non-null
+        //      here always refers to THIS share);
+        //   3. idx->pow_hash cached from LevelDB metadata at startup load.
+        // The old code read only the thread_local: phase-1 PoW runs on
+        // verify-pool workers while attempt_verify runs on the compute thread,
+        // so peer shares that met the block target NEVER fired m_on_block_found
+        // (or the merged check) — peer-found blocks were invisible to the
+        // found-blocks store and the dashboard.
+        auto& share_var = chain.get_share(share_hash);
+        auto* idx = chain.get_index(share_hash);
+        uint256 pow_hash;
+        share_var.invoke([&](auto* s) { pow_hash = s->m_pow_hash; });
+        if (pow_hash.IsNull())
+            pow_hash = g_last_pow_hash;
+        if (pow_hash.IsNull() && idx)
+            pow_hash = idx->pow_hash;
+
+        // Cache pow_hash on the index (for restart block scan — avoids recomputing PoW)
+        if (idx && !pow_hash.IsNull())
+            idx->pow_hash = pow_hash;
 
         // Add to verified chain
-        auto& share_var = chain.get_share(share_hash);
         if (!verified.contains(share_hash))
             verified.add(share_var);
 
@@ -535,13 +554,20 @@ public:
         if (m_on_share_verified)
             m_on_share_verified(share_hash);
 
-        // Block detection: if share_init_verify flagged this share as a block solution,
-        // fire the callback. Matches p2pool's tracker.verified.added watcher (node.py:289).
-        if (m_on_block_found && g_last_init_is_block) {
-            g_last_init_is_block = false;
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->is_block_solution = true;
-            m_on_block_found(share_hash);
+        // Block detection: derive from the share's PoW hash vs the BLOCK target
+        // (min_header.m_bits from GBT — far harder than the share target), not
+        // from a cross-thread flag. Matches p2pool's tracker.verified.added
+        // watcher (node.py:289) — detects blocks from ANY pool participant.
+        if (m_on_block_found && !pow_hash.IsNull()) {
+            bool is_block = false;
+            share_var.invoke([&](auto* s) {
+                uint256 block_target = chain::bits_to_target(s->m_min_header.m_bits);
+                is_block = !block_target.IsNull() && pow_hash <= block_target;
+            });
+            if (is_block) {
+                if (idx) idx->is_block_solution = true;
+                m_on_block_found(share_hash);
+            }
         }
 
         // Report share difficulty for best-share dashboard tracking
@@ -559,9 +585,10 @@ public:
 
         // Merged block detection: check ALL verified shares against DOGE target.
         // A share can meet the DOGE target without meeting the LTC target
-        // (DOGE difficulty is much lower). The pow_hash was cached by share_init_verify.
-        if (m_on_merged_block_check && !g_last_pow_hash.IsNull()) {
-            m_on_merged_block_check(share_hash, g_last_pow_hash);
+        // (DOGE difficulty is much lower). Uses the resolved pow_hash above —
+        // NOT the thread_local, which is unset on the compute thread.
+        if (m_on_merged_block_check && !pow_hash.IsNull()) {
+            m_on_merged_block_check(share_hash, pow_hash);
         }
 
         // Naughty propagation: if parent is naughty, increment (up to 6 generations)

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -391,6 +391,13 @@ void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
                     {
                         share.ACTION({
                             obj->m_hash = share_init_verify(*obj, *m_tracker.m_params, true);
+                            // Carry the PoW result WITH the share: the
+                            // thread_local scratch set here (verify pool)
+                            // is invisible to the compute thread that runs
+                            // attempt_verify() later. Without this, peer
+                            // shares meeting the block target were never
+                            // reported (block-found + merged callbacks).
+                            obj->m_pow_hash = g_last_pow_hash;
                         });
                     }
                     catch (const std::exception&)

--- a/src/impl/ltc/share_check.hpp
+++ b/src/impl/ltc/share_check.hpp
@@ -477,6 +477,14 @@ inline thread_local uint256 g_last_pow_hash;  // scrypt hash of the share header
 template <typename ShareT>
 uint256 share_init_verify(const ShareT& share, const core::CoinParams& params, bool check_pow = true)
 {
+    // Reset the per-thread scratch UNCONDITIONALLY so a check_pow=false call
+    // can never leave a STALE pow_hash/is_block from a previously verified
+    // share on this thread. Callers must treat a null g_last_pow_hash after
+    // this call as "PoW not computed here" and fall back to the value carried
+    // on the share (m_pow_hash) or the chain index.
+    g_last_init_is_block = false;
+    g_last_pow_hash = uint256();
+
     // --- Basic validation ---
     if (share.m_coinbase.size() < 2 || share.m_coinbase.size() > 100)
         throw std::invalid_argument("bad coinbase size");
@@ -2533,6 +2541,9 @@ uint256 create_local_share_v35(
             if (pow_hash > target) {
                 return uint256();  // didn't meet share target
             }
+            // Carry the PoW result on the share itself (transient field) so
+            // attempt_verify() can run block/merged detection on any thread.
+            share.m_pow_hash = pow_hash;
             LOG_INFO << "[Pool] V35 SHARE CREATED! pow=" << pow_hash.GetHex().substr(0, 16)
                      << " target=" << target.GetHex().substr(0, 16)
                      << " diff=" << chain::target_to_difficulty(target);
@@ -3184,6 +3195,9 @@ uint256 create_local_share(
                 // Expected: most stratum pseudoshares don't meet share target
                 return uint256();
             }
+            // Carry the PoW result on the share itself (transient field) so
+            // attempt_verify() can run block/merged detection on any thread.
+            share.m_pow_hash = pow_hash;
             LOG_INFO << "[Pool] REAL SHARE CREATED! pow=" << pow_hash.GetHex().substr(0, 16)
                      << " target=" << target.GetHex().substr(0, 16)
                      << " diff=" << chain::target_to_difficulty(target);

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -552,14 +552,33 @@ public:
         // Success — clear any previous fail count
         m_verify_fail_count.erase(share_hash);
 
+        // Resolve this share's PoW hash WITHOUT trusting thread_locals across
+        // threads. Priority:
+        //   1. m_pow_hash carried on the share — set during phase-1 reception
+        //      (verify pool) or local creation; survives thread hops;
+        //   2. g_last_pow_hash IF verify_share() above just recomputed PoW on
+        //      THIS thread (share_init_verify resets it on entry, so non-null
+        //      here always refers to THIS share);
+        //   3. idx->pow_hash cached from LevelDB metadata at startup load.
+        // The old code read only the thread_local: phase-1 scrypt runs on
+        // verify-pool workers while attempt_verify runs on the compute thread,
+        // so peer shares that met the block target NEVER fired m_on_block_found
+        // or m_on_merged_block_check — peer-found blocks (parent LTC and merged
+        // DOGE) were invisible to the found-blocks store and the dashboard.
+        auto& share_var = chain.get_share(share_hash);
+        auto* idx = chain.get_index(share_hash);
+        uint256 pow_hash;
+        share_var.invoke([&](auto* s) { pow_hash = s->m_pow_hash; });
+        if (pow_hash.IsNull())
+            pow_hash = g_last_pow_hash;
+        if (pow_hash.IsNull() && idx)
+            pow_hash = idx->pow_hash;
+
         // Cache pow_hash on the index (for restart block scan — avoids recomputing scrypt)
-        if (!g_last_pow_hash.IsNull()) {
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->pow_hash = g_last_pow_hash;
-        }
+        if (idx && !pow_hash.IsNull())
+            idx->pow_hash = pow_hash;
 
         // Add to verified chain
-        auto& share_var = chain.get_share(share_hash);
         if (!verified.contains(share_hash))
             verified.add(share_var);
 
@@ -567,13 +586,20 @@ public:
         if (m_on_share_verified)
             m_on_share_verified(share_hash);
 
-        // Block detection: if share_init_verify flagged this share as a block solution,
-        // fire the callback. Matches p2pool's tracker.verified.added watcher (node.py:289).
-        if (m_on_block_found && g_last_init_is_block) {
-            g_last_init_is_block = false;
-            auto* idx = chain.get_index(share_hash);
-            if (idx) idx->is_block_solution = true;
-            m_on_block_found(share_hash);
+        // Block detection: derive from the share's PoW hash vs the BLOCK target
+        // (min_header.m_bits from GBT — far harder than the share target), not
+        // from a cross-thread flag. Matches p2pool's tracker.verified.added
+        // watcher (node.py:289) — detects blocks from ANY pool participant.
+        if (m_on_block_found && !pow_hash.IsNull()) {
+            bool is_block = false;
+            share_var.invoke([&](auto* s) {
+                uint256 block_target = chain::bits_to_target(s->m_min_header.m_bits);
+                is_block = !block_target.IsNull() && pow_hash <= block_target;
+            });
+            if (is_block) {
+                if (idx) idx->is_block_solution = true;
+                m_on_block_found(share_hash);
+            }
         }
 
         // Report share difficulty for best-share dashboard tracking
@@ -591,9 +617,10 @@ public:
 
         // Merged block detection: check ALL verified shares against DOGE target.
         // A share can meet the DOGE target without meeting the LTC target
-        // (DOGE difficulty is much lower). The pow_hash was cached by share_init_verify.
-        if (m_on_merged_block_check && !g_last_pow_hash.IsNull()) {
-            m_on_merged_block_check(share_hash, g_last_pow_hash);
+        // (DOGE difficulty is much lower). Uses the resolved pow_hash above —
+        // NOT the thread_local, which is unset on the compute thread.
+        if (m_on_merged_block_check && !pow_hash.IsNull()) {
+            m_on_merged_block_check(share_hash, pow_hash);
         }
 
         // Naughty propagation: if parent is naughty, increment (up to 6 generations)

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -18,7 +18,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # measurement that justifies it, and that an all-pass window logs no blocked
     # line and actually activates. Same folding rule: into the existing
     # allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/peer_block_pow_carry_test.cpp
+++ b/src/impl/ltc/test/peer_block_pow_carry_test.cpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// PEER-BLOCK-POW-CARRY — source-structural guard pinning that the PoW result
+// travels WITH the share across threads, so peer-found blocks are reported.
+//
+// THE DEFECT THIS PINS (ltc.voidbind.com, 2026-08-27):
+//   Share reception is two-phase: phase 1 runs share_init_verify() (the
+//   expensive PoW hash) on m_verify_pool WORKER threads; attempt_verify()
+//   runs later on the COMPUTE thread and calls share_init_verify() with
+//   check_pow=false (the hash is already set). The block-found signal lived
+//   only in thread_local scratch (g_last_init_is_block / g_last_pow_hash) set
+//   on the worker thread — invisible to the compute thread. Result: a peer
+//   share that met the parent block target logged "[BLOCK] Peer share meets
+//   block target" in phase 1 and then fired NOTHING: no m_on_block_found, no
+//   m_on_merged_block_check, no record_found_block. Every peer-found block —
+//   parent chain AND merged/aux (DOGE) — was invisible to /recent_blocks,
+//   /recent_merged_blocks and the dashboard. Live repro: p2p-spb's share
+//   521906df2ba641bf (2026-08-27 13:57:26 CEST) carried an accepted DOGE
+//   block (height 6349371, 2f3e4d8aa870c238) and met the LTC block target;
+//   the node surfaced neither.
+//
+//   A second, latent defect rode along: attempt_verify cached the stale
+//   thread_local into idx->pow_hash ("if (!g_last_pow_hash.IsNull())
+//   idx->pow_hash = g_last_pow_hash;") — on any thread that had previously
+//   computed a DIFFERENT share's PoW, the WRONG pow hash could be cached and
+//   fed to the merged-target comparison.
+//
+// THE FIX SHAPE THIS ASSERTS (per lane btc/ltc/dgb/bch):
+//   1. phase 1 (node.cpp) copies the freshly computed PoW onto the share:
+//      "obj->m_pow_hash = g_last_pow_hash;" — same thread, same call.
+//   2. share_init_verify() (share_check.hpp) resets the thread_local scratch
+//      UNCONDITIONALLY at entry, so a check_pow=false call can never leave a
+//      stale value observable.
+//   3. attempt_verify() (share_tracker.hpp) reads the share-carried
+//      m_pow_hash (with same-thread g_last_pow_hash and idx->pow_hash as
+//      fallbacks) and derives is-block from "pow_hash <= block_target" — it
+//      must NOT consume the cross-thread g_last_init_is_block flag.
+//
+// WHY A STRUCTURAL TEST: a runtime repro needs a full CHAIN_LENGTH verified
+// PPLNS chain (attempt_verify's GENTX gate) plus a two-thread pipeline — the
+// same situation as the #1131 owns_data guard in this directory. Asserting
+// the shipped source's shape over comment-stripped text is the deterministic
+// red/green this invariant admits: restore the thread_local consumption in
+// attempt_verify -> RED; drop the phase-1 carry -> RED.
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifndef C2POOL_IMPL_DIR
+#error "C2POOL_IMPL_DIR must be defined by CMake to the path of src/impl"
+#endif
+
+namespace {
+
+std::string read_text(const std::string& path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets and line breaks.
+// The fix's own doc comments deliberately quote the pre-fix thread_local
+// consumption, so the assertions below MUST run over comment-free code.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine; out[i] = ' '; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; }
+            else if (c == '"') st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i;
+            else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i;
+            else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+struct Lane {
+    const char* name;
+    bool has_merged_check;  // bch is standalone-parent: no merged leg
+};
+
+const std::vector<Lane> kLanes = {
+    {"btc", true}, {"ltc", true}, {"dgb", true}, {"bch", false},
+};
+
+std::string lane_file(const Lane& l, const char* fname)
+{
+    return std::string(C2POOL_IMPL_DIR) + "/" + l.name + "/" + fname;
+}
+
+} // namespace
+
+// (1) attempt_verify must not consume the cross-thread flag, and must derive
+//     the block verdict from the share-carried PoW hash vs the block target.
+TEST(PeerBlockPowCarry, TrackerDerivesBlockFromCarriedPow)
+{
+    for (const auto& l : kLanes) {
+        SCOPED_TRACE(l.name);
+        const std::string code =
+            strip_comments(read_text(lane_file(l, "share_tracker.hpp")));
+
+        // The cross-thread flag must be GONE from the tracker entirely.
+        EXPECT_EQ(code.find("g_last_init_is_block"), std::string::npos)
+            << l.name << ": attempt_verify consumes the thread_local block "
+            "flag again — peer-found blocks will vanish (set on a verify-pool "
+            "worker, read on the compute thread).";
+
+        // Share-carried PoW is the primary source...
+        EXPECT_NE(code.find("pow_hash = s->m_pow_hash"), std::string::npos)
+            << l.name << ": attempt_verify no longer reads the PoW hash "
+            "carried on the share (m_pow_hash).";
+
+        // ...and the block verdict is derived from it against the block target.
+        EXPECT_NE(code.find("pow_hash <= block_target"), std::string::npos)
+            << l.name << ": attempt_verify no longer derives the block verdict "
+            "from the carried pow vs min_header block target.";
+
+        if (l.has_merged_check) {
+            // The merged (aux/DOGE) leg must feed the RESOLVED pow, not the
+            // thread_local.
+            EXPECT_NE(code.find("m_on_merged_block_check(share_hash, pow_hash)"),
+                      std::string::npos)
+                << l.name << ": merged block check no longer receives the "
+                "resolved per-share pow_hash.";
+            EXPECT_EQ(code.find("m_on_merged_block_check(share_hash, g_last_pow_hash)"),
+                      std::string::npos)
+                << l.name << ": merged block check reads the thread_local "
+                "again — peer-found merged blocks will vanish.";
+        }
+    }
+}
+
+// (2) phase-1 reception must copy the PoW result onto the share on the SAME
+//     thread that computed it.
+TEST(PeerBlockPowCarry, Phase1CarriesPowOntoShare)
+{
+    for (const auto& l : kLanes) {
+        SCOPED_TRACE(l.name);
+        const std::string code =
+            strip_comments(read_text(lane_file(l, "node.cpp")));
+        EXPECT_NE(code.find("obj->m_pow_hash = g_last_pow_hash"), std::string::npos)
+            << l.name << ": phase-1 reception no longer copies the computed "
+            "PoW onto the share — attempt_verify on the compute thread will "
+            "see a null pow and drop peer-found blocks.";
+    }
+}
+
+// (3) share_init_verify must reset the thread_local scratch unconditionally
+//     at entry (before any validation/early-out), so a check_pow=false call
+//     can never leave a STALE pow/flag from a previous share on that thread.
+TEST(PeerBlockPowCarry, InitVerifyResetsScratchUnconditionally)
+{
+    for (const auto& l : kLanes) {
+        SCOPED_TRACE(l.name);
+        const std::string code =
+            strip_comments(read_text(lane_file(l, "share_check.hpp")));
+
+        const size_t fn = code.find("uint256 share_init_verify(");
+        ASSERT_NE(fn, std::string::npos) << l.name;
+        // First early-out of the function body: the coinbase size check.
+        const size_t first_check = code.find("bad coinbase size", fn);
+        ASSERT_NE(first_check, std::string::npos) << l.name;
+
+        const size_t flag_reset = code.find("g_last_init_is_block = false", fn);
+        const size_t pow_reset  = code.find("g_last_pow_hash = uint256()", fn);
+        EXPECT_TRUE(flag_reset != std::string::npos && flag_reset < first_check)
+            << l.name << ": share_init_verify no longer resets "
+            "g_last_init_is_block at entry — stale per-thread state can leak.";
+        EXPECT_TRUE(pow_reset != std::string::npos && pow_reset < first_check)
+            << l.name << ": share_init_verify no longer resets "
+            "g_last_pow_hash at entry — a stale pow can be cached onto the "
+            "WRONG share's index and fed to the merged-target comparison.";
+    }
+}

--- a/src/sharechain/share.hpp
+++ b/src/sharechain/share.hpp
@@ -32,6 +32,18 @@ struct BaseShare
     hash_t m_hash{};
     hash_t m_prev_hash{};
 
+    // Transient (NEVER serialized): PoW hash computed by share_init_verify()
+    // when the share was received (phase 1 on the verify pool) or created
+    // locally. Carries the PoW result WITH the share across threads —
+    // the thread_local scratch (g_last_pow_hash / g_last_init_is_block) set
+    // on a verify-pool worker is invisible to the compute thread that later
+    // runs attempt_verify() with check_pow=false, which silently dropped
+    // every peer-found block (parent-chain AND merged/aux) from the
+    // found-blocks store. Null when PoW has not been computed for this
+    // in-memory instance (e.g. shares loaded from LevelDB with a cached
+    // index pow_hash).
+    hash_t m_pow_hash{};
+
     constexpr static bool check_version(int threshold_version)
     {
         return version >= threshold_version;


### PR DESCRIPTION
## Live defect (ltc.voidbind.com, 2026-08-27)

Operator report: p2p-spb found a valid DOGE block; neither the DOGE block nor the LTC-side block appeared on ltc.voidbind.com.

Verified on the live node (contabo, merged LTC+DOGE v36):

- 13:57:26 CEST the node received peer share `521906df2ba641bf` and logged `[BLOCK] Peer share meets block target` -- a real LTC-target hit.
- That share carried an ACCEPTED merged DOGE block: height 6349371, hash `2f3e4d8aa870c238...`, coinbase tag `/P2Pool v36/`, is_aux=true, 10,001.7 DOGE reward (confirmed on the DOGE chain via blockchair).
- The LTC counterpart `521906df...` is NOT in the canonical LTC chain (litecoinspace: not found) -- genuinely orphaned/lost at the source node, not a c2pool defect.
- Neither `GOT BLOCK FROM PEER!` nor `*** MERGED BLOCK FROM PEER!` ever fired; `/recent_blocks` held only 2 stale relay rows (found_by=unknown) and `/recent_merged_blocks` had nothing newer than Aug-12.

## Root cause

Share reception is two-phase: phase 1 runs `share_init_verify()` (expensive PoW) on `m_verify_pool` WORKER threads; `attempt_verify()` runs later on the COMPUTE thread and calls `share_init_verify()` with `check_pow=false` (the hash is already set). The block verdict and pow hash lived only in thread_local scratch (`g_last_init_is_block` / `g_last_pow_hash`) set on the worker thread -- invisible to the compute thread. So for EVERY peer share:

- `m_on_block_found` never fired (flag false on the compute thread) -> no `record_found_block`, no `schedule_block_verification`;
- `m_on_merged_block_check` was gated on a null/stale pow -> peer-found merged (DOGE) blocks never detected;
- latent corruption: a STALE `g_last_pow_hash` from an unrelated share could be cached as `idx->pow_hash` for the wrong share.

Dash is unaffected (X11 identity hash is recomputed in-thread on every verify). DOGE has no own tracker (aux leg of LTC).

## Fix (coin-generic)

- `chain::BaseShare` gains transient `m_pow_hash` (never serialized). Phase-1 reception and local share creation store the freshly computed PoW on the share -- same thread, same call.
- `share_init_verify()` resets the thread_local scratch unconditionally at entry so `check_pow=false` calls can never expose stale values.
- `attempt_verify()` resolves the pow (share-carried -> same-thread recompute -> index cache) and derives the verdict from `pow <= min_header block target`; the merged check receives the resolved pow. No cross-thread thread_local reads remain in the trackers.
- The LTC peer-found record now labels authorship `sharechain_peer` (climb-only; cannot downgrade a local `this_node` record).

## Verification

- Structural KAT `peer_block_pow_carry_test` (folded into the ltc `share_test` target) pins all three legs across btc/ltc/dgb/bch; restoring the thread_local consumption or dropping the phase-1 carry goes red.
- ltc `share_test`: 97/97 pass. `btc_share_test`: 199/199 pass.
- `c2pool` (LTC lane), btc/dgb libs and `c2pool-bch` all build clean (gcc13 CI profile).
- Reward-path untouched: no consensus, PPLNS, or share-validation semantics change; the only behavioral change is that the already-wired found-block reporting callbacks now actually receive the events they were written for.

Source-side context: the finder node (p2p-spb) was intermittently peerless and had lost daemon contact around the find window, which explains the LTC orphan and delayed propagation. That does not diminish this defect -- the share DID reach this node, met the block target in its logs, and was still not surfaced.