### PR TITLE
dash(coinbase): stop burning the 2% finder fee on ownerless work (#960)

### DIFF
--- a/src/impl/dash/coinbase_builder.hpp
+++ b/src/impl/dash/coinbase_builder.hpp
@@ -140,8 +140,35 @@ inline std::vector<MinerPayout> compute_dash_payouts(
     }
 
     // 4. (pre-v36 only) 2% block-finder fee to the share creator.
+    //
+    // ZERO-PKH GUARD (#960, money path). A zero miner_pubkey_hash is not a
+    // miner -- it is the sentinel every caller of this function already uses
+    // to mean "this coinbase has no finder":
+    //   * work_source.cpp build_connection_coinbase, ownerless stratum
+    //     session whose login carried no P2PKH script -- its own comment
+    //     reads "No usable miner script: all-to-donation";
+    //   * main_dash.cpp --mine-block with no --payout-pubkey-hash
+    //     ("uint160 payout_pkh;   // default all-zero");
+    //   * main_dash.cpp embedded-oracle proposal coinbase
+    //     ("uint160 zero_pkh;   // pool-only coinbase (no finder)");
+    //   * main_dash.cpp --regtest-force-won-block
+    //     ("uint160 payout_pkh;   // all-zero placeholder finder").
+    // Paying the slice anyway emitted P2PKH(0x0000...0000) -- an output no
+    // key can ever spend. The 2% was BURNED, not credited: strictly worse
+    // than p2pool-dash, which credits ownerless work to the node operator
+    // and destroys nothing. Suppressing the output lets step 5 sweep the
+    // slice into the donation tail, which is exactly what all four call
+    // sites above already claim to do.
+    //
+    // NOT consensus-visible. Every path that MINTS or VERIFIES a share
+    // derives the finder script from the share's own m_pubkey_hash through
+    // share_producer.hpp build_gentx / share_check.hpp, never through this
+    // function; and the mint fail-closes on a non-P2PKH payout script
+    // (share_producer_bind.hpp pubkey_hash_from_p2pkh returns nullopt), so a
+    // minted share cannot carry a zero pubkey hash in the first place.
+    // compute_dash_payouts only shapes coinbases that no share commits to.
     auto this_script = dash::pubkey_hash_to_script2(miner_pubkey_hash);
-    if (!v36)
+    if (!v36 && !miner_pubkey_hash.IsNull())
         amounts[this_script] = amounts[this_script] + (worker_payout / 50);
 
     // 5. amounts[DONATION] += worker_payout - Σamounts  (remainder incl. rounding).

--- a/src/impl/dash/dashboard_pplns.hpp
+++ b/src/impl/dash/dashboard_pplns.hpp
@@ -39,7 +39,12 @@
 // Finder fee: compute_dash_payouts credits the pre-v36 2% block-finder fee to
 // the caller-supplied pubkey hash. A pool-wide "current payouts" view has no
 // finder (the next block's winner is unknown), so it is computed with a ZERO
-// pubkey hash and that one output is then dropped. This matches LTC exactly —
+// pubkey hash and the 2% slice is then held OUT of the rendered split. Since
+// #1369 a zero pubkey hash emits no finder output at all (it used to emit an
+// unspendable P2PKH(0x00..00) burn); the allocator sweeps the slice into the
+// donation tail instead, so pplns_payouts_at subtracts it back out of the
+// donation before rendering (see the guard at the render loop). Either way the
+// pool-wide view sums to ~98% of the worker payout. This matches LTC exactly —
 // share_tracker.hpp:2058 documents get_v35_expected_payouts as "amounts WITHOUT
 // finder fee — caller adds subsidy/200", and main_ltc.cpp's pplns_fn returns it
 // unmodified for the pre-v36 arm. The per-share view has a real finder (the
@@ -194,6 +199,32 @@ inline PplnsView pplns_payouts_at(
         else
             view.payouts[addr] = amt;
     };
+
+    // #1369 follow-up (money-path DISPLAY parity). Before #1369 an ownerless
+    // coinbase (zero finder pubkey hash) still emitted a P2PKH(0x00..00) burn
+    // output carrying the pre-v36 2% block-finder slice, and this pool-wide
+    // view dropped exactly that zero-pkh output (the `add` lambda's
+    // finder_script match), so it summed to ~98% of worker_payout — the LTC
+    // contract in the header note (finder fee omitted; the next block's winner
+    // is unknown). #1369 stopped the burn: compute_dash_payouts now emits NO
+    // zero-pkh output and step 5's remainder sweeps the slice into the donation
+    // tail instead, so there is nothing left for the drop to match and the view
+    // sums to the full 100%. Subtract the swept slice back out of the donation
+    // here so the rendered pool-wide split is byte-for-byte the pre-#1369
+    // number. This fires ONLY on the zero-finder pool-wide arm; the per-share
+    // view (real, non-null finder — drop_finder_output=false) and the v36 arm
+    // (no finder fee at all) are untouched. Display only: no mint/serve/coinbase
+    // path reads this view.
+    if (drop_finder_output && finder_pubkey_hash.IsNull()
+        && !core::version_gate::is_v36_active(params.current_share_version)
+        && !outs.empty()) {
+        const uint64_t finder_slice = view.worker_payout / 50;  // == coinbase_builder step 4
+        dash::coinbase::MinerPayout& donation = outs.back();
+        const std::vector<unsigned char> donation_script(
+            dash::DONATION_SCRIPT.begin(), dash::DONATION_SCRIPT.end());
+        if (donation.script == donation_script && donation.amount >= finder_slice)
+            donation.amount -= finder_slice;
+    }
 
     for (size_t i = 0; i < n_workers; ++i)
         add(outs[i]);

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -2273,15 +2273,32 @@ core::stratum::CoinbaseResult DASHWorkSource::build_connection_coinbase(
         uint160 finder_pkh;   // zero unless the payout script is P2PKH
         const bool have_pkh = p2pkh_pubkey_hash(payout_script, finder_pkh);
 
+        // OWNERLESS SESSION ALARM (#960). The old warning sat inside the
+        // genesis branch below, so a pool with a WARM sharechain served an
+        // ownerless miner in complete silence -- and that is precisely the
+        // case where money moved: the PPLNS window paid normally while the
+        // 2% block-finder slice went to a zero pubkey hash. Warn on BOTH
+        // arms, rate-limited the way the producer-degrade line above is, so
+        // the operator sees the misconfiguration BEFORE a block is found
+        // rather than after. Log-only: it changes no output.
+        if (!have_pkh) {
+            static int ownerless_log = 0;
+            if (ownerless_log++ % 50 == 0)
+                LOG_WARNING << "[DASH-STRATUM] OWNERLESS session: payout script is "
+                            << (payout_script.empty()
+                                    ? std::string("EMPTY")
+                                    : (std::to_string(payout_script.size())
+                                       + "B non-P2PKH"))
+                            << " -- no finder output is emitted, the whole worker "
+                               "payout routes to the donation tail, and this job "
+                               "mints NO sharechain credit (authorize with a "
+                               "P2PKH DASH address as the stratum username)";
+        }
+
         if (weights.empty() || total_weight == 0) {
             if (have_pkh) {
                 weights[payout_script] = 1;
                 total_weight = 1;
-            } else if (!payout_script.empty()) {
-                LOG_WARNING << "[DASH-STRATUM] payout script is not P2PKH ("
-                            << payout_script.size() << "B) -- genesis coinbase "
-                               "routes worker payout to the donation tail "
-                               "(authorize with a P2PKH DASH address)";
             }
             // No usable miner script: all-to-donation (still a valid block).
         }

--- a/test/test_dash_coinbase_parity.cpp
+++ b/test/test_dash_coinbase_parity.cpp
@@ -537,3 +537,132 @@ TEST(DashCoinbaseMarker, MintAndBlockCoinbaseScriptSigsAgree) {
         EXPECT_EQ(hex(block_sig), hex(mint_sig)) << "testnet=" << testnet;
     }
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// (20) #960 ZERO-PKH GUARD — the ownerless finder slice must not be burned.
+//
+// REPRODUCER (pre-fix, on master): an ownerless stratum session — one whose
+// login carried no P2PKH script, so work_source.cpp build_connection_coinbase
+// leaves finder_pkh zero and comments "No usable miner script: all-to-donation"
+// — still reached step 4 of compute_dash_payouts, which unconditionally did
+//
+//     amounts[pubkey_hash_to_script2(0x0000…0000)] += worker_payout / 50
+//
+// emitting a 25-byte P2PKH output over an all-zero hash160. No key hashes to
+// zero, so the 2% block-finder fee was DESTROYED. p2pool-dash credits the same
+// work to the node operator's own pubkey hash and destroys nothing; burning is
+// strictly worse than either crediting or donating.
+//
+// The guard suppresses the finder output when the pubkey hash is null, so the
+// slice falls to the step-5 donation remainder — the "all-to-donation" outcome
+// the serving code already documents. Pinned on BOTH sharechain arms, because
+// the burn happened on both: cold (no PPLNS window) and warm (window pays
+// normally, only the finder slice burns).
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+
+// The unspendable script the pre-fix code emitted for a zero finder hash.
+std::vector<unsigned char> burn_script() {
+    return dash::pubkey_hash_to_script2(uint160());
+}
+
+bool has_script(const std::vector<dash::coinbase::MinerPayout>& outs,
+                const std::vector<unsigned char>& s) {
+    for (const auto& o : outs)
+        if (o.script == s) return true;
+    return false;
+}
+
+uint64_t amount_of(const std::vector<dash::coinbase::MinerPayout>& outs,
+                   const std::vector<unsigned char>& s) {
+    uint64_t total = 0;
+    for (const auto& o : outs)
+        if (o.script == s) total += o.amount;
+    return total;
+}
+
+}  // namespace
+
+// (20a) COLD sharechain (empty weights): every satoshi goes to the donation
+//       tail; no burn output at all.
+TEST(DashCoinbaseZeroFinderGuard, ColdChainOwnerlessWorkPaysDonationNotBurn) {
+    auto params = dash::make_coin_params(true);
+    ASSERT_LT(params.current_share_version, 36u)
+        << "this KAT pins the PRE-v36 arm, the one DASH actually runs";
+
+    const uint64_t subsidy = 5000000000ull;   // 50 DASH, no GBT payments
+    uint160 zero_finder;                      // ownerless: no P2PKH login script
+    ASSERT_TRUE(zero_finder.IsNull());
+
+    auto outs = dash::coinbase::compute_dash_payouts(
+        subsidy, /*payments=*/{}, zero_finder,
+        /*weights=*/{}, /*total_weight=*/0, params);
+
+    // The burn output is GONE (pre-fix it held subsidy/50 = 100000000 sat).
+    EXPECT_FALSE(has_script(outs, burn_script()))
+        << "finder slice emitted to P2PKH(0x00..00) — unspendable burn";
+
+    // Only the always-emitted donation line survives, holding the whole
+    // worker payout including the slice that used to burn.
+    ASSERT_EQ(outs.size(), 1u);
+    EXPECT_EQ(outs[0].script, dash::DONATION_SCRIPT);
+    EXPECT_EQ(outs[0].amount, subsidy);
+
+    uint64_t sum = 0; for (const auto& o : outs) sum += o.amount;
+    EXPECT_EQ(sum, subsidy) << "worker_payout conservation (data.py invariant)";
+}
+
+// (20b) WARM sharechain: the PPLNS window still pays its miners exactly as
+//       before; only the finder slice moves from the burn script to donation.
+TEST(DashCoinbaseZeroFinderGuard, WarmChainOwnerlessFinderSliceFallsToDonation) {
+    auto params = dash::make_coin_params(true);
+
+    std::vector<unsigned char> hA(20, 0x11);
+    const auto scriptA = dash::pubkey_hash_to_script2(uint160(hA));
+    std::map<std::vector<unsigned char>, uint64_t> weights;
+    weights[scriptA] = 100;
+
+    const uint64_t subsidy = 5000000000ull;
+    uint160 zero_finder;
+
+    auto outs = dash::coinbase::compute_dash_payouts(
+        subsidy, /*payments=*/{}, zero_finder, weights,
+        /*total_weight=*/100, params);
+
+    EXPECT_FALSE(has_script(outs, burn_script()));
+
+    // The window miner is UNTOUCHED by the guard: pre-v36 pays 49/50 of the
+    // worker payout across the weight set.
+    EXPECT_EQ(amount_of(outs, scriptA), subsidy / 50 * 49);
+
+    // The 2% the pre-fix code burned now sits in the donation tail.
+    EXPECT_EQ(amount_of(outs, dash::DONATION_SCRIPT), subsidy - subsidy / 50 * 49);
+    EXPECT_GE(amount_of(outs, dash::DONATION_SCRIPT), subsidy / 50);
+
+    uint64_t sum = 0; for (const auto& o : outs) sum += o.amount;
+    EXPECT_EQ(sum, subsidy);
+}
+
+// (20c) NON-REGRESSION: a real (non-zero) finder hash still collects the
+//       pre-v36 2%. The guard must fire on the zero sentinel ONLY — this is
+//       the case that carries every ordinary owned session's money.
+TEST(DashCoinbaseZeroFinderGuard, RealFinderStillCollectsTwoPercent) {
+    auto params = dash::make_coin_params(true);
+
+    std::vector<unsigned char> finder_h(20, 0x07);
+    const uint160 finder(finder_h);
+    ASSERT_FALSE(finder.IsNull());
+    const auto finder_script = dash::pubkey_hash_to_script2(finder);
+
+    const uint64_t subsidy = 5000000000ull;
+    auto outs = dash::coinbase::compute_dash_payouts(
+        subsidy, /*payments=*/{}, finder,
+        /*weights=*/{}, /*total_weight=*/0, params);
+
+    ASSERT_EQ(outs.size(), 2u);                       // finder + donation
+    EXPECT_EQ(outs[0].script, finder_script);
+    EXPECT_EQ(outs[0].amount, subsidy / 50);          // the 2% block-finder fee
+    EXPECT_EQ(outs[1].script, dash::DONATION_SCRIPT);
+    EXPECT_EQ(outs[1].amount, subsidy - subsidy / 50);
+}


### PR DESCRIPTION
Fixes the burn half of #960 (*"ownerless stratum work burns the 2% finder fee to P2PKH(0x00..00)"*).

## Reproducer

An **ownerless** stratum session — one whose login carried no P2PKH DASH address, so `DASHWorkSource::build_connection_coinbase` (`src/impl/dash/stratum/work_source.cpp`, the per-connection stratum coinbase builder) leaves its finder pubkey hash zero — still reached step 4 of `dash::coinbase::compute_dash_payouts` (`src/impl/dash/coinbase_builder.hpp`, the C++ port of p2pool-dash's `generate_transaction`). On the pre-v36 arm DASH actually mines (`src/impl/dash/params.hpp` pins `current_share_version = 16`) that step ran unconditionally:

```cpp
auto this_script = dash::pubkey_hash_to_script2(miner_pubkey_hash);
if (!v36)
    amounts[this_script] = amounts[this_script] + (worker_payout / 50);
```

With `miner_pubkey_hash == 0` this emits a 25-byte P2PKH output over an all-zero hash160. No key hashes to zero, so the 2% block-finder fee was **destroyed**, not paid.

Everything the issue says about the surrounding behaviour reproduces on current `master` (`100a9c1`, *"Carry share PoW across threads so peer-found blocks surface on the dashboard"*): the block is still submitted and accepted, the existing PPLNS window is still paid in full, and only the finder slice burns. On an empty sharechain the outcome was ~2% burned / ~98% donated. That is strictly worse than the p2pool-dash oracle (`p2pool/work.py` `get_user_details`), which credits ownerless work to the node operator's own pubkey hash and destroys nothing.

## Remedy, and why it mirrors the existing pattern

**Emit no finder output when the pubkey hash is null**, letting step 5's donation remainder sweep the slice into the donation tail.

This invents no policy — it is what every call site that passes a zero hash *already documents*, and every one of them was in fact emitting a burn:

| call site | its own comment |
|---|---|
| `work_source.cpp` `build_connection_coinbase` (ownerless stratum serve) | `// No usable miner script: all-to-donation (still a valid block).` |
| `main_dash.cpp` `--mine-block` (standalone block producer) | `uint160 payout_pkh;   // default all-zero` |
| `main_dash.cpp` `--regtest-force-won-block` (E5 relay seam) | `uint160 payout_pkh;   // all-zero placeholder finder` |
| `main_dash.cpp` embedded-oracle proposal coinbase | `uint160 zero_pkh;   // pool-only coinbase (no finder)` |

The zero hash is already the codebase's sentinel for *"this coinbase has no finder"*; the guard makes the payout math agree with it. It also matches the neighbouring convention for an unusable payout target elsewhere in the DASH/DGB code — `dash::pplns::compute_payouts` (`src/impl/dash/pplns.hpp`) returns an empty result rather than paying an empty `fallback_script`, and the DGB fee arm's fallback-script closure is a no-op when no operator identity is set.

## Not consensus-visible — no version gate needed

The issue flags a **CONSENSUS GATE** on its own proposed remedy. It does not bind this one, and the reason is structural rather than a judgement call:

* Every path that **mints** or **verifies** a share derives the finder script from the *share's own* `m_pubkey_hash`, through `dash::producer::build_gentx` (`src/impl/dash/share_producer.hpp`, the mint-side gentx serializer) or the verifier rebuild in `src/impl/dash/share_check.hpp` — never through `compute_dash_payouts`. Neither is touched here.
* The mint **fail-closes** on a non-P2PKH payout script: `pubkey_hash_from_p2pkh` (`src/impl/dash/share_producer_bind.hpp`, the exact inverse of `pubkey_hash_to_script2`) returns `nullopt`, so a minted share cannot carry a zero pubkey hash to begin with.
* The ownerless serve is the **non-producer** arm — the one logged as *"serving non-producer coinbase (mint disabled for this job)"* — and its solve is declined at `set_mint_share_fn` for want of a frozen producer job.

So `compute_dash_payouts` only ever shapes coinbases that **no share commits to**. A peer has nothing to reject.

## Second half of the report: the loud warning

The issue also asks for a loud warning so an operator sees the misconfiguration *before* a block is found. The existing warning sat inside the genesis branch, so a pool with a **warm** sharechain served an ownerless miner in complete silence — exactly the case where money moved. It now fires on both arms, rate-limited 1-in-50 like the neighbouring producer-degrade line, and names all three consequences (no finder output, payout to donation, no sharechain credit). Log-only; it changes no output.

## Test evidence

Three cases appended to `test/test_dash_coinbase_parity.cpp` (the DASH coinbase byte-parity suite vs the p2pool-dash oracle):

* `DashCoinbaseZeroFinderGuard.ColdChainOwnerlessWorkPaysDonationNotBurn` — empty weights: no burn output exists at all; the single donation line holds the whole subsidy.
* `DashCoinbaseZeroFinderGuard.WarmChainOwnerlessFinderSliceFallsToDonation` — a weighted PPLNS window: the window miner's 49/50 is byte-for-byte unchanged, and the 2% lands in the donation tail instead of the burn script.
* `DashCoinbaseZeroFinderGuard.RealFinderStillCollectsTwoPercent` — non-regression: an ordinary owned session still collects `worker_payout / 50` at its own script.

**RED baseline confirmed** by reverting the one-line condition and rebuilding: the first two fail (`has_script(outs, burn_script())` is `true`; donation is short by exactly `worker_payout/50` = 100000000 sat on the fixture), the third passes either way.

Whole targets green, not just the new cases:

```
test_dash_coinbase_parity      22/22 PASSED
test_dash_stratum_work_source  132/132 PASSED
test_dash_block_producer       9/9 PASSED   (builds its coinbase with a zero finder)
test_dash_g3_assembled         9/9 PASSED
```

## Deliberately out of scope

The issue's alternative remedy — routing the slice to the node operator for full p2pool parity — is a **separate policy decision**, not folded in here. It needs `--node-owner-address` (`src/c2pool/main_dash.cpp`, the node-owner fee destination, already parsed into `fee_policy.node_owner_script`) plumbed through to the work source, and would fall back to this same donation behaviour whenever that flag is unset. Note the issue's `--mining-address` does not exist on this codebase; `--node-owner-address` is the DASH equivalent.

Not self-merging — this is a money-path change and wants a review tap.
