### PR TITLE
ci: btc embedded-standalone daemonless smoke

### DIFF
--- a/.github/workflows/btc-embedded-standalone-smoke.yml
+++ b/.github/workflows/btc-embedded-standalone-smoke.yml
@@ -1,0 +1,124 @@
+name: BTC embedded-standalone daemonless smoke
+
+# ci-steward 2026-08-30. First CI coverage of the btc embedded-standalone
+# (daemonless) path proven live as btc.voidbind.com: c2pool-btc with NO
+# bitcoind, --coin-p2p-discover + --http :808x, headers climbing, HTTP 200.
+# A regression on that path is otherwise invisible until prod.
+#
+# Builds the c2pool-btc target, boots it daemonless, and asserts (bounded):
+# process stays up, HTTP ENGINE endpoint returns 200 (ENGINE, not /v36_status),
+# and the HeaderChain tip advances (headers climbing). Runs github-hosted for
+# guaranteed real DNS + P2P egress (the whole point of the smoke). The gate
+# emits a NAMED, logged skip if the coin network is unreachable, so a silent
+# skip can never read as green.
+#
+# Neutral-skip on branches/coins without the btc embedded-standalone sources
+# (PR #47 per-coin source-presence guard preserved — this job is an ADDITIVE
+# guard and does NOT relax the coin-matrix guard).
+
+on:
+  # additive: callable by ci-required.yml aggregator (no push/PR behaviour change)
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'ci-steward/btc-embedded-standalone-smoke'
+  pull_request:
+    paths:
+      - 'src/c2pool/main_btc.cpp'
+      - 'src/impl/btc/coin/coin_peer_manager.hpp'
+      - 'src/impl/btc/coin/chain_seeds.hpp'
+      - 'src/impl/btc/coin/header_chain.hpp'
+      - 'tests/gates/btc_embedded_standalone_smoke.sh'
+      - '.github/workflows/btc-embedded-standalone-smoke.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
+
+jobs:
+  btc-embedded-standalone-smoke:
+    name: BTC embedded-standalone daemonless smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check btc embedded-standalone source presence
+        id: presence
+        run: |
+          if [ -f "src/c2pool/main_btc.cpp" ] && [ -f "tests/gates/btc_embedded_standalone_smoke.sh" ]; then
+            echo "exists=1" >> "$GITHUB_OUTPUT"
+            echo "::notice::btc embedded-standalone sources present — running daemonless smoke."
+          else
+            echo "exists=0" >> "$GITHUB_OUTPUT"
+            echo "::notice::btc embedded-standalone sources absent on this branch — neutral skip (PR #47 guard preserved)."
+          fi
+
+      - name: Set per-job Conan home
+        if: steps.presence.outputs.exists == '1'
+        run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
+
+      - name: Install system dependencies
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            g++ ccache cmake make libleveldb-dev libsecp256k1-dev
+
+      - uses: actions/setup-python@v6
+        if: steps.presence.outputs.exists == '1'
+        with: { python-version: '3.12' }
+
+      - name: Install Conan 2
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          pip install "conan>=2.0,<3.0"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Restore Conan cache
+        if: steps.presence.outputs.exists == '1'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/conan2
+          key: conan2-ubuntu24-gcc13-btc-smoke-${{ hashFiles('conanfile.txt', 'ci/conan/linux-gcc13.profile', 'conan.lock') }}
+          restore-keys: |
+            conan2-ubuntu24-gcc13-btc-smoke-
+            conan2-ubuntu24-gcc13-
+
+      # Match the green coin-matrix provisioning exactly: lockfile-pinned deps
+      # and an EXPLICIT build_type=Release so conan generates the Release dep
+      # data cmake then consumes (no host/build build_type drift).
+      - name: Conan install
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          for attempt in 1 2 3; do
+            if conan install . \
+              -pr:a=ci/conan/linux-gcc13.profile \
+              --lockfile=conan.lock \
+              --build=missing \
+              --output-folder=build_ci \
+              --settings=build_type=Release; then exit 0; fi
+            echo "conan install failed (attempt $attempt/3); retrying in $((attempt * 15))s"
+            sleep $((attempt * 15))
+          done
+          exit 1
+
+      - name: Configure
+        if: steps.presence.outputs.exists == '1'
+        run: |
+          cmake -S . -B build_ci \
+            -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build c2pool-btc target
+        if: steps.presence.outputs.exists == '1'
+        run: cmake --build build_ci --target c2pool-btc -j"$(nproc)"
+
+      - name: Run btc embedded-standalone daemonless smoke
+        if: steps.presence.outputs.exists == '1'
+        shell: bash
+        env:
+          BUILD_DIR: build_ci
+        run: bash tests/gates/btc_embedded_standalone_smoke.sh

