### PR TITLE
btc: dedicated readvertise_best_share() bypassing shared-hash dedup on re-advert (#885)

### DIFF
--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1189,28 +1189,59 @@ uint256 NodeImpl::advertised_best_share()
     return uint256::ZERO;
 }
 
-// ROOT-2 re-advert. Unlike ltc/dgb (which have a dedicated readvertise that
-// bypasses the de-dup set), this delegates to broadcast_share, so the walk still
-// breaks on the first hash already in m_shared_share_hashes.
-//
-// Interaction with the F2 marking change: marking is now a strict SUBSET of what
-// the pre-fix code marked (only hashes a peer actually accepted). The walk breaks
-// later or in the same place, never earlier, so this re-advert re-pushes a
-// superset of what it used to — monotonically better, no regression. It is
-// strictly better in the case that motivated ROOT-2: head shares minted while no
-// peer was connected are no longer marked, so a peer that handshook during the
-// empty window now receives them. It does NOT fully close ROOT-2 here — head
-// shares already accepted by some OTHER peer stay marked and the walk still
-// breaks, exactly as before. Closing that needs the ltc/dgb-style de-dup-bypass
-// readvertise; pre-existing gap, out of scope for this change.
-void NodeImpl::readvertise_best()
+void NodeImpl::readvertise_best_share()
 {
-    if (m_peers.empty())
+    // ROOT-2 re-advertisement.  A peer that finished its version handshake
+    // while our verified chain was empty got a NULL best_share and never
+    // called download_shares(); broadcast_share() may not wake it either, because
+    // its walk breaks on the first hash already in m_shared_share_hashes.  Here
+    // we re-push the tip walk to every peer WITHOUT consulting the de-dup set.
+    // Advertise-only: never affects local work creation.
+    //
+    // This is the ltc/dgb-style de-dup-bypass re-advert (ltc/node.cpp,
+    // dgb/node.cpp).  The prior BTC readvertise_best() delegated to
+    // broadcast_share, whose walk breaks on the first hash already in
+    // m_shared_share_hashes, so a head share already accepted by some OTHER peer
+    // stayed masked and the re-advert never reached a freshly-handshook peer.
+    // Walking the head directly closes that gap.
+    uint256 head = advertised_best_share();
+    if (head.IsNull() || head == uint256::ZERO)
         return;
-    uint256 adv = advertised_best_share();
-    if (adv.IsNull() || adv == uint256::ZERO)
+
+    // Same try_to_lock discipline as broadcast_share (node.hpp:67): never block
+    // the IO thread on the tracker mutex.  If think() holds it now, the next
+    // trigger (best-change or the timer) retries.
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
         return;
-    broadcast_share(adv);
+
+    if (!m_chain || !m_chain->contains(head))
+        return;
+
+    std::vector<uint256> to_send;
+    int32_t height = m_chain->get_height(head);
+    int32_t walk = std::min(height, 5);
+    for (auto [hash, data] : m_chain->get_chain(head, walk)) {
+        if (m_rejected_share_hashes.count(hash))
+            continue; // never re-broadcast peer-rejected shares
+        to_send.push_back(hash);
+    }
+    if (to_send.empty())
+        return;
+
+    // Advertise-only path: deliberately ignores the de-dup set, so nothing is
+    // marked here.  Record only what was ACTUALLY written (F2) — a share the
+    // tx-completeness gate withheld must not be blamed for a later peer drop,
+    // which would mark it rejected and make the walk above `continue` past it
+    // forever.
+    auto now = std::chrono::steady_clock::now();
+    for (auto& [nonce, peer] : m_peers) {
+        std::vector<uint256> sent = send_shares(peer, to_send);
+        if (!sent.empty())
+            m_last_broadcast_to[peer->addr()] = {sent, now};
+    }
+    LOG_INFO << "[readvertise] re-pushed " << to_send.size()
+             << " head share(s) to " << m_peers.size() << " peer(s) (ROOT-2)";
 }
 
 void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_hash)
@@ -1971,7 +2002,7 @@ void NodeImpl::run_think()
                 // Root-2: re-advertise our new head.  A peer that handshook
                 // before we had a chain saw a ZERO advert and never issued
                 // download_shares -- re-announce so it pulls our shares now.
