### PR TITLE
btc: populate dashboard block-value/node-fee cards on the daemonless zero-rig relay

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -32,6 +32,7 @@
 // non-broadcaster shape suitable for B2-net smoke testing.
 
 #include <impl/btc/coin/header_chain.hpp>
+#include <impl/btc/coin/template_builder.hpp> // btc::coin::get_block_subsidy — zero-rig block-value projection (dashboard cards)
 #include <impl/btc/coin/tip_reconcile_gate.hpp> // B5b: TipReconcileGate SSOT (10s re-poll cadence + fire predicate) shared with tip_reconcile_test.cpp
 #include <impl/btc/coin/mempool.hpp>
 #include <impl/btc/coin/node.hpp>
@@ -2592,6 +2593,56 @@ int main(int argc, char* argv[])
             return p2p_node_raw->best_share_hash();
         });
 
+        // §6b Block value (MINERS BLOCK VALUE / NODE FEE cards) — mirror of the
+        // DASH #1409 daemonless zero-rig fallback, BTC-adapted. The web MI is
+        // stood up with a NULL IMiningNode (above), so refresh_work() never fills
+        // m_cached_template and the core block-value read (web_server.cpp ~4316)
+        // stays 0; with no set_coin_work_fn producer the fallback at ~4325 has
+        // nothing to fall back to, so the cards read 0.0000 BTC / 0.0 % on the
+        // zero-rig relay even though the embedded header follower knows the tip.
+        // Project CoinWorkInfo from the header-follower tip + the ported-from-Core
+        // BTC subsidy formula (template_builder.hpp get_block_subsidy, the SAME
+        // math block_assembly.hpp uses to build real coinbases). Unlike DASH,
+        // BTC has NO treasury / NO masternode split / NO platform burn: the
+        // whole subsidy is the miners' block value (gross, pre-POOL-fee), so
+        // payments_total_sat = burn_sat = 0 and the card's "(gross, pre-fee)"
+        // label is exact — net = gross − pool_fee. This is a NON-fetching read
+        // of already-published header state; it never invokes the money-path
+        // template builder from a display timer. Projection excludes tx fees,
+        // flagged by block_value_basis="projected" (template_age_sec=-1). Once
+        // rigs connect the same header tip drives it; there is no live-template
+        // path to prefer on this NULL-IMiningNode web MI.
+        mi->set_coin_work_fn(
+            [&header_chain, ws = work_source.get(),
+             halving = chain_params.subsidy_halving_interval]()
+                -> core::MiningInterface::CoinWorkInfo {
+                core::MiningInterface::CoinWorkInfo info;
+                const uint32_t tip = header_chain.height();
+                if (tip == 0) return info;   // header follower not yet synced
+                const uint32_t height = tip + 1;
+                info.valid              = true;
+                info.projected          = true;
+                info.height             = height;
+                // block_value == full subsidy on a coinbase-only body (no tx
+                // fees on a projection). BTC has no protocol outputs to carve
+                // out, so miners get the whole amount.
+                info.coinbase_value_sat = btc::coin::get_block_subsidy(height, halving);
+                info.payment_amount_sat = 0;
+                info.payments_total_sat = 0;
+                info.burn_sat           = 0;
+                // Coin network difficulty from the last observed BTC block
+                // target (same source as the sharechain-stats netdiff feed).
+                if (ws) {
+                    uint32_t bb = ws->last_block_bits();
+                    if (bb) info.network_difficulty =
+                        chain::target_to_difficulty(chain::bits_to_target(bb));
+                }
+                // No sourced template: age is not a wall-clock; -1 renders
+                // block_value_age as null and block_value_basis "projected".
+                info.template_age_sec = -1;
+                return info;
+            });
+
         // §3 PPLNS distribution — /pplns/current requires m_pplns_fn on the web
         // MI. Reuse the EXACT lambda already given to the stratum work_source
         // (main_btc.cpp:1749): AutoRatchet picks the live share version and the
