### PR TITLE
nmc: fix embedded merged-mining arm SEGV on stop + OOM balloon mid-IBD

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -539,6 +539,18 @@ int main(int argc, char* argv[])
     std::unique_ptr<nmc::coin::Mempool>        nmc_pool;
     std::unique_ptr<nmc::coin::NMCChainParams> nmc_params_ptr;
 
+    // SEGV FIX: own the NMC header-admission thread pools at main scope. Each
+    // pool runs connect_locked() on a raw HeaderChain* (nc) captured by the
+    // per-broadcaster header sink; the pool's shared_ptr previously lived ONLY
+    // inside that sink lambda (held by the broadcaster). Because
+    // merged_broadcasters is declared before nmc_chain, RAII destroys nmc_chain
+    // FIRST and joins the pool only later when the broadcaster dies — so a pool
+    // worker still admitting a header batch dereferences the freed chain. This
+    // was the SEGV on EVERY clean stop of the NMC arm. Holding the pools here
+    // lets the explicit teardown below stop()+join() them BEFORE nmc_chain is
+    // destroyed, closing the use-after-free deterministically.
+    std::vector<std::shared_ptr<boost::asio::thread_pool>> nmc_hdr_pools;
+
     if (!merged_configs.empty()) {
         mm_manager = std::make_unique<c2pool::merged::MergedMiningManager>(ioc);
         for (size_t ci = 0; ci < merged_configs.size(); ++ci) {
@@ -651,6 +663,10 @@ int main(int argc, char* argv[])
                 // (80-byte-only, drops the AuxPoW proof; structurally
                 // insufficient for a chain that has been AuxPoW since 2014).
                 auto nmc_hdr_pool = std::make_shared<boost::asio::thread_pool>(1);
+                // SEGV FIX: also own the pool at main scope so shutdown can
+                // stop()+join() it before nmc_chain is destroyed (see the
+                // nmc_hdr_pools declaration + the teardown block at end-of-main).
+                nmc_hdr_pools.push_back(nmc_hdr_pool);
                 auto* bcaster_ptr = broadcaster.get();
                 auto* nc = nmc_chain.get();
 
@@ -3174,6 +3190,29 @@ int main(int argc, char* argv[])
     stratum_server_for_shutdown.reset();
     work_source_for_shutdown.reset();
     p2p_node.reset();
+
+    // SEGV FIX: tear down the NMC merged arm in a controlled order BEFORE the
+    // embedded HeaderChain (nmc_chain) is destroyed by end-of-scope RAII.
+    //   1. drop the merged-mining manager first — its poll thread references the
+    //      broadcasters via set_block_relay_fn, so it must stop before they die.
+    //   2. clear the broadcasters — stops their network/peer threads and releases
+    //      the header-sink lambdas that post admission batches to the pools, so
+    //      no new connect_locked() work can be queued after this point.
+    //   3. stop() + join() every header-admission pool — discards queued batches
+    //      and drains any in-flight connect_locked() call so no worker thread can
+    //      still be touching the chain.
+    // Only after all three is it safe for nmc_chain / nmc_pool to be destroyed at
+    // end of main. Without this ordering a pool worker admitting a header batch
+    // raced the chain's destructor -> use-after-free (the SEGV on every clean
+    // stop of the NMC arm; core-dump crashing thread was the header pool inside
+    // HeaderChain::connect_locked while main() destroyed the chain).
+    mm_manager.reset();
+    merged_broadcasters.clear();
+    for (auto& p : nmc_hdr_pools) {
+        if (p) { p->stop(); p->join(); }
+    }
+    nmc_hdr_pools.clear();
+
     LOG_INFO << "[BTC] Shutdown complete.";
     return 0;
 }

--- a/src/impl/nmc/coin/header_chain.hpp
+++ b/src/impl/nmc/coin/header_chain.hpp
@@ -814,6 +814,13 @@ struct IndexEntryDiskV1 {
 
     /// Materialize the slim in-memory form. auxpow is reconstructed as nullopt
     /// in this leg (blob deferred); status carries the merge-mined verdict.
+    ///
+    /// MEMORY: the resident IndexEntry deliberately does NOT carry the AuxPow
+    /// blob. It stays on disk behind has_auxpow and is never needed after
+    /// admission (verification runs BEFORE connect); keeping it resident across
+    /// the ~740k-header NMC history is the OOM balloon this defers. status
+    /// (HEADER_VALID_CHAIN for a merge-mined header) preserves the validation
+    /// verdict, matching connect_locked which also drops the blob post-persist.
     IndexEntry to_entry() const {
         IndexEntry e;
         e.header     = header;
@@ -821,7 +828,7 @@ struct IndexEntryDiskV1 {
         e.height     = height;
         e.chain_work = chain_work;
         e.status     = status;
-        e.auxpow     = auxpow;         // P1f(a): blob restored behind has_auxpow
+        e.auxpow     = std::nullopt;  // blob stays on disk behind has_auxpow
         return e;
     }
 
@@ -1345,6 +1352,20 @@ private:
         // idempotent / orphan / activation-gate early returns above never reach
         // here, so nothing is written for a rejected header.
         persist_entry_locked(bh, tip_changed);
+
+        // MEMORY: the verified AuxPow proof is now durably on disk behind
+        // has_auxpow (persist_entry_locked / IndexEntryDiskV1, P1f(a)). Drop the
+        // resident copy so m_index stays headers-only (~200 B/entry) instead of
+        // pinning the full parent coinbase tx + two merkle branches + parent
+        // header (~1-3 KB) for every merge-mined header across the ~740k-header
+        // NMC history -- the residency balloon that OOM-killed the embedded arm
+        // mid-IBD under MemoryMax. status (HEADER_VALID_CHAIN) and chain_work are
+        // retained, so fork-choice and validation state are unaffected; the blob
+        // is verified BEFORE connect (add_auxpow_header -> check_proof) and no
+        // path reads the resident IndexEntry::auxpow after admission (disk
+        // restore likewise defers it, see to_entry()).
+        if (auto it = m_index.find(bh); it != m_index.end())
+            it->second.auxpow.reset();
         return true;
     }
 
@@ -1456,7 +1477,13 @@ private:
     // cumulative-work / fork-choice path (P1e), and LevelDB persistence +
     // reload incl. the AuxPow blob (P1f). Still deferred: nBits difficulty
     // RETARGET validation (calculate_next_work is provided but not enforced in
-    // connect_locked). NMC keeps a full-residency m_index with no height-index.
+    // connect_locked -- tracked as a hardening follow-up; low-nBits headers
+    // cannot outweigh the honest chain since chain_work is derived from nBits).
+    // MEMORY: m_index is HEADERS-ONLY -- the AuxPow proof blob is persisted to
+    // LevelDB behind has_auxpow and dropped from the resident IndexEntry after
+    // admission (connect_locked) and never restored into RAM (to_entry), so RSS
+    // plateaus at ~200 B/entry across the full ~740k-header NMC history instead
+    // of ballooning by the ~1-3 KB proof per merge-mined header. No height-index.
 };
 
 } // namespace coin

