### PR TITLE
dashboard: feed embedded coin header-sync progress into /broadcaster_status (lights up the sync cards)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1974,6 +1974,36 @@ int main(int argc, char* argv[])
             };
         });
 
+        // Embedded coin header-sync provider (dashboard telemetry only):
+        // feeds /broadcaster_status header_height/current_height/
+        // target_height/sync_percent + connected_peers[].startingheight so
+        // the dashboard sync cards render the REAL BTC header-chain tip --
+        // never the sharechain height. Sources: the embedded HeaderChain tip
+        // + its version-advertised peer tip, plus the single embedded P2P
+        // peer's startingheight. Captured objects are main-scope and outlive
+        // ioc.run(); all reads are display-only.
+        mi->set_coin_sync_status_fn([&header_chain, &coin_node]() -> nlohmann::json {
+            nlohmann::json s = nlohmann::json::object();
+            const uint32_t hh = header_chain.height();
+            uint32_t th = header_chain.peer_tip_height();
+            nlohmann::json peers = nlohmann::json::array();
+            auto* p2p = coin_node.p2p();
+            if (p2p != nullptr && p2p->peer_version() > 0) {
+                const uint32_t sh = p2p->peer_start_height();
+                if (sh > th) th = sh;
+                peers.push_back({
+                    {"subver", p2p->peer_subver()},
+                    {"startingheight", sh},
+                    {"conntime", p2p->peer_uptime_sec()},
+                    {"connected", true},
+                });
+            }
+            s["header_height"] = hh;
+            s["target_height"] = th;
+            s["peers"] = std::move(peers);
+            return s;
+        });
+
         // ── #995/#1155 BTC found-block record + chain-sourced confirm/orphan ─
         // Wire the won-block reporter slot (declared above, fired by
         // make_on_block_found AFTER both broadcast arms) to record_found_block +

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4363,6 +4363,39 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         {"testnet", testnet},
                         {"coins", nlohmann::json::array({c})}};
                 });
+
+            // Embedded coin header-sync provider (dashboard telemetry only):
+            // feeds /broadcaster_status header_height/current_height/
+            // target_height/sync_percent + connected_peers[].startingheight so
+            // the dashboard sync cards render the REAL DASH header-chain tip --
+            // never the sharechain height. header_height = embedded HeaderChain
+            // tip; target_height = the pool's monotone best peer-advertised
+            // height, raised by per-peer startingheight. Same lifetime contract
+            // as the topology hook directly above: web_server is reset() after
+            // ioc.run() returns, BEFORE header_chain / coin_p2p unwind.
+            web_server->get_mining_interface()->set_coin_sync_status_fn(
+                [hc = header_chain.get(), cp = coin_p2p.get()]() -> nlohmann::json {
+                    nlohmann::json s = nlohmann::json::object();
+                    const uint32_t hh = hc ? hc->height() : 0;
+                    uint32_t th = cp ? cp->best_peer_height() : 0;
+                    nlohmann::json peers = nlohmann::json::array();
+                    if (cp) {
+                        for (const auto& pb : cp->peer_briefs()) {
+                            if (pb.start_height > th) th = pb.start_height;
+                            peers.push_back({
+                                {"addr", pb.addr},
+                                {"subver", pb.subver},
+                                {"startingheight", pb.start_height},
+                                {"conntime", pb.age_sec},
+                                {"connected", pb.handshaked},
+                            });
+                        }
+                    }
+                    s["header_height"] = hh;
+                    s["target_height"] = th;
+                    s["peers"] = std::move(peers);
+                    return s;
+                });
         }
 
         maintainer = std::make_unique<dash::coin::CoinStateMaintainer>(node_coin_state);

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -1475,6 +1475,35 @@ int run_node(const core::CoinParams& params, bool testnet,
             return r;
         });
 
