### PR TITLE
sharechain: keep a stale-tip node serving and never accept-then-drop a redialing peer

### DIFF
--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -229,6 +229,19 @@ void NodeImpl::close_connection(const NetService& service)
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
 
+    // Drop stale nonce->peer entries for this endpoint (parity with error()).
+    // close_connection is a peer-removal path too — without this a graceful
+    // close (e.g. the REPLACE-OLD duplicate swap) could leave a dangling
+    // m_peers[nonce] entry that makes later reconnects look like false
+    // duplicates.
+    for (auto it = m_peers.begin(); it != m_peers.end(); )
+    {
+        if (it->second && it->second->addr() == service)
+            it = m_peers.erase(it);
+        else
+            ++it;
+    }
+
     // Cancel pending share requests for this peer (same as in error())
     {
         std::vector<uint256> to_cancel;
@@ -298,10 +311,38 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
                 return std::nullopt;
         }
 
-        if (m_peers.contains(msg->m_nonce))
+        // Reject peers running too-old protocol BEFORE we touch m_peers, so a
+        // rejected handshake never inserts (and then has to unwind) a nonce entry.
+        // A refusal is pre-insert, with a logged reason + a thrown disconnect that
+        // the bridge turns into a clean error()+cleanup — never a silent
+        // accept-then-drop.
+        if (msg->m_version < bch::PoolConfig::MINIMUM_PROTOCOL_VERSION)
         {
-                LOG_DEBUG_POOL << "Detected duplicate connection, disconnecting from " << peer->addr().to_string();
-                return std::nullopt;
+            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
+                        << " protocol " << msg->m_version
+                        << " < minimum " << bch::PoolConfig::MINIMUM_PROTOCOL_VERSION
+                        << ", disconnecting";
+            throw std::runtime_error("peer protocol too old");
+        }
+
+        // Duplicate-nonce policy: REPLACE-OLD (accept-then-drop busy-loop fix).
+        // A peer redialing with the same (per-process) nonce is signalling its
+        // previous connection is gone from its side. The existing m_peers entry is
+        // very likely a half-dead connection we have not yet timed out (up to
+        // PEER_TIMEOUT_TIME away). Silently dropping the NEW dial wastes the
+        // accepted socket and forces the peer into a ~3s redial busy-loop,
+        // starving it of the bulk chain download it is asking for. Instead close
+        // the stale connection and accept the newest one, logged at INFO.
+        if (auto dup = m_peers.find(msg->m_nonce); dup != m_peers.end())
+        {
+                NetService old_addr = dup->second ? dup->second->addr() : NetService{};
+                LOG_INFO << "[Pool] Replacing stale duplicate connection for peer "
+                         << msg->m_addr_from.m_endpoint.to_string()
+                         << " (nonce match): closing previous " << old_addr.to_string()
+                         << ", accepting new " << peer->addr().to_string();
+                m_peers.erase(dup);
+                if (old_addr != peer->addr())
+                        close_connection(old_addr);
         }
 
         peer->m_nonce = msg->m_nonce;
@@ -312,16 +353,6 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
         {
             auto getaddrs_msg = bch::message_getaddrs::make_raw(8);
             peer->write(std::move(getaddrs_msg));
-        }
-
-        // Reject peers running too-old protocol
-        if (msg->m_version < bch::PoolConfig::MINIMUM_PROTOCOL_VERSION)
-        {
-            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
-                        << " protocol " << msg->m_version
-                        << " < minimum " << bch::PoolConfig::MINIMUM_PROTOCOL_VERSION
-                        << ", disconnecting";
-            throw std::runtime_error("peer protocol too old");
         }
 
         if (!msg->m_best_share.IsNull())

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -229,6 +229,19 @@ void NodeImpl::close_connection(const NetService& service)
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
 
+    // Drop stale nonce->peer entries for this endpoint (parity with error()).
+    // close_connection is a peer-removal path too — without this a graceful
+    // close (e.g. the REPLACE-OLD duplicate swap) could leave a dangling
+    // m_peers[nonce] entry that makes later reconnects look like false
+    // duplicates.
+    for (auto it = m_peers.begin(); it != m_peers.end(); )
+    {
+        if (it->second && it->second->addr() == service)
+            it = m_peers.erase(it);
+        else
+            ++it;
+    }
+
     // Cancel pending share requests for this peer (same as in error())
     {
         std::vector<uint256> to_cancel;
@@ -298,10 +311,38 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
                 return std::nullopt;
         }
 