-                readvertise_best();
+                readvertise_best_share();
             } else if (result.best.IsNull()) {
                 LOG_WARNING << "[ASYNC-THINK] IO-phase: result.best is NULL — verified_tails="
                             << m_tracker.verified.get_tails().size()
@@ -1988,7 +2019,7 @@ void NodeImpl::run_think()
                 m_verified_was_empty = false;
                 if (!m_readvert_timer)
                     m_readvert_timer = std::make_unique<core::Timer>(m_context, false);
-                m_readvert_timer->start(10, [this]() { readvertise_best(); });
+                m_readvert_timer->start(10, [this]() { readvertise_best_share(); });
                 LOG_INFO << "[readvertise] verified chain populated — scheduled "
                             "10s re-advert (ROOT-2)";
             }
@@ -2497,7 +2528,7 @@ void NodeImpl::clean_tracker()
         if (clean_best_changed && m_on_best_share_changed) {
             LOG_INFO << "[CLEAN] IO-phase: work refresh (best changed)";
             m_on_best_share_changed();
-            readvertise_best();   // root-2: re-announce new head to peers
+            readvertise_best_share();   // root-2: re-announce new head to peers
         }
         drain_pending_adds();
         m_think_running.store(false);

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -417,7 +417,10 @@ public:
     /// connected peers.  Invoked when think()/clean updates the best share so a
     /// peer that completed the version handshake before we had any shares (when
     /// our advert was ZERO) still learns our head and pulls via download_shares.
-    void readvertise_best();
+    /// Walks the head WITHOUT consulting the m_shared_share_hashes de-dup set
+    /// (ltc/dgb pattern), so a head share already accepted by another peer is
+    /// still re-pushed to a freshly-handshook one (ROOT-2, issue #885).
+    void readvertise_best_share();
 
     /// Start downloading shares from a peer, beginning at `target_hash`.
     /// Recursively fetches parents until the chain is connected or CHAIN_LENGTH reached.

--- a/src/impl/btc/test/broadcast_gate_test.cpp
+++ b/src/impl/btc/test/broadcast_gate_test.cpp
@@ -31,6 +31,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include <utility>
@@ -208,6 +209,69 @@ TEST(BtcBroadcastMarking, WalkStrandedWhenMarkedBeforeSend)
         EXPECT_EQ(marked.size(), 2u);
         EXPECT_TRUE(walk(chain, marked).empty());   // now correctly de-duped
     }
+}
+
+// #885: readvertise_best_share re-pushes a head share the de-dup set would
+// otherwise mask, exactly where broadcast_share's walk breaks. A peer that
+// handshook while our verified chain was empty never called download_shares();
+// it must be re-served the tip. But the tip's parents were already accepted by
+// an EARLIER peer, so they sit in m_shared_share_hashes. broadcast_share's walk
+// breaks on the first such hash; readvertise_best_share ignores the de-dup set
+// and re-pushes the whole tip window, skipping only peer-REJECTED hashes.
+TEST(BtcBroadcastMarking, ReadvertiseBypassesDedupSet)
+{
+    // The tip-first walk broadcast_share performs: breaks on the first marked
+    // hash (the delegate the pre-#885 readvertise_best relied on).
+    auto broadcast_walk = [](const std::vector<uint256>& chain_tip_first,
+                             const std::set<uint256>& marked) {
+        std::vector<uint256> to_send;
+        for (const auto& hash : chain_tip_first) {
+            if (marked.count(hash))
+                break;
+            to_send.push_back(hash);
+        }
+        return to_send;
+    };
+
+    // The tip-first walk readvertise_best_share() performs: it does NOT consult
+    // the de-dup set, so a head share already in m_shared_share_hashes is still
+    // re-pushed. It skips only peer-REJECTED hashes.
+    auto readvertise_walk = [](const std::vector<uint256>& chain_tip_first,
+                               const std::set<uint256>& rejected) {
+        std::vector<uint256> to_send;
+        for (const auto& hash : chain_tip_first) {
+            if (rejected.count(hash))
+                continue;   // never re-broadcast a peer-rejected share
+            to_send.push_back(hash);
+        }
+        return to_send;
+    };
+
+    const std::vector<uint256> chain{S3, S2, S1};   // S3 is the tip
+
+    // broadcast_share delegate (pre-#885 readvertise_best): if the TIP itself is
+    // already marked the walk yields NOTHING, so a freshly-handshook peer is
+    // never re-served the head.
+    const std::set<uint256> marked_incl_tip{S3, S2, S1};
+    EXPECT_TRUE(broadcast_walk(chain, marked_incl_tip).empty());
+
+    // ...and even with only the parents marked the walk breaks after the tip.
+    const std::set<uint256> marked_parents{S2, S1};
+    EXPECT_EQ(broadcast_walk(chain, marked_parents).size(), 1u);
+
+    // readvertise_best_share (the fix): the de-dup set is ignored entirely, so
+    // the full tip window is re-pushed regardless of prior sharing.
+    const std::set<uint256> no_rejects;
+    auto readv = readvertise_walk(chain, no_rejects);
+    ASSERT_EQ(readv.size(), 3u);
+    EXPECT_EQ(readv[0], S3);        // starts at the tip
+    EXPECT_EQ(readv[2], S1);        // reaches the shared parents
+
+    // ...but a peer-REJECTED share is still never re-broadcast.
+    const std::set<uint256> rejected{S2};
+    auto readv_rej = readvertise_walk(chain, rejected);
+    ASSERT_EQ(readv_rej.size(), 2u);
+    EXPECT_TRUE(std::find(readv_rej.begin(), readv_rej.end(), S2) == readv_rej.end());
 }
 
 


