### PR TITLE
btc: node-owner fee + dev-donation flag family (-f/--fee, --node-owner-address, --give-author)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -65,6 +65,7 @@
 #include <core/pack.hpp>
 #include <core/hash.hpp>
 #include <core/stratum_server.hpp>
+#include <core/address_utils.hpp>       // core::address_to_script (node-owner fee destination)
 #include <core/web_server.hpp>          // H-STATS.944: operator dashboard + graph_db persist
 #include <btclibs/util/strencodings.h>
 
@@ -138,7 +139,17 @@ static void print_usage()
         "  --merged SPEC   embedded merged-mined aux chain (NMC under BTC),\n"
         "                  colon spec SYMBOL:CHAIN_ID:HOST:PORT:USER:PASS[:P2P_PORT]\n"
         "                  e.g. NMC:1:127.0.0.1:8336:nmcrpc:pass  (Namecoin)\n"
-        "                  Omit for a single SHA256d BTC parent (no aux).\n";
+        "                  Omit for a single SHA256d BTC parent (no aux).\n"
+        "  -f, --fee PCT   node-owner fee percent (default 0 = off). With prob.\n"
+        "                  PCT%%, a job's payout identity becomes --node-owner-address\n"
+        "                  (committed into the share; verify reproduces it — NOT a\n"
+        "                  separate coinbase output). Requires --node-owner-address.\n"
+        "  --node-owner-address ADDR  destination for the node-owner fee\n"
+        "                  (P2PKH/P2SH/P2WPKH). Ignored (fee disabled) if undecodable.\n"
+        "  --give-author PCT  dev-donation percent (alias --dev-donation). Default\n"
+        "                  keeps the built-in 0.5%%; 0 allowed (donation output still\n"
+        "                  emits per p2pool dust-marker semantics, amount 0). Changes\n"
+        "                  the donation AMOUNT only — the donation script is unchanged.\n";
 }
 
 /// BTC wire-protocol magic bytes per network (pchMessageStart).
@@ -175,6 +186,15 @@ int main(int argc, char* argv[])
     std::string rpc_endpoint;               // --coin-rpc HOST:PORT: submitblock backup endpoint override (no secret)
     std::string rpc_conf_path;              // --coin-rpc-auth PATH: bitcoin.conf creds (default ~/.bitcoin/bitcoin.conf)
     std::vector<std::string> merged_chain_specs; // --merged SPEC entries (embedded NMC aux; consumed in later PE slices)
+    // Node-owner fee + dev-donation (ported from main_dash.cpp -f/--fee /
+    // --node-owner-address / --give-author). Defaults leave an UNFLAGGED BTC
+    // deployment byte-identical: fee 0 (off) and donation u16 = 50 (0.5%, the
+    // pre-existing hardcoded value). --give-author only changes the donation
+    // AMOUNT; the donation SCRIPT (forrestv) is never touched.
+    double      node_owner_fee    = 0.0;   // -f/--fee PCT: node-owner fee %, default 0 (off)
+    std::string node_owner_address;        // --node-owner-address ADDR: fee destination
+    double      dev_donation      = 0.0;   // --give-author PCT: dev donation %
+    bool        give_author_set   = false; // true once --give-author/--dev-donation seen
 
     for (int i = 1; i < argc; ++i)
     {
@@ -304,6 +324,24 @@ int main(int argc, char* argv[])
             // following PE slices. Absent == BTC v35 byte-for-byte.
             merged_chain_specs.push_back(argv[++i]);
         }