+        // Embedded coin header-sync provider (dashboard telemetry only):
+        // feeds /broadcaster_status header_height/current_height/
+        // target_height/sync_percent + connected_peers[].startingheight so
+        // the dashboard sync cards render the REAL DGB header-chain tip --
+        // never the sharechain height. header_height = embedded HeaderChain
+        // absolute tip (checkpoint-aware numbering); the target/peer row
+        // come from the single embedded coin P2P peer's version metadata
+        // (empty until --coin-daemon arms it). Captures are main-scope
+        // objects that outlive ioc.run(); all reads display-only.
+        mi->set_coin_sync_status_fn([&header_chain, &coin_p2p]() -> nlohmann::json {
+            nlohmann::json s = nlohmann::json::object();
+            const uint32_t hh = header_chain.tip_height().value_or(0);
+            uint32_t th = 0;
+            nlohmann::json peers = nlohmann::json::array();
+            if (coin_p2p && coin_p2p->peer_version() > 0) {
+                th = coin_p2p->peer_start_height();
+                peers.push_back({
+                    {"subver", coin_p2p->peer_subver()},
+                    {"startingheight", th},
+                    {"conntime", coin_p2p->peer_uptime_sec()},
+                    {"connected", true},
+                });
+            }
+            s["header_height"] = hh;
+            s["target_height"] = th;
+            s["peers"] = std::move(peers);
+            return s;
+        });
+
         // (4) scrypt pool stats — sharechain length feeds getinfo poolshares.
         mi->set_sharechain_stats_fn([&p2p_node]() {
             nlohmann::json r = nlohmann::json::object();

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -7253,6 +7253,28 @@ int main(int argc, char* argv[]) {
                 web_server.get_mining_interface()->set_ltc_peer_info_fn(
                     [bcaster = embedded_broadcaster.get()]() { return bcaster->get_peer_info(); });
             }
+            // Embedded coin header-sync provider (dashboard telemetry only):
+            // feeds /broadcaster_status header_height/current_height/
+            // target_height/sync_percent + connected_peers[].startingheight so
+            // the dashboard sync cards render the REAL LTC header-chain tip --
+            // never the sharechain height. header_height = embedded LTC
+            // HeaderChain tip; the target derives from the broadcaster peers'
+            // version-advertised startingheight (get_peer_info carries it and
+            // the core merge takes the max over connected peers). Raw captures
+            // match the set_ltc_peer_info_fn / backfill hooks beside this:
+            // both objects are function-scope and outlive ioc.run().
+            if (embedded_chain || embedded_broadcaster) {
+                web_server.get_mining_interface()->set_coin_sync_status_fn(
+                    [hc = embedded_chain.get(),
+                     bcaster = embedded_broadcaster.get()]() -> nlohmann::json {
+                        nlohmann::json s = nlohmann::json::object();
+                        s["header_height"] = hc ? hc->height() : 0;
+                        s["target_height"] = 0;  // derived from peers by the merge
+                        s["peers"] = bcaster ? bcaster->get_peer_info()
+                                             : nlohmann::json::array();
+                        return s;
+                    });
+            }
             {
                 auto it = merged_broadcasters.find(98);  // DOGE
                 if (it != merged_broadcasters.end()) {

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5315,8 +5315,42 @@ nlohmann::json MiningInterface::rest_node_topology()
     // D0.2 auto-detect below when unset, so the endpoint is always truthful.
     if (m_node_topology_fn) {
         auto t = m_node_topology_fn();
-        if (!t.is_null())
+        if (!t.is_null()) {
+            // Normalize a flat single-coin emit ({"coin": ...} with no coins
+            // array -- the BTC/BCH lane shape) into the {coins:[...]} wrapper
+            // the dashboard's renderNodeTopology() requires; a flat emit was
+            // previously invisible to the card. Display-shape only.
+            if (!t.contains("coins") && t.contains("coin")) {
+                nlohmann::json wrapped = nlohmann::json::object();
+                wrapped["node_symbol"]   = t.value("coin", std::string{});
+                wrapped["auto_detected"] = false;
+                if (!t.contains("primary")) t["primary"] = true;
+                wrapped["coins"] = nlohmann::json::array({std::move(t)});
+                t = std::move(wrapped);
+            }
+            // Enrich the primary coin row with the embedded header-sync
+            // provider fields (header_height/target_height/sync_percent/
+            // synced) when the lane's topology emit does not already carry
+            // them -- the same coin-generic source /broadcaster_status uses.
+            // Additive: rows that already publish header_height (DASH) are
+            // untouched, and with no provider nothing is fabricated.
+            if (m_coin_sync_status_fn && t.contains("coins") && t["coins"].is_array()) {
+                nlohmann::json sync = nlohmann::json::object();
+                augment_with_coin_sync_status(sync);
+                if (sync.value("target_height", 0ull) > 0) {
+                    for (auto& c : t["coins"]) {
+                        if (!c.is_object() || c.contains("header_height")) continue;
+                        // The provider describes the node's PRIMARY coin chain.
+                        if (!c.value("primary", false) && t["coins"].size() > 1) continue;
+                        c["header_height"] = sync["header_height"];
+                        c["target_height"] = sync["target_height"];
+                        c["sync_percent"]  = sync["sync_percent"];
+                        if (!c.contains("synced")) c["synced"] = sync["synced"];
+                    }
+                }
+            }
             return t;
+        }
     }
 
     auto upper = [](std::string str) {
@@ -7055,6 +7089,71 @@ nlohmann::json MiningInterface::rest_discovered_merged_blocks()
     return arr;
 }
 
+// ── Embedded coin header-sync merge (dashboard telemetry only) ──────────────
+// Folds the per-lane coin header-sync provider snapshot into a
+// /broadcaster_status response so the dashboard's "embedded daemon REAL sync"
+// card (header_height/target_height/sync_percent + synced flag) and the
+// "Header Sync %" stat card (current_height vs max connected-peer
+// startingheight) render real values instead of blanks. STRICTLY ADDITIVE:
+// pre-existing keys (running, last_broadcast, peers, chains, ...) are never
+// overwritten, so every current consumer keeps its exact contract.
+//   header_height / current_height = the embedded coin header-chain TIP (the
+//     real coin header chain the node syncs -- NOT the sharechain height).
+//   target_height = the lane's best network-tip estimate, raised to the max
+//     startingheight among the provider's connected peers; 0 when unknown.
+//   sync_percent  = clamp(100 * header_height / target_height, 0..100);
+//     100 when the target is unknown but the lane says synced, else 0.
+//   synced        = the lane's verdict when it states one, else header within
+//     2 blocks of a known target. syncing = !synced.
+//   connected_peers = the provider's peer list (carries startingheight so the
+//     dashboard can compute max itself); mirrored into "peers" only when no
+//     other source populated that key.
+void MiningInterface::augment_with_coin_sync_status(nlohmann::json& result)
+{
+    if (!m_coin_sync_status_fn) return;
+    nlohmann::json s;
+    try { s = m_coin_sync_status_fn(); } catch (...) { return; }
+    if (!s.is_object()) return;
+
+    const uint64_t header_height = s.value("header_height", 0ull);
+    uint64_t target_height = s.value("target_height", 0ull);
+
+    nlohmann::json peers = nlohmann::json::array();
+    if (s.contains("peers") && s["peers"].is_array()) {
+        peers = s["peers"];
+        for (const auto& p : peers) {
+            if (!p.is_object() || !p.value("connected", true)) continue;
+            const uint64_t sh = p.value("startingheight", 0ull);
+            if (sh > target_height) target_height = sh;
+        }
+    }
+
+    bool synced;
+    double sync_percent;
+    if (target_height > 0) {
+        sync_percent = 100.0 * static_cast<double>(header_height)
+                             / static_cast<double>(target_height);
+        if (sync_percent > 100.0) sync_percent = 100.0;
+        if (sync_percent < 0.0)   sync_percent = 0.0;
+        synced = (header_height + 2 >= target_height);
+    } else {
+        synced = s.value("synced", false);
+        sync_percent = synced ? 100.0 : 0.0;
+    }
+    // The lane's own verdict, when it states one, wins over the heuristic.
+    if (s.contains("synced") && s["synced"].is_boolean())
+        synced = s["synced"].get<bool>();
+
+    if (!result.contains("header_height"))   result["header_height"]   = header_height;
+    if (!result.contains("current_height"))  result["current_height"]  = header_height;
+    if (!result.contains("target_height"))   result["target_height"]   = target_height;
+    if (!result.contains("sync_percent"))    result["sync_percent"]    = sync_percent;
+    if (!result.contains("synced"))          result["synced"]          = synced;
+    if (!result.contains("syncing"))         result["syncing"]         = !synced;
+    if (!result.contains("connected_peers")) result["connected_peers"] = peers;
+    if (!result.contains("peers") && !peers.empty()) result["peers"] = peers;
+}
+
 nlohmann::json MiningInterface::rest_broadcaster_status()
 {
     nlohmann::json result = nlohmann::json::object();
@@ -7067,6 +7166,7 @@ nlohmann::json MiningInterface::rest_broadcaster_status()
         result["total_blocks_found"] = m_mm_manager->get_total_blocks();
         if (m_ltc_peer_info_fn)
             result["peers"] = m_ltc_peer_info_fn();
+        augment_with_coin_sync_status(result);
         return result;
     }
 
@@ -7085,11 +7185,27 @@ nlohmann::json MiningInterface::rest_broadcaster_status()
         result["enabled"] = true;
         result["peers"] = std::move(peers);
         result["total_blocks_found"] = 0;  // no coin-side found-block counter yet
+        augment_with_coin_sync_status(result);
         return result;
     }
 
+    // Fallback path. The historical {last_broadcast, running} pair stays --
+    // the header-sync fields ride ADDITIVELY beside it. When the sync
+    // provider reports at least one CONNECTED coin peer the embedded node IS
+    // relaying, so running mirrors the coin_peer_info_fn semantics above
+    // (running == any_connected); with no provider or no peers it remains
+    // false, byte-identical to the old emit.
     result["running"] = false;
     result["last_broadcast"] = nullptr;
+    augment_with_coin_sync_status(result);
+    if (result.contains("connected_peers") && result["connected_peers"].is_array()) {
+        for (const auto& p : result["connected_peers"]) {
+            if (p.is_object() && p.value("connected", false)) {
+                result["running"] = true;
+                break;
+            }
+        }
+    }
     return result;
 }
 

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -837,7 +837,8 @@ public:
     void set_block_verify_fn(block_verify_fn_t fn);
     void set_io_context(boost::asio::io_context* ctx) { m_context = ctx;
         m_main_thread_id = std::this_thread::get_id();
-        LOG_INFO << "MiningInterface::set_io_context this=" << this << " ctx=" << ctx; }
+        LOG_INFO << "MiningInterface::set_io_context this=" << this << " ctx=" << ctx;
+        start_cache_refresh_pump(); }
 
     /// Thread-safe cached callback entry.  Main thread computes + publishes;
     /// HTTP thread reads a shared_ptr snapshot (mutex-guarded for portability).
@@ -1050,6 +1051,24 @@ public:
     // running=true top-level flag.
     void set_coin_peer_info_fn(coin_peer_info_fn fn) { m_coin_peer_info_fn = thread_safe_wrap(std::move(fn)); }
 
+    // Embedded coin header-sync status provider (dashboard telemetry ONLY).
+    // Wired at standup by EACH coin lane (main_btc / main_dash / main_ltc /
+    // main_dgb + bch pool_entrypoint) so /broadcaster_status can report the
+    // REAL embedded coin header-chain sync state coin-generically -- the coin
+    // header tip, NOT the sharechain height. Provider contract (JSON object,
+    // every field optional; omit rather than fabricate):
+    //   { "header_height": <embedded coin header-chain tip height>,
+    //     "target_height": <best network-tip estimate, e.g. best peer
+    //                       startingheight / advertised tip>,
+    //     "synced":        <bool, the lane's own verdict (optional)>,
+    //     "peers": [ {addr?, subver?, startingheight, conntime?, connected}.. ] }
+    // rest_broadcaster_status() merges the snapshot ADDITIVELY as
+    // header_height / current_height / target_height / sync_percent / synced /
+    // syncing / connected_peers (last_broadcast + running are untouched), and
+    // rest_node_topology() enriches the primary coin row from the same
+    // provider. Display-only: no share-validity / reward / consensus reads.
+    void set_coin_sync_status_fn(coin_peer_info_fn fn) { m_coin_sync_status_fn = thread_safe_wrap(std::move(fn)); }
+
     // Callback fired whenever a block submission is attempted.
     // Arguments: header hex (first 80 bytes), stale_info (none=accepted, orphan=stale prev, doa=daemon rejected).
     void set_on_block_submitted(std::function<void(const std::string& header_hex, int stale_info)> fn);
@@ -1138,6 +1157,31 @@ private:
     std::vector<std::function<void()>> m_cache_refresh_fns; // populated by thread_safe_wrap
     std::vector<std::function<void()>> m_tip_cache_refresh_fns; // opted in via mark_last_cache_tip_driven()
     std::atomic<int64_t>               m_last_tip_refresh_ts{0};
+    // Self-scheduling RCU-cache pump. Every zero-arg thread_safe_wrap() provider
+    // (peers, topology, and the coin header-sync feed) publishes its snapshot on
+    // the io/main thread here so the HTTP thread reads a warm cache instead of the
+    // CacheEntry default (a null json). main_dash/main_ltc already drive
+    // refresh_http_caches() from their own timers; BTC/DGB/BCH did NOT, which left
+    // any wrapped provider cold on those lanes (the header-sync fields never
+    // surfaced on /broadcaster_status). Starting the pump from set_io_context()
+    // makes the behaviour coin-generic: armed exactly when a lane stands up its
+    // dashboard (the only caller of set_io_context), redundant-but-harmless where
+    // a lane also pumps manually. Display/telemetry only.
+    std::unique_ptr<boost::asio::steady_timer> m_cache_refresh_timer;
+    void start_cache_refresh_pump() {
+        if (!m_context || m_cache_refresh_timer) return;   // once, dashboard lanes only
+        m_cache_refresh_timer = std::make_unique<boost::asio::steady_timer>(*m_context);
+        arm_cache_refresh_pump();
+    }
+    void arm_cache_refresh_pump() {
+        if (!m_cache_refresh_timer) return;
+        m_cache_refresh_timer->expires_after(std::chrono::seconds(2));
+        m_cache_refresh_timer->async_wait([this](const boost::system::error_code& ec) {
+            if (ec) return;   // cancelled at shutdown (timer destroyed with `this`)
+            refresh_http_caches();
+            arm_cache_refresh_pump();
+        });
+    }
     std::atomic<bool>       m_work_valid{false};
     std::atomic<uint64_t>   m_work_generation{0};       // incremented on each refresh_work()
     std::atomic<int64_t>    m_last_work_update_time{0}; // monotonic seconds since epoch
@@ -1348,6 +1392,11 @@ private:
     coin_peer_info_fn m_ltc_peer_info_fn;
     coin_peer_info_fn m_doge_peer_info_fn;
     coin_peer_info_fn m_coin_peer_info_fn;
+    coin_peer_info_fn m_coin_sync_status_fn;  // embedded coin header-sync provider
+    // Merge the header-sync provider snapshot into a /broadcaster_status
+    // response (additive fields only; running/last_broadcast untouched).
+    // No-op when the provider is unwired or throws.
+    void augment_with_coin_sync_status(nlohmann::json& result);
     block_verify_fn_t m_block_verify_fn;  // default (parent chain)
     std::map<std::string, block_verify_fn_t> m_chain_verify_fns; // per-chain
     void verify_found_block(size_t index);

--- a/src/impl/bch/coin/embedded_daemon.hpp
+++ b/src/impl/bch/coin/embedded_daemon.hpp
@@ -669,6 +669,36 @@ public:
         };
     }
 
