### PR TITLE
dgb: bound the embedded HeaderChain to a rolling window so RSS plateaus

### DIFF
--- a/src/impl/dgb/coin/header_chain.hpp
+++ b/src/impl/dgb/coin/header_chain.hpp
@@ -43,6 +43,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <functional>
 #include <limits>
 #include <optional>
@@ -274,6 +275,7 @@ public:
 
             m_chain.push_back(h);
             m_cumulative_work += work_from_target(h.target);  // credited
+            trim_to_window();
             return IngestResult::VALIDATED_SCRYPT;
         }
 
@@ -282,6 +284,7 @@ public:
             // Extends the header chain; work-neutral (NO m_cumulative_work
             // change) and excluded from the retarget window by construction.
             m_chain.push_back(h);
+            trim_to_window();
             return IngestResult::ACCEPTED_CONTINUITY;
         }
     }
@@ -389,6 +392,40 @@ public:
     // the tip + its 10 nearest ancestors == 11 timestamps).
     static constexpr std::size_t MEDIAN_TIME_SPAN = 11;
 
+    // ── Rolling in-memory window bound (RSS plateau) ────────────────────────
+    // DigiByte's ~15 s block time makes this the fastest-growing embedded
+    // HeaderChain in the fleet: sync-from-genesis accumulates the ENTIRE ~24 M
+    // header history in RAM (~112 B/HeaderSample × 24.1 M ≈ 2.7 GB resident,
+    // the single largest memory consumer on the voidbind host and an OOM on a
+    // no-swap box). Nothing in this class needs the full history: the only
+    // consumers that index into m_chain read the TAIL —
+    //   * median_time_past()      -> last MEDIAN_TIME_SPAN (11) headers,
+    //   * next_retarget_window(w)  -> last `w` SCRYPT ancestors (retarget
+    //                                 scaffolding; w == 0 / disabled on the live
+    //                                 default-constructed chain),
+    //   * tip_hash() / tip_height() / next_block_height() -> back()/size().
+    // Absolute height is a pure function of base + index, and cumulative_work is
+    // a running scalar, so the chain can drop headers OLDER than a bounded
+    // window without changing ANY observable value: on eviction we pop_front()
+    // and bump m_base_height by the same count, leaving tip_height(),
+    // next_block_height() and cumulative_work() bit-identical while RAM
+    // plateaus. This mirrors the BTC lane's bounded working set
+    // (src/impl/btc/coin/header_chain.hpp HEADER_CACHE_CAP LRU) adapted to DGB's
+    // positional, hash-keyless, reorg-free structure — a rolling tail window is
+    // the DGB-appropriate form of the same "bounded RAM + trusted checkpoint of
+    // older headers" bound.
+    //
+    // The cap must comfortably exceed every tail consumer AND any legal reorg
+    // depth. 16384 headers ≈ 2.8 days of DGB blocks — vastly beyond the 11-wide
+    // MTP window, beyond any DigiShield retarget window, and beyond the minutes-
+    // scale finality a legal reorg could reach; the daemon-independent PoW/MTP
+    // gates a header ingest runs are all context-free or tail-local, so a header
+    // dropped below the window is never needed to validate the tip or a
+    // fork the chain could switch to. At 16384 × 112 B ≈ 1.8 MB the header
+    // subsystem's RSS is bounded regardless of chain height. Retained headers
+    // never exceed CAP + 1 transiently (one push_back before one pop_front).
+    static constexpr std::size_t HEADER_WINDOW_CAP = 16384;
+
     // MedianTimePast: median nTime over the tip and its (up to) MEDIAN_TIME_SPAN
     // nearest ancestors. Walks ALL appended headers regardless of algo --
     // DigiByte Core's GetMedianTimePast walks the block index, which interleaves
@@ -411,6 +448,23 @@ public:
     }
 
 private:
+    // Drop headers older than HEADER_WINDOW_CAP so RAM plateaus regardless of
+    // chain height. Popping the front and advancing m_base_height by the same
+    // count is height-neutral: tip_height() == m_base_height + size() - 1 and
+    // next_block_height() == m_base_height + size() are both invariant across a
+    // pop_front()+(++m_base_height). cumulative_work is a monotone running
+    // scalar (total work ever credited, never consumed by a V36 consensus
+    // path), so it is deliberately NOT decremented for an evicted header. Called
+    // after every push_back, so at most one eviction fires per append; the while
+    // loop is defensive should the cap ever be lowered at runtime.
+    void trim_to_window()
+    {
+        while (m_chain.size() > HEADER_WINDOW_CAP) {
+            m_chain.pop_front();
+            ++m_base_height;
+        }
+    }
+
     // Work proxy: inversely proportional to the target. The full-width field
     // narrows to low64() for the proxy, keeping cumulative_work byte-identical
     // for every uint64-range vector; the embedded port swaps in arith_uint256
