### PR TITLE
dgb: port block subsidy from DigiByte Core (COIN=1e8), fix 100x embedded-coinbase underpay

### DIFF
--- a/src/impl/dgb/coin/embedded_coinbase_value.hpp
+++ b/src/impl/dgb/coin/embedded_coinbase_value.hpp
@@ -42,7 +42,18 @@ namespace dgb::coin
 // Mirrors src/impl/ltc/coin/template_builder.hpp:
 //     uint64_t coinbasevalue = subsidy + total_fees;
 // but sources the subsidy through the coin's CoinParams::subsidy_func SSOT
-// (the DGB oracle decay schedule) rather than a hardcoded halving formula.
+// (the DigiByte Core GetBlockSubsidy port) rather than a hardcoded halving
+// formula.
+//
+// UNIT RECONCILIATION (money-path invariant): both terms are DGB satoshis
+// (1e8/DGB). subsidy_func == dgb::CoinParams::subsidy now returns DigiByte Core
+// GetBlockSubsidy() output in satoshis (COIN=1e8), and total_fees is the raw
+// satoshi sum of the included transactions' fees (the same unit digibyted folds
+// into GBT "coinbasevalue"). The sum is therefore unit-consistent and needs NO
+// rescale here. Before the subsidy fix the SSOT returned 1e6 units while fees
+// were 1e8 sats -- a mixed-unit coinbasevalue that underpaid ~100x. The fix is
+// entirely in the subsidy SSOT; this addition must stay a bare '+' with no
+// scaling factor (a stray x100 here would double-count the fix and overpay).
 //
 // Throws std::logic_error if subsidy_func is unset — an empty std::function
 // here means the CoinParams factory was not wired, which must fail loudly at

--- a/src/impl/dgb/config_coin.hpp
+++ b/src/impl/dgb/config_coin.hpp
@@ -119,65 +119,81 @@ public:
     static constexpr uint32_t DUMB_SCRYPT_DIFF = 65536;  // 2^16
 
     // -----------------------------------------------------------------------
-    // DGB subsidy schedule -- EXACT replica of the p2pool-dgb-scrypt oracle
-    // get_subsidy() (bitcoin/networks/digibyte.py, IDENTIFIER 4B62545B1A631AFE).
-    // V36 conformance = parity with DGB's OWN canonical reference, so the
-    // oracle behaviour IS the spec -- including COIN=1e6 (NOT 1e8) and the
-    // weeks/months + 1 decay count. These are not quirks to "fix" (card #156).
-    // 3-bucket: COMPAT (pre-v36 per-coin baseline, temporary for the crossing;
-    // NOT a v36-native cross-coin standardization).
+    // DGB block subsidy -- EXACT port of DigiByte Core consensus
+    // GetBlockSubsidy(nHeight, consensusParams) (src/validation.cpp), the
+    // authoritative supply curve every DGB mainnet node validates against.
+    // Ground truth is DigiByte Core, NOT the p2pool-dgb-scrypt display oracle:
+    // that oracle's get_subsidy() carried COIN=1e6 and never built a coinbase
+    // in python p2pool (the real value came from digibyted's GBT
+    // coinbasevalue), so its 1e6 unit was a display artifact. This module,
+    // however, feeds the LIVE daemonless coinbase-build path
+    // (embedded_coinbase_value.hpp), where the returned value is written raw as
+    // the coinbase vout in satoshis. At COIN=1e6 that underpaid the real reward
+    // ~100x (built 2.53558070 DGB vs the on-chain 253.55810338 DGB at the live
+    // Scrypt tip ~24.12M), which reverses the earlier card #156 "oracle IS the
+    // spec" ruling: for a real coinbase the spec is DigiByte Core, and COIN is
+    // 1e8 (src/consensus/amount.h). A naive x100 rescale is NOT parity -- the
+    // 1e6 decay loop truncates coarser and lands thousands of sats off; the
+    // decay must run at full 1e8 precision, which this port does.
     //
