### PR TITLE
c2pool-qt: reject wrong-coin payout address in the launch form (QP-B)

### DIFF
--- a/ui/c2pool-qt/CMakeLists.txt
+++ b/ui/c2pool-qt/CMakeLists.txt
@@ -16,6 +16,7 @@ project(c2pool_qt LANGUAGES CXX)
 # Install on Debian/Ubuntu via:
 #   sudo apt install qt6-webengine-dev qt6-webchannel-dev
 find_package(Qt6 6.2 REQUIRED COMPONENTS
+    Core
     Widgets
     Network
     WebEngineCore
@@ -163,6 +164,19 @@ if(C2POOL_QT_BUILD_TESTS)
     target_include_directories(c2pool-qt_test_reward_safe_launch PRIVATE src)
     add_test(NAME reward_safe_launch
              COMMAND c2pool-qt_test_reward_safe_launch)
+
+    # ── QP-B address-flavor gate ─────────────────────────────────────────
+    # Proves a wrong-coin base58 payout address (e.g. a DASH 'X…' address in
+    # a Litecoin profile) is rejected, while bech32/cashaddr/unknown flavors
+    # pass through unjudged. AddressValidator is Qt-Core only (QString +
+    # QCryptographicHash), so this links Qt6::Core and runs headless.
+    add_executable(c2pool-qt_test_address_validator
+        test/test_address_validator.cpp
+    )
+    target_include_directories(c2pool-qt_test_address_validator PRIVATE src)
+    target_link_libraries(c2pool-qt_test_address_validator PRIVATE Qt6::Core)
+    add_test(NAME address_validator
+             COMMAND c2pool-qt_test_address_validator)
 
     # ── Teardown leak/crash gate (issue #852) ────────────────────────────
     # The embedded-view host tore itself down via deregisterObject(nullptr),

--- a/ui/c2pool-qt/src/AddressValidator.hpp
+++ b/ui/c2pool-qt/src/AddressValidator.hpp
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// AddressValidator — in-UI payout-address flavor check (QP-B).
+//
+// c2pool-qt is coin-generic: the same launch form serves LTC/BTC/DOGE/
+// DASH/DGB/BCH. A payout address pasted into the wrong coin's profile is
+// a silent money mistake — miners paid to an address the winning coin's
+// nodes reject, or worse, an address that decodes to a DIFFERENT live
+// chain. This validator catches the unambiguous case: a base58check
+// address whose version byte belongs to a *known other coin*.
+//
+// Design (deliberately low false-positive so it never blocks a valid
+// launch):
+//   • Only base58check (25-byte, checksum-verified) addresses are judged.
+//     bech32 / cashaddr / anything else decode-fails here and is passed
+//     through UNJUDGED (NotBase58Check) — we do not model those yet and
+//     must not reject a valid segwit/cashaddr address.
+//   • WrongCoin — and only WrongCoin — is a hard launch blocker. It fires
+//     when the version byte matches NO network of the active coin but DOES
+//     match some other coin in the CoinProfiles table (e.g. a DASH 'X…'
+//     address, version 76, typed into a Litecoin profile).
+//   • Version-byte collisions between coins (BTC/BCH share 0/5; DOGE/DGB
+//     share 30) resolve in the user's favour: if the version is valid for
+//     the active coin under ANY network, the verdict is Ok.
+//
+// Qt Core only (QString / QByteArray / QCryptographicHash) — no Widgets,
+// no WebEngine — so it is unit-testable without a display.
+
+#pragma once
+
+#include "CoinProfiles.hpp"
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QLatin1String>
+#include <QString>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace c2pool_qt {
+
+enum class AddressVerdict {
+    Ok,             ///< base58check valid; version belongs to the active coin
+    WrongCoin,      ///< base58check valid; version belongs to a DIFFERENT coin
+    UnknownVersion, ///< base58check valid; version not in our coin table
+    NotBase58Check, ///< empty / bech32 / cashaddr / not a 25-byte b58check payload
+};
+
+struct AddressCheck {
+    AddressVerdict verdict{AddressVerdict::NotBase58Check};
+    QString        detectedCoinLabel;  ///< set when WrongCoin (the coin it belongs to)
+    QString        message;            ///< human-readable; empty on Ok / empty input
+
+    /// The ONLY blocking condition — a positively-identified wrong-coin
+    /// address. Everything else is advisory so a valid launch is never
+    /// stopped by a coin we simply do not model.
+    bool blocksLaunch() const { return verdict == AddressVerdict::WrongCoin; }
+};
+
+namespace detail {
+
+/// Decode a base58 string into raw bytes (big-endian). Returns false on any
+/// character outside the base58 alphabet (which cleanly rejects bech32 —
+/// '0','1','O','I','l' are not in the alphabet — and cashaddr's ':').
+inline bool decodeBase58(const QString& in, std::vector<uint8_t>& out)
+{
+    static const char kAlphabet[] =
+        "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    out.clear();
+    if (in.isEmpty()) return false;
+
+    std::vector<uint8_t> num;  // big-endian base-256 accumulator
+    num.reserve(in.size());
+    for (QChar qc : in) {
+        const char c = qc.toLatin1();
+        if (c == 0) return false;  // non-latin1 => not base58
+        const char* p = std::strchr(kAlphabet, c);
+        if (p == nullptr || c == '\0') return false;
+        int carry = static_cast<int>(p - kAlphabet);
+        for (auto it = num.rbegin(); it != num.rend(); ++it) {
+            carry += 58 * (*it);
+            *it = static_cast<uint8_t>(carry & 0xFF);
+            carry >>= 8;
+        }
+        while (carry > 0) {
+            num.insert(num.begin(), static_cast<uint8_t>(carry & 0xFF));
+            carry >>= 8;
+        }
+    }
+    // Each leading '1' is a leading zero byte.
+    int leadingOnes = 0;
+    for (QChar qc : in) {
+        if (qc == QLatin1Char('1')) ++leadingOnes; else break;
+    }
+    out.assign(static_cast<size_t>(leadingOnes), 0);
+    out.insert(out.end(), num.begin(), num.end());
+    return true;
+}
+
+/// True when `version` is a valid base58 address prefix for `p` on ANY
+/// network (mainnet or testnet, P2PKH or P2SH). -1 fields never match.
+inline bool versionMatchesCoin(const CoinProfile& p, int version)
+{
+    return version == p.p2pkhVersionMainnet
+        || version == p.p2shVersionMainnet
+        || version == p.p2pkhVersionTestnet
+        || version == p.p2shVersionTestnet;
+}
+
+} // namespace detail
+
+/// Validate a payout address for the coin identified by `activeSymbol`.
+/// `testnet` currently only shapes messaging; matching accepts either
+/// network of the active coin so a mainnet/testnet slip is not blocked.
+inline AddressCheck validatePayoutAddress(const QString& address,
+                                          const QString& activeSymbol,
+                                          bool /*testnet*/ = false)
+{
+    AddressCheck result;
+    const QString addr = address.trimmed();
+    if (addr.isEmpty()) {
+        // Empty is fine — PageLaunch only emits --address when non-empty
+        // (and can auto-detect from the wallet).
+        result.verdict = AddressVerdict::NotBase58Check;
+        return result;
+    }
+
+    std::vector<uint8_t> raw;
+    if (!detail::decodeBase58(addr, raw) || raw.size() != 25) {
+        // Not a base58check address (bech32 / cashaddr / malformed). We do
+        // not model those, so pass through unjudged.
+        result.verdict = AddressVerdict::NotBase58Check;
+        return result;
+    }
+
+    // base58check = 1 version byte + 20 payload bytes + 4 checksum bytes.
+    // checksum = first 4 bytes of SHA256d(version||payload).
+    const QByteArray body(reinterpret_cast<const char*>(raw.data()), 21);
+    const QByteArray h1 = QCryptographicHash::hash(body, QCryptographicHash::Sha256);
+    const QByteArray h2 = QCryptographicHash::hash(h1, QCryptographicHash::Sha256);
+    if (std::memcmp(h2.constData(), raw.data() + 21, 4) != 0) {
+        // Looks base58 but the checksum fails — most likely a typo. Advisory
+        // only (never a hard block, to stay low false-positive).
+        result.verdict = AddressVerdict::NotBase58Check;
+        return result;
+    }
+
+    const int version = raw[0];
+    const CoinProfile& active = coinProfile(activeSymbol);
+
+    if (detail::versionMatchesCoin(active, version)) {
+        result.verdict = AddressVerdict::Ok;
+        return result;
+    }
+
+    // Version does not belong to the active coin. Does it belong to a
+    // known other coin? If so this is the money-mistake we must block.
+    int count = 0;
+    const CoinProfile* profiles = coinProfiles(count);
+    for (int i = 0; i < count; ++i) {
+        const CoinProfile& p = profiles[i];
+        if (p.symbol == active.symbol) continue;
+        if (detail::versionMatchesCoin(p, version)) {
+            result.verdict = AddressVerdict::WrongCoin;
+            result.detectedCoinLabel = p.displayLabel;
+            result.message = QStringLiteral(
+                "This is a %1 address (base58 version %2), but the active coin "
+                "is %3. Enter a %3 payout address or switch profiles.")
+                .arg(p.displayLabel)
+                .arg(version)
+                .arg(active.displayLabel);
+            return result;
+        }
+    }
+
+    // Valid base58check, but a version we do not model. Advisory only.
+    result.verdict = AddressVerdict::UnknownVersion;
+    result.message = QStringLiteral(
+        "Unrecognised address version %1 — cannot confirm this is a valid %2 "
+        "address.")
+        .arg(version)
+        .arg(active.displayLabel);
+    return result;
+}
+
+} // namespace c2pool_qt