+    /// Embedded coin header-sync snapshot for the core::WebServer
+    /// /broadcaster_status merge (MiningInterface::set_coin_sync_status_fn).
+    /// Display-only, same read set as dashboard_topology(): header_height =
+    /// the embedded BCH HeaderChain tip (never the sharechain height),
+    /// target_height = the peer-advertised tip raised by the single embedded
+    /// peer's startingheight, peers = that peer's version metadata (BCH's
+    /// embedded transport is single-peer -- 0-or-1 rows, never a fabricated
+    /// getpeerinfo table).
+    nlohmann::json sync_status() {
+        const uint32_t hh = ibd_synced_height();
+        uint32_t th = m_chain.peer_tip_height();
+        nlohmann::json peers = nlohmann::json::array();
+        auto* p2p = m_node.p2p();
+        if (p2p != nullptr && p2p->peer_version() > 0) {
+            const uint32_t sh = p2p->peer_start_height();
+            if (sh > th) th = sh;
+            peers.push_back({
+                {"subver", p2p->peer_subver()},
+                {"startingheight", sh},
+                {"conntime", p2p->peer_uptime_sec()},
+                {"connected", true},
+            });
+        }
+        nlohmann::json s = nlohmann::json::object();
+        s["header_height"] = hh;
+        s["target_height"] = th;
+        s["peers"] = std::move(peers);
+        return s;
+    }
+
 private:
     /// Populate the three converged seed tiers (idempotent). Mirrors the DGB
     /// tier-3 wire (main_dgb.cpp): DNS (tier 1) + fixed (tier 2) from

