### PR TITLE
btc: fix sharechain coinbase scriptSig + ref_hash parity so accepted shares earn PPLNS credit

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1612,7 +1612,10 @@ int main(int argc, char* argv[])
         [p2p_node_raw, auto_ratchet](const uint256& prev_share_hash,
                        const std::vector<unsigned char>& scriptSig,
                        const std::vector<unsigned char>& payout_script,
-                       uint64_t subsidy, uint32_t block_bits, uint32_t timestamp)
+                       uint64_t subsidy, uint32_t block_bits, uint32_t timestamp,
+                       bool segwit_active,
+                       const std::vector<uint256>& txid_merkle_branches,
+                       const uint256& witness_root)
         -> core::stratum::RefHashResult
         {
             // Phase 12 contract: produce both the ref_hash AND the full
@@ -1641,19 +1644,49 @@ int main(int argc, char* argv[])
             p.donation            = 50;            // 0.5% (matches finder fee)
             p.stale_info          = 0;
             p.desired_version     = 35;
-            p.has_segwit          = false;         // TODO Phase 8c+: detect from rules
             p.timestamp           = timestamp;
             // p.bits / p.max_bits set below from compute_share_target
 
-            // Heuristic v35 pubkey extract: P2PKH is 0x76 0xa9 0x14 + 20B + 0x88 0xac.
+            // Pubkey extract — MUST mirror create_local_share_v35
+            // (share_check.hpp:2230-2242) so the address string the mint
+            // freezes into the share equals the one this ref_hash commits to.
+            // P2PKH  (25B): 76 a9 14 <20> 88 ac -> type 0
+            // P2SH   (23B): a9 14 <20> 87        -> type 2
+            // P2WPKH (22B): 00 14 <20>           -> type 1
             if (payout_script.size() == 25 && payout_script[0] == 0x76 &&
                 payout_script[1] == 0xa9 && payout_script[2] == 0x14 &&
                 payout_script[23] == 0x88 && payout_script[24] == 0xac)
             {
                 std::memcpy(p.pubkey_hash.begin(), payout_script.data() + 3, 20);
                 p.pubkey_type = 0;
+            } else if (payout_script.size() == 23 && payout_script[0] == 0xa9) {
+                std::memcpy(p.pubkey_hash.begin(), payout_script.data() + 2, 20);
+                p.pubkey_type = 2;
+            } else if (payout_script.size() == 22 && payout_script[0] == 0x00) {
+                std::memcpy(p.pubkey_hash.begin(), payout_script.data() + 2, 20);
+                p.pubkey_type = 1;
+            } else if (payout_script.size() >= 20) {
+                std::memcpy(p.pubkey_hash.begin(), payout_script.data(), 20);
             }
-            // Bech32 P2WSH/P2WPKH: leave pubkey_hash zeroed for now (TODO).
+            // V35 shares serialize the ADDRESS string (VarStr), not the
+            // pubkey_hash — populate it with the SAME derivation the mint
+            // uses (share_check.hpp:2242). Leaving it empty made the
+            // template ref_hash diverge from attempt_verify's recompute.
+            p.address = btc::pubkey_hash_to_address(p.pubkey_hash, p.pubkey_type);
+
+            // Segwit (v33+): the frozen ref serializes segwit_data (txid
+            // merkle branches + wtxid merkle root) for segwit-active share
+            // versions. Populate it from the job's frozen values so the
+            // OP_RETURN ref_hash matches what create_local_share_v35 stores
+            // and attempt_verify recomputes. has_segwit is gated on the GBT
+            // template's segwit activation (mirrors the mint's
+            // segwit_active && !witness_commitment.empty()).
+            p.has_segwit = segwit_active;
+            if (p.has_segwit) {
+                p.segwit_data.m_txid_merkle_link.m_branch = txid_merkle_branches;
+                p.segwit_data.m_txid_merkle_link.m_index  = 0;
+                p.segwit_data.m_wtxid_merkle_root         = witness_root;
+            }
 
             // Defaults if tracker access fails — fall back to block bits so
             // we still emit *some* ref_hash. These won't validate against
@@ -1835,9 +1868,16 @@ int main(int argc, char* argv[])
             min_header.m_bits      = read_le32(header_80b.data() + 72);
             min_header.m_nonce     = read_le32(header_80b.data() + 76);
 
-            // ── Wrap coinbase + convert merkle branches ──
-            BaseScript coinbase_bs(std::vector<unsigned char>(
-                full_coinbase.begin(), full_coinbase.end()));
+            // ── Wrap coinbase scriptSig + convert merkle branches ──
+            // The share's m_coinbase field is the coinbase *scriptSig*
+            // (share_init_verify bounds it to 2..100 bytes), NOT the full
+            // coinbase transaction. Storing the whole 600+ byte gentx here
+            // made attempt_verify throw "bad coinbase size" and the share got
+            // zero PPLNS credit. Extract the scriptSig at the fixed offset
+            // (mirrors dgb/stratum/work_source.cpp:118). actual_coinbase_bytes
+            // below stays the full gentx (hash_link + OP_RETURN ref override).
+            BaseScript coinbase_bs(
+                btc::stratum::extract_coinbase_scriptsig(full_coinbase));
 
             // Wire format for stratum branches is hex of LE-internal bytes
             // (see get_stratum_merkle_branches).  Parse via ParseHex+memcpy

--- a/src/impl/btc/share_check.hpp
+++ b/src/impl/btc/share_check.hpp
@@ -287,7 +287,7 @@ inline std::string pubkey_hash_to_address(const uint160& pubkey_hash, uint8_t pu
     bool testnet = PoolConfig::is_testnet;
     if (pubkey_type == 0) {
         // P2PKH: Base58Check with version byte
-        uint8_t ver = testnet ? 0x6f : 0x30;
+        uint8_t ver = testnet ? 0x6f : 0x00;  // BTC mainnet P2PKH (was 0x30 LTC)
         std::vector<unsigned char> payload(21);
         payload[0] = ver;
         std::memcpy(payload.data() + 1, pubkey_hash.data(), 20);
@@ -300,7 +300,7 @@ inline std::string pubkey_hash_to_address(const uint160& pubkey_hash, uint8_t pu
         return bech32::encode_segwit(hrp, 0, prog);
     } else if (pubkey_type == 2) {
         // P2SH: Base58Check with version byte
-        uint8_t ver = testnet ? 0xc4 : 0x32;
+        uint8_t ver = testnet ? 0xc4 : 0x05;  // BTC mainnet P2SH (was 0x32 LTC)
         std::vector<unsigned char> payload(21);
         payload[0] = ver;
         std::memcpy(payload.data() + 1, pubkey_hash.data(), 20);
@@ -397,8 +397,24 @@ inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParam
     ref_stream << p.stale_info;
     ::Serialize(ref_stream, VarInt(p.desired_version));
 
-    if (p.has_segwit)
-        ref_stream << p.segwit_data;
+    // segwit_data (v33+): PossiblyNoneType — for segwit-active share versions
+    // this field is ALWAYS serialized, exactly as share_init_verify
+    // (share_check.hpp:574-587) and create_local_share_v35 (:2350-2356) do.
+    // When the job carries no segwit data, write the None sentinel (empty
+    // branch + zero root). Serializing this ONLY when has_segwit was true
+    // made the template-time OP_RETURN ref_hash diverge from the ref_hash
+    // attempt_verify recomputes off the stored share -> the share failed
+    // verification and earned no PPLNS credit.
+    if (p.share_version >= btc::PoolConfig::SEGWIT_ACTIVATION_VERSION) {
+        if (p.has_segwit) {
+            ref_stream << p.segwit_data;
+        } else {
+            std::vector<uint256> empty_branch;
+            ref_stream << empty_branch;
+            uint256 zero_root;
+            ref_stream << zero_root;
+        }
+    }
 
     // V36: merged_addresses (after segwit_data, before far_share_hash)
     if (core::version_gate::is_v36_active(p.share_version))

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -301,6 +301,13 @@ nlohmann::json BTCWorkSource::get_current_work_template() const
 
 std::vector<std::string> BTCWorkSource::get_stratum_merkle_branches() const
 {
+    // Public override: fold the branches from a freshly-read template.
+    return get_stratum_merkle_branches(cached_template());
+}
+
+std::vector<std::string> BTCWorkSource::get_stratum_merkle_branches(
+    const std::shared_ptr<const btc::coin::rpc::WorkData>& wd) const
+{
     // Stratum merkle branches: at each level, the SIBLING of the left-most
     // node (the one that descends from the coinbase). The miner reconstructs
     // the merkle root by:
@@ -311,7 +318,10 @@ std::vector<std::string> BTCWorkSource::get_stratum_merkle_branches() const
     // Algorithm matches Bitcoin Core's merkle.cpp: at every level, if the
     // count is odd, duplicate the last element. The branches list is
     // typically log2(N) entries for N transactions.
-    auto wd = cached_template();
+    //
+    // Folds the CALLER-supplied template snapshot so build_connection_coinbase
+    // can freeze the branches from the exact same `wd` it built the coinbase
+    // and OP_RETURN ref_hash from (no second cached_template() read).
     if (!wd || wd->m_hashes.empty()) return {};
 
     // PRODUCER/CONSUMER CONTRACT: wd->m_hashes is the pure tx-hash list
@@ -522,6 +532,47 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
         return a.first  < b.first;
     });
 
+    // ── Freeze the segwit inputs to the ref_hash BEFORE computing it ──
+    // The v33+ share serializes segwit_data (txid merkle branches + wtxid
+    // merkle root) into the ref that the OP_RETURN commits to. So these must
+    // be computed here, from THIS template snapshot (`wd`), and fed into
+    // ref_hash_fn — otherwise the committed ref_hash omits segwit while
+    // attempt_verify's recompute (off the stored share) includes it, and the
+    // share is rejected with no PPLNS credit. Computing them once off `wd`
+    // (not a second cached_template() read) also closes the sub-ms template
+    // -roll race between the coinbase body and its frozen branches.
+    std::vector<std::string> branch_hexes = get_stratum_merkle_branches(wd);
+    std::vector<uint256> frozen_branches_u256;
+    frozen_branches_u256.reserve(branch_hexes.size());
+    for (const auto& h : branch_hexes) {
+        uint256 b;
+        auto bb = ParseHex(h);
+        if (bb.size() == 32) std::memcpy(b.begin(), bb.data(), 32);
+        frozen_branches_u256.push_back(b);
+    }
+
+    // wtxid merkle root — the coinbase-only witness root is the leaf-0
+    // placeholder folded by witness_merkle_root(). Computed here off `wd` so
+    // both the ref_hash (below) and the BIP141 commitment output (further
+    // down) share ONE value.
+    uint256 witness_root_uint;
+    if (segwit_active) {
+        std::vector<uint256> other_wtxids;
+        other_wtxids.reserve(wd->m_txs.size());
+        if (auto txs_field = wd->m_data.find("transactions");
+            txs_field != wd->m_data.end() && txs_field->is_array())
+        {
+            for (const auto& t : *txs_field) {
+                if (!t.is_object()) continue;
+                if (auto h = t.find("hash"); h != t.end() && h->is_string()) {
+                    uint256 wt; wt.SetHex(h->get<std::string>().c_str());
+                    other_wtxids.push_back(wt);
+                }
+            }
+        }
+        witness_root_uint = btc::coin::witness_merkle_root(other_wtxids);
+    }
+
     // ── ref_hash + chain-walked frozen_ref values (Phase 12) ──
     // The ref_hash_fn lambda walks the share tracker for the actual
     // network share target (bits/max_bits) plus the chain-position
@@ -535,7 +586,9 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
     if (ref_hash_fn) {
         try {
             rh_result = ref_hash_fn(prev_share_hash, scriptsig, payout_script,
-                                    coinbasevalue, block_bits, curtime);
+                                    coinbasevalue, block_bits, curtime,
+                                    segwit_active, frozen_branches_u256,
+                                    witness_root_uint);
             if (rh_result.bits != 0) {
                 share_bits_.store(rh_result.bits, std::memory_order_relaxed);
                 share_max_bits_.store(rh_result.max_bits, std::memory_order_relaxed);
@@ -563,27 +616,10 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
     // For coinbase-only templates (no other txs) the witness root is just
     // the coinbase wtxid (zero), so commitment = SHA256d(zero32 || zero32).
     std::vector<uint8_t> witness_commitment_script;  // empty if segwit not active
-    uint256 witness_root_uint;
+    // witness_root_uint was computed ONCE above (before ref_hash_fn) off the
+    // same `wd`; reuse it here so the BIP141 commitment output and the frozen
+    // ref's segwit wtxid root are guaranteed identical.
     if (segwit_active) {
-        // Collect the OTHER txs' wtxids (template "hash" field); the coinbase
-        // wtxid placeholder (BIP141 = 32 zero bytes) at leaf 0 is prepended by
-        // the shared witness_merkle_root() SSOT helper, so the leaf-0 contract
-        // lives in ONE place (mirrors the txid-merkle leaf-0 fix, PR #570).
-        std::vector<uint256> other_wtxids;
-        other_wtxids.reserve(wd->m_txs.size());
-        if (auto txs_field = wd->m_data.find("transactions");
-            txs_field != wd->m_data.end() && txs_field->is_array())
-        {
-            for (const auto& t : *txs_field) {
-                if (!t.is_object()) continue;
-                if (auto h = t.find("hash"); h != t.end() && h->is_string()) {
-                    uint256 wt; wt.SetHex(h->get<std::string>().c_str());
-                    other_wtxids.push_back(wt);
-                }
-            }
-        }
-        witness_root_uint = btc::coin::witness_merkle_root(other_wtxids);
-
         // commitment_hash = SHA256d(witness_root || witness_reserved_value)
         std::array<uint8_t, 64> commit_in;
         std::memcpy(commit_in.data(),      witness_root_uint.data(),    32);
@@ -680,14 +716,11 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
     snap.frozen_ref.far_share_hash  = rh_result.far_share_hash;
     snap.frozen_ref.ref_hash        = ref_hash;
     snap.frozen_ref.last_txout_nonce = ref_nonce;
+    // Freeze the SAME branches + wtxid root that fed the ref_hash above so the
+    // mint (create_local_share_v35) reconstructs byte-identical segwit_data.
+    snap.frozen_ref.frozen_merkle_branches = frozen_branches_u256;
+    snap.frozen_ref.frozen_witness_root    = witness_root_uint;
 
-    auto branches = get_stratum_merkle_branches();
-    for (const auto& h : branches) {
-        uint256 b;
-        auto bb = ParseHex(h);
-        if (bb.size() == 32) std::memcpy(b.begin(), bb.data(), 32);
-        snap.frozen_ref.frozen_merkle_branches.push_back(b);
-    }
     auto txs_field = wd->m_data.find("transactions");
     if (txs_field != wd->m_data.end() && txs_field->is_array()) {
         // a1 + H5 memo: build the per-tx hex vector ONCE and hand the snapshot a
@@ -705,7 +738,7 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
         snap.tx_data = btc::stratum::detail::tx_data_memo_get_or_build(
             wd->m_hashes, *txs_field, tx_data_fp_, tx_data_memo_);
     }
-    snap.merkle_branches = std::move(branches);
+    snap.merkle_branches = std::move(branch_hexes);
 
     return result;
 }

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -57,6 +57,44 @@ namespace c2pool { namespace merged { class MergedMiningManager; } }
 
 namespace btc::stratum {
 
+// Extract the coinbase scriptSig from a reconstructed coinbase TRANSACTION.
+// The mint seam (create_local_share) stores the scriptSig in share.m_coinbase,
+// which share_init_verify bounds to 2..100 bytes — so the mint MUST be handed
+// the scriptSig, NOT the full gentx. Coinbase tx layout:
+//   version(4) | vin_count(1=0x01) | prev_hash(32) | prev_idx(4) |
+//   scriptSig(varint len + bytes) | sequence(4) | ...
+// so the scriptSig length varint sits at fixed offset 41 (matches the coinb1
+// assembly in build_connection_coinbase). The 8-byte extranonce lands in the
+// OP_RETURN nonce slot near the tail, never in the scriptSig, so the bytes
+// recovered here are exactly the scriptSig the producer froze at template
+// time — which is what keeps the mint's recomputed ref_hash equal to the one
+// the miner's coinbase committed to. Port of dgb/stratum/work_source.cpp:118
+// (per-coin copy per the coin-isolation invariant); lifted to the header so
+// the mint call site in main_btc.cpp can reach it.
+inline std::vector<unsigned char>
+extract_coinbase_scriptsig(const std::vector<uint8_t>& coinbase_tx) {
+    constexpr size_t kScriptOffset = 4 + 1 + 32 + 4;  // = 41
+    if (coinbase_tx.size() < kScriptOffset + 1)
+        return {};  // truncated -> empty (fail-closed; mint declines on size<2)
+    size_t off = kScriptOffset;
+    uint64_t len = coinbase_tx[off++];
+    // A coinbase scriptSig is consensus-capped at 100 bytes, so its length is
+    // always a single-byte varint (< 0xfd). Handle the wider markers only to
+    // stay well-formed against a malformed buffer.
+    if (len == 0xfd) {
+        if (off + 2 > coinbase_tx.size()) return {};
+        len = static_cast<uint64_t>(coinbase_tx[off])
+            | (static_cast<uint64_t>(coinbase_tx[off + 1]) << 8);
+        off += 2;
+    } else if (len >= 0xfe) {
+        return {};  // implausible for a coinbase scriptSig -> fail-closed
+    }
+    if (off + len > coinbase_tx.size())
+        return {};  // length overruns the buffer -> fail-closed
+    return std::vector<unsigned char>(coinbase_tx.begin() + off,
+                                      coinbase_tx.begin() + off + len);
+}
+
 class BTCWorkSource : public core::stratum::IWorkSource
 {
 public:
@@ -103,11 +141,19 @@ public:
     /// candidate share timestamp; the lambda may clip it forward to
     /// `prev->m_timestamp + 1` and report the clipped value back via
     /// the result's `timestamp` field.
+    /// `segwit_active`, `txid_merkle_branches` and `witness_root` carry the
+    /// job's frozen segwit state so the ref_hash the OP_RETURN commits to
+    /// serializes segwit_data identically to the share attempt_verify later
+    /// reconstructs (share_check.hpp:574-587). All three are computed once,
+    /// from the SAME template snapshot the coinbase is built from.
     using RefHashFn = std::function<core::stratum::RefHashResult(
         const uint256& prev_share_hash,
         const std::vector<unsigned char>& coinbase_scriptSig,
         const std::vector<unsigned char>& payout_script,
-        uint64_t subsidy, uint32_t block_bits, uint32_t timestamp)>;
+        uint64_t subsidy, uint32_t block_bits, uint32_t timestamp,
+        bool segwit_active,
+        const std::vector<uint256>& txid_merkle_branches,
+        const uint256& witness_root)>;
 
     /// Sharechain WRITE path. Called from mining_submit when a share's
     /// SHA256d PoW meets sharechain (not block) target. main_btc.cpp wires
@@ -300,6 +346,15 @@ private:
     mutable uint64_t template_cache_epoch_{~0ull};
     // Build-or-reuse the cached template under template_mutex_.
     std::shared_ptr<const btc::coin::rpc::WorkData> cached_template() const;
+
+    // Fold the stratum merkle branches from an ALREADY-snapshotted template.
+    // build_connection_coinbase uses this overload with the single `wd` it
+    // read once, so the OP_RETURN ref_hash, the coinbase body, and the frozen
+    // branches all come from the same template snapshot (no second
+    // cached_template() read that a tip roll could desync). The no-arg public
+    // override delegates here with cached_template().
+    std::vector<std::string> get_stratum_merkle_branches(
+        const std::shared_ptr<const btc::coin::rpc::WorkData>& wd) const;
 };
 
 }  // namespace btc::stratum


### PR DESCRIPTION
## Summary

BTC-lane shares that were **accepted at stratum** were **rejected by the sharechain** `attempt_verify` with `bad coinbase size` and earned **zero PPLNS credit**. This fixes the coinbase construction and the template-time `ref_hash` so a correct share passes verification (the size check is not loosened — the construction is corrected).

The committed `ref_hash` (coinbase OP_RETURN, at template time) must serialize byte-identically to the `ref_hash` `attempt_verify` recomputes from the stored share (`create_local_share_v35` fields). Four divergences are closed, all mirroring the DGB precedent and `create_local_share_v35`:

1. **Coinbase scriptSig extract.** `share.m_coinbase` is the coinbase *scriptSig* (bounded 2..100 bytes by `share_init_verify`), not the full gentx. The mint stored the whole 600+ byte coinbase → `bad coinbase size` throw. Extract the scriptSig at the fixed offset (port of the DGB `work_source` helper, lifted to the header so the mint call site reaches it). `actual_coinbase_bytes` stays the full gentx.
2. **Address populated at template time** with the same `pubkey_hash_to_address` derivation the mint uses (V35 ref serializes the address VarStr; the template lambda left it empty), plus the mint's full P2PKH/P2SH/P2WPKH extraction. `pubkey_hash_to_address` now emits BTC mainnet version bytes (P2PKH `0x00`, P2SH `0x05`) instead of LTC bytes. Symmetric change — money was never misdirected (the coinbase pays the right `pubkey_hash`); this makes the address string BTC-correct on both sides.
3. **`segwit_data` always serialized for v33+ shares**, matching `share_init_verify` and `create_local_share_v35` (value, or the empty-branch/zero-root None sentinel). The template lambda now receives the job's frozen txid merkle branches + wtxid root and populates `segwit_data` from them.
4. **Single template snapshot.** `build_connection_coinbase` now folds the frozen branches and the wtxid root from the exact same `wd` it builds the coinbase and OP_RETURN from, closing a sub-ms template-roll race (adds a `get_stratum_merkle_branches(wd)` overload).

## Scope

BTC-lane only: `src/impl/btc/**`, `src/c2pool/main_btc.cpp`. No behavior change for LTC/DGB/DASH/other lanes (`compute_ref_hash_for_work` and `pubkey_hash_to_address` are the BTC-namespaced copies).

## Testing

Release build of `c2pool-btc` (`-O3 -DNDEBUG`) is clean (0 errors). Prestaged to the btc.voidbind.com canary for a live-verify soak (bitAXE shares expected to pass `attempt_verify` and accrue PPLNS weight); not yet cut over.
