### PR TITLE
btc: --sharechain-addnode flag + suppress public-seed dialing on custom sharechain nets

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -89,6 +89,7 @@
 #include <malloc.h>         // [MEM] periodic malloc_trim(0) bounds glibc pool fragmentation (glibc-only)
 #endif
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <iostream>
 #include <map>
@@ -119,7 +120,17 @@ static void print_usage()
         "                       127.0.0.1:48333 (testnet4)\n"
         "                       127.0.0.1:18443 (regtest)\n"
         "  --p2pool H:P    BTC p2pool peer (jtoomim/SPB v35 + protocol 3502)\n"
-        "                  e.g. p2p-spb.xyz:9333\n"
+        "                  e.g. p2p-spb.xyz:9333. Single-peer alias for\n"
+        "                  --sharechain-addnode (exclusive target).\n"
+        "  --sharechain-addnode H:P  explicit sharechain (pool P2P) peer to\n"
+        "                  seed/pin. REPEATABLE. When given, the public p2pool\n"
+        "                  seed list is NOT dialed and the saved addr book is\n"
+        "                  reset — the node dials ONLY these peers. Use to join\n"
+        "                  a private/federation sharechain (with --network-id\n"
+        "                  --prefix). e.g. --sharechain-addnode 10.0.0.5:9333\n"
+        "                  NOTE: setting --network-id alone (no addnode) also\n"
+        "                  suppresses the public seed list — a custom-identity\n"
+        "                  node must never dial the open BTC p2pool network.\n"
         "  --stratum [H:]P stratum TCP listener for miners (B4-stratum)\n"
         "                  e.g. --stratum 9332           (binds 0.0.0.0:9332)\n"
         "                       --stratum 127.0.0.1:9332 (loopback only)\n"
@@ -183,6 +194,11 @@ int main(int argc, char* argv[])
     uint16_t    bitcoind_port = 0;
     std::string p2pool_host;
     uint16_t    p2pool_port   = 0;
+    // --sharechain-addnode HOST:PORT (repeatable): explicit federation
+    // sharechain peer(s). --p2pool folds in here as a single-entry alias so
+    // its old exclusive-target semantics are preserved. Non-empty => dial ONLY
+    // these peers (public seeds cleared, addrs.json reset).
+    std::vector<std::pair<std::string, uint16_t>> sharechain_addnodes;
     std::string stratum_addr  = "0.0.0.0";  // listen all interfaces by default
     uint16_t    stratum_port  = 0;          // 0 disables stratum; --stratum sets it
     std::string http_addr     = "0.0.0.0";  // dashboard bind; --http sets it (H-STATS.944)
@@ -261,6 +277,26 @@ int main(int argc, char* argv[])
             }
             p2pool_host = ep.substr(0, colon);
             p2pool_port = static_cast<uint16_t>(std::stoi(ep.substr(colon + 1)));