--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -693,6 +693,10 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
         // reads are display-only (lock-free snapshots / atomics).
         //   /api/node_topology -- BCHN embedded daemon peers + synced height.
         mi->set_node_topology_fn([&daemon]() { return daemon.dashboard_topology(); });
+        //   /broadcaster_status header-sync fields -- the embedded BCH
+        //   header-chain tip + single-peer startingheight (display-only; the
+        //   core merge computes sync_percent/synced/connected_peers from it).
+        mi->set_coin_sync_status_fn([&daemon]() { return daemon.sync_status(); });
         //   share-peers -- the pool node sharechain P2P peer snapshot.
         mi->set_peer_info_fn([&node]() { return node.get_peer_info_json(); });
         //   pool hashrate -- lock-free tracker snapshot published by think().

--- a/src/impl/btc/coin/node.hpp
+++ b/src/impl/btc/coin/node.hpp
@@ -216,6 +216,11 @@ public:
 
     bool has_p2p() const { return m_p2p != nullptr; }
 
+    /// Expose the embedded P2P driver for DISPLAY-ONLY reads (dashboard
+    /// header-sync provider: peer subver/startingheight/uptime). Mirrors the
+    /// BCH node.hpp p2p() accessor. May be null when no P2P sink is armed.
+    NodeP2P<config_t>* p2p() { return m_p2p.get(); }
+
     /// Send getheaders to drive header sync (BIP 31).
     /// Locator should be hashes from chain tip back to genesis (sparsely);
     /// for an empty chain pass {genesis_hash}. Stop = uint256::ZERO means

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -1298,6 +1298,27 @@ public:
         for (const auto& p : m_pool) out.push_back(p->age_sec());
         return out;
     }
