### PR TITLE
dash: read-only GET /embedded_template exposing the last-served embedded template

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -4210,6 +4210,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 std::cout << "[run] dashboard local-hashrate + per-worker "
                              "registry + block-value/net-diff bound to the DASH "
                              "stratum acceptor\n";
+
+                // ── /embedded_template (READ-ONLY observability) ───────────
+                // Expose the LAST embedded template this node SERVED to miners
+                // so the live validation harness can testmempoolaccept every
+                // served tx and bind the served merkle_branch to txs[]. The
+                // closure calls DASHWorkSource::embedded_template_json(), which
+                // reads only the non-fetching peek_template() snapshot -- no
+                // GBT fetch, no NodeCoinState read, no serve-path effect, and
+                // zero cost when unpolled (serialized on request only).
+                mi->set_embedded_template_fn(
+                    [wsrc = work_source.get()]() -> nlohmann::json {
+                        return wsrc->embedded_template_json();
+                    });
             }
         } else {
             std::cout << "[run] stratum FAILED to bind " << stratum_host << ":"

--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -428,6 +428,8 @@ void HttpSession::process_request()
                 rest_result = mining_interface_->rest_node_topology();
             else if (target == "/embedded_oracle")
                 rest_result = mining_interface_->rest_embedded_oracle();
+            else if (target == "/embedded_template")
+                rest_result = mining_interface_->rest_embedded_template();
             else if (target == "/luck_stats")
                 rest_result = mining_interface_->rest_luck_stats();
             else if (target == "/ban_stats")

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5337,6 +5337,17 @@ nlohmann::json MiningInterface::rest_embedded_oracle()
         {"note", "embedded-oracle-shadow not wired on this node"}};
 }
 