+            // Fold --p2pool into the unified explicit-peer list. A single
+            // --p2pool preserves its historical exclusive-target semantics
+            // (bootstrap = this one peer, addrs.json reset, target_outbound=1).
+            sharechain_addnodes.emplace_back(p2pool_host, p2pool_port);
+        }
+        else if (arg == "--sharechain-addnode" && i + 1 < argc)
+        {
+            // --sharechain-addnode HOST:PORT — repeatable. Seed/pin explicit
+            // federation sharechain peer(s). Same HOST:PORT validation as
+            // --p2pool; multiple flags accumulate.
+            std::string ep = argv[++i];
+            auto colon = ep.rfind(':');
+            if (colon == std::string::npos)
+            {
+                std::cerr << "--sharechain-addnode requires HOST:PORT\n";
+                return 1;
+            }
+            sharechain_addnodes.emplace_back(
+                ep.substr(0, colon),
+                static_cast<uint16_t>(std::stoi(ep.substr(colon + 1))));
         }
         else if (arg == "--stratum" && i + 1 < argc)
         {
@@ -1408,35 +1444,80 @@ int main(int argc, char* argv[])
     config.pool()->m_prefix = ParseHexBytes(btc::PoolConfig::prefix_hex());
     config.m_testnet        = testnet;
 
-    if (!p2pool_host.empty() && p2pool_port != 0)
-    {
-        // Single explicit target — clear defaults so we dial only the named peer.
-        config.pool()->m_bootstrap_addrs.clear();
-        config.pool()->m_bootstrap_addrs.emplace_back(p2pool_host, p2pool_port);
+    // Explicit precedence: --sharechain-addnode/--p2pool > --regtest >
+    // custom --network-id > public default. select_sharechain_bootstrap_mode
+    // (config_pool.hpp) is the pure, unit-tested seam.
+    const bool has_custom_network_id = !network_id_hex.empty();
+    const btc::SharechainBootstrapMode bootstrap_mode =
+        btc::select_sharechain_bootstrap_mode(
+            /*has_explicit_peers=*/!sharechain_addnodes.empty(),
+            /*regtest=*/regtest,
+            /*has_custom_network_id=*/has_custom_network_id);
 
-        // AddrStore ctor reads addrs.json from disk if present, MERGING any
-        // saved-from-prior-runs peers with our bootstrap_addrs. Saved peers
-        // can outrank our just-added explicit target (get_good_peers scores
-        // by first_seen/last_seen). When --p2pool is given the user has
-        // explicitly chosen this peer — reset addr store so it actually wins.
+    switch (bootstrap_mode)
+    {
+    case btc::SharechainBootstrapMode::ExplicitPeers:
+    {
+        // --sharechain-addnode (repeatable) and/or --p2pool. Dial ONLY the
+        // named peers — clear defaults and reset the saved addr book so saved
+        // public peers can't outrank the explicit targets (get_good_peers
+        // scores by first_seen/last_seen).
+        config.pool()->m_bootstrap_addrs.clear();
+        for (const auto& [h, p] : sharechain_addnodes)
+            config.pool()->m_bootstrap_addrs.emplace_back(h, p);
+
         const auto addrs_path = net_dir / "addrs.json";
         std::error_code rm_ec;
         std::filesystem::remove(addrs_path, rm_ec);  // best-effort
 
-        LOG_INFO << "[BTC] Sharechain bootstrap: explicit --p2pool "
-                 << p2pool_host << ":" << p2pool_port
-                 << " (addrs.json reset to enforce exclusive target)";
+        LOG_INFO << "[BTC] Sharechain bootstrap: " << sharechain_addnodes.size()
+                 << " explicit peer(s) (--sharechain-addnode/--p2pool; "
+                 << "addrs.json reset to enforce exclusive targets)";
+        break;
     }
-    else if (regtest)
-    {
+    case btc::SharechainBootstrapMode::RegtestIsolated:
         // Isolated regtest standup: NEVER dial the public mainnet p2pool seeds
         // (DEFAULT_BOOTSTRAP_HOSTS). Leaving the addr store empty keeps the
         // sharechain solo/local so a won block is never relayed to real peers.
-        // Supply --p2pool HOST:PORT to dial an explicit isolated tuned-net peer.
+        // Supply --sharechain-addnode HOST:PORT to dial an isolated tuned peer.
         LOG_INFO << "[BTC] Sharechain bootstrap: regtest — 0 public seeds (isolated)";
-    }
-    else
+        break;
+    case btc::SharechainBootstrapMode::CustomNetSuppressed:
     {
+        // Custom sharechain identity (--network-id) but no explicit peer. A
+        // federation must NOT dial the public BTC p2pool seeds: their
+        // prefix/identifier differ, the handshake is rejected at read_prefix,
+        // and the public address book poisons redials forever. Suppress the
+        // public seed list entirely. Additionally do a ONE-TIME reset of any
+        // addrs.json inherited from a prior public-net run, keyed by an
+        // identity marker file so legitimately-learned federation peers
+        // persist/redial afterwards.
+        const std::string identity = btc::PoolConfig::identifier_hex() + " "
+                                   + btc::PoolConfig::prefix_hex();
+        const auto marker_path = net_dir / "sharechain_identity";
+        std::string saved_identity;
+        {
+            std::ifstream mf(marker_path);
+            if (mf) std::getline(mf, saved_identity);
+        }
+        if (saved_identity != identity)
+        {
+            const auto addrs_path = net_dir / "addrs.json";
+            std::error_code rm_ec;
+            std::filesystem::remove(addrs_path, rm_ec);  // best-effort one-time
+            std::ofstream mf(marker_path, std::ios::trunc);
+            if (mf) mf << identity << "\n";
+            LOG_INFO << "[BTC] custom network-id: sharechain identity "
+                     << (saved_identity.empty() ? "unmarked" : "changed")
+                     << " → addrs.json reset once";
+        }
+        LOG_INFO << "[BTC] custom network-id: public sharechain seeds suppressed"
+                 << " (id=" << btc::PoolConfig::identifier_hex()
+                 << " prefix=" << btc::PoolConfig::prefix_hex()
+                 << "); supply --sharechain-addnode to seed a federation peer";
+        break;
+    }
+    case btc::SharechainBootstrapMode::PublicDefault:
         // Default seed list (PoolConfig::DEFAULT_BOOTSTRAP_HOSTS, port 9333).
         for (const auto& host : btc::PoolConfig::DEFAULT_BOOTSTRAP_HOSTS)
         {
@@ -1449,10 +1530,21 @@ int main(int argc, char* argv[])
         LOG_INFO << "[BTC] Sharechain bootstrap: "
                  << config.pool()->m_bootstrap_addrs.size()
                  << " default seeds";
+        break;
     }
 
     auto p2p_node = std::make_unique<btc::Node>(&ioc, &config);
-    p2p_node->set_target_outbound_peers(p2pool_host.empty() ? 4 : 1);
+    p2p_node->set_target_outbound_peers(
+        sharechain_addnodes.empty()
+            ? 4
+            : std::max<size_t>(1, sharechain_addnodes.size()));
+    // Suppress the coin-seed escalation bootstrapper on federation/custom nets
+    // and whenever explicit sharechain peers are pinned: its escalation tier
+    // injects PUBLIC Bitcoin COIN seeds (port 8333) into the pool addr store
+    // whenever the outbound deficit persists — which on a custom net is
+    // permanent — so a federation would perpetually dial the open coin network.
+    if (has_custom_network_id || !sharechain_addnodes.empty())
+        p2p_node->set_seed_escalation_enabled(false);
     // Default sharechain P2P port is 9333 (oracle byte-parity); --sharechain-port
     // overrides it for an isolated second instance (G3b tuned-net) without
     // touching the default or any shared-base constant.

--- a/src/impl/btc/config_pool.hpp
+++ b/src/impl/btc/config_pool.hpp
@@ -229,4 +229,33 @@ public:
     std::vector<NetService> m_bootstrap_addrs;
 };
 
+// ---------------------------------------------------------------------------
+// Sharechain bootstrap-source selection (pure, testable seam)
+//
+// main_btc must decide which sharechain (pool P2P) peers to bootstrap from.
+// Historically the ELSE branch loaded the PUBLIC BTC p2pool seed list
+// (DEFAULT_BOOTSTRAP_HOSTS, port 9333) EVEN when a custom --network-id/--prefix
+// federation identity was set — so a federation node dialed the open network
+// it can never handshake (prefix mismatch → read_prefix disconnect), poisoning
+// its addr book with public peers. This resolver makes the precedence explicit
+// and unit-testable. Defaults (no custom id, no explicit peers) → PublicDefault,
+// byte-identical to prior behavior.
+// ---------------------------------------------------------------------------
+enum class SharechainBootstrapMode {
+    ExplicitPeers,        // --sharechain-addnode/--p2pool given: dial ONLY those
+    RegtestIsolated,      // --regtest: 0 seeds, solo/local
+    CustomNetSuppressed,  // custom --network-id, no explicit peers: 0 public seeds
+    PublicDefault,        // public net, no explicit peers: DEFAULT_BOOTSTRAP_HOSTS
+};
+
+// Precedence: explicit peers > regtest > custom-network-id > public default.
+inline SharechainBootstrapMode select_sharechain_bootstrap_mode(
+    bool has_explicit_peers, bool regtest, bool has_custom_network_id)
+{
+    if (has_explicit_peers)   return SharechainBootstrapMode::ExplicitPeers;
+    if (regtest)              return SharechainBootstrapMode::RegtestIsolated;
+    if (has_custom_network_id) return SharechainBootstrapMode::CustomNetSuppressed;
+    return SharechainBootstrapMode::PublicDefault;
+}
+
 } // namespace btc

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1593,6 +1593,13 @@ void NodeImpl::start_outbound_connections()
     //                    tier resolves nothing and the FSM fast-advances past it
     //                    to the fixed tier (empty-tier advance path).
     //   tier 1 = fixed — static NetService fallback list (sync, works today).
+    //
+    // Skipped entirely on custom/federation nets (m_seed_escalation_enabled
+    // == false): the fixed tier is PUBLIC Bitcoin COIN seeds (port 8333) and a
+    // federation sharechain must never dial the open coin network. The tick
+    // sites below already null-check m_seed_bootstrapper, so leaving it unset
+    // simply disables escalation while the normal dial path keeps running.
+    if (m_seed_escalation_enabled)
     {
         const bool testnet = m_config->m_testnet;
         std::vector<btc::coin::SeedBootstrapper::TierFn> tiers;
@@ -1619,6 +1626,11 @@ void NodeImpl::start_outbound_connections()
             },
             std::move(tiers),
             std::random_device{}());  // per-node startup jitter decorrelation