-        if (m_peers.contains(msg->m_nonce))
+        // Reject peers running too-old protocol BEFORE we touch m_peers, so a
+        // rejected handshake never inserts (and then has to unwind) a nonce entry.
+        // A refusal is pre-insert, with a logged reason + a thrown disconnect that
+        // the bridge turns into a clean error()+cleanup — never a silent
+        // accept-then-drop.
+        if (msg->m_version < btc::PoolConfig::MINIMUM_PROTOCOL_VERSION)
         {
-                LOG_DEBUG_POOL << "Detected duplicate connection, disconnecting from " << peer->addr().to_string();
-                return std::nullopt;
+            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
+                        << " protocol " << msg->m_version
+                        << " < minimum " << btc::PoolConfig::MINIMUM_PROTOCOL_VERSION
+                        << ", disconnecting";
+            throw std::runtime_error("peer protocol too old");
+        }
+
+        // Duplicate-nonce policy: REPLACE-OLD (accept-then-drop busy-loop fix).
+        // A peer redialing with the same (per-process) nonce is signalling its
+        // previous connection is gone from its side. The existing m_peers entry is
+        // very likely a half-dead connection we have not yet timed out (up to
+        // PEER_TIMEOUT_TIME away). Silently dropping the NEW dial wastes the
+        // accepted socket and forces the peer into a ~3s redial busy-loop,
+        // starving it of the bulk chain download it is asking for. Instead close
+        // the stale connection and accept the newest one, logged at INFO.
+        if (auto dup = m_peers.find(msg->m_nonce); dup != m_peers.end())
+        {
+                NetService old_addr = dup->second ? dup->second->addr() : NetService{};
+                LOG_INFO << "[Pool] Replacing stale duplicate connection for peer "
+                         << msg->m_addr_from.m_endpoint.to_string()
+                         << " (nonce match): closing previous " << old_addr.to_string()
+                         << ", accepting new " << peer->addr().to_string();
+                m_peers.erase(dup);
+                if (old_addr != peer->addr())
+                        close_connection(old_addr);
         }
 
         peer->m_nonce = msg->m_nonce;
@@ -312,16 +353,6 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
         {
             auto getaddrs_msg = btc::message_getaddrs::make_raw(8);
             peer->write(std::move(getaddrs_msg));
-        }
-
-        // Reject peers running too-old protocol
-        if (msg->m_version < btc::PoolConfig::MINIMUM_PROTOCOL_VERSION)
-        {
-            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
-                        << " protocol " << msg->m_version
-                        << " < minimum " << btc::PoolConfig::MINIMUM_PROTOCOL_VERSION
-                        << ", disconnecting";
-            throw std::runtime_error("peer protocol too old");
         }
 
         if (!msg->m_best_share.IsNull())

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -230,6 +230,19 @@ void NodeImpl::close_connection(const NetService& service)
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
 
+    // Drop stale nonce->peer entries for this endpoint (parity with error()).
+    // close_connection is a peer-removal path too — without this a graceful
+    // close (e.g. the REPLACE-OLD duplicate swap) could leave a dangling
+    // m_peers[nonce] entry that makes later reconnects look like false
+    // duplicates.
+    for (auto it = m_peers.begin(); it != m_peers.end(); )
+    {
+        if (it->second && it->second->addr() == service)
+            it = m_peers.erase(it);
+        else
+            ++it;
+    }
+
     // Cancel pending share requests for this peer (same as in error())
     {
         std::vector<uint256> to_cancel;
@@ -299,10 +312,43 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
                 return std::nullopt;
         }
 