--- a/ui/c2pool-qt/src/CoinProfiles.hpp
+++ b/ui/c2pool-qt/src/CoinProfiles.hpp
@@ -80,6 +80,16 @@ struct CoinProfile {
 
     bool masternodePayee;   ///< coin pays a masternode/founder split (DASH) — surfaced as a note
     bool experimental;      ///< PerCoinRun binary still stabilising (DGB/BCH) — surfaced as a note
+
+    // Base58 address version bytes (P2PKH / P2SH, mainnet / testnet), used by
+    // AddressValidator to reject a wrong-coin payout address in the UI. Values
+    // mirror the node's impl/<coin>/params.hpp base58Prefixes and CoinBridge's
+    // JS descriptor table. DASH cross-checked vs dashpay/dash chainparams.cpp
+    // (mainnet 76/16, testnet 140/19).
+    int p2pkhVersionMainnet;
+    int p2shVersionMainnet;
+    int p2pkhVersionTestnet;
+    int p2shVersionTestnet;
 };
 
 /// Ordered profile table. Order drives the chain combo. DASH is first-class.
@@ -92,19 +102,22 @@ inline const CoinProfile* coinProfiles(int& countOut)
          CliFamily::LegacyUnified, "",
          9332, 19332,
          "", "", "", "", false, true,
