### PR TITLE
dash(daemonless): serve the FULL mempool by default in the dashd-cut posture

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -68,6 +68,7 @@
 #include <impl/dash/coin/fold_live_controller.hpp>  // dash::coin::FoldLiveController (PR-C1 live tip-tracking fold)
 #include <impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.h>  // PR-C4 consensus-exact CheckInputScripts C API
 #include <impl/dash/coin/arm_resolution.hpp>   // dash::coin::resolve_embedded_arm (#738 arm decision, one place)
+#include <impl/dash/coin/good_citizen_defaults.hpp>   // dash::coin::resolve_good_citizen_tx_serve — daemonless FULL-MEMPOOL default
 #include <impl/dash/coin/embedded_startup_invariant.hpp>  // C-startup-invariant: embedded fresh-gate => body-first serve tip
 #include <impl/dash/coin/dkg_window.hpp>       // dash::coin::is_dkg_commitment_window (BLOCKER-1 guard)
 #include <impl/dash/coin/dkg_commitments.hpp>  // E1: build_daemonless_qc_plan (serve DKG windows daemonlessly)
@@ -459,8 +460,10 @@ void print_banner(const char* argv0)
         << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-asn-diversity]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
-        << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs]\n"
-        << "           [--embedded-tx-serve-own-set]\n"
+        << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs[=false]]\n"
+        << "           [--embedded-tx-serve-own-set[=false]]\n"
+        << "             (mempool serving levers default ON when NO dashd arm is given —\n"
+        << "              daemonless nodes serve the FULL mempool; =false opts out)\n"
         << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
         << "           [--embedded-getmnlistd-tracker]\n"
         << "           [--embedded-fold-live PATH] [--embedded-fold-live-expect HASH]\n"
@@ -9533,15 +9536,24 @@ int main(int argc, char** argv)
     // body instead -- consensus-valid, fees exactly 0, nothing to overstate
     // (see NodeCoinState::set_utxo_immature_policy).
     bool embedded_utxo_immature_serve_empty = false;
-    // --embedded-serve-mempool-txs: OPT-IN fee-carrying embedded templates.
-    // Default OFF = coinbase-only serving (values exact, fees forgone); the
-    // mempool-tx body path with its G1-G4 guards (mempool.hpp; audit
-    // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) arms only on explicit
-    // operator decision, and only once the MEMPOOL VALIDITY GATE
-    // (mempool_validity_gate.hpp) reports zero transactions refused by dashd's
-    // testmempoolaccept over its sustained window.
+    // --embedded-serve-mempool-txs: fee-carrying embedded templates.
+    // Posture-dependent default (good_citizen_defaults.hpp): on a dashd-ARMED
+    // node it stays OFF — there the gbt cross-check/fallback serves dashd's
+    // full template, so tx fullness is already provided and existing
+    // deployments keep their served bytes. On a DAEMONLESS node (no
+    // --coin-rpc / --coin-rpc-auth / --submit-block) it defaults ON together
+    // with its companion levers: SERVE THE FULL MEMPOOL is the good-citizen
+    // baseline — a daemonless pool that wins with a coinbase-only template
+    // mines a block that processes zero DASH transactions. The mempool-tx
+    // body path carries its G1-G4 guards (mempool.hpp; audit
+    // DASH_CONNECTBLOCK_REJECT_SURFACE_AUDIT.md) unconditionally once armed,
+    // and the serve-time internal-consistency referee (tx_serve_referee.hpp)
+    // self-validates every fee-carrying template with zero dashd calls.
+    // Explicit opt-out: --embedded-serve-mempool-txs=false.
     bool embedded_serve_mempool_txs = false;