+        else if ((arg == "-f" || arg == "--fee") && i + 1 < argc)
+        {
+            // p2pool node-owner fee percent. 0 (default) = off. Applied as a
+            // committed payout-identity substitution (NOT a coinbase output).
+            node_owner_fee = std::strtod(argv[++i], nullptr);
+        }
+        else if (arg == "--node-owner-address" && i + 1 < argc)
+        {
+            node_owner_address = argv[++i];
+        }
+        else if ((arg == "--give-author" || arg == "--dev-donation") && i + 1 < argc)
+        {
+            // Dev-donation percent -> the share's committed donation u16. 0 is
+            // allowed (donation output still emits as the dust marker). Only the
+            // AMOUNT changes; the donation script stays the compiled default.
+            dev_donation    = std::strtod(argv[++i], nullptr);
+            give_author_set = true;
+        }
         else
         {
             std::cerr << "unknown arg: " << arg << "\n";
@@ -322,6 +360,22 @@ int main(int argc, char* argv[])
     {
         print_usage();
         return 1;
+    }
+
+    // ── Dev-donation u16 (p2pool committed donation field) ──
+    // Default 50 (0.5%) keeps an UNFLAGGED deployment byte-identical to the two
+    // pre-existing hardcoded donation=50 sites below (ref_hash + create_local_share).
+    // --give-author overrides it: round(65535 * pct / 100), clamped to [0,65535].
+    // 0 is allowed (the donation output still emits as the p2pool dust marker; only
+    // its amount goes to ~0). The donation SCRIPT is never affected here.
+    uint16_t donation_u16 = 50;
+    if (give_author_set) {
+        double pct = dev_donation;
+        if (pct < 0.0)   pct = 0.0;
+        if (pct > 100.0) pct = 100.0;
+        uint64_t v = static_cast<uint64_t>(65535.0 * pct / 100.0 + 0.5);
+        if (v > 65535) v = 65535;
+        donation_u16 = static_cast<uint16_t>(v);
     }
 
     btc::PoolConfig::is_testnet = testnet;
@@ -1515,6 +1569,26 @@ int main(int argc, char* argv[])
         header_chain, mempool, testnet, std::move(stratum_submit_fn));
     work_source_for_shutdown = work_source;  // expose to signal handler
 
+    // ── Node-owner fee (p2pool -f/--fee + --node-owner-address) ──
+    // Ported from main_dash.cpp: with probability node_owner_fee%, a job's
+    // payout identity becomes the owner's script (committed into the share; the
+    // verify side reproduces it — NO extra coinbase output, NO share-format or
+    // verify change). Default (fee 0 / no address) leaves every job paying the
+    // miner, byte-identical to the pre-fee build. An undecodable address DISABLES
+    // the fee rather than silently paying an unspendable script.
+    if (node_owner_fee > 0.0 && !node_owner_address.empty()) {
+        auto owner_script = core::address_to_script(node_owner_address);
+        if (!owner_script.empty()) {
+            work_source->set_node_owner_fee(node_owner_fee, std::move(owner_script));
+            LOG_INFO << "[run] node-owner fee ARMED: " << node_owner_fee
+                     << "% -> " << node_owner_address;
+        } else {
+            LOG_WARNING << "[run] --fee " << node_owner_fee
+                        << " set but --node-owner-address '" << node_owner_address
+                        << "' is not decodable — node-owner fee DISABLED";
+        }
+    }
+
     // PA/PB: hand the merged-mining manager to the work source (PR-2a seam,
     // work_source.hpp set_merged_mining_manager). null absent --merged =>
     // has_merged_chain() false, plain-BTC path byte-identical.
