### PR TITLE
ci(web-static): extract Chrome zip in-process via yauzl, no system unzip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1003,6 +1003,14 @@ jobs:
         run: npm run verify
 
       - name: Install Chrome for pixel-regression harness
+        # Fast-fail cap: the warm-cache path is seconds and a cold fetch of
+        # the ~135MB Chrome-for-Testing zip is minutes even on VM905's
+        # throttled egress. Bound the step so a stalled CDN download surfaces
+        # a retryable red in minutes instead of wedging the runner >40min with
+        # no output (run 33317959171). This caps ONLY the browser provision;
+        # the "Visual pixel-diff harness" step below stays uncapped and fully
+        # gating (no continue-on-error anywhere near the diff).
+        timeout-minutes: 15
         run: |
           # GitHub-hosted: apt google-chrome/chromium is a real .deb and launches.
           # Self-hosted VM905 only offers snap chromium, which refuses to launch
@@ -1040,34 +1048,64 @@ jobs:
             PIN="$(sed -nE "s/.*chrome: *.([0-9.]+).*/\\1/p" node_modules/puppeteer-core/lib/puppeteer/revisions.js | head -1)"
             test -n "$PIN" || { echo "could not read pinned Chrome revision from puppeteer-core"; exit 1; }
             echo "puppeteer-core pins Chrome-for-Testing $PIN"
+            # PRIMARY extraction fix is the yauzl devDependency of
+            # sharechain-explorer (installed by npm ci above): @puppeteer/browsers
+            # discovers it via require() and unpacks the Chrome zip IN-PROCESS,
+            # so extraction NEVER depends on a system unzip binary. Before yauzl,
+            # a runner without unzip (VM905 has none) hit "no zip archiver is
+            # available", and the retry loop then re-downloaded 135MB per attempt
+            # → a >40min wedge (run 33317959171). The two lines below are a
+            # belt-and-suspenders ONLY: keep /usr/bin on PATH so a present unzip
+            # is found, and best-effort provision one — both fully guarded so a
+            # missing/locked apt can never fail the job. yauzl remains the fix.
+            case ":$PATH:" in *:/usr/bin:*) ;; *) export PATH="/usr/bin:$PATH" ;; esac
+            command -v unzip >/dev/null 2>&1 || flock /tmp/c2pool-apt.lock \
+              sudo -n apt-get install -y --no-install-recommends unzip >/dev/null 2>&1 || true
             CHROME_BIN="$(ls -1 "$HOME"/.cache/puppeteer/chrome/*"$PIN"/chrome-linux64/chrome ./chrome/*"$PIN"/chrome-linux64/chrome 2>/dev/null | tail -1 || true)"
             if [ ! -x "$CHROME_BIN" ]; then