+nlohmann::json MiningInterface::rest_embedded_template()
+{
+    if (m_embedded_template_fn) {
+        auto j = m_embedded_template_fn();
+        if (!j.is_null())
+            return j;
+    }
+    return nlohmann::json{{"state", "unavailable"},
+        {"note", "embedded-template endpoint not wired on this node"}};
+}
+
 nlohmann::json MiningInterface::rest_node_topology()
 {
     // D0.3 seam: prefer the per-coin StatsProvider hook when the wiring layer

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -561,6 +561,16 @@ public:
     void set_embedded_oracle_fn(embedded_oracle_fn_t fn) { m_embedded_oracle_fn = thread_safe_wrap(std::move(fn)); }
     nlohmann::json rest_embedded_oracle();            // /embedded_oracle
 
+    // ── /embedded_template — READ-ONLY snapshot of the LAST embedded template
+    // this node SERVED to miners (height/coinbase/txs[txid,raw,fee]/cbtx/
+    // superblock-placeholder + the served stratum merkle_branch). Serialized on
+    // request only, touches no serving/consensus state, zero cost when unpolled.
+    // Bound by the coin target (main_dash.cpp) to DASHWorkSource::
+    // embedded_template_json(). Unset -> a {state:unavailable} shape.
+    using embedded_template_fn_t = std::function<nlohmann::json()>;
+    void set_embedded_template_fn(embedded_template_fn_t fn) { m_embedded_template_fn = thread_safe_wrap(std::move(fn)); }
+    nlohmann::json rest_embedded_template();          // /embedded_template
+
     // Sharechain stats callback — returns live tracker data for the /sharechain/stats endpoint
     using sharechain_stats_fn_t = std::function<nlohmann::json()>;
     void set_sharechain_stats_fn(sharechain_stats_fn_t fn) { m_sharechain_stats_fn = thread_safe_wrap(std::move(fn)); }
@@ -1254,6 +1264,7 @@ private:
     coin_peers_fn_t m_coin_peers_fn;
     node_topology_fn_t m_node_topology_fn;  // D0.3 per-coin stats provider (optional)
     embedded_oracle_fn_t m_embedded_oracle_fn;  // /embedded_oracle shadow-validator stats (optional)
+    embedded_template_fn_t m_embedded_template_fn;  // /embedded_template last-served snapshot (optional)
     // Rate limiter for /api/coin_peers: IP → last request time
     std::map<std::string, std::chrono::steady_clock::time_point> m_coin_peers_rate_limit;
     sharechain_window_fn_t m_sharechain_window_fn;

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -351,6 +351,160 @@ int64_t DASHWorkSource::peek_template_age_sec() const
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// READ-ONLY observability: /embedded_template.
+//
+// A JSON snapshot of the LAST embedded template this node SERVED to miners.
+// Everything here reads the cached peek_template() snapshot -- an immutable
+// shared_ptr<const DashWorkData> -- plus pure, coin-state-free helpers
+// (make_coin_params over the is_testnet_ member, compute_dash_payouts, build,
+// the coinbase merkle helpers). It touches NO NodeCoinState and takes NO lock
+// the serve path holds, so it is safe from the dashboard HTTP thread, costs
+// nothing when unpolled, and cannot perturb the coinbase the miners hash.
+//
+// The byte-binding contract (the harness acceptance test): txs[] is exactly the
+// leaf set [tx1..txN] folded (with a coinbase placeholder at leaf 0) into the
+// served coinbase merkle root, and merkle_branch[] is recomputed from that SAME
+// cached snapshot -- so recomputing the stratum branch from txs[] txids
+// reproduces the branch miners received.
+// ─────────────────────────────────────────────────────────────────────────────
+nlohmann::json DASHWorkSource::embedded_template_json() const
+{
+    auto wd = peek_template();   // last-served snapshot; no fetch, no coin-state
+    if (!wd) {
+        return nlohmann::json{
+            {"state", "no_template_served_yet"},
+            {"note",  "no embedded template has been sourced yet -- poll again"}};
+    }
+
+    nlohmann::json out = nlohmann::json::object();
+    out["state"]             = "ok";
+    out["height"]            = wd->m_height;
+    out["previousblockhash"] = wd->m_previous_block.GetHex();
+    out["version"]           = wd->m_version;
+    out["nbits"]             = dash::coinbase::be_hex_u32(wd->m_bits);
+    out["curtime"]           = static_cast<uint64_t>(
+        wd->m_curtime ? wd->m_curtime
+                      : static_cast<uint32_t>(std::time(nullptr)));
+    if (wd->m_mintime)
+        out["mintime"] = wd->m_mintime;
+    out["coinbasevalue_duffs"] = wd->m_coinbase_value;
+    out["template_age_sec"]    = peek_template_age_sec();
+
+    // ── The served tx set (byte-binding subject) ─────────────────────────
+    // txid is the block-explorer display form (GetHex, reverse-of-internal),
+    // matching dashd's getrawtransaction / testmempoolaccept output so the
+    // harness can correlate a served tx to dashd's verdict directly. The
+    // merkle helpers below fold the INTERNAL bytes (GetChars) -- a consumer
+    // reproducing the branch reverses each txid back to internal order.
+    nlohmann::json txs = nlohmann::json::array();
+    uint64_t total_fees = 0;
+    for (size_t i = 0; i < wd->m_tx_hashes.size(); ++i) {
+        nlohmann::json tx = nlohmann::json::object();
+        tx["txid"] = wd->m_tx_hashes[i].GetHex();
+        if (i < wd->m_tx_data_hex.size())
+            tx["raw"] = wd->m_tx_data_hex[i];
+        if (i < wd->m_tx_fees.size()) {
+            tx["fee_duffs"] = wd->m_tx_fees[i];
+            total_fees += wd->m_tx_fees[i];
+        }
+        txs.push_back(std::move(tx));
+    }
+    out["txs"]              = std::move(txs);
+    out["total_fees_duffs"] = total_fees;
+
+    // The contiguous mempool-sourced range of the body (the only range the
+    // validity gate should probe: type-6 quorum commitments and a zero-fee
+    // pinned donation are refused by relay policy BY DESIGN).
+    out["mempool_tx_first_index"] = wd->m_mempool_tx_first_index;
+    out["mempool_tx_count"]       = wd->m_mempool_tx_count;
+    if (!wd->m_txset_empty_cause.empty())
+        out["txset_empty_cause"] = wd->m_txset_empty_cause;
+
+    // ── The served stratum merkle branch (recomputed from THIS snapshot) ──
+    // Identical construction to get_stratum_merkle_branches(): [placeholder,
+    // tx1..txN] with a coinbase placeholder at leaf 0. Emitted so the harness
+    // has the reference branch to bind txs[] against.
+    {
+        std::vector<uint256> leaves;
+        leaves.reserve(1 + wd->m_tx_hashes.size());
+        leaves.push_back(uint256::ZERO);
+        leaves.insert(leaves.end(), wd->m_tx_hashes.begin(), wd->m_tx_hashes.end());
+        auto branch_hex = dash::coinbase::merkle_branches_hex(
+            dash::coinbase::merkle_branches_raw(leaves));
+        out["merkle_branch"] = branch_hex;
+    }
+
+    // ── Canonical template coinbase (pure assembly, no coin state) ────────
+    // Zero extranonce, no miner payout (whole worker portion -> donation
+    // tail), assembled through the SAME SSOTs the serve path uses. Lets the
+    // harness fold a concrete merkleroot; the per-session miner payout +
+    // extranonce vary but the masternode/superblock/CbTx outputs and the tx
+    // set the coinbase commits to do not.
+    try {
+        const core::CoinParams params = dash::make_coin_params(is_testnet_);
+        std::map<std::vector<unsigned char>, uint64_t> weights;  // empty
+        uint160 finder_pkh;                                      // zero
+        auto tx_outs = dash::coinbase::compute_dash_payouts(
+            wd->m_coinbase_value, wd->m_packed_payments, finder_pkh,
+            weights, /*total_weight=*/0, params);
+        dash::coinbase::CoinbaseLayout layout = dash::coinbase::build(
+            *wd, tx_outs,
+            dash::SharechainConfig::coinbase_text(params.is_testnet),
+            params, /*ref_hash=*/uint256::ZERO);
+
+        out["coinbase_hex"] = HexStr(layout.bytes);
+        out["coinbase_note"] =
+            "canonical template coinbase (zero extranonce, no miner payout); "
+            "per-session miner payout + extranonce vary";
+
+        // Full-block merkle root over [coinbase_txid, tx1..txN].
+        const uint256 cb_txid = dash::coin::coinbase_txid(layout.bytes);
+        std::vector<uint256> block_leaves;
+        block_leaves.reserve(1 + wd->m_tx_hashes.size());
+        block_leaves.push_back(cb_txid);
+        block_leaves.insert(block_leaves.end(),
+                            wd->m_tx_hashes.begin(), wd->m_tx_hashes.end());
+        out["coinbase_txid"] = cb_txid.GetHex();
+        out["merkleroot"]    = dash::coin::compute_merkle_root(block_leaves).GetHex();
+    } catch (const std::exception& e) {
+        // Never a 500: report the canonical-coinbase failure inline and still
+        // serve the tx set + branch (the byte-binding subject).
+        out["coinbase_hex"]  = nullptr;
+        out["merkleroot"]    = nullptr;
+        out["coinbase_note"] = std::string("canonical coinbase unavailable: ") + e.what();
+    }
+
+    // ── CbTx (DIP4 coinbase special-tx payload) ──────────────────────────
+    out["coinbase_payload_hex"] = HexStr(wd->m_coinbase_payload);
+    coin::vendor::CCbTx cbtx;
+    if (coin::vendor::parse_cbtx(wd->m_coinbase_payload, cbtx)) {
+        nlohmann::json cb = nlohmann::json::object();
+        cb["version"]           = cbtx.nVersion;
+        cb["height"]            = cbtx.nHeight;
+        cb["merkleRootMNList"]  = cbtx.merkleRootMNList.GetHex();
+        if (cbtx.nVersion >= coin::vendor::CCbTx::VERSION_MERKLE_ROOT_QUORUMS)
+            cb["merkleRootQuorums"] = cbtx.merkleRootQuorums.GetHex();
+        if (cbtx.nVersion >= coin::vendor::CCbTx::VERSION_CLSIG_AND_BALANCE) {
+            cb["bestCLHeightDiff"]  = cbtx.bestCLHeightDiff;
+            cb["bestCLSig_present"] = cbtx.has_best_cl_signature();
+            cb["creditPoolBalance"] = cbtx.creditPoolBalance;
+        }
+        out["cbtx"] = std::move(cb);
+    } else {
+        out["cbtx"] = nullptr;
+    }
+
+    // ── Superblock placeholder (govsync port pending: wf wxrmpvbao) ───────
+    // The field is emitted now so the harness can read it unconditionally;
+    // it flips to active with real payouts once the govsync lane lands.
+    out["superblock"] = nlohmann::json{
+        {"active",  false},
+        {"payouts", nlohmann::json::array()}};
+
+    return out;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // IWorkSource: work generation -- Stage 4c (the template trio).
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -555,6 +555,33 @@ public:
     /// presented a stale block_value as current on 2026-08-05.
     int64_t peek_template_age_sec() const;
 
+    /// READ-ONLY observability (/embedded_template): a JSON snapshot of the
+    /// LAST embedded template this node SERVED to miners. Sourced from
+    /// peek_template() -- the same non-fetching cached snapshot the block-value
+    /// card already reads -- so it triggers NO GBT fetch, reads NO NodeCoinState
+    /// (safe from the dashboard HTTP thread), and has ZERO cost when unpolled
+    /// (serialized on request only). It NEVER rebuilds the template: the tx set,
+    /// header fields and CbTx payload are exactly the cached ones the miners got.
+    ///
+    /// The txs[] array is exactly the leaves folded into the served coinbase's
+    /// merkle root ([coinbase placeholder, tx1..txN]), and the returned
+    /// merkle_branch[] is recomputed from that same cached snapshot, so a
+    /// consumer that recomputes the stratum branch from txs[] txids reproduces
+    /// the branch miners received -- the byte-binding the live validation
+    /// harness asserts before it testmempoolaccept's each served tx.
+    ///
+    /// coinbase_hex is the CANONICAL template coinbase (zero extranonce, no
+    /// miner payout -> the whole worker portion routes to the donation tail),
+    /// assembled purely from the cached template through the SAME
+    /// compute_dash_payouts/build SSOTs the serve path uses; the per-session
+    /// miner payout + extranonce vary, but the masternode/superblock/CbTx
+    /// outputs and the tx set it commits to do not. merkleroot folds that
+    /// coinbase txid over txs[].
+    ///
+    /// Returns a clear {"state":"no_template_served_yet"} object (NOT an error)
+    /// when nothing has been sourced yet.
+    nlohmann::json embedded_template_json() const;
+
 private:
     /// Template cache resolve: return the cached DashWorkData snapshot when it
     /// is still fresh (same work_generation AND younger than the staleness


### PR DESCRIPTION
## What

Adds a localhost-bound, **read-only** `GET /embedded_template` endpoint to the DASH web server. It exposes a JSON snapshot of the **last embedded template the node actually served to miners**, so an external validation harness can `testmempoolaccept` every served transaction and bind the served set to the coinbase's merkle commitment.

Registered next to the existing `/local_stats` / `/embedded_oracle` routes (`http_session.cpp`), wired through a `MiningInterface` callback (`web_server.{hpp,cpp}`) to `DASHWorkSource::embedded_template_json()`.

## Response shape

```
{ state, height, previousblockhash, version, nbits, curtime,
  coinbasevalue_duffs, total_fees_duffs, template_age_sec,
  txs: [ { txid, raw, fee_duffs } ],
  merkle_branch: [...],                       // served stratum branch
  coinbase_hex, coinbase_txid, merkleroot,    // canonical template coinbase
  coinbase_payload_hex,
  cbtx: { version, height, merkleRootMNList, merkleRootQuorums,
          bestCLHeightDiff, bestCLSig_present, creditPoolBalance },
  mempool_tx_first_index, mempool_tx_count,
  superblock: { active: false, payouts: [] } } // placeholder for the govsync follower
```

Before any template is sourced it returns `{state:"no_template_served_yet"}` (HTTP 200), never a 500.

## Safety / cost

- Sourced from the same non-fetching cached template (`peek_template()`) the block-value card already reads: **no GBT fetch, no NodeCoinState read**, safe from the dashboard HTTP thread.
- **Serialized only on request** — zero cost when unpolled.
- **Never rebuilds** the template: the tx set, header fields and CbTx are exactly the cached ones the miners received.
- **No consensus or serve-path behavior change** — the endpoint only reads the already-built last-served template.

## Byte-binding (acceptance test)

`txs[]` is exactly the leaf set folded (with a coinbase placeholder at leaf 0) into the served coinbase merkle root, and `merkle_branch` is recomputed from that same snapshot via the identical construction `get_stratum_merkle_branches()` uses. Recomputing the stratum branch from `txs[]` txids reproduces the branch miners received.

Verified live against a node's own stratum `mining.notify`:

| height | ntxs | branch_len | recomputed == endpoint | recomputed == stratum notify |
|--------|------|-----------|------------------------|------------------------------|
| 2530916 | 2 | 2 | PASS | PASS |
| 2530918 | 7 | 3 | PASS | PASS |

All three branch vectors byte-identical at both heights. Empty-state and fully-populated paths both exercised. Isolated build, zero-rig proof instance.