+    }
+    else
+    {
+        LOG_INFO << "[Pool] Coin-seed escalation disabled "
+                    "(custom/federation net) — public COIN seeds suppressed";
     }
 
     // Try to connect to peers right away

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -524,6 +524,15 @@ public:
     /// A value of 0 disables outbound dialing.
     void set_target_outbound_peers(size_t count) { m_target_outbound_peers = count; }
 
+    /// Enable/disable the coin-seed escalation bootstrapper (default: enabled).
+    /// The escalation tier injects PUBLIC Bitcoin COIN seeds (port 8333) into
+    /// the POOL addr store whenever the outbound deficit persists. On a
+    /// custom/federation sharechain (custom --network-id/--prefix) that deficit
+    /// is permanent, so a federation would perpetually dial the open coin
+    /// network. main_btc disables this on custom nets / explicit-peer configs.
+    /// Must be called before start_outbound_connections().
+    void set_seed_escalation_enabled(bool enabled) { m_seed_escalation_enabled = enabled; }
+
     /// Set max total P2P peers (inbound + outbound).
     void set_max_peers(size_t count) { m_max_peers = count; }
 
@@ -683,6 +692,11 @@ protected:
     // signal into the pull-based Snapshot the bootstrapper reads each tick.
     std::unique_ptr<btc::coin::SeedBootstrapper> m_seed_bootstrapper;
     bool m_seed_candidates_exhausted = false;
