### PR TITLE
dash: populate dashboard block-value/node-fee cards on the daemonless zero-rig relay

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1649,6 +1649,42 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 out["chain_height"]   = chain_ht;
                 out["stored_shares"]  = static_cast<int>(chain.size());  // all shares in the DB (incl. forks)
 
+                // ── Share-explorer nav: heads / tails / verified_* ────────────
+                // /web/heads, /web/tails, /web/verified_heads, /web/verified_tails
+                // (rest_web_heads/…) return sc["heads"] etc. ONLY if the key is
+                // present, else fall through to an empty array. This DASH lambda
+                // never emitted them, so all four served [] on the daemonless
+                // canary while /sharechain/window served the full 10k-share
+                // window from the SAME tracker (green-matrix #170 gap). Surface
+                // them from the tracker exactly as the LTC lane does
+                // (main_ltc.cpp: get_heads()/get_tails() on chain and verified).
+                // Honest-empty preserved: the arrays are empty only when the
+                // tracker truly has no heads/tails, and the busy-tick
+                // s_last_good cache carries these keys once populated (no flap).
+                {
+                    auto& verified = guard->verified;
+
+                    nlohmann::json heads_arr = nlohmann::json::array();
+                    for (const auto& [head_hash, tail_hash] : chain.get_heads())
+                        heads_arr.push_back(head_hash.GetHex());
+                    out["heads"] = std::move(heads_arr);
+
+                    nlohmann::json vheads_arr = nlohmann::json::array();
+                    for (const auto& [head_hash, tail_hash] : verified.get_heads())
+                        vheads_arr.push_back(head_hash.GetHex());
+                    out["verified_heads"] = std::move(vheads_arr);
+
+                    nlohmann::json tails_arr = nlohmann::json::array();
+                    for (const auto& [tail_hash, head_hashes] : chain.get_tails())
+                        tails_arr.push_back(tail_hash.GetHex());
+                    out["tails"] = std::move(tails_arr);
+
+                    nlohmann::json vtails_arr = nlohmann::json::array();
+                    for (const auto& [tail_hash, head_hashes] : verified.get_tails())
+                        vtails_arr.push_back(tail_hash.GetHex());
+                    out["verified_tails"] = std::move(vtails_arr);
+                }
+
                 // ── Single backward walk: desired-version votes, share-format
                 //    counts, per-miner tally, and V36 propagation depth ──────────
                 std::map<int, int> desired_counts;   // m_desired_version → count
@@ -4041,7 +4077,7 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // attempts_to_block read the live values. Non-fetching peek;
                 // display only, never drives coinbase or consensus.
                 mi->set_coin_work_fn(
-                    [wsrc = work_source.get(), &coinwork_maintainer]()
+                    [wsrc = work_source.get(), &coinwork_maintainer, testnet]()
                         -> core::MiningInterface::CoinWorkInfo {
                         core::MiningInterface::CoinWorkInfo info;
                         auto t = wsrc->peek_template();
@@ -4091,6 +4127,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                                     info.valid              = true;
                                     info.projected          = true;
                                     info.height             = height;
+                                    // SUPERBLOCK honesty: at a governance
+                                    // superblock height the real coinbase also
+                                    // pays the voted treasury budget as extra
+                                    // outputs. A daemonless node cannot know
+                                    // the voted total (needs governance
+                                    // objects), so reward/payments below EXCLUDE
+                                    // that lane — flag it instead of
+                                    // fabricating an amount. The miner share is
+                                    // exact regardless: superblock payouts come
+                                    // from the 20% carve-out already deducted
+                                    // from every block's subsidy. Cycle is
+                                    // network-specific (mainnet 16616, tn 24).
+                                    info.superblock =
+                                        dash::coin::is_superblock_height(
+                                            height,
+                                            testnet
+                                                ? dash::coin::
+                                                      DASH_SUPERBLOCK_CYCLE_TESTNET
+                                                : dash::coin::
+                                                      DASH_SUPERBLOCK_CYCLE_MAINNET);
                                     info.coinbase_value_sat =
                                         static_cast<uint64_t>(reward);
                                     info.payment_amount_sat =

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3981,6 +3981,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         });
     }
 