-    bool embedded_tx_serve_own_set = false;  // --embedded-tx-serve-own-set, default OFF
+    bool embedded_serve_mempool_txs_off = false;  // --embedded-serve-mempool-txs=false
+    bool embedded_tx_serve_own_set = false;  // --embedded-tx-serve-own-set; daemonless default ON
+    bool embedded_tx_serve_own_set_off = false;   // --embedded-tx-serve-own-set=false
     bool embedded_accrue_asset_locks = false;  // #107 PHASE 2, default OFF
     bool embedded_accrue_asset_unlocks = false;  // #143 Variant B (type-9), default OFF
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
@@ -9560,8 +9572,11 @@ int main(int argc, char** argv)
     // the [MEMPOOL-VALIDITY] series says it is safe: ZERO transactions that
     // dashd's testmempoolaccept refuses, over a sustained window
     // (mempool_validity_gate.hpp). NOT the [SHADOW-TXSET] ours_only number --
-    // that is a coverage statistic and gates nothing.
+    // that is a coverage statistic and gates nothing. DAEMONLESS default ON
+    // (good_citizen_defaults.hpp): without the pull the mempool never fills
+    // and full-mempool serving is vacuously coinbase-only.
     bool embedded_mempool_ingest = false;
+    bool embedded_mempool_ingest_off = false;     // --embedded-mempool-ingest=false
     // --embedded-null-arm (#127): optimistic null commitment at fresh
     // window-open slots + template upgrade to the real commitment. DEFAULT
     // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
@@ -9577,12 +9592,18 @@ int main(int argc, char** argv)
     // conflict-tx-lock feed). DEFAULT OFF — off, no getdata for inv type 31
     // and the handler decodes-and-discards (wire + template behaviour
     // byte-identical); on, every isdlock is still individually BLS-gated
-    // before Mempool::add_islock (fail-closed at every hop).
+    // before Mempool::add_islock (fail-closed at every hop). DAEMONLESS
+    // default ON (good_citizen_defaults.hpp) — the IS mining hold self-gates
+    // on feed liveness, so the feed only ADDS safety.
     bool embedded_ingest_isdlock = false;
+    bool embedded_ingest_isdlock_off = false;     // --embedded-ingest-isdlock=false
     // --embedded-ingest-dstx (W5-B): arm the CoinJoin DSTX lane (getdata
     // pull + BLS-verified zero-fee admission with dashd's +0.1 COIN
-    // prioritisation delta). DEFAULT OFF — wire and templates byte-identical.
+    // prioritisation delta). Dashd-armed default OFF — wire and templates
+    // byte-identical. DAEMONLESS default ON (good_citizen_defaults.hpp):
+    // without it CoinJoin txs are structurally excluded from served blocks.
     bool embedded_ingest_dstx = false;
+    bool embedded_ingest_dstx_off = false;        // --embedded-ingest-dstx=false
     // --embedded-proactive-rotate (PR-3): LOW-RATE proactive coin-P2P peer
     // rotation. DEFAULT OFF — the coin client keeps its stall-only rotation,
     // byte-identical to master.
@@ -9688,14 +9709,20 @@ int main(int argc, char** argv)
             embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
             embedded_serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs=false") == 0)
+            embedded_serve_mempool_txs_off = true;  // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-tx-serve-own-set") == 0)
             embedded_tx_serve_own_set = true;
+        else if (std::strcmp(argv[i], "--embedded-tx-serve-own-set=false") == 0)
+            embedded_tx_serve_own_set_off = true;   // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks") == 0)
             embedded_accrue_asset_locks = true;   // #107 PHASE 2
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-unlocks") == 0)
             embedded_accrue_asset_unlocks = true; // #143 Variant B (type-9)
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
+        else if (std::strcmp(argv[i], "--embedded-mempool-ingest=false") == 0)
+            embedded_mempool_ingest_off = true;     // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-null-arm") == 0)
             embedded_null_arm = true;   // #127
         else if (std::strcmp(argv[i], "--embedded-null-arm=false") == 0)
@@ -9738,8 +9765,12 @@ int main(int argc, char** argv)
             embedded_fold_checkscripts = true;  // PR-C4: consensus-exact input-script check on the served template
         else if (std::strcmp(argv[i], "--embedded-ingest-isdlock") == 0)
             embedded_ingest_isdlock = true;   // G4 conflict-tx-lock feed