-         0, 0, false, false},
+         0, 0, false, false,
+         48, 50, 111, 58},
         {"bitcoin", "Bitcoin", "c2pool", "bitcoind", "SHA-256d",
          "1… / bc1… (P2PKH/bech32)",
          CliFamily::LegacyUnified, "",
          8332, 18332,
          "", "", "", "", false, true,
-         0, 0, false, false},
+         0, 0, false, false,
+         0, 5, 111, 196},
         {"dogecoin", "Dogecoin", "c2pool", "dogecoind", "Scrypt (AuxPoW)",
          "D… (P2PKH)",
          CliFamily::LegacyUnified, "",
          22555, 44555,
          "", "", "", "", false, true,
-         0, 0, false, false},
+         0, 0, false, false,
+         30, 22, 113, 196},
 
         // ── PerCoinRun: dedicated per-coin binaries ──────────────────────────
         // DASH — X11, masternode-payee coin, dashd parent. Default launch is
@@ -115,7 +128,8 @@ inline const CoinProfile* coinProfiles(int& countOut)
          9998, 19998,
          "--coin-rpc", "--coin-rpc-auth", "~/.dashcore/dash.conf",
          "--listen", /*testnet*/ true, /*webPort*/ true,
-         3333, 8080, /*masternode*/ true, /*experimental*/ false},
+         3333, 8080, /*masternode*/ true, /*experimental*/ false,
+         76, 16, 140, 19},
 
         // DigiByte — multi-algo (Scrypt here), digibyted parent. No --testnet
         // flag (mainnet/regtest only) and no --web-port on this binary.