+    // ── DAEMONLESS zero-rig block-value fallback source ───────────────────
+    // The set_coin_work_fn lambda below feeds the dashboard's block-value /
+    // node-fee cards from wsrc->peek_template(). On a fully-daemonless relay
+    // with ZERO connected miners no stratum work demand ever sources a
+    // template, so peek_template() is null and block_value read 0. This
+    // pointer lets the lambda fall back to the header follower's published
+    // tip + the ported-from-dashd subsidy formulas (exactly the #57/#1366
+    // maintainer-fallback pattern already used for network_difficulty). It is
+    // assigned right after the CoinStateMaintainer is constructed below (stays
+    // null and harmless until then) and captured by-reference so the lambda
+    // sees it once live. Display/telemetry only; never drives coinbase.
+    dash::coin::CoinStateMaintainer* coinwork_maintainer = nullptr;
+
     if (stratum_port != 0) {
         stratum_server = std::make_unique<core::StratumServer>(
             ioc, stratum_host, stratum_port, work_source);
@@ -4028,11 +4041,83 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // attempts_to_block read the live values. Non-fetching peek;
                 // display only, never drives coinbase or consensus.
                 mi->set_coin_work_fn(
-                    [wsrc = work_source.get()]()
+                    [wsrc = work_source.get(), &coinwork_maintainer]()
                         -> core::MiningInterface::CoinWorkInfo {
                         core::MiningInterface::CoinWorkInfo info;
                         auto t = wsrc->peek_template();
-                        if (!t) return info;
+                        if (!t) {
+                            // ── DAEMONLESS ZERO-RIG FALLBACK ──────────────
+                            // No stratum work demand ever sourced a template
+                            // (peek_template() null on a zero-rig relay), so
+                            // the block-value / node-fee cards read 0 on the
+                            // fully-daemonless canary even though the header
+                            // follower knows the tip. Project the values from
+                            // the published tip + the ported-from-dashd pure
+                            // subsidy formulas (subsidy.hpp) — the SAME math
+                            // embedded_gbt.hpp uses to build the real accepted
+                            // coinbases (proven on-chain h=2516911/...). This
+                            // is a NON-fetching read of already-published
+                            // state; it never invokes the money-path template
+                            // builder from a display timer (#57 invariant).
+                            if (coinwork_maintainer) {
+                                uint32_t tip =
+                                    coinwork_maintainer->serve_tip_height();
+                                if (tip == 0)
+                                    tip = coinwork_maintainer
+                                              ->header_tip_height();
+                                if (tip != 0) {
+                                    uint32_t height = tip + 1;
+                                    int64_t reward =
+                                        dash::coin::
+                                            compute_dash_block_reward_post_v20(
+                                                height);
+                                    int64_t mn_lane =
+                                        dash::coin::
+                                            compute_dash_mn_payment_post_v20(
+                                                reward);
+                                    int64_t burn =
+                                        dash::coin::
+                                            compute_dash_platform_reward_post_v20_mn_rr(
+                                                height);
+                                    // block_value == subsidy on a coinbase-
+                                    // only body (no tx fees); the MN lane
+                                    // (3/4) holds the payee + the DIP-0027
+                                    // platform burn carved out of it, leaving
+                                    // miners the 1/4 the card displays. Keep
+                                    // payment_amount_sat = MN payee alone
+                                    // (its documented share-serialized
+                                    // meaning); payments_total_sat = the whole
+                                    // MN lane (payee + burn) the card nets out.
+                                    info.valid              = true;
+                                    info.projected          = true;
+                                    info.height             = height;
+                                    info.coinbase_value_sat =
+                                        static_cast<uint64_t>(reward);
+                                    info.payment_amount_sat =
+                                        static_cast<uint64_t>(
+                                            std::max<int64_t>(0,
+                                                              mn_lane - burn));
+                                    info.payments_total_sat =
+                                        static_cast<uint64_t>(mn_lane);
+                                    info.burn_sat =
+                                        static_cast<uint64_t>(burn);
+                                    uint32_t bits =
+                                        coinwork_maintainer
+                                            ->published_bits_for_next();
+                                    if (bits != 0)
+                                        info.network_difficulty =
+                                            chain::target_to_difficulty(
+                                                dash::coin::target_from_nbits(
+                                                    bits));
+                                    // No sourced template: age is not a
+                                    // wall-clock; -1 renders block_value_age
+                                    // as null and block_value_basis as
+                                    // "projected" so the card can say so.
+                                    info.template_age_sec = -1;
+                                }
+                            }
+                            return info;
+                        }
                         info.valid              = true;
                         info.coinbase_value_sat = t->m_coinbase_value;
                         info.payment_amount_sat = t->m_payment_amount;
@@ -4411,6 +4496,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // Display/telemetry only; the tick is cancelled before teardown, so the
         // maintainer always outlives every read.
         netdiff_maintainer = maintainer.get();
+        // Same header follower feeds the daemonless zero-rig block-value
+        // fallback in the set_coin_work_fn lambda above (captured by
+        // reference; null until now). The maintainer outlives every web read.
+        coinwork_maintainer = maintainer.get();
         mn_ckpt_lane = std::make_unique<dash::coin::MnCheckpointLane>();
         mn_ckpt_lane->set_max_bridge_blocks(g_mn_bridge_max_blocks);
 

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4351,6 +4351,13 @@ nlohmann::json MiningInterface::rest_local_stats()
             coin_work.template_age_sec >= 0
                 ? nlohmann::json(coin_work.template_age_sec)
                 : nlohmann::json(nullptr);
+        // Honest provenance: "template" = read off a sourced work template
+        // (live block value, has an age); "projected" = derived from the
+        // header follower's published tip + pure subsidy formulas on a
+        // daemonless zero-rig relay (exact miner share, no wall-clock age,
+        // superblock/fee extras not reflected). Lets the card label it.
+        result["block_value_basis"] =
+            coin_work.projected ? "projected" : "template";
     }
     // #948 gross-vs-net honesty. block_value_miner has always been NET of the
     // pool fee while block_value_payments is GROSS: two sibling fields sharing

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4358,6 +4358,16 @@ nlohmann::json MiningInterface::rest_local_stats()
         // superblock/fee extras not reflected). Lets the card label it.
         result["block_value_basis"] =
             coin_work.projected ? "projected" : "template";
+        // Superblock honesty: when the tip height is a DASH governance
+        // superblock, the real coinbase ALSO pays the voted treasury budget as
+        // extra outputs. A daemonless node cannot know the voted total, so
+        // block_value / block_value_payments EXCLUDE that lane here — flag the
+        // height rather than fabricate a payout. The miner share is exact
+        // regardless (superblock payouts come from the 20% carve-out already
+        // deducted from every block's subsidy). Emitted only when true so the
+        // key stays absent on ordinary heights and all non-DASH coins.
+        if (coin_work.superblock)
+            result["block_value_superblock"] = true;
     }
     // #948 gross-vs-net honesty. block_value_miner has always been NET of the
     // pool fee while block_value_payments is GROSS: two sibling fields sharing

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -702,6 +702,14 @@ public:
         // A stale template renders as a legitimate-looking block_value; the
         // age is what lets the dashboard say "this number is N minutes old".
         int64_t  template_age_sec = -1;
+        // TRUE when these values were PROJECTED from the header follower's
+        // published tip + the pure subsidy formulas rather than read off a
+        // sourced work template. Happens on a fully-daemonless zero-rig relay
+        // where no stratum work demand ever built a template: the miner share
+        // (subsidy/4) and MN split are exact, but there is no wall-clock age
+        // and superblock/fee extras are not reflected. Surfaced as
+        // block_value_basis so the card can label a projection honestly.
+        bool     projected = false;
     };
     void set_coin_work_fn(std::function<CoinWorkInfo()> fn) { m_coin_work_fn = thread_safe_wrap(std::move(fn)); }
 

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -710,6 +710,15 @@ public:
         // and superblock/fee extras are not reflected. Surfaced as
         // block_value_basis so the card can label a projection honestly.
         bool     projected = false;
