### PR TITLE
explorer: reveal black background on full-window shift (keep #1382 black-holes fixed)

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -5755,18 +5755,41 @@
                     ctx.fillStyle = '#0d0d1a';
                     ctx.fillRect(0, 0, cssW, cssH);
 
-                    // ═══ SETTLED BASE LAYER ═══
-                    // Paint every share at its FINAL grid position first, so
-                    // no cell is ever background-black during the animation.
-                    // The wave / born / dying flourishes draw on top of this
-                    // congruent all-green grid. Without it, cells that are only
-                    // mid-transit (the pre-wave tail rows the window grew into,
-                    // and cells vacated during the tail→head slide) read as
-                    // black holes until the wave reaches them. Identity to the
-                    // settled render() when the animation is idle.
+                    // ═══ SETTLED BASE LAYER (landed cells only) ═══
+                    // Paint a share at its FINAL grid position only once it can
+                    // no longer be mid-transit: new shares (their destination
+                    // cell is owned by the born ceremony and pre-painted in the
+                    // wave loop), shares with no recorded old position (the
+                    // wave loop draws them at dst from frame one), shares whose
+                    // old and new grid cells coincide, and shares whose slide
+                    // has LANDED (same stagger maths as the wave loop below).
+                    // Shares still waiting to slide are painted by the wave
+                    // loop at their OLD cell, and mid-slide shares at the
+                    // interpolated cell — so a cell being vacated during the
+                    // conveyor shift reveals the #0d0d1a background (the
+                    // visible black edge of the shift), while no genuinely
+                    // settled cell is ever black. Identity to the settled
+                    // render() when the animation is idle.
                     ctx.globalAlpha = 1;
+                    var _blP2e = elapsed - phase2Start;
                     for (var _bi = 0; _bi < animTotal; _bi++) {
                         var _bp = newPos[_bi];
+                        if (_bi >= newCount) {
+                            var _blS = animShares[_bi];
+                            var _blO = animOldPos[_blS.H || _blS.h];
+                            if (_blO) {
+                                var _blOx, _blOy;
+                                if (typeof _blO.idx === 'number') {
+                                    _blOx = ml + (_blO.idx % cols) * step;
+                                    _blOy = Math.floor(_blO.idx / cols) * step;
+                                } else { _blOx = _blO.x; _blOy = _blO.y; }
+                                if (_blOx !== _bp.x || _blOy !== _bp.y) {
+                                    var _blFr = (animTotal - 1 - _bi) / (animTotal - newCount);
+                                    var _blT = Math.max(0, Math.min(1, (_blP2e - _blFr * phase2Dur * 0.7) / 600));
+                                    if (_blT < 1) continue; // in transit — leave the cell black
+                                }
+                            }
+                        }
                         ctx.fillStyle = animColors[_bi];
                         ctx.fillRect(_bp.x, _bp.y, cs, cs);
                     }


### PR DESCRIPTION
## Problem

After the #1375/#1382 black-hole fix, the operator reported a new regression: on a **full-window conveyor shift** (oldest shares evict, newest append, the whole 4320-share window slides/refits), the region being vacated/revealed during the slide was painted **solid green** instead of exposing the **#0d0d1a black background** — you should see the black edge of the conveyor sliding, not a green field with a faint seam.

## Root cause

The #1382 fix added an unconditional **"SETTLED BASE LAYER"** pass to `_animate3D`'s per-frame `frame()` in `web-static/dashboard.html`. Right after the `#0d0d1a` background clear it painted **every** share at its **final** post-refit grid position (`newPos[_bi]`) with its final colour on **every** frame:

```js
for (var _bi = 0; _bi < animTotal; _bi++) { var _bp = newPos[_bi]; ctx.fillStyle = animColors[_bi]; ctx.fillRect(_bp.x, _bp.y, cs, cs); }
```

On a full-window shift **every** grid cell is *some* share's final position, so this pre-painted the entire canvas solid green before the wave loop drew the surviving shares at their old/interpolated positions. The cell a share has lifted off — the moving conveyor gap, and the tail rows the window grew into — was therefore green underneath, never showing the exposed black edge.

The two symptoms are in **direct tension**: this same base layer is what keeps first-SSE black holes at 0. Removing it re-opens the holes; keeping it as-is keeps the green-under-shift. The fix must satisfy both.

## Fix (display-only, one file)

Replace the unconditional base layer with a **landed-cells-only** gated base layer. A share is painted at its final cell only when it *cannot* be mid-transit:

- new (born) shares — `i < newCount`, head cell owned by the born ceremony;
- shares with no recorded old position (wave loop draws them at dst from frame 0);
- shares whose old and new grid cells coincide (never move);
- shares whose slide has **landed** (same stagger maths as the wave loop, byte-identical constants).

Everything else `continue`s and the cell stays `#0d0d1a`, revealing the conveyor's black edge; the wave loop then draws that share at its old/interpolated cell. All stagger constants (`(animTotal-1-_bi)/(animTotal-newCount)`, `phase2Dur*0.7`, `/600`) are kept **byte-identical** to the wave loop so the handoff has no per-cell flicker. Full-hash keying (`s.H||s.h`) and idx re-derivation (post-refit layout) from #1379/#1382 are preserved.

Nothing else changes: wave loop, born-dst pre-paint, idx re-derivation, tip-cursor advance, end-of-animation `self.render()`, `mergeDelta` and all SSE handling untouched. **LTC byte-identical.** No SSE payload change.

Only `web-static/dashboard.html` carries this pass repo-wide; the `sharechain-explorer/` bundle (`?new-explorer=1` path) never had a full-grid base layer and is intentionally untouched.

## Verification (both symptoms, against the real captured canary SSE stream)

Reused the `#1382` harness on `/tmp/sse-capture` (`window0.json` full 4320 window → `press_delta_0` +4 full-window shift → `delta_1..6` +1).

**Tier 1 — fillRect-stream harness** (`replay-shift.js`, drives the VERBATIM patched inline `_animate3D`):

| metric | master (defect) | patched (fixed) |
|---|---|---|
| first-press (+4) `blackCellsMax` during anim | **0** (green shift) | **28** (black revealed) |
| +1 deltas `blackCellsMax` during anim | **0** | **4** |
| `blackCellsLastAnimFrame` | 0 | **0** |
| `blackCellsFinalStaticRender` | 0 | **0** (#1382 holds) |
| `paintedCellKeysFinalRender` | 4321 | **4321** |
| `dyingHold/dyingDissolve/headTriangles` | — | **byte-identical** to master |

The required flip: black now appears **only** in-transit and drains to 0 by settle; every legacy metric unchanged.

**Tier 2 — real headless chromium** (real canvas, `ctx.getImageData` at all 4320 grid-cell centres, actual pixels — not a recording stub):

| phase | master `#0d0d1a` cells peak | patched `#0d0d1a` cells peak | patched last-frame | patched settle |
|---|---|---|---|---|
| first-press (+4 full-window shift) | **0** (solid green) | **30** (black edge exposed) | 0 | 0 |
| +1 deltas | 0 | 6 | 0 | 0 |

Master paints the whole window green during the shift (0 exposed black pixels — the reported bug); patched exposes a real `#0d0d1a` conveyor edge mid-shift and drains it to 0 by the settled end-state (no occupied cell black — #1382 holds). Before/after mid-shift canvas screenshots captured: master = solid green field with a tiny black notch bottom-right (matches the operator's screenshot 1); patched = visible black conveyor edge on the sliding margins.

## Not deployed

PR only. No contabo/canary deploy — operator authorizes deploy separately.