+    /// One-call per-peer snapshot for DISPLAY-ONLY consumers (the dashboard
+    /// header-sync provider). A single walk over m_pool so addr/subver/
+    /// start_height/age describe the SAME peer set — zipping the individual
+    /// vector accessors could interleave with a pool mutation between calls.
+    /// No pool state is touched.
+    struct PeerBrief {
+        std::string addr;          // key (addr:port)
+        std::string subver;        // version-message user agent
+        uint32_t    start_height;  // peer-advertised chain height at connect
+        int64_t     age_sec;       // connection age
+        bool        handshaked;    // version/verack complete
+    };
+    std::vector<PeerBrief> peer_briefs() const
+    {
+        std::vector<PeerBrief> out;
+        out.reserve(m_pool.size());
+        for (const auto& p : m_pool)
+            out.push_back(PeerBrief{p->key, p->subver, p->start_height,
+                                    p->age_sec(), p->handshake.complete()});
+        return out;
+    }
     uint64_t sessions_started() const { return m_sessions_started; }
     uint64_t sessions_lost() const { return m_sessions_lost; }
     const InvDedup& inv_dedup() const { return m_inv_dedup; }


### PR DESCRIPTION
## What

The dashboard already ships two embedded-daemon sync cards, but the backend never fed them, so they rendered blank:

1. the **"embedded daemon REAL sync"** card (node-topology row: `c.header_height` / `c.target_height` / `c.sync_percent` + `synced` flag, `web-static/dashboard.html` ~3205-3232), and
2. the **"Header Sync %"** stat card (computes `min(100, current_height / max(peers[].startingheight) * 100)`, `dashboard.html` ~5066-5089), fed from the `/broadcaster_status` / `/merged_broadcaster_status` fetches.

Verified live on the DASH canary: `GET /broadcaster_status` returned only `{"last_broadcast":null,"running":false}` — no `header_height`, no `target_height`, no peer `startingheight` anywhere.

## How

**Core (`src/core/web_server.{hpp,cpp}`)** — one new provider seam + an additive merge:

- `MiningInterface::set_coin_sync_status_fn(...)` — a per-lane callback returning `{header_height, target_height, synced?, peers:[{addr?, subver?, startingheight, conntime?, connected}...]}`.
- `rest_broadcaster_status()` now folds that snapshot in on **every** exit path as `header_height` / `current_height` / `target_height` / `sync_percent` (clamped 0..100) / `synced` / `syncing` / `connected_peers`. `target_height` is raised to the max `startingheight` among connected peers. **Strictly additive**: `last_broadcast`, `running`, `peers`, `chains`, and every other pre-existing key keep their exact prior semantics (the historical fallback emit is byte-compatible when no provider is wired; with a provider reporting a connected coin peer, `running` mirrors the existing `coin_peer_info_fn` any-connected rule).
- `rest_node_topology()` wraps a flat single-coin topology emit (the BTC/BCH shape, previously invisible to the card) into the `{coins:[...]}` wrapper the frontend requires, and enriches the primary coin row with `header_height`/`target_height`/`sync_percent`/`synced` from the same provider when the lane's own emit does not carry them (DASH's richer emit is untouched; nothing is fabricated when the target is unknown).