@@ -125,7 +139,8 @@ inline const CoinProfile* coinProfiles(int& countOut)
          14024, 14025,
          "--coin-rpc", "--coin-rpc-auth", "~/.digibyte/digibyte.conf",
          "--sharechain-port", /*testnet*/ false, /*webPort*/ false,
-         5022, 0, /*masternode*/ false, /*experimental*/ true},
+         5022, 0, /*masternode*/ false, /*experimental*/ true,
+         30, 63, 126, 140},
 
         // Bitcoin Cash — BCHN parent. Uses `--pool`, creds via --rpc-conf
         // (no --coin-rpc endpoint override), --p2p-port for the sharechain.
@@ -135,7 +150,8 @@ inline const CoinProfile* coinProfiles(int& countOut)
          8332, 18332,
          "", "--rpc-conf", "~/.bitcoin/bitcoin.conf",
          "--p2p-port", /*testnet*/ true, /*webPort*/ false,
-         3333, 0, /*masternode*/ false, /*experimental*/ true},
+         3333, 0, /*masternode*/ false, /*experimental*/ true,
+         0, 5, 111, 196},
     };
     countOut = static_cast<int>(sizeof(kProfiles) / sizeof(kProfiles[0]));
     return kProfiles;

--- a/ui/c2pool-qt/src/PageLaunch.cpp
+++ b/ui/c2pool-qt/src/PageLaunch.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "PageLaunch.hpp"
 
+#include "AddressValidator.hpp"
 #include "CoinProfiles.hpp"
 #include "LaunchCommand.hpp"
 #include "SettingsStore.hpp"
@@ -281,6 +282,14 @@ void PageLaunch::setupUi()
         addressEdit_->setPlaceholderText("payout address for the selected coin");
         addressEdit_->setToolTip("--address / --solo-address  (YOUR mining payout address)");
         form->addRow("Payout address:", addressEdit_);
+
+        // Inline address-flavor status (QP-B). Hidden until it has something
+        // to say; turns red for a positively-identified wrong-coin address
+        // (which launch() then refuses to start).
+        addressStatusLabel_ = new QLabel;
+        addressStatusLabel_->setWordWrap(true);
+        addressStatusLabel_->setVisible(false);
+        form->addRow("", addressStatusLabel_);
 
         autoDetectWalletCheck_ = new QCheckBox("Auto-detect wallet address");
         autoDetectWalletCheck_->setChecked(true);
@@ -589,9 +598,16 @@ void PageLaunch::setupUi()
         vbox->addWidget(g);
     }
 
+    // Live address-flavor validation (QP-B). Re-check whenever the address,
+    // the node-owner address, the coin, or the testnet flag changes.
+    connect(addressEdit_,        &QLineEdit::textChanged, this, &PageLaunch::validateAddressField);
+    connect(nodeOwnerAddrEdit_,  &QLineEdit::textChanged, this, &PageLaunch::validateAddressField);
+    connect(testnetCheck_,       &QCheckBox::toggled,     this, &PageLaunch::validateAddressField);
+
     vbox->addStretch();
     onBuildPreview();  // initial preview
     emitApiBaseUrlChanged();
+    validateAddressField();
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -844,6 +860,7 @@ void PageLaunch::updateNetworkDefaults()
     applyProfileUi();
     onBuildPreview();
     emitApiBaseUrlChanged();
+    validateAddressField();
 }
 
 void PageLaunch::applyProfileUi()
@@ -904,6 +921,56 @@ void PageLaunch::emitApiBaseUrlChanged()
     emit apiBaseUrlChanged(suggestedApiBaseUrl());
 }
 
