### PR TITLE
dash(daemonless): dashd-cut MN-checkpoint/replay bridge — rebased (9/17 survive, supersedes #1294)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7598,6 +7598,51 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                             " fold_qfcommit past the anchor resolves its"
                                             " member set and the store extends toward"
                                             " tip.";
+                                // ── ASSEMBLE + KEY the straddle cycle NOW ────
+                                // The seed made the cycle DERIVABLE (snapshots +
+                                // work-lists present); this drives dashd's
+                                // ComputeQuorumMembersByQuarterRotation over them
+                                // (the engine's compute_rotation_cycle, verbatim)
+                                // and registers the ordered member set keyed by
+                                // (llmqType, cycle_base+quorumIndex) — the exact
+                                // key fold_qfcommit's m_members_fn(type,quorumHash)
+                                // resolves a commitment quorumHash to. Done BEFORE
+                                // draining the held blocks so the qfcommit at
+                                // cycle_base+mining_window_start (the height the
+                                // store used to cap at) resolves its member set
+                                // and the fold folds THROUGH toward tip.
+                                {
+                                    auto dr = qbr->derive_members_for_cycle(
+                                        sseed->llmq_type, sseed->cycle_base);
+                                    if (dr.ok)
+                                        LOG_INFO << "[MN-DIFF-DB] straddle cycle"
+                                                    " base h=" << sseed->cycle_base
+                                                 << " (type "
+                                                 << int(sseed->llmq_type)
+                                                 << ") rotated member sets"
+                                                    " ASSEMBLED + KEYED: "
+                                                 << dr.member_sets << "/"
+                                                 << dr.expected_sets
+                                                 << " quorumIndex lists (quorum"
+                                                    " size " << dr.quorum_size
+                                                 << ") — fold_qfcommit resolves"
+                                                    " past the anchor.";
+                                    else
+                                        LOG_WARNING << "[MN-DIFF-DB] straddle cycle"
+                                                       " base h="
+                                                    << sseed->cycle_base
+                                                    << " (type "
+                                                    << int(sseed->llmq_type)
+                                                    << ") member assembly"
+                                                       " INCOMPLETE ("
+                                                    << dr.member_sets << "/"
+                                                    << dr.expected_sets << "): "
+                                                    << dr.skip_reason
+                                                    << " — store will cap at the"
+                                                       " cycle's first punishing"
+                                                       " qfcommit; callers fall"
+                                                       " through (reward-safe).";
+                                }
                                 if (!sseed->hold.empty()) {
                                     for (auto& pr : sseed->hold)
                                         (*feed)(pr.second, pr.first);

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4071,6 +4071,14 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // root+payee-checked per-block commit it needs. Seeded at the same anchor
     // the bridge stands on; sinks MnDiffWriter::on_folded off ITS OWN commit.
     std::unique_ptr<dash::coin::replay::DmlFoldEngine>         mn_bridge_fold_engine;
+    // DASHD-CUT ARM (resolver wiring): the parallel store engine, like the
+    // main replay-fold path, needs the W4 quorum-member resolver or its fold
+    // FAILS CLOSED at the first punishing qfcommit (llmqType=5 @ h=2513130,
+    // ~130 past the anchor) and the store caps there. Stand up a SECOND
+    // QuorumReplayEngine + ReplayQuorumBridge whose ctor installs
+    // set_members_fn onto mn_bridge_fold_engine, seeded at the SAME anchor.
+    std::unique_ptr<dash::coin::replay::QuorumReplayEngine>    mn_bridge_quorum_engine;
+    std::unique_ptr<dash::coin::replay::ReplayQuorumBridge>    mn_bridge_quorum_bridge;
     // PR-2 FORWARD: dashd's mined-commitment store, fed from the same replayed
     // bodies. shared_ptr because the qc-plan lambda (installed far above, on
     // the serve path) captures it by value and must see it appear later — it
@@ -7045,9 +7053,78 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         std::make_unique<rp::DmlFoldEngine>(fcfg);
                     mn_diff_writer = std::make_unique<rp::MnDiffWriter>(
                         *mn_diff_store, *mn_bridge_fold_engine);
+
+                    // ── RESOLVER WIRING (the fix) ────────────────────────
+                    // The parallel store engine, like the main replay-fold
+                    // path, needs the W4 quorum-member resolver or its fold
+                    // fails closed at the first punishing qfcommit (llmqType=5
+                    // @ h=2513130, only ~130 past the anchor): "no quorum-
+                    // member resolver is installed -- PoSe punishes cannot be
+                    // folded, failing closed". That cap is why the store
+                    // covered only ~130 heights and the bridge fell back to the
+                    // capped network getmnlistd probe (payee-desync).
+                    //
+                    // Mirror the main-path --replay-fold-quorums seam: a SECOND
+                    // QuorumReplayEngine seeded at the SAME full-state anchor and
+                    // a SECOND ReplayQuorumBridge whose ctor installs
+                    // set_members_fn onto mn_bridge_fold_engine. The engine
+                    // self-DERIVES rotated + non-rotated member sets from the
+                    // SAME replayed blocks the store folds (dashd
+                    // CalcQuorumMembers / GetAllQuorumMembers analog),
+                    // self-checked vs each block's committed merkleRootQuorums --
+                    // no qrinfo/P2P dependency. The fold then applies dashd
+                    // HandleQuorumCommitment PoSe-punishes (already ported in
+                    // replay_fold_engine.hpp) so the folded list re-hashes to the
+                    // committed merkleRootMNList PAST the qfcommit and the store
+                    // COVERS heights to tip. A WRONG member set -> root mismatch
+                    // -> the writer's own root self-check REFUSES the row -> store
+                    // stays empty -> callers fall through to the network path
+                    // (reward-safe by construction).
+                    {
+                        namespace rq = dash::coin::replay;
+                        rq::QuorumReplayConfig qcfg;
+                        qcfg.enabled = true;
+                        qcfg.network = testnet
+                            ? dash::coin::LlmqNetwork::Testnet
+                            : dash::coin::LlmqNetwork::Mainnet;
+                        if (testnet) qcfg.v20_floor = 905'100u;
+                        mn_bridge_quorum_engine =
+                            std::make_unique<rq::QuorumReplayEngine>(qcfg);
+                        mn_bridge_quorum_engine->seed_cursor(
+                            ckpt.height, ckpt.blockhash);
+                        rq::QuorumBridgeConfig bcfg;
+                        bcfg.network = qcfg.network;
+                        mn_bridge_quorum_bridge =
+                            std::make_unique<rq::ReplayQuorumBridge>(
+                                *mn_bridge_fold_engine,
+                                *mn_bridge_quorum_engine, bcfg);
+                        // Pre-anchor height->hash from the PoW-verified header
+                        // chain: a commitment mined just after the anchor whose
+                        // quorum BASE predates it still resolves instead of
+                        // failing the lane on an unknown base (mirrors the main
+                        // path's back = 3*576 + 64 window).
+                        size_t qseeded = 0;
+                        const uint32_t qback = 3u * 576u + 64u;
+                        for (uint32_t hh = (ckpt.height > qback
+                                                ? ckpt.height - qback : 1);
+                             hh < ckpt.height; ++hh) {
+                            auto he = header_chain->get_header_by_height(hh);
+                            if (!he) continue;
+                            mn_bridge_quorum_bridge->seed_block_hash(hh, he->hash);
+                            ++qseeded;
+                        }
+                        LOG_INFO << "[MN-DIFF-DB] store-engine quorum resolver"
+                                    " WIRED: second QuorumReplayEngine seeded at"
+                                    " anchor h=" << ckpt.height
+                                 << " (" << qseeded << " pre-anchor header"
+                                    " hashes); set_members_fn installed on the"
+                                    " parallel DML engine -- prime_at_anchor"
+                                    " deferred to the anchor snapshot seed.";
+                    }
                     mn_ckpt_lane->set_on_anchor_snapshot(
                         [eng = mn_bridge_fold_engine.get(),
                          w   = mn_diff_writer.get(),
+                         qbr = mn_bridge_quorum_bridge.get(),
                          anchor = ckpt, net = net_name](
                             const dash::coin::vendor::CSimplifiedMNList& asml,
                             uint32_t /*anchor_h*/) {
@@ -7172,6 +7249,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                        " inert, callers unchanged.";
                                 return;
                             }
+                            // Resolver lane: retain the anchor MN list in the
+                            // quorum bridge's window now that the fold engine is
+                            // seeded (m_dml.height()==anchor), so rotated member
+                            // derivation has its base list. Mirrors the main path.
+                            if (qbr) qbr->prime_at_anchor();
                             LOG_INFO
                                 << "[MN-DIFF-DB] FULL-STATE anchor seed OK: "
                                 << with_facets << " MNs seeded root-fields from the"
@@ -7193,13 +7275,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     mn_ckpt_lane->set_on_block_applied(
                         [eng = mn_bridge_fold_engine.get(),
                          w   = mn_diff_writer.get(),
+                         qbr = mn_bridge_quorum_bridge.get(),
                          logged = std::make_shared<bool>(false)](
                             const dash::coin::BlockType& blk, uint32_t h) {
                             if (eng->poisoned()) return;
                             if (eng->size() == 0) return;   // seed deferred to the anchor fold; nothing to fold yet
                             const uint256 bh =
                                 rp::DmlFoldEngine::block_header_hash(blk);
+                            // Feed the parallel quorum lane the SAME block so its
+                            // member derivation stays in lockstep with the fold;
+                            // observe() BEFORE the punish pass consumes
+                            // members_for(), after_fold() AFTER retains work-block
+                            // lists. Mirrors the main path's pre_fold/post_fold.
+                            if (qbr) qbr->observe(h, bh, blk);
                             const auto fr = eng->fold_block(blk, h);
+                            if (qbr) qbr->after_fold(h);
                             if (fr.ok) {
                                 w->on_folded(h, bh, blk, fr);
                                 return;

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -106,6 +106,7 @@
 #include <impl/dash/coin/mnlist_seed.hpp>        // OPTIONAL V20 getmnlistdiff seed (--replay-mnlist-seed-*, #154 escape hatch)
 #include <impl/dash/coin/replay_fold_consumer.hpp> // W5: bulk lane -> W1 DML fold + per-block root check
 #include <impl/dash/coin/replay_quorum_bridge.hpp> // SEAM: W4 quorum lane <-> W1 MembersFn
+#include <impl/dash/coin/historical_sml.hpp> // authenticate_historical_snapshot (DIP-4 R3, straddle-seed)
 #include <impl/dash/coin/replay_payee_publish.hpp> // SEAM: W1 fold -> the PAYEE queue that gates serving
 #include <impl/dash/coin/mn_diff_store.hpp>      // dashd evodb dmn_D4/dmn_S3 port: per-block MN list diffs + snapshots
 #include <impl/dash/coin/mn_gap_repair.hpp>      // payee-queue gap-repair seam (maintainer + checkpoint bridge)
@@ -7268,47 +7269,302 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                    " on-demand fold source 0-RTT/uncapped from it.";
                         });
 
-                    // THE WRITE FEED: every block the bridge folds CLEANLY is
-                    // handed to the parallel engine; only its OWN root-checked
-                    // commit sinks the writer. A once-latched poison log names
-                    // the reality when a partial anchor cannot reproduce roots.
+                    // ── DIP-24 ROTATED-QUORUM STRADDLE BOOTSTRAP (getqrinfo) ─────
+                    // The store engine is seeded at the anchor with ZERO
+                    // pre-anchor quarter snapshots (only pre-anchor header
+                    // hashes, above). The FIRST rotated (DIP-24, llmqType=5)
+                    // cycle mined AFTER the anchor has a base B0 whose three
+                    // quarter predecessors (B0-C/2C/3C) all sit BELOW the
+                    // anchor, so the engine's self_contained_from is beyond it
+                    // and it cannot self-derive that cycle's member set from
+                    // the replayed post-anchor stream alone. Its first punishing
+                    // qfcommit then hits fold_qfcommit with "resolver has no
+                    // member set", the parallel fold fails closed only ~a
+                    // window past the anchor, the store caps, and the payee lane
+                    // falls to the capped network probe (the #149-class payee
+                    // desync). FIX (dashd DIP-24 CGetQuorumRotationInfo /
+                    // BuildQuorumSnapshot, the companion to the #1261 full-SML
+                    // seed): fetch getqrinfo(B0) once at cold arm, DIP-4/merkle
+                    // authenticate the returned quarter snapshots + work lists
+                    // against the committed roots, and seed them so cycle B0 is
+                    // derivable. A WRONG snapshot -> wrong members -> folded root
+                    // mismatch -> the writer's own root self-check REFUSES the
+                    // row -> store empty -> callers fall through (reward-safe by
+                    // construction; never a bad mint).
+                    struct StoreStraddleSeed {
+                        bool     armed{false};
+                        bool     sent{false};
+                        bool     landed{false};
+                        bool     exhausted{false};
+                        uint8_t  llmq_type{5};
+                        uint32_t C{0};
+                        uint32_t cycle_base{0};     // B0 = first rotated cycle base > anchor
+                        uint32_t first_need_h{0};   // hold straddle blocks at/after this height
+                        uint32_t last_send_h{0};
+                        uint256  cycle_base_hash;
+                        std::vector<std::pair<uint32_t, dash::coin::BlockType>> hold;
+                    };
+                    auto sseed = std::make_shared<StoreStraddleSeed>();
+                    {
+                        const uint32_t anchor_h = ckpt.height;
+                        for (const auto& pv : dash::coin::enabled_llmqs(
+                                 testnet ? dash::coin::LlmqNetwork::Testnet
+                                         : dash::coin::LlmqNetwork::Mainnet)) {
+                            if (!pv.use_rotation || pv.dkg_interval == 0) continue;
+                            sseed->llmq_type   = pv.type;
+                            sseed->C           = pv.dkg_interval;
+                            sseed->cycle_base  = ((anchor_h / pv.dkg_interval) + 1u)
+                                                 * pv.dkg_interval;
+                            // Hold from the cycle base itself (conservative): the
+                            // engine derives cycle B0's members no later than the
+                            // block that carries B0's first punishing qfcommit, and
+                            // no earlier than observing B0; gating at the base is
+                            // correct for both and costs at most a few dozen buffered
+                            // blocks in the rare case the reply is slow.
+                            sseed->first_need_h = sseed->cycle_base;
+                            sseed->armed        = true;
+                            break;   // one rotated type on mainnet (type 5)
+                        }
+                        if (sseed->armed)
+                            LOG_INFO << "[MN-DIFF-DB] store-engine rotated-quorum"
+                                        " bootstrap ARMED: getqrinfo(cycle_base h="
+                                     << sseed->cycle_base << ", type="
+                                     << int(sseed->llmq_type) << ", C=" << sseed->C
+                                     << ") will seed the pre-anchor quarter"
+                                        " snapshots+work-lists for the cycle that"
+                                        " STRADDLES anchor h=" << anchor_h
+                                     << " (its H-C/2C/3C predecessors are all below"
+                                        " the anchor; the store engine cannot"
+                                        " self-derive them).";
+                    }
+
+                    // The shared per-block fold drive. Both the live feed and the
+                    // held-block drain call THIS, so a block folded from the hold
+                    // buffer takes the exact same observe/fold/after_fold/writer
+                    // path as a live one.
+                    auto feed = std::make_shared<
+                        std::function<void(const dash::coin::BlockType&, uint32_t)>>();
+                    *feed = [eng = mn_bridge_fold_engine.get(),
+                             w   = mn_diff_writer.get(),
+                             qbr = mn_bridge_quorum_bridge.get(),
+                             logged = std::make_shared<bool>(false)](
+                                const dash::coin::BlockType& blk, uint32_t h) {
+                        if (eng->poisoned()) return;
+                        if (eng->size() == 0) return;   // seed deferred to the anchor fold
+                        const uint256 bh = rp::DmlFoldEngine::block_header_hash(blk);
+                        if (qbr) qbr->observe(h, bh, blk);
+                        const auto fr = eng->fold_block(blk, h);
+                        if (qbr) qbr->after_fold(h);
+                        if (fr.ok) { w->on_folded(h, bh, blk, fr); return; }
+                        if (!*logged) {
+                            *logged = true;
+                            LOG_WARNING
+                                << "[MN-DIFF-DB] cold-bridge parallel fold could"
+                                   " not extend the store at h=" << h << " ("
+                                << fr.error << "). The store keeps only heights up"
+                                   " to here; every height above REPAIR-REFUSES and"
+                                   " the probe/on-demand paths fall through to the"
+                                   " network unchanged (reward-safe).";
+                        }
+                    };
+
+                    // The qrinfo reply consumer: authenticate the straddle-cycle
+                    // snapshots + work lists and seed them into the store engine.
+                    // Additive (coexists with the serve-path consumer at
+                    // main_dash.cpp:4446); it filters by the reply's H so only OUR
+                    // getqrinfo(B0) reply is consumed.
+                    if (coin_p2p && sseed->armed) {
+                        coin_p2p->add_qrinfo_consumer(
+                            [sseed, feed,
+                             qbr = mn_bridge_quorum_bridge.get(),
+                             hc  = header_chain.get(),
+                             anchor_h = ckpt.height, net = net_name](
+                                const dash::coin::vendor::CQuorumRotationInfo& info) {
+                                if (!sseed->armed || sseed->landed) return;
+                                namespace v  = dash::coin::vendor;
+                                namespace rq = dash::coin::replay;
+                                // Bind: OUR reply's mnListDiffH sits at B0-8.
+                                v::CCbTx hcb;
+                                if (info.mnListDiffH.cbTx.type != 5
+                                    || !v::parse_cbtx(
+                                           info.mnListDiffH.cbTx.extra_payload, hcb)
+                                    || hcb.nHeight < 0) return;
+                                if (static_cast<uint32_t>(hcb.nHeight)
+                                    != sseed->cycle_base - 8u) return;   // not ours
+                                dash::coin::MerkleRootOfHashFn mroot =
+                                    [hc](const uint256& b)
+                                        -> std::optional<uint256> {
+                                        if (auto e = hc->get_header(b))
+                                            return e->header.m_merkle_root;
+                                        return std::nullopt;
+                                    };
+                                const v::CSimplifiedMNListDiff* diffs[3] = {
+                                    &info.mnListDiffAtHMinusC,
+                                    &info.mnListDiffAtHMinus2C,
+                                    &info.mnListDiffAtHMinus3C };
+                                const v::CQuorumSnapshot* snaps[3] = {
+                                    &info.quorumSnapshotAtHMinusC,
+                                    &info.quorumSnapshotAtHMinus2C,
+                                    &info.quorumSnapshotAtHMinus3C };
+                                rq::QSnapshotSeed qs;  qs.network = net;
+                                rq::WorkListSeed  wl;  wl.network = net;
+                                wl.llmq_type  = sseed->llmq_type;
+                                wl.cycle_base = sseed->cycle_base;
+                                wl.interval   = sseed->C;
+                                for (size_t i = 0; i < 3; ++i) {
+                                    const uint32_t cyc = sseed->cycle_base
+                                        - static_cast<uint32_t>(i + 1) * sseed->C;
+                                    const uint32_t work_h = cyc - 8u;
+                                    // A qrinfo cycle diff is a FULL list (applied
+                                    // onto empty); a delete means it is not.
+                                    if (!diffs[i]->deletedMNs.empty()) {
+                                        LOG_WARNING << "[MN-DIFF-DB] getqrinfo cycle"
+                                                       " diff " << i << " is not a"
+                                                       " full list (deletes) — rotated"
+                                                       " bootstrap fails closed, retry.";
+                                        return;
+                                    }
+                                    v::CCbTx cbtx;
+                                    auto sml = dash::coin::authenticate_historical_snapshot(
+                                        *diffs[i], work_h, mroot, cbtx, "MN-DIFF-DB-QR");
+                                    if (!sml) {
+                                        LOG_WARNING << "[MN-DIFF-DB] getqrinfo cycle"
+                                                       " diff " << i << " DIP-4 auth"
+                                                       " FAILED at work h=" << work_h
+                                                    << " — rotated bootstrap fails"
+                                                       " closed, retry.";
+                                        return;
+                                    }
+                                    rq::QSnapshotSeedEntry se;
+                                    se.llmq_type  = sseed->llmq_type;
+                                    se.cycle_base = cyc;
+                                    se.snapshot   = *snaps[i];
+                                    qs.entries.push_back(std::move(se));
+                                    rq::WorkListSeedEntry we;
+                                    we.work_height = work_h;
+                                    we.cycle_base  = cyc;
+                                    we.block_hash  = diffs[i]->blockHash;
+                                    if (cbtx.nVersion >= v::CCbTx::VERSION_CLSIG_AND_BALANCE
+                                        && cbtx.has_best_cl_signature()) {
+                                        we.has_cl = true;
+                                        std::memcpy(we.cl_sig.data(),
+                                                    cbtx.bestCLSignature.data(),
+                                                    we.cl_sig.size());
+                                    }
+                                    we.entries.reserve(sml->mnList.size());
+                                    for (const auto& e : sml->mnList) {
+                                        rq::QuorumMnEntry qe;
+                                        qe.proTxHash      = e.proRegTxHash;
+                                        qe.confirmedHash  = e.confirmedHash;
+                                        qe.is_valid       = e.isValid;
+                                        qe.n_type         = e.nType;
+                                        qe.has_collateral = false;
+                                        we.entries.push_back(std::move(qe));
+                                    }
+                                    wl.works.push_back(std::move(we));
+                                }
+                                qs.ok = true;  wl.ok = true;
+                                std::string e1, e2;
+                                const bool ok1 = qbr->seed_snapshots(qs, anchor_h, e1);
+                                const bool ok2 = qbr->seed_work_lists(wl, anchor_h, e2);
+                                if (!ok1 || !ok2) {
+                                    LOG_ERROR << "[MN-DIFF-DB] getqrinfo rotated"
+                                                 " bootstrap seed REJECTED (snapshots: "
+                                              << (ok1 ? "ok" : e1) << "; work-lists: "
+                                              << (ok2 ? "ok" : e2) << ") — store engine"
+                                                 " stays without the straddle snapshots;"
+                                                 " callers fall through (reward-safe).";
+                                    return;
+                                }
+                                sseed->landed = true;
+                                LOG_INFO << "[MN-DIFF-DB] getqrinfo rotated bootstrap"
+                                            " SEEDED: " << qs.entries.size()
+                                         << " pre-anchor quarter snapshots + "
+                                         << wl.works.size() << " work-lists for cycle"
+                                            " base h=" << sseed->cycle_base << " (type "
+                                         << int(sseed->llmq_type) << "); cycle "
+                                         << sseed->cycle_base << " is now derivable —"
+                                            " fold_qfcommit past the anchor resolves its"
+                                            " member set and the store extends toward"
+                                            " tip.";
+                                if (!sseed->hold.empty()) {
+                                    for (auto& pr : sseed->hold)
+                                        (*feed)(pr.second, pr.first);
+                                    sseed->hold.clear();
+                                }
+                            });
+                    }
+
+                    // THE WRITE FEED: the SAME shared drive as the hold-buffer
+                    // drain (feed), wrapped by the rotated-quorum ORDERING GATE.
+                    // getqrinfo(B0) is a P2P round-trip that races the parallel
+                    // fold advancing from the anchor; a straddle block folded
+                    // BEFORE its snapshots are seeded fails closed and POISONS
+                    // the engine. So: issue the fetch once a body-serving peer is
+                    // certainly up, HOLD straddle blocks until the seed lands
+                    // (then drain them in order), and — reward-safe fallback — if
+                    // the reply never arrives within a bounded hold, cap the store
+                    // below the straddle and let callers fall through unchanged
+                    // rather than poison.
                     mn_ckpt_lane->set_on_block_applied(
-                        [eng = mn_bridge_fold_engine.get(),
-                         w   = mn_diff_writer.get(),
-                         qbr = mn_bridge_quorum_bridge.get(),
-                         logged = std::make_shared<bool>(false)](
+                        [sseed, feed, cp = coin_p2p.get(),
+                         hc = header_chain.get()](
                             const dash::coin::BlockType& blk, uint32_t h) {
-                            if (eng->poisoned()) return;
-                            if (eng->size() == 0) return;   // seed deferred to the anchor fold; nothing to fold yet
-                            const uint256 bh =
-                                rp::DmlFoldEngine::block_header_hash(blk);
-                            // Feed the parallel quorum lane the SAME block so its
-                            // member derivation stays in lockstep with the fold;
-                            // observe() BEFORE the punish pass consumes
-                            // members_for(), after_fold() AFTER retains work-block
-                            // lists. Mirrors the main path's pre_fold/post_fold.
-                            if (qbr) qbr->observe(h, bh, blk);
-                            const auto fr = eng->fold_block(blk, h);
-                            if (qbr) qbr->after_fold(h);
-                            if (fr.ok) {
-                                w->on_folded(h, bh, blk, fr);
-                                return;
+                            // Lazy one-shot getqrinfo(B0): fire on the first folded
+                            // block, when headers are synced and a body-serving
+                            // peer exists.
+                            if (sseed->armed && !sseed->sent) {
+                                if (auto he = hc->get_header_by_height(
+                                        sseed->cycle_base)) {
+                                    sseed->cycle_base_hash = he->hash;
+                                    if (cp) cp->send_getqrinfo(
+                                        {}, he->hash, /*extra=*/false);
+                                    sseed->sent        = true;
+                                    sseed->last_send_h = h;
+                                    LOG_INFO << "[MN-DIFF-DB] getqrinfo issued for"
+                                                " straddling cycle base h="
+                                             << sseed->cycle_base
+                                             << " — bootstrap the store engine's"
+                                                " rotated member derivation across"
+                                                " the anchor.";
+                                }
                             }
-                            if (!*logged) {
-                                *logged = true;
-                                LOG_WARNING
-                                    << "[MN-DIFF-DB] cold-bridge parallel fold"
-                                       " could not extend the store at h=" << h
-                                    << " (" << fr.error << "). The store keeps"
-                                       " only its anchor row; every height above"
-                                       " REPAIR-REFUSES and the probe/on-demand"
-                                       " paths fall through to the network"
-                                       " unchanged (reward-safe). With the"
-                                       " full-state anchor seed this is NOT the"
-                                       " expected cold-bridge state: it means the"
-                                       " parallel fold diverged from a committed"
-                                       " cbTx root at this height.";
+                            // Seed landed while blocks were held -> drain first.
+                            if (sseed->landed && !sseed->hold.empty()) {
+                                for (auto& pr : sseed->hold)
+                                    (*feed)(pr.second, pr.first);
+                                sseed->hold.clear();
                             }
+                            // Hold blocks that would ask the resolver for the
+                            // straddling cycle before its snapshots are seeded.
+                            if (sseed->armed && !sseed->landed
+                                && h >= sseed->first_need_h) {
+                                if (sseed->exhausted) return;   // gave up: never fold unseeded
+                                constexpr size_t kHoldCap = 2000;
+                                if (sseed->hold.size() < kHoldCap) {
+                                    sseed->hold.emplace_back(h, blk);
+                                    if (sseed->sent
+                                        && h >= sseed->last_send_h + 24u) {
+                                        if (auto he = hc->get_header_by_height(
+                                                sseed->cycle_base)) {
+                                            if (cp) cp->send_getqrinfo(
+                                                {}, he->hash, false);
+                                            sseed->last_send_h = h;
+                                        }
+                                    }
+                                } else {
+                                    sseed->exhausted = true;
+                                    sseed->hold.clear();
+                                    LOG_WARNING
+                                        << "[MN-DIFF-DB] getqrinfo straddle seed did"
+                                           " not arrive before the hold cap at h="
+                                        << h << "; store caps below the straddling"
+                                           " cycle and callers fall through to the"
+                                           " network path (reward-safe, no bad mint).";
+                                }
+                                return;   // do not fold a straddle block unseeded
+                            }
+                            (*feed)(blk, h);
                         });
 
                     // THE READ SEAM: the 0-RTT gap-repair the SOURCE callers

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -104,6 +104,7 @@
 #include <impl/dash/coin/replay_utxo_fold.hpp>   // W3: full-history replay standalone UTXO fold (--replay-utxo-*)
 #include <impl/dash/coin/replay_prestate.hpp>    // W5: anchor prestate loader (--replay-fold-prestate)
 #include <impl/dash/coin/mnlist_seed.hpp>        // OPTIONAL V20 getmnlistdiff seed (--replay-mnlist-seed-*, #154 escape hatch)
+#include <impl/dash/coin/mn_checkpoint_dump.hpp> // self-derived MN-set checkpoint dump (--dump-mn-checkpoint)
 #include <impl/dash/coin/replay_fold_consumer.hpp> // W5: bulk lane -> W1 DML fold + per-block root check
 #include <impl/dash/coin/replay_quorum_bridge.hpp> // SEAM: W4 quorum lane <-> W1 MembersFn
 #include <impl/dash/coin/historical_sml.hpp> // authenticate_historical_snapshot (DIP-4 R3, straddle-seed)
@@ -268,6 +269,13 @@ bool g_mn_bridge_no_cursor = false;
 bool        g_replay_bulk = false;            // --replay-bulk: arm the lane
 std::string g_replay_bulk_capture_dir;        // --replay-bulk-capture DIR (implies --replay-bulk)
 uint32_t    g_replay_bulk_start = 0;          // --replay-bulk-start H (0 = network default: mainnet DIP3 1028160)
+// ── DASHD-CUT: self-derived MN-set checkpoint dump (--dump-mn-checkpoint H FILE) ─
+// When the --replay-bulk DML fold's cursor reaches H, serialize its REGISTERED
+// masternode set to the checkpoint .inc at FILE — SELF-DERIVED from the fold's
+// own root-checked ReplayMNState, no dashd RPC, no trusted protx snapshot
+// (operator decision 2026-08-17). One-shot; the fold is unaffected otherwise.
+uint32_t    g_dump_mn_checkpoint_height = 0;  // 0 = off
+std::string g_dump_mn_checkpoint_file;
 
 // ── W5 INTEGRATION: drive the W1 DML fold from the W2 bulk lane ───────────
 // --replay-fold-prestate FILE seeds the W1 fold engine from a full-state
@@ -480,6 +488,7 @@ void print_banner(const char* argv0)
         << "           [--replay-fold-qsnapshot FILE] [--replay-fold-worklists FILE]\n"
         << "           [--replay-mnlist-seed-height H --replay-mnlist-seed-source getmnlistdiff --replay-mnlist-seed-file FILE]\n"
         << "           [--replay-mined-commitment-index] [--embedded-mined-commitment-index]\n"
+        << "           [--dump-mn-checkpoint H FILE]\n"
         << "           [--embedded-no-dashd-mn-seed [--embedded-fold-only-proof]]\n"
         << "           [--oracle-graduation-blocks N] [--oracle-class-coverage K]\n"
         << "           [--give-author PCT] [-f|--fee PCT] [--node-owner-address ADDR]\n"
@@ -647,6 +656,11 @@ void print_banner(const char* argv0)
         << "        caches raw bodies into append-only segment files (fleet re-fold\n"
         << "        cache; implies --replay-bulk). --replay-bulk-start H overrides\n"
         << "        the first fetched height (default: mainnet DIP3 1028160).\n"
+        << "        --dump-mn-checkpoint H FILE serializes the --replay-fold DML\n"
+        << "        set at height H to the checkpoint .inc at FILE, SELF-DERIVED\n"
+        << "        from the fold's own root-checked state (no dashd RPC, no\n"
+        << "        protx snapshot; registered-not-valid; reuses the runtime\n"
+        << "        parser field order + digest, self-verifies before writing).\n"
         << "        --external-ip ADDR (alias --stratum-advertise / --public-host)\n"
         << "        overrides the miner-facing host shown in the dashboard Stratum\n"
         << "        URL -- for NAT / port-mapped nodes whose outbound IP is not the\n"
@@ -8011,6 +8025,52 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // carries a payout script. A fold that diverged, is poisoned,
                 // or is behind the tip can never become the authoritative
                 // snapshot, and the refusal names which condition blocked.
+                // ── DASHD-CUT: self-derived MN-set checkpoint DUMP ────────
+                // One-shot: when the fold cursor reaches H, serialize the
+                // registered set to FILE (mn_checkpoint_dump.hpp). SELF-DERIVED
+                // — every field comes from the fold's own root-checked
+                // ReplayMNState (scriptPayout verbatim from the ProRegTx it
+                // replayed; nLastPaidHeight from the payee bookkeeping it
+                // keeps), never a dashd protx snapshot. Serve-inert: it only
+                // reads the engine and writes one file. The write self-verifies
+                // through parse_mn_checkpoint() so it can never emit a file the
+                // runtime cold-start would refuse.
+                if (g_dump_mn_checkpoint_height != 0 && replay_fold_consumer) {
+                    const uint32_t dump_h = g_dump_mn_checkpoint_height;
+                    const std::string dump_file = g_dump_mn_checkpoint_file;
+                    replay_fold_consumer->set_dump_hook(
+                        dump_h,
+                        [dump_file, dump_h](const rp::DmlFoldEngine& eng,
+                                            uint32_t reached) {
+                            const std::string source =
+                                "self-derived from chain via c2pool"
+                                " --replay-bulk at H=" + std::to_string(reached)
+                                + " (blockhash " + eng.block_hash().GetHex()
+                                + ")";
+                            const std::string generated =
+                                dash::coin::mn_dump_detail::iso8601_utc_now();
+                            std::string err;
+                            if (dash::coin::write_mn_checkpoint_inc(
+                                    eng, dump_file, source, generated, err)) {
+                                std::cout << "[run] --dump-mn-checkpoint: WROTE "
+                                          << eng.size() << " registered"
+                                             " masternodes at h=" << reached
+                                          << " to " << dump_file
+                                          << " (self-derived, no dashd) —"
+                                             " verified through"
+                                             " parse_mn_checkpoint()\n";
+                            } else {
+                                std::cerr << "[run] --dump-mn-checkpoint FAILED"
+                                             " at h=" << reached << ": " << err
+                                          << "\n";
+                            }
+                        });
+                    std::cout << "[run] --dump-mn-checkpoint ARMED: the fold will"
+                                 " serialize its registered MN set at h="
+                              << dump_h << " to " << dump_file
+                              << " (self-derived from chain; no dashd RPC)\n";
+                }
+
                 if (replay_fold_consumer) {
                     replay_payee_pub =
                         std::make_unique<rp::ReplayPayeePublisher>(
@@ -10151,6 +10211,13 @@ int main(int argc, char** argv)
         else if (std::strcmp(argv[i], "--replay-bulk-start") == 0 && i + 1 < argc)
             g_replay_bulk_start = static_cast<uint32_t>(
                 std::strtoul(argv[++i], nullptr, 10));
+        // DASHD-CUT: dump the fold's registered MN set at H to a checkpoint
+        // .inc (self-derived; no dashd). Takes two args: H and FILE.
+        else if (std::strcmp(argv[i], "--dump-mn-checkpoint") == 0 && i + 2 < argc) {
+            g_dump_mn_checkpoint_height = static_cast<uint32_t>(
+                std::strtoul(argv[++i], nullptr, 10));
+            g_dump_mn_checkpoint_file = argv[++i];
+        }
         // W5: anchor-seeded DML fold driven by the bulk lane.
         else if (std::strcmp(argv[i], "--replay-fold-prestate") == 0 && i + 1 < argc) {
             g_replay_fold_prestate = argv[++i];

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7757,6 +7757,66 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             (*feed)(blk, h);
                         });
 
+                    // ── DASHD-CUT: self-derived MN-set checkpoint DUMP off the
+                    // MN-CKPT BRIDGE (task #154, the #1 dashd-cut pacing item).
+                    // The bridge SEEDS from the baked checkpoint and forward-
+                    // folds block-by-block (apply_block == dashd
+                    // BuildNewListFromBlock parity) to H in MINUTES over the
+                    // coin-P2P feed — no --replay-bulk, no --replay-fold-prestate,
+                    // no dashd. When it reaches H the hook serializes the bridge's
+                    // OWN payout-bearing set (MnStateMachine::entries()) to FILE.
+                    // SELF-DERIVED: every field comes from the bridge's own fold
+                    // (scriptPayout verbatim from the ProRegTx it replayed;
+                    // nLastPaidHeight from the payee bookkeeping it keeps), never
+                    // a dashd protx snapshot and never getmnlistdiff (which is
+                    // payout-stripped). The write self-verifies through
+                    // parse_mn_checkpoint() so it can never emit a file the
+                    // runtime cold-start would refuse. This is the exact analog
+                    // of the replay-fold consumer's set_dump_hook install (the
+                    // --replay-fold-prestate arm); the two are mutually exclusive
+                    // by the g_replay_fold_prestate predicate this block already
+                    // stands under.
+                    if (g_dump_mn_checkpoint_height != 0) {
+                        const uint32_t    dump_h    = g_dump_mn_checkpoint_height;
+                        const std::string dump_file = g_dump_mn_checkpoint_file;
+                        const std::string net       = net_name;
+                        mn_ckpt_lane->set_dump_hook(
+                            dump_h,
+                            [dump_file, net](const dash::coin::MnStateMachine& machine,
+                                             uint32_t reached,
+                                             const uint256& blockhash) {
+                                const std::string source =
+                                    "self-derived from chain via c2pool MN-CKPT"
+                                    " bridge at H=" + std::to_string(reached)
+                                    + " (blockhash " + blockhash.GetHex() + ")";
+                                const std::string generated =
+                                    dash::coin::mn_dump_detail::iso8601_utc_now();
+                                std::string err;
+                                if (dash::coin::write_mn_checkpoint_inc(
+                                        machine.entries(), reached, blockhash,
+                                        net, dump_file, source, generated, err)) {
+                                    std::cout << "[run] --dump-mn-checkpoint"
+                                                 " (BRIDGE): WROTE "
+                                              << machine.size() << " registered"
+                                                 " masternodes at h=" << reached
+                                              << " to " << dump_file
+                                              << " (self-derived via the MN-CKPT"
+                                                 " bridge, no dashd) — verified"
+                                                 " through parse_mn_checkpoint()\n";
+                                } else {
+                                    std::cerr << "[run] --dump-mn-checkpoint"
+                                                 " (BRIDGE) FAILED at h="
+                                              << reached << ": " << err << "\n";
+                                }
+                            });
+                        std::cout << "[run] --dump-mn-checkpoint ARMED on the"
+                                     " MN-CKPT BRIDGE: the bridge will serialize"
+                                     " its registered MN set at h=" << dump_h
+                                  << " to " << dump_file
+                                  << " (self-derived from chain via the baked-"
+                                     "checkpoint fold; no dashd RPC)\n";
+                    }
+
                     // THE READ SEAM: the 0-RTT gap-repair the SOURCE callers
                     // use, reconstructed from the store and cross-checked at
                     // every hop against OUR PoW-validated header chain.

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7023,7 +7023,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             // matches, the store COVERS heights and the ban-state probe /
             // on-demand fold source 0-RTT/uncapped from it.
             if (mn_ckpt_lane && header_chain && ckpt.ok
-                && !mn_diff_store) {
+                && !mn_diff_store
+                // UAF FIX (yield to the deep replay-fold): the cold MN-CKPT
+                // store-bridge and the W5 replay-fold arm (main_dash.cpp ~7288)
+                // both drive the SINGLE mn_diff_store/mn_diff_writer, but they
+                // are MUTUALLY EXCLUSIVE by design -- this block's own header
+                // comment names it "the COLD MN-CKPT bridge path (no
+                // --replay-bulk / --replay-fold-prestate)". The guard never
+                // actually enforced that: this arm runs FIRST (cold bridge),
+                // creates store/writer A and installs set_on_anchor_snapshot()
+                // whose lambda captures raw w=mn_diff_writer.get(); the later W5
+                // make_unique then FREES writer A behind that lambda's back, and
+                // the historical-snapshot callback dereferences the freed writer
+                // -> MnDiffWriter::arm()->save_snapshot() UAF (SIGSEGV/SIGBUS).
+                // When --replay-fold-prestate is set the deep replay owns the
+                // store; the cold bridge YIELDS. Normal cold start (no prestate)
+                // is UNCHANGED -- this predicate is true there.
+                && g_replay_fold_prestate.empty()) {
                 namespace rp = dash::coin::replay;
                 mn_diff_store = std::make_unique<rp::MnDiffStore>(
                     (core::filesystem::config_path() / net_subdir
@@ -8179,7 +8195,22 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // the store is simply absent and both repair callers keep
                 // their historical wipe/demote fail-closed behavior — the
                 // store is an accelerator, never consensus-required.
-                if (replay_fold_consumer) {
+                if (replay_fold_consumer && mn_diff_store) {
+                    // DEFENSIVE (named fail-closed, not a clobber): the cold
+                    // MN-CKPT store-bridge (main_dash.cpp ~6182) must have YIELDED
+                    // when a prestate is configured. If it did not, a make_unique
+                    // here would FREE the cold bridge's live MnDiffWriter while
+                    // its set_on_anchor_snapshot lambda still holds it raw -> UAF.
+                    // Refuse instead. The deep replay then folds WITHOUT the
+                    // accelerator store (reward-safe: the store is never
+                    // consensus-required, only a gap-repair accelerator).
+                    LOG_ERROR << "[MN-DIFF-DB] INVARIANT VIOLATED: cold-bridge"
+                                 " store present while arming the W5 deep-replay"
+                                 " store -- refusing to clobber a live writer"
+                                 " (would UAF the cold-bridge anchor lambda);"
+                                 " W5 accelerator store DISABLED (reward-safe).";
+                }
+                if (replay_fold_consumer && !mn_diff_store) {
                     mn_diff_store = std::make_unique<rp::MnDiffStore>(
                         (core::filesystem::config_path() / net_subdir
                             / "dash_mn_diff_db").string());

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -7303,6 +7303,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         uint32_t last_send_h{0};
                         uint256  cycle_base_hash;
                         std::vector<std::pair<uint32_t, dash::coin::BlockType>> hold;
+                        // Pre-anchor header backfill (cold fast-start): leg (b)
+                        // of the getqrinfo snapshot auth needs the FULL headers
+                        // of the three rotated work blocks, all BELOW the anchor
+                        // and absent from the lone-anchor cold chain. One-shot
+                        // backward getheaders installs the span DOWN from the
+                        // trusted anchor before the seed can authenticate.
+                        bool     backfill_sent{false};
+                        uint256  anchor_hash;      // trusted downward-link root
+                        uint32_t anchor_height{0};
                     };
                     auto sseed = std::make_shared<StoreStraddleSeed>();
                     {
@@ -7322,6 +7331,8 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             // correct for both and costs at most a few dozen buffered
                             // blocks in the rare case the reply is slow.
                             sseed->first_need_h = sseed->cycle_base;
+                            sseed->anchor_hash  = ckpt.blockhash;
+                            sseed->anchor_height= anchor_h;
                             sseed->armed        = true;
                             break;   // one rotated type on mainnet (type 5)
                         }
@@ -7336,6 +7347,42 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                      << " (its H-C/2C/3C predecessors are all below"
                                         " the anchor; the store engine cannot"
                                         " self-derive them).";
+                    }
+
+                    // ── PRE-ANCHOR HEADER BACKFILL INSTALLER ─────────────────
+                    // The one-shot backward getheaders issued by the qrinfo
+                    // consumer below (when the work-block headers leg (b) needs
+                    // are absent at cold fast-start) returns a `headers` batch
+                    // spanning [h-4C .. anchor]. It arrives on the new_headers
+                    // event, where the forward add_headers path orphan-rejects
+                    // every pre-anchor header (parent not held). This installer
+                    // instead links them DOWN from the trusted anchor via
+                    // HeaderChain::install_preanchor_span (X11 prev-hash chain +
+                    // PoW, reward-safe), then re-drives getqrinfo so leg (b)
+                    // authenticates promptly. Self-guarding: it no-ops unless the
+                    // backfill was issued and not yet landed, and a batch that
+                    // does not reach the anchor installs nothing.
+                    if (sseed->armed) {
+                        coin_feed_subs.push_back(
+                            coin_state.new_headers.subscribe(
+                                [sseed, hc = header_chain.get(),
+                                 cp = coin_p2p.get()](
+                                    const std::vector<dash::coin::BlockHeaderType>&
+                                        batch) {
+                                    if (!sseed->armed || sseed->landed) return;
+                                    if (!sseed->backfill_sent) return;
+                                    if (batch.empty()) return;
+                                    const size_t n = hc->install_preanchor_span(
+                                        sseed->anchor_hash, batch);
+                                    if (n == 0) return;
+                                    // Re-drive getqrinfo now that the pre-anchor
+                                    // work-block headers are held → leg (b)
+                                    // authenticates on the next reply.
+                                    if (cp && !sseed->cycle_base_hash.IsNull())
+                                        cp->send_getqrinfo(
+                                            {}, sseed->cycle_base_hash,
+                                            /*extra=*/true);
+                                }));
                     }
 
                     // The shared per-block fold drive. Both the live feed and the
@@ -7378,6 +7425,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                             [sseed, feed,
                              qbr = mn_bridge_quorum_bridge.get(),
                              hc  = header_chain.get(),
+                             cp  = coin_p2p.get(),
                              anchor_h = ckpt.height, net = net_name](
                                 const dash::coin::vendor::CQuorumRotationInfo& info) {
                                 if (!sseed->armed || sseed->landed) return;
@@ -7391,6 +7439,69 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                     || hcb.nHeight < 0) return;
                                 if (static_cast<uint32_t>(hcb.nHeight)
                                     != sseed->cycle_base - 8u) return;   // not ours
+
+                                // ── PRE-ANCHOR HEADER BACKFILL GATE ──────────
+                                // leg (b) below needs the FULL headers of the
+                                // three rotated work blocks (h-C/2C/3C), all
+                                // BELOW the fast-start anchor. At cold start the
+                                // header chain holds only the anchor, so the auth
+                                // fails closed 'block header not held'. Fetch the
+                                // pre-anchor span (once) and install it DOWN from
+                                // the trusted anchor BEFORE authenticating.
+                                {
+                                    const uint256 wh_c  =
+                                        info.mnListDiffAtHMinusC.blockHash;
+                                    const uint256 wh_2c =
+                                        info.mnListDiffAtHMinus2C.blockHash;
+                                    const uint256 wh_3c =
+                                        info.mnListDiffAtHMinus3C.blockHash;
+                                    if (!hc->has_header(wh_c)
+                                        || !hc->has_header(wh_2c)
+                                        || !hc->has_header(wh_3c)) {
+                                        // getheaders replies START at locator+1,
+                                        // so to INCLUDE the deepest work block
+                                        // (h-3C) the locator is seeded one rotated
+                                        // cycle DEEPER — the h-4C block from the
+                                        // extraShare leg. That hash is used ONLY
+                                        // as a locator; it is never trusted (a bad
+                                        // one yields no downward linkage from the
+                                        // anchor → zero installs → fail closed).
+                                        if (!sseed->backfill_sent && cp
+                                            && info.extraShare
+                                            && info.mnListDiffAtHMinus4C) {
+                                            const uint256 loc =
+                                                info.mnListDiffAtHMinus4C->blockHash;
+                                            const std::string peer =
+                                                cp->primary_peer_key();
+                                            if (!peer.empty()
+                                                && cp->send_getheaders_to(
+                                                       peer, 70230, {loc},
+                                                       sseed->anchor_hash)) {
+                                                sseed->backfill_sent = true;
+                                                LOG_INFO << "[MN-DIFF-DB] pre-anchor"
+                                                    " header BACKFILL issued:"
+                                                    " getheaders locator=h-4C "
+                                                    << loc.GetHex().substr(0, 16)
+                                                    << " stop=anchor "
+                                                    << sseed->anchor_hash.GetHex()
+                                                           .substr(0, 16)
+                                                    << " — installs the h-C/2C/3C"
+                                                       " work-block headers leg (b)"
+                                                       " needs; getqrinfo retries"
+                                                       " once the span lands.";
+                                            }
+                                        } else if (!info.extraShare
+                                                   || !info.mnListDiffAtHMinus4C) {
+                                            LOG_WARNING << "[MN-DIFF-DB] getqrinfo"
+                                                " reply lacks the h-4C extraShare"
+                                                " leg — cannot seed a locator below"
+                                                " the deepest work block; rotated"
+                                                " bootstrap fails closed"
+                                                " (reward-safe), retry.";
+                                        }
+                                        return;   // headers absent → fail closed
+                                    }
+                                }
                                 dash::coin::MerkleRootOfHashFn mroot =
                                     [hc](const uint256& b)
                                         -> std::optional<uint256> {
@@ -7517,8 +7628,12 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                 if (auto he = hc->get_header_by_height(
                                         sseed->cycle_base)) {
                                     sseed->cycle_base_hash = he->hash;
+                                    // extra=true: the reply must carry the h-4C
+                                    // leg, whose blockHash seeds a getheaders
+                                    // locator BELOW the deepest work block so the
+                                    // pre-anchor backfill span includes h-3C.
                                     if (cp) cp->send_getqrinfo(
-                                        {}, he->hash, /*extra=*/false);
+                                        {}, he->hash, /*extra=*/true);
                                     sseed->sent        = true;
                                     sseed->last_send_h = h;
                                     LOG_INFO << "[MN-DIFF-DB] getqrinfo issued for"
@@ -7548,7 +7663,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                         if (auto he = hc->get_header_by_height(
                                                 sseed->cycle_base)) {
                                             if (cp) cp->send_getqrinfo(
-                                                {}, he->hash, false);
+                                                {}, he->hash, /*extra=*/true);
                                             sseed->last_send_h = h;
                                         }
                                     }

--- a/src/impl/dash/coin/header_chain.hpp
+++ b/src/impl/dash/coin/header_chain.hpp
@@ -563,6 +563,110 @@ public:
         return accepted;
     }
 
+    // Feature macro: the cold-start pre-anchor header backfill primitive
+    // below exists. Guards the KAT so it still compiles on a pre-fix tree.
+#ifndef C2POOL_PREANCHOR_SPAN_BACKFILL
+#define C2POOL_PREANCHOR_SPAN_BACKFILL 1
+#endif
+    /// Install a PRE-ANCHOR header span that links DOWNWARD from a trusted,
+    /// already-held block (the fast-start anchor). The forward add_header path
+    /// cannot do this: a pre-anchor header's parent is not held, so it
+    /// orphan-rejects (add_header_internal :660-661). At cold fast-start the
+    /// chain holds a LONE anchor and none of the work-block headers BELOW it
+    /// that the DIP-4 historical-snapshot auth (leg (b), historical_sml.hpp)
+    /// must consult — so getqrinfo rotated-quarter snapshots fail closed with
+    /// "block header not held". This walks DOWN from `anchor_hash` (which MUST
+    /// be held) through the supplied getheaders batch, authenticating each
+    /// parent by (1) X11(header) == the prev-hash its already-trusted child
+    /// commits to, and (2) check_pow against pow_limit — exactly the two legs
+    /// dashd requires of any header it stores. Headers that do not chain
+    /// downward from the trusted anchor are IGNORED (fail closed). Does NOT
+    /// move the tip / best-work: pre-anchor headers never compete for the tip,
+    /// and the synthetic-anchor daemon-tip honesty guards stay intact.
+    ///
+    /// REWARD-SAFETY: every installed header is bound to the release-pinned
+    /// anchor by an unbroken X11 prev-hash chain AND is independently
+    /// PoW-verified, so a wrong/forged header can never enter the view leg (b)
+    /// consults. A lying peer that returns garbage produces no linkage → zero
+    /// installs → leg (b) still fails closed.
+    ///
+    /// Returns the number of headers newly installed.
+    size_t install_preanchor_span(const uint256& anchor_hash,
+                                  const std::vector<BlockHeaderType>& batch)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        // The anchor is the trust root of the downward walk; it must be held.
+        auto anchor_it = m_headers.find(anchor_hash);
+        if (anchor_it == m_headers.end()) return 0;
+        const uint32_t anchor_height = anchor_it->second.height;
+
+        // Index the batch by X11 identity so prev-hash pointers can be
+        // followed. A header's presence here means it hashes to a specific
+        // block id; whether that id is TRUSTED is decided only by the walk.
+        std::map<uint256, const BlockHeaderType*> by_hash;
+        for (const auto& h : batch)
+            by_hash[x11_hash(h)] = &h;
+
+        // Bootstrap: the stored anchor entry keeps a SYNTHETIC prev (ZERO) so
+        // it never masquerades as a daemon tip, so read the anchor's REAL
+        // previous-block hash from the batch's own copy of the anchor header
+        // (getheaders with hash_stop=anchor returns it as the terminal entry).
+        // That copy is trusted the instant X11(copy) == the release-pinned
+        // anchor hash — which is exactly its key in by_hash.
+        auto anchor_hdr = by_hash.find(anchor_hash);
+        if (anchor_hdr == by_hash.end()) return 0;   // span never reached the anchor
+
+        uint32_t child_height = anchor_height;
+        uint256  parent_hash  = anchor_hdr->second->m_previous_block;
+
+        size_t installed = 0;
+        while (!parent_hash.IsNull() && child_height > 0) {
+            auto pit = by_hash.find(parent_hash);
+            if (pit == by_hash.end()) break;   // bottom of the supplied span
+            const BlockHeaderType& ph = *pit->second;
+            const uint32_t parent_height = child_height - 1;
+            // (1) X11 identity: pit was keyed by X11==parent_hash, and
+            //     parent_hash is the value the trusted child commits to — the
+            //     link is cryptographic. (2) PoW must be real.
+            if (!check_pow(parent_hash, ph.m_bits, m_params.pow_limit)) {
+                LOG_WARNING << "[EMB-DASH] pre-anchor backfill PoW FAIL at h="
+                            << parent_height << " hash="
+                            << parent_hash.GetHex().substr(0, 24)
+                            << " — stop (fail closed)";
+                break;
+            }
+            if (!m_headers.count(parent_hash)) {
+                IndexEntry e;
+                e.header     = ph;
+                e.hash       = parent_hash;
+                e.height     = parent_height;
+                // Pre-anchor cumulative work is unknown (genesis..anchor not
+                // held) and never consulted: these entries never enter tip
+                // selection. Zero keeps them strictly below m_best_work.
+                e.chain_work = uint256::ZERO;
+                e.prev_hash  = ph.m_previous_block;
+                e.status     = HEADER_VALID_CHAIN;
+                m_headers[parent_hash] = e;
+                // Bonus: back-fill the height index so get_header_by_height
+                // resolves pre-anchor heights too (harmless — forward entries
+                // at >= anchor are untouched; a later reorg rebuild walks from
+                // the synthetic anchor and simply drops these again, which
+                // leg (b)'s by-HASH lookup does not depend on).
+                m_height_index[parent_height] = parent_hash;
+                persist_header(e);
+                ++installed;
+            }
+            child_height = parent_height;
+            parent_hash  = ph.m_previous_block;
+        }
+        if (installed)
+            LOG_INFO << "[EMB-DASH] pre-anchor backfill INSTALLED " << installed
+                     << " header(s) down to h=" << child_height
+                     << " (X11-linked + PoW-verified from trusted anchor h="
+                     << anchor_height << "); DIP-4 leg (b) can now consult them.";
+        return installed;
+    }
+
     std::vector<uint256> get_locator() const {
         std::lock_guard<std::mutex> lock(m_mutex);
         return get_locator_internal();

--- a/src/impl/dash/coin/mn_checkpoint_dump.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_dump.hpp
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// SELF-DERIVED masternode-set checkpoint DUMP (dashd-cut, operator decision
+/// 2026-08-17).
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHAT THIS IS, AND WHY IT IS NOT gen_mn_checkpoint.py
+/// ─────────────────────────────────────────────────────────────────────────
+/// tools/dash/gen_mn_checkpoint.py mints the checkpoint .inc from a dashd
+/// `protx list registered true <height>` SNAPSHOT — a set dashd itself never
+/// consumes, obtained over RPC. The two payout-bearing fields the DIP-4 wire
+/// does NOT carry and merkleRootMNList does NOT commit — `scriptPayout` and
+/// `nLastPaidHeight` — are therefore TRUSTED from that snapshot.
+///
+/// This emitter produces the SAME checkpoint .inc payload (byte-identical in
+/// the digest domain, so the runtime parser in mn_checkpoint.hpp accepts it
+/// identically), but sourced entirely from the FOLD's own state: a
+/// DmlFoldEngine that replayed every block body from DIP-3 activation forward,
+/// self-checking each block's computed merkleRootMNList against that block's
+/// own committed cbTx root (replay_fold_consumer.hpp). `scriptPayout` is taken
+/// VERBATIM from the ProRegTx/ProUpRegTx body the fold replayed
+/// (chain-authentic); `nLastPaidHeight` is the payee bookkeeping the fold
+/// already keeps (dashd BuildNewListFromBlock parity). No dashd, no RPC, no
+/// trusted snapshot.
+///
+/// REWARD-SAFETY comes from REUSE, not from new code:
+///   * the 17-field order + conversions are the SAME the runtime parser reads
+///     (mn_checkpoint.hpp:66-83, 417-505) and gen_mn_checkpoint.py writes
+///     (build_mn_record), so a dumped set == the parser's expectation by
+///     construction;
+///   * the digest is the SAME function the parser and the generator agree on
+///     (mn_checkpoint_digest, mn_checkpoint.hpp:280);
+///   * write_mn_checkpoint_inc() PARSES its own output through
+///     parse_mn_checkpoint() before writing — it never emits a file the
+///     runtime would refuse;
+///   * REGISTERED, not valid-filtered: every entry the fold still holds is
+///     emitted, PoSe-banned ones included (they carry poseBanHeight>0, from
+///     which the parser re-derives isValid == false). This is the load-bearing
+///     property mn_checkpoint.hpp:88-104 spells out.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// THE ONE LOAD-BEARING BYTE-ORDER SUBTLETY
+/// ─────────────────────────────────────────────────────────────────────────
+/// proTxHash / collateralHash are uint256 HASHES the parser reads via
+/// uint256S (SetHex → byte-reversed into internal storage). Their .inc column
+/// is DISPLAY hex, so we emit them with GetHex() (which reverses back).
+///
+/// keyIDOwner / keyIDVoting are uint160 CKeyIDs whose .inc column is the RAW
+/// hash160 bytes (mn_checkpoint.hpp:201-210 hex_to_uint160 stores the payload
+/// bytes DIRECTLY, NOT reversed). We therefore emit them FORWARD (m_data
+/// order), NOT GetHex(). GetHex() here would silently byte-reverse the CKeyID
+/// and the round trip would fail. Same for pubKeyOperator (a raw 48-byte BLS
+/// blob) and the scriptPayout/scriptOperatorPayout byte vectors.
+///
+/// And the SORT: gen_mn_checkpoint.py sorts records by proTxHash DISPLAY hex
+/// ascending. std::map<uint256,...> iterates in INTERNAL (memcmp-LE) order,
+/// which is NOT the display order, so we re-sort the formatted lines by the
+/// display-hex proTxHash string — never trust the map iteration order for the
+/// .inc line order.
+///
+/// STRICTLY single-coin (src/impl/dash/coin/ only). Header-only, filesystem
+/// touch confined to write_mn_checkpoint_inc(). KAT-pinned
+/// (test/test_dash_mn_checkpoint.cpp::DashMnCheckpointDump).
+
+#include <impl/dash/coin/replay_fold_engine.hpp>   // DmlFoldEngine, ReplayMNState
+#include <impl/dash/coin/mn_checkpoint.hpp>         // mn_checkpoint_digest, kMnCheckpointMagic, parse_mn_checkpoint
+#include <impl/dash/coin/vendor/providertx.hpp>     // MnType
+
+#include <core/uint256.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+namespace mn_dump_detail {
+
+inline std::string hex_lower(const unsigned char* p, size_t n)
+{
+    static const char* kHex = "0123456789abcdef";
+    std::string s;
+    s.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i) {
+        s.push_back(kHex[p[i] >> 4]);
+        s.push_back(kHex[p[i] & 0x0f]);
+    }
+    return s;
+}
+
+// FORWARD (little-endian limb) hex of a base_uint — the raw CKeyID bytes the
+// checkpoint columns carry. mn_checkpoint.hpp::hex_to_uint160 builds the
+// uint160 with `pn[x] = ReadLE32(bytes + x*4)` (core/uint256.cpp vch ctor), so
+// the original bytes are recovered with the matching WriteLE32 per limb. NOT
+// GetHex(), which emits BE / display order. See the header comment "THE ONE
+// LOAD-BEARING BYTE-ORDER SUBTLETY".
+template <unsigned int BITS>
+inline std::string hex_forward(const ::base_uint<BITS>& b)
+{
+    unsigned char bytes[::base_uint<BITS>::BYTES];
+    for (int x = 0; x < ::base_uint<BITS>::WIDTH; ++x) {
+        const uint32_t v = b.pn[x];
+        bytes[x * 4 + 0] = static_cast<unsigned char>(v & 0xff);
+        bytes[x * 4 + 1] = static_cast<unsigned char>((v >> 8) & 0xff);
+        bytes[x * 4 + 2] = static_cast<unsigned char>((v >> 16) & 0xff);
+        bytes[x * 4 + 3] = static_cast<unsigned char>((v >> 24) & 0xff);
+    }
+    return hex_lower(bytes, static_cast<size_t>(::base_uint<BITS>::BYTES));
+}
+
+template <unsigned int BITS>
+inline bool base_uint_is_null(const ::base_uint<BITS>& b)
+{
+    for (int x = 0; x < ::base_uint<BITS>::WIDTH; ++x)
+        if (b.pn[x]) return false;
+    return true;
+}
+
+inline bool blob_is_null(const unsigned char* p, size_t n)
+{
+    for (size_t i = 0; i < n; ++i)
+        if (p[i]) return false;
+    return true;
+}
+
+// dashd's -1 "never" sentinel (and any negative) clamps to 0, byte-exact with
+// gen_mn_checkpoint.py::_clamp_height. ReplayMNState carries these as int32_t
+// with NEVER == -1 (replay_fold_engine.hpp:186), so a non-banned MN's
+// nPoSeBanHeight == -1 emits as 0 and the parser derives isValid == true.
+inline int32_t clamp_height(int32_t v) { return v > 0 ? v : 0; }
+
+// ISO-8601 UTC, matching gen_mn_checkpoint.py::_iso_now ("%Y-%m-%dT%H:%M:%SZ").
+inline std::string iso8601_utc_now()
+{
+    std::time_t t = std::time(nullptr);
+    std::tm tmv{};
+#if defined(_WIN32)
+    gmtime_s(&tmv, &t);
+#else
+    gmtime_r(&t, &tmv);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tmv);
+    return std::string(buf);
+}
+
+// The .inc C-string-literal wrapper for one payload line, byte-exact with
+// gen_mn_checkpoint.py::_c_literal: escape backslash and quote, append \n.
+inline std::string c_literal(const std::string& line)
+{
+    std::string s;
+    s.reserve(line.size() + 6);
+    s.push_back('"');
+    for (char c : line) {
+        if (c == '\\') s += "\\\\";
+        else if (c == '"') s += "\\\"";
+        else s.push_back(c);
+    }
+    s += "\\n\"";
+    return s;
+}
+
+// The generated-file banner. The payload it wraps is byte-identical to the
+// generator's; this comment is NOT — it names the self-derived provenance.
+// It is stripped from the digest domain (mn_checkpoint.hpp in_digest_domain)
+// AND by gen_mn_checkpoint.py::unwrap_inc (both drop `//` / comment lines), so
+// it is not load-bearing and cannot change the loaded set or the digest.
+inline constexpr const char* kSelfDerivedIncHeader =
+    "// SPDX-License-Identifier: AGPL-3.0-or-later\n"
+    "//\n"
+    "// GENERATED FILE -- DO NOT EDIT BY HAND.\n"
+    "// Self-derived from chain by c2pool --replay-bulk (dashd BuildNewListFromBlock\n"
+    "// parity), NOT captured from a dashd `protx list` snapshot. The trailing\n"
+    "// `digest` line commits every other line, so a hand edit is rejected at load\n"
+    "// time.\n"
+    "//\n"
+    "// THIS IS A TRUST ANCHOR. See src/impl/dash/coin/checkpoints/README.md and\n"
+    "// the \"DASH daemonless masternode-set checkpoint\" section of README.md.\n"
+    "//\n";
+
+} // namespace mn_dump_detail
+
+/// One `mn` .inc line for a registered masternode, in the authoritative
+/// 17-field order (mn_checkpoint.hpp:66-83). REUSED by the dumper and the KAT.
+inline std::string emit_mn_record_line(const uint256& protx,
+                                       const replay::ReplayMNState& st)
+{
+    using namespace mn_dump_detail;
+    std::ostringstream o;
+    o << "mn "
+      << protx.GetHex() << ' '                                  //  1 proTxHash (display)
+      << st.collateralOutpoint.hash.GetHex() << ' '            //  2 collateralHash (display)
+      << st.collateralOutpoint.index << ' '                    //  3 collateralIndex
+      << ((st.nType == vendor::MnType::EVO) ? 1 : 0) << ' '    //  4 type
+      << st.nVersion << ' '                                    //  5 version
+      << clamp_height(st.nRegisteredHeight) << ' '             //  6 registeredHeight
+      << clamp_height(st.nLastPaidHeight) << ' '               //  7 lastPaidHeight
+      << clamp_height(st.nPoSeRevivedHeight) << ' '            //  8 poseRevivedHeight
+      << clamp_height(st.nPoSeBanHeight) << ' '                //  9 poseBanHeight
+      << clamp_height(st.nConsecutivePayments) << ' '          // 10 consecutivePayments
+      << st.nRevocationReason << ' '                           // 11 revocationReason
+      << st.nOperatorReward << ' '                             // 12 operatorReward (bps)
+      // 13 scriptPayout — REQUIRED, verbatim ProRegTx bytes (chain-authentic).
+      << hex_lower(st.scriptPayout.m_data.data(), st.scriptPayout.m_data.size()) << ' ';
+    // 14 scriptOperatorPayout — `-` when unset.
+    if (st.scriptOperatorPayout.m_data.empty())
+        o << "- ";
+    else
+        o << hex_lower(st.scriptOperatorPayout.m_data.data(),
+                       st.scriptOperatorPayout.m_data.size()) << ' ';
+    // 15 keyIDOwner — FORWARD hash160 bytes, `-` when null.
+    if (base_uint_is_null(st.keyIDOwner))
+        o << "- ";
+    else
+        o << hex_forward(st.keyIDOwner) << ' ';
+    // 16 keyIDVoting — FORWARD hash160 bytes, `-` when null.
+    if (base_uint_is_null(st.keyIDVoting))
+        o << "- ";
+    else
+        o << hex_forward(st.keyIDVoting) << ' ';
+    // 17 pubKeyOperator — FORWARD 48-byte BLS blob, `-` when null.
+    if (blob_is_null(st.pubKeyOperator.data(), st.pubKeyOperator.size()))
+        o << "-";
+    else
+        o << hex_lower(st.pubKeyOperator.data(), st.pubKeyOperator.size());
+    return o.str();
+}
+
+struct MnCheckpointDump {
+    bool        ok{false};
+    std::string error;      // populated iff !ok
+    std::string payload;    // the raw checkpoint payload (what parse_mn_checkpoint reads)
+    std::string inc;        // the .inc file (C-string-literal wrapped payload)
+    std::string digest;     // the SHA-256 the payload commits to
+    uint32_t    height{0};
+    uint64_t    count{0};
+};
+
+/// Serialize a fold engine's REGISTERED masternode set at its current cursor
+/// height to the checkpoint payload + .inc. `source` becomes the `source`
+/// line (the operator decision requires it to name the self-derived
+/// provenance, e.g. "self-derived from chain via c2pool --replay-bulk at H");
+/// `generated` is the ISO-8601 timestamp (mn_dump_detail::iso8601_utc_now()).
+inline MnCheckpointDump emit_mn_checkpoint_dump(const replay::DmlFoldEngine& engine,
+                                                const std::string& source,
+                                                const std::string& generated)
+{
+    using namespace mn_dump_detail;
+    MnCheckpointDump r;
+    r.height = engine.height();
+
+    if (engine.poisoned()) {
+        r.error = "fold engine is POISONED (" + engine.poison_reason()
+                + ") — refusing to dump a diverged set";
+        return r;
+    }
+    if (engine.size() == 0) {
+        r.error = "fold holds 0 registered masternodes — refusing to write an"
+                  " empty anchor (fail-closed)";
+        return r;
+    }
+
+    // Format every registered MN; refuse a payee-less one exactly as the
+    // runtime parser would (mn_checkpoint.hpp:470-480).
+    std::vector<std::pair<std::string, std::string>> rows;  // (protx display hex, line)
+    rows.reserve(engine.size());
+    for (const auto& [protx, st] : engine.entries()) {
+        if (st.scriptPayout.m_data.empty()) {
+            r.error = "registered MN " + protx.GetHex().substr(0, 16)
+                    + " carries an empty scriptPayout — a payee-less MN would"
+                      " project a wrong payee (fail-closed)";
+            return r;
+        }
+        rows.emplace_back(protx.GetHex(), emit_mn_record_line(protx, st));
+    }
+    // Sort by proTxHash DISPLAY hex ascending — byte-parity with
+    // gen_mn_checkpoint.py `records.sort(key=lambda r: r[0])`. Map order is
+    // internal-byte order and would NOT match.
+    std::sort(rows.begin(), rows.end(),
+              [](const auto& a, const auto& b) { return a.first < b.first; });
+
+    std::vector<std::string> mn_lines;
+    mn_lines.reserve(rows.size());
+    for (auto& kv : rows) mn_lines.push_back(std::move(kv.second));
+
+    // 7-line header, exact order/formatting of gen_mn_checkpoint.py.
+    std::vector<std::string> header = {
+        std::string(kMnCheckpointMagic),
+        "network " + engine.network(),
+        "height " + std::to_string(engine.height()),
+        "blockhash " + engine.block_hash().GetHex(),
+        "source " + source,
+        "generated " + generated,
+        "count " + std::to_string(mn_lines.size()),
+    };
+
+    // Digest over header + mn lines (the digest line itself is never in the
+    // domain — mn_checkpoint_digest enforces that anyway).
+    std::string domain;
+    for (const auto& l : header)   { domain += l; domain += '\n'; }
+    for (const auto& l : mn_lines) { domain += l; domain += '\n'; }
+    r.digest = mn_checkpoint_digest(domain);
+
+    // Raw payload = header + digest line + mn lines + a trailing blank line
+    // (the trailing `"\n"` gen_mn_checkpoint.py::write_inc appends).
+    std::string payload;
+    for (const auto& l : header)   { payload += l; payload += '\n'; }
+    payload += "digest " + r.digest + '\n';
+    for (const auto& l : mn_lines) { payload += l; payload += '\n'; }
+    payload += '\n';
+    r.payload = std::move(payload);
+
+    // .inc = banner + blank + C-string-literal per payload line + trailing
+    // `"\n"`, byte-identical to gen_mn_checkpoint.py::write_inc EXCEPT the
+    // leading // banner (not in the digest domain; see kSelfDerivedIncHeader).
+    std::string inc = kSelfDerivedIncHeader;
+    inc += "\n";
+    for (const auto& l : header)   { inc += c_literal(l);                 inc += '\n'; }
+    inc += c_literal("digest " + r.digest); inc += '\n';
+    for (const auto& l : mn_lines) { inc += c_literal(l);                 inc += '\n'; }
+    inc += "\"\\n\"\n";
+    r.inc = std::move(inc);
+
+    r.count = mn_lines.size();
+    r.ok = true;
+    return r;
+}
+
+/// Dump + SELF-VERIFY + write the .inc. Never writes a file the runtime parser
+/// would refuse: the payload is round-tripped through parse_mn_checkpoint()
+/// (with the engine's own network) before the file is opened. Returns true on
+/// success; on failure `error` names the blocking condition and no file is
+/// written (or a partial write is reported).
+inline bool write_mn_checkpoint_inc(const replay::DmlFoldEngine& engine,
+                                    const std::string& path,
+                                    const std::string& source,
+                                    const std::string& generated,
+                                    std::string& error)
+{
+    MnCheckpointDump d = emit_mn_checkpoint_dump(engine, source, generated);
+    if (!d.ok) { error = d.error; return false; }
+
+    // The reward-safety gate: our own output must parse clean under the very
+    // parser the runtime cold-start uses, or we do not ship it.
+    MnCheckpoint cp = parse_mn_checkpoint(d.payload, engine.network());
+    if (!cp.ok) {
+        error = "self-check FAILED — the dumped payload was rejected by"
+                " parse_mn_checkpoint(): " + cp.error;
+        return false;
+    }
+    if (cp.entries.size() != d.count) {
+        error = "self-check FAILED — parsed " + std::to_string(cp.entries.size())
+              + " entries, dumped " + std::to_string(d.count);
+        return false;
+    }
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f) { error = "cannot open '" + path + "' for writing"; return false; }
+    f << d.inc;
+    f.flush();
+    if (!f.good()) { error = "write to '" + path + "' failed"; return false; }
+    return true;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mn_checkpoint_dump.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_dump.hpp
@@ -73,6 +73,7 @@
 #include <cstdint>
 #include <ctime>
 #include <fstream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -243,43 +244,20 @@ struct MnCheckpointDump {
     uint64_t    count{0};
 };
 
-/// Serialize a fold engine's REGISTERED masternode set at its current cursor
-/// height to the checkpoint payload + .inc. `source` becomes the `source`
-/// line (the operator decision requires it to name the self-derived
-/// provenance, e.g. "self-derived from chain via c2pool --replay-bulk at H");
-/// `generated` is the ISO-8601 timestamp (mn_dump_detail::iso8601_utc_now()).
-inline MnCheckpointDump emit_mn_checkpoint_dump(const replay::DmlFoldEngine& engine,
-                                                const std::string& source,
-                                                const std::string& generated)
+/// Shared assembly tail: sorted `rows` (proTxHash DISPLAY hex, mn line) ->
+/// 7-line header + digest + payload + .inc, in the exact gen_mn_checkpoint.py
+/// byte format. REWARD-SAFETY-CRITICAL: single-sourced so the DmlFoldEngine
+/// dumper and the MN-CKPT bridge dumper cannot ever diverge in the format they
+/// emit. Pure serialization — no consensus/fold logic.
+inline MnCheckpointDump finish_mn_checkpoint_dump(
+    std::vector<std::pair<std::string, std::string>> rows,
+    uint32_t height, const uint256& blockhash, const std::string& network,
+    const std::string& source, const std::string& generated)
 {
     using namespace mn_dump_detail;
     MnCheckpointDump r;
-    r.height = engine.height();
+    r.height = height;
 
-    if (engine.poisoned()) {
-        r.error = "fold engine is POISONED (" + engine.poison_reason()
-                + ") — refusing to dump a diverged set";
-        return r;
-    }
-    if (engine.size() == 0) {
-        r.error = "fold holds 0 registered masternodes — refusing to write an"
-                  " empty anchor (fail-closed)";
-        return r;
-    }
-
-    // Format every registered MN; refuse a payee-less one exactly as the
-    // runtime parser would (mn_checkpoint.hpp:470-480).
-    std::vector<std::pair<std::string, std::string>> rows;  // (protx display hex, line)
-    rows.reserve(engine.size());
-    for (const auto& [protx, st] : engine.entries()) {
-        if (st.scriptPayout.m_data.empty()) {
-            r.error = "registered MN " + protx.GetHex().substr(0, 16)
-                    + " carries an empty scriptPayout — a payee-less MN would"
-                      " project a wrong payee (fail-closed)";
-            return r;
-        }
-        rows.emplace_back(protx.GetHex(), emit_mn_record_line(protx, st));
-    }
     // Sort by proTxHash DISPLAY hex ascending — byte-parity with
     // gen_mn_checkpoint.py `records.sort(key=lambda r: r[0])`. Map order is
     // internal-byte order and would NOT match.
@@ -293,9 +271,9 @@ inline MnCheckpointDump emit_mn_checkpoint_dump(const replay::DmlFoldEngine& eng
     // 7-line header, exact order/formatting of gen_mn_checkpoint.py.
     std::vector<std::string> header = {
         std::string(kMnCheckpointMagic),
-        "network " + engine.network(),
-        "height " + std::to_string(engine.height()),
-        "blockhash " + engine.block_hash().GetHex(),
+        "network " + network,
+        "height " + std::to_string(height),
+        "blockhash " + blockhash.GetHex(),
         "source " + source,
         "generated " + generated,
         "count " + std::to_string(mn_lines.size()),
@@ -333,6 +311,119 @@ inline MnCheckpointDump emit_mn_checkpoint_dump(const replay::DmlFoldEngine& eng
     return r;
 }
 
+/// MNState (mn_state_db.hpp — the MN-CKPT bridge's per-entry payee state) ->
+/// the ReplayMNState fields emit_mn_record_line() serializes. The bridge's
+/// MnStateMachine folds the SAME 17 checkpoint fields (it is SEEDED from a
+/// parsed checkpoint, whose native entry type IS MNState), so this is a pure
+/// field-copy — no consensus/fold logic — and produces byte-identical output
+/// to a dump of the same MN off the DmlFoldEngine path. Heights are
+/// non-negative in MNState (0 == "never/unset"); emit_mn_record_line clamps
+/// <=0 to 0 either way, so the ban/revive sentinels agree.
+inline replay::ReplayMNState mnstate_to_replay_line(const MNState& mn)
+{
+    replay::ReplayMNState st;
+    st.nType                = mn.nType;
+    st.nVersion             = mn.nVersion;
+    st.collateralOutpoint   = mn.collateralOutpoint;
+    st.nOperatorReward      = mn.nOperatorReward;
+    st.nRegisteredHeight    = static_cast<int32_t>(mn.nRegisteredHeight);
+    st.nLastPaidHeight      = static_cast<int32_t>(mn.nLastPaidHeight);
+    st.nConsecutivePayments = static_cast<int32_t>(mn.nConsecutivePayments);
+    st.nPoSeRevivedHeight   = static_cast<int32_t>(mn.nPoSeRevivedHeight);
+    st.nPoSeBanHeight       = static_cast<int32_t>(mn.nPoSeBanHeight);
+    st.nRevocationReason    = mn.nRevocationReason;
+    st.keyIDOwner           = mn.keyIDOwner;
+    st.pubKeyOperator       = mn.pubKeyOperator;
+    st.keyIDVoting          = mn.keyIDVoting;
+    st.scriptPayout         = mn.scriptPayout;
+    st.scriptOperatorPayout = mn.scriptOperatorPayout;
+    return st;
+}
+
+/// Serialize a fold engine's REGISTERED masternode set at its current cursor
+/// height to the checkpoint payload + .inc. `source` becomes the `source`
+/// line (the operator decision requires it to name the self-derived
+/// provenance, e.g. "self-derived from chain via c2pool --replay-bulk at H");
+/// `generated` is the ISO-8601 timestamp (mn_dump_detail::iso8601_utc_now()).
+inline MnCheckpointDump emit_mn_checkpoint_dump(const replay::DmlFoldEngine& engine,
+                                                const std::string& source,
+                                                const std::string& generated)
+{
+    using namespace mn_dump_detail;
+    MnCheckpointDump r;
+    r.height = engine.height();
+
+    if (engine.poisoned()) {
+        r.error = "fold engine is POISONED (" + engine.poison_reason()
+                + ") — refusing to dump a diverged set";
+        return r;
+    }
+    if (engine.size() == 0) {
+        r.error = "fold holds 0 registered masternodes — refusing to write an"
+                  " empty anchor (fail-closed)";
+        return r;
+    }
+
+    // Format every registered MN; refuse a payee-less one exactly as the
+    // runtime parser would (mn_checkpoint.hpp:470-480).
+    std::vector<std::pair<std::string, std::string>> rows;  // (protx display hex, line)
+    rows.reserve(engine.size());
+    for (const auto& [protx, st] : engine.entries()) {
+        if (st.scriptPayout.m_data.empty()) {
+            r.error = "registered MN " + protx.GetHex().substr(0, 16)
+                    + " carries an empty scriptPayout — a payee-less MN would"
+                      " project a wrong payee (fail-closed)";
+            return r;
+        }
+        rows.emplace_back(protx.GetHex(), emit_mn_record_line(protx, st));
+    }
+    return finish_mn_checkpoint_dump(std::move(rows), engine.height(),
+                                     engine.block_hash(), engine.network(),
+                                     source, generated);
+}
+
+/// MN-CKPT BRIDGE overload. Serialize the bridge's OWN reconstructed set —
+/// MnStateMachine::entries(), std::map<uint256, MNState> — at the height it
+/// bridged to. Byte-identical format to the DmlFoldEngine dumper above: it
+/// shares finish_mn_checkpoint_dump() and emit_mn_record_line() verbatim, only
+/// adapting each MNState to the line fields (mnstate_to_replay_line). The
+/// bridge carries no `poisoned()` flag; a diverged bridge fails closed at the
+/// lane (it never reaches the dump height), and an empty/payee-less set is
+/// still refused here exactly as the engine path refuses it. `height`,
+/// `blockhash` and `network` name the cursor the bridge stands on (the lane
+/// supplies the block hash from OUR PoW-validated header chain).
+inline MnCheckpointDump emit_mn_checkpoint_dump(
+    const std::map<uint256, MNState>& entries,
+    uint32_t height, const uint256& blockhash, const std::string& network,
+    const std::string& source, const std::string& generated)
+{
+    MnCheckpointDump r;
+    r.height = height;
+
+    if (entries.empty()) {
+        r.error = "bridge holds 0 registered masternodes — refusing to write an"
+                  " empty anchor (fail-closed)";
+        return r;
+    }
+
+    // Format every registered MN; refuse a payee-less one exactly as the
+    // runtime parser would (mn_checkpoint.hpp:470-480).
+    std::vector<std::pair<std::string, std::string>> rows;  // (protx display hex, line)
+    rows.reserve(entries.size());
+    for (const auto& [protx, mn] : entries) {
+        if (mn.scriptPayout.m_data.empty()) {
+            r.error = "registered MN " + protx.GetHex().substr(0, 16)
+                    + " carries an empty scriptPayout — a payee-less MN would"
+                      " project a wrong payee (fail-closed)";
+            return r;
+        }
+        rows.emplace_back(protx.GetHex(),
+                          emit_mn_record_line(protx, mnstate_to_replay_line(mn)));
+    }
+    return finish_mn_checkpoint_dump(std::move(rows), height, blockhash,
+                                     network, source, generated);
+}
+
 /// Dump + SELF-VERIFY + write the .inc. Never writes a file the runtime parser
 /// would refuse: the payload is round-tripped through parse_mn_checkpoint()
 /// (with the engine's own network) before the file is opened. Returns true on
@@ -350,6 +441,45 @@ inline bool write_mn_checkpoint_inc(const replay::DmlFoldEngine& engine,
     // The reward-safety gate: our own output must parse clean under the very
     // parser the runtime cold-start uses, or we do not ship it.
     MnCheckpoint cp = parse_mn_checkpoint(d.payload, engine.network());
+    if (!cp.ok) {
+        error = "self-check FAILED — the dumped payload was rejected by"
+                " parse_mn_checkpoint(): " + cp.error;
+        return false;
+    }
+    if (cp.entries.size() != d.count) {
+        error = "self-check FAILED — parsed " + std::to_string(cp.entries.size())
+              + " entries, dumped " + std::to_string(d.count);
+        return false;
+    }
+
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    if (!f) { error = "cannot open '" + path + "' for writing"; return false; }
+    f << d.inc;
+    f.flush();
+    if (!f.good()) { error = "write to '" + path + "' failed"; return false; }
+    return true;
+}
+
+/// MN-CKPT BRIDGE overload of the self-verifying writer. The self-check is the
+/// same reward-safety gate VERBATIM: the emitted payload is round-tripped
+/// through parse_mn_checkpoint(payload, network) — the very parser the runtime
+/// cold-start uses — before the file is opened, so a bridge set that fails
+/// self-parse is NEVER written.
+inline bool write_mn_checkpoint_inc(const std::map<uint256, MNState>& entries,
+                                    uint32_t height, const uint256& blockhash,
+                                    const std::string& network,
+                                    const std::string& path,
+                                    const std::string& source,
+                                    const std::string& generated,
+                                    std::string& error)
+{
+    MnCheckpointDump d = emit_mn_checkpoint_dump(entries, height, blockhash,
+                                                 network, source, generated);
+    if (!d.ok) { error = d.error; return false; }
+
+    // The reward-safety gate: our own output must parse clean under the very
+    // parser the runtime cold-start uses, or we do not ship it.
+    MnCheckpoint cp = parse_mn_checkpoint(d.payload, network);
     if (!cp.ok) {
         error = "self-check FAILED — the dumped payload was rejected by"
                 " parse_mn_checkpoint(): " + cp.error;

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -364,6 +364,24 @@ public:
         m_on_block_applied = std::move(fn);
     }
 
+    /// ── DASHD-CUT: self-derived checkpoint DUMP-AT-HEIGHT hook (task #154) ──
+    /// One-shot: install a target height and a sink. The instant the bridge
+    /// folds CLEANLY up to `target_height` at its contiguous cursor, the hook
+    /// fires with the bridged MnStateMachine, the reached height, and that
+    /// height's block hash (from OUR PoW-validated header chain). The caller
+    /// serializes the bridge's own payout-bearing set to a checkpoint .inc —
+    /// self-derived, no dashd. Exact analog of FoldReplayConsumer::set_dump_hook.
+    /// Fires from the SAME clean-fold event that feeds set_on_block_applied
+    /// (forward-contiguous, once per height), so it never fires on a gapped or
+    /// payee-desynced fold. Optional — unset is a no-op.
+    void set_dump_hook(uint32_t target_height,
+                       std::function<void(const MnStateMachine&, uint32_t,
+                                          const uint256&)> h)
+    {
+        m_dump_target = target_height;
+        m_dump_hook   = std::move(h);
+    }
+
     /// FULL-STATE ANCHOR SEED seam (dashd-cut MN diff store). The lane's OWN
     /// first fold is the anchor fold: begin_fold(m_anchor_height) requests
     /// getmnlistd(base=ZERO, target=anchor_hash) and on_historical_snapshot()
@@ -2061,6 +2079,8 @@ public:
         // engine so the store writer emits this height's root+payee-checked
         // diff. Forward-contiguous, once per height, in order.
         if (m_on_block_applied) m_on_block_applied(block, height);
+        // task #154: self-derived checkpoint dump, off the SAME clean fold.
+        maybe_fire_dump(height);
         // #91: DELIVERED, and only now. Every guard above had to pass — no
         // gap, no payee desync, a non-empty set — before this height is a
         // height a restart may resume from.
@@ -3314,6 +3334,8 @@ private:
         // feed it to the parallel engine exactly as the ordinary post-apply
         // path does, so the store's per-height diff chain has no hole here.
         if (m_on_block_applied) m_on_block_applied(m_ondemand_block, height);
+        // task #154: self-derived checkpoint dump, off the SAME clean fold.
+        maybe_fire_dump(height);
         m_sml_recovered += m_ondemand_r.sml_recovered;
         m_registered    += m_ondemand_r.registered;
         m_spent         += m_ondemand_r.spent;
@@ -4177,6 +4199,34 @@ public:
     // payee-only checkpoint omits. Unset = no-op.
     std::function<void(const vendor::CSimplifiedMNList&, uint32_t)>
         m_on_anchor_snapshot;
+    // dashd-cut SELF-DERIVED CHECKPOINT DUMP seam (task #154). One-shot: when
+    // the bridge's contiguous cursor reaches m_dump_target, hand the caller the
+    // bridged MnStateMachine (its payout-bearing set) + the reached height + the
+    // block hash so it can serialize a self-derived checkpoint (.inc) from the
+    // bridge's OWN reconstruction — no dashd, no getmnlistdiff. Exact analog of
+    // FoldReplayConsumer::set_dump_hook on the replay-fold path. Unset = no-op.
+    uint32_t    m_dump_target{0};   // 0 = off
+    bool        m_dumped{false};
+    std::function<void(const MnStateMachine&, uint32_t /*reached*/,
+                       const uint256& /*blockhash*/)>
+        m_dump_hook;
+
+    // Fire the one-shot self-derived checkpoint dump the instant the bridge's
+    // clean, contiguous cursor reaches m_dump_target. Called from every
+    // clean-fold site (right after m_on_block_applied fires), so it inherits the
+    // same "no gap, no payee desync, non-empty set" guarantees those sites do.
+    void maybe_fire_dump(uint32_t height)
+    {
+        if (!m_dump_hook || m_dumped || m_dump_target == 0
+            || height != m_dump_target)
+            return;
+        m_dumped = true;
+        uint256 blockhash;
+        if (m_header_hash_at) {
+            if (auto h = m_header_hash_at(height)) blockhash = *h;
+        }
+        m_dump_hook(m_machine, height, blockhash);
+    }
     // dashd-cut SOURCE observability: pre-block ban state resolved from the
     // diff store (0-RTT) instead of a capped network probe/fold. These are the
     // counts that prove the store SERVED — a green run has probe/fold caps

--- a/src/impl/dash/coin/replay_fold_consumer.hpp
+++ b/src/impl/dash/coin/replay_fold_consumer.hpp
@@ -153,6 +153,24 @@ public:
         m_post_fold = std::move(h);
     }
 
+    /// ── The self-derived checkpoint DUMP seam (mn_checkpoint_dump.hpp) ────
+    /// A ONE-SHOT hook that fires exactly once, right after the successful
+    /// fold whose cursor first REACHES `target_height`. Deliberately SEPARATE
+    /// from set_post_fold so it never contends with the W4 quorum seam (which
+    /// owns post_fold): a --dump-mn-checkpoint run also needs --replay-fold-
+    /// quorums, so both must coexist. The hook receives the engine at H so it
+    /// can serialize the registered set it just proved (each block up to and
+    /// including H self-checked against its own committed merkleRootMNList).
+    /// The fold is strictly forward-contiguous (+1/block), so height == H
+    /// happens at most once; the m_dumped latch guarantees at-most-once even
+    /// if a later re-offer of H arrives.
+    void set_dump_hook(uint32_t target_height,
+                       std::function<void(const DmlFoldEngine&, uint32_t)> h)
+    {
+        m_dump_target = target_height;
+        m_dump_hook   = std::move(h);
+    }
+
     /// ── The diff-store seam (mn_diff_store.hpp) ──────────────────────────
     /// Invoked for every block whose fold COMPLETED — i.e. after the root
     /// self-check passed and the counters above were credited. This is the
@@ -250,6 +268,15 @@ public:
         if (m_post_fold) m_post_fold(height);
         if (m_diff_sink) m_diff_sink(height, hash, block, r);
 
+        // One-shot self-derived checkpoint dump AT the target height. Runs
+        // after post_fold/diff_sink so the diff store has recorded H too. Only
+        // ever fires on a fold that reached H through the byte-exact root
+        // chain above — a diverged/poisoned fold returns before this point.
+        if (m_dump_hook && !m_dumped && height == m_dump_target) {
+            m_dumped = true;
+            m_dump_hook(m_engine, height);
+        }
+
         if (m_utxo_sink && !m_utxo_sink(height, hash, block)) {
             // Tier-B is a DECORATION: its failure is reported but must never
             // invalidate the Tier-A root chain that already passed here.
@@ -325,6 +352,9 @@ private:
     BlockHook         m_pre_fold;
     std::function<void(uint32_t)> m_post_fold;
     DiffSink          m_diff_sink;
+    uint32_t          m_dump_target{0};
+    bool              m_dumped{false};
+    std::function<void(const DmlFoldEngine&, uint32_t)> m_dump_hook;
     uint32_t          m_progress_every;
     FoldConsumerStats m_stats;
     std::chrono::steady_clock::time_point m_started;

--- a/src/impl/dash/coin/replay_fold_engine.hpp
+++ b/src/impl/dash/coin/replay_fold_engine.hpp
@@ -359,6 +359,12 @@ struct ReplayMNState
 struct FoldGates
 {
     int32_t dip0003_height{1028160};   // fold start — no DML below this
+    // DIP3 has TWO distinct heights (dashd deploymentstatus.h:52 comment:
+    // "'active' and 'enforced' are different statuses for DIP0003"). The
+    // deterministic MN list is BUILT from activation (dip0003_height); the
+    // coinbase paying GetMNPayee(list) is only ENFORCED from here on. dashd
+    // mainnet chainparams.cpp:186 DIP0003EnforcementHeight = 1047200.
+    int32_t dip0003_enforcement_height{1047200};
     int32_t v19_height{1899072};       // basic BLS (per-entry nVersion wrapper)
     int32_t mn_rr_height{2128896};     // MN reward reallocation (Evo 4-in-a-row OFF)
     int32_t masternode_min_confirmations{15};
@@ -369,6 +375,13 @@ struct FoldGates
 
     bool v19_active(int32_t h) const   { return h >= v19_height; }
     bool mn_rr_active(int32_t h) const { return h >= mn_rr_height; }
+    // dashd deploymentstatus.h:53 DeploymentDIP0003Enforced(h) == h >= EnfHeight.
+    // Gates the coinbase payee cross-check: below this dashd's own consensus
+    // rule (CMNPaymentsProcessor::IsTransactionValid, payments.cpp:114) returns
+    // valid WITHOUT checking the det payee, so the coinbase pays the legacy
+    // masternode winner, not GetMNPayee(list) — a cross-check here would be
+    // stricter than dashd and false-poison a correct fold.
+    bool dip0003_enforced(int32_t h) const { return h >= dip0003_enforcement_height; }
 };
 
 /// Feature flag for the whole engine. `enabled` MUST be set explicitly —
@@ -414,6 +427,13 @@ struct FoldResult
     // a projection that is NOT paid fails the fold closed, it never leaves
     // this flag quietly clear.
     bool        payee_paid_verified{false};
+    // True when the payee cross-check was SKIPPED because this height is below
+    // DIP3 enforcement (dashd does not commit the det payee to the coinbase
+    // there either). The SET self-check (merkleRootMNList) still ran; only the
+    // payee AXIS is not coinbase-committed yet. Diagnostic only — the fold is
+    // still fully derived and self-consistent (nLastPaidHeight accumulates on
+    // the projected payee exactly as dashd BuildNewListFromBlock does).
+    bool        payee_check_preenforcement_skipped{false};
 };
 
 class DmlFoldEngine
@@ -895,7 +915,30 @@ public:
         // members WITHIN a group. A within-group swap is invisible to the
         // coinbase and therefore invisible to any consumer of it, including
         // dashd's own validation of our block.
-        if (r.payee && !payee_script_pre.empty()) {
+        //
+        // DIP3-ENFORCEMENT GATE (dashd parity, DIP3-genesis regime fix):
+        // dashd builds the deterministic list from DIP3 ACTIVATION (1028160)
+        // but only ENFORCES the coinbase paying GetMNPayee(list) from
+        // DIP0003EnforcementHeight (1047200) — CMNPaymentsProcessor::
+        // IsTransactionValid (payments.cpp:114) returns valid WITHOUT checking
+        // the payee when !DeploymentDIP0003Enforced(h). In the [activation,
+        // enforcement) window the historical coinbase pays the LEGACY
+        // masternode winner, not the det projection, so this cross-check —
+        // which is correct at tip — is STRICTER THAN DASHD there and false-
+        // poisons a byte-correct fold (observed: h=1028163, merkleRootMNList
+        // MATCHED, payee projection sound, coinbase simply pays the legacy
+        // winner). Mirror dashd's gate exactly. The SET self-check above stays
+        // UNCONDITIONAL; the payee projection + nLastPaidHeight bookkeeping
+        // (passes 0/5) also run unconditionally, so the payee axis stays fully
+        // derived and self-consistent across the window and is correct the
+        // instant enforcement begins. Production (tip ~2.5M) is far above
+        // enforcement, so the money-path check is UNCHANGED.
+        if (r.payee && !payee_script_pre.empty()
+            && !m_cfg.gates.dip0003_enforced(H)) {
+            r.payee_check_preenforcement_skipped = true;
+        }
+        if (r.payee && !payee_script_pre.empty()
+            && m_cfg.gates.dip0003_enforced(H)) {
             bool paid = false;
             if (!block.m_txs.empty()) {
                 for (const auto& out : block.m_txs[0].vout) {

--- a/src/impl/dash/coin/replay_prestate.hpp
+++ b/src/impl/dash/coin/replay_prestate.hpp
@@ -31,6 +31,9 @@
 //   * every per-mn hash field is WIRE hex (raw internal bytes, memcpy'd).
 
 #include <impl/dash/coin/replay_fold_engine.hpp>
+#include <impl/dash/coin/replay_bulk_fetch.hpp>   // MAINNET_DIP3_HEIGHT — the
+                                                  // SAME constant --replay-bulk-start
+                                                  // defaults to (do NOT re-literal it)
 
 #include <cstdint>
 #include <cstring>
@@ -332,8 +335,31 @@ inline Prestate parse_prestate_text(const std::string& text)
         return fail("prestate declares count=" + std::to_string(declared)
                     + " but carries " + std::to_string(ps.entries.size())
                     + " mn records");
-    if (ps.entries.empty())
-        return fail("prestate carries no masternodes");
+    // ── SCOPED empty-set relaxation (reward-safe, DIP3-activation ONLY) ──────
+    //
+    // An empty entries set is CHAIN-TRUE at exactly one height: the DIP3
+    // activation height. DASH's deterministic masternode list is empty until
+    // the first ProRegTx at/after DIP3 enforcement, so the W1 fold must be
+    // seedable from an EMPTY set at h=MAINNET_DIP3_HEIGHT to derive the whole
+    // set FROM CHAIN (dashd BuildNewListFromBlock parity) instead of capturing
+    // it from dashd RPC. We reuse the SAME constant --replay-bulk-start
+    // defaults to (rp::MAINNET_DIP3_HEIGHT == 1028160); no fresh literal.
+    //
+    // At EVERY other height an empty set stays a HARD reject: there it can only
+    // mean a half-parsed / records-dropped seed, which would seed a replay that
+    // diverges SILENTLY (the very failure this loader exists to refuse).
+    //
+    // This relaxation is FAIL-CLOSED and can never mint: the empty seed is not
+    // trusted on faith. The fold's per-block merkleRootMNList self-check
+    // (replay_fold_engine.hpp poison() ~:815) HARD-STOPS at the first post-DIP3
+    // ProRegTx block if the empty-at-DIP3 seed (or its anchor hash/height) is
+    // wrong — a wrong seed folds to the wrong root and poisons the engine
+    // instead of serving wrong bytes. DIP-4 / root self-checks stay strict.
+    if (ps.entries.empty() && ps.height != MAINNET_DIP3_HEIGHT)
+        return fail("prestate carries no masternodes (an empty set is chain-true"
+                    " ONLY at the DIP3 activation height "
+                    + std::to_string(MAINNET_DIP3_HEIGHT) + ", not at h="
+                    + std::to_string(ps.height) + ")");
 
     ps.ok = true;
     return ps;

--- a/src/impl/dash/coin/replay_quorum_bridge.hpp
+++ b/src/impl/dash/coin/replay_quorum_bridge.hpp
@@ -738,6 +738,25 @@ public:
         return std::nullopt;
     }
 
+    /// Drive the straddle-cycle member assembly the moment the getqrinfo
+    /// seed lands (store-engine bootstrap, main_dash.cpp). Pass-through to the
+    /// engine; folds the outcome into the report counters so a run states
+    /// whether the seeded cycle became derivable. See
+    /// QuorumReplayEngine::derive_members_for_cycle for the reward-safety
+    /// argument (a wrong set fails the writer's root self-check closed).
+    QuorumReplayEngine::DeriveCycleResult
+    derive_members_for_cycle(uint8_t llmq_type, uint32_t cycle_base)
+    {
+        auto r = m_quorum.derive_members_for_cycle(llmq_type, cycle_base);
+        if (r.ok) {
+            ++m_stats.member_cycles_derived;
+        } else {
+            ++m_stats.member_cycles_skipped;
+            if (!r.skip_reason.empty()) m_stats.last_skip_reason = r.skip_reason;
+        }
+        return r;
+    }
+
     size_t retained_lists() const { return m_lists.size(); }
 
     /// dashd CDeterministicMN → the member-computation view. Carries the

--- a/src/impl/dash/coin/replay_quorum_engine.hpp
+++ b/src/impl/dash/coin/replay_quorum_engine.hpp
@@ -1045,6 +1045,91 @@ public:
         return mit->second;
     }
 
+    /// Result of an out-of-band single-cycle member derivation.
+    struct DeriveCycleResult {
+        bool        ok{false};
+        uint8_t     llmq_type{0};
+        uint32_t    cycle_base{0};
+        size_t      member_sets{0};   // # of quorumIndex lists now registered
+        size_t      quorum_size{0};   // members per set (for the log)
+        size_t      expected_sets{0}; // signingActiveQuorumCount
+        std::string skip_reason;      // engine's own named miss on !ok
+    };
+
+    /// Out-of-band derivation of ONE rotated cycle's member sets from the
+    /// already-seeded quarter snapshots + work-lists (the getqrinfo straddle
+    /// bootstrap). It drives the SAME compute_rotation_cycle path
+    /// derive_cycles_at() runs at forward-observe — no new consensus code —
+    /// but at the moment the seed LANDS, so the straddle cycle's ordered
+    /// member sets are registered under m_members[{type, cycle_base+index}]
+    /// (exactly the key fold_qfcommit's m_members_fn(type, quorumHash) lookup
+    /// resolves a commitment quorumHash to, via m_height_by_hash) BEFORE any
+    /// held block drains into the fold. Without this the member set is only
+    /// ever attempted lazily during the forward drain, and on the seeded
+    /// straddle cycle that attempt does not populate a result the qfcommit at
+    /// cycle_base+mining_window_start can consume, so the store caps there.
+    ///
+    /// Idempotent (re-storing identical members is a no-op) and reward-safe by
+    /// construction: a WRONG member set later re-hashes to the wrong
+    /// merkleRootMNList and the writer's per-row root self-check refuses the
+    /// row, so callers fall through to the network path — never a bad mint.
+    DeriveCycleResult derive_members_for_cycle(uint8_t llmq_type,
+                                               uint32_t cycle_base)
+    {
+        DeriveCycleResult out;
+        out.llmq_type  = llmq_type;
+        out.cycle_base = cycle_base;
+        const LlmqParamsView* p = replay_llmq_params(m_cfg.network, llmq_type);
+        if (p == nullptr) {
+            out.skip_reason = "llmqType " + std::to_string(int(llmq_type))
+                            + " not in this network's chainparams llmq list";
+            return out;
+        }
+        if (!p->use_rotation) {
+            out.skip_reason = "llmqType " + std::to_string(int(llmq_type))
+                            + " is not a rotated LLMQ — no quarter-rotation "
+                              "member set to assemble";
+            return out;
+        }
+        out.quorum_size   = p->size;
+        out.expected_sets = p->signing_active_quorum_count;
+
+        // Run the engine's own per-cycle derivation verbatim at the cycle
+        // base. derive_cycles_at only acts on types whose dkgInterval divides
+        // the height, so this touches exactly the cycle(s) rooted here.
+        QuorumObserveResult r;
+        r.height = cycle_base;
+        derive_cycles_at(cycle_base, r);
+
+        // Success == the ordered member set for THIS type/cycle is now
+        // registered for every signingActiveQuorumCount index.
+        size_t have = 0;
+        for (uint32_t i = 0; i < p->signing_active_quorum_count; ++i) {
+            if (m_members.count({llmq_type, cycle_base + i})) ++have;
+        }
+        out.member_sets = have;
+        out.ok = (p->signing_active_quorum_count > 0
+                  && have == p->signing_active_quorum_count);
+        if (!out.ok) {
+            const std::string needle =
+                "type " + std::to_string(int(llmq_type)) + " ";
+            for (const auto& s : r.member_skip_reasons) {
+                if (s.find(needle) != std::string::npos) {
+                    out.skip_reason = s;
+                    break;
+                }
+            }
+            if (out.skip_reason.empty())
+                out.skip_reason = "derive produced " + std::to_string(have)
+                    + "/" + std::to_string(p->signing_active_quorum_count)
+                    + " member sets for type " + std::to_string(int(llmq_type))
+                    + " cycle base h=" + std::to_string(cycle_base)
+                    + " with no named skip (inputs present but assembly "
+                      "incomplete)";
+        }
+        return out;
+    }
+
     /// The produced (or seeded) per-cycle snapshot — the qrinfo replacement.
     std::optional<vendor::CQuorumSnapshot> snapshot_for(uint8_t type,
                                                         uint32_t cycle_base) const

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1345,7 +1345,8 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_154_parity_kat.cpp
                    test_dash_lane_diag.cpp
                    test_dash_header_checkpoint_coincide.cpp
-                   test_dash_anchor_header_merkle_root.cpp)
+                   test_dash_anchor_header_merkle_root.cpp
+                   test_dash_preanchor_header_backfill.cpp)
     target_link_libraries(test_dash_node_reception_wire PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -955,7 +955,8 @@ if (BUILD_TESTING AND GTest_FOUND)
                    test_dash_replay_run.cpp
                    test_dash_replay_quorum_seam.cpp
                    test_dash_replay_payee_publish.cpp
-                   test_dash_replay_mnlist_seed.cpp)
+                   test_dash_replay_mnlist_seed.cpp
+                   test_dash_replay_prestate_empty_dip3.cpp)
     target_link_libraries(test_dash_mn_state PRIVATE
         GTest::gtest_main GTest::gtest
         dash_bls_verify dash_x11 core

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -39,6 +39,8 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/mn_checkpoint.hpp>       // parse_mn_checkpoint (DUT)
+#include <impl/dash/coin/mn_checkpoint_dump.hpp>  // emit_mn_checkpoint_dump / write_mn_checkpoint_inc (DUT)
+#include <impl/dash/coin/replay_fold_engine.hpp>  // DmlFoldEngine / ReplayMNState (dump source)
 #include <impl/dash/coin/mn_checkpoint_lane.hpp>  // MnCheckpointLane (DUT)
 #include <impl/dash/coin/mn_bridge_cursor.hpp>    // MnBridgeCursorStore (DUT, #91)
 #include <impl/dash/coin/vendor/providertx.hpp>   // CProUpServTx (revival leg)
@@ -58,6 +60,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -343,6 +346,232 @@ TEST(DashMnCheckpoint, CheckpointSetIsFieldIdenticalToRpcSeed)
         EXPECT_EQ(ck.collateralOutpoint.hash, rpc_mn.collateralOutpoint.hash);
         EXPECT_EQ(ck.collateralOutpoint.index, rpc_mn.collateralOutpoint.index);
     }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2b. THE SELF-DERIVED DUMP round trip (dashd-cut, operator decision
+//     2026-08-17). A DmlFoldEngine's registered set is serialized by
+//     mn_checkpoint_dump.hpp to the checkpoint payload, and that payload
+//     parses back through parse_mn_checkpoint() FIELD-IDENTICAL to the
+//     ReplayMNState it came from — the replay-dumped analog of
+//     CheckpointSetIsFieldIdenticalToRpcSeed. No dashd, no RPC, no snapshot:
+//     the source is the fold's own state.
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+using dash::coin::replay::DmlFoldEngine;
+using dash::coin::replay::ReplayMNState;
+using dash::coin::replay::FoldConfig;
+
+uint160 u160_of(uint8_t b)
+{
+    std::vector<unsigned char> v(20, b);
+    return uint160(v);
+}
+
+// A P2PKH scriptPubKey over a 20-byte hash160 filled with `b`.
+std::vector<unsigned char> p2pkh(uint8_t b)
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    s.insert(s.end(), 20, b);
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+
+ReplayMNState make_replay_mn(uint8_t seed, uint8_t type, int32_t reg,
+                             int32_t last_paid, int32_t revived, int32_t ban,
+                             uint16_t opreward, bool op_payout)
+{
+    ReplayMNState st;
+    st.nType   = type;
+    st.nVersion = (type == dash::coin::vendor::MnType::EVO) ? 2 : 1;
+    // Unique collateral outpoint per MN (the parser's dup-guard).
+    const char* hx = "0123456789abcdef";
+    std::string chash(62, '0');
+    chash.push_back(hx[(seed >> 4) & 0xf]);
+    chash.push_back(hx[seed & 0xf]);
+    st.collateralOutpoint.hash  = uint256S(chash);
+    st.collateralOutpoint.index = seed;
+    st.nOperatorReward   = opreward;
+    st.nRegisteredHeight = reg;
+    st.nLastPaidHeight   = last_paid;
+    st.nPoSeRevivedHeight = revived;
+    st.nPoSeBanHeight    = ban;
+    st.nConsecutivePayments = 0;
+    st.keyIDOwner  = u160_of(static_cast<uint8_t>(0x10 + seed));
+    st.keyIDVoting = u160_of(static_cast<uint8_t>(0x20 + seed));
+    st.pubKeyOperator.fill(static_cast<uint8_t>(0x30 + seed));
+    st.scriptPayout.m_data = p2pkh(static_cast<uint8_t>(0x40 + seed));
+    if (op_payout)
+        st.scriptOperatorPayout.m_data = p2pkh(static_cast<uint8_t>(0x50 + seed));
+    return st;
+}
+
+int32_t clamp0(int32_t v) { return v > 0 ? v : 0; }
+
+} // namespace
+
+TEST(DashMnCheckpointDump, ReplayDumpedSetRoundTripsFieldIdenticalToParser)
+{
+    // Three masternodes whose proTxHash DISPLAY order differs from the
+    // std::map<uint256> INTERNAL (memcmp-LE) order, so the emitter's re-sort
+    // by display hex is actually exercised (not a no-op on map order).
+    const uint256 pA = uint256S(std::string(64, '1'));            // display 11..11
+    const uint256 pB = uint256S(std::string(64, '2'));            // display 22..22
+    const uint256 pC = uint256S(std::string(62, '0') + "ff");     // display 00..ff
+    // display ascending:  pC < pA < pB
+    // internal ascending: pA < pB < pC  (reversed bytes) — different.
+
+    std::vector<std::pair<uint256, ReplayMNState>> entries;
+    // Regular, never banned (NEVER sentinel), no operator payout, reward 0.
+    entries.emplace_back(pA, make_replay_mn(
+        1, dash::coin::vendor::MnType::REGULAR, 1028500, 2500001,
+        ReplayMNState::NEVER, ReplayMNState::NEVER, 0, /*op_payout=*/false));
+    // Evo, PoSe-banned, operator reward + operator payout, revived earlier.
+    entries.emplace_back(pB, make_replay_mn(
+        2, dash::coin::vendor::MnType::EVO, 1500000, 2400000,
+        2450000, 2490000, 500, /*op_payout=*/true));
+    // Regular, never paid (nLastPaidHeight 0), never banned.
+    entries.emplace_back(pC, make_replay_mn(
+        3, dash::coin::vendor::MnType::REGULAR, 2000000, 0,
+        ReplayMNState::NEVER, ReplayMNState::NEVER, 0, /*op_payout=*/false));
+
+    FoldConfig fcfg;
+    fcfg.enabled = true;
+    DmlFoldEngine engine(fcfg);
+    const uint32_t H = 2522504;
+    const uint256 Hhash = uint256S(std::string(62, '0') + "aa");
+    // seed() is the same API the anchor prestate loader uses; it takes a COPY.
+    auto seed_copy = entries;
+    engine.seed(std::move(seed_copy), entries.size(), H, Hhash, "mainnet");
+
+    // ── DUMP ────────────────────────────────────────────────────────────
+    auto dump = dash::coin::emit_mn_checkpoint_dump(
+        engine, "self-derived from chain via c2pool --replay-bulk at H=2522504",
+        "2026-08-17T00:00:00Z");
+    ASSERT_TRUE(dump.ok) << dump.error;
+    EXPECT_EQ(dump.count, 3u);
+    EXPECT_EQ(dump.height, H);
+
+    // The .inc line order is proTxHash DISPLAY hex ascending (pC, pA, pB),
+    // NOT the engine's internal map order (pA, pB, pC).
+    const size_t iC = dump.payload.find("mn " + pC.GetHex());
+    const size_t iA = dump.payload.find("mn " + pA.GetHex());
+    const size_t iB = dump.payload.find("mn " + pB.GetHex());
+    ASSERT_NE(iC, std::string::npos);
+    ASSERT_NE(iA, std::string::npos);
+    ASSERT_NE(iB, std::string::npos);
+    EXPECT_LT(iC, iA) << "dump must sort by DISPLAY hex, not map order";
+    EXPECT_LT(iA, iB);
+
+    // The digest the payload declares is the one the shared function recomputes.
+    EXPECT_EQ(dash::coin::mn_checkpoint_digest(dump.payload), dump.digest);
+    EXPECT_NE(dump.payload.find("digest " + dump.digest), std::string::npos);
+    EXPECT_NE(dump.payload.find(
+        "source self-derived from chain via c2pool --replay-bulk at H=2522504"),
+        std::string::npos);
+
+    // Determinism: dumping the same engine again is byte-identical.
+    auto dump2 = dash::coin::emit_mn_checkpoint_dump(
+        engine, "self-derived from chain via c2pool --replay-bulk at H=2522504",
+        "2026-08-17T00:00:00Z");
+    ASSERT_TRUE(dump2.ok) << dump2.error;
+    EXPECT_EQ(dump.payload, dump2.payload);
+    EXPECT_EQ(dump.inc, dump2.inc);
+
+    // ── PARSE the dump back through the RUNTIME parser ──────────────────
+    MnCheckpoint cp = parse_mn_checkpoint(dump.payload, "mainnet");
+    ASSERT_TRUE(cp.ok) << cp.error;
+    EXPECT_FALSE(cp.unpinned);
+    EXPECT_EQ(cp.height, H);
+    EXPECT_EQ(cp.blockhash, Hhash);
+    ASSERT_EQ(cp.entries.size(), 3u);
+
+    // ── FIELD-IDENTICAL to the source ReplayMNState ─────────────────────
+    std::map<uint256, MNState> parsed(cp.entries.begin(), cp.entries.end());
+    for (const auto& [protx, src] : entries) {
+        auto it = parsed.find(protx);
+        ASSERT_NE(it, parsed.end()) << "dump lost MN " << protx.GetHex();
+        const MNState& got = it->second;
+
+        // THE payee keystone — verbatim ProRegTx bytes survive the round trip.
+        EXPECT_EQ(got.scriptPayout.m_data, src.scriptPayout.m_data)
+            << "PAYEE MISMATCH for " << protx.GetHex();
+        EXPECT_EQ(got.scriptOperatorPayout.m_data, src.scriptOperatorPayout.m_data);
+
+        // Heights: dashd -1/NEVER and negatives clamp to 0, else verbatim.
+        EXPECT_EQ(got.nRegisteredHeight,  (uint32_t)clamp0(src.nRegisteredHeight));
+        EXPECT_EQ(got.nLastPaidHeight,    (uint32_t)clamp0(src.nLastPaidHeight));
+        EXPECT_EQ(got.nPoSeRevivedHeight, (uint32_t)clamp0(src.nPoSeRevivedHeight));
+        EXPECT_EQ(got.nPoSeBanHeight,     (uint32_t)clamp0(src.nPoSeBanHeight));
+
+        EXPECT_EQ((uint16_t)got.nType, src.nType);
+        EXPECT_EQ(got.nVersion, src.nVersion);
+        EXPECT_EQ(got.nOperatorReward, src.nOperatorReward);
+        EXPECT_EQ(got.nRevocationReason, src.nRevocationReason);
+
+        // CKeyIDs / BLS pubkey — forward-byte columns, not GetHex()-reversed.
+        EXPECT_EQ(got.keyIDOwner, src.keyIDOwner)
+            << "keyIDOwner byte-order regression for " << protx.GetHex();
+        EXPECT_EQ(got.keyIDVoting, src.keyIDVoting);
+        EXPECT_EQ(got.pubKeyOperator, src.pubKeyOperator);
+
+        EXPECT_EQ(got.collateralOutpoint.hash, src.collateralOutpoint.hash);
+        EXPECT_EQ(got.collateralOutpoint.index, src.collateralOutpoint.index);
+
+        // isValid is DERIVED as (poseBanHeight == 0) — banned MNs come back
+        // present-but-INELIGIBLE (registered-not-valid).
+        EXPECT_EQ(got.isValid, !src.IsBanned())
+            << "registered-not-valid projection wrong for " << protx.GetHex();
+    }
+
+    // The banned Evo MN is PRESENT (registered set), not filtered out.
+    EXPECT_EQ(parsed.at(pB).isValid, false);
+    EXPECT_GT(parsed.at(pB).nPoSeBanHeight, 0u);
+
+    // ── write_mn_checkpoint_inc self-verifies + writes a real .inc file ──
+    const std::string path = "/tmp/c2pool_dump_kat_"
+        + std::to_string(getpid()) + ".inc";
+    std::string werr;
+    ASSERT_TRUE(dash::coin::write_mn_checkpoint_inc(
+        engine, path, "self-derived from chain via c2pool --replay-bulk at H=2522504",
+        "2026-08-17T00:00:00Z", werr)) << werr;
+    std::ifstream in(path);
+    std::string incfile((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(incfile, dump.inc);
+    EXPECT_NE(incfile.find("Self-derived from chain by c2pool --replay-bulk"),
+              std::string::npos);
+    std::remove(path.c_str());
+}
+
+TEST(DashMnCheckpointDump, EmptyEngineAndPayeelessRefuse)
+{
+    FoldConfig fcfg;
+    fcfg.enabled = true;
+
+    // Empty fold — refuse rather than write an empty anchor.
+    DmlFoldEngine empty(fcfg);
+    empty.seed({}, 0, 2522504, uint256S(std::string(62, '0') + "aa"), "mainnet");
+    auto d0 = dash::coin::emit_mn_checkpoint_dump(empty, "src", "gen");
+    EXPECT_FALSE(d0.ok);
+    EXPECT_NE(d0.error.find("0 registered"), std::string::npos);
+
+    // A registered MN with an empty scriptPayout — fail closed, never emit a
+    // payee-less line the runtime parser would reject anyway.
+    DmlFoldEngine e(fcfg);
+    ReplayMNState bad = make_replay_mn(
+        7, dash::coin::vendor::MnType::REGULAR, 2000000, 2500000,
+        ReplayMNState::NEVER, ReplayMNState::NEVER, 0, false);
+    bad.scriptPayout.m_data.clear();
+    std::vector<std::pair<uint256, ReplayMNState>> one;
+    one.emplace_back(uint256S(std::string(64, '3')), bad);
+    e.seed(std::move(one), 1, 2522504,
+           uint256S(std::string(62, '0') + "aa"), "mainnet");
+    auto d1 = dash::coin::emit_mn_checkpoint_dump(e, "src", "gen");
+    EXPECT_FALSE(d1.ok);
+    EXPECT_NE(d1.error.find("scriptPayout"), std::string::npos);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/test/test_dash_preanchor_header_backfill.cpp
+++ b/test/test_dash_preanchor_header_backfill.cpp
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+/// DASH daemonless COLD-START pre-anchor header backfill KAT (#1263 stack).
+///
+/// THE INCIDENT (2026-08-17, vm905, --coin-rpc removed, dashd ABSENT). The
+/// #1263 getqrinfo straddle seed is FULLY WIRED — the cold node asks for the
+/// rotated-quorum snapshot at the cycle base, the peer answers, the consumer
+/// binds mnListDiffAtHMinusC at exactly B0-C-8 — yet the seed NEVER lands:
+///
+///     [MN-DIFF-DB] getqrinfo cycle diff 0 DIP-4 auth FAILED at work h=2512792
+///     ...historical snapshot AUTH FAILED (block header not held)...
+///
+/// ROOT CAUSE. The three rotated quarter snapshots for cycle 2513088 are at
+/// WORK blocks 2512792 / 2512504 / 2512216 — all BELOW the fast-start anchor
+/// (2513000). At cold fast-start HeaderChain holds a LONE anchor and none of
+/// those pre-anchor headers, so DIP-4 leg (b) — bind the snapshot's cbTx merkle
+/// proof to OUR PoW-verified header's hashMerkleRoot — fails "block header not
+/// held" and the snapshot is consumed-but-never-applied. The store caps below
+/// the straddle, the resolver arms capped, the bridge falls to the network
+/// payee lane → PAYEE DESYNC fail-closed → no embedded template. The forward
+/// add_header path cannot fix this: a pre-anchor header's parent is not held,
+/// so it orphan-rejects.
+///
+/// THE FIX (this PR, dashd-parity). At cold store-arm, once the qrinfo reply is
+/// in hand, one-shot BACKWARD getheaders fetches the pre-anchor span and
+/// HeaderChain::install_preanchor_span installs it by walking DOWN from the
+/// trusted anchor: each parent is bound to its already-trusted child by an
+/// X11 prev-hash link AND independently check_pow-verified — exactly the two
+/// legs dashd requires of any header it stores (LookupBlockIndex over its full
+/// header tree). DIP-4 leg (b) stays STRICT (header must be held); a
+/// wrong/missing header installs nothing → leg (b) still fails closed → no bad
+/// mint. The tip / best-work are never moved (pre-anchor headers never compete
+/// for the tip; the synthetic-anchor daemon-tip honesty guards stay intact).
+///
+/// RED → GREEN is demonstrated WITHIN each test at runtime: BEFORE install,
+/// get_header(work_block) == nullopt and the leg-(b) merkle_root_of_hash
+/// callback returns nullopt ("block header not held"); AFTER install, the same
+/// callback returns the header's real merkleRoot — the exact value
+/// authenticate_historical_snapshot reads for its step-(b) proof. Fail-closed
+/// tests prove a PoW-broken or anchor-detached batch installs nothing.
+///
+/// The whole file is guarded on the fix's feature macro so it still COMPILES
+/// (empty) on a pre-fix tree that lacks install_preanchor_span. #143 note:
+/// FOLDED into the allowlisted test_dash_node_reception_wire target (a
+/// standalone add_executable would silently report "Not Run").
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/header_chain.hpp>   // HeaderChain, params, x11_hash, check_pow
+
+#include <core/uint256.hpp>
+
+#include <cstdio>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#ifdef C2POOL_PREANCHOR_SPAN_BACKFILL
+
+using dash::coin::HeaderChain;
+using dash::coin::DashChainParams;
+using dash::coin::BlockHeaderType;
+using dash::coin::make_dash_chain_params_mainnet;
+using dash::coin::x11_hash;
+
+namespace {
+
+// bits = 0x207fffff decodes to target 0x7fffff·2^(8·29) (~2^255) — the largest
+// compact-representable target. pow_limit is set EQUAL to that target so
+// check_pow's `target > pow_limit` guard passes; roughly half of random X11
+// hashes fall under it, so mine_hdr grinds the nonce a couple of times to make
+// each synthetic header PoW-VALID. X11 identity + prev-hash linkage are
+// exercised exactly as in production; only the difficulty is relaxed so a KAT
+// needs no real proof-of-work.
+constexpr uint32_t kEasyBits = 0x207fffffu;
+
+DashChainParams make_easy_params()
+{
+    DashChainParams p = make_dash_chain_params_mainnet();
+    p.pow_limit.SetHex(
+        "7fffff0000000000000000000000000000000000000000000000000000000000");
+    // Drop the mainnet fast-start pin; each test installs its own synthetic
+    // anchor via set_dynamic_checkpoint so it controls the anchor header.
+    p.fast_start_checkpoint.reset();
+    p.genesis_hash = uint256::ZERO;   // no genesis stub — start empty
+    return p;
+}
+
+// The distinct, non-null merkleRoot for the header at height `tag` — encoded so
+// the leg-(b) assertion can prove the RIGHT header's root is returned.
+uint256 tag_root(uint32_t tag)
+{
+    char buf[9];
+    std::snprintf(buf, sizeof buf, "%08x", tag);
+    std::string hex = "bb";
+    hex += buf;
+    hex.resize(64, '0');
+    uint256 r;
+    r.SetHex(hex);
+    return r;
+}
+
+// A header linking to `prev`, tagged at height `tag`, WITHOUT grinding PoW.
+// Used to plant a deliberately PoW-broken header (bits carry an impossible
+// target).
+BlockHeaderType raw_hdr(const uint256& prev, uint32_t bits, uint32_t tag)
+{
+    BlockHeaderType h;
+    h.m_version        = 0x20000000u;
+    h.m_previous_block = prev;
+    h.m_merkle_root    = tag_root(tag);
+    h.m_timestamp      = 1785000000u + tag;
+    h.m_bits           = bits;
+    h.m_nonce          = tag;
+    return h;
+}
+
+// A PoW-VALID header: grind the nonce until X11(header) <= target(kEasyBits).
+BlockHeaderType mine_hdr(const uint256& prev, const uint256& pow_limit,
+                         uint32_t tag)
+{
+    BlockHeaderType h = raw_hdr(prev, kEasyBits, tag);
+    for (uint32_t n = 0; ; ++n) {
+        h.m_nonce = n;
+        if (dash::coin::check_pow(x11_hash(h), h.m_bits, pow_limit))
+            return h;
+    }
+}
+
+struct SynthChain {
+    DashChainParams params;
+    uint32_t easy_bits{0};
+    uint32_t anchor_height{0};
+    uint256  anchor_hash;
+    BlockHeaderType anchor_hdr;
+    // batch = getheaders reply span [deepest .. anchor], anchor terminal
+    std::vector<BlockHeaderType> batch;
+    // hashes by height for assertions (heights below anchor)
+    std::vector<std::pair<uint32_t, uint256>> below;   // {height, hash}
+    std::vector<uint256> below_roots;                  // parallel merkleRoots
+};
+
+// Build a `count`-deep pre-anchor span below `anchor_height`. Header for the
+// deepest block links to a parent NOT in the batch, so the downward walk stops
+// there (the natural bottom of a bounded getheaders reply).
+SynthChain build_chain(uint32_t anchor_height, int count)
+{
+    SynthChain c;
+    c.params        = make_easy_params();
+    c.easy_bits     = kEasyBits;
+    c.anchor_height = anchor_height;
+
+    const uint32_t bottom_h = anchor_height - static_cast<uint32_t>(count);
+    // parent of the deepest header — intentionally absent from the batch.
+    uint256 prev; prev.SetHex(
+        "deadbeef00000000000000000000000000000000000000000000000000000000");
+
+    std::vector<BlockHeaderType> chain;   // bottom → anchor
+    for (uint32_t h = bottom_h; h <= anchor_height; ++h) {
+        BlockHeaderType hd = mine_hdr(prev, c.params.pow_limit, /*tag=*/h);
+        uint256 id = x11_hash(hd);
+        if (h == anchor_height) {
+            c.anchor_hdr  = hd;
+            c.anchor_hash = id;
+        } else {
+            c.below.emplace_back(h, id);
+            c.below_roots.push_back(hd.m_merkle_root);
+        }
+        chain.push_back(hd);
+        prev = id;   // next header's parent
+    }
+    // getheaders returns ascending; the installer indexes by hash regardless.
+    c.batch = chain;
+    return c;
+}
+
+// Byte-for-byte the leg-(b) callback main_dash.cpp binds as `mroot` (the
+// std::function signature of dash::coin::MerkleRootOfHashFn).
+std::function<std::optional<uint256>(const uint256&)>
+leg_b(const HeaderChain& hc)
+{
+    return [&hc](const uint256& b) -> std::optional<uint256> {
+        if (auto e = hc.get_header(b))
+            return e->header.m_merkle_root;
+        return std::nullopt;
+    };
+}
+
+} // namespace
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. RED → GREEN. Before install the three pre-anchor work-block headers are
+//    absent and leg (b) fails "block header not held"; after
+//    install_preanchor_span walks them down from the trusted anchor, leg (b)
+//    returns each real merkleRoot — the seed authenticates.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, InstallMakesLegBConsultPreanchorHeaders)
+{
+    SynthChain c = build_chain(/*anchor_height=*/2513000, /*count=*/3);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);   // lone anchor
+    ASSERT_EQ(hc.height(), c.anchor_height);
+
+    auto legb = leg_b(hc);
+
+    // RED (in-test): every pre-anchor work-block header is absent → leg (b)
+    // returns nullopt ("block header not held") → snapshot fails closed.
+    for (const auto& [h, id] : c.below) {
+        EXPECT_FALSE(hc.has_header(id))
+            << "pre-anchor header at h=" << h << " must be absent at cold start";
+        EXPECT_FALSE(legb(id).has_value())
+            << "leg (b) must fail closed for the un-held header at h=" << h;
+    }
+
+    // Install the pre-anchor span walking DOWN from the trusted anchor.
+    const size_t n = hc.install_preanchor_span(c.anchor_hash, c.batch);
+    EXPECT_EQ(n, c.below.size())
+        << "every X11-linked + PoW-verified pre-anchor header must install";
+
+    // GREEN (in-test): leg (b) now returns each header's REAL merkleRoot.
+    for (size_t i = 0; i < c.below.size(); ++i) {
+        const auto& [h, id] = c.below[i];
+        ASSERT_TRUE(hc.has_header(id))
+            << "pre-anchor header at h=" << h << " must be held after install";
+        auto root = legb(id);
+        ASSERT_TRUE(root.has_value())
+            << "leg (b) must now find the installed header at h=" << h;
+        EXPECT_EQ(*root, c.below_roots[i])
+            << "leg (b) must return the header's real merkleRoot at h=" << h;
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. TIP UNMOVED. Pre-anchor headers never compete for the tip: the install
+//    must leave m_tip / height at the anchor so the synthetic-anchor daemon-
+//    tip honesty guards stay intact.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, InstallDoesNotMoveTheTip)
+{
+    SynthChain c = build_chain(2513000, 5);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);
+
+    const uint32_t tip_before = hc.height();
+    auto           head_before = hc.tip();
+    ASSERT_TRUE(head_before.has_value());
+
+    ASSERT_EQ(hc.install_preanchor_span(c.anchor_hash, c.batch), c.below.size());
+
+    EXPECT_EQ(hc.height(), tip_before) << "the tip height must not move";
+    auto head_after = hc.tip();
+    ASSERT_TRUE(head_after.has_value());
+    EXPECT_EQ(head_after->hash, head_before->hash)
+        << "the tip hash must stay at the anchor";
+    EXPECT_EQ(head_after->hash, c.anchor_hash);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. FAIL-CLOSED: broken PoW. A header in the span whose bits FAIL check_pow
+//    stops the downward walk; nothing at or below it installs, so leg (b)
+//    still fails closed for those heights — never a bad mint.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, PoWBrokenHeaderStopsWalkFailClosed)
+{
+    SynthChain c = build_chain(2513000, 4);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);
+
+    // c.below is {anchor-1, anchor-2, anchor-3, anchor-4} in ascending height.
+    // Break PoW on the SECOND header below the anchor (anchor-2): a compact
+    // bits encoding a near-zero target that no X11 hash can satisfy. Its X11
+    // id changes, so re-key the batch AND the anchor's child links accordingly
+    // by rebuilding from the corrupted header up to the anchor.
+    // Simplest faithful corruption: rebuild the chain, flipping one header's
+    // bits to an impossible target, and re-link everything above it.
+    const uint32_t impossible  = 0x03000001u;   // target ~ 1 → X11 hash > target
+    const uint32_t bottom_h    = c.anchor_height - 4;
+    uint256 prev; prev.SetHex(
+        "deadbeef00000000000000000000000000000000000000000000000000000000");
+    std::vector<BlockHeaderType> batch;
+    uint256 anchor_hash;
+    uint256 broken_id, below_top_id;   // anchor-2 (broken), anchor-1
+    for (uint32_t h = bottom_h; h <= c.anchor_height; ++h) {
+        const bool is_broken = (h == c.anchor_height - 2);
+        // Good headers are PoW-mined; the broken one carries an impossible
+        // target (no nonce can satisfy it) so check_pow rejects it.
+        BlockHeaderType hd = is_broken
+            ? raw_hdr(prev, impossible, /*tag=*/h)
+            : mine_hdr(prev, c.params.pow_limit, /*tag=*/h);
+        uint256 id = x11_hash(hd);
+        if (h == c.anchor_height)      anchor_hash   = id;
+        if (h == c.anchor_height - 2)  broken_id     = id;
+        if (h == c.anchor_height - 1)  below_top_id  = id;
+        batch.push_back(hd);
+        prev = id;
+    }
+    HeaderChain hc2(c.params);
+    ASSERT_TRUE(hc2.init());
+    hc2.set_dynamic_checkpoint(c.anchor_height, anchor_hash);
+
+    const size_t n = hc2.install_preanchor_span(anchor_hash, batch);
+    // Only anchor-1 (directly below the anchor, PoW-good) installs; the walk
+    // hits the impossible-PoW anchor-2 and STOPS.
+    EXPECT_EQ(n, 1u) << "walk must stop at the first PoW-broken header";
+    EXPECT_TRUE(hc2.has_header(below_top_id))
+        << "the PoW-good header directly below the anchor installs";
+    EXPECT_FALSE(hc2.has_header(broken_id))
+        << "a PoW-broken header must NEVER be installed (fail closed)";
+    EXPECT_FALSE(leg_b(hc2)(broken_id).has_value())
+        << "leg (b) must fail closed for the rejected header";
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. FAIL-CLOSED: batch never reaches the anchor. A span whose top header is
+//    NOT the trusted anchor (a lying peer, or a wrong stop hash) yields no
+//    downward linkage from the anchor → zero installs → leg (b) unchanged.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, BatchWithoutAnchorInstallsNothing)
+{
+    SynthChain c = build_chain(2513000, 3);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    hc.set_dynamic_checkpoint(c.anchor_height, c.anchor_hash);
+
+    // Drop the terminal (anchor) header from the batch: the walk can find no
+    // trusted root to descend from.
+    std::vector<BlockHeaderType> no_anchor(c.batch.begin(), c.batch.end() - 1);
+    EXPECT_EQ(hc.install_preanchor_span(c.anchor_hash, no_anchor), 0u)
+        << "a batch that never reaches the anchor must install nothing";
+
+    // Entirely unrelated garbage installs nothing either.
+    std::vector<BlockHeaderType> garbage;
+    garbage.push_back(mine_hdr(uint256::ZERO, c.params.pow_limit, /*tag=*/777u));
+    EXPECT_EQ(hc.install_preanchor_span(c.anchor_hash, garbage), 0u)
+        << "a batch with no linkage to the anchor must install nothing";
+
+    for (const auto& [h, id] : c.below) {
+        (void)h;
+        EXPECT_FALSE(leg_b(hc)(id).has_value())
+            << "leg (b) stays fail-closed when the span never authenticated";
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 5. ANCHOR MUST BE HELD. If the claimed anchor is not in the header index,
+//    the install refuses outright (no trust root) — installs nothing.
+// ─────────────────────────────────────────────────────────────────────────
+TEST(DashPreanchorHeaderBackfill, UnheldAnchorInstallsNothing)
+{
+    SynthChain c = build_chain(2513000, 3);
+    HeaderChain hc(c.params);
+    ASSERT_TRUE(hc.init());
+    // NOTE: do NOT seed the anchor — it is unheld.
+    EXPECT_FALSE(hc.has_header(c.anchor_hash));
+    EXPECT_EQ(hc.install_preanchor_span(c.anchor_hash, c.batch), 0u)
+        << "install must refuse when the anchor (trust root) is not held";
+}
+
+#endif // C2POOL_PREANCHOR_SPAN_BACKFILL

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -1761,6 +1761,8 @@ TEST(DashReplayFoldIncrementalMerkle, DeltaPathByteIdenticalAndExaminesOnlyK)
     const std::vector<CSimplifiedMNListEntry> absent = { incmerkle_mk_entry(99999) };
     EXPECT_FALSE(cache.apply_value_changes(absent).has_value())
         << "an absent key must bail to the full-rebuild fallback";
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // DIP3-GENESIS payee cross-check gate (dashd DeploymentDIP0003Enforced parity).
 //

--- a/test/test_dash_replay_fold.cpp
+++ b/test/test_dash_replay_fold.cpp
@@ -666,6 +666,12 @@ static FoldConfig synth_cfg()
     FoldConfig cfg;
     cfg.enabled = true;
     cfg.gates.dip0003_height = 1;
+    // Synthetic vectors model the ENFORCED regime (their coinbases pay the
+    // projected payee via make_block(&eng)); keep the payee cross-check ON so
+    // the existing payee-axis assertions still bind. The DIP3-genesis window
+    // (activation<h<enforcement) is exercised explicitly by the
+    // PreEnforcementPayeeCheck suite, which lowers dip0003_enforcement_height.
+    cfg.gates.dip0003_enforcement_height = 1;
     cfg.gates.v19_height     = 1;
     cfg.gates.mn_rr_height   = 1;
     return cfg;
@@ -1755,4 +1761,116 @@ TEST(DashReplayFoldIncrementalMerkle, DeltaPathByteIdenticalAndExaminesOnlyK)
     const std::vector<CSimplifiedMNListEntry> absent = { incmerkle_mk_entry(99999) };
     EXPECT_FALSE(cache.apply_value_changes(absent).has_value())
         << "an absent key must bail to the full-rebuild fallback";
+// ─────────────────────────────────────────────────────────────────────────────
+// DIP3-GENESIS payee cross-check gate (dashd DeploymentDIP0003Enforced parity).
+//
+// The deterministic MN list is BUILT from DIP3 ACTIVATION (h=1028160) but the
+// coinbase paying GetMNPayee(list) is only ENFORCED from DIP0003EnforcementHeight
+// (mainnet 1047200). In the [activation, enforcement) window dashd's own
+// consensus rule CMNPaymentsProcessor::IsTransactionValid (masternode/
+// payments.cpp:114) returns valid WITHOUT checking the det payee — the coinbase
+// pays the LEGACY masternode winner, not the det projection. So the fold's payee
+// cross-check must not run there, or it false-poisons a byte-correct fold — the
+// observed h=1028163 divergence: merkleRootMNList MATCHED, projection sound, the
+// coinbase simply pays the legacy winner (which drifts from the det order once
+// more than a couple of MNs are registered).
+//
+// This is the ONE property the payee gate changes: the SAME state + SAME
+// payment-block (coinbase pays nobody) POISONS when the height is at/above
+// enforcement (RED — the check is still strict where dashd enforces it) and
+// FOLDS THROUGH when the height is below enforcement (GREEN — the DIP3-genesis
+// window no longer false-poisons). The merkleRootMNList SET self-check runs in
+// BOTH arms regardless.
+namespace {
+// Two MNs registered at h=101; both configs are identical except the enforcement
+// height, so the only variable is the gate under test.
+struct PayeeGateFixture {
+    DmlFoldEngine eng;
+    uint256       payment_root;   // SML root after the reg block (unchanged by pay)
+    uint256       reg_hash;       // block hash the payment block builds on
+    explicit PayeeGateFixture(int32_t enforcement_height)
+        : eng(make_cfg(enforcement_height))
+    {
+        eng.seed({}, /*total_registered=*/0, /*height=*/100, raw256(9));
+        auto p1  = make_proreg(1);
+        auto p2  = make_proreg(2);
+        auto tx1 = make_special_tx(1, p1, 1);
+        auto tx2 = make_special_tx(1, p2, 2);
+        const uint256 mn1 = tx_hash_of(tx1), mn2 = tx_hash_of(tx2);
+        payment_root = root_of({expected_entry_of(p1, mn1),
+                                expected_entry_of(p2, mn2)});
+        auto reg_blk = make_block(101, raw256(9), payment_root, {tx1, tx2});
+        auto rr = eng.fold_block(reg_blk, 101);
+        EXPECT_TRUE(rr.ok) << "register fold must succeed: " << rr.error;
+        EXPECT_EQ(rr.registered, 2u);
+    }
+    static FoldConfig make_cfg(int32_t enforcement_height)
+    {
+        FoldConfig cfg;
+        cfg.enabled = true;
+        cfg.gates.dip0003_height             = 1;
+        cfg.gates.dip0003_enforcement_height = enforcement_height;
+        // v19/mn_rr far out (classic payee path); confirmations far out so no
+        // confirmedHash mutation at h=102 keeps the SML root stable across the
+        // payment fold.
+        cfg.gates.v19_height                 = 100000000;
+        cfg.gates.mn_rr_height               = 100000000;
+        cfg.gates.masternode_min_confirmations = 100000000;
+        return cfg;
+    }
+};
+} // namespace
+
+// GREEN: h=102 is BELOW enforcement (103). A payment block whose coinbase pays
+// NOBODY folds THROUGH — dashd does not commit the det payee to the coinbase
+// there. The SET self-check still ran (root matched); the payee axis is derived
+// and self-consistent (nLastPaidHeight bumped on the projection).
+TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeeMismatchFoldsThrough)
+{
+    PayeeGateFixture fx(/*enforcement_height=*/103);  // 102 < 103 ⇒ pre-enforcement
+    ASSERT_TRUE(fx.eng.project_payee(102).has_value())
+        << "a payee must be projected (else the test proves nothing)";
+    auto pay_blk = make_block(102, raw256(9), fx.payment_root,
+                              /*special_txs=*/{}, /*pay_from=*/nullptr);
+    auto r = fx.eng.fold_block(pay_blk, 102);
+    ASSERT_TRUE(r.ok) << "pre-enforcement payee mismatch must NOT poison (dashd "
+                         "IsTransactionValid skips the check below enforcement): "
+                      << r.error;
+    EXPECT_TRUE(r.payee.has_value());
+    EXPECT_TRUE(r.payee_check_preenforcement_skipped)
+        << "the skip must be recorded, not silently absent";
+    EXPECT_FALSE(r.payee_paid_verified);
+    EXPECT_EQ(r.computed_root, r.committed_root);   // SET self-check still bound
+    EXPECT_TRUE(r.payee_marked);                    // nLastPaidHeight still bumped
+}
+
+// RED: the SAME state + SAME payment block, but h=102 is AT enforcement (102).
+// The coinbase pays nobody, so the strict payee cross-check fires and POISONS —
+// exactly as it must at tip, where dashd enforces the det payee. This proves the
+// gate is scoped to the genesis window, not a blanket disable of the check.
+TEST(DashReplayFoldPreEnforcement, AtEnforcementPayeeMismatchStillPoisons)
+{
+    PayeeGateFixture fx(/*enforcement_height=*/102);  // 102 >= 102 ⇒ enforced
+    ASSERT_TRUE(fx.eng.project_payee(102).has_value());
+    auto pay_blk = make_block(102, raw256(9), fx.payment_root,
+                              /*special_txs=*/{}, /*pay_from=*/nullptr);
+    auto r = fx.eng.fold_block(pay_blk, 102);
+    ASSERT_FALSE(r.ok) << "at/after enforcement a payee mismatch MUST poison";
+    EXPECT_NE(r.error.find("PAYEE MISMATCH"), std::string::npos) << r.error;
+    EXPECT_FALSE(r.payee_check_preenforcement_skipped);
+}
+
+// Control: when the pre-enforcement block DOES pay the projected payee (the
+// common case, since legacy and det winners coincide while the set is tiny),
+// the fold succeeds and the skip flag is NOT set — the check simply passed.
+TEST(DashReplayFoldPreEnforcement, BelowEnforcementPayeePaidIsNotFlaggedSkipped)
+{
+    PayeeGateFixture fx(/*enforcement_height=*/103);
+    auto pay_blk = make_block(102, raw256(9), fx.payment_root,
+                              /*special_txs=*/{}, /*pay_from=*/&fx.eng);
+    auto r = fx.eng.fold_block(pay_blk, 102);
+    ASSERT_TRUE(r.ok) << r.error;
+    // Below enforcement the check is skipped regardless of whether the coinbase
+    // happens to pay the projection; the flag reflects the GATE, not the match.
+    EXPECT_TRUE(r.payee_check_preenforcement_skipped);
 }

--- a/test/test_dash_replay_prestate_empty_dip3.cpp
+++ b/test/test_dash_replay_prestate_empty_dip3.cpp
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT: the SCOPED empty-prestate relaxation in replay_prestate.hpp.
+//
+// A TRUE from-DIP3 self-derive seeds the W1 fold from an EMPTY masternode set
+// at the DIP3 activation height (h = MAINNET_DIP3_HEIGHT = 1028160): DASH's
+// deterministic MN list is empty until the first ProRegTx at/after DIP3
+// enforcement, so empty-at-DIP3 is CHAIN-TRUE and lets the whole set be
+// derived from chain (dashd BuildNewListFromBlock parity) instead of captured
+// from dashd RPC.
+//
+// The loader (parse_prestate_text) historically rejected EVERY empty entries
+// set ("a half-parsed masternode set would seed a replay that diverges
+// silently"). This suite pins the reward-safe relaxation:
+//
+//   * empty prestate AT the DIP3 activation height  -> ACCEPTED
+//   * empty prestate at ANY other height            -> HARD REJECT
+//   * an empty DIP3 seed reproduces the empty-list merkleRootMNList
+//     (uint256::ZERO) through the SAME seed_engine_from_prestate root
+//     self-check a live replay trusts.
+//
+// The relaxation is fail-closed: the empty seed is never minted on faith —
+// the fold's per-block merkleRootMNList self-check (replay_fold_engine.hpp
+// poison()) hard-stops at the first post-DIP3 ProRegTx block if the seed is
+// wrong. This suite proves the LOADER gate; the fold self-check is covered by
+// test_dash_replay_fold.cpp (RootMismatchIsAHardStopWithNamedHeight).
+//
+// Folded into the test_dash_mn_state executable (the allowlisted target that
+// already builds the W1/W5 replay TUs) so it is actually built + run in CI —
+// a standalone add_executable would be a #143 NOT_BUILT sentinel.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/replay_prestate.hpp>
+
+#include <string>
+
+namespace {
+
+namespace rp = dash::coin::replay;
+
+// The well-known empty-list merkleRootMNList: dashd returns the null hash for a
+// CSimplifiedMNList with no entries (CalcMerkleRoot: `if (mnList.empty())
+// return uint256();`), which is exactly what DmlFoldEngine::compute_sml_root()
+// returns for an empty engine. 64 zero hex nibbles.
+const std::string kEmptyListRoot =
+    "0000000000000000000000000000000000000000000000000000000000000000";
+
+// A distinctive 64-hex placeholder for the anchor block hash. parse_prestate_text
+// validates only that blockhash is 64 hex chars; its CHAIN identity is the
+// fold's job (each folded block carries its own hashPrevBlock + committed root),
+// not the loader's — so this unit test of the loader uses a fixture value.
+const std::string kAnchorHashPlaceholder =
+    "00000000000000000abcdef0123456789abcdef0123456789abcdef012345678";
+
+std::string make_empty_prestate(uint32_t height, const std::string& mnroot)
+{
+    std::string t;
+    t += rp::kPrestateMagic;              t += "\n";
+    t += "network mainnet\n";
+    t += "height " + std::to_string(height) + "\n";
+    t += "blockhash " + kAnchorHashPlaceholder + "\n";
+    t += "mnroot " + mnroot + "\n";
+    t += "count 0\n";
+    return t;
+}
+
+} // namespace
+
+// ── The relaxation: empty AT DIP3 activation is ACCEPTED ─────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateAtDip3ActivationAccepted)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT, kEmptyListRoot));
+    ASSERT_TRUE(ps.ok) << "empty prestate at the DIP3 activation height must be "
+                          "accepted (chain-true empty set), got: " << ps.error;
+    EXPECT_TRUE(ps.entries.empty());
+    EXPECT_EQ(ps.height, rp::MAINNET_DIP3_HEIGHT);
+}
+
+// ── The scope: empty ABOVE DIP3 stays a HARD REJECT ──────────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateAboveDip3Rejected)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(2513000, kEmptyListRoot));
+    EXPECT_FALSE(ps.ok) << "an empty set above DIP3 must stay a hard reject";
+    EXPECT_NE(ps.error.find("DIP3 activation height"), std::string::npos)
+        << "the rejection must name why empty is only legal at DIP3: "
+        << ps.error;
+}
+
+// ── The scope: empty BELOW DIP3 stays a HARD REJECT ──────────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateBelowDip3Rejected)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT - 1, kEmptyListRoot));
+    EXPECT_FALSE(ps.ok) << "an empty set below DIP3 must stay a hard reject";
+}
+
+// ── The scope: the relaxation is SPOT-EXACT, not a window ────────────────────
+TEST(DashReplayPrestateEmptyDip3, EmptyPrestateOneAboveDip3Rejected)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT + 1, kEmptyListRoot));
+    EXPECT_FALSE(ps.ok)
+        << "the relaxation is scoped to the EXACT DIP3 height, not h>=DIP3";
+}
+
+// ── Other guards remain intact under the relaxation ──────────────────────────
+// A count/records mismatch must still fail even at the DIP3 height: the empty
+// relaxation only reaches the `entries.empty()` gate AFTER the count-parity
+// gate, so a header that declares count=1 with zero mn records is still caught.
+TEST(DashReplayPrestateEmptyDip3, CountMismatchStillFailsAtDip3)
+{
+    std::string t;
+    t += rp::kPrestateMagic;              t += "\n";
+    t += "network mainnet\n";
+    t += "height " + std::to_string(rp::MAINNET_DIP3_HEIGHT) + "\n";
+    t += "blockhash " + kAnchorHashPlaceholder + "\n";
+    t += "mnroot " + kEmptyListRoot + "\n";
+    t += "count 1\n";   // declares 1, carries 0
+    const auto ps = rp::parse_prestate_text(t);
+    EXPECT_FALSE(ps.ok);
+    EXPECT_NE(ps.error.find("count"), std::string::npos) << ps.error;
+}
+
+// ── End to end: the empty DIP3 seed reproduces the committed empty-list root ──
+// This is the check a live replay actually trusts: seed the engine from the
+// empty DIP3 prestate and RE-VERIFY that the seeded (empty) state computes the
+// prestate's committed merkleRootMNList. compute_sml_root() over an empty
+// engine is uint256::ZERO — the well-known empty-list root — so the anchor is
+// self-consistent, and any wrong post-DIP3 fold poisons at its own height.
+TEST(DashReplayPrestateEmptyDip3, EmptyDip3SeedReproducesEmptyListRoot)
+{
+    const auto ps = rp::parse_prestate_text(
+        make_empty_prestate(rp::MAINNET_DIP3_HEIGHT, kEmptyListRoot));
+    ASSERT_TRUE(ps.ok) << ps.error;
+
+    rp::FoldConfig fcfg;
+    fcfg.enabled = true;
+    rp::DmlFoldEngine eng(fcfg);
+
+    const std::string serr = rp::seed_engine_from_prestate(eng, ps);
+    EXPECT_TRUE(serr.empty())
+        << "seeding an empty engine at DIP3 must reproduce the empty-list "
+           "merkleRootMNList (uint256::ZERO): " << serr;
+    EXPECT_EQ(eng.size(), 0u);
+    EXPECT_EQ(eng.compute_sml_root().GetHex(), kEmptyListRoot);
+}

--- a/test/test_dash_replay_quorum_engine.cpp
+++ b/test/test_dash_replay_quorum_engine.cpp
@@ -596,6 +596,162 @@ TEST(DashReplayQuorumEngine, KatC_OwnSnapshotFeedsTheNextCycleIdentically)
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// KAT-D — the STORE-ENGINE straddle bootstrap: derive_members_for_cycle()
+// ASSEMBLES the rotated cycle's 32 ordered member sets from the SEEDED
+// quarters (getqrinfo straddle seed) and KEYS them by (llmqType,
+// cycle_base+quorumIndex), so fold_qfcommit's m_members_fn(type, quorumHash)
+// lookup resolves — the fix for the store capping at cycle_base +
+// mining_window_start. KAT-B proved compute_rotation_cycle's math is
+// dashd-exact; this proves the ENGINE WRAPPER that drives it from the seed
+// and the members_for KEYING the fold consumes.
+//
+//  RED (drop a seeded quarter, or revert the wiring): derive returns ok=false
+//      with a NAMED skip, members_for() is nullopt, the fold fails closed.
+//  GREEN: 32/32 sets registered, each == dashd's golden order (KAT-B
+//      goldens), resolvable through members_for by the per-index quorum base
+//      hash exactly as fold_qfcommit resolves a commitment quorumHash.
+//  REWARD-SAFE: a TAMPERED quarter still runs the math but the assembled set
+//      DIFFERS from dashd's — the divergence the writer's per-row
+//      merkleRootMNList self-check catches, so the store fails closed and
+//      callers fall through to the network path (never a bad mint).
+// ═══════════════════════════════════════════════════════════════════════════
+TEST(DashReplayQuorumEngine, KatD_DeriveMembersForCycleAssemblesAndKeysStraddleCycle)
+{
+    QrinfoCycles q;
+    ASSERT_TRUE(q.load()) << "mainnet qrinfo must decode + authenticate";
+    auto kat = load_member_kat();
+    ASSERT_EQ(kat.size(), 32u);
+
+    // The cycle-H work block's own hash + CL — chain data the store OBSERVES
+    // forward before the hold; derive recomputes the H modifier from these
+    // (it does NOT read a seeded H modifier), so it must reproduce
+    // q.modifiers[0] for the members to match the goldens.
+    const uint32_t workH = kCycleBase - kWorkDiffDepth;
+    const uint256  workH_hash = q.info.mnListDiffH.blockHash;
+    std::optional<std::array<uint8_t, CFinalCommitment::BLS_SIG_SIZE>> workH_cl;
+    {
+        dash::coin::vendor::CCbTx cb;
+        ASSERT_TRUE(dash::coin::vendor::parse_cbtx(
+            q.info.mnListDiffH.cbTx.extra_payload, cb));
+        if (cb.nVersion >= dash::coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE
+            && cb.has_best_cl_signature())
+            workH_cl = cb.bestCLSignature;
+    }
+
+    // Seed an engine to the same state the store-engine bridge holds when the
+    // getqrinfo straddle seed lands: the three previous-quarter snapshots +
+    // modifiers + work-lists, and the cycle-H work block chain fields.
+    auto seed_engine = [&](QuorumReplayEngine& eng, bool seed_hminusC) {
+        std::map<uint32_t, std::vector<QuorumMnEntry>> lists_by_h;
+        lists_by_h[kCycleBase - kWorkDiffDepth]              = q.lists[0];
+        lists_by_h[kCycleBase - 1u * kC - kWorkDiffDepth]    = q.lists[1];
+        lists_by_h[kCycleBase - 2u * kC - kWorkDiffDepth]    = q.lists[2];
+        lists_by_h[kCycleBase - 3u * kC - kWorkDiffDepth]    = q.lists[3];
+        eng.set_mn_list_at_fn(
+            [lists_by_h](uint32_t h)
+                -> std::optional<std::vector<QuorumMnEntry>> {
+                auto it = lists_by_h.find(h);
+                if (it == lists_by_h.end()) return std::nullopt;
+                return it->second;
+            });
+        eng.seed_block_hash(workH, workH_hash);
+        eng.seed_work_block_cl(workH, workH_cl);
+        for (size_t i = 1; i <= 3; ++i) {
+            if (i == 1 && !seed_hminusC) continue;   // RED: drop the H-C quarter
+            const uint32_t base = kCycleBase - static_cast<uint32_t>(i) * kC;
+            eng.seed_snapshot(kType6075, base, *q.snaps[i - 1]);
+            eng.seed_modifier(kType6075, base, q.modifiers[i]);
+        }
+    };
+
+    // Per-index quorum base hashes, so members_for() resolves the way
+    // fold_qfcommit does: quorumHash -> height (cycle_base+index) -> members.
+    auto seed_index_hashes = [&](QuorumReplayEngine& eng, char tag,
+                                 std::array<uint256, 32>& qhash) {
+        for (uint32_t idx = 0; idx < 32; ++idx) {
+            std::string h(64, '0');
+            h[0]  = tag;
+            h[58] = "0123456789abcdef"[(idx >> 8) & 0xf];
+            h[59] = "0123456789abcdef"[(idx >> 4) & 0xf];
+            h[60] = "0123456789abcdef"[idx & 0xf];
+            qhash[idx].SetHex(h);
+            eng.seed_block_hash(kCycleBase + idx, qhash[idx]);
+        }
+    };
+
+    // ── GREEN: assembled + keyed, dashd-exact, resolvable ─────────────────
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_engine(eng, /*seed_hminusC=*/true);
+        std::array<uint256, 32> qhash;
+        seed_index_hashes(eng, 'e', qhash);
+
+        auto dr = eng.derive_members_for_cycle(kType6075, kCycleBase);
+        ASSERT_TRUE(dr.ok) << dr.skip_reason;
+        EXPECT_EQ(dr.member_sets, 32u);
+        EXPECT_EQ(dr.expected_sets, 32u);
+        EXPECT_EQ(dr.quorum_size, 60u);
+
+        for (const auto& row : kat) {
+            ASSERT_LT(row.index, 32u);
+            auto m = eng.members_for(kType6075, qhash[row.index]);
+            ASSERT_TRUE(m.has_value())
+                << "quorumIndex " << row.index << " must resolve after derive";
+            auto got = protx_hex(*m);
+            ASSERT_EQ(got.size(), row.protx.size())
+                << "quorumIndex " << row.index;
+            for (size_t i = 0; i < got.size(); ++i)
+                EXPECT_EQ(got[i], row.protx[i])
+                    << "quorumIndex " << row.index << " member INDEX " << i
+                    << " diverges from dashd (this is the validMembers slot — "
+                       "consensus)";
+        }
+    }
+
+    // ── RED: a missing quarter → named skip, no member set, fail-closed ────
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_engine(eng, /*seed_hminusC=*/false);
+        uint256 qh0;
+        qh0.SetHex(
+            "0000000000000000000000000000000000000000000000000000000000000e00");
+        eng.seed_block_hash(kCycleBase, qh0);
+
+        auto dr = eng.derive_members_for_cycle(kType6075, kCycleBase);
+        EXPECT_FALSE(dr.ok);
+        EXPECT_LT(dr.member_sets, 32u);
+        EXPECT_FALSE(dr.skip_reason.empty()) << "the miss must be NAMED";
+        EXPECT_FALSE(eng.members_for(kType6075, qh0).has_value())
+            << "a missing quarter must leave the fold with NO member set "
+               "(fail-closed), never a guessed one";
+    }
+
+    // ── REWARD-SAFE: a tampered quarter assembles a DETECTABLY WRONG set ───
+    {
+        QuorumReplayEngine eng(mainnet_cfg());
+        seed_engine(eng, /*seed_hminusC=*/true);
+        CQuorumSnapshot bad = *q.snaps[0];   // H-C quarter
+        ASSERT_FALSE(bad.activeQuorumMembers.empty());
+        bad.activeQuorumMembers[0] = !bad.activeQuorumMembers[0];
+        eng.seed_snapshot(kType6075, kCycleBase - kC, bad);
+        std::array<uint256, 32> qhash;
+        seed_index_hashes(eng, 'f', qhash);
+
+        (void)eng.derive_members_for_cycle(kType6075, kCycleBase);
+        bool any_diff = false;
+        for (const auto& row : kat) {
+            auto m = eng.members_for(kType6075, qhash[row.index]);
+            if (!m) { any_diff = true; break; }
+            if (protx_hex(*m) != row.protx) { any_diff = true; break; }
+        }
+        EXPECT_TRUE(any_diff)
+            << "a tampered quarter must NOT reproduce dashd's members — that "
+               "divergence is exactly what the writer's per-row "
+               "merkleRootMNList self-check catches (reward-safe fail-closed)";
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Engine discipline (synthetic)
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Rebase of #1294 (dashd-cut MN-checkpoint / replay bridge) onto current master.

The original 17-commit branch was 95 commits behind. On rebase, **8 commits were already patch-equivalent on master** (superseded by the merged dashd-cut series #1229–#1262) and dropped; **9 commits survived** as genuinely-unmerged content:

- self-derived MN checkpoint emit from the MN-CKPT bridge
- gate the replay-fold payee cross-check on DIP3 ENFORCEMENT (not activation)
- fix cold-bridge/replay-fold MnDiffWriter UAF (store-arm mutual exclusion)
- seed the W1 fold from an EMPTY set at the DIP3 activation height
- self-derived MN-set checkpoint dump (`--dump-mn-checkpoint H FILE`)
- assemble+key the store-engine straddle cycle member set on getqrinfo seed
- cold-arm pre-anchor header backfill so getqrinfo snapshots authenticate
- bootstrap the store-engine rotated-quorum resolver across the anchor
- wire the W4 quorum-member resolver into the MN diff-store parallel fold engine

Rebase resolved with zero remaining conflict markers; conflicting hunks reconciled to keep master's merged behaviour and layer only the branch's additive content.

Verification (off-CI): `c2pool-dash` target compiles clean on the gcc13 profile. Full test suite + platform matrix left to CI.

Supersedes #1294 (close once green). Consensus-adjacent DASH code — hold for maintainer merge tap; do not auto-merge.