-    // Integer math mirrors the oracle bit-for-bit: each decay step is
-    //   q -= q / N   (truncating division), NOT q * (N-1) / N -- the two round
-    // differently for non-divisible q, and the oracle rounding is consensus.
+    // Mainnet consensus constants (src/kernel/chainparams.cpp) match DGB Core
+    // exactly. Integer math mirrors Core bit-for-bit: each decay step is
+    //   nSubsidy -= nSubsidy / N   (truncating division), and the Period VI
+    // months count is blocks * BLOCK_TIME_SECONDS / SECONDS_PER_MONTH with
+    // BLOCK_TIME_SECONDS=15 and SECONDS_PER_MONTH=60*60*24*365/12=2'628'000.
+    // Floor mirrors current Core master (nSubsidy < COIN -> 0); Core accepts
+    // underpay (ConnectBlock rejects only overpay, "bad-cb-amount") and the
+    // floor is ~40 years out, so it never bites at the live tip.
     // -----------------------------------------------------------------------
     static uint64_t subsidy(uint32_t height)
     {
-        static constexpr uint64_t COIN                         = 1'000'000;   // oracle COIN = 1e6
+        static constexpr uint64_t COIN                         = 100'000'000; // DGB Core COIN = 1e8
         static constexpr uint32_t nDiffChangeTarget            = 67'200;
         static constexpr uint32_t alwaysUpdateDiffChangeTarget = 400'000;
         static constexpr uint32_t patchBlockRewardDuration     = 10'080;
         static constexpr uint32_t workComputationChangeTarget  = 1'430'000;
         static constexpr uint32_t patchBlockRewardDuration2    = 80'160;
+        static constexpr uint64_t BLOCK_TIME_SECONDS           = 15;
+        static constexpr uint64_t SECONDS_PER_MONTH            = 60ull * 60 * 24 * 365 / 12; // 2'628'000
 
         uint64_t nSubsidy = COIN;
         if (height < nDiffChangeTarget) {
-            // Phase 1: pre-DigiShield fixed rewards.
-            nSubsidy = 8'000 * COIN;
+            // Periods I-III: pre-DigiShield fixed rewards.
             if (height < 1'440)
                 nSubsidy = 72'000 * COIN;
             else if (height < 5'760)
                 nSubsidy = 16'000 * COIN;
+            else
+                nSubsidy = 8'000 * COIN;
         } else if (height < alwaysUpdateDiffChangeTarget) {
-            // Phase 2: -0.5% per (weeks+1), weeks = blocks / 10080.
-            uint64_t qSubsidy = 8'000 * COIN;
+            // Period IV: -0.5% per week, weeks = blocks / 10080 + 1.
+            nSubsidy = 8'000 * COIN;
             uint32_t blocks = height - nDiffChangeTarget;
             uint32_t weeks = (blocks / patchBlockRewardDuration) + 1;
             for (uint32_t i = 0; i < weeks; ++i)
-                qSubsidy -= qSubsidy / 200;
-            nSubsidy = qSubsidy;
+                nSubsidy -= nSubsidy / 200;
         } else if (height < workComputationChangeTarget) {
-            // Phase 3: -1% per (weeks+1), weeks = blocks / 80160.
-            uint64_t qSubsidy = 2'459 * COIN;
+            // Period V: -1% per period, weeks = blocks / 80160 + 1.
+            nSubsidy = 2'459 * COIN;
             uint32_t blocks = height - alwaysUpdateDiffChangeTarget;
             uint32_t weeks = (blocks / patchBlockRewardDuration2) + 1;
             for (uint32_t i = 0; i < weeks; ++i)
-                qSubsidy -= qSubsidy / 100;
-            nSubsidy = qSubsidy;
+                nSubsidy -= nSubsidy / 100;
         } else {
-            // Phase 4: monthly decay (x98884/100000) after work-computation change.
-            uint64_t qSubsidy = 2'157 * COIN / 2;
-            uint32_t blocks = height - workComputationChangeTarget;
-            uint32_t months = static_cast<uint32_t>(
-                static_cast<uint64_t>(blocks) * 15 / (3600 * 24 * 365 / 12));
-            for (uint32_t i = 0; i < months; ++i) {
-                qSubsidy *= 98'884;
-                qSubsidy /= 100'000;
+            // Period VI: monthly decay (x98884/100000) after the DigiSpeed
+            // work-computation-change hard fork at block 1'430'000.
+            nSubsidy = 2'157 * COIN / 2;
+            uint64_t blocks = static_cast<uint64_t>(height) - workComputationChangeTarget;
+            uint64_t months = blocks * BLOCK_TIME_SECONDS / SECONDS_PER_MONTH;
+            for (uint64_t i = 0; i < months; ++i) {
+                nSubsidy *= 98'884;
+                nSubsidy /= 100'000;
             }
-            nSubsidy = qSubsidy;
         }
+        // Core master clamps a sub-1-DGB reward to 0 (released 8.22.x clamped
+        // to COIN; both moot at the tip -- the floor is ~40 years out).
         if (nSubsidy < COIN)
-            nSubsidy = COIN;
+            nSubsidy = 0;
         return nSubsidy;
     }
 

--- a/src/impl/dgb/config_coin.hpp
+++ b/src/impl/dgb/config_coin.hpp
@@ -141,9 +141,13 @@ public:
     //   nSubsidy -= nSubsidy / N   (truncating division), and the Period VI
     // months count is blocks * BLOCK_TIME_SECONDS / SECONDS_PER_MONTH with
     // BLOCK_TIME_SECONDS=15 and SECONDS_PER_MONTH=60*60*24*365/12=2'628'000.
-    // Floor mirrors current Core master (nSubsidy < COIN -> 0); Core accepts
-    // underpay (ConnectBlock rejects only overpay, "bad-cb-amount") and the
-    // floor is ~40 years out, so it never bites at the live tip.
+    // Floor: DigiByte Core clamps a sub-1-DGB reward to 0. This was verified
+    // byte-for-byte against the released consensus (feature/8.22.0-final) and
+    // the latest release (v9.26.5): both run `if (nSubsidy < COIN) nSubsidy = 0;`
+    // -- the "Make sure the reward is at least 1 DGB" comment above it in Core is
+    // stale, the code writes 0, not COIN. Core accepts underpay (ConnectBlock
+    // rejects only overpay, "bad-cb-amount") and the floor is ~40 years out, so
+    // it never bites at the live tip -- but the port mirrors Core exactly anyway.
     // -----------------------------------------------------------------------
     static uint64_t subsidy(uint32_t height)
     {
@@ -190,8 +194,10 @@ public:
                 nSubsidy /= 100'000;
             }
         }
-        // Core master clamps a sub-1-DGB reward to 0 (released 8.22.x clamped
-        // to COIN; both moot at the tip -- the floor is ~40 years out).
+        // DigiByte Core clamps a sub-1-DGB reward to 0 -- verified identical in
+        // the released 8.22.0-final consensus and in v9.26.5 (the Core comment
+        // says "at least 1 DGB" but the code assigns 0). Moot at the tip: the
+        // floor is ~40 years out.
         if (nSubsidy < COIN)
             nSubsidy = 0;
         return nSubsidy;

--- a/src/impl/dgb/params.hpp
+++ b/src/impl/dgb/params.hpp
@@ -67,7 +67,8 @@ inline core::CoinParams make_coin_params(bool testnet)
     p.pow_func        = core::pow::scrypt;
     p.block_hash_func = core::pow::sha256d;
 
-    // Subsidy: DGB 3-phase decay schedule (config_coin.hpp SSOT)
+    // Subsidy: DigiByte Core GetBlockSubsidy port, 6-period schedule, COIN=1e8
+    // (config_coin.hpp SSOT). Feeds the daemonless coinbase-build path.
     p.subsidy_func = [](uint32_t height) -> uint64_t {
         return CoinParams::subsidy(height);
     };

--- a/src/impl/dgb/test/coinbase_value_parity_test.cpp
+++ b/src/impl/dgb/test/coinbase_value_parity_test.cpp
@@ -79,17 +79,17 @@ core::SubsidyFunc oracle_subsidy() {
     return [](uint32_t height) -> uint64_t { return dgb::CoinParams::subsidy(height); };
 }
 
-// Captured p2pool-dgb-scrypt oracle subsidy on each side of every reward-era
-// boundary -- the SAME vectors dgb_work_source_test pins. Reusing the captured
-// numbers (not just the live function) double-locks the parity figure.
+// DigiByte Core GetBlockSubsidy() on each side of every reward-period boundary
+// (satoshis, COIN=1e8) -- the SAME vectors dgb_work_source_test pins. Reusing the
+// captured numbers (not just the live function) double-locks the parity figure.
 struct EraVec { uint32_t height; uint64_t subsidy; const char* era; };
 constexpr EraVec kEraBoundaries[] = {
-    {67199,   8000000000ULL, "phase1-fixed last"},
-    {67200,   7960000000ULL, "phase2 -0.5%/wk first"},
-    {399999,  6746441103ULL, "phase2 last"},
-    {400000,  2434410000ULL, "phase3 -1%/wk first"},
-    {1429999, 2157824200ULL, "phase3 last"},
-    {1430000, 1078500000ULL, "phase4 monthly-decay first"},
+    {67199,   800000000000ULL, "PeriodIII-fixed last"},
+    {67200,   796000000000ULL, "PeriodIV -0.5%/wk first"},
+    {399999,  674644108854ULL, "PeriodIV last"},
+    {400000,  243441000000ULL, "PeriodV -1%/wk first"},
+    {1429999, 215782419560ULL, "PeriodV last"},
+    {1430000, 107850000000ULL, "PeriodVI monthly-decay first"},
 };
 
 // Minimal, distinct fee-known tx tagged by its output value (mirrors the

--- a/src/impl/dgb/test/work_source_test.cpp
+++ b/src/impl/dgb/test/work_source_test.cpp
@@ -456,8 +456,8 @@ TEST(DgbWorkSource, WorkTemplateEmitsHeightAndCoinbaseValueViaSsot)
     ASSERT_TRUE(tmpl.contains("coinbasevalue"));
     // next_h = next_block_height() = base_height (empty chain) = 400000.
     EXPECT_EQ(tmpl["height"].get<uint32_t>(), 400000u);
-    // Zero embedded fees, no external GBT -> oracle subsidy at the boundary.
-    EXPECT_EQ(tmpl["coinbasevalue"].get<uint64_t>(), 2434410000ULL);
+    // Zero embedded fees, no external GBT -> DigiByte Core subsidy at the boundary.
+    EXPECT_EQ(tmpl["coinbasevalue"].get<uint64_t>(), 243441000000ULL);
 }
 
 // Stage 4c GBT scaffold: alongside height + coinbasevalue, the work template
@@ -496,17 +496,17 @@ TEST(DgbWorkSource, WorkTemplateEmitsGbtScaffoldFields)
 }
 
 // ── Embedded coinbasevalue: first production caller of subsidy_func ──────────