+    // When false, start_outbound_connections() never constructs the
+    // SeedBootstrapper — set by main_btc on custom/federation nets so the
+    // escalation tier can't inject public COIN seeds (port 8333) into the pool
+    // addr store. Default true preserves public-net behavior byte-for-byte.
+    bool m_seed_escalation_enabled = true;
     // Periodic have_tx/losing_tx delta sweep (core/tx_advertiser.hpp). Cadence
     // mirrors the canonical known-tx removal loop, node.py:298 t.start(10).
     std::unique_ptr<core::Timer> m_tx_advert_timer;

--- a/src/impl/btc/test/regtest_sharechain_isolation_test.cpp
+++ b/src/impl/btc/test/regtest_sharechain_isolation_test.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "../config_coin.hpp"
+#include "../config_pool.hpp"
 
 // The incident itself: regtest=true with testnet=false (main_btc resets it).
 // This MUST isolate to bitcoin_regtest; the pre-fix code returned "bitcoin".
@@ -53,4 +54,54 @@ TEST(RegtestSharechainIsolation, AllThreeNamespacesDistinct)
     EXPECT_NE(rt, tn);
     EXPECT_NE(rt, mn);
     EXPECT_NE(tn, mn);
+}
+// ---------------------------------------------------------------------------
+// Sharechain bootstrap-source precedence KATs (select_sharechain_bootstrap_mode).
+//
+// Regression guard for the btc.voidbind federation-dial incident: a node with
+// a custom --network-id (federation identity) still loaded the PUBLIC BTC
+// p2pool seed list, so it perpetually dialed the open network it can never
+// handshake (prefix mismatch), never sharing the federation sharechain. These
+// KATs pin the precedence: explicit peers > regtest > custom-net > public.
+// ---------------------------------------------------------------------------
+using btc::SharechainBootstrapMode;
+using btc::select_sharechain_bootstrap_mode;
+
+// Explicit peers (--sharechain-addnode/--p2pool) win over everything, even a
+// custom net or regtest also being set.
+TEST(SharechainBootstrap, ExplicitPeersWinAlways)
+{
+    EXPECT_EQ(select_sharechain_bootstrap_mode(true, false, false),
+              SharechainBootstrapMode::ExplicitPeers);
+    EXPECT_EQ(select_sharechain_bootstrap_mode(true, true,  true),
+              SharechainBootstrapMode::ExplicitPeers);
+    EXPECT_EQ(select_sharechain_bootstrap_mode(true, false, true),
+              SharechainBootstrapMode::ExplicitPeers);
+}
+
+// regtest (no explicit peers) → isolated, never the public seeds.
+TEST(SharechainBootstrap, RegtestIsolatedWhenNoExplicitPeers)
+{
+    EXPECT_EQ(select_sharechain_bootstrap_mode(false, true, false),
+              SharechainBootstrapMode::RegtestIsolated);
+    // regtest beats custom-net when both set but no explicit peers.
+    EXPECT_EQ(select_sharechain_bootstrap_mode(false, true, true),
+              SharechainBootstrapMode::RegtestIsolated);
+}
+
+// The incident itself: a custom network-id with NO explicit peer must NOT
+// dial the public seeds — it selects the suppressed mode, not PublicDefault.
+TEST(SharechainBootstrap, CustomNetSuppressesPublicSeeds)
+{
+    EXPECT_EQ(select_sharechain_bootstrap_mode(false, false, true),
+              SharechainBootstrapMode::CustomNetSuppressed);
+    EXPECT_NE(select_sharechain_bootstrap_mode(false, false, true),
+              SharechainBootstrapMode::PublicDefault);
+}
+
+// Public net, no explicit peers, not regtest → the historical default path.
+TEST(SharechainBootstrap, PublicDefaultUnchanged)
+{
+    EXPECT_EQ(select_sharechain_bootstrap_mode(false, false, false),
+              SharechainBootstrapMode::PublicDefault);
 }


