### PR TITLE
btc: advertise canonical GBT block version (0x20000000) — fixes 100% bitAXE low-diff rejects on btc.voidbind

### DIFF
--- a/src/impl/btc/coin/template_builder.hpp
+++ b/src/impl/btc/coin/template_builder.hpp
@@ -295,9 +295,13 @@ public:
         }
 
         // ── Block version ──────────────────────────────────────────────────
-        uint32_t block_version = static_cast<uint32_t>(tip.header.m_version);
-        if (block_version < BIP9_BASE_VERSION)
-            block_version = BIP9_BASE_VERSION;
+        // Canonical GBT version, matching bitcoind ComputeBlockVersion: TOP_BITS
+        // only (no deployments to signal). NEVER inherit tip.header.m_version — a
+        // mainnet tip carries another miner's BIP310-rolled bits inside the
+        // 0x1fffe000 rolling mask; advertising them makes a version-rolling
+        // miner's submitted version_bits lossy, so no pool-side formula can
+        // recover the hashed version and every share rejects as a random hash.
+        uint32_t block_version = BIP9_BASE_VERSION;
 
         // ── Subsidy ────────────────────────────────────────────────────────
         uint64_t subsidy = get_block_subsidy(next_h, chain.params().subsidy_halving_interval);


### PR DESCRIPTION
## Live bug: 100% of bitAXE shares reject as `low-diff` on btc.voidbind.com

Three real bitAXE miners (ASIC, mainnet BTC) connected to the embedded-standalone `c2pool-btc` pool at `btc.voidbind.com:9334` had **~100% of their shares rejected** with `[Stratum] REJECT low-diff ... hash_diff=~3e-10 required=0.0005`. A `hash_diff` of ~2^-31 is the difficulty of a *random* hash — the pool was reconstructing a block header that is **not** the one the bitAXE hashed.

## Root cause — `template_builder.hpp:298`

The embedded BTC template builder inherited the block version straight from the previous block's header:

```cpp
uint32_t block_version = static_cast<uint32_t>(tip.header.m_version);
if (block_version < BIP9_BASE_VERSION)
 block_version = BIP9_BASE_VERSION;
```

A live mainnet tip carries **another miner's BIP310-rolled version bits inside the `0x1fffe000` rolling mask**. Observed live: tip version `0x32EF0000`, of which `0x32EF0000 & 0x1fffe000 = 0x12EF0000` sits *inside* the rolling mask.

ESP-Miner/AxeOS negotiates version-rolling mask `1fffe000` and submits `version_bits = rolled & ~job_version` in `mining.submit` param[5]. When the advertised `job.version` already has bits in the mask, the counter bits that overlap those in-mask job bits (`ctr & job & mask`) are **destroyed in transit** — no pool-side recovery formula (XOR *or* mask-OR) can reconstruct them. The shared `stratum_server.cpp` XOR recovery (`effective = job.version ^ miner_version_bits`) then produces a version the miner never hashed (e.g. pool built `0x36EFA000`, miner hashed `0x36A0A000` — one byte differs), SHA256d avalanches, and every share looks like a random hash.

## Fix — advertise a clean version

```cpp
uint32_t block_version = BIP9_BASE_VERSION; // 0x20000000
```

This matches bitcoind's `ComputeBlockVersion` (`VERSIONBITS_TOP_BITS`, no active deployments to signal). With `job.version & 0x1fffe000 == 0`, ESP-Miner's submitted bits equal both the XOR delta and the mask content, so the existing shared XOR recovery is **bit-exact** and shares accept — with no bitAXE restart. A BTC block at version `0x20000000` is consensus-valid (post-BIP9 standard top-bits `001`).

**Shared-coin safety:** the change is confined to `src/impl/btc/coin/template_builder.hpp`, compiled only into the BTC lane. `stratum_server.cpp` is deliberately **not** touched — its XOR recovery is standard-correct and becomes provably exact once the BTC job version is clean. DASH/LTC are daemon/replay-fed and already supply clean GBT versions, so their share acceptance cannot regress.

**Follow-up (latent):** `src/impl/ltc/coin/template_builder.hpp:217` has the identical inherit-tip-version pattern; latent today because scrypt ASICs don't version-roll. Same one-line fix should land there separately.

## Live proof — deployed to btc.voidbind.com and measured against real hardware

Rebuilt `c2pool-btc-796a34be`, repointed the live systemd unit (all flags + payout `13zQ...` preserved), restarted `07:36:48`.

**Template version before/after (pool log):**
- before: `TemplateBuilder: version=0x32ef0000` (rolled tip)
- after: `TemplateBuilder: height=964536 version=0x20000000` (clean)

**Pool journal, 200 s window post-fix:** `Pseudoshare accepted` × 308, `[Stratum] REJECT` × **0** (was 39 low-diff rejects in the 90 s *before* the fix). Accepted `hash_diff` values 316–1955 — real work, far above the 0.0005 requirement.

**bitAXE hardware counters (`/api/system/info`):**

| miner | BEFORE (pre-fix)<br>acc / rej | AFTER +3.5 min<br>acc / rej | Δ accepted | Δ rejected |
|-------|------------------|------------------|-----------|-----------|
| 192.168.86.36 | 14 / 391 | 162 / 526 | **+97** | 0 (frozen) |
| 192.168.86.108 | 38 / 878 | 270 / 1059 | **+140** | 0 (frozen) |
| 192.168.86.170 | 37 / 843 | 297 / 1033 | **+167** | 0 (frozen) |

(AFTER window is T0→+3.5 min, both sampled post-restart; the reject counters are cumulative-since-boot and stopped advancing entirely once clean templates began — accepts climb monotonically, rejects frozen.)

Root cause independently confirmed by byte-level offline header reconstruction: with only the version corrected, 19/19 captured live shares become valid at diffs 276–6945; all other suspects (coinbase assembly, extranonce endianness, merkle branch order/endianness, ntime, prevhash endianness, nbits) ruled out.