-        if (m_peers.contains(msg->m_nonce))
+        // Reject peers running too-old protocol BEFORE we touch m_peers, so a
+        // rejected handshake never inserts (and then has to unwind) a nonce entry.
+        // The floor is the RUNTIME ratcheted value (cold 1400, lifted to 3500 once
+        // >=95% of window work desires the best share's version --
+        // apply_min_protocol_ratchet), NOT the immutable config floor. Read
+        // lock-free; compute thread publishes via store. A refusal is pre-insert
+        // with a logged reason + a thrown disconnect — never a silent
+        // accept-then-drop.
+        const uint32_t min_proto =
+            m_runtime_min_protocol_version.load(std::memory_order_relaxed);
+        if (msg->m_version < min_proto)
         {
-                LOG_DEBUG_POOL << "Detected duplicate connection, disconnecting from " << peer->addr().to_string();
-                return std::nullopt;
+            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
+                        << " protocol " << msg->m_version
+                        << " < minimum " << min_proto
+                        << ", disconnecting";
+            throw std::runtime_error("peer protocol too old");
+        }
+
+        // Duplicate-nonce policy: REPLACE-OLD (accept-then-drop busy-loop fix).
+        // A peer redialing with the same (per-process) nonce is signalling its
+        // previous connection is gone from its side. The existing m_peers entry is
+        // very likely a half-dead connection we have not yet timed out (up to
+        // PEER_TIMEOUT_TIME away). Silently dropping the NEW dial wastes the
+        // accepted socket and forces the peer into a ~3s redial busy-loop,
+        // starving it of the bulk chain download it is asking for. Instead close
+        // the stale connection and accept the newest one, logged at INFO.
+        if (auto dup = m_peers.find(msg->m_nonce); dup != m_peers.end())
+        {
+                NetService old_addr = dup->second ? dup->second->addr() : NetService{};
+                LOG_INFO << "[Pool] Replacing stale duplicate connection for peer "
+                         << msg->m_addr_from.m_endpoint.to_string()
+                         << " (nonce match): closing previous " << old_addr.to_string()
+                         << ", accepting new " << peer->addr().to_string();
+                m_peers.erase(dup);
+                if (old_addr != peer->addr())
+                        close_connection(old_addr);
         }
 
         peer->m_nonce = msg->m_nonce;
@@ -313,21 +359,6 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
         {
             auto getaddrs_msg = dgb::message_getaddrs::make_raw(8);
             peer->write(std::move(getaddrs_msg));
-        }
-
-        // Reject peers running too-old protocol. The floor is the RUNTIME
-        // ratcheted value (cold 1400, lifted to 3500 once >=95% of window work
-        // desires the best share's version -- apply_min_protocol_ratchet), NOT the
-        // immutable config floor. Read lock-free; compute thread publishes via store.
-        const uint32_t min_proto =
-            m_runtime_min_protocol_version.load(std::memory_order_relaxed);
-        if (msg->m_version < min_proto)
-        {
-            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
-                        << " protocol " << msg->m_version
-                        << " < minimum " << min_proto
-                        << ", disconnecting";
-            throw std::runtime_error("peer protocol too old");
         }
 
         if (!msg->m_best_share.IsNull())

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -228,6 +228,19 @@ void NodeImpl::close_connection(const NetService& service)
     m_pending_outbound.erase(service);
     m_outbound_addrs.erase(service);
 
+    // Drop stale nonce->peer entries for this endpoint (parity with error()).
+    // close_connection is a peer-removal path too — without this a graceful
+    // close (e.g. the REPLACE-OLD duplicate swap) could leave a dangling
+    // m_peers[nonce] entry that makes later reconnects look like false
+    // duplicates.
+    for (auto it = m_peers.begin(); it != m_peers.end(); )
+    {
+        if (it->second && it->second->addr() == service)
+            it = m_peers.erase(it);
+        else
+            ++it;
+    }
+
     // Cancel pending share requests for this peer (same as in error())
     {
         std::vector<uint256> to_cancel;
@@ -297,10 +310,39 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
                 return std::nullopt;
         }
 
-        if (m_peers.contains(msg->m_nonce))
+        // Reject peers running too-old protocol BEFORE we touch m_peers, so a
+        // rejected handshake never inserts (and then has to unwind) a nonce entry.
+        // A refusal is pre-insert, with a logged reason + a thrown disconnect that
+        // the bridge turns into a clean error()+cleanup — never a silent
+        // accept-then-drop.
+        if (msg->m_version < m_tracker.m_params->minimum_protocol_version)
         {
-                LOG_DEBUG_POOL << "Detected duplicate connection, disconnecting from " << peer->addr().to_string();
-                return std::nullopt;
+            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
+                        << " protocol " << msg->m_version
+                        << " < minimum " << m_tracker.m_params->minimum_protocol_version
+                        << ", disconnecting";
+            throw std::runtime_error("peer protocol too old");
+        }
+
+        // Duplicate-nonce policy: REPLACE-OLD (accept-then-drop busy-loop fix).
+        // A peer redialing with the same (per-process) nonce is signalling its
+        // previous connection is gone from its side. The existing m_peers entry is
+        // very likely a half-dead connection we have not yet timed out (up to
+        // PEER_TIMEOUT_TIME away). Silently dropping the NEW dial — the pre-fix
+        // behaviour — wastes the accepted socket and forces the peer into a ~3s
+        // redial busy-loop, starving it of the bulk chain download it is asking
+        // for. Instead close the stale connection and accept the newest one, so a
+        // behind/fresh peer is actually served. Logged at INFO with the reason.
+        if (auto dup = m_peers.find(msg->m_nonce); dup != m_peers.end())
+        {
+                NetService old_addr = dup->second ? dup->second->addr() : NetService{};
+                LOG_INFO << "[Pool] Replacing stale duplicate connection for peer "
+                         << msg->m_addr_from.m_endpoint.to_string()
+                         << " (nonce match): closing previous " << old_addr.to_string()
+                         << ", accepting new " << peer->addr().to_string();
+                m_peers.erase(dup);
+                if (old_addr != peer->addr())
+                        close_connection(old_addr);
         }
 
         peer->m_nonce = msg->m_nonce;
