### PR TITLE
explorer: born placeholder stays black until the share lands (keep #1382+#1383)

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -5789,6 +5789,16 @@
                                     if (_blT < 1) continue; // in transit — leave the cell black
                                 }
                             }
+                        } else {
+                            // Born share: leave its destination cell #0d0d1a
+                            // black until the born ceremony has LANDED it
+                            // (bt >= 1). Same phase3Start/phase3Dur/150 stagger
+                            // as the wave loop below, so the base layer never
+                            // pre-paints the head cell green before the fly-in
+                            // lands. _bi is the born index here (dst=newPos[_bi]).
+                            var _boS = _bi * 150 / phase3Dur;
+                            var _boT = Math.max(0, Math.min(1, ((elapsed - phase3Start) / phase3Dur - _boS) / (1 - _boS)));
+                            if (_boT < 1) continue; // born share not yet landed — leave dst #0d0d1a
                         }
                         ctx.fillStyle = animColors[_bi];
                         ctx.fillRect(_bp.x, _bp.y, cs, cs);
@@ -5830,16 +5840,18 @@
                             // Birth position: below destination, shifted 1 row down for shadow clearance
                             var bFinalY = Math.min(dst.y + step * 8, cssH * 0.5);
 
-                            // Always paint the destination grid cell first so
-                            // the new share's head cell is never black while the
-                            // birth ceremony (coalesce/hold/land) plays out
-                            // below it. The coalesce/hold branches set
-                            // globalAlpha=0 to skip the generic draw, which
-                            // otherwise left the destination cell unpainted
-                            // (black) for the whole fly-in.
-                            ctx.globalAlpha = 1;
-                            ctx.fillStyle = animColors[i];
-                            ctx.fillRect(dst.x, dst.y, cs, cs);
+                            // Paint the destination grid cell ONLY once the born
+                            // share has landed (bt >= 1). Before landing the cell
+                            // must stay #0d0d1a black (placeholder), then the born
+                            // ceremony's LAND square (bt in [~0.88,1]) covers the
+                            // cell and hands over seamlessly to this settled paint
+                            // at bt >= 1 — no black flash after land, no green flash
+                            // before it.
+                            if (bt >= 1) {
+                                ctx.globalAlpha = 1;
+                                ctx.fillStyle = animColors[i];
+                                ctx.fillRect(dst.x, dst.y, cs, cs);
+                            }
 
                             if (bt <= 0) {
                                 // Birth not started yet — destination already painted above


### PR DESCRIPTION
## The third sharechain-explorer paint bug

After a whole-window shift, the very-new **born** placeholder cell was painted GREEN from animation frame 0. It should stay `#0d0d1a` black until the born share visually **lands** in that cell, then turn its final color.

## Root cause (localised, then verified)

Two unconditional pre-paints in `_animate3D`'s per-frame `frame()` (`web-static/dashboard.html`) painted the born share's destination cell its final color from frame 0, while the born ceremony (coalesce → hold → land) was still playing 8 rows below it:

1. **SETTLED BASE LAYER loop** — the `if (_bi >= newCount)` in-transit gate (the #1383 fix) covered only *sliding* shares; born shares (`_bi < newCount`) fell straight through to the unconditional `ctx.fillRect` at `animColors[_bi]`.
2. **Wave-loop born branch** — the "Always paint the destination grid cell first" pre-paint drew `dst` before the coalesce/hold/land sub-branches.

Gating only one site changes nothing — both had to be gated.

## Fix

Gate **both** born-dst paints on the born ceremony's own land predicate `bt >= 1`, byte-matched to the wave-loop stagger (`phase3Start`/`phase3Dur`/`150`). While the born share has not landed, its dst cell is left `#0d0d1a`. The ceremony's LAND square covers the cell from `bt≈0.88` and hands over to the settled paint exactly at `bt >= 1` — no black flash after land, no green flash before it.

**Untouched:** the #1383 sliding-share gate (`_bi >= newCount`), full-hash keys (`s.H||s.h`), idx re-derivation, tip-cursor advance, end-of-animation `self.render()`, `mergeDelta`, SSE handling, and the `sharechain-explorer/` bundle (`?new-explorer=1`, which has no full-grid base layer).

Display-only, LTC byte-identical (the gate reads only existing locals `elapsed`/`phase3Start`/`phase3Dur`/`newCount`/`bt`). One file: `web-static/dashboard.html` (+22/-10).

## Verification — real headless chromium + the sse-capture node harness

Drove `window0 → press_delta_0 (+4 born) → +1 SSE deltas → full-window shift`.

**Three-way invariant, all hold simultaneously:**

| Invariant | Result |
|---|---|
| **#1382** first-SSE/full-window black-hole count | **0** — `paintedCellKeysFinalRender = 4321`, identical to master; `blackCellsFinalStaticRender = 0` |
| **#1383** shift reveals `#0d0d1a` on the conveyor gap | **preserved** — `blackCellsMax = 28`, `animFramesWithBlack = 173-176/184`; sliding gate byte-untouched |
| **NEW** born placeholder black until land | **fixed** — see below |

**Real chromium born-cell probe** (samples each born cell center off the actual 2D canvas via `getImageData`):

| | mid-ceremony t=5600ms (bt<0.88) | at land t=7400ms (bt≥1) |
|---|---|---|
| **master (defect)** | `[46,125,50]` GREEN | `[46,125,50]` green |
| **this PR (fix)** | `[13,13,26]` **#0d0d1a BLACK** | `[46,125,50]` green |

**Headless pixel-composite harness** (`replay-born.js`) — per born cell over the clean-vacated window (~62-64 frames):
- master: `greenShouldBeBlackFrames = 62-64` (≈2.5s of should-be-black placeholder painted green)
- this PR: `greenShouldBeBlackFrames = 0`; the born dst composites to `#0d0d1a` from t=4480 through t=7000, then the ceremony's LAND square (final color) covers it at t=7040, handing to the settled paint at t=7400 — **no flicker at the landing boundary** (black through t=7000, no green before; green from t=7040 under the covering land square, no black gap after).

## Not deployed

PR only. Frontend deploy to contabo/canary is a separate operator-authorized zero-restart file copy.