+        // TRUE when `height` is a DASH governance superblock height. At such a
+        // height the real coinbase ALSO pays the voted treasury budget as
+        // extra outputs, but a daemonless node cannot know the voted total
+        // (needs governance objects) — so coinbase_value_sat / payments here
+        // EXCLUDE that lane. The miner share is unaffected (superblock payouts
+        // come from the 20% carve-out already deducted from every block's
+        // subsidy). Surfaced as block_value_superblock so the card can say the
+        // treasury-payout lane is not reflected, WITHOUT fabricating an amount.
+        bool     superblock = false;
     };
     void set_coin_work_fn(std::function<CoinWorkInfo()> fn) { m_coin_work_fn = thread_safe_wrap(std::move(fn)); }
 

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1892,17 +1892,17 @@
                 
                 <!-- Second Row: Miners Block Value -->
                 <div class="stat-card">
-                    <h3><span class="icon">💰</span> Miners Block Value <small style="opacity:0.7;">(gross, pre-fee)</small></h3>
+                    <h3><span class="icon">💰</span> Miners Block Value <small style="opacity:0.7;">(after MN + treasury; before pool fee)</small></h3>
                     <div class="stat-value warning"><span id="block_value_miner">-</span> <small class="symbol-small" id="block_value_symbol">-</small></div>
                     <div class="stat-sub merged-child-hint" style="color: #c3a634; font-size: 1.1em; margin-top: -4px;">+<span id="merged_block_value">-</span> <span class="merged-child-symbol-hint">DOGE</span></div>