--- a/src/impl/nmc/test/auxpow_merkle_test.cpp
+++ b/src/impl/nmc/test/auxpow_merkle_test.cpp
@@ -908,7 +908,45 @@ TEST(NmcP1eStore, VerifiedAuxPowConnectsAtActivationHeight)
     EXPECT_TRUE(chain_.has_header(aux));
     EXPECT_EQ(chain_.height(), 1u);
     ASSERT_TRUE(chain_.get_header(aux).has_value());
-    EXPECT_TRUE(chain_.get_header(aux)->auxpow.has_value());
+    // MEMORY: the verified proof is persisted to disk behind has_auxpow, then
+    // DROPPED from the resident IndexEntry so m_index stays headers-only across
+    // the full NMC history (the OOM-balloon fix). The merge-mined verdict is
+    // preserved by status, not by keeping the blob in RAM.
+    EXPECT_FALSE(chain_.get_header(aux)->auxpow.has_value());
+    EXPECT_EQ(chain_.get_header(aux)->status, nmc::coin::HEADER_VALID_CHAIN);
+}
+
+// MEMORY / OOM-balloon fix: admitting a merge-mined header must NOT grow the
+// resident index by the AuxPow proof size. The proof (parent coinbase tx + two
+// merkle branches + parent header, ~1-3 KB) is written to LevelDB behind
+// has_auxpow and immediately released from the resident IndexEntry; only the
+// slim header + status + chain_work remain in RAM. This is the invariant that
+// keeps RSS flat across a ~740k-header IBD instead of OOM-killing the arm.
+TEST(NmcP1eStore, AdmittedAuxPowIsDroppedFromResidentIndex)
+{
+    HeaderChain chain_(params_activation(1));       // activation at height 1
+    uint256 z; z.SetNull();
+    BlockHeaderType g = plain_header(z, 0x1d00ffffu, 1);
+    ASSERT_TRUE(chain_.add_header(g));              // genesis (height 0, plain)
+
+    uint32_t aux_bits = 0x207fffffu;
+    BlockHeaderType h1 = plain_header(block_hash(g), aux_bits, 7);
+    uint256 aux = block_hash(h1);
+    AuxPow ap = complete_proof(aux, /*parent_own_bits=*/0x1d00ffffu);
+    ASSERT_TRUE(mine_parent(ap, chain::bits_to_target(aux_bits)));
+    ASSERT_EQ(chain_.verify_auxpow_header(h1, ap), AuxPow::CheckResult::VALID);
+    ASSERT_TRUE(chain_.add_auxpow_header(h1, ap));
+
+    auto e = chain_.get_header(aux);
+    ASSERT_TRUE(e.has_value());
+    // The resident entry carries the header + verdict, but NOT the proof blob.
+    EXPECT_FALSE(e->auxpow.has_value());
+    EXPECT_EQ(e->status, nmc::coin::HEADER_VALID_CHAIN);
+    EXPECT_EQ(e->block_hash, aux);
+    // The genesis (plain, no proof) is likewise slim — nothing to drop.
+    auto ge = chain_.get_header(block_hash(g));
+    ASSERT_TRUE(ge.has_value());
+    EXPECT_FALSE(ge->auxpow.has_value());
 }
 
 TEST(NmcP1eStore, PrematureAuxPowIsRejectedByStoreEvenWhenProofValid)