**Per-lane wiring** (each lane supplies its own header-chain tip + coin-peer startingheights; no coin is hardcoded in core):

| Lane | header tip source | target / peers source |
|---|---|---|
| `main_btc.cpp` | embedded `btc::coin::HeaderChain` `height()` | `peer_tip_height()` + single embedded P2P peer (`Node::p2p()` accessor added, mirror of the existing BCH one) |
| `main_dash.cpp` | `dash::coin::HeaderChain` `height()` | `CoinClient::best_peer_height()` + per-peer pool snapshot (`peer_briefs()` accessor added beside `peer_ages_sec()`) |
| `main_ltc.cpp` | embedded `ltc::coin::HeaderChain` `height()` | broadcaster `get_peer_info()` (already carries `startingheight`) |
| `main_dgb.cpp` | `HeaderChain::tip_height()` (checkpoint-aware absolute) | single embedded coin P2P peer version metadata |
| `bch/pool_entrypoint.hpp` | `EmbeddedBchDaemon::sync_status()` (new, same read set as `dashboard_topology()`) | `m_chain.peer_tip_height()` + single peer |

Display/telemetry only — zero reads or writes on share-validity, reward, coinbase, or consensus paths. All callbacks go through the existing `thread_safe_wrap` RCU cache like every other dashboard feed. No frontend changes.