@@ -436,7 +490,11 @@ private:
     DigiShieldParams          m_ds_params{};        // retarget gate params
     uint32_t                  m_base_height = 0;   // abs height of m_chain[0]
     std::size_t               m_retarget_window = 0; // Scrypt window depth
-    std::vector<HeaderSample> m_chain;          // oldest .. newest
+    // Bounded rolling window, oldest .. newest (front == m_base_height). A
+    // std::deque gives O(1) pop_front() for eviction (trim_to_window); every
+    // access here is positional / back() / size(), all O(1) on a deque, so the
+    // container swap from std::vector is behaviour-preserving for consumers.
+    std::deque<HeaderSample>  m_chain;          // oldest .. newest (<= CAP)
     uint64_t                  m_cumulative_work = 0;
 };
 

--- a/src/impl/dgb/test/header_chain_test.cpp
+++ b/src/impl/dgb/test/header_chain_test.cpp
@@ -131,6 +131,57 @@ TEST(HeaderChainValidate, EmptyChainAndZeroWindowAreSafe)
     EXPECT_EQ(rw.scrypt_samples, 0u);
 }
 
+// ---------------------------------------------------------------------------
+// Rolling in-memory window bound (RSS plateau). Appending far more than
+// HEADER_WINDOW_CAP headers must NOT grow the in-memory chain without bound:
+// size() plateaus at the cap while every ABSOLUTE-height / work accessor stays
+// exactly what an unbounded chain would report. This is the unit-level proof
+// that dropping ancient headers is observationally invisible to the tip.
+// ---------------------------------------------------------------------------
+TEST(HeaderChainWindowBound, SizePlateausWhileHeightAndWorkStayExact)
+{
+    HeaderChain hc;
+    const std::size_t CAP = HeaderChain::HEADER_WINDOW_CAP;
+    const std::size_t N   = CAP + 5000;   // well past the cap
+
+    // All-Scrypt, strictly increasing time (satisfies the MTP monotonicity
+    // gate), constant target 100 (pow_hash 0 <= 100 passes; default-ctor chain
+    // leaves the pow_limit ceiling unconfigured).
+    for (std::size_t i = 0; i < N; ++i) {
+        ASSERT_EQ(hc.validate_and_append({SCRYPT,
+                                          static_cast<int64_t>(1000 + i), 100}),
+                  IngestResult::VALIDATED_SCRYPT)
+            << "append " << i << " unexpectedly rejected";
+    }
+
+    // In-memory footprint is bounded, NOT proportional to N.
+    EXPECT_EQ(hc.size(), CAP);
+
+    // Absolute height is a pure function of base + index: the front was evicted
+    // and m_base_height advanced by the same count, so the tip is still at the
+    // Nth block regardless of how many headers were dropped.
+    ASSERT_TRUE(hc.tip_height().has_value());
+    EXPECT_EQ(hc.tip_height().value(), static_cast<uint32_t>(N - 1));
+    EXPECT_EQ(hc.next_block_height(), static_cast<uint32_t>(N));
+    EXPECT_EQ(hc.base_height(), static_cast<uint32_t>(N - CAP));
+
+    // cumulative_work is a monotone running scalar: total work ever credited,
+    // never decremented for an evicted header.
+    EXPECT_EQ(hc.cumulative_work(), static_cast<uint64_t>(N) * (UINT64_MAX / 100));
+
+    // The tail is intact: MedianTimePast reads the last 11 timestamps, which are
+    // the newest appended (1000 + N-11 .. 1000 + N-1); median == upper-middle.
+    EXPECT_EQ(hc.median_time_past(),
+              static_cast<int64_t>(1000 + (N - 1) - HeaderChain::MEDIAN_TIME_SPAN / 2));
+
+    // And validation continues correctly across the eviction boundary: the next
+    // header (strictly newer) is accepted and advances the tip by exactly one.
+    ASSERT_EQ(hc.validate_and_append({SCRYPT, static_cast<int64_t>(1000 + N), 100}),
+              IngestResult::VALIDATED_SCRYPT);
+    EXPECT_EQ(hc.size(), CAP);                                  // still bounded
+    EXPECT_EQ(hc.tip_height().value(), static_cast<uint32_t>(N));
+}
+
 
 // ---------------------------------------------------------------------------
 // DigiShield/MultiShield damped retarget multiply (digishield_next_target).


### PR DESCRIPTION
## Problem

The DGB embedded coin `HeaderChain` (the SPV header set kept in RAM for `--coin-p2p-discover` daemonless operation) grew without bound. Every appended header was `push_back()`ed into an append-only `std::vector<HeaderSample>` with no eviction, cap, or disk backing — there is no LevelDB member, no prune, no LRU anywhere in the class.