+        else if (std::strcmp(argv[i], "--embedded-ingest-isdlock=false") == 0)
+            embedded_ingest_isdlock_off = true;     // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-ingest-dstx") == 0)
             embedded_ingest_dstx = true;      // W5-B CoinJoin DSTX feed
+        else if (std::strcmp(argv[i], "--embedded-ingest-dstx=false") == 0)
+            embedded_ingest_dstx_off = true;        // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-proactive-rotate") == 0)
             embedded_proactive_rotate = true; // PR-3 proactive peer rotation
         // PR-1 LATENCY-AWARE PEER SCORING. Wire the CLI flag to the existing
@@ -10058,6 +10089,59 @@ int main(int argc, char** argv)
                       << " conflicts with web dashboard port, moving dashboard to "
                       << (stratum_port + 1) << "\n";
             web_port = static_cast<uint16_t>(stratum_port + 1);
+        }
+        // ── GOOD-CITIZEN DEFAULT: daemonless nodes SERVE THE FULL MEMPOOL ──
+        // The operator-declared posture decides: with no dashd arm requested
+        // (--coin-rpc / --coin-rpc-auth / --submit-block all absent) the
+        // embedded builder is the only template source, and a coinbase-only
+        // default means the pool mines blocks that process zero DASH
+        // transactions — a bad network citizen. Resolve the five mempool-
+        // serving levers through the pure, KAT-tested resolver
+        // (good_citizen_defaults.hpp): daemonless => not-spelled-out levers
+        // default ON (serving + the serve-time self-validation referee are
+        // armed TOGETHER, never apart); dashd-armed => byte-identical to the
+        // requested flags. --<flag>=false is the explicit opt-out either way.
+        {
+            const bool daemonless_posture = rpc_endpoint.empty()
+                                         && rpc_conf_path.empty()
+                                         && submit_hex.empty();
+            const dash::coin::TxServeResolution txr =
+                dash::coin::resolve_good_citizen_tx_serve(
+                    daemonless_posture,
+                    dash::coin::TxServeLevers{
+                        {embedded_serve_mempool_txs, embedded_serve_mempool_txs_off},
+                        {embedded_tx_serve_own_set,  embedded_tx_serve_own_set_off},
+                        {embedded_mempool_ingest,    embedded_mempool_ingest_off},
+                        {embedded_ingest_isdlock,    embedded_ingest_isdlock_off},
+                        {embedded_ingest_dstx,       embedded_ingest_dstx_off}});
+            embedded_serve_mempool_txs = txr.serve_mempool_txs;
+            embedded_tx_serve_own_set  = txr.tx_serve_own_set;
+            embedded_mempool_ingest    = txr.mempool_ingest;
+            embedded_ingest_isdlock    = txr.ingest_isdlock;
+            embedded_ingest_dstx       = txr.ingest_dstx;
+            if (txr.defaulted_any)
+                std::cout << "[run] good-citizen default (daemonless posture): "
+                             "FULL-MEMPOOL tx-serving armed"
+                             " serve-mempool-txs="
+                          << (txr.serve_mempool_txs ? "on" : "off")
+                          << " tx-serve-own-set="
+                          << (txr.tx_serve_own_set ? "on" : "off")
+                          << " mempool-ingest="
+                          << (txr.mempool_ingest ? "on" : "off")
+                          << " ingest-isdlock="
+                          << (txr.ingest_isdlock ? "on" : "off")
+                          << " ingest-dstx="
+                          << (txr.ingest_dstx ? "on" : "off")
+                          << " (opt-out: --embedded-serve-mempool-txs=false "
+                             "et al.)\n";
+            if (txr.unsafe_serve_without_referee)
+                std::cout << "[run] WARNING: --embedded-tx-serve-own-set=false"
+                             " with mempool-tx serving ON in the daemonless"
+                             " posture DISARMS the serve-time self-validation"
+                             " referee (tx_serve_referee.hpp) — fee-carrying"
+                             " templates will serve with no serve-time"
+                             " cross-check. Not a supported production"
+                             " configuration.\n";
         }
         return run_node(testnet, rpc_endpoint, rpc_conf_path, submit_hex, peer,
                         stratum_host, stratum_port, web_host, web_port,

--- a/src/impl/dash/coin/good_citizen_defaults.hpp
+++ b/src/impl/dash/coin/good_citizen_defaults.hpp
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// GOOD-CITIZEN DEFAULT for the daemonless (dashd-cut) posture: SERVE THE
+/// FULL MEMPOOL unless the operator explicitly opts out.
+///
+/// == WHY THIS EXISTS ========================================================
+/// A node started WITHOUT any dashd arm (--coin-rpc / --coin-rpc-auth /
+/// --submit-block all absent) serves templates built ONLY by the embedded
+/// builder. Before this resolver, the mempool-tx serving levers all defaulted
+/// OFF (the repo's money-path flag rule), so a daemonless node's templates
+/// were coinbase-only: a pool that wins a block with them mines a block that
+/// processes ZERO DASH transactions. That is a bad network citizen — it hurts
+/// chain throughput and user confirmation times, and it directly undermines
+/// the claim that this pool is infrastructure worth funding. The baseline for
+/// a daemonless node is what dashd's own CreateNewBlock does: include every
+/// valid mempool transaction, filling the block.
+///
+/// On a dashd-ARMED node the defaults stay exactly as before (all OFF):
+/// there the gbt cross-check / fallback already serves dashd's full template
+/// when the embedded body is coinbase-only, so tx fullness is provided by
+/// dashd and flipping embedded defaults would change served bytes on
+/// deployments that did not ask for it.
+///
+/// == WHAT IS FLIPPED (daemonless posture only) ==============================
+///   serve_mempool_txs  — the embedded builder packs the selected mempool set
+///                        (G1-G4 guarded; blockMinFeeRate + nConsecutiveFailed
+///                        selection parity; IS/CL-hold).
+///   tx_serve_own_set   — REQUIRED with the above in daemonless mode: it arms
+///                        the serve-time internal-consistency referee
+///                        (tx_serve_referee.hpp — coinbase fee-exact, every tx
+///                        fee_fold_proven, no intra-set double-spend, ZERO
+///                        dashd calls). Without it a fee-carrying template
+///                        would serve with no serve-time self-validation,
+///                        because the only other referee call site lives in
+///                        the dashd gbt-xcheck branch that a daemonless node
+///                        never enters.
+///   mempool_ingest     — the coin-P2P MSG_TX pull; without it the mempool
+///                        never fills and "serving" is vacuously coinbase-only.
+///   ingest_isdlock     — islock knowledge feed for the InstantSend mining
+///                        hold (conflict defence). The hold self-gates on feed
+///                        liveness, so this only ADDS safety.
+///   ingest_dstx        — CoinJoin DSTX lane; without it CoinJoin txs are
+///                        structurally excluded from served blocks (a
+///                        fullness gap vs dashd).
+///
+/// Each lever keeps an explicit opt-out (--<flag>=false). An explicit ON is
+/// honoured in both postures. The resolver is a pure function so the
+/// truth table is KAT-testable (test_dash_good_citizen_defaults.cpp).
+///
+/// == REWARD SAFETY ==========================================================
+/// The flip arms exactly the ladder proven live on the production money node
+/// (block 2526820: 48 mempool txs + coinbase, arm=EMBEDDED, self-validation
+/// OK, chainlocked). All build-time guards are unconditional once armed:
+/// selection admits only fee_fold_proven txs against the spent-aware UTXO
+/// view, the utxo-stale-at-tip window serves coinbase-only fail-closed
+/// (node_coin_state.hpp Window 2), admission rejects already-confirmed txs,
+/// and the referee fail-closes to no-work (last good work held) — never an
+/// unvalidated serve. A node without the embedded UTXO lane degrades to
+/// coinbase-only (nothing fee-proves), never to an unsafe serve.
+
+namespace dash {
+namespace coin {
+
+/// One mempool-serving lever as requested on the command line. `on` is the
+/// positive flag; `explicit_off` records the --<flag>=false spelling. Both
+/// false = "operator said nothing" = eligible for the good-citizen default.
+struct TxServeLever {
+    bool on{false};
+    bool explicit_off{false};
+};
+
+/// The five levers the good-citizen default governs.
+struct TxServeLevers {
+    TxServeLever serve_mempool_txs;
+    TxServeLever tx_serve_own_set;
+    TxServeLever mempool_ingest;
+    TxServeLever ingest_isdlock;
+    TxServeLever ingest_dstx;
+};
+
+/// Resolved arming decision plus the facts a caller needs to log truthfully.
+struct TxServeResolution {
+    bool serve_mempool_txs{false};
+    bool tx_serve_own_set{false};
+    bool mempool_ingest{false};
+    bool ingest_isdlock{false};
+    bool ingest_dstx{false};
+    /// True iff the daemonless default flipped at least one lever ON that the
+    /// operator did not spell out — the caller logs WHICH posture armed it.
+    bool defaulted_any{false};
+    /// True iff the resolved combination can serve fee-carrying templates
+    /// with the serve-time referee disarmed: serve_mempool_txs ON while
+    /// tx_serve_own_set is OFF in the daemonless posture. Impossible via
+    /// defaults (the resolver arms them together); reachable only by an
+    /// explicit operator opt-out — the caller must WARN, loudly.
+    bool unsafe_serve_without_referee{false};
+};
+
+/// THE resolver. `daemonless_posture` is the operator-declared cut posture:
+/// no --coin-rpc, no --coin-rpc-auth, no --submit-block on the command line.
+/// (A stray ~/.dashcore/dash.conf may still arm a dashd fallback inside
+/// run_node; that only ADDS guards — the gbt cross-check — on top of the
+/// referee, so the flip is safe in that corner too, and the operator's
+/// declared posture, not the stray file, decides the default.)
+inline TxServeResolution resolve_good_citizen_tx_serve(
+    bool daemonless_posture, const TxServeLevers& req)
+{
+    const auto resolve = [daemonless_posture](const TxServeLever& l,
+                                              bool& defaulted) -> bool {
+        if (l.explicit_off) return false;          // operator opt-out wins
+        if (l.on) return true;                     // explicit ON honoured
+        if (daemonless_posture) { defaulted = true; return true; }
+        return false;                              // dashd-armed: unchanged
+    };
+
+    TxServeResolution r;
+    r.serve_mempool_txs = resolve(req.serve_mempool_txs, r.defaulted_any);
+    r.tx_serve_own_set  = resolve(req.tx_serve_own_set,  r.defaulted_any);
+    r.mempool_ingest    = resolve(req.mempool_ingest,    r.defaulted_any);
+    r.ingest_isdlock    = resolve(req.ingest_isdlock,    r.defaulted_any);
+    r.ingest_dstx       = resolve(req.ingest_dstx,       r.defaulted_any);
+    r.unsafe_serve_without_referee =
+        daemonless_posture && r.serve_mempool_txs && !r.tx_serve_own_set;
+    return r;
+}
+
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -308,7 +308,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # DASH serve-gate journal per-cause time KAT (h=2518004 count-vs-time trap):
     # pure, header-only policy object; no socket/ltc/pool dependency. Mirrors
     # the test_dash_min_protocol_gate link set.
-    add_executable(test_dash_serve_gate_journal test_dash_serve_gate_journal.cpp test_dash_serve_gate_ledger.cpp)
+    # test_dash_good_citizen_defaults.cpp rides this allowlisted binary on
+    # purpose: build.yml's fixed --target allowlist cannot gain a new exe
+    # without workflow scope, and a gtest source compiled into an already-
+    # allowlisted binary is built AND run by CI (no NOT_BUILT hole). The
+    # resolver under test is pure/header-only (good_citizen_defaults.hpp) and
+    # needs exactly this link set.
+    add_executable(test_dash_serve_gate_journal test_dash_serve_gate_journal.cpp test_dash_serve_gate_ledger.cpp test_dash_good_citizen_defaults.cpp)
     target_link_libraries(test_dash_serve_gate_journal PRIVATE
         GTest::gtest_main GTest::gtest
         dash_x11 core

--- a/test/test_dash_good_citizen_defaults.cpp
+++ b/test/test_dash_good_citizen_defaults.cpp
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT for the daemonless good-citizen mempool-serving defaults
+// (impl/dash/coin/good_citizen_defaults.hpp).
+//
+// The contract under test:
+//   * dashd-ARMED posture (any of --coin-rpc/--coin-rpc-auth/--submit-block):
+//     resolution is byte-identical to the requested flags — the default never
+//     flips anything, existing deployments keep their served bytes.
+//   * DAEMONLESS posture: every lever the operator did not spell out resolves
+//     ON (serve the full mempool by default); an explicit --<flag>=false
+//     opt-out wins; an explicit ON is honoured.
+//   * The unsafe corner (fee-carrying serve with the serve-time referee
+//     disarmed) is impossible via defaults and is NAMED when an explicit
+//     opt-out creates it.
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/good_citizen_defaults.hpp>
+
+using dash::coin::TxServeLever;
+using dash::coin::TxServeLevers;
+using dash::coin::TxServeResolution;
+using dash::coin::resolve_good_citizen_tx_serve;
+
+namespace {
+
+TxServeLever off()          { return TxServeLever{false, false}; }
+TxServeLever on()           { return TxServeLever{true,  false}; }
+TxServeLever forced_off()   { return TxServeLever{false, true};  }
+
+TxServeLevers all_default() { return TxServeLevers{off(), off(), off(), off(), off()}; }
+
+} // namespace
+
+// ── dashd-armed posture: the resolver is an identity on the requested set ──
+
+TEST(DashGoodCitizenDefaults, DashdArmedAllDefaultStaysAllOff)
+{
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/false, all_default());
+    EXPECT_FALSE(r.serve_mempool_txs);
+    EXPECT_FALSE(r.tx_serve_own_set);
+    EXPECT_FALSE(r.mempool_ingest);
+    EXPECT_FALSE(r.ingest_isdlock);
+    EXPECT_FALSE(r.ingest_dstx);
+    EXPECT_FALSE(r.defaulted_any);
+    EXPECT_FALSE(r.unsafe_serve_without_referee);
+}
+
+TEST(DashGoodCitizenDefaults, DashdArmedExplicitOnIsHonoured)
+{
+    TxServeLevers req = all_default();
+    req.serve_mempool_txs = on();
+    req.tx_serve_own_set  = on();
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/false, req);
+    EXPECT_TRUE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.tx_serve_own_set);
+    EXPECT_FALSE(r.mempool_ingest);   // not requested, not defaulted
+    EXPECT_FALSE(r.defaulted_any);
+    EXPECT_FALSE(r.unsafe_serve_without_referee);  // referee concern is the
+                                                   // daemonless posture's
+}
+
+TEST(DashGoodCitizenDefaults, DashdArmedExplicitOffStaysOff)
+{
+    TxServeLevers req = all_default();
+    req.mempool_ingest = forced_off();
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/false, req);
+    EXPECT_FALSE(r.mempool_ingest);
+    EXPECT_FALSE(r.defaulted_any);
+}
+
+// ── daemonless posture: full-mempool serving is the default ────────────────
+
+TEST(DashGoodCitizenDefaults, DaemonlessAllDefaultArmsFullMempoolServing)
+{
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, all_default());
+    EXPECT_TRUE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.tx_serve_own_set);   // referee armed WITH serving, always
+    EXPECT_TRUE(r.mempool_ingest);
+    EXPECT_TRUE(r.ingest_isdlock);
+    EXPECT_TRUE(r.ingest_dstx);
+    EXPECT_TRUE(r.defaulted_any);
+    EXPECT_FALSE(r.unsafe_serve_without_referee);
+}
+
+TEST(DashGoodCitizenDefaults, DaemonlessExplicitOnIsNotCountedAsDefaulted)
+{
+    TxServeLevers req{on(), on(), on(), on(), on()};
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    EXPECT_TRUE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.tx_serve_own_set);
+    EXPECT_TRUE(r.mempool_ingest);
+    EXPECT_TRUE(r.ingest_isdlock);
+    EXPECT_TRUE(r.ingest_dstx);
+    EXPECT_FALSE(r.defaulted_any);     // nothing was defaulted — all explicit
+    EXPECT_FALSE(r.unsafe_serve_without_referee);
+}
+
+TEST(DashGoodCitizenDefaults, DaemonlessSingleOptOutKeepsTheRestOn)
+{
+    TxServeLevers req = all_default();
+    req.ingest_dstx = forced_off();
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    EXPECT_TRUE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.tx_serve_own_set);
+    EXPECT_TRUE(r.mempool_ingest);
+    EXPECT_TRUE(r.ingest_isdlock);
+    EXPECT_FALSE(r.ingest_dstx);       // the one opt-out
+    EXPECT_TRUE(r.defaulted_any);
+    EXPECT_FALSE(r.unsafe_serve_without_referee);
+}
+
+TEST(DashGoodCitizenDefaults, DaemonlessFullOptOutRestoresCoinbaseOnly)
+{
+    const TxServeLevers req{forced_off(), forced_off(), forced_off(),
+                            forced_off(), forced_off()};
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    EXPECT_FALSE(r.serve_mempool_txs);
+    EXPECT_FALSE(r.tx_serve_own_set);
+    EXPECT_FALSE(r.mempool_ingest);
+    EXPECT_FALSE(r.ingest_isdlock);
+    EXPECT_FALSE(r.ingest_dstx);
+    EXPECT_FALSE(r.defaulted_any);
+    EXPECT_FALSE(r.unsafe_serve_without_referee);  // no fee-carrying serve
+}
+
+// ── the unsafe corner is named, and unreachable via defaults ───────────────
+
+TEST(DashGoodCitizenDefaults, DaemonlessRefereeOptOutWithServingOnIsNamedUnsafe)
+{
+    TxServeLevers req = all_default();
+    req.tx_serve_own_set = forced_off();   // operator disarms the referee...
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    EXPECT_TRUE(r.serve_mempool_txs);      // ...while serving still defaults ON
+    EXPECT_FALSE(r.tx_serve_own_set);
+    EXPECT_TRUE(r.unsafe_serve_without_referee);
+}
+
+TEST(DashGoodCitizenDefaults, DaemonlessServeOptOutIsNotUnsafe)
+{
+    TxServeLevers req = all_default();
+    req.serve_mempool_txs = forced_off();
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    EXPECT_FALSE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.tx_serve_own_set);       // referee stays armed (harmless)
+    EXPECT_FALSE(r.unsafe_serve_without_referee);
+}
+
+TEST(DashGoodCitizenDefaults, ExplicitOffBeatsExplicitOn)
+{
+    // Both spellings on one command line: the opt-out wins (fail-safe).
+    TxServeLevers req = all_default();
+    req.serve_mempool_txs = TxServeLever{true, true};
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    EXPECT_FALSE(r.serve_mempool_txs);
+}