### PR DESCRIPTION
## Summary

Closes the BTC half of #885. ROOT-2 re-advertisement re-pushes the head to peers
that finished the version handshake while our verified chain was empty (they got
a NULL `best_share` and never called `download_shares()`). BTC implemented this
by delegating to `broadcast_share`, whose walk **breaks on the first hash already
in `m_shared_share_hashes`** — so a head share already accepted by some OTHER
peer stayed masked and a freshly-handshook peer never received it. On BTC the
re-advert was therefore a no-op for any share already marked shared, which is the
common case for a locally-created head share.

BCH was already fixed on master by #1360; this brings BTC in line so both coins
re-advertise correctly. LTC (`ltc/node.cpp`) and DGB (`dgb/node.cpp`) already
have the dedicated bypass and are untouched.

## Change

- `btc/node.cpp`: replace `readvertise_best()` (delegate to `broadcast_share`)
  with a dedicated `readvertise_best_share()` that walks the head **without**
  consulting the `m_shared_share_hashes` de-dup set, mirroring ltc/dgb and the
  merged BCH #1360.
  - Still skips peer-**rejected** hashes (`m_rejected_share_hashes`) — never
    re-broadcasts a share a peer already refused.
  - Records only what was **actually written** into `m_last_broadcast_to` (F2),
    so a share the tx-completeness gate withheld cannot be blamed for a later
    peer drop and thereby be permanently excluded from all future re-adverts.
  - Advertise-only: never affects local work creation. Same `try_to_lock`
    discipline as `broadcast_share` — never blocks the IO thread on the tracker
    mutex.
- `btc/node.hpp`: rename the declaration + update the doc comment.
- The three call sites (`run_think` best-change, the one-shot re-advert timer,
  `clean_tracker`) now call `readvertise_best_share()`.

## Test

Adds a KAT to `btc_share_test`'s `broadcast_gate_test` (already wired into CI):
the `broadcast_share` walk strands an all-marked head, while the readvertise walk
re-pushes the whole tip window ignoring the de-dup set and still excludes a
peer-rejected hash. Mirrors the BCH KAT added in #1360.

## Scope / safety

- p2p advertise path only. No share bytes, minting, payout, or consensus surface
  touched. Does **not** touch #906 (v37 hardening) or any v36 wire format.
- Structural verification: every symbol used by the new function is already used
  by BTC's own `broadcast_share` (`send_shares`, `m_chain->contains/get_height/
  get_chain`, `m_peers`, `peer->addr()`, `m_last_broadcast_to`,
  `m_rejected_share_hashes`, the `try_to_lock` shared-lock). The change is a
  line-for-line mirror of the already-merged, CI-green BCH #1360. A fresh full
  coin-binary build was not run (shared build fleet was saturated and has no
  standing BTC tree); relying on CI to build `btc_share_test` + the btc binary.
