### PR TITLE
dashboard: render Local + Local DOA hashrate series at zero baseline

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -8470,7 +8470,9 @@
                     dashStyle: 'ShortDot',
                     marker: { enabled: false },
                     visible: seriesVisibility.local,
-                    yAxis: 0
+                    yAxis: 0,
+                    clip: false,
+                    zIndex: 4
                 }, {
                     type: 'spline',
                     name: 'Local DOA',
@@ -8480,7 +8482,9 @@
                     dashStyle: 'ShortDot',
                     marker: { enabled: false },
                     visible: seriesVisibility.localdoa,
-                    yAxis: 0
+                    yAxis: 0,
+                    clip: false,
+                    zIndex: 4
                 }]
             });
             
@@ -9189,7 +9193,9 @@
                     dashStyle: 'ShortDot',
                     marker: { enabled: false },
                     visible: seriesVisibility.local,
-                    yAxis: 0
+                    yAxis: 0,
+                    clip: false,
+                    zIndex: 4
                 }, {
                     type: 'spline',
                     name: 'Local DOA',
@@ -9199,7 +9205,9 @@
                     dashStyle: 'ShortDot',
                     marker: { enabled: false },
                     visible: seriesVisibility.localdoa,
-                    yAxis: 0
+                    yAxis: 0,
+                    clip: false,
+                    zIndex: 4
                 }]
             });
         }


### PR DESCRIPTION
## Problem

On a zero-rig node (no connected miners) the **Local** hashrate line never
appears on the main dashboard chart, even though PR #1141 added the Local +
Local DOA series, the `/web/graph_data/local_hash_rate/*` endpoints serve a
real series, and the legend chip is present. Observed live on
dash.voidbind.com: `/local_stats` reports `local_hashps=0.0` (honest zero,
no miners) and the graph endpoint returns an all-`0.0` series, but the line
is invisible.

## Root cause (display geometry, not data)

The Local / Local DOA series share the primary linear yAxis (`min: 0`) with
the pool Hashrate area. When every sample is `0.0`, each point plots at
`plotY == plotHeight` — the exact bottom edge of the plot area. Highcharts
clips each series to a rect whose height equals `plotHeight`, so the clip
boundary bisects the 2px `ShortDot` stroke: only a ~1px sliver survives,
landing directly on the 1px x-axis line and reading as invisible.

Proven by rendering the site's own bundled Highcharts 11.4.0 in jsdom with
an all-zero Local series over a nonzero pool area:

| | `clip-path` on series group | clip rect height | firstPlotY |
|---|---|---|---|
| **before (master)** | `url(#…)` (clipped) | 232 (= plotHeight) | 232 (bottom edge) |
| **after (this PR)** | `none` | — | 232 (bottom edge) |

The point stays at the baseline (value is genuinely 0 — no fabrication);
removing the clip lets the full stroke paint instead of being half-cut.

## Fix

Add `clip: false` to the **Local** and **Local DOA** series in both chart
builders — compact `renderHashrateGraph` and fullscreen
`renderFullscreenGraph`. `zIndex: 4` keeps the dotted local line above the
pool area fill (whose threshold-0 fill would otherwise cover the baseline).

Display-only: no data or value changes. A zero-rig node still reports `0.0`;
the fix only makes the honest flat-zero line visible with its existing
legend chip. Touches no reward/consensus/serve code — `web-static/dashboard.html`
only, +12/-4.

## Scope

Coin-generic. Every voidbind lane that runs zero-rig inherits the fix at its
next redeploy (the frontend ships bundled in the binary):
- **dash / dgb**: local series is all-zero → flat-zero line now visible.
- **btc**: local is nonzero but ~0.09% of the pool axis, so it already hugs
  the baseline; this fix helps the exact-zero case. The tiny-fraction case
  on a shared linear axis is inherent and left as an optional follow-up
  (separate axis / hover emphasis), not addressed here.