-// One pin on each side of every DGB reward-era boundary (p2pool-dgb-scrypt
-// oracle vectors, test_dgb_subsidy.cpp).
+// One pin on each side of every DGB reward-period boundary (DigiByte Core
+// GetBlockSubsidy() vectors, satoshis/COIN=1e8, test_dgb_subsidy.cpp).
 namespace {
 struct EraVec { uint32_t height; uint64_t subsidy; const char* era; };
 constexpr EraVec kEraBoundaries[] = {
-    {67199,   8000000000ULL, "phase1-fixed last"},
-    {67200,   7960000000ULL, "phase2 -0.5%/wk first"},
-    {399999,  6746441103ULL, "phase2 last"},
-    {400000,  2434410000ULL, "phase3 -1%/wk first"},
-    {1429999, 2157824200ULL, "phase3 last"},
-    {1430000, 1078500000ULL, "phase4 monthly-decay first"},
+    {67199,   800000000000ULL, "PeriodIII-fixed last"},
+    {67200,   796000000000ULL, "PeriodIV -0.5%/wk first"},
+    {399999,  674644108854ULL, "PeriodIV last"},
+    {400000,  243441000000ULL, "PeriodV -1%/wk first"},
+    {1429999, 215782419560ULL, "PeriodV last"},
+    {1430000, 107850000000ULL, "PeriodVI monthly-decay first"},
 };
 }  // namespace
 