+void PageLaunch::validateAddressField()
+{
+    if (addressStatusLabel_ == nullptr) return;
+
+    const QString chain   = currentChain();
+    const bool    testnet = testnetCheck_ && testnetCheck_->isChecked();
+
+    // The payout address is the money-critical field; the node-owner address
+    // (fee payout) is checked too. Surface the payout verdict first.
+    const c2pool_qt::AddressCheck payout =
+        c2pool_qt::validatePayoutAddress(addressEdit_->text(), chain, testnet);
+    const c2pool_qt::AddressCheck owner =
+        c2pool_qt::validatePayoutAddress(
+            nodeOwnerAddrEdit_ ? nodeOwnerAddrEdit_->text() : QString(),
+            chain, testnet);
+
+    // Choose the message to show: a hard wrong-coin block wins; then an
+    // advisory (unknown version); otherwise clear.
+    auto pick = [](const c2pool_qt::AddressCheck& c) {
+        return c.verdict == c2pool_qt::AddressVerdict::WrongCoin
+            || c.verdict == c2pool_qt::AddressVerdict::UnknownVersion;
+    };
+
+    QString text;
+    bool blocking = false;
+    if (payout.blocksLaunch()) {
+        text = QStringLiteral("Payout address: %1").arg(payout.message);
+        blocking = true;
+    } else if (owner.blocksLaunch()) {
+        text = QStringLiteral("Node owner address: %1").arg(owner.message);
+        blocking = true;
+    } else if (pick(payout)) {
+        text = QStringLiteral("Payout address: %1").arg(payout.message);
+    } else if (pick(owner)) {
+        text = QStringLiteral("Node owner address: %1").arg(owner.message);
+    }
+
+    if (text.isEmpty()) {
+        addressStatusLabel_->clear();
+        addressStatusLabel_->setVisible(false);
+        return;
+    }
+    addressStatusLabel_->setText((blocking ? QStringLiteral("⛔ ")   // ⛔
+                                           : QStringLiteral("⚠ "))  // ⚠
+                                 + text);
+    addressStatusLabel_->setStyleSheet(blocking ? "color: #b04020;"
+                                                : "color: #a06000;");
+    addressStatusLabel_->setVisible(true);
+}
+
 void PageLaunch::addMergedRow()
 {
     const int row = mergedTable_->rowCount();
@@ -934,6 +1001,28 @@ void PageLaunch::launch()
         emit daemonStateChanged("Daemon: already running", "color: #b04020;");
         return;
     }