-                    <div class="stat-detail" style="white-space: nowrap;" title="#948: this card shows the GROSS miner share; the pool fee is deducted to give the NET amount the API reports as block_value_miner">Fee: <span id="block_value_fee">-</span> &rarr; net <span id="block_value_miner_net">-</span></div>
+                    <div class="stat-detail" style="white-space: nowrap;" title="This card headline is the MINERS' share of the block — the DASH subsidy AFTER the masternode payment and the platform/treasury lane (DIP-0027 burn) are deducted. It is chain-truth: a deterministic function of the block HEIGHT, identical on every node, the same split embedded_gbt.hpp uses to build accepted coinbases. 'Gross'/'pre-fee' here means before the POOL fee only; the pool fee is then subtracted to give the NET amount the API reports as block_value_miner.">Fee: <span id="block_value_fee">-</span> &rarr; net <span id="block_value_miner_net">-</span></div>
                     <!-- #block_value and #block_value_payments were both written
                          by renderLocalStats but had NO elements in this page. The
                          card showed the miner slice with nothing to compare it
                          against, so on DASH there was no way to see that 1.7702
                          total minus 1.3277 of protocol outputs is what leaves
                          miners 0.4426. -->
-                    <div class="stat-detail" style="white-space: nowrap;" title="Full coinbase value of the block being worked on, and the protocol-mandated outputs deducted from it before the miner split (masternode / superblock / platform burn). Shown only on coins that have such a lane.">Block: <span id="block_value">-</span><span id="block_value_payments_part" style="display: none;"> &minus; protocol <span id="block_value_payments">-</span><span id="block_value_burn_part" style="display: none;"> (burn <span id="block_value_burn">-</span>)</span></span></div>
+                    <div class="stat-detail" style="white-space: nowrap;" title="Full coinbase value of the block being worked on, and the protocol-mandated outputs deducted from it before the miner split (masternode / superblock / platform burn). Shown only on coins that have such a lane.">Block: <span id="block_value">-</span><span id="block_value_payments_part" style="display: none;"> &minus; protocol <span id="block_value_payments">-</span><span id="block_value_burn_part" style="display: none;"> (burn <span id="block_value_burn">-</span>)</span></span><span id="block_value_superblock_part" style="display: none; opacity: 0.7;" title="This height is a DASH governance superblock: the real coinbase also pays the voted treasury budget as extra outputs. A daemonless node cannot know the voted total, so it is NOT included here — but the MINERS' share above is unaffected, since superblock payouts come from the 20% carve-out already deducted from every block."> &nbsp;(+ superblock treasury payouts, not shown)</span></div>
                     <div class="stat-detail" style="white-space: nowrap;">Expected: <span id="time_to_block">-</span> <span class="merged-child-hint"><span style="color: #c3a634;">|</span> <span style="color: #c3a634;"><span id="time_to_merged_block">-</span></span></span></div>
                 </div>
                 
@@ -3453,6 +3453,15 @@
                     d3.select('#block_value_payments').text(d3.format('.4f')(_bvp));
                 if (_hasBurn)
                     d3.select('#block_value_burn').text(d3.format('.4f')(_burn));
+                // Superblock honesty: at a DASH governance superblock height the
+                // real coinbase carries the voted treasury budget as extra
+                // outputs. A daemonless node cannot know the voted total, so
+                // block_value / block_value_payments EXCLUDE that lane — the
+                // backend flags the height instead of fabricating a payout. The
+                // miners' share is unaffected either way. Set on EVERY pass so
+                // the note never sticks after the tip leaves a superblock.
+                d3.select('#block_value_superblock_part')
+                    .style('display', local_stats.block_value_superblock === true ? null : 'none');
                 // #948: the card headline is the GROSS (pre-fee) miner share so it
                 // matches the API block_value_miner_gross field and the label says so;
                 // the fee and the resulting NET (legacy block_value_miner) are shown below.