### PR DESCRIPTION
## Problem

A `c2pool-btc` node given a custom sharechain identity (`--network-id`/`--prefix`, i.e. a private/federation network) still loaded the **public** BTC p2pool seed list (`PoolConfig::DEFAULT_BOOTSTRAP_HOSTS`, port 9333) in the `else` branch of the bootstrap selector. It therefore perpetually dialed the open p2pool network it can never handshake with: inbound and outbound framing is rejected at `read_prefix()` the moment the prefix bytes mismatch, so no shares are exchanged and the learned public addresses poison the persisted addr book (`addrs.json`) forever. The coin-seed escalation tier compounded it by injecting public Bitcoin coin seeds (port 8333) into the pool addr store whenever the outbound deficit persisted, which on a custom net is permanent.

There was also no repeatable way to pin an explicit federation sharechain peer: only the single-target `--p2pool HOST:PORT` existed.

## Changes (BTC lane only; public-net behavior byte-identical)

- **`--sharechain-addnode HOST:PORT` (repeatable)** seeds/pins explicit federation sharechain peers. `--p2pool` folds in as a single-entry alias, preserving its historical exclusive-target semantics.
- The bootstrap-source decision is made explicit and unit-testable via `select_sharechain_bootstrap_mode()`. Precedence: explicit peers > regtest > custom network-id > public default.
- When a custom `--network-id` is set with no explicit peers, the public seed list is suppressed entirely and a one-time `addrs.json` reset is keyed by a `<data-dir>/<net>/sharechain_identity` marker so legitimately-learned federation peers persist and redial afterwards.
- `NodeImpl::set_seed_escalation_enabled(bool)` added; `main_btc` disables the coin-seed escalation bootstrapper on custom/federation nets and whenever explicit peers are pinned.
- KATs pin the bootstrap-source precedence truth table (ride the existing `btc_share_test` executable).

The default path (no custom network-id, no explicit peers) is untouched and continues to load `DEFAULT_BOOTSTRAP_HOSTS`.

## Verification

Built `c2pool-btc` (c2pool/dcfed4e3). `btc_share_test` bootstrap KATs: 8/8 pass.

Isolated scratch instance (own data-dir/ports, same `--network-id 7242ef345e1bed6b --prefix 3b3e1286f446b891`), three runs:

- **`--sharechain-addnode 127.0.0.1:9333`** (same-identity peer): dialed the peer, handshake **accepted** (prefix matched, protocol 3502 parsed), and **shares exchanged** (43 shares downloaded, parent-share sync in progress). Log: `Sharechain bootstrap: 1 explicit peer(s)` + `Coin-seed escalation disabled`. Outbound connections: exactly one sharechain peer (the target) plus one coin peer — **zero** public `:9333`.
- **custom network-id, no addnode**, with a pre-poisoned `addrs.json` (3 public p2pool entries): log `custom network-id: sharechain identity unmarked -> addrs.json reset once` + `public sharechain seeds suppressed`; `addrs.json` reset to empty, identity marker written, `0 bootstrap addrs`, **no** `:9333` dialing.
- **no `--network-id`** (public default): `Sharechain bootstrap: 7 default seeds` loaded — unchanged.