--- a/tests/gates/btc_embedded_standalone_smoke.sh
+++ b/tests/gates/btc_embedded_standalone_smoke.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# btc embedded-standalone daemonless boot smoke.
+# ci-steward 2026-08-30. First CI coverage of the btc embedded-standalone
+# (daemonless) path proven live as btc.voidbind.com: c2pool-btc with NO
+# bitcoind, --coin-p2p-discover + --http :808x, headers climbing, HTTP 200.
+# A regression on that path is otherwise invisible until prod.
+#
+# Boots the already-built c2pool-btc daemonless (no bitcoind, no --coin-rpc-*),
+# arms coin-network peer discovery (--coin-p2p-discover) and the operator
+# dashboard (--http), then asserts, within a BOUNDED window:
+#   1. the process stays up (no early crash / exit),
+#   2. the HTTP ENGINE endpoint returns 200 (check ENGINE, i.e. /node_info,
+#      NOT /v36_status, per the prod-redline-check-engine convention),
+#   3. the HeaderChain tip ADVANCES past the init baseline (headers climbing;
+#      canonical line "[BTC] new_headers: ... chain_height=<H>").
+#
+# Egress-honest: if DNS / P2P egress to the coin network is blocked, emit a
+# NAMED, logged skip so a network-isolated runner can never read as a silent
+# green. Short smoke, not a soak — bounded by SMOKE_WINDOW.
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build_ci}"
+HTTP_PORT="${HTTP_PORT:-8089}"
+BOOT_GRACE="${BOOT_GRACE:-20}"        # seconds to let the engine bind + handshake
+SMOKE_WINDOW="${SMOKE_WINDOW:-180}"   # max seconds to observe header progress
+
+# Locate the binary (default cmake layout, with a find fallback).
+BIN="${BIN:-$BUILD_DIR/src/c2pool/c2pool-btc}"
+if [ ! -x "$BIN" ]; then
+  BIN="$(find "$BUILD_DIR" -type f -name c2pool-btc -perm -u+x 2>/dev/null | head -1 || true)"
+fi
+[ -n "$BIN" ] && [ -x "$BIN" ] || { echo "::error::c2pool-btc binary not found under $BUILD_DIR"; exit 1; }
+
+DATA_DIR="$(mktemp -d /tmp/c2pool-btc-smoke.XXXXXX)"
+LOG="$DATA_DIR/node.log"
+NODE_PID=""
+cleanup() {
+  if [ -n "$NODE_PID" ]; then
+    kill "$NODE_PID" 2>/dev/null || true
+    wait "$NODE_PID" 2>/dev/null || true
+  fi
+  rm -rf "$DATA_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "[btc-smoke] binary: $BIN"
+echo "[btc-smoke] booting embedded-standalone: --coin-p2p-discover --http 127.0.0.1:$HTTP_PORT (no bitcoind)"
+"$BIN" --coin-p2p-discover --http "127.0.0.1:$HTTP_PORT" --data-dir "$DATA_DIR" > "$LOG" 2>&1 &
+NODE_PID=$!
+
+# 1) process stays up through the boot grace
+sleep "$BOOT_GRACE"
+if ! kill -0 "$NODE_PID" 2>/dev/null; then
+  echo "::error::c2pool-btc exited during boot grace — engine did not stay up"
+  echo "---- node.log ----"; cat "$LOG"; exit 1
+fi
+echo "[btc-smoke] engine still up after ${BOOT_GRACE}s boot grace"
+
+# Egress-honest NAMED skip: coin-network unreachable => logged skip, not green.
+if grep -qiE "no route to host|network is unreachable|name resolution fail|temporary failure in name resolution|dns.*(fail|unreachable)|no seeds|0 peers discovered" "$LOG"; then
+  echo "::notice::[btc-smoke] SKIP — coin-network egress blocked (DNS/P2P unreachable). NAMED skip, not a silent green."
+  echo "---- node.log (tail) ----"; tail -40 "$LOG"; exit 0
+fi
+
+# 2) HTTP ENGINE endpoint returns 200 (ENGINE, not /v36_status)
+code="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$HTTP_PORT/node_info" || true)"
+if [ "$code" != "200" ]; then
+  echo "::error::HTTP engine endpoint /node_info returned '$code' (expected 200)"
+  echo "---- node.log ----"; cat "$LOG"; exit 1
+fi
+echo "[btc-smoke] HTTP engine endpoint 200 OK (/node_info)"
+
+# baseline header height from the HeaderChain init line
+base_h="$(grep -oE '\[BTC\] HeaderChain initialized:.*height=[0-9]+' "$LOG" | grep -oE 'height=[0-9]+' | tail -1 | cut -d= -f2 || true)"
+base_h="${base_h:-0}"
+echo "[btc-smoke] baseline header height=$base_h"
+
+# 3) HeaderChain tip advances within the bounded window
+deadline=$(( SECONDS + SMOKE_WINDOW ))
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if ! kill -0 "$NODE_PID" 2>/dev/null; then
+    echo "::error::c2pool-btc exited mid-smoke"; echo "---- node.log ----"; cat "$LOG"; exit 1
+  fi
+  cur_h="$(grep -oE '\[BTC\] new_headers:.*chain_height=[0-9]+' "$LOG" | grep -oE 'chain_height=[0-9]+' | grep -oE '[0-9]+' | sort -n | tail -1 || true)"
+  cur_h="${cur_h:-0}"
+  if [ "$cur_h" -gt "$base_h" ]; then
+    echo "[btc-smoke] PASS — HeaderChain tip advanced $base_h -> $cur_h (engine red-line green)"
+    exit 0
+  fi
+  sleep 5
+done
+
+echo "::error::HeaderChain tip did not advance past $base_h within ${SMOKE_WINDOW}s (no headers climbing)"
+echo "---- node.log (tail) ----"; tail -120 "$LOG"; exit 1