-              # Partial-cache guard: an interrupted prior download can leave
-              # the versioned dir present with NO chrome-linux64/chrome binary.
-              # @puppeteer/browsers treats "dir exists" as installed and refuses
-              # to re-fetch, so every retry short-circuits to the same broken
-              # path and the gate false-reds (linux-151.0.7922.77 on
-              # actions-runner-8, run 31607961557). The install runs with no
-              # --path from working-directory web-static/sharechain-explorer, so
-              # the versioned dir lands under CWD ./chrome/*"$PIN", NOT only
-              # ~/.cache/puppeteer (the corrupt dir on actions-runner-2, run
-              # 31685136400, was ./chrome/linux-151.0.7922.77). Purge BOTH roots
-              # for this PIN before AND between fetch attempts so the download
-              # re-runs regardless of which layout holds the stale dir.
-              purge_partial() {
-                for d in "$HOME"/.cache/puppeteer/chrome/*"$PIN" ./chrome/*"$PIN"; do
-                  [ -d "$d" ] && [ ! -x "$d/chrome-linux64/chrome" ] && rm -rf "$d"
-                done
-                return 0
-              }
-              purge_partial
-              for attempt in 1 2 3; do
-                CHROME_BIN="$(npx --yes @puppeteer/browsers install "chrome@$PIN" | tail -1 | awk '{print $NF}')" \
-                  && [ -x "$CHROME_BIN" ] && break
-                echo "chrome-for-testing fetch attempt $attempt failed; retrying in $((attempt*10))s"
+              # Cold cache: serialize the fetch across the runners that share
+              # this $HOME (VM905 hosts actions-runner-2..8 on one home dir), so
+              # concurrent web-static jobs don't race the same 135MB download
+              # into the same versioned dir. Hold the lock on its own fd for the
+              # whole cold path; mirror the existing /tmp/c2pool-apt.lock idiom.
+              CACHE_DIR="$HOME/.cache/puppeteer"
+              exec 9>/tmp/c2pool-puppeteer.lock
+              flock 9
+              # Re-check the warm cache now that we hold the lock — a concurrent
+              # job may have finished the download while we waited on flock.
+              CHROME_BIN="$(ls -1 "$CACHE_DIR"/chrome/*"$PIN"/chrome-linux64/chrome 2>/dev/null | tail -1 || true)"
+              if [ ! -x "$CHROME_BIN" ]; then
+                # Partial-cache guard: an interrupted prior download can leave
+                # the versioned dir present with NO chrome-linux64/chrome binary.
+                # @puppeteer/browsers treats "dir exists" as installed and refuses
+                # to re-fetch, so every retry short-circuits to the same broken
+                # path and the gate false-reds (linux-151.0.7922.77 on
+                # actions-runner-8, run 31607961557). Purge BOTH the persistent
+                # cache root and any legacy CWD ./chrome/*"$PIN" (older runs
+                # installed with no --path, e.g. run 31685136400) for this PIN
+                # before AND between fetch attempts so the download re-runs
+                # regardless of which layout holds the stale dir.
+                purge_partial() {
+                  for d in "$CACHE_DIR"/chrome/*"$PIN" ./chrome/*"$PIN"; do
+                    [ -d "$d" ] && [ ! -x "$d/chrome-linux64/chrome" ] && rm -rf "$d"
+                  done
+                  return 0
+                }
                 purge_partial
-                sleep $((attempt*10))
-              done
+                for attempt in 1 2 3; do
+                  # --path pins the download into the PERSISTENT per-host cache
+                  # (survives the "Prune runner workspace" step, which only drops
+                  # the CWD checkout) so a warm run touches NO network and every
+                  # runner sharing this $HOME reuses one fill. Extraction is
+                  # in-process via the yauzl devDependency — no system unzip.
+                  CHROME_BIN="$(npx --yes @puppeteer/browsers install "chrome@$PIN" --path "$CACHE_DIR" | tail -1 | awk '{print $NF}')" \
+                    && [ -x "$CHROME_BIN" ] && break
+                  echo "chrome-for-testing fetch attempt $attempt failed; retrying in $((attempt*10))s"
+                  purge_partial
+                  sleep $((attempt*10))
+                done
+              fi
+              flock -u 9
             fi
             test -x "$CHROME_BIN" || { echo "puppeteer chrome install failed after retries"; exit 1; }
             echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"

--- a/web-static/sharechain-explorer/package-lock.json
+++ b/web-static/sharechain-explorer/package-lock.json
@@ -15,7 +15,8 @@
         "pngjs": "^7.0.0",
         "puppeteer-core": "^25.6.0",
         "tsx": "^4.22.4",
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "yauzl": "^3.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -719,6 +720,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pixelmatch": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-6.0.0.tgz",
@@ -958,6 +966,19 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/zod": {

--- a/web-static/sharechain-explorer/package.json
+++ b/web-static/sharechain-explorer/package.json
@@ -30,6 +30,7 @@
     "pngjs": "^7.0.0",
     "puppeteer-core": "^25.6.0",
     "tsx": "^4.22.4",
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "yauzl": "^3.4.0"
   }
 }


### PR DESCRIPTION
## Problem

The `Web-static verify` job's `Install Chrome for pixel-regression harness` step provisions a Chrome-for-Testing build through `@puppeteer/browsers`. On a runner without a system `unzip` binary (the self-hosted VM905 runners have none), extraction fails with:

```
All providers failed for chrome ...:
 - DefaultProvider: Extraction failed: no zip archiver is available.
   Install `unzip` (or `tar.exe`/Powershell on Windows), or add the optional `yauzl` dependency.
```

The step's bounded retry loop then re-downloads the ~135MB zip from byte 0 on every attempt (extraction is a guaranteed failure without an archiver), wedging the step for 40+ minutes with no output before it finally red-fails. Observed on run 33317959171 (runner actions-runner-8).

## Fix

Runner-agnostic, robustness + speed, and the pixel-diff gate is left fully intact.

1. **Primary — in-process extraction via `yauzl`.** Add `yauzl` as a devDependency of `@c2pool/sharechain-explorer` (the only package carrying `puppeteer-core`/`@puppeteer/browsers`) and update the lockfile. `@puppeteer/browsers` discovers `yauzl` via `require()` and unpacks the zip in-process, so extraction no longer depends on any system `unzip` on any runner. This is the puppeteer-documented fallback the error message itself names.

   Verified locally on Node 22 (matching CI) with the exact locked `@puppeteer/browsers@3.2.0`, under a `PATH` containing only node/sh/bash and **no unzip**: before yauzl the install reproduced the exact CI error; after installing yauzl the zip extracted in-process and produced an executable binary, exit 0.

2. **Belt-and-suspenders (secondary).** Keep `/usr/bin` on `PATH` and best-effort provision `unzip`, both fully guarded so a missing/locked apt can never fail the job. `yauzl` is the primary fix; this is not relied upon.

3. **Persistent cache + serialize the fetch.** Pass `--path` so the download lands in the persistent per-host `~/.cache/puppeteer` (which survives the `Prune runner workspace` step that only drops the CWD checkout). A warm run then touches no network, and every runner sharing the home dir reuses one fill. The cold fetch is serialized under a `flock` so concurrent jobs don't race the same download, with a warm re-check after acquiring the lock.

4. **Fast-fail timeout.** Cap the install step with `timeout-minutes: 15` so a stalled CDN download fails fast and retryably instead of wedging the runner 40+ min.

## Gate not weakened

The `Visual pixel-diff harness` step is untouched — no `timeout-minutes`, no `continue-on-error`, still fully gating. The timeout added applies only to the Chrome-provisioning step.

## Proof

This PR's own `Web-static verify` check exercises the Chrome install and must go green (yauzl extraction path, no unzip error).