--- a/test/test_dgb_coinbase_value.cpp
+++ b/test/test_dgb_coinbase_value.cpp
@@ -8,7 +8,7 @@
 // (Stage 4c, work_source.cpp) and that takes a live digibyted GBT coinbasevalue
 // verbatim whenever present (the external-daemon fallback that MUST PERSIST).
 //
-// The subsidy values themselves are byte-exact vs the p2pool-dgb-scrypt oracle
+// The subsidy values themselves are byte-exact vs DigiByte Core GetBlockSubsidy
 // (see test_dgb_subsidy.cpp). This test proves the *wiring*: that the embedded
 // coinbasevalue is derived THROUGH the CoinParams::subsidy_func indirection
 // (which params.hpp populates and which previously had zero invocation sites)
@@ -32,15 +32,16 @@ const core::SubsidyFunc kSubsidyFunc =
 
 struct EraVec { uint32_t height; uint64_t subsidy; const char* era; };
 
-// One pin on each side of every reward-era boundary. Expected subsidy values
-// are the p2pool-dgb-scrypt oracle vectors (test_dgb_subsidy.cpp).
+// One pin on each side of every reward-period boundary. Expected subsidy values
+// are the DigiByte Core GetBlockSubsidy() vectors (satoshis/COIN=1e8,
+// test_dgb_subsidy.cpp).
 constexpr EraVec kEraBoundaries[] = {
-    {67199,   8000000000ULL, "phase1-fixed last"},
-    {67200,   7960000000ULL, "phase2 -0.5%/wk first"},
-    {399999,  6746441103ULL, "phase2 last"},
-    {400000,  2434410000ULL, "phase3 -1%/wk first"},
-    {1429999, 2157824200ULL, "phase3 last"},
-    {1430000, 1078500000ULL, "phase4 monthly-decay first"},
+    {67199,   800000000000ULL, "PeriodIII-fixed last"},
+    {67200,   796000000000ULL, "PeriodIV -0.5%/wk first"},
+    {399999,  674644108854ULL, "PeriodIV last"},
+    {400000,  243441000000ULL, "PeriodV -1%/wk first"},
+    {1429999, 215782419560ULL, "PeriodV last"},
+    {1430000, 107850000000ULL, "PeriodVI monthly-decay first"},
 };
 
 } // namespace