@@ -1331,12 +1369,20 @@ TEST(NmcP1fPersist, DiskRoundTripPreservesMergeMinedStatusAndAuxFlag)
     ps >> back;
     EXPECT_EQ(back.has_auxpow, 1);
 
+    // The DISK form preserves the proof blob byte-for-byte (P1f(a) durability):
+    // the codec is where the AuxPow persists, so the assertion is on the on-disk
+    // struct after unpack, not on the resident projection.
+    ASSERT_TRUE(back.auxpow.has_value());                 // P1f(a): blob durable on disk
+    EXPECT_EQ(back.auxpow->chain_merkle_index, e.auxpow->chain_merkle_index);
+    EXPECT_EQ(parent_coinbase_txid(back.auxpow->parent_coinbase),
+              parent_coinbase_txid(e.auxpow->parent_coinbase));
+
+    // The RESIDENT projection deliberately defers the blob (OOM-balloon fix):
+    // to_entry() keeps the merge-mined verdict via status but leaves auxpow
+    // empty so a reload cannot re-balloon RAM.
     IndexEntry r = back.to_entry();
     EXPECT_EQ(r.status, nmc::coin::HEADER_VALID_CHAIN);    // status survives reload
-    ASSERT_TRUE(r.auxpow.has_value());                    // P1f(a): blob now restored
-    EXPECT_EQ(r.auxpow->chain_merkle_index, e.auxpow->chain_merkle_index);
-    EXPECT_EQ(parent_coinbase_txid(r.auxpow->parent_coinbase),
-              parent_coinbase_txid(e.auxpow->parent_coinbase));
+    EXPECT_FALSE(r.auxpow.has_value());                   // resident stays slim
 }
 
 TEST(NmcP1fPersist, ReopenRestoresEmptyChainAsEmpty)
@@ -1465,7 +1511,12 @@ TEST(NmcP1fAcceptPersist, ValidatedAuxPowHeaderSurvivesReopenViaAcceptPath)
         EXPECT_EQ(b.tip()->block_hash, aux);                   // tip advanced + survived
         ASSERT_TRUE(b.get_header(aux).has_value());
         EXPECT_EQ(b.get_header(aux)->status, nmc::coin::HEADER_VALID_CHAIN);
-        EXPECT_TRUE(b.get_header(aux)->auxpow.has_value());    // P1f(a) blob restored thru live path
+        // MEMORY: the P1f(a) proof blob remains DURABLE on disk (has_auxpow=1,
+        // codec covered by DiskRoundTripPreservesMergeMinedStatusAndAuxFlag), but
+        // it is NOT rehydrated into the resident index on reload — to_entry()
+        // defers it so a restart cannot re-balloon RAM. The merge-mined verdict
+        // is carried by status, which survives the round-trip above.
+        EXPECT_FALSE(b.get_header(aux)->auxpow.has_value());
     }
 }
 
@@ -1572,14 +1623,17 @@ TEST(NmcAuxPowPersist, IndexEntryDiskV1RoundTripsAuxPowBlob)
     ASSERT_EQ(back.has_auxpow, 1);
     ASSERT_TRUE(back.auxpow.has_value());
 
+    // Blob durability is asserted on the DISK struct (back), where the proof is
+    // persisted byte-for-byte; the resident projection defers it by design.
+    EXPECT_EQ(back.auxpow->chain_merkle_index,      e.auxpow->chain_merkle_index);
+    EXPECT_EQ(back.auxpow->parent_coinbase_branch,  e.auxpow->parent_coinbase_branch);
+    EXPECT_EQ(parent_coinbase_txid(back.auxpow->parent_coinbase),
+              parent_coinbase_txid(e.auxpow->parent_coinbase));
+
     IndexEntry r = back.to_entry();
     EXPECT_EQ(r.height, e.height);
     EXPECT_EQ(r.status, e.status);