With DigiByte's ~15 s block time this is the fastest-growing embedded HeaderChain in the fleet: the node syncs from genesis and holds the **entire** header history resident. At the live chain height (~24.1M headers) that is `112 B/HeaderSample × 24.1M ≈ 2.7 GB`, matching the measured RSS on the voidbind host (2.6–2.7 GB) — the single largest memory consumer there, and an OOM on a no-swap box. Because nothing is persisted, each restart also re-downloads all ~24.1M headers from genesis and rebuilds the same balloon.

## Root cause

`validate_and_append()` only ever `push_back()`s (both the `VALIDATED_SCRYPT` and `ACCEPTED_CONTINUITY` paths). Every consumer that indexes into the chain reads only the **tail**:

- `median_time_past()` → last 11 headers (`MEDIAN_TIME_SPAN`);
- `next_retarget_window(w)` → last `w` Scrypt ancestors (retarget scaffolding; disabled on the live default-constructed chain);
- `tip_hash()` / `tip_height()` / `next_block_height()` → `back()` / `size()`.

The `getheaders` sync driver anchors its locator on `tip_hash()` (or genesis), never deep history. Absolute height is a pure function of `base + index`, and `cumulative_work` is a running scalar — so headers older than a bounded window can be dropped without changing any observable value.

## The bound (ported, not invented)

This mirrors the bounded RAM working set the **BTC/BCH lane already runs** (`src/impl/btc/coin/header_chain.hpp`, `HEADER_CACHE_CAP`), adapted to DGB's positional, hash-keyless, reorg-free header structure. On each append we `pop_front()` any header beyond `HEADER_WINDOW_CAP` (16384, ~2.8 days of DGB blocks) and advance `m_base_height` by the same count, leaving `tip_height()`, `next_block_height()` and `cumulative_work()` bit-identical. The container becomes a `std::deque` for O(1) `pop_front()`; every access is positional / `back()` / `size()`, all O(1) on a deque, so the swap is behaviour-preserving.

The cap comfortably exceeds every tail consumer (11-wide MTP, any retarget window) and any legal reorg depth, and trimming fires **during the initial sync too**, so the resync-time balloon is bounded as well as steady state.

## Proof (RSS plateau + observability invariance)

Process-level ingest of 3,000,000 synthetic headers, old (unbounded vector) vs new (rolling window), same stream:

| appended | OLD chain_size | OLD RSS | NEW chain_size | NEW RSS |
|---|---|---|---|---|
| 250k | 250,001 | 30.9 MB | 16,384 | **5.3 MB** |
| 1.0M | 1,000,001 | 113 MB | 16,384 | **5.3 MB** |
| 2.0M | 2,000,001 | 222 MB | 16,384 | **5.3 MB** |
| 3.0M | 3,000,000 | 332 MB | 16,384 | **5.3 MB** |

OLD climbs linearly (~112 B/header → 2.7 GB at the live height); NEW is **flat at ~5.3 MB** from the moment eviction begins. Final accessors on the bounded chain: `tip_height = N-1`, `next_block_height = N`, `base_height = N - CAP`, `cumulative_work` unchanged — exactly what the unbounded chain reports.

## Validation safety

- **Tip validation:** the ingest gates read only the tail — MTP monotonicity (last 11), per-header context-free PoW (pow_limit ceiling + `scrypt(header) ≤ declared target`); the parent-difficulty retarget gate is a documented no-op in V36. A 16384-header window vastly exceeds every consumer.
- **Legal reorg:** 16384 headers ≈ 2.8 days of DGB blocks — far beyond the minutes-scale finality a legal reorg could reach.
- **Work accounting:** `m_cumulative_work` is a monotone running scalar; work-neutral continuity headers stay work-neutral. It is deliberately not decremented on eviction.
- **Cold restart / daemonless serve:** unchanged — the node still syncs from `tip_hash()`/genesis and serves `previousblockhash` / BIP34 height from the tip. (Adding LevelDB persistence to also cut the ~70-min genesis resync is a separate follow-up; this PR is the RAM bound only.)

Adds a unit test (`header_chain_test.cpp`, already in the CI `--target` allowlist) asserting `size()` plateaus at the cap while every absolute-height / work / MTP accessor stays exact across the eviction boundary, and that validation continues correctly for the next header.

## Other lanes

- **btc / bch:** already bounded (LRU + LevelDB present) — **not leaking**.
- **ltc / dash / doge:** half-ported (LevelDB persistence + checkpoint but no LRU eviction) — a much slower latent leak at their block rates, and a different hash-keyed structure, so it needs a separate LRU-on-map change. Not touched here. DGB is the only lane with no disk store, no checkpoint, and a 15 s block rate — uniquely both the resync balloon and the fastest growth.

## Deploy

Not a self-merge — this touches the coin validation path via header availability, so review-required. A binary built from this branch is prestaged on the voidbind host for the operator to swap into `c2pool-dgb-voidbind.service`.