--- a/test/test_dgb_subsidy.cpp
+++ b/test/test_dgb_subsidy.cpp
@@ -50,7 +50,8 @@ constexpr SubsidyVec kCoreVectors[] = {
     {4057999,       92168922949ULL},
     {4058000,       91140317768ULL},
     {20000000,      33193486585ULL},
-    {24125022,      25355810338ULL},  // LIVE Scrypt tip == on-chain coinbase
+    {24125001,      25355810338ULL},  // LIVE Scrypt tip (months=129 band)
+    {24125022,      25355810338ULL},  // == on-chain coinbase at 47515a15f270cbb4
 };
 
 // Independent DigiByte Core GetBlockSubsidy() reference implementation, kept
@@ -98,9 +99,14 @@ TEST(DgbSubsidy, MatchesDigiByteCoreVectors) {
 // The tip value is the money-critical one: it is exactly what a solved block's
 // coinbase would pay, and must equal the real on-chain coinbase to the satoshi.
 TEST(DgbSubsidy, LiveTipMatchesOnChainCoinbase) {
-    EXPECT_EQ(dgb::CoinParams::subsidy(24125022u), 25355810338ULL)
-        << "built DGB coinbase subsidy != on-chain coinbase at the live Scrypt tip "
+    // Both heights fall in the months=129 monthly-decay band and pay the same
+    // value; 24125001 is the money-critical build height, 24125022 is a block
+    // whose on-chain coinbase vout total is byte-identical to this value.
+    EXPECT_EQ(dgb::CoinParams::subsidy(24125001u), 25355810338ULL)
+        << "built DGB coinbase subsidy != DigiByte Core at the live Scrypt tip "
            "-- real hashrate would underpay or the block would be rejected";
+    EXPECT_EQ(dgb::CoinParams::subsidy(24125022u), 25355810338ULL)
+        << "built DGB coinbase subsidy != on-chain coinbase at the live Scrypt tip";
 }
 
 // Full-domain byte parity against an independent Core reference: boundaries,

--- a/test/test_dgb_subsidy.cpp
+++ b/test/test_dgb_subsidy.cpp
@@ -1,14 +1,23 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-// Regression test: DGB block subsidy vs the coin's OWN canonical oracle,
-// p2pool-dgb-scrypt (bitcoin/networks/digibyte.py :: get_subsidy).
+// Regression test: DGB block subsidy vs DigiByte Core consensus.
 //
-// Operator decision, card #156 (2026-06-17): V36 = parity with DGB's own
-// reference, so the oracle behaviour IS the spec -- including COIN=1e6 and the
-// weeks/months + 1 decay count. These are NOT quirks to "fix". 3-bucket: COMPAT
-// (pre-v36 per-coin baseline, temporary for the crossing-soak).
+// GROUND TRUTH = DigiByte Core GetBlockSubsidy(nHeight, consensusParams)
+// (src/validation.cpp), the supply curve every DGB mainnet node validates
+// against. COIN = 1e8 (src/consensus/amount.h). dgb::CoinParams::subsidy is an
+// exact port of that function and feeds the live daemonless coinbase-build path
+// (embedded_coinbase_value.hpp), so it MUST match Core to the satoshi -- an
+// under- or over-scaled value silently destroys reward or gets the block
+// rejected (bad-cb-amount) once real hashrate mines.
 //
-// Vectors generated deterministically by executing the oracle get_subsidy() at
-// the boundary and interior of every reward phase (all four phases + floor).
+// This supersedes the earlier card #156 "the p2pool-dgb-scrypt oracle IS the
+// spec" ruling: that oracle's COIN=1e6 get_subsidy() was display-only (it never
+// built a coinbase in python p2pool), and binding it verbatim to a real coinbase
+// underpaid ~100x. For a real coinbase the spec is DigiByte Core.
+//
+// Vectors are the DigiByte Core GetBlockSubsidy() output (satoshis, COIN=1e8) at
+// the boundary and interior of every reward period, plus the live Scrypt tip
+// whose value is byte-identical to the on-chain coinbase at height 24,125,022
+// (coinbase vout total 25,355,810,338 sat = 253.55810338 DGB).
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -19,45 +28,103 @@ namespace {
 
 struct SubsidyVec { uint32_t height; uint64_t expected; };
 
-// Oracle p2pool-dgb-scrypt get_subsidy() reference vectors (satoshis, COIN=1e6).
-constexpr SubsidyVec kOracleVectors[] = {
-    {0,        72000000000ULL},  // phase 1: 72000 DGB
-    {1,        72000000000ULL},
-    {1439,     72000000000ULL},
-    {1440,     16000000000ULL},  // phase 1 step -> 16000
-    {5759,     16000000000ULL},
-    {5760,      8000000000ULL},  // phase 1 step -> 8000
-    {67199,     8000000000ULL},
-    {67200,     7960000000ULL},  // phase 2 in: weeks+1 = 1 -> -0.5%
-    {77280,     7920200000ULL},
-    {87359,     7920200000ULL},
-    {87360,     7880599000ULL},
-    {399999,    6746441103ULL},
-    {400000,    2434410000ULL},  // phase 3 in: base 2459, weeks+1 = 1 -> -1%
-    {480159,    2434410000ULL},
-    {480160,    2410065900ULL},
-    {1429999,   2157824200ULL},
-    {1430000,   1078500000ULL},  // phase 4 in: base 2157/2
-    {4057999,    921689224ULL},
-    {4058000,    911403172ULL},
-    {20000000,   331934836ULL},
+// DigiByte Core GetBlockSubsidy() reference vectors (satoshis, COIN=1e8).
+constexpr SubsidyVec kCoreVectors[] = {
+    {0,           7200000000000ULL},  // Period I:   72000 DGB
+    {1,           7200000000000ULL},
+    {1439,        7200000000000ULL},
+    {1440,        1600000000000ULL},  // Period II:  16000 DGB
+    {5759,        1600000000000ULL},
+    {5760,         800000000000ULL},  // Period III:  8000 DGB
+    {67199,        800000000000ULL},
+    {67200,        796000000000ULL},  // Period IV in: weeks=1 -> -0.5%
+    {77280,        792020000000ULL},
+    {87359,        792020000000ULL},
+    {87360,        788059900000ULL},
+    {399999,       674644108854ULL},
+    {400000,       243441000000ULL},  // Period V in: base 2459, weeks=1 -> -1%
+    {480159,       243441000000ULL},
+    {480160,       241006590000ULL},
+    {1429999,      215782419560ULL},
+    {1430000,      107850000000ULL},  // Period VI in: base 2157/2, DigiSpeed HF
+    {4057999,       92168922949ULL},
+    {4058000,       91140317768ULL},
+    {20000000,      33193486585ULL},
+    {24125022,      25355810338ULL},  // LIVE Scrypt tip == on-chain coinbase
 };
+
+// Independent DigiByte Core GetBlockSubsidy() reference implementation, kept
+// separate from the ported CoinParams::subsidy so the full-domain sweep below
+// cannot pass by sharing a bug with the code under test.
+uint64_t core_reference_subsidy(uint32_t nHeight) {
+    constexpr uint64_t COIN = 100000000ULL;
+    constexpr uint32_t nDiffChangeTarget = 67200;
+    constexpr uint32_t alwaysUpdateDiffChangeTarget = 400000;
+    constexpr uint32_t workComputationChangeTarget = 1430000;
+    constexpr uint32_t patchBlockRewardDuration = 10080;
+    constexpr uint32_t patchBlockRewardDuration2 = 80160;
+    uint64_t nSubsidy = COIN;
+    if (nHeight < nDiffChangeTarget) {
+        if (nHeight < 1440) nSubsidy = 72000 * COIN;
+        else if (nHeight < 5760) nSubsidy = 16000 * COIN;
+        else nSubsidy = 8000 * COIN;
+    } else if (nHeight < alwaysUpdateDiffChangeTarget) {
+        nSubsidy = 8000 * COIN;
+        uint32_t weeks = ((nHeight - nDiffChangeTarget) / patchBlockRewardDuration) + 1;
+        for (uint32_t i = 0; i < weeks; ++i) nSubsidy -= nSubsidy / 200;
+    } else if (nHeight < workComputationChangeTarget) {
+        nSubsidy = 2459 * COIN;
+        uint32_t weeks = ((nHeight - alwaysUpdateDiffChangeTarget) / patchBlockRewardDuration2) + 1;
+        for (uint32_t i = 0; i < weeks; ++i) nSubsidy -= nSubsidy / 100;
+    } else {
+        nSubsidy = 2157 * COIN / 2;
+        uint64_t months = (static_cast<uint64_t>(nHeight) - workComputationChangeTarget)
+                          * 15ULL / (60ULL * 60 * 24 * 365 / 12);
+        for (uint64_t i = 0; i < months; ++i) { nSubsidy *= 98884; nSubsidy /= 100000; }
+    }
+    if (nSubsidy < COIN) nSubsidy = 0;
+    return nSubsidy;
+}
 
 }  // namespace
 
-TEST(DgbSubsidy, MatchesOracleVectors) {
-    for (const auto& v : kOracleVectors) {
+TEST(DgbSubsidy, MatchesDigiByteCoreVectors) {
+    for (const auto& v : kCoreVectors) {
         EXPECT_EQ(dgb::CoinParams::subsidy(v.height), v.expected)
-            << "subsidy(" << v.height << ") diverged from the p2pool-dgb-scrypt oracle";
+            << "subsidy(" << v.height << ") diverged from DigiByte Core";
     }
 }
 
-TEST(DgbSubsidy, NeverBelowCoinFloor) {
-    // Oracle clamps: if nSubsidy < COIN -> COIN. COIN = 1e6 sat.
-    // Sweep deep into the monthly-decay region where the reward is floored.
-    for (uint32_t h = 0; h < 80u; ++h) {
-        const uint32_t height = 130000000u + h * 1000000u;
-        EXPECT_GE(dgb::CoinParams::subsidy(height), 1000000ULL)
-            << "subsidy floor breached at height " << height;
+// The tip value is the money-critical one: it is exactly what a solved block's
+// coinbase would pay, and must equal the real on-chain coinbase to the satoshi.
+TEST(DgbSubsidy, LiveTipMatchesOnChainCoinbase) {
+    EXPECT_EQ(dgb::CoinParams::subsidy(24125022u), 25355810338ULL)
+        << "built DGB coinbase subsidy != on-chain coinbase at the live Scrypt tip "
+           "-- real hashrate would underpay or the block would be rejected";
+}
+
+// Full-domain byte parity against an independent Core reference: boundaries,
+// every-block near each hard fork, and a coarse sweep across all six periods
+// including the far-future floor-to-zero region.
+TEST(DgbSubsidy, ByteParityWithCoreAcrossDomain) {
+    auto check = [](uint32_t h) {
+        ASSERT_EQ(dgb::CoinParams::subsidy(h), core_reference_subsidy(h))
+            << "byte divergence from DigiByte Core at height " << h;
+    };
+    for (uint32_t h : {0u, 1439u, 1440u, 5759u, 5760u, 67199u, 67200u, 67201u,
+                       399999u, 400000u, 400001u, 1429999u, 1430000u, 1430001u})
+        check(h);
+    for (uint32_t h = 0; h <= 60000000u; h += 97777u) check(h);   // all periods + zero floor
+}
+
+// DigiByte Core master floors a sub-1-DGB reward to 0 (ConnectBlock accepts
+// underpay; overpay is what gets rejected). Deep in the monthly-decay era the
+// reward reaches 0 and stays there.
+TEST(DgbSubsidy, FloorsToZeroFarInTheFuture) {
+    // Below the 1-DGB (1e8 sat) floor the port returns exactly 0, matching Core.
+    for (uint32_t h = 120000000u; h < 200000000u; h += 5000000u) {
+        EXPECT_EQ(dgb::CoinParams::subsidy(h), core_reference_subsidy(h))
+            << "floor-region divergence from Core at height " << h;
     }
+    EXPECT_EQ(dgb::CoinParams::subsidy(130000000u), 0ULL);
 }


### PR DESCRIPTION
## Summary

CONSENSUS / MONEY-CRITICAL. The DGB embedded coinbase-build path underpaid the block reward ~100x. This ports the DGB block subsidy from DigiByte Core (COIN=1e8) so a solved DGB block pays the real reward. Report-first; **do not merge or deploy without operator review** — this changes a live money path and reverses an earlier ruling.

## The bug

`dgb::CoinParams::subsidy` (config_coin.hpp) replicated the p2pool-dgb-scrypt display oracle, which carries **COIN=1e6**. That oracle never built a coinbase in python p2pool — the real value came from `digibyted`'s GBT `coinbasevalue`, so its 1e6 unit was a display artifact. In c2pool the same function feeds the **live daemonless coinbase-build path** (`embedded_coinbase_value.hpp`), where the returned value is written raw as the coinbase vout in satoshis. Consensus (DigiByte Core `amount.h`) is **1e8**, and there is no scale anywhere on the path:

```
params.hpp (verbatim lambda) -> embedded_coinbase_value.hpp (subsidy+fees, no scale)
  -> work_source.cpp (verbatim) -> gentx_coinbase.hpp (raw 8-byte LE vout write)
```

So at the current Scrypt tip the built coinbase paid **2.53558070 DGB** instead of the on-chain **253.55810338 DGB** — a 100.0000132x underpay.

It has never fired: no DGB block has been mined through the embedded path, and the external-GBT fallback takes `digibyted`'s value verbatim. It would fire the **first time real hashrate solves a block** on the daemonless node (contabo, stratum :9434). DigiByte Core accepts underpay (ConnectBlock rejects only *overpay*, `bad-cb-amount`), so every such block would be **VALID but silently destroy ~251 DGB** of reward.

## Ground truth (triple-proven)

1. **DigiByte Core** `GetBlockSubsidy(nHeight, consensusParams)` (`src/validation.cpp`), COIN=1e8 (`src/consensus/amount.h`), mainnet constants (`src/kernel/chainparams.cpp`).
2. **Recomputed** from the Core formula at the tip -> `25,355,810,338` sat.
3. **Live chain**: on-chain coinbase at height 24,125,022 = `25,355,810,338` sat (253.55810338 DGB) — byte-identical.

## Fix

Port `GetBlockSubsidy` exactly: COIN=1e8, master floor semantics (sub-1-DGB reward clamped to 0). The six-period schedule shape, constants, truncating decay loops, and the Period VI `months = blocks * 15 / 2628000` count already matched Core — only the unit and floor differed. A naive x100 rescale at the build site is **not** parity: the 1e6 decay loop truncates coarser and lands thousands of sats off (e.g. x100 = 25,355,807,000, short 3,338 sat). The decay must run at full 1e8 precision.

This supersedes the earlier "the oracle IS the spec" ruling — for a real coinbase the spec is DigiByte Core. The schedule is *more* correct than the stale 3-phase farsider C module (which predates the block-1,430,000 DigiSpeed fork and returns ~125 DGB), so this does **not** move toward farsider. The DOGE lane's `get_doge_block_subsidy` was spot-confirmed already exact and is untouched.

## Red / green proof

Compiled the shipped `subsidy()` function text before and after the change:

| height | before (1e6, shipped) | after (1e8, ported) | DGB-Core / on-chain |
|---|---|---|---|
| 24125022 (live tip) | 253,558,070 | **25,355,810,338** | 25,355,810,338 |
| 67200 | 7,960,000,000 | 796,000,000,000 | 796,000,000,000 |
| 400000 | 2,434,410,000 | 243,441,000,000 | 243,441,000,000 |
| 1430000 | 1,078,500,000 | 107,850,000,000 | 107,850,000,000 |
| 20000000 | 331,934,836 | 33,193,486,585 | 33,193,486,585 |

Before: 5/5 mismatch (RED). After: 5/5 match + a 644-point full-domain byte-parity sweep against an independent Core reference (GREEN).

## Tests

`test/test_dgb_subsidy.cpp`, `test/test_dgb_coinbase_value.cpp`, `src/impl/dgb/test/coinbase_value_parity_test.cpp`, `src/impl/dgb/test/work_source_test.cpp` updated to DigiByte Core vectors (satoshis, 1e8). `test_dgb_subsidy` adds the live-tip on-chain vector and a full-domain byte-parity sweep vs an independent Core reference implementation.

## Do not

- Merge without operator go (consensus/reward path).
- Point real hashrate at the DGB pool until this is merged and deployed.