-    ASSERT_TRUE(r.auxpow.has_value());
-    EXPECT_EQ(r.auxpow->chain_merkle_index,      e.auxpow->chain_merkle_index);
-    EXPECT_EQ(r.auxpow->parent_coinbase_branch,  e.auxpow->parent_coinbase_branch);
-    EXPECT_EQ(parent_coinbase_txid(r.auxpow->parent_coinbase),
-              parent_coinbase_txid(e.auxpow->parent_coinbase));
+    EXPECT_FALSE(r.auxpow.has_value());   // OOM-balloon fix: resident stays slim
 
     // A proofless entry trails no blob and restores to nullopt.
     IndexEntry plain = e; plain.auxpow = std::nullopt;


### PR DESCRIPTION
## What

The embedded NMC merged-mining arm on the BTC parent (`--merged NMC:...`) could not sustain a daemonless run: it **SEGV'd on every clean stop**, and it **OOM-killed itself mid-IBD**. Two independent lifecycle defects, both fixed here. No commitment-format or consensus change — the findable `fabe6d6d` aux commitment and the AuxPoW P2P header-feed are already on master; this makes the arm actually reach and hold sync.

## 1. SEGV — use-after-free on shutdown (`src/c2pool/main_btc.cpp`)

The per-broadcaster NMC header-admission `thread_pool` runs `HeaderChain::connect_locked()` on a raw `HeaderChain*` captured by the header sink. That pool's `shared_ptr` lived **only** inside the sink lambda owned by the `CoinBroadcaster`, and `merged_broadcasters` is declared *before* `nmc_chain` — so RAII destroyed the `HeaderChain` first and joined the pool only later, letting a worker still admitting a header batch dereference the freed chain.

Fix: own the pools at main scope and add an explicit teardown that, **before** the chain is destroyed, drops the merged-mining manager, clears the broadcasters (no new sink posts), then `stop()`+`join()`s every pool (drains in-flight `connect_locked`). The absent aux-RPC target is unrelated to the crash — every `AuxChainRPC` call is already try/catch-wrapped and degrades to the embedded arm.

## 2. OOM balloon — full-residency proof blobs (`src/impl/nmc/coin/header_chain.hpp`)

Every merge-mined header kept its full `AuxPow` proof (parent coinbase tx + two merkle branches + parent header, ~1–3 KB) resident in a full-residency `m_index`, so a ~740k-header IBD ballooned RSS until the OOM killer fired. The verified proof is **already persisted to LevelDB behind `has_auxpow`**, so:

- `connect_locked` drops the resident copy right after persist;
- `to_entry` no longer rehydrates the blob on reload.

`status` (`HEADER_VALID_CHAIN`) and `chain_work` are retained; nothing reads the resident blob after admission (verification runs *before* connect). `m_index` is now headers-only (~200 B/entry).

## Tests (`src/impl/nmc/test/auxpow_merkle_test.cpp`)

- New `NmcP1eStore.AdmittedAuxPowIsDroppedFromResidentIndex` pins the headers-only invariant.
- The accept/persist and disk-codec KATs now assert blob durability on the on-disk struct (where it persists) and slim residency on the projection.
- Red/green verified: the residency assertions **fail on the pre-fix source, pass with it**. Full `nmc_auxpow_merkle_test` suite 92/92 green; existing `fabe6d6d` commitment KATs unchanged and green.

## Verification

- `c2pool-btc` builds clean.
- Local: NMC arm started + SIGTERM'd 3× → exit 0, no core dumps, clean "Shutdown complete".
- Live daemonless run (3 GB `MemoryMax`, no namecoind): P2P AuxPoW header-feed sees the real NMC tip (peer height 840354) and admits headers past the AuxPoW activation height; RSS **~89 MB at height 554000** (≈165 B/header — the balloon is gone; the pre-fix binary OOM-killed in this range). A stop cycle exited `status=0` (previously always `status=11/SEGV`), 230 MB peak.

## Scope / follow-ups

- BTC/NMC arm only. The identical unjoined-pool pattern exists latently in `main_ltc.cpp` (DOGE-merged arm) — filed as a follow-up, not touched here to keep this reward-adjacent change tight.
- `nBits` retarget enforcement in `connect_locked` remains a hardening follow-up (low-`nBits` headers cannot outweigh the honest chain since `chain_work` derives from `nBits`).

Consensus-adjacent (coinbase aux-commitment neighbourhood, though untouched here) — please do not self-merge; operator merge tap on full green.