@@ -311,16 +353,6 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
         {
             auto getaddrs_msg = ltc::message_getaddrs::make_raw(8);
             peer->write(std::move(getaddrs_msg));
-        }
-
-        // Reject peers running too-old protocol
-        if (msg->m_version < m_tracker.m_params->minimum_protocol_version)
-        {
-            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
-                        << " protocol " << msg->m_version
-                        << " < minimum " << m_tracker.m_params->minimum_protocol_version
-                        << ", disconnecting";
-            throw std::runtime_error("peer protocol too old");
         }
 
         if (!msg->m_best_share.IsNull())
@@ -441,12 +473,19 @@ void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
         // new batch (peers re-advertise their best share, so dropped shares
         // are re-requested later) and warn instead of growing unbounded.
         if (m_pending_adds.size() >= MAX_PENDING_ADDS) {
+            // Drop the OLDEST queued batch, not the incoming one. The newest
+            // batches carry the shares that extend the current live tip (incl.
+            // the incumbent-extending and challenger-backfill shares that a
+            // wedged think() needs to converge); the oldest queued batch is the
+            // most stale. Dropping newest — the pre-fix behaviour — starved the
+            // node of exactly the inputs that would advance/unfreeze its tip.
             LOG_WARNING << "[ASYNC-DEFER] BACKPRESSURE: pending_adds at cap ("
                         << m_pending_adds.size() << "/" << MAX_PENDING_ADDS
-                        << "), dropping batch of " << data.m_items.size()
-                        << " shares from " << addr.to_string()
-                        << " — think() may be wedged";
-            return;
+                        << "), dropping OLDEST queued batch to admit "
+                        << data.m_items.size() << " newer shares from " << addr.to_string()
+                        << " — think() may be slow";
+            m_pending_adds.erase(m_pending_adds.begin());
+            // fall through and queue the incoming (newest) batch below
         }
         LOG_INFO << "[ASYNC-DEFER] processing_shares_phase2: mutex busy, queuing "
                  << data.m_items.size() << " shares from " << addr.to_string()
@@ -1748,6 +1787,71 @@ void NodeImpl::disarm_think_watchdog()
         m_watchdog_timer->cancel();
 }
 
+ltc::SupersedeHint NodeImpl::gate_supersede_convergence(ltc::SupersedeHint hint)
+{
+    // Compute-thread only; caller holds the exclusive tracker lock.
+    const auto now = std::chrono::steady_clock::now();
+
+    // Expire old denylist entries so a segment whose parent later becomes
+    // obtainable can be retried.
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL)
+            it = m_supersede_denylist.erase(it);
+        else
+            ++it;
+    }
+
+    if (!hint.active)
+        return hint;
+
+    const uint256 seg = hint.target_segment_last;
+
+    // Already proven unconvergeable and not yet expired — keep it suppressed so
+    // the elevated-verify treadmill stays off and GC can reclaim the segment.
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable (parent unobtainable) — hint"
+                        " suppressed; normal argmax + GC continue";
+        return ltc::SupersedeHint{};
+    }
+
+    // Forward-progress metric: the challenger's verified accumulated height. On a
+    // genuinely converging fork this climbs every cycle as the elevated budget
+    // verifies deeper; on an unrooted/unobtainable-parent fork it stays pinned.
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); }
+    catch (...) { acc = 0; }
+
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height)
+    {
+        prog.last_acc_height = acc;
+        prog.stall_cycles = 0;
+    }
+    else
+    {
+        ++prog.stall_cycles;
+    }
+
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " made no verified-height progress in " << prog.stall_cycles
+                    << " cycles (verified_acc_height stuck at " << acc
+                    << "; missing parent unobtainable from all peers) — denylisting for "
+                    << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return ltc::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // Skip if a think() is already running on the compute thread.
@@ -1817,6 +1921,11 @@ void NodeImpl::run_think()
         ltc::SupersedeHint supersede = bootstrap
             ? ltc::SupersedeHint{}
             : m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET);