### PR DESCRIPTION
## What

First CI coverage of the **btc embedded-standalone (daemonless)** path — proven live as `btc.voidbind.com`: `c2pool-btc` with **no bitcoind**, `--coin-p2p-discover --http :808x`, headers climbing, HTTP 200. That path currently has zero CI coverage, so a regression there is invisible until prod.

## How

New workflow `btc-embedded-standalone-smoke.yml` (github-hosted `ubuntu-24.04` for guaranteed real DNS + P2P egress, mirroring `ltc-embedded-bootstrap-live-gate`):
1. Builds the `c2pool-btc` target.
2. Boots it daemonless via `tests/gates/btc_embedded_standalone_smoke.sh`: `--coin-p2p-discover --http 127.0.0.1:8089`, no bitcoind, no `--coin-rpc-*`.
3. Bounded assertions (`SMOKE_WINDOW` default 180s — short smoke, not a soak):
   - process stays up (no early crash),
   - HTTP **ENGINE** endpoint `/node_info` returns **200** (ENGINE, **not** `/v36_status`, per the prod-redline-check-engine convention),
   - HeaderChain tip **advances** past the init baseline (parses `[BTC] new_headers: ... chain_height=` climbing).

Egress-honest: a **NAMED, logged skip** fires if the coin network is unreachable, so a network-isolated runner can never read as a silent green.

## Acceptance criteria

- [x] Builds btc target + boots embedded-standalone (no bitcoind), `--coin-p2p-discover` + `--http` on a test port.
- [x] Asserts process up, HTTP 200, header height advances (ENGINE red-line, not v36status).
- [x] Bounded runtime; does **not** relax any per-coin source-presence guard — adds an independent additive guard, coin-matrix PR #47 guard untouched.
- [x] New branch + PR; no master push, no self-merge (operator push-approval gate).

Not a required check until a confirmed non-hollow green rollup.