### PR TITLE
dashboard: fix intermittent load-time "not displaying" (PPLNS + sharechain) behind a reverse proxy

### DIFF
--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -1040,7 +1040,17 @@ void HttpSession::process_request()
 void HttpSession::send_response(http::response<http::string_body> response)
 {
     auto self = shared_from_this();
-    
+
+    // We shut down the send side of this socket immediately after the write
+    // completes (below), i.e. every response is the last one on its
+    // connection. Advertise that on the wire. Without an explicit
+    // "Connection: close", HTTP/1.1 defaults to keep-alive, so a reverse
+    // proxy (Caddy) pools and reuses the upstream connection — then races the
+    // server's FIN and intermittently returns 502 to the browser. Setting
+    // keep_alive(false) emits the header that matches our actual behaviour and
+    // eliminates that 502 class for every endpoint.
+    response.keep_alive(false);
+
     auto response_ptr = std::make_shared<http::response<http::string_body>>(std::move(response));
     
     http::async_write(socket_, *response_ptr,

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -7182,9 +7182,25 @@
                     grid.appendChild(cell);
                 });
         }
-        function loadMainPPLNS() {
+        // Bounded retries before the PPLNS treemap gives up. The treemap
+        // fetches its 355-byte /current_merged_payouts exactly once at page
+        // load (see page-init rationale), so a single transient failure — e.g.
+        // an intermittent 502 when a reverse proxy reuses an upstream socket
+        // the server has already half-closed — used to strand PPLNS at
+        // "Loading..." until the next manual/auto refresh. Retry with backoff
+        // (1.5s/3s/4.5s) so it self-heals, mirroring the sharechain-window
+        // retry above. Keeps the existing #pplns-loading placeholder visible
+        // (renderMainPPLNS only hides it on success).
+        var _pplnsLoadMaxRetries = 3;
+        function loadMainPPLNS(_attempt) {
+            var attempt = _attempt || 0;
             d3.json('../current_merged_payouts', function(payouts) {
-                if (!payouts || typeof payouts !== 'object') return;
+                if (!payouts || typeof payouts !== 'object') {
+                    if (attempt < _pplnsLoadMaxRetries) {
+                        setTimeout(function() { loadMainPPLNS(attempt + 1); }, 1500 * (attempt + 1));
+                    }
+                    return;
+                }
                 _cachedPPLNSPayouts = payouts;
                 renderMainPPLNS(payouts);
             });


### PR DESCRIPTION
## Symptom
On the live DASH canary (dash.voidbind.com, behind Caddy) the PPLNS treemap and the sharechain/defrag explorer intermittently render as a permanent **"Loading..."** on some page loads, while the backend, served file, and endpoints are all healthy. Direct requests to the upstream never fail; only browser-parallel loads through the proxy do, ~1 per few loads.

## Root cause
`HttpSession::send_response()` shuts down the send side of the socket immediately after **every** write — every response is the last one on its connection — but never emitted a `Connection: close` header. HTTP/1.1 therefore defaults to keep-alive on the wire, so Caddy pools and reuses the upstream connection and intermittently loses the race against the server's FIN, returning a sporadic **502** to the browser.

Both critical views fetch **once at page load with no retry**, so a single 502 on either strands that view at "Loading..." until a manual/auto refresh — an intermittent, load-time lottery that also explains why every served-file/binary check came back healthy.

## Fix (two independent parts)
1. **Backend** (`src/core/http_session.cpp`): `response.keep_alive(false)` in `send_response()` so the advertised header matches the actual close-after-every-response behaviour. Caddy stops reusing dead upstream sockets → the whole intermittent-502 class disappears for **every** endpoint (also the `/web/graph_data/*` tiles).
2. **Frontend** (`web-static/dashboard.html`): bounded retry with backoff (1.5s/3s/4.5s, 3 attempts) around the PPLNS treemap's one-shot `/current_merged_payouts` fetch, mirroring the sharechain-window retry already present in the defrag explorer. Keeps the `#pplns-loading` placeholder visible until data arrives.

The two parts are complementary: the header fix removes the cause; the retry is belt-and-suspenders for any remaining transient (DPI throttling, momentary stall) and is frontend-only / zero-restart.

## Verification
- Backend: live `curl -i` against the upstream confirmed responses carried **no** `Connection` header while the code half-closes after every write — the exact mismatch.
- Frontend retry deployed to the live canary's durable dashboard dir (per-request read, zero restart); served file re-verified over HTTPS.
- Diff is minimal: 29 insertions, 3 deletions, two files.