While wiring this I found the *reason* the fields were blank went one layer deeper than a missing provider: the zero-arg `thread_safe_wrap` providers only surface on the HTTP thread after `refresh_http_caches()` runs on the io/main thread, and only `main_dash` / `main_ltc` ever drove that (from their own 2 s timers). `main_btc` / `main_dgb` / `bch` never pumped it, so a wrapped provider stayed cold (the `CacheEntry` null-json default) on those lanes — which is exactly why only `node_topology` (stored *unwrapped*) worked there. Fixed coin-generically in one place: `MiningInterface` now self-schedules `refresh_http_caches()` on a 2 s timer started from `set_io_context()` (armed exactly when a lane stands up its dashboard; redundant-but-harmless where a lane also pumps manually), instead of adding a timer to three more lane files.

## Verification (live)

Built `c2pool-btc` (green) and ran it syncing the embedded BTC header chain from genesis against a live mainnet coin peer:

```
c2pool-btc --bitcoind <mainnet-peer>:8333 --coin-p2p-discover \
           --http 127.0.0.1:18080 --sharechain-port 19333 --data-dir /tmp/btc-syncverify
```

`GET /broadcaster_status` (snapshot mid-IBD):

```json
{
  "header_height": 52000,
  "current_height": 52000,
  "target_height": 961639,
  "sync_percent": 5.407434598638367,
  "synced": false,
  "syncing": true,
  "running": true,
  "last_broadcast": null,
  "connected_peers": [
    { "connected": true, "conntime": 249, "startingheight": 961639,
      "subver": "/Satoshi:29.4.0/Knots:20260508/" }
  ],
  "peers": [ { "connected": true, "conntime": 249, "startingheight": 961639,
      "subver": "/Satoshi:29.4.0/Knots:20260508/" } ]
}
```

- `header_height` == `current_height` is the **REAL climbing embedded coin header tip** — re-curled every ~14 s it stepped 2000 → 6000 → 14000 → 22000 → 32000 → 44000 → 52000, matching the node's own `[BTC] new_headers: accepted=2000 chain_height=…` log. It is the coin header chain, **not** the sharechain (the sharechain held ~18 891 shares at the same moment — a different series entirely).
- `target_height` (961639) == the connected coin peer's advertised `startingheight`; `sync_percent` climbed 0.2 % → 5.4 %, always in 0..100; `synced:false`/`syncing:true` during IBD; `connected_peers[0].startingheight` populated.
- `last_broadcast` (null) + `running` retained; `running` correctly reads `true` once a coin peer is connected.
- `/api/node_topology` primary coin row now carries `header_height:52000` / `target_height:961639` / `sync_percent:5.4` / `synced:false` → the **"embedded daemon REAL sync"** card renders `hdr/target/percent` instead of blank; and `current_height` / `max(peers[].startingheight)` feed the **"Header Sync %"** stat (52000 / 961639 ≈ 5.4 %). Both cards non-blank.
- `/local_stats`, `/global_stats`, `/peers` all HTTP 200 — unregressed.

Before this change the same endpoint returned exactly `{"last_broadcast":null,"running":false}`.