### PR DESCRIPTION
## Problem

On a fully-daemonless DASH web node with zero connected miners (dash.voidbind.com canary: `--embedded-null-arm --embedded-utxo`, no `--coin-rpc`), the dashboard MINERS BLOCK VALUE and NODE FEE cards read `0.0000` even though mining, PPLNS, sharechain and luck all populate correctly.

Root cause per card:

- **MINERS BLOCK VALUE = 0** — `block_value` comes from the `set_coin_work_fn` feed (`main_dash.cpp`), which reads `DASHWorkSource::peek_template()`. On a zero-rig relay no stratum work demand ever sources a template, so `peek_template()` is null and the feed returns `valid=false`. Live `/local_stats` showed `block_value=0.0` with `block_value_height` absent — the `coin_work.valid=false` branch. This is the exact zero-rig-relay emptiness the #57/#1366 network-difficulty maintainer fallback already fixed for `network_difficulty` two blocks below this feed; that earlier fix covered only netdiff, never the coinbase value/height/payments.
- **NODE FEE = 0.0%** — correct and truthful, not a wiring gap. This node runs with no `--fee` and `--give-author 0`, so `set_node_fee_from_address` never fires and `m_pool_fee_percent` keeps its `0.0` default. A fee-free node truthfully reports `0.0%`; the `0.0000 DASH per block` amount is `block_value x 0 = 0`. No change to fee wiring.

## Fix

Extend the `set_coin_work_fn` lambda with the same maintainer fallback the netdiff feed uses: when `peek_template()` is null, project `CoinWorkInfo` from the `CoinStateMaintainer` published tip (`serve_tip_height()`, else `header_tip_height()`) plus the ported-from-dashd pure subsidy formulas in `subsidy.hpp` that `embedded_gbt.hpp` already uses to build accepted coinbases:

- `coinbase_value_sat = compute_dash_block_reward_post_v20(height)` (block value == subsidy on a coinbase-only body)
- `payments_total_sat = compute_dash_mn_payment_post_v20(...)` (the 3/4 masternode lane)
- `burn_sat = compute_dash_platform_reward_post_v20_mn_rr(height)` (DIP-0027 platform burn carved out of the MN lane)
- miners keep the 1/4 the card displays

The projection is gated on the same `m_have_tip` condition that gates the proven-live `network_difficulty` feed (both only publish once the serve tip is present), so block value lights up exactly when netdiff does. It is a non-fetching read of already-published state and never invokes the money-path template builder from a display timer (respects the #57 invariant). A new `block_value_basis` field (`projected` vs `template`) lets the card label a projection honestly (no wall-clock template age).

Display/telemetry only: no coinbase, consensus, or share-serialization field is touched.

## Live proof (daemonless zero-rig instance, this build)

`/local_stats` before -> after serve-tip promotion:

```
before:  block_value=0.0   block_value_height=absent   attempts_to_block=INT64_MIN
after:   block_value=1.64378041   block_value_height=2530489   block_value_basis=projected
         block_value_payments=1.2328353   block_value_burn=0.46231323
         block_value_miner_gross=0.41094511   node_fee=0.0   fee_percent=0.0
         attempts_to_block=403015202361655168
```

Arithmetic reconciles exactly: `miner_gross + payments = block_value`; `payments = block_value x 3/4`; `burn = payments x 375/1000`; `block_value` matches the current-era subsidy (164378041 duff). Node fee stays a truthful `0.0%` / `0.0000`.

## Scope / cross-lane

DASH-only source change (`main_dash.cpp`); the shared `web_server` emit already renders these fields. The same demand-fed `set_coin_work_fn` exists on every embedded-standalone lane, so the identical zero-rig hole is present on btc.voidbind (#1406 wired the demand-fed feed there) and on dgb/bch. BTC/DGB/BCH subsidy is a plain halving function, so the mirror is straightforward; recommend a follow-up per lane after this proves live.

Draft: display-side, operator deploys via ExecStart binary swap on the canary (flags unchanged).
