### PR TITLE
btc: follow the network v35 on the public sharechain (mint-freshness gate, ratchet truth, dashboard feeds)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1782,7 +1782,8 @@ int main(int argc, char* argv[])
         });
 
     work_source->set_ref_hash_fn(
-        [p2p_node_raw, auto_ratchet, donation_u16, &merged_configs](const uint256& prev_share_hash,
+        [p2p_node_raw, auto_ratchet, donation_u16, &merged_configs,
+         ws_bits = work_source.get()](const uint256& prev_share_hash,
                        const std::vector<unsigned char>& scriptSig,
                        const std::vector<unsigned char>& payout_script,
                        uint64_t subsidy, uint32_t block_bits, uint32_t timestamp,
@@ -1804,6 +1805,9 @@ int main(int argc, char* argv[])
             // running. Pre-Phase-12 we used `bits` (block bits) directly
             // as p.bits — that produced ref_hashes peers couldn't verify
             // (ref_hash includes share_bits, not block_bits).
+            // Record the BTC block target for the dashboard net-difficulty feed.
+            if (ws_bits) ws_bits->note_block_bits(block_bits);
+
             core::stratum::RefHashResult result;
             result.share_version   = 35;
             result.desired_version = 35;
@@ -2195,6 +2199,42 @@ int main(int argc, char* argv[])
             auto [voted_ver, voted_desired] = auto_ratchet->get_share_version(
                 p2p_node_raw->tracker(), job.prev_share_hash);
 
+            // ── C1: fail-closed mint-freshness gate (money) ──────────────────
+            // job.prev_share_hash is our best-VERIFIED tip (best_share_hash_fn →
+            // NodeImpl::best_share_hash, the verified head). On a mature foreign
+            // v35 chain the verified tip can lag the tallest RAW head the network
+            // handed us by thousands of shares while verification catches up.
+            // Minting on that stale parent extends a PRIVATE low-difficulty fork:
+            // compute_share_target has retargeted the share target down to our own
+            // few-TH/s, so the minted share sits far below the network's real
+            // share difficulty, the public PPLNS never credits it, and python
+            // peers reject/disconnect after the broadcast. Fail-closed: refuse the
+            // mint (miners keep their accepted pseudoshare work) until the verified
+            // tip catches the raw head. This STRICTLY REDUCES what we broadcast and
+            // can never mint a wrong share — reward-path safe. Cold start / genesis
+            // (prev null or unknown) is exempt so the first shares can still form.
+            {
+                auto& tk = p2p_node_raw->tracker();
+                int32_t raw_h = -1;
+                for (const auto& [hh, th] : tk.chain.get_heads()) {
+                    auto h = tk.chain.get_height(hh);
+                    if (h > raw_h) raw_h = h;
+                }
+                int32_t v_h = (!job.prev_share_hash.IsNull()
+                               && tk.chain.contains(job.prev_share_hash))
+                    ? tk.chain.get_height(job.prev_share_hash) : -1;
+                constexpr int32_t STALE_SHARES = 30;  // ~15 min at the ~30s cadence
+                if (raw_h >= 0 && v_h >= 0 && (raw_h - v_h) > STALE_SHARES) {
+                    static int stale_log = 0;
+                    if (stale_log++ % 20 == 0)
+                        LOG_WARNING << "[BTC-CREATE-SHARE] refused: verified tip stale"
+                                    << " (v_h=" << v_h << " raw_h=" << raw_h
+                                    << " gap=" << (raw_h - v_h) << " > " << STALE_SHARES
+                                    << ") — not extending a private low-diff fork";
+                    return uint256::ZERO;
+                }
+            }
+
             uint256 share_hash;
             // Merged-mining (NMC AuxPoW): one aux payout entry per --merged
             // chain, keyed by chain_id, paying the SAME deterministic effective
@@ -2522,14 +2562,165 @@ int main(int argc, char* argv[])
         mi->set_pool_hashrate_fn([p2p_node_raw]() -> double {
             return p2p_node_raw->get_tracker_snapshot().pool_hashrate;
         });
-        mi->set_sharechain_stats_fn([p2p_node_raw]() {
-            auto s = p2p_node_raw->get_tracker_snapshot();
-            return nlohmann::json{
-                {"chain_count", s.chain_count},
-                {"verified_count", s.verified_count},
-                {"head_count", s.head_count},
-                {"pool_hashrate", s.pool_hashrate},
-            };
+
+        // Seed the REST fallback share version from the AutoRatchet's live
+        // answer (VOTING on the public v35 chain → 35). Without this the
+        // dashboard read m_cached_share_version's header default and reported
+        // auto_ratchet.v36_active=true on a 100%-v35 chain (mirrors LTC
+        // main_ltc.cpp:3284). The stats fn below keeps it fresh every refresh.
+        {
+            int64_t initial_ver = 35;
+            auto guard = p2p_node_raw->read_tracker();
+            if (guard) {
+                auto [iv, idv] = auto_ratchet->get_share_version(*guard, uint256::ZERO);
+                initial_ver = iv;
+            }
+            mi->set_cached_share_version(initial_ver);
+        }
+
+        // Full sharechain stats — emits the LTC-family key set every REST
+        // consumer (rest_v36_status / rest_version_signaling / local_stats /
+        // graph) expects. The prior 4-field stub emitted chain_count/… which
+        // none of those keys matched, so /v36_status.share_chain.height and
+        // sample_size read 0 and version_signaling early-returned (overall_total
+        // <10), letting live_share_version fall back to the bogus header 36.
+        // Direct tracker walk under the read guard (BTC has no StatsSkipList);
+        // tip-driven cadence keeps the O(chain_length) walk off the hot path.
+        mi->set_sharechain_stats_fn([p2p_node_raw, auto_ratchet,
+                                     ws = work_source.get(), mi]() -> nlohmann::json {
+            static std::mutex   s_cache_mutex;
+            static nlohmann::json s_last_good;
+
+            auto guard = p2p_node_raw->read_tracker();
+            if (!guard) {
+                // Busy (compute thread holds the exclusive lock): hand back the
+                // last full result refreshed with volatile snapshot fields so
+                // the vote/sampling data does not flap to empty.
+                auto snap = p2p_node_raw->get_tracker_snapshot();
+                std::lock_guard<std::mutex> lock(s_cache_mutex);
+                nlohmann::json out = s_last_good.is_null()
+                    ? nlohmann::json::object() : s_last_good;
+                out["chain_height"]   = snap.chain_count;
+                out["total_shares"]   = snap.chain_count;
+                out["verified_count"] = snap.verified_count;
+                out["fork_count"]     = snap.fork_count;
+                return out;
+            }
+
+            auto& chain    = guard->chain;
+            auto& verified = guard->verified;
+
+            // Tallest RAW head (not the verified best) so the stats reflect the
+            // whole adopted chain even while the verified tip catches up.
+            uint256 best; int32_t best_height = -1;
+            for (const auto& [head_hash, tail_hash] : chain.get_heads()) {
+                auto h = chain.get_height(head_hash);
+                if (h > best_height) { best = head_hash; best_height = h; }
+            }
+
+            const int chain_len = static_cast<int>(btc::PoolConfig::chain_length());
+            const int chain_ht  = best.IsNull() ? 0 : static_cast<int>(chain.get_height(best));
+            const int walk      = std::min(chain_ht, chain_len);
+            const int skip_cnt  = std::min(chain_ht, chain_len * 9 / 10);
+            const int sample_cnt= std::min(chain_ht - skip_cnt, chain_len / 10);
+
+            std::map<std::string,int>    version_counts, desired_counts, miner_counts;
+            std::map<std::string,double> sampling_weights;  // work-weighted desired ver
+            double difficulty_sum = 0.0;
+            int total = 0, orphan = 0, dead = 0;
+
+            if (!best.IsNull() && walk > 0) {
+                int i = 0;
+                for (auto [hash, data] : chain.get_chain(best, walk)) {
+                    data.share.invoke([&](auto* s) {
+                        using T = std::remove_pointer_t<decltype(s)>;
+                        ++total;
+                        version_counts[std::to_string(static_cast<int>(T::version))]++;
+                        desired_counts[std::to_string(static_cast<int>(s->m_desired_version))]++;
+                        int si = static_cast<int>(s->m_stale_info);
+                        if (si == 253) ++orphan; else if (si == 254) ++dead;
+                        auto target = chain::bits_to_target(s->m_bits);
+                        difficulty_sum += chain::target_to_difficulty(target);
+                        std::string miner;
+                        if constexpr (requires { s->m_address; })
+                            miner = HexStr(s->m_address.m_data);
+                        else if constexpr (requires { s->m_pubkey_hash; })
+                            miner = s->m_pubkey_hash.GetHex();
+                        if (!miner.empty()) miner_counts[miner]++;
+                        if (i >= skip_cnt && i < skip_cnt + sample_cnt) {
+                            auto att = chain::target_to_average_attempts(target);
+                            sampling_weights[std::to_string(
+                                static_cast<int>(s->m_desired_version))] +=
+                                static_cast<double>(att.GetLow64());
+                        }
+                    });
+                    ++i;
+                }
+            }
+
+            // Live share version straight from the ratchet (ground truth for
+            // rest_version_signaling's auto_ratchet block + local_stats).
+            int64_t live_ver = 35;
+            { auto [lv, ldv] = auto_ratchet->get_share_version(*guard, best); live_ver = lv; }
+            if (mi) mi->set_cached_share_version(live_ver);
+
+            // Coin network difficulty from the last observed BTC block target
+            // (fills /local_stats net_difficulty + the netdiff graph series).
+            if (mi && ws) {
+                uint32_t bb = ws->last_block_bits();
+                if (bb) mi->update_network_difficulty(
+                    chain::target_to_difficulty(chain::bits_to_target(bb)), "btc-template");
+            }
+
+            nlohmann::json result;
+            result["chain_height"]  = chain_ht;
+            result["chain_length"]  = chain_len;
+            result["chain_tip_hash"]= best.IsNull() ? "" : best.GetHex();
+            result["total_shares"]  = total;
+            result["orphan_shares"] = orphan;
+            result["dead_shares"]   = dead;
+            result["fork_count"]    = static_cast<int>(chain.get_heads().size());
+            result["verified_count"]= static_cast<int>(verified.size());
+            result["shares_by_version"]         = version_counts;
+            result["shares_by_desired_version"] = desired_counts;
+            result["shares_by_miner"]           = miner_counts;
+            result["sampling_desired_version"]  = sampling_weights;
+            result["sampling_total"]            = sample_cnt;
+            result["average_difficulty"] = total > 0 ? difficulty_sum / total : 1.0;
+            result["live_share_version"] = live_ver;
+
+            nlohmann::json heads_arr = nlohmann::json::array();
+            for (auto& [h, t] : chain.get_heads()) heads_arr.push_back(h.GetHex());
+            result["heads"] = std::move(heads_arr);
+            nlohmann::json vheads_arr = nlohmann::json::array();
+            for (auto& [h, t] : verified.get_heads()) vheads_arr.push_back(h.GetHex());
+            result["verified_heads"] = std::move(vheads_arr);
+            nlohmann::json tails_arr = nlohmann::json::array();
+            for (auto& [t, hs] : chain.get_tails()) tails_arr.push_back(t.GetHex());
+            result["tails"] = std::move(tails_arr);
+
+            {
+                std::lock_guard<std::mutex> lock(s_cache_mutex);
+                s_last_good = result;
+            }
+            return result;
+        });
+        // Tip-driven: the payload only changes when a share lands (~1/30s on the
+        // public chain), not every second — keep it off the periodic refresh.
+        mi->mark_last_cache_tip_driven();
+
+        // Bridge the stratum worker registry (bitAXE sessions register on the
+        // BTCWorkSource, which was never wired to the WebServer → /local_stats
+        // showed "No miners connected" while rigs were live).
+        mi->set_stratum_workers_fn([ws = work_source.get()]() {
+            return ws ? ws->snapshot_stratum_workers()
+                      : std::map<std::string, core::stratum::WorkerInfo>{};
+        });
+        mi->set_stratum_hashrate_fn([ws = work_source.get()]() -> double {
+            if (!ws) return 0.0;
+            double total = 0.0;
+            for (auto& [id, w] : ws->snapshot_stratum_workers()) total += w.hashrate;
+            return total;
         });
         mi->set_node_topology_fn([&header_chain, &coin_node]() {
             const uint32_t synced   = header_chain.height();

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1310,7 +1310,14 @@ private:
     std::vector<std::pair<std::string, uint64_t>> m_cached_pplns_outputs;
     uint256 m_cached_pplns_best_share;
     bool m_cached_raw_scripts{false};
-    int64_t m_cached_share_version{36};  // V35/V36 PPLNS selection
+    // V35/V36 PPLNS selection. Defaults to the v35 network floor: this is the
+    // fallback rest_v36_status()/rest_version_signaling() read when a coin lane
+    // has not wired set_cached_share_version() or has no on-chain vote data yet.
+    // A {36} default made an unwired lane (BTC on the public v35 chain) report
+    // auto_ratchet.v36_active=true purely from this header value, even though the
+    // AutoRatchet state machine was VOTING and minting v35. The truthful floor is
+    // v35 — the ratchet lifts it to 36 only after the chain actually votes.
+    int64_t m_cached_share_version{35};
     std::string m_cached_witness_commitment;
     uint256 m_cached_witness_root;  // raw wtxid merkle root
     std::vector<uint8_t> m_cached_mm_commitment;

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -124,6 +124,31 @@ protected:
         s.verified_count = static_cast<int>(m_tracker.verified.size());
         s.head_count = static_cast<int>(m_tracker.chain.get_heads().size());
         s.fork_count = s.head_count;
+
+        // Pool hashrate estimate (H/s) over TARGET_LOOKBEHIND at the tallest
+        // head — the same p2pool get_pool_attempts_per_second the LTC family
+        // publishes. Without this, set_pool_hashrate_fn / the graph / local_stats
+        // read the never-populated snapshot field and reported 0 forever while
+        // the node was mining. Runs on the compute thread under the exclusive
+        // tracker lock (via run_think), so the chain read is safe.
+        try {
+            uint256 best; int32_t best_h = -1;
+            for (const auto& [head_hash, tail_hash] : m_tracker.chain.get_heads()) {
+                auto h = m_tracker.chain.get_height(head_hash);
+                if (h > best_h) { best = head_hash; best_h = h; }
+            }
+            if (!best.IsNull() && best_h >= 2) {
+                auto lookback = std::min(best_h,
+                    static_cast<int32_t>(btc::PoolConfig::TARGET_LOOKBEHIND));
+                uint288 aps = m_tracker.get_pool_attempts_per_second(
+                    best, lookback, /*min_work=*/false);
+                double hr = 0;
+                for (int i = uint288::WIDTH - 1; i >= 0; --i)
+                    hr = hr * 4294967296.0 + aps.pn[i];
+                s.pool_hashrate = hr;
+            }
+        } catch (...) { /* display-only; leave 0 on any transient */ }
+
         std::lock_guard<std::mutex> lock(m_snapshot_mutex);
         m_snapshot = s;
     }

--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -908,6 +908,17 @@ public:
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
         m_think_needs_continue = false;
 
+        // Frontier diagnostic (C2): when the verified tip lags the raw chain by
+        // a wide margin the mint path extends a stale private fork (money bug).
+        // Phase 2 swallows the first non-advancing share, so the CAUSE (missing
+        // parent body vs a deterministic v35 share_check incompatibility) was
+        // invisible. Log the FIRST failed frontier share + its parent state once
+        // per pass so the wedge root cause is measurable rather than inferred.
+        // Diagnostic only — changes no verification rule.
+        bool  p2_frontier_logged = false;
+        const int p2_raw_verified_gap =
+            static_cast<int>(chain.size()) - static_cast<int>(verified.size());
+
         // ── V36 livelock mirror: cooperative-yield budget for the scoring walk ──
         // The Phase 3/4 scoring step walks the decayed-cumulative-weight + PPLNS
         // window per scored head while holding m_tracker_mutex.  On a healthy
@@ -1074,8 +1085,29 @@ public:
                     // With our budget, don't count already-verified shares against it.
                     // Head B's walk through Head A's verified territory should be free.
                     bool was_already_verified = verified.contains(hash);
-                    if (!attempt_verify(hash))
+                    if (!attempt_verify(hash)) {
+                        // C2 frontier diagnostic: classify WHY the frontier share
+                        // will not verify. prev_in_chain=false → missing parent
+                        // body (need download); prev_in_chain && prev_verified →
+                        // a deterministic verify failure (candidate v35
+                        // share_check incompatibility → replay the bytes through
+                        // python p2pool before touching share_check.hpp).
+                        if (!p2_frontier_logged && p2_raw_verified_gap > 200) {
+                            p2_frontier_logged = true;
+                            bool prev_in_chain    = !prev_hash.IsNull() && chain.contains(prev_hash);
+                            bool prev_verified    = !prev_hash.IsNull() && verified.contains(prev_hash);
+                            LOG_WARNING << "[think-P2-frontier] stuck share=" << hash.GetHex().substr(0,16)
+                                        << " ver=" << share_ver
+                                        << " prev=" << prev_hash.GetHex().substr(0,16)
+                                        << " prev_in_chain=" << prev_in_chain
+                                        << " prev_verified=" << prev_verified
+                                        << " raw_verified_gap=" << p2_raw_verified_gap
+                                        << " reason=" << (!prev_in_chain ? "missing-parent-body"
+                                                          : (prev_verified ? "deterministic-verify-fail"
+                                                                           : "parent-unverified"));
+                        }
                         break;
+                    }
                     ++p2_verified_count;
                     if (!was_already_verified) {
                         --budget_remaining;

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -264,6 +264,23 @@ public:
         share_max_bits_.store(max_bits, std::memory_order_relaxed);
     }
 
+    /// Record the most recent BTC BLOCK header nBits observed while building
+    /// work (the GBT block target). Display-only: the dashboard derives the
+    /// coin network difficulty from this (/local_stats net_difficulty). 0 =
+    /// unknown (no work built yet).
+    void note_block_bits(uint32_t bits) { last_block_bits_.store(bits, std::memory_order_relaxed); }
+    uint32_t last_block_bits() const { return last_block_bits_.load(std::memory_order_relaxed); }
+
+    /// Lock-safe copy of the per-connection worker registry, for the dashboard
+    /// (set_stratum_workers_fn / set_stratum_hashrate_fn). The stratum sessions
+    /// register/update here (workers_) but nothing bridged it to the WebServer,
+    /// so /local_stats reported "No miners connected" while bitAXEs were live.
+    std::map<std::string, core::stratum::WorkerInfo> snapshot_stratum_workers() const
+    {
+        std::lock_guard<std::mutex> lk(workers_mutex_);
+        return workers_;
+    }
+
     /// Wire the share-tracker accessor that returns the current best-share
     /// hash. Called once at startup from main_btc.cpp after ShareTracker
     /// is constructed.
@@ -337,6 +354,8 @@ private:
     // ref_hash_fn's tracker.compute_share_target result (Phase 12).
     mutable std::atomic<uint32_t>       share_bits_{0};
     mutable std::atomic<uint32_t>       share_max_bits_{0};
+    // Most recent BTC BLOCK header nBits (GBT block target) — dashboard net diff.
+    std::atomic<uint32_t>               last_block_bits_{0};
 
     // Worker registry (per-connection metadata)
     mutable std::mutex          workers_mutex_;


### PR DESCRIPTION
## Summary

c2pool-btc on the public jtoomim/SPB **v35** sharechain (btc.voidbind) was mining
onto a stale private fork and rendering a misleading/empty dashboard. This fixes
four independent defects. **No share-format or verification-rule code is touched**
(`share.hpp` / `share_check.hpp` unchanged), so v35 byte-compatibility and the
accept gate are preserved by construction — the diff is entirely mint-timing,
snapshot, display, and diagnostics.

The public network is deliberately staying on v35 (no incentive to move to v36
until merged-mining ships), so c2pool must **follow** the network version, never
push it. The AutoRatchet state machine already does this correctly (it was VOTING
and minting v35); the reported `v36_active:true` was a dashboard artifact, not a
real activation.

## Changes

**C1 — mint-freshness gate (money).** The create-share path parents each mint on
our best-VERIFIED tip. On a mature foreign v35 chain that tip can lag the tallest
RAW head by thousands of shares while verification catches up; minting there
extends a private low-difficulty fork (`compute_share_target` retargets down to
our own hashrate) that the public PPLNS never credits and peers reject after
broadcast. Refuse to mint when `raw_head_height - parent_height` exceeds a small
threshold (miners keep their accepted pseudoshare work). Fail-closed: strictly
reduces what we broadcast, can never mint a wrong share, cold-start/genesis exempt.

**C2 — frontier diagnostic.** Phase 2 swallowed the first non-advancing frontier
share, hiding whether the verified tip lags due to a missing parent body or a
deterministic verify failure. Log the first stuck share and classify the cause
once per pass. Diagnostic only — no verification-rule change.

**C3 — ratchet truth (display).** `m_cached_share_version` defaulted to 36, so an
unwired lane reported `auto_ratchet.v36_active=true` on a 100%-v35 chain. Default
it to the v35 floor, seed it from the ratchet at startup, and emit the live ratchet
version through the sharechain stats fn so `rest_version_signaling` reports ground
truth.

**C4 — dashboard feeds (display).** BTC emitted a 4-field stats stub whose keys none
of the REST consumers matched, so `/v36_status` height/sample_size read 0 and
`version_signaling` early-returned. Emit the full LTC-family key set
(`chain_height`/`chain_length`/`total_shares`/`shares_by_version`/
`shares_by_desired_version`/`sampling_desired_version`/`average_difficulty`/
`live_share_version` + heads/tails). Fill `pool_hashrate` in `publish_snapshot`
from `get_pool_attempts_per_second` at the tallest head, push the coin network
difficulty from the observed block target, and bridge the stratum worker registry
so `/local_stats` shows connected miners and hashrate.

## Safety

- Only mint-timing / snapshot / display / diagnostic code changes; share format
  bytes and the v35 accept gate are untouched.
- C1 is fail-closed and only ever mints **less** — reward-path safe.
- C3/C4 are display-only; C2 is logging-only.
- Builds clean (`cmake --build build --target c2pool-btc -j6`).

Prestaged on btc.voidbind for operator restart; the live money pool is not
restarted by this PR.