+    // ── QP-B: refuse to launch with a wrong-coin payout/node-owner address ──
+    // Only a positively-identified other-coin base58 address blocks; bech32/
+    // cashaddr/unknown-version addresses pass through (advisory only) so a
+    // valid launch is never stopped by a flavor we do not model.
+    const QString chain = currentChain();
+    const bool testnet = testnetCheck_ && testnetCheck_->isChecked();
+    const c2pool_qt::AddressCheck payoutCheck =
+        c2pool_qt::validatePayoutAddress(addressEdit_->text(), chain, testnet);
+    const c2pool_qt::AddressCheck ownerCheck =
+        c2pool_qt::validatePayoutAddress(
+            nodeOwnerAddrEdit_ ? nodeOwnerAddrEdit_->text() : QString(),
+            chain, testnet);
+    if (payoutCheck.blocksLaunch() || ownerCheck.blocksLaunch()) {
+        validateAddressField();
+        const c2pool_qt::AddressCheck& bad =
+            payoutCheck.blocksLaunch() ? payoutCheck : ownerCheck;
+        emit daemonStateChanged(
+            QStringLiteral("Daemon: refused — %1").arg(bad.message),
+            "color: #b04020;");
+        return;
+    }
+
     onBuildPreview();
     const QString cmd = buildCommand();
     if (cmd.trimmed().isEmpty()) {

--- a/ui/c2pool-qt/src/PageLaunch.hpp
+++ b/ui/c2pool-qt/src/PageLaunch.hpp
@@ -81,6 +81,10 @@ private slots:
     void removeSelectedMergedRow();
     void updateNetworkDefaults();
     void emitApiBaseUrlChanged();
+    /// Re-check the payout / node-owner address fields against the active
+    /// coin and refresh the inline status label. Advisory except for a
+    /// positively-identified wrong-coin address, which launch() blocks.
+    void validateAddressField();
 
 private:
     void setupUi();
@@ -134,6 +138,7 @@ private:
 
     // ── Payout & Fees ───────────────────────────────────────────────────────
     QLineEdit*     addressEdit_;
+    QLabel*        addressStatusLabel_{nullptr}; ///< inline wrong-coin / advisory notice
     QCheckBox*     autoDetectWalletCheck_; ///< --auto-detect-wallet (default on)
     QDoubleSpinBox* feeSpinBox_;        ///< -f / --fee (node-owner fee %)
     QDoubleSpinBox* giveAuthorSpinBox_; ///< --give-author (dev donation %)

--- a/ui/c2pool-qt/test/test_address_validator.cpp
+++ b/ui/c2pool-qt/test/test_address_validator.cpp
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// test_address_validator — QP-B acceptance gate.
+//
+// Proves the in-UI payout-address flavor check:
+//   • accepts an address whose base58 version belongs to the active coin
+//     (either network — mainnet/testnet slips are not blocked);
+//   • BLOCKS a base58 address that belongs to a DIFFERENT known coin
+//     (the "DASH address typed into a Litecoin profile" case), naming the
+//     coin it actually belongs to;
+//   • passes bech32 / cashaddr / malformed / checksum-failing input through
+//     UNJUDGED (NotBase58Check) so a valid launch is never blocked by a
+//     flavor we do not model;
+//   • treats cross-coin version-byte collisions (BTC/BCH 0/5, DOGE/DGB 30)
+//     in the user's favour.
+//
+// Links Qt6::Core only (no Widgets / WebEngine) so it runs headless in CI.
+// Test addresses are generated in-process by base58check-ENCODING a known
+// payload with each coin's version byte — self-consistent, no external
+// fixture strings that could rot.
+
+#include "../src/AddressValidator.hpp"
+#include "../src/CoinProfiles.hpp"
+
+#include <QByteArray>
+#include <QCryptographicHash>
+#include <QString>
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+using c2pool_qt::AddressVerdict;
+using c2pool_qt::validatePayoutAddress;
+
+namespace {
+
+int failures = 0;
+
+void check(bool cond, const char* what)
+{
+    std::printf("  [%s] %s\n", cond ? "PASS" : "FAIL", what);
+    if (!cond) ++failures;
+}
+
+// base58 encode raw bytes (big-endian). Mirror of Bitcoin's EncodeBase58.
+QString encodeBase58(const std::vector<uint8_t>& in)
+{
+    static const char kAlphabet[] =
+        "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    std::vector<uint8_t> digits;  // big-endian base-58
+    for (uint8_t byte : in) {
+        int carry = byte;
+        for (auto it = digits.rbegin(); it != digits.rend(); ++it) {
+            carry += 256 * (*it);
+            *it = static_cast<uint8_t>(carry % 58);
+            carry /= 58;
+        }
+        while (carry > 0) {
+            digits.insert(digits.begin(), static_cast<uint8_t>(carry % 58));
+            carry /= 58;
+        }
+    }
+    QString out;
+    for (uint8_t b : in) {
+        if (b == 0) out.append(QLatin1Char('1')); else break;
+    }
+    for (uint8_t d : digits) out.append(QLatin1Char(kAlphabet[d]));
+    return out;
+}
+
+// Build a valid base58check address: version || 20-byte payload || sha256d[:4].
+QString makeAddress(int version, uint8_t fill = 0x11)
+{
+    std::vector<uint8_t> body;
+    body.push_back(static_cast<uint8_t>(version));
+    for (int i = 0; i < 20; ++i) body.push_back(fill);
+    const QByteArray bodyBa(reinterpret_cast<const char*>(body.data()),
+                            static_cast<int>(body.size()));
+    const QByteArray h1 = QCryptographicHash::hash(bodyBa, QCryptographicHash::Sha256);
+    const QByteArray h2 = QCryptographicHash::hash(h1, QCryptographicHash::Sha256);
+    std::vector<uint8_t> full = body;
+    for (int i = 0; i < 4; ++i) full.push_back(static_cast<uint8_t>(h2[i]));
+    return encodeBase58(full);
+}
+
+} // namespace
+
+int main()
+{
+    std::printf("test_address_validator\n");
+
+    // ── Sanity: version bytes loaded into CoinProfiles are the expected ones.
+    check(c2pool_qt::coinProfile("dash").p2pkhVersionMainnet == 76,
+          "CoinProfiles: DASH mainnet P2PKH version == 76");
+    check(c2pool_qt::coinProfile("dash").p2shVersionMainnet == 16,
+          "CoinProfiles: DASH mainnet P2SH version == 16");
+    check(c2pool_qt::coinProfile("litecoin").p2pkhVersionMainnet == 48,
+          "CoinProfiles: LTC mainnet P2PKH version == 48");
+
+    // ── Ok: right coin.
+    {
+        const QString dashAddr = makeAddress(76);
+        auto r = validatePayoutAddress(dashAddr, "dash", false);
+        check(r.verdict == AddressVerdict::Ok, "DASH P2PKH addr in DASH profile → Ok");
+        check(!r.blocksLaunch(), "DASH addr in DASH profile does not block launch");
+    }
+
+    // ── ★ Core QP-B case: DASH address typed into a Litecoin profile.
+    {
+        const QString dashAddr = makeAddress(76);
+        auto r = validatePayoutAddress(dashAddr, "litecoin", false);
+        check(r.verdict == AddressVerdict::WrongCoin,
+              "DASH addr in LTC profile → WrongCoin");
+        check(r.blocksLaunch(), "wrong-coin addr BLOCKS launch");
+        check(r.detectedCoinLabel == QStringLiteral("Dash"),
+              "wrong-coin detected as Dash");
+        check(!r.message.isEmpty(), "wrong-coin carries a message");
+    }
+
+    // ── Symmetric: LTC address typed into a DASH profile.
+    {
+        const QString ltcAddr = makeAddress(48);
+        auto r = validatePayoutAddress(ltcAddr, "dash", false);
+        check(r.verdict == AddressVerdict::WrongCoin,
+              "LTC addr in DASH profile → WrongCoin");
+        check(r.detectedCoinLabel == QStringLiteral("Litecoin"),
+              "wrong-coin detected as Litecoin");
+    }
+
+    // ── DASH P2SH ('7…', version 16) in DASH profile → Ok.
+    {
+        const QString dashScript = makeAddress(16);
+        auto r = validatePayoutAddress(dashScript, "dash", false);
+        check(r.verdict == AddressVerdict::Ok, "DASH P2SH addr in DASH profile → Ok");
+    }
+
+    // ── Any-network acceptance: DASH testnet version (140) in a mainnet
+    //    (testnet=false) DASH profile is NOT blocked.
+    {
+        const QString dashTestnet = makeAddress(140);
+        auto r = validatePayoutAddress(dashTestnet, "dash", false);
+        check(r.verdict == AddressVerdict::Ok,
+              "DASH testnet-version addr in mainnet DASH profile → Ok (not blocked)");
+    }
+
+    // ── Collision favours the user: BTC version (0) in a BCH profile → Ok
+    //    (BCH legacy addresses share BTC's version bytes).
+    {
+        const QString btcAddr = makeAddress(0);
+        auto r = validatePayoutAddress(btcAddr, "bitcoincash", false);
+        check(r.verdict == AddressVerdict::Ok,
+              "BTC-version addr in BCH profile → Ok (shared version, favour user)");
+    }
+
+    // ── Unknown version: never a hard block, only advisory.
+    {
+        const QString weird = makeAddress(99);
+        auto r = validatePayoutAddress(weird, "dash", false);
+        check(r.verdict == AddressVerdict::UnknownVersion,
+              "unmodelled version → UnknownVersion");
+        check(!r.blocksLaunch(), "unknown version does not block launch");
+    }
+
+    // ── Empty input → NotBase58Check, no block.
+    {
+        auto r = validatePayoutAddress("   ", "dash", false);
+        check(r.verdict == AddressVerdict::NotBase58Check, "empty addr → NotBase58Check");
+        check(!r.blocksLaunch(), "empty addr does not block launch");
+    }
+
+    // ── bech32 (contains '0', outside base58) → passed through unjudged.
+    {
+        auto r = validatePayoutAddress(
+            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", "bitcoin", false);
+        check(r.verdict == AddressVerdict::NotBase58Check,
+              "bech32 addr → NotBase58Check (not blocked)");
+        check(!r.blocksLaunch(), "bech32 addr does not block launch");
+    }
+
+    // ── Checksum failure (valid DASH addr with one char mangled) → unjudged.
+    {
+        QString dashAddr = makeAddress(76);
+        // Flip a middle character to a different base58 digit.
+        const int mid = dashAddr.size() / 2;
+        dashAddr[mid] = (dashAddr[mid] == QLatin1Char('A')) ? QLatin1Char('B')
+                                                            : QLatin1Char('A');
+        auto r = validatePayoutAddress(dashAddr, "dash", false);
+        check(r.verdict == AddressVerdict::NotBase58Check,
+              "checksum-broken addr → NotBase58Check (advisory, not a block)");
+        check(!r.blocksLaunch(), "checksum-broken addr does not block launch");
+    }
+
+    std::printf("%s (%d failure%s)\n", failures == 0 ? "ALL PASS" : "FAILED",
+                failures, failures == 1 ? "" : "s");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## What

Adds per-coin payout-address validation to the c2pool-qt launch form. The
form is coin-generic (LTC/BTC/DOGE/DASH/DGB/BCH), so a payout or node-owner
address pasted into the wrong coin's profile was a silent money mistake.
This is task **QP-C → QP-B** from `C2POOL_QT_PLAN.md`.

### QP-C confirmed already complete on master (no change needed)

Before implementing QP-B I verified the QP-C wiring the plan asked to
confirm. It is already present on master:

- `MainWindow` builds `SharechainBridge` / `PplnsBridge` / `SettingsBridge`
  / `CoinBridge` and renders `dashboard-embed.html` (Sharechain page) and
  `pplns-embed.html` (PPLNS page + the embedded half of `PageMining`) via
  `PageEmbedded` over `QWebChannel`.
- Both embed HTML hosts resolve the active coin from `CoinBridge`
  (`channel.objects.coin.currentCoinDescriptor`) and boot the view for that
  coin — coin-generic, DASH included (landed via #1190 and the explorer
  work).
- A profile switch that changes the coin re-boots the embeds
  (`MainWindow` reload of the sharechain/PPLNS pages + `PageMining`
  reloadEmbed) and `CoinBridge` emits `coinChanged`.

Live-oracle data validation is a running-node soak, not a code change, so
it is out of scope for this PR.

## QP-B — address-flavor validation (this PR)

- **`CoinProfiles.hpp`**: record base58 P2PKH/P2SH version bytes per coin
  (mainnet + testnet), mirroring `impl/<coin>/params.hpp` and the
  `CoinBridge` descriptor table. DASH cross-checked against dashpay
  chainparams (mainnet 76/16, testnet 140/19).
- **`AddressValidator.hpp`** (Qt-Core only): base58check decode + version
  match. Low false-positive by design — only a positively-identified
  other-coin address is a hard block; bech32 / cashaddr / checksum
  failures / unmodelled versions pass through advisory-only, so a valid
  launch is never blocked by a flavor we do not model. Cross-coin version
  collisions (BTC/BCH `0/5`, DOGE/DGB `30`) resolve in the user's favour.
- **`PageLaunch`**: inline status label under the payout field, live
  re-check on address / coin / testnet change, and a `launch()`-time gate
  that refuses to start the daemon for a wrong-coin payout or node-owner
  address (names the coin it actually belongs to).
- **`test_address_validator`**: headless Qt-Core ctest (22 assertions),
  registered behind `C2POOL_QT_BUILD_TESTS`.

Reward safety (plan §1) is untouched: the change only adds a pre-launch
refusal path; it never alters argv assembly in `build_percoin_argv()`.

## Verification (a full Qt WebEngine build is heavy — minimal by design)

- `test_address_validator` compiled against Qt6Core 6.4.2 and run locally:
  **22/22 PASS**, including the core case (DASH `X…` address in a Litecoin
  profile → WrongCoin, blocks launch, detected as "Dash").
- Decoder cross-checked against a real external address (Bitcoin genesis,
  version 0): `Ok` in a bitcoin profile, `WrongCoin (Bitcoin)` in a dash
  profile.
- `PageLaunch.cpp` passes `g++ -fsyntax-only` against the Qt Widgets
  headers (no moc/link).
- Full `c2pool-qt` WebEngine build + `ctest` left to CI.