+        // Tip-freeze fix: refuse to keep spending the elevated verify budget on a
+        // challenger that never converges (missing parent unobtainable). Clears
+        // the hint after SUPERSEDE_STALL_LIMIT cycles of zero verified-height
+        // progress — breaking the treadmill and re-enabling GC of the zombie.
+        supersede = gate_supersede_convergence(supersede);
         m_supersede_hint = supersede;
         uint256 prev_best_for_flip = m_best_share_hash;
         if (supersede.active) {
@@ -2238,7 +2347,8 @@ void NodeImpl::clean_tracker()
             constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
             m_supersede_hint = bootstrap
                 ? ltc::SupersedeHint{}
-                : m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET);
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
                      << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
                      << (bootstrap ? " BOOTSTRAP" : "")

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -200,6 +200,34 @@ protected:
     // stuck-on-persisted-head latch). Inactive on a healthy node.
     ltc::SupersedeHint m_supersede_hint;
 
+    // ── Supersede-convergence liveness (tip-freeze livelock fix) ──────────
+    // The restart-reorg elevated verify budget assumes the challenger segment
+    // will eventually verify to CHAIN_LENGTH and the Phase-3 argmax will flip.
+    // That assumption fails when the challenger's missing parent is UNOBTAINABLE
+    // — no connected peer still retains it (its retention window has moved past
+    // that share). Then the challenger's verified height never advances,
+    // compute_supersede_hint re-arms it every cycle, and think() draws the
+    // elevated scrypt budget on the same never-winning shares forever: an
+    // infinite treadmill that holds the exclusive tracker lock for minutes,
+    // during which the IO serve path (handle_get_share, try_to_lock) returns
+    // EMPTY and inbound share batches are back-pressure dropped — the node
+    // refuses exactly the inputs that would advance/unfreeze its tip (the F4
+    // majority-deadlock pattern). We detect zero forward progress over
+    // SUPERSEDE_STALL_LIMIT consecutive cycles and denylist the segment (keyed
+    // by its stable target_segment_last) for SUPERSEDE_DENYLIST_TTL, which
+    // deactivates the hint — stopping the treadmill AND re-enabling GC of the
+    // zombie segment (clean_tracker's Guard-1b / tail-drop exemptions stop
+    // matching an inactive hint). A later-obtainable parent retries after TTL.
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    // Deactivate the hint if the challenger segment is proven unconvergeable
+    // (already denylisted, or freshly stalled this call). Compute-thread only,
+    // called under the exclusive tracker lock. Returns the (possibly cleared) hint.
+    ltc::SupersedeHint gate_supersede_convergence(ltc::SupersedeHint hint);
+
     // Buffer of newly verified share hashes, flushed to LevelDB periodically
     std::vector<uint256> m_verified_flush_buf;
 

--- a/src/impl/ltc/share_tracker.hpp
+++ b/src/impl/ltc/share_tracker.hpp
@@ -844,6 +844,26 @@ public:
         // exclusive lock between chunks (the lock-segmentation seam).
         m_think_needs_continue = false;
 
+        // Wall-clock bound on a single think() cycle (tip-freeze livelock fix).
+        // The exclusive tracker lock is held for the whole of think(); while it
+        // is held the IO serve path (handle_get_share, send_shares) uses
+        // try_to_lock and returns EMPTY, so a multi-second — in the livelock,
+        // multi-MINUTE — hold degenerates a behind peer's bulk download to empty
+        // replies and back-pressures inbound shares. Cap the per-cycle hold;
+        // m_think_needs_continue makes run_think() repost the remainder next tick
+        // (releasing+reacquiring the lock between chunks). Bootstrap is exempt:
+        // there is no verified chain to serve yet and stratum is not serving real
+        // work, so the initial full verify runs uncapped (matches p2pool's
+        // synchronous initial sync).
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
+
         // Phase-1 verification budget — async-model adaptation mirroring the
         // Phase-2 THINK_VERIFY_BUDGET below. p2pool walks walk_count=head_height
         // for rooted heads (last is None, data.py:2131) but prunes aggressively
@@ -1103,6 +1123,15 @@ public:
         prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