@@ -1609,7 +1683,7 @@ int main(int argc, char* argv[])
         });
 
     work_source->set_ref_hash_fn(
-        [p2p_node_raw, auto_ratchet](const uint256& prev_share_hash,
+        [p2p_node_raw, auto_ratchet, donation_u16](const uint256& prev_share_hash,
                        const std::vector<unsigned char>& scriptSig,
                        const std::vector<unsigned char>& payout_script,
                        uint64_t subsidy, uint32_t block_bits, uint32_t timestamp,
@@ -1641,7 +1715,7 @@ int main(int argc, char* argv[])
             p.coinbase_scriptSig  = scriptSig;
             p.share_nonce         = 0;             // matches LTC line 4281
             p.subsidy             = subsidy;
-            p.donation            = 50;            // 0.5% (matches finder fee)
+            p.donation            = donation_u16;  // --give-author (default 50 = 0.5%)
             p.stale_info          = 0;
             p.desired_version     = 35;
             p.timestamp           = timestamp;
@@ -1840,7 +1914,7 @@ int main(int argc, char* argv[])
     //     what the coinbase OP_RETURN claims
     //   - calls tracker.add(share) — attempt_verify runs later in think()
     work_source->set_create_share_fn(
-        [p2p_node_raw, auto_ratchet, &template_capture, &merged_configs](const std::vector<unsigned char>& full_coinbase,
+        [p2p_node_raw, auto_ratchet, &template_capture, &merged_configs, donation_u16](const std::vector<unsigned char>& full_coinbase,
                        const std::vector<uint8_t>&        header_80b,
                        const core::stratum::JobSnapshot&  job,
                        const std::vector<unsigned char>& payout_script)
@@ -1934,7 +2008,7 @@ int main(int argc, char* argv[])
                     /* prev_share */            job.prev_share_hash,
                     merkle_branches,
                     payout_script,
-                    /* donation */              50,         // 0.5%
+                    /* donation */              donation_u16,  // --give-author (default 50)
                     /* merged_addrs */          merged_addrs,
                     /* stale_info */            btc::StaleInfo::none,
                     /* segwit_active */         job.segwit_active,

--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -141,13 +141,13 @@ static void print_usage()
         "                  e.g. NMC:1:127.0.0.1:8336:nmcrpc:pass  (Namecoin)\n"
         "                  Omit for a single SHA256d BTC parent (no aux).\n"
         "  -f, --fee PCT   node-owner fee percent (default 0 = off). With prob.\n"
-        "                  PCT%%, a job's payout identity becomes --node-owner-address\n"
+        "                  PCT%, a job's payout identity becomes --node-owner-address\n"
         "                  (committed into the share; verify reproduces it — NOT a\n"
         "                  separate coinbase output). Requires --node-owner-address.\n"
         "  --node-owner-address ADDR  destination for the node-owner fee\n"
         "                  (P2PKH/P2SH/P2WPKH). Ignored (fee disabled) if undecodable.\n"
         "  --give-author PCT  dev-donation percent (alias --dev-donation). Default\n"
-        "                  keeps the built-in 0.5%%; 0 allowed (donation output still\n"
+        "                  keeps the built-in 0.5%; 0 allowed (donation output still\n"
         "                  emits per p2pool dust-marker semantics, amount 0). Changes\n"
         "                  the donation AMOUNT only — the donation script is unchanged.\n";
 }

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -374,7 +374,7 @@ std::pair<std::string, std::string> BTCWorkSource::get_coinbase_parts() const
 
 core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
     const uint256& prev_share_hash,
-    const std::string& /*extranonce1_hex*/,
+    const std::string& extranonce1_hex,
     const std::vector<unsigned char>& payout_script,
     const std::vector<std::pair<uint32_t, std::vector<unsigned char>>>& /*merged_addrs*/) const
 {
@@ -509,13 +509,27 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
     // being present and could diverge from verify by up to the cap. Integer floor
     // division (subsidy//200), no float on the money path; the moved value is an
     // exact integer satoshi count (<= 2^53, exact in double).
-    if (!payouts.empty() && coinbasevalue > 0 && !payout_script.empty()) {
-        payouts[payout_script] += static_cast<double>(coinbasevalue / 200);
+    //
+    // Node-owner fee (p2pool -f/--fee): resolve the payout IDENTITY that
+    // receives this share's finder fee (and, via the committed share, its future
+    // PPLNS weight). effective_payout_script substitutes the node owner's script
+    // for ~fee% of jobs, deterministically on (prev_share_hash, extranonce1,
+    // miner_script) so the SAME decision is reproduced at submit time
+    // (mining_submit :960) and by attempt_verify — no new coinbase output, no
+    // share-format change. Default (fee 0 / no owner) => eff_script == payout_script,
+    // byte-identical to the pre-fee coinbase. eff_script also feeds the ref_hash_fn
+    // below so the OP_RETURN commits to the substituted identity.
+    const std::vector<unsigned char> eff_script =
+        effective_payout_script(payout_script, prev_share_hash, extranonce1_hex);
+
+    if (!payouts.empty() && coinbasevalue > 0 && !eff_script.empty()) {
+        payouts[eff_script] += static_cast<double>(coinbasevalue / 200);
     }
 
-    // Degraded fallback: full subsidy → miner (only if miner address is OK).
-    if (payouts.empty() && !payout_script.empty()) {
-        payouts[payout_script] = static_cast<double>(coinbasevalue);
+    // Degraded fallback: full subsidy → miner/owner (only if the resolved
+    // address is OK).
+    if (payouts.empty() && !eff_script.empty()) {
+        payouts[eff_script] = static_cast<double>(coinbasevalue);
     }
 
     // ── Donation output: extract it so it is NEVER amount-sorted into the payout
@@ -613,7 +627,7 @@ core::stratum::CoinbaseResult BTCWorkSource::build_connection_coinbase(
     core::stratum::RefHashResult rh_result;
     if (ref_hash_fn) {
         try {
-            rh_result = ref_hash_fn(prev_share_hash, scriptsig, payout_script,
+            rh_result = ref_hash_fn(prev_share_hash, scriptsig, eff_script,
                                     coinbasevalue, block_bits, curtime,
                                     segwit_active, frozen_branches_u256,
                                     witness_root_uint);
@@ -957,7 +971,16 @@ nlohmann::json BTCWorkSource::mining_submit(
             // means the share can still be ADDED locally but won't carry
             // a payout — peers will reject it on consensus check, which
             // we tolerate during dev.
-            auto payout_script = core::address_to_script(username);
+            // Node-owner fee (p2pool -f/--fee): apply the SAME deterministic
+            // substitution build_connection_coinbase used at job-build time, so
+            // the share this mint commits carries the identity the frozen job
+            // coinbase (and its OP_RETURN ref_hash) already paid — otherwise a
+            // substituted share hits the #1394 gentx-mismatch decline. Inputs
+            // (job->prev_share_hash, session extranonce1, miner script) are the
+            // exact ones the build side rolled on. Default (fee off) => identity.
+            auto payout_script = effective_payout_script(
+                core::address_to_script(username),
+                job->prev_share_hash, extranonce1);
 
             try {
                 share_hash = create_fn(coinbase, header, *job, payout_script);
@@ -1241,6 +1264,57 @@ void BTCWorkSource::set_donation_script(std::vector<unsigned char> script)
 {
     std::lock_guard<std::mutex> lk(callback_mutex_);
     donation_script_ = std::move(script);
+}
+
+void BTCWorkSource::set_node_owner_fee(double pct, std::vector<unsigned char> script)
+{
+    std::lock_guard<std::mutex> lk(callback_mutex_);
+    node_owner_fee_pct_ = pct;
+    node_owner_script_  = std::move(script);
+}
+
+// Deterministic per-(tip, connection) node-fee roll. BTC derives the payout
+// script from the miner's username at BOTH job build (stratum_server.cpp:1613)
+// and submit (mining_submit :960); a random template-side roll would make the
+// created share's committed identity mismatch the frozen job coinbase — exactly
+// the #1394 gentx-mismatch decline class. A pure function of data BOTH sites
+// hold (prev_share_hash + the session extranonce1 + the miner script) keeps
+// template + share + verify coherent with no job-state carry: prev_share_hash
+// re-rolls the decision every share interval (statistically p2pool's per-getwork
+// roll, work.py:1592), extranonce1 decorrelates concurrent connections. The fee
+// is NOT a coinbase output — it is a payout-identity substitution that flows
+// into the share's existing committed pubkey_hash/address, so attempt_verify
+// reproduces the resulting coinbase byte-for-byte with zero verify changes.
+std::vector<unsigned char> BTCWorkSource::effective_payout_script(
+    const std::vector<unsigned char>& miner_script,
+    const uint256& prev_share_hash,
+    const std::string& extranonce1_hex) const
+{
+    double pct;
+    std::vector<unsigned char> owner;
+    {
+        std::lock_guard<std::mutex> lk(callback_mutex_);
+        pct   = node_owner_fee_pct_;
+        owner = node_owner_script_;
+    }
+    if (pct <= 0.0 || owner.empty() || miner_script.empty())
+        return miner_script;
+
+    std::vector<uint8_t> buf;
+    buf.reserve(32 + extranonce1_hex.size() + miner_script.size());
+    buf.insert(buf.end(), prev_share_hash.begin(), prev_share_hash.end());
+    buf.insert(buf.end(), extranonce1_hex.begin(), extranonce1_hex.end());
+    buf.insert(buf.end(), miner_script.begin(), miner_script.end());
+
+    const uint256 h = Hash(std::span<const uint8_t>(buf.data(), buf.size()));
+    // First 8 bytes as a little-endian u64 (no dependency on a uint256 accessor
+    // name); modulo 100000 gives 0.001%-granular rolls.
+    uint64_t roll = 0;
+    for (int i = 0; i < 8; ++i)
+        roll |= static_cast<uint64_t>(h.begin()[i]) << (8 * i);
+    roll %= 100000;
+
+    return (static_cast<double>(roll) < pct * 1000.0) ? owner : miner_script;
 }
 
 }  // namespace btc::stratum

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -1302,11 +1302,12 @@ std::vector<unsigned char> BTCWorkSource::effective_payout_script(
 
     std::vector<uint8_t> buf;
     buf.reserve(32 + extranonce1_hex.size() + miner_script.size());
-    buf.insert(buf.end(), prev_share_hash.begin(), prev_share_hash.end());
+    uint256 psh = prev_share_hash;  // non-const copy: core::uint256 begin()/end() are non-const-only
+    buf.insert(buf.end(), psh.begin(), psh.end());
     buf.insert(buf.end(), extranonce1_hex.begin(), extranonce1_hex.end());
     buf.insert(buf.end(), miner_script.begin(), miner_script.end());
 
-    const uint256 h = Hash(std::span<const uint8_t>(buf.data(), buf.size()));
+    uint256 h = Hash(std::span<const uint8_t>(buf.data(), buf.size()));
     // First 8 bytes as a little-endian u64 (no dependency on a uint256 accessor
     // name); modulo 100000 gives 0.001%-granular rolls.
     uint64_t roll = 0;

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -288,7 +288,27 @@ public:
     /// PPLNS map so it always appears as an output.
     void set_donation_script(std::vector<unsigned char> script);
 
+    /// p2pool -f/--fee node-owner fee. With probability `pct`% a job's payout
+    /// IDENTITY becomes the owner's `script` (committed INTO the share via its
+    /// existing pubkey_hash/address field — NOT a new coinbase output). The
+    /// decision is a deterministic roll over (prev_share_hash, extranonce1,
+    /// miner_script), which are identical at job build (build_connection_coinbase)
+    /// and at submit (mining_submit), so template + share + verify stay coherent
+    /// (the #1394 gentx-mismatch class is avoided without any share-format or
+    /// verify change). pct<=0 or an empty owner script leaves every job paying the
+    /// miner — i.e. the default is off. Ported from main_dash.cpp / LTC
+    /// web_server.cpp set_node_fee_from_address.
+    void set_node_owner_fee(double pct, std::vector<unsigned char> script);
+
 private:
+    /// Resolve the effective payout script for a job/share: the node owner's
+    /// script with probability node_owner_fee_pct_%, else the miner's own
+    /// script. Deterministic in its inputs so job build and submit agree.
+    std::vector<unsigned char> effective_payout_script(
+        const std::vector<unsigned char>& miner_script,
+        const uint256& prev_share_hash,
+        const std::string& extranonce1_hex) const;
+
     // External dependencies (non-owning references)
     btc::coin::HeaderChain&     chain_;
     btc::coin::Mempool&         mempool_;
@@ -321,6 +341,10 @@ private:
     RefHashFn                   ref_hash_fn_;
     CreateShareFn               create_share_fn_;
     std::vector<unsigned char>  donation_script_;
+    // Node-owner fee (p2pool -f/--fee). Guarded by callback_mutex_. Default off
+    // (pct 0, empty script) => effective_payout_script always returns the miner.
+    double                      node_owner_fee_pct_{0.0};
+    std::vector<unsigned char>  node_owner_script_;
 
     // Merged-mining manager (embedded NMC etc.); non-owning, set by
     // main_btc.cpp. null => no merged chains configured.


### PR DESCRIPTION
## Summary

Ports the p2pool / `main_dash.cpp` **node-owner fee + dev-donation** flag family to the BTC lane so a node operator can take a node-owner fee and set the dev-donation percentage, with **template AND verify reproducing the resulting coinbase** (shares still persist, `attempt_verify` unaffected).

New flags on `c2pool-btc` (all BTC-lane-scoped):

- `-f`, `--fee PCT` — node-owner fee percent (**default 0 = off**).
- `--node-owner-address ADDR` — fee destination (P2PKH / P2SH / P2WPKH).
- `--give-author PCT` (alias `--dev-donation`) — dev-donation percent; **default keeps the built-in 0.5%**, `0` allowed.

## Consensus model — committed-per-share (matches DASH / p2pool)

The node-owner fee is **NOT a new coinbase output**. It is a **payout-identity substitution**: with probability `fee%`, a job's payout identity becomes the owner's script, which flows into

1. the job coinbase (the finder fee `subsidy/200` output + future PPLNS weight), **and**
2. the created share's committed `pubkey_hash`/address.

`attempt_verify` (`share_check.hpp` `generate_share_transaction`) already reconstructs the finder fee from the share's **own** committed identity, so verify recomputes the coinbase byte-for-byte **with zero verify-side or share-format change**. This is the same mechanism DASH uses (`main_dash.cpp` `MintFeePolicy` / `resolve_mint_identity`) and p2pool's `work.py` probabilistic identity substitution.

### Coherence (why this does not hit the #1394 gentx-mismatch class)

BTC derives the payout script from the username at **two** points — job build (`stratum_server.cpp` → `build_connection_coinbase`) and submit (`mining_submit`, which re-derives it and hands it to `create_local_share`). A random template-side roll would desync the created share from the frozen coinbase and decline **every** substituted share (exactly PR #1394's class).

The substitution is therefore a **deterministic roll** over `(prev_share_hash, session extranonce1, miner_script)` — inputs both sites hold identically for a given job/session — so template, share and verify never diverge, with no job-state carry, no new share field, and no verify change. `prev_share_hash` re-rolls the decision every share interval; `extranonce1` decorrelates concurrent connections.

### `--give-author`

Sets the share's committed donation `u16` (`round(65535 * pct / 100)`), replacing the two hardcoded `donation = 50` sites (ref_hash lambda + `create_local_share`). Default stays `50` (0.5%) so an **unflagged deployment is byte-identical**. `0` is allowed — the donation output is still emitted (dust marker at amount 0). It changes the donation **amount only**; the donation **script is untouched**.

## Wiring

- `src/c2pool/main_btc.cpp` — arg parsing (+usage), `donation_u16` computed once and captured into the ref_hash / create_share lambdas, `set_node_owner_fee` wired after work-source construction (an undecodable owner address **disables** the fee, never pays an unspendable script).
- `src/impl/btc/stratum/work_source.{hpp,cpp}` — `node_owner_fee_pct_` / `node_owner_script_` members (guarded by `callback_mutex_`), `set_node_owner_fee` setter, `effective_payout_script` helper; applied in `build_connection_coinbase` (finder fee, degraded fallback, ref_hash) and in `mining_submit` before `create_share`.

## Safety / defaults

- **Defaults: fee 0 (off), donation `u16` 50** → an unflagged binary is byte-identical to before.
- **No changes to `share_check.hpp`** — verify is not loosened.
- BTC-lane-scoped only; LTC / DGB / DASH / BCH untouched.

## Build / verification

- Builds clean (`Release`, `cmake --build build --target c2pool-btc`).
- `--help` lists the three flags; unflagged startup path unchanged.
- Prestaged on the `btc.voidbind.com` canary (no service change) for the operator-directed `--fee 0.1 --node-owner-address 13zQ… --give-author 0` deploy: expect a `0.1%` coinbase output to `76a914…88ac`, dev-donation amount `0`, and `attempt_verify` FAILED staying `0` (shares persist).