### PR DESCRIPTION
## Problem — the daemonless posture is a bad network citizen by default

A node started with **no dashd arm** (`--coin-rpc` / `--coin-rpc-auth` / `--submit-block` all absent) serves templates built only by the embedded builder. Every mempool-serving lever defaults OFF, so its templates are **coinbase-only** (`suppress_cause=mempool-txs-disabled`, `node_coin_state.hpp:1404`): a pool winning with them mines blocks that process **zero DASH transactions**. That hurts chain throughput and user confirmation times, and it is a direct argument against the pool in front of masternode owners.

This is not hypothetical: the fully-daemonless canary (dash.voidbind.com) runs today with `--embedded-mainnet --embedded-utxo --embedded-null-arm` and none of the serving levers, while dashd's current `getblocktemplate` carries 7-8 txs it would exclude. The dashd-armed hotel nodes are unaffected — their won blocks carry the mempool (last 11 pool-won blocks on-chain: nTx = 15, 2, 61, 144, 47, 14, 15, 1, 38, 10, 23) because the operator drop-in arms the full ladder there and the gbt cross-check/fallback backstops fullness.

## Fix — full-mempool serving is the DEFAULT in the daemonless posture

A new pure resolver (`src/impl/dash/coin/good_citizen_defaults.hpp`) resolves five levers just before `run_node`:

| lever | dashd-armed default | daemonless default |
|---|---|---|
| `--embedded-serve-mempool-txs` | OFF (unchanged) | **ON** |
| `--embedded-tx-serve-own-set` | OFF (unchanged) | **ON** |
| `--embedded-mempool-ingest` | OFF (unchanged) | **ON** |
| `--embedded-ingest-isdlock` | OFF (unchanged) | **ON** |
| `--embedded-ingest-dstx` | OFF (unchanged) | **ON** |

* **Dashd-armed posture: byte-identical.** The resolver is an identity on the requested flags — no existing deployment changes served bytes.
* **Daemonless posture:** levers the operator did not spell out default ON. Each keeps an explicit opt-out spelling `--<flag>=false` (existing `=false` pattern). Serving and the serve-time referee arm **together, never apart**: the only other referee call site lives in the dashd gbt-xcheck branch a daemonless node never enters, so serving without `tx-serve-own-set` would mean fee-carrying templates with zero serve-time self-validation. The one way to reach that corner is an explicit `--embedded-tx-serve-own-set=false` opt-out, which is loudly named at startup as unsupported.

## Reward safety

The flip arms exactly the ladder already proven live on the production money node (block 2526820: 48 mempool txs + coinbase, `arm=EMBEDDED`, `embedded self-validation OK`, chainlocked). All guards are unconditional once armed and none is weakened here:

* selection admits only `fee_fold_proven` txs against the spent-aware UTXO view (G1 ancestor closure, G2 sigops, G3 coinbase maturity, G4 islock conflicts; `blockMinFeeRate` + `nConsecutiveFailed` parity; IS/CL-hold; admission-side already-confirmed reject);
* the `utxo-stale-at-tip` window fail-closes to coinbase-only (Window-2, `node_coin_state.hpp`);
* the serve-time internal-consistency referee (`tx_serve_referee.hpp`: coinbase fee-exact, all fees fold-proven, no intra-set double-spend, zero dashd calls) fail-closes to no-work with the last good work held;
* a node without the embedded UTXO lane degrades to coinbase-only — nothing fee-proves — never to an unsafe serve.

## Tests

`test/test_dash_good_citizen_defaults.cpp` — 9 KATs over the resolver truth table (identity in the dashd-armed posture, full arming in the daemonless posture, per-lever opt-out, referee-corner naming, off-beats-on). The KAT source rides the allowlisted `test_dash_serve_gate_journal` binary so CI builds **and runs** it (build.yml's fixed `--target` list cannot gain a new exe without workflow scope — avoiding the NOT_BUILT hole).

Build-verified on the bare-metal CI host (191): `test_dash_serve_gate_journal` full suite + `c2pool-dash` Release build.

## Deploy note (not part of this PR)

With this merged, the contabo canary picks up full-mempool serving on its next binary refresh with **no drop-in change** (it already runs the daemonless posture). Refs #155, #132, #120; builds on #1110, #1148, #1230, #1232, #125, #1325.