+            // Wall-clock bound (tip-freeze fix): stop the per-head sweep once this
+            // cycle has held the exclusive lock long enough; the remainder resumes
+            // next tick. No-op under bootstrap.
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+
             // Restart-reorg: is this verified head the frontier of the challenger
             // segment named by the hint? Matched by segment identity (the shared
             // missing-parent), so it survives the frontier advancing tick to tick.
@@ -1200,6 +1229,17 @@ public:
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
                                  << " verifications, deferring remainder"
                                  << (is_challenger ? " (challenger elevated pool spent)" : "");
+                        break;
+                    }
+                    // Wall-clock bound (tip-freeze fix): even with budget left, do
+                    // not hold the exclusive lock past THINK_MAX_WALL_MS — each
+                    // scrypt verify is ~20ms, so a large elevated pool could pin
+                    // the lock for many seconds. Resume next tick. Checked every
+                    // 8 verifies to keep the steady_clock reads cheap.
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] wall-clock cap hit after " << p2_verified_count
+                                 << " verifications, deferring remainder";
                         break;
                     }
 


### PR DESCRIPTION
## Problem

A warm-restarted LTC/DOGE sharechain node could wedge its own tip and then
starve the peers that would heal it. Observed on a production node whose tip
froze for ~9 hours; a plain restart cleared the runtime wedge but the build
could re-enter it.

Two coupled liveness defects:

**1. Tip-freeze livelock (restart-reorg supersede).** The elevated verify
budget that lets a warm-loaded node converge onto a higher-work fork assumes
the fork's missing parent is obtainable. When no connected peer still retains
that parent (its retention window has moved past that share), the challenger's
verified height never advances, `compute_supersede_hint` re-arms it every
cycle, and `think()` spends the elevated scrypt budget on the same
never-winning shares forever — holding the exclusive tracker mutex for
minutes at a time. While it is held, the serve path (`handle_get_share`,
`try_to_lock`) returns empty and inbound share batches are back-pressure
dropped, so the node refuses exactly the shares that would advance its tip.
The stale-tip state is self-sustaining; only a restart (state wipe) cleared it.

**2. Accept-then-drop peer busy-loop.** On a duplicate handshake nonce the
node silently dropped the NEW connection and kept the OLD (often half-dead)
one until the 100s peer timeout. A python-p2pool peer, whose nonce is stable
across redials, therefore hit accept → version → silent close in 2–5 ms on
every ~3 s redial for the whole timeout window and was never served the bulk
chain download it was asking for (631 established / 627 lost over the window).

## Fix

**Supersede liveness (LTC lane):**
- Gate the supersede hint: after `SUPERSEDE_STALL_LIMIT` cycles with no
  verified-height progress, denylist the challenger segment (TTL-bounded, so a
  later-obtainable parent retries). Deactivating the hint stops the elevated-
  verify treadmill and re-enables GC of the zombie segment — `clean_tracker`'s
  Guard-1b / tail-drop exemptions stop matching an inactive hint.
- Bound each `think()` cycle to `THINK_MAX_WALL_MS` wall time (bootstrap
  exempt); `needs_continue` already reposts the remainder next tick, so the
  exclusive lock is never held for minutes.
- On `pending_adds` backpressure, drop the OLDEST queued batch rather than the
  incoming one — the newest batches carry the shares that extend the live tip.

**Handshake / serve path (LTC, mirrored to DGB/BCH/BTC):**
- Duplicate-nonce policy is now REPLACE-OLD: close the stale connection and
  accept the newest dial, logged at INFO. A redial with the same nonce means
  the peer's previous connection is gone from its side, so the newest dial is
  authoritative and a behind peer is actually served instead of busy-looped.
- Move the min-protocol-version reject BEFORE the `m_peers` insert, so a
  refusal is pre-insert with a logged reason and never a silent
  accept-then-drop.
- Give `close_connection` the same `m_peers`-by-endpoint cleanup that `error()`
  has, so the REPLACE-OLD swap can never leave a dangling nonce entry.

The design mirrors the majority/liveness principle: recovery machinery must
never starve the inputs (shares, peers) that recovery needs.

## Testing

- Builds clean (GCC-13 Release, LTC `c2pool` target).
- `share_test`: 97/97 pass, including all 9 `LtcRestartReorgSupersede.*`
  cases — the supersede detector is unchanged; the gate is additive on top.
- New binary boots clean on the LTC mainnet sharechain (no crash, listener up).

Recommended pre-merge canary: a fresh/behind peer bulk-download against a node
running a synthetic long `think()`, and a python-p2pool peer redial loop, to
watch a behind peer get served and the connection hold (no 3 s accept-then-drop).