@@ -2836,6 +2887,13 @@ int main(int argc, char* argv[])
             nlohmann::json tails_arr = nlohmann::json::array();
             for (auto& [t, hs] : chain.get_tails()) tails_arr.push_back(t.GetHex());
             result["tails"] = std::move(tails_arr);
+            // Mirror #1409: emit verified_tails so /web/verified_tails serves
+            // the real verified sharechain tails instead of falling through to
+            // [] (web_server.cpp handles absent key as empty). Completes the
+            // heads/verified_heads/tails set already emitted above.
+            nlohmann::json vtails_arr = nlohmann::json::array();
+            for (auto& [t, hs] : verified.get_tails()) vtails_arr.push_back(t.GetHex());
+            result["verified_tails"] = std::move(vtails_arr);
 
             {
                 std::lock_guard<std::mutex> lock(s_cache_mutex);


### PR DESCRIPTION
## Summary

Mirror of the DASH block-value/node-fee dashboard fix (merged as #1409) into
the BTC lane. On the daemonless zero-rig BTC relay (btc.voidbind), the
dashboard MINERS BLOCK VALUE and NODE FEE cards read `0.0000 BTC` / `0.0 %`
because the web `MiningInterface` is stood up with a NULL `IMiningNode`:
`refresh_work()` never fills `m_cached_template`, and no `set_coin_work_fn`
producer was installed, so the core zero-value fallback had nothing to source
even though the embedded header follower already knew the tip.

The core consumer side is already generic (post-#1409:
`CoinWorkInfo.projected` / `block_value_basis` / `block_value_height` /
`template_age_sec`). This change adds only the BTC lane-side producer.

## Changes (display-only, single file `src/c2pool/main_btc.cpp`)

1. **Block value (zero-rig projection).** Install `set_coin_work_fn` on the web
   MI, projecting `CoinWorkInfo` from the header-follower tip plus the
   ported-from-Core BTC subsidy (`template_builder.hpp get_block_subsidy`, the
   same helper `block_assembly.hpp` uses to build real coinbases). BTC has no
   treasury / masternode split / platform burn, so the whole subsidy is the
   miners' block value (gross, pre-pool-fee): `payments_total_sat = burn_sat = 0`
   and the card's "(gross, pre-fee)" label is exact. Marked
   `block_value_basis="projected"` with `template_age_sec=-1` so the card labels
   the projection honestly (tx fees excluded on a projection). Non-fetching read
   of published header state; never invokes the money-path template builder from
   a display timer. The halving interval is read from
   `chain_params.subsidy_halving_interval` (210000 mainnet, 150 regtest) rather
   than hardcoded.

2. **`verified_tails`.** Emit `verified_tails` from the sharechain-stats feed so
   `/web/verified_tails` serves the real verified tails instead of falling
   through to an empty array, completing the heads/verified_heads/tails set.

Node-fee percent is already fed via `set_pool_fee_percent` (merged in #1406), so
the NODE FEE card shows the configured `--fee` once block_value is non-zero. No
fee-code change is needed here; no Best-Share change (it stays honestly empty
while this node mints nothing under the verify-backfill wedge).

## Live proof (isolated zero-rig instance on contabo, mainnet, tip 964772)

```
/fee                      -> 0.1
/local_stats.fee_percent  -> 0.1
/local_stats.block_value          -> 3.125         (50 BTC >> 4 halvings)
/local_stats.block_value_height   -> 964773        (tip + 1)
/local_stats.block_value_basis    -> "projected"
/local_stats.block_value_miner_gross -> 3.125       (full subsidy, no treasury)
/local_stats.block_value_fee      -> 0.003125       (3.125 x 0.1%)
/local_stats.block_value_miner_net-> 3.121875
/web/heads / tails / verified_heads / verified_tails -> all non-empty
/best_share has_best_share -> false  (honest: mints nothing under the wedge)
```

Built in an isolated worktree on contabo; proven on an isolated zero-rig
instance on spare ports without touching the live pool. Reward, target,
share-serialization and consensus paths are untouched.
