### PR TITLE
dash: daemonless superblock govsync feed — inv 17/18 getdata pull + store populate (flag default-OFF)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6738,27 +6738,34 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // from exactly what the SML has applied, never a stranded base.
                 cp->send_getmnlistd(maint ? maint->sml_current_hash() : uint256::ZERO, tip);
                 // E-SUPERBLOCK: prime the governance object sync (triggers +
-                // proposals) to EVERY handshaked peer so a superblock height
-                // can be served daemonlessly. Zero nProp + empty filter =>
-                // request all objects. dashcore answers with INVENTORY
-                // (MSG_GOVERNANCE_OBJECT=17 invs); the inv handler now
-                // getdata-pulls those (batched) when the gov arm is armed, the
-                // govobj handler fires a per-object vote sync (govsync
-                // nProp=objectHash) for each accepted TRIGGER, and its
-                // MSG_GOVERNANCE_OBJECT_VOTE=18 reply invs are pulled the same
-                // way — so the store now populates instead of staying inert.
+                // proposals) so a superblock height can be served daemonlessly.
+                // send_govsync_prime() primes each NOT-YET-PRIMED handshaked peer
+                // EXACTLY ONCE per expiry window (dashd punishes a repeated full
+                // govsync from the same address: CGovernanceManager::SyncObjects
+                // Misbehaving(20)). This callback also re-fires on primary
+                // promotion, where the prime is a deliberate no-op — every peer
+                // is already primed, so nobody is written and no ban score
+                // accrues. Zero nProp + empty filter => request all objects;
+                // dashcore answers with INVENTORY (MSG_GOVERNANCE_OBJECT=17
+                // invs); the inv handler getdata-pulls those (batched) when the
+                // gov arm is armed, the govobj handler fires a per-object vote
+                // sync (govsync nProp=objectHash) for each accepted TRIGGER, and
+                // its MSG_GOVERNANCE_OBJECT_VOTE=18 reply invs are pulled the
+                // same way — so the store populates instead of staying inert.
                 // OFF (no --embedded-govsync/--embedded-superblock) the getdata
-                // is not sent, so this govsync is a harmless unanswered request
-                // (wire byte-identical to master's inert leg).
-                cp->send_govsync();
-                // R5: record govsync peer coverage per HANDSHAKED peer +
-                // (re)arm the quiescence window for the completeness
-                // determination. Under --coin-p2p-discover the bounded pool
-                // holds >= 2 peers, so recording each distinct key is what lets
-                // the min_peers (>=2) completeness floor ever flip TRUE (the
-                // serve-side R5 gate). With one peer it stays FALSE —
-                // reward-safe.
-                for (const auto& pk : cp->handshaked_peer_keys())
+                // is not sent, so the prime is a harmless unanswered request; the
+                // OFF-arm wire is once-per-peer (not loop-all-per-event), which
+                // is itself the fix — the old loop-all leg carried the same
+                // per-repeat ban hazard.
+                //
+                // R5: record govsync peer coverage from the NEWLY primed keys
+                // (never handshaked_peer_keys() — recording an already-primed
+                // peer would spuriously re-arm the quiescence window and delay
+                // completeness). Under --coin-p2p-discover the bounded pool holds
+                // >= 2 peers, so >= 2 distinct keys accumulate across handshakes
+                // and the min_peers (>=2) completeness floor can flip TRUE (the
+                // serve-side R5 gate). With one peer it stays FALSE — reward-safe.
+                for (const auto& pk : cp->send_govsync_prime())
                     maint->note_govsync_requested(pk);
             });
 

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1019,6 +1019,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // requires --embedded-serve-mempool-txs; the #1218
              // gbt-xcheck-txmerkle guard is untouched and stays the referee.
              bool embedded_ingest_dstx = false,
+             // --embedded-govsync (E-SUPERBLOCK): OBSERVE-ONLY arm of the
+             // governance sourcing lane — inv(MSG_GOVERNANCE_OBJECT=17 /
+             // _VOTE=18) getdata pull + per-object vote sync so the
+             // GovernanceStore POPULATES from the live govsync feed
+             // (BLS-verified operator votes, EvoNode-4x weighted tally). It
+             // does NOT arm SERVING: --embedded-superblock is the separate
+             // serve gate. DEFAULT OFF => no gov inv earns a getdata and the
+             // store stays empty (wire byte-identical to master). This lets the
+             // canary prove store-populate live WITHOUT touching the serve
+             // path. --embedded-superblock implies this (serving needs the
+             // feed), so passing either arms the pull.
+             bool embedded_govsync = false,
              // --embedded-proactive-rotate (PR-3): arm the LOW-RATE proactive
              // coin-P2P peer rotation. DEFAULT OFF => the coin client runs the
              // stall-only rotation (#147/#148), byte-identical to master. ON, a
@@ -6651,6 +6663,23 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          " is a drop (fail-closed, no state change).\n";
         }
 
+        // E-SUPERBLOCK: arm the governance sourcing lane when observe-only
+        // --embedded-govsync OR the serve gate --embedded-superblock is set
+        // (serving needs the feed). OFF => no gov inv earns a getdata, the
+        // GovernanceStore stays empty, every superblock height falls back to
+        // dashd — byte-identical to master.
+        if (embedded_govsync || embedded_superblock) {
+            coin_p2p->set_gov_pull(true);
+            std::cout << "[run] "
+                      << (embedded_superblock ? "--embedded-superblock"
+                                              : "--embedded-govsync")
+                      << ": coin-P2P governance sync ARMED (inv 17/18 batched"
+                         " getdata + per-object vote sync). The store populates"
+                         " from BLS-verified operator votes with EvoNode-4x"
+                         " weighting; SERVING stays gated on"
+                         " --embedded-superblock + the R5 completeness gate.\n";
+        }
+
         if (embedded_ingest_isdlock) {
             coin_p2p->set_isdlock_pull(true);
             std::cout << "[run] --embedded-ingest-isdlock: coin-P2P"
@@ -6708,24 +6737,29 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // the full cold snapshot; a reconnect after some sync re-requests
                 // from exactly what the SML has applied, never a stranded base.
                 cp->send_getmnlistd(maint ? maint->sml_current_hash() : uint256::ZERO, tip);
-                // E-SUPERBLOCK: prime the governance object/vote sync (triggers
-                // + funding votes) so a superblock height can be served
-                // daemonlessly. Zero nProp + empty filter => request all.
-                // Handshake-only today — there is NO tip-change re-prime yet.
-                // KNOWN GAP (pre-enable requirement): dashcore answers govsync
-                // with INVENTORY (MSG_GOVERNANCE_OBJECT/_VOTE invs), not
-                // direct govobj/govobjvote messages, and our inv handler does
-                // not getdata governance types — so this leg is currently
-                // INERT (an extra fail-closed layer: the store stays empty).
-                // The inv-driven getdata + per-object vote sync + periodic
-                // re-prime co-land with vote-verify before any enable.
+                // E-SUPERBLOCK: prime the governance object sync (triggers +
+                // proposals) to EVERY handshaked peer so a superblock height
+                // can be served daemonlessly. Zero nProp + empty filter =>
+                // request all objects. dashcore answers with INVENTORY
+                // (MSG_GOVERNANCE_OBJECT=17 invs); the inv handler now
+                // getdata-pulls those (batched) when the gov arm is armed, the
+                // govobj handler fires a per-object vote sync (govsync
+                // nProp=objectHash) for each accepted TRIGGER, and its
+                // MSG_GOVERNANCE_OBJECT_VOTE=18 reply invs are pulled the same
+                // way — so the store now populates instead of staying inert.
+                // OFF (no --embedded-govsync/--embedded-superblock) the getdata
+                // is not sent, so this govsync is a harmless unanswered request
+                // (wire byte-identical to master's inert leg).
                 cp->send_govsync();
-                // R5: record govsync peer coverage + (re)arm the quiescence
-                // window for the completeness determination. With the current
-                // single-peer connection model this covers ONE peer, so the
-                // default min_peers floor (>=2) keeps the completeness predicate
-                // FALSE — reward-safe until multi-peer govsync lands.
-                maint->note_govsync_requested(cp->peer_key());
+                // R5: record govsync peer coverage per HANDSHAKED peer +
+                // (re)arm the quiescence window for the completeness
+                // determination. Under --coin-p2p-discover the bounded pool
+                // holds >= 2 peers, so recording each distinct key is what lets
+                // the min_peers (>=2) completeness floor ever flip TRUE (the
+                // serve-side R5 gate). With one peer it stays FALSE —
+                // reward-safe.
+                for (const auto& pk : cp->handshaked_peer_keys())
+                    maint->note_govsync_requested(pk);
             });
 
         std::cout << "[run] E2a live-feed wired: header-chain(" << hdr_db
@@ -9796,6 +9830,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                         << (mn_ckpt_lane ? mn_ckpt_lane->waiting_for()
                                          : std::string("n/a"))
                         << " hdr_tip=" << (header_chain ? header_chain->height() : 0)
+                        // E-SUPERBLOCK govsync store status (grep-provable on the
+                        // observe-only soak): triggers held / weighted funding
+                        // threshold / distinct peers primed (R5 coverage floor)
+                        // / whether the completeness gate is currently TRUE.
+                        // triggers>0 with coverage>=2 and complete=1 is the
+                        // shape that lets a superblock height serve daemonlessly.
+                        << " gov_triggers="
+                        << (maintainer ? maintainer->gov_store().trigger_count()
+                                       : 0)
+                        << " gov_threshold="
+                        << (maintainer ? maintainer->gov_store().funding_threshold()
+                                       : 0)
+                        << " gov_peers="
+                        << (maintainer
+                                ? maintainer->gov_sync_status().requested_peer_count()
+                                : 0)
+                        << " gov_complete="
+                        << (maintainer
+                                ? (maintainer->gov_sync_complete() ? 1 : 0)
+                                : 0)
                         << " trigger=" << (changed ? "shape-change" : "heartbeat")
                         << " suppressed=" << *embed_since;
                     *embed_shape = shape.str();
@@ -10390,6 +10444,7 @@ int main(int argc, char** argv)
         dash::coin::p2p::CoinClient<dash::Config>::DEFAULT_POOL_PEERS;
     bool force_won_block = false;              // --regtest-force-won-block: fail-closed regtest E5 harness (drive one real won block through the run-path dual-path)
     bool embedded_superblock = false;          // --embedded-superblock: OPT-IN daemonless superblock payee sourcing via govsync (E-SUPERBLOCK); default OFF = superblock heights fall back to dashd (reward-safe)
+    bool embedded_govsync = false;             // --embedded-govsync: OBSERVE-ONLY arm of the governance sourcing lane (inv 17/18 pull + store populate); default OFF; does NOT arm serving (that is --embedded-superblock)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
     bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
@@ -10568,6 +10623,8 @@ int main(int argc, char** argv)
             force_won_block = true;
         else if (std::strcmp(argv[i], "--embedded-superblock") == 0)
             embedded_superblock = true;
+        else if (std::strcmp(argv[i], "--embedded-govsync") == 0)
+            embedded_govsync = true;
         else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
             embedded_utxo = true;
         else if (std::strcmp(argv[i], "--embedded-utxo-immature-serve-empty") == 0)
@@ -11042,6 +11099,7 @@ int main(int argc, char** argv)
                         embedded_accrue_asset_unlocks, // #143 Variant B
                         embedded_ingest_isdlock,       // G4 isdlock feed
                         embedded_ingest_dstx,          // W5-B DSTX feed
+                        embedded_govsync,              // E-SUPERBLOCK gov-sourcing observe arm
                         embedded_proactive_rotate,    // PR-3 proactive rotation
                         embedded_asn_diversity,        // PR-4 ASN diversity
                         embedded_fold_live_db,         // PR-C1 embedded-fold-live

--- a/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
+++ b/src/impl/bitcoin_family/coin/base_p2p_messages.hpp
@@ -122,6 +122,17 @@ struct inventory_type
                                         // NOTE: 16, NOT the retired legacy
                                         // MSG_ISLOCK=30 — protocol.h keeps
                                         // this enum backwards compatible)
+        govobject       = 17,           // MSG_GOVERNANCE_OBJECT (dashcore
+                                        // protocol.h:508). Governance object
+                                        // inv; the hash is the object identity
+                                        // hash (govobject_hash). getdata-pulled
+                                        // only when the daemonless governance
+                                        // arm is armed (E-SUPERBLOCK).
+        govobjectvote   = 18,           // MSG_GOVERNANCE_OBJECT_VOTE (dashcore
+                                        // protocol.h:509). Governance vote inv;
+                                        // the hash is the vote identity hash
+                                        // (govvote_identity_hash). Served
+                                        // per-object via a govsync(nProp=hash).
         quorum_final_commitment = 21,   // MSG_QUORUM_FINAL_COMMITMENT
         clsig           = 29,           // MSG_CLSIG (dashcore protocol.h:522)
         isdlock         = 31,           // MSG_ISDLOCK (dashcore protocol.h:524,

--- a/src/impl/dash/coin/govsync_status.hpp
+++ b/src/impl/dash/coin/govsync_status.hpp
@@ -59,8 +59,10 @@ inline constexpr int64_t DASH_GOVSYNC_SETTLE_SECS_DEFAULT = 60;
 /// (or its votes) — a one-peer "quiesced" view is exactly the partial-view
 /// hazard. dashcore syncs governance from multiple peers for the same reason.
 /// DEFAULT 2 (fail-closed leaning): a single-peer deployment can NEVER assert
-/// completeness, so it stays on the reward-safe dashd fallback until the
-/// multi-peer govsync leg lands.
+/// completeness, so it stays on the reward-safe dashd fallback. The multi-peer
+/// govsync leg that primes >= 2 distinct peers is CoinClient::send_govsync_prime()
+/// (each handshaked peer asked for the full object set exactly once per expiry
+/// window); the keys it returns are what feed note_govsync_requested here.
 inline constexpr size_t DASH_GOVSYNC_MIN_PEERS_DEFAULT = 2;
 
 /// Tracks daemonless governance-sync progress and answers is_complete(now).

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -48,8 +48,8 @@
 //     PeerSession above. No shared mutable per-connection state.
 //   * Inbound fan-in dedup (InvDedup above): the same inv now arrives from
 //     several peers; ONE getdata is issued, from a bounded expiring set.
-//   * A designated PRIMARY peer carries every request/response leg
-//     (getheaders / getmnlistd / getqrinfo / govsync / getdata-for-block), so
+//   * A designated PRIMARY peer carries every stateful request/response leg
+//     (getheaders / getmnlistd / getqrinfo / getdata-for-block), so
 //     a reply is always matched to the peer that was asked and the
 //     ReplyMatcher state on that Connection stays coherent. Non-primary peers
 //     are witnesses: they deliver inv-pushed traffic and are pulled from, but
@@ -917,14 +917,25 @@ private:
     // gated. A governance inv is otherwise inert: without the pull the
     // govobj/govobjvote handlers never fire and the GovernanceStore stays
     // empty, so a superblock height can never be served daemonlessly. OFF by
-    // default => the wire is byte-identical to the pre-fix node (govsync is
-    // still SENT at handshake, but the inv answer is not pulled). No budget:
-    // gov invs are batched to ONE getdata per inv message and dashd
-    // rate-limits full govsync per peer.
+    // default => the inv answer is not pulled and the store stays inert
+    // (a govsync(nProp=0) is still SENT once per peer at its handshake — the
+    // coverage-prime leg — but with the pull off its reply is ignored). No
+    // budget: gov invs are batched to ONE getdata per inv message, and the
+    // prime is sent to each peer EXACTLY ONCE per expiry window (send_govsync_prime,
+    // below) because dashd PUNISHES a repeated full govsync with Misbehaving(20).
     bool     m_gov_pull_enabled{false};
     uint64_t m_gov_inv_offered{0};   // inv(gov) SEEN on the wire, pre-dedup
     uint64_t m_gov_inv_seen{0};      // inv(gov) admitted by the dedup (armed)
     uint64_t m_gov_pull_sent{0};     // getdata(gov) invs issued (batched)
+    // E-SUPERBLOCK govsync PRIME bookkeeping: peer_key -> wall-seconds of the
+    // last full govsync(nProp=0) we sent that peer. Enforces the EXACTLY-ONCE-
+    // per-peer-per-window discipline (routing class 3): a repeated full govsync
+    // inside dashd's per-request fulfilled window draws Misbehaving(20) in
+    // CGovernanceManager::SyncObjects, so send_govsync_prime() skips any peer
+    // whose recorded time is within m_govsync_reprime_secs. Mirrors dashcore's
+    // own netfulfilledman HasFulfilledRequest("governance-sync") gate.
+    std::map<std::string, int64_t> m_govsync_primed;   // peer_key -> primed-at
+    int64_t  m_govsync_reprime_secs{3600};             // dashd mainnet 1h expiry
     size_t   m_tx_pull_inflight_cap{64};
     std::map<uint256, int64_t> m_tx_pull_inflight;   // txid -> requested-at
     uint64_t m_tx_inv_offered{0};    // inv(MSG_TX) SEEN on the wire, pre-dedup
@@ -1303,9 +1314,12 @@ public:
         for (const auto& p : m_pool) out.push_back(p->key);
         return out;
     }
-    // NOTE: handshaked_peer_keys() (the HANDSHAKE-COMPLETE peer set the govsync
-    // call site records via note_govsync_requested for the R5 coverage floor)
-    // is defined once below, near the bulk-scheduler peer accessors.
+    // NOTE: handshaked_peer_keys() (the HANDSHAKE-COMPLETE peer set) is defined
+    // once below, near the bulk-scheduler peer accessors. The R5 govsync
+    // coverage floor is NOT recorded from it — it is recorded from the keys
+    // RETURNED by send_govsync_prime() (the peers actually primed this round),
+    // so an already-primed peer that is re-visited does not spuriously re-arm
+    // the quiescence window / re-count as a fresh request.
     /// Per-peer connection age in seconds, in pool order — durability, direct.
     std::vector<int64_t> peer_ages_sec() const
     {
@@ -1727,20 +1741,41 @@ public:
 
     // ── request/response legs — PRIMARY-TARGETED ─────────────────────────
     //
-    // ROUTING POLICY. Every leg below is a QUESTION whose answer must be
-    // matched to the peer that was asked: the ReplyMatcher deferral state lives
-    // on that peer's Connection (p2p_connection.hpp), the historical-mnlistdiff
-    // demux keys on the reply's own content, and fanning a getmnlistd /
-    // getqrinfo / govsync out to N peers would multiply an entire mainnet
-    // governance stream by N for no extra evidence. So they all go to the
-    // PRIMARY peer, and the reply arrives on the primary's socket, where
-    // handle() routes it back to that same session. Non-primary peers are
-    // witnesses: they are never asked a stateful question.
+    // ROUTING POLICY. Three classes of outbound ask, distinguished by how the
+    // ANSWER relates to the peer, NOT by importance:
+    //
+    //   1. STATEFUL, CURSOR-MATCHED -> PRIMARY ONLY. Every leg below is a
+    //      QUESTION whose answer must be matched to the peer that was asked: the
+    //      ReplyMatcher deferral state lives on that peer's Connection
+    //      (p2p_connection.hpp), and getmnlistd / getqrinfo carry a
+    //      requester-supplied baseBlock->block cursor that the reply
+    //      (mnlistdiff / qrinfo) is COMPUTED FROM and must be applied against on
+    //      the asking session. Fanning these out would both mis-route the
+    //      cursor-bound reply and multiply the stream by N. So getheaders /
+    //      getmnlistd / getqrinfo / mempool go to the PRIMARY, and the reply
+    //      arrives on the primary's socket, where handle() routes it back to
+    //      that same session. Non-primary peers are witnesses here.
+    //   2. REPEAT-SAFE COVERAGE BROADCAST -> ALL PEERS. getaddr (discovery
+    //      breadth refills the pool) and won-block relay: the reply carries no
+    //      per-peer matching state, repeats are a protocol non-event, and
+    //      breadth/redundancy is the whole value. Fanned out deliberately.
+    //   3. REPEAT-PUNISHED COVERAGE PRIME -> EACH PEER EXACTLY ONCE. govsync
+    //      (nProp=0): its reply is a full object-inv dump with NO requester
+    //      cursor — bodies merge into the ONE GovernanceStore regardless of
+    //      which session delivered them, so multi-peer coverage is the defence
+    //      against a single peer withholding the winning trigger (R5). But
+    //      unlike getaddr, dashd PUNISHES a repeated full govsync from the same
+    //      address inside the netfulfilledman window with Misbehaving(20)
+    //      (CGovernanceManager::SyncObjects), so it cannot be a plain broadcast.
+    //      send_govsync_prime() (below) sends it to each handshaked peer AT MOST
+    //      ONCE per expiry window — the requester-side mirror of dashcore's own
+    //      CMasternodeSync + netfulfilledman once-per-peer gate.
     //
     // When the primary is lost, another handshaked peer is promoted and
     // m_on_handshake_complete re-fires — which is exactly the re-ask the
-    // single-peer client already performed on every reconnect, so no leg
-    // silently loses its driver.
+    // single-peer client already performed on every reconnect, so no class-1 leg
+    // silently loses its driver; the class-3 prime is idempotent across the
+    // re-fire (already-primed peers are skipped).
 
     /// Send a getheaders request (E2 sync driver seam; unused by E1 run_node).
     void send_getheaders(uint32_t version, const std::vector<uint256>& locator, const uint256& stop)
@@ -2267,41 +2302,78 @@ public:
         m_primary->note_request_sent(DatumClass::QrInfo, arrival_now_ms());
     }
 
-    /// Send a govsync (MNGOVERNANCESYNC) — E-SUPERBLOCK governance-object sync
-    /// seam. A zero nProp with an EMPTY bloom filter requests ALL governance
+    /// Send a govsync (MNGOVERNANCESYNC) PRIME — E-SUPERBLOCK governance-object
+    /// sync seam. A zero nProp with an EMPTY bloom filter requests ALL governance
     /// objects + votes; the peer streams them back as govobj / govobjvote
     /// messages, which the handlers above forward into the GovernanceStore.
     ///
-    /// COVERAGE: sends to EVERY handshaked peer, not just m_primary — dashcore
-    /// answers a govsync(nProp=0) with OBJECT invs only (SyncObjects), and the
-    /// R5 completeness predicate (set_superblock_sync_complete_fn) needs
-    /// >= min_peers (2) DISTINCT peers primed before it can flip TRUE. The
-    /// call site records each primed peer via note_govsync_requested (see the
-    /// keys returned by handshaked_peer_keys()). dashd rate-limits full govsync
-    /// per peer, so the re-prime at each handshake completion is safe. Returns
-    /// the number of peers written to (0 = no handshaked peer yet).
-    std::size_t send_govsync()
+    /// COVERAGE-PRIME, EXACTLY ONCE PER PEER (routing class 3). dashcore answers a
+    /// govsync(nProp=0) with OBJECT invs only (SyncObjects), and the R5
+    /// completeness predicate (set_superblock_sync_complete_fn) needs
+    /// >= min_peers (2) DISTINCT peers primed before it can flip TRUE — coverage
+    /// is the defence against a single peer withholding the winning trigger.
+    ///
+    /// But a full govsync must be sent to each peer AT MOST ONCE per expiry
+    /// window: dashd PUNISHES a repeat from the same address inside its
+    /// per-request fulfilled window (Params().FulfilledRequestExpireTime(), 1h on
+    /// mainnet) with Misbehaving(20) in CGovernanceManager::SyncObjects ("Asking
+    /// for the whole list multiple times in a short period of time is no good") —
+    /// five repeats = score 100 = ban. This is the requester-side mirror of
+    /// dashcore's own CMasternodeSync + netfulfilledman
+    /// HasFulfilledRequest("governance-sync") gate. So this primes each handshaked
+    /// peer whose key is not already in m_govsync_primed (within
+    /// m_govsync_reprime_secs), records it, and RETURNS the vector of NEWLY primed
+    /// keys. Invoked from on_handshake_complete: at each new handshake it writes to
+    /// exactly the one new unprimed peer; on primary promotion / a re-fire it
+    /// writes to NOBODY. The R5 coverage is recorded from the RETURNED keys, so it
+    /// accrues peer-by-peer across handshakes without any single call fanning out.
+    std::vector<std::string> send_govsync_prime()
     {
-        std::size_t sent = 0;
+        std::vector<std::string> primed;
+        const int64_t now = now_sec();
         for (auto& p : m_pool) {
             if (!p->handshake.complete()) continue;
+            auto it = m_govsync_primed.find(p->key);
+            if (it != m_govsync_primed.end() &&
+                m_govsync_reprime_secs > 0 &&
+                now - it->second < m_govsync_reprime_secs) {
+                // already primed within the expiry window — a repeat here is
+                // exactly the CGovernanceManager::SyncObjects Misbehaving(20)
+                // hazard, so skip it (dashd's own netfulfilledman once-only gate).
+                continue;
+            }
             auto m = message_govsync::make_raw(
                 uint256::ZERO,           // nProp = 0 => request all objects
                 std::vector<uint8_t>{},  // empty filter vData
                 /*nHashFuncs=*/0u, /*nTweak=*/0u, /*nFlags=*/uint8_t{0});
             p->write(m);
-            ++sent;
+            m_govsync_primed[p->key] = now;
+            primed.push_back(p->key);
         }
-        return sent;
+        return primed;
     }
 
-    /// Per-object vote sync (E-SUPERBLOCK): dashcore serves a governance
-    /// object's VOTES only in reply to a govsync whose nProp is that object's
-    /// hash (CGovernanceManager::SyncSingleObjVotes). A govsync(nProp=0) invs
-    /// OBJECTS only, never their votes, so a trigger's funding votes are
-    /// unreachable until we ask for them by hash. Fired from the govobj handler
-    /// the moment a TRIGGER object is accepted, to every handshaked peer so the
-    /// tally can reach the funding threshold. Bloom filter empty (match none =>
+    /// TEST/DEPLOYMENT SEAM: the govsync-prime re-ask TTL, seconds. Default 3600
+    /// (dashd's mainnet nFulfilledRequestExpireTime). 0 disables the once-only
+    /// guard so every call re-primes — used by the reprime-after-expiry KAT.
+    void set_govsync_reprime_secs(int64_t secs) { m_govsync_reprime_secs = secs; }
+
+    /// Per-object vote sync (E-SUPERBLOCK, routing class 2 for THIS leg): dashcore
+    /// serves a governance object's VOTES only in reply to a govsync whose nProp
+    /// is that object's hash (CGovernanceManager::SyncSingleObjVotes). A
+    /// govsync(nProp=0) invs OBJECTS only, never their votes, so a trigger's
+    /// funding votes are unreachable until we ask for them by hash. Fired from the
+    /// govobj handler the moment a TRIGGER object is accepted, to every handshaked
+    /// peer so the tally can reach the funding threshold.
+    ///
+    /// FANOUT IS SAFE HERE (unlike the nProp=0 prime): SyncSingleObjVotes has NO
+    /// netfulfilledman gate and draws NO Misbehaving penalty — per-object vote
+    /// sync repeats are not punished — and the reply is bounded by one object's
+    /// vote set (the inv handler further collapses N-peer vote invs to one batched
+    /// getdata per vote). Multi-peer vote gathering is the tally defence: a single
+    /// peer withholding a trigger's funding votes must not hold the tally under the
+    /// funding threshold. It fires once per accepted trigger, so it is naturally
+    /// once-per-object, not churn-multiplied. Bloom filter empty (match none =>
     /// send all votes for the object).
     std::size_t send_govsync(const uint256& prop)
     {

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -912,6 +912,19 @@ private:
     uint64_t m_dstx_inv_seen{0};     // inv(MSG_DSTX) admitted by the dedup
     uint64_t m_dstx_pull_sent{0};    // getdata(MSG_DSTX) issued
     uint64_t m_dstx_received{0};     // dstx bodies that arrived
+    // E-SUPERBLOCK governance sourcing lane (--embedded-govsync observe-only OR
+    // --embedded-superblock): OPT-IN, and — like DSTX — the GETDATA ITSELF is
+    // gated. A governance inv is otherwise inert: without the pull the
+    // govobj/govobjvote handlers never fire and the GovernanceStore stays
+    // empty, so a superblock height can never be served daemonlessly. OFF by
+    // default => the wire is byte-identical to the pre-fix node (govsync is
+    // still SENT at handshake, but the inv answer is not pulled). No budget:
+    // gov invs are batched to ONE getdata per inv message and dashd
+    // rate-limits full govsync per peer.
+    bool     m_gov_pull_enabled{false};
+    uint64_t m_gov_inv_offered{0};   // inv(gov) SEEN on the wire, pre-dedup
+    uint64_t m_gov_inv_seen{0};      // inv(gov) admitted by the dedup (armed)
+    uint64_t m_gov_pull_sent{0};     // getdata(gov) invs issued (batched)
     size_t   m_tx_pull_inflight_cap{64};
     std::map<uint256, int64_t> m_tx_pull_inflight;   // txid -> requested-at
     uint64_t m_tx_inv_offered{0};    // inv(MSG_TX) SEEN on the wire, pre-dedup
@@ -1290,6 +1303,9 @@ public:
         for (const auto& p : m_pool) out.push_back(p->key);
         return out;
     }
+    // NOTE: handshaked_peer_keys() (the HANDSHAKE-COMPLETE peer set the govsync
+    // call site records via note_govsync_requested for the R5 coverage floor)
+    // is defined once below, near the bulk-scheduler peer accessors.
     /// Per-peer connection age in seconds, in pool order — durability, direct.
     std::vector<int64_t> peer_ages_sec() const
     {
@@ -1810,6 +1826,35 @@ public:
     void set_dstx_pull(bool on) { m_dstx_pull_enabled = on; }
     bool dstx_pull_enabled() const { return m_dstx_pull_enabled; }
 
+    /// Arm the E-SUPERBLOCK governance sourcing lane (--embedded-govsync
+    /// observe-only OR --embedded-superblock). OFF by default: an explicit
+    /// operator decision. Like DSTX this gates the GETDATA itself — a
+    /// governance inv (MSG_GOVERNANCE_OBJECT=17 / _VOTE=18) has no fee-only-safe
+    /// unconditional consumer, so off-flag no gov inv earns a request and the
+    /// wire is byte-identical to master (the govsync request still goes out at
+    /// handshake, but its inv answer is not pulled → the store stays empty →
+    /// every superblock height falls back to dashd, the pre-fix behaviour).
+    /// ON arms the batched getdata + per-object vote sync; SERVING is separately
+    /// gated by --embedded-superblock, so --embedded-govsync alone proves the
+    /// store populates on the live canary WITHOUT arming the serve path.
+    void set_gov_pull(bool on) { m_gov_pull_enabled = on; }
+    bool gov_pull_enabled() const { return m_gov_pull_enabled; }
+
+    /// One greppable line for the observe-only soak: governance invs the peer
+    /// announced, how many were admitted+pulled once armed. Zero offered =
+    /// "peer is not serving governance"; offered>0 with getdata>0 and the store
+    /// counters (maintainer EMBED-STATUS) still zero = a verify/weight gap.
+    std::string gov_ingest_status() const
+    {
+        return "[GOVSYNC-INGEST] armed=" + std::string(m_gov_pull_enabled ? "1" : "0")
+             + " gov_inv_offered=" + std::to_string(m_gov_inv_offered)
+             + " gov_inv=" + std::to_string(m_gov_inv_seen)
+             + " getdata=" + std::to_string(m_gov_pull_sent);
+    }
+    uint64_t gov_inv_offered_count() const { return m_gov_inv_offered; }
+    uint64_t gov_inv_seen_count()    const { return m_gov_inv_seen; }
+    uint64_t gov_pull_sent_count()   const { return m_gov_pull_sent; }
+
     /// One greppable line: what the ingest lane asked for and what it got.
     /// received < pull_sent is normal (notfound, races, peers that drop);
     /// received == 0 with pull_sent > 0 for a sustained period is the
@@ -2226,14 +2271,49 @@ public:
     /// seam. A zero nProp with an EMPTY bloom filter requests ALL governance
     /// objects + votes; the peer streams them back as govobj / govobjvote
     /// messages, which the handlers above forward into the GovernanceStore.
-    void send_govsync()
+    ///
+    /// COVERAGE: sends to EVERY handshaked peer, not just m_primary — dashcore
+    /// answers a govsync(nProp=0) with OBJECT invs only (SyncObjects), and the
+    /// R5 completeness predicate (set_superblock_sync_complete_fn) needs
+    /// >= min_peers (2) DISTINCT peers primed before it can flip TRUE. The
+    /// call site records each primed peer via note_govsync_requested (see the
+    /// keys returned by handshaked_peer_keys()). dashd rate-limits full govsync
+    /// per peer, so the re-prime at each handshake completion is safe. Returns
+    /// the number of peers written to (0 = no handshaked peer yet).
+    std::size_t send_govsync()
     {
-        if (!m_primary) return;
-        auto msg = message_govsync::make_raw(
-            uint256::ZERO,               // nProp = 0 => request all
-            std::vector<uint8_t>{},      // empty filter vData
-            /*nHashFuncs=*/0u, /*nTweak=*/0u, /*nFlags=*/uint8_t{0});
-        m_primary->write(msg);
+        std::size_t sent = 0;
+        for (auto& p : m_pool) {
+            if (!p->handshake.complete()) continue;
+            auto m = message_govsync::make_raw(
+                uint256::ZERO,           // nProp = 0 => request all objects
+                std::vector<uint8_t>{},  // empty filter vData
+                /*nHashFuncs=*/0u, /*nTweak=*/0u, /*nFlags=*/uint8_t{0});
+            p->write(m);
+            ++sent;
+        }
+        return sent;
+    }
+
+    /// Per-object vote sync (E-SUPERBLOCK): dashcore serves a governance
+    /// object's VOTES only in reply to a govsync whose nProp is that object's
+    /// hash (CGovernanceManager::SyncSingleObjVotes). A govsync(nProp=0) invs
+    /// OBJECTS only, never their votes, so a trigger's funding votes are
+    /// unreachable until we ask for them by hash. Fired from the govobj handler
+    /// the moment a TRIGGER object is accepted, to every handshaked peer so the
+    /// tally can reach the funding threshold. Bloom filter empty (match none =>
+    /// send all votes for the object).
+    std::size_t send_govsync(const uint256& prop)
+    {
+        std::size_t sent = 0;
+        for (auto& p : m_pool) {
+            if (!p->handshake.complete()) continue;
+            auto m = message_govsync::make_raw(
+                prop, std::vector<uint8_t>{}, 0u, 0u, uint8_t{0});
+            p->write(m);
+            ++sent;
+        }
+        return sent;
     }
 
     /// Relay a pre-serialized won block as a `block` P2P message (the embedded
@@ -3538,6 +3618,15 @@ private:
         // Block invs fire new_block (the E2 ingest seam, which pulls headers
         // then the block). Object invs in the pull policy get an immediate
         // getdata; everything else is ignored.
+        //
+        // E-SUPERBLOCK: governance invs (MSG_GOVERNANCE_OBJECT=17,
+        // MSG_GOVERNANCE_OBJECT_VOTE=18) are collected across THIS inv message
+        // and pulled with ONE batched getdata after the loop. A mainnet govsync
+        // answers with thousands of vote invs in a single inv message (the
+        // oracle currently holds ~5400 votes); emitting one getdata per inv
+        // would be a self-inflicted flood. InvDedup still collapses the N-peer
+        // fan-in to one pull per (type, hash) before an inv reaches the batch.
+        std::vector<inventory_type> gov_pull_batch;
         for (auto& inv : msg->m_invs)
         {
             // inv_type_is_pulled is the TYPE predicate. isdlock is pulled
@@ -3546,7 +3635,16 @@ private:
             // isdlock. The runtime opt-in (--embedded-ingest-isdlock) gates
             // only the BLS-verified new_isdlock lane at the handler, not
             // the getdata.
-            const bool pulled = inv_type_is_pulled(inv.m_type);
+            //
+            // Governance invs are pull-eligible BY TYPE (inv_type_is_pulled)
+            // but RUNTIME-GATED (m_gov_pull_enabled) and BATCHED, so they are
+            // pulled through the gov branch below, not the unconditional
+            // `pulled` path — is_gov_type factors them out of `pulled` exactly
+            // as the is_dstx precedent factors DSTX out of the tx path.
+            const bool is_gov_type = (inv.base_type() == inventory_type::govobject
+                                   || inv.base_type() == inventory_type::govobjectvote);
+            const bool is_gov = is_gov_type && m_gov_pull_enabled;
+            const bool pulled = inv_type_is_pulled(inv.m_type) && !is_gov_type;
             const bool is_block = (inv.base_type() == inventory_type::block);
             const bool is_tx = (inv.base_type() == inventory_type::tx)
                             && m_tx_pull_enabled;
@@ -3561,7 +3659,11 @@ private:
             // are filtering". Same announcement from N peers = N offered, 1
             // admitted — that gap is the fan-in the pool exists to produce.
             if (inv.base_type() == inventory_type::tx) ++m_tx_inv_offered;
-            if (!pulled && !is_block && !is_tx && !is_dstx)
+            // Offered-vs-admitted for governance: count gov invs the peer
+            // announces even when the arm is OFF, so the observe-only soak can
+            // tell "peer is not announcing governance" from "we are not pulling".
+            if (is_gov_type) ++m_gov_inv_offered;
+            if (!pulled && !is_block && !is_tx && !is_dstx && !is_gov)
                 continue;   // not actionable — do not spend a dedup slot on it
             if (!m_inv_dedup.admit(static_cast<uint32_t>(inv.m_type), inv.m_hash, now))
             {
@@ -3596,6 +3698,17 @@ private:
                 auto getdata_msg = message_getdata::make_raw(
                     {inventory_type(inv.m_type, inv.m_hash)});
                 p->write(getdata_msg);
+                continue;
+            }
+            if (is_gov)
+            {
+                // E-SUPERBLOCK gated pull: collect this admitted governance inv
+                // for the ONE batched getdata after the loop (echo the announced
+                // type + hash straight back — the govobj inv hash is the object
+                // identity hash, the govobjvote inv hash is the vote identity
+                // hash; both are only ever echoed to the peer, never derived).
+                ++m_gov_inv_seen;
+                gov_pull_batch.emplace_back(inv.m_type, inv.m_hash);
                 continue;
             }
             if (is_tx || is_dstx)
@@ -3644,6 +3757,17 @@ private:
             // holds the block, not to an arbitrary primary (block_source).
             record_block_announcer(inv.m_hash, p->key);
             m_coin->new_block.happened(inv.m_hash);
+        }
+        // E-SUPERBLOCK: ONE batched getdata for every admitted governance inv
+        // in this inv message (objects on the initial govsync, per-object vote
+        // invs on a govsync(nProp=hash) — see send_govsync). Asking the peer
+        // that ANNOUNCED them routes every govobj/govobjvote reply back to this
+        // same session, where the handlers below forward them into the store.
+        if (!gov_pull_batch.empty())
+        {
+            m_gov_pull_sent += gov_pull_batch.size();
+            auto getdata_msg = message_getdata::make_raw(gov_pull_batch);
+            p->write(getdata_msg);
         }
     }
 
@@ -4098,6 +4222,21 @@ private:
                  << rec.object_hash.GetHex().substr(0, 16) << " type="
                  << rec.object_type << " data=" << rec.vch_data.size() << "B";
         m_coin->new_govobject.happened(rec);
+        // E-SUPERBLOCK per-object vote sync: a govsync(nProp=0) invs OBJECTS
+        // only — a TRIGGER's funding votes are served only in reply to a
+        // govsync(nProp=objectHash) (dashcore SyncSingleObjVotes). Fire it now
+        // for every accepted TRIGGER (GOVERNANCE_OBJECT_TRIGGER == 2) so the
+        // funding tally can reach the threshold. Gated on the arm so an
+        // unarmed node stays wire-identical; the reply's vote invs ride the
+        // same gated batched-getdata path as the objects.
+        if (m_gov_pull_enabled &&
+            rec.object_type == ::dash::coin::GOVERNANCE_OBJECT_TRIGGER)
+        {
+            const std::size_t primed = send_govsync(rec.object_hash);
+            LOG_INFO << "[" << m_chain_label << "] govobj TRIGGER "
+                     << rec.object_hash.GetHex().substr(0, 16)
+                     << " -> per-object vote sync to " << primed << " peer[s]";
+        }
     }
 
     ADD_P2P_HANDLER(govobjvote)

--- a/src/impl/dash/coin/p2p_messages.hpp
+++ b/src/impl/dash/coin/p2p_messages.hpp
@@ -189,11 +189,24 @@ END_MESSAGE()
 ///
 /// Block invs are deliberately NOT here: they take the getheaders-then-block
 /// path in the inv handler, not a bare getdata.
+///
+/// govobject (17) / govobjectvote (18) ARE pull-eligible types (E-SUPERBLOCK:
+/// dashcore answers a govsync with governance INVENTORY, not the objects
+/// directly — CGovernanceManager::SyncObjects / SyncSingleObjVotes — so without
+/// a getdata for these types the govobj / govobjvote handlers never fire and
+/// the GovernanceStore stays empty, exactly the pre-fix inert leg). Unlike
+/// clsig / isdlock they are RUNTIME-GATED, not unconditional: the inv handler
+/// pulls them only when m_gov_pull_enabled is armed (--embedded-govsync
+/// observe-only OR --embedded-superblock), the same is_dstx precedent. Keeping
+/// them in this TYPE predicate documents "these are getdata-pull types"; the
+/// handler decides whether to actually pull.
 inline bool inv_type_is_pulled(inventory_type::inv_type t)
 {
     return t == inventory_type::quorum_final_commitment
         || t == inventory_type::clsig
-        || t == inventory_type::isdlock;
+        || t == inventory_type::isdlock
+        || t == inventory_type::govobject
+        || t == inventory_type::govobjectvote;
 }
 
 // ── Phase C-SML step 4: Simplified MN List sync messages ──────────────

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -50,6 +50,7 @@
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/p2p_client.hpp>
+#include <impl/dash/coin/govsync_status.hpp>   // R5 coverage wiring proof
 #include <impl/dash/config.hpp>
 
 #include <core/netaddress.hpp>
@@ -845,10 +846,13 @@ TEST(DashCoinP2PPool, won_block_with_no_handshaked_peer_reports_zero_not_success
 
 TEST(DashCoinP2PPool, stateful_request_legs_go_to_the_primary_only)
 {
-    // getmnlistd / getqrinfo / getheaders / govsync are QUESTIONS whose answers
-    // must be matched to the peer that was asked. Fanning them out would
-    // multiply an entire mainnet governance stream by the pool size for no
-    // extra evidence.
+    // getmnlistd / getqrinfo / getheaders / mempool are STATEFUL, CURSOR-MATCHED
+    // QUESTIONS whose answers must be matched to the peer that was asked (routing
+    // class 1): the reply is computed FROM a requester-supplied cursor and applied
+    // against the asking session. Fanning them out would mis-route the reply and
+    // multiply the stream by the pool size for no extra evidence. (govsync is NOT
+    // here — it is a coverage-prime, routing class 3; see
+    // govsync_prime_covers_every_handshaked_peer_exactly_once below.)
     PoolRig rig;
     rig.client.set_max_peers(3);
     rig.handshake(1);
@@ -860,14 +864,143 @@ TEST(DashCoinP2PPool, stateful_request_legs_go_to_the_primary_only)
 
     rig.client.send_getheaders(70230, {}, uint256::ZERO);
     rig.client.send_getmnlistd(uint256::ZERO, uint256::ONE);
-    rig.client.send_govsync();
     rig.client.send_mempool();
 
-    EXPECT_EQ(rig.session(1)->msgs_sent, before[0] + 4u)
+    EXPECT_EQ(rig.session(1)->msgs_sent, before[0] + 3u)
         << "the request legs did not land on the primary";
     EXPECT_EQ(rig.session(2)->msgs_sent, before[1])
         << "a stateful request was fanned out to a witness peer";
     EXPECT_EQ(rig.session(3)->msgs_sent, before[2]);
+}
+
+// ── govsync (nProp=0) is a COVERAGE-PRIME: each peer asked EXACTLY once ────────
+
+TEST(DashCoinP2PPool, govsync_prime_covers_every_handshaked_peer_exactly_once)
+{
+    // govsync(nProp=0) is neither a primary-only stateful question nor a
+    // repeat-safe getaddr broadcast: its reply (full object invs) merges into the
+    // ONE GovernanceStore regardless of which peer sent it, so multi-peer coverage
+    // is the defence against a single peer hiding the winning funding trigger —
+    // BUT dashd PUNISHES a repeated full govsync from the same address with
+    // Misbehaving(20) (CGovernanceManager::SyncObjects). So the prime must reach
+    // every handshaked peer, and reach each one AT MOST ONCE per expiry window.
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(3);
+    rig.handshake(1);
+    rig.handshake(2);
+    rig.handshake(3);
+
+    std::vector<uint64_t> before;
+    for (int i = 1; i <= 3; ++i) before.push_back(rig.session(i)->msgs_sent);
+
+    // First prime: every handshaked peer is asked exactly once; the returned
+    // vector is the coverage record (3 distinct keys).
+    auto primed1 = rig.client.send_govsync_prime();
+    EXPECT_EQ(primed1.size(), 3u) << "the prime did not cover all 3 handshaked peers";
+    for (int i = 1; i <= 3; ++i)
+        EXPECT_EQ(rig.session(i)->msgs_sent, before[i - 1] + 1u)
+            << "peer " << i << " was not primed";
+
+    // Second prime (same expiry window): NOBODY is re-asked — a repeat would earn
+    // dashd's Misbehaving(20). Returns empty (no new coverage), no bytes written.
+    auto primed2 = rig.client.send_govsync_prime();
+    EXPECT_TRUE(primed2.empty()) << "a repeat prime re-asked an already-primed peer "
+                                    "(dashd Misbehaving(20) / ban vector)";
+    for (int i = 1; i <= 3; ++i)
+        EXPECT_EQ(rig.session(i)->msgs_sent, before[i - 1] + 1u)
+            << "peer " << i << " was re-primed inside the expiry window";
+}
+
+TEST(DashCoinP2PPool, govsync_prime_is_incremental_for_late_handshakes)
+{
+    // The prime fires from on_handshake_complete: at each new handshake it must
+    // write to exactly the ONE newly-handshaked (still-unprimed) peer, never
+    // re-touch the peers already primed at earlier handshakes.
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(3);
+    rig.handshake(1);
+    rig.handshake(2);
+
+    // Prime the first two.
+    auto r1 = rig.client.send_govsync_prime();
+    EXPECT_EQ(r1.size(), 2u);
+    const uint64_t s1 = rig.session(1)->msgs_sent;
+    const uint64_t s2 = rig.session(2)->msgs_sent;
+
+    // A third peer completes its handshake; prime again.
+    rig.handshake(3);
+    const uint64_t s3_before = rig.session(3)->msgs_sent;
+    auto r2 = rig.client.send_govsync_prime();
+
+    ASSERT_EQ(r2.size(), 1u) << "the incremental prime touched more than the new peer";
+    EXPECT_EQ(r2[0], PoolRig::peer_key(3));
+    EXPECT_EQ(rig.session(1)->msgs_sent, s1) << "peer 1 re-primed on a later handshake";
+    EXPECT_EQ(rig.session(2)->msgs_sent, s2) << "peer 2 re-primed on a later handshake";
+    EXPECT_EQ(rig.session(3)->msgs_sent, s3_before + 1u) << "the new peer was not primed";
+}
+
+TEST(DashCoinP2PPool, govsync_prime_reprime_after_expiry)
+{
+    // The once-only guard is an EXPIRY window (dashd's per-request fulfilled
+    // window, ~1h on mainnet), not a permanent latch: once it lapses the peer may
+    // be re-asked (dashcore re-syncs governance after its fulfilled request
+    // expires). set_govsync_reprime_secs(0) collapses the window so a second call
+    // re-primes, proving the TTL semantics rather than a one-shot flag.
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(2);
+    rig.client.set_govsync_reprime_secs(0);   // window lapses immediately
+    rig.handshake(1);
+    rig.handshake(2);
+
+    auto r1 = rig.client.send_govsync_prime();
+    EXPECT_EQ(r1.size(), 2u);
+    auto r2 = rig.client.send_govsync_prime();
+    EXPECT_EQ(r2.size(), 2u) << "a lapsed expiry window did not permit a re-prime";
+}
+
+TEST(DashCoinP2PPool, govsync_prime_returned_keys_drive_R5_to_two_peer_completeness)
+{
+    // THE MACHINE-CHECKED STATEMENT that a single peer can NEVER be the sole
+    // governance source: feed the keys RETURNED by the prime across handshakes
+    // into the production GovSyncStatus (the R5 completeness predicate the
+    // superblock serve path consults). One peer must stay INCOMPLETE; two DISTINCT
+    // primed peers must be able to cross the min_peers=2 floor and, after settle +
+    // quiescence, flip is_complete() TRUE — exactly the wiring main_dash performs
+    // (`for (pk : cp->send_govsync_prime()) maint->note_govsync_requested(pk)`).
+    using dash::coin::GovSyncStatus;
+    GovSyncStatus gov;                      // defaults: min_peers=2, settle=60, quiesce=30
+    const int64_t t0 = 1'000'000;
+
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.fake_now = t0;
+    rig.client.set_max_peers(2);
+
+    // First peer handshakes and is primed -> record its returned key.
+    rig.handshake(1);
+    for (const auto& pk : rig.client.send_govsync_prime())
+        gov.note_govsync_requested(pk, rig.fake_now);
+    EXPECT_EQ(gov.requested_peer_count(), 1u);
+    EXPECT_FALSE(gov.is_complete(t0 + 10'000))
+        << "a single primed peer must never be a complete governance view";
+
+    // Second DISTINCT peer handshakes later and is primed -> coverage reaches 2.
+    rig.fake_now = t0 + 5;
+    rig.handshake(2);
+    for (const auto& pk : rig.client.send_govsync_prime())
+        gov.note_govsync_requested(pk, rig.fake_now);
+    EXPECT_EQ(gov.requested_peer_count(), 2u)
+        << "two handshakes did not accrue two DISTINCT primed peers";
+
+    // Not settled yet (60s floor since first request).
+    EXPECT_FALSE(gov.is_complete(t0 + 30));
+    // After the settle floor AND the quiescence window with no new arrivals, the
+    // >=2-peer view is COMPLETE — the serve path may now trust the store.
+    EXPECT_TRUE(gov.is_complete(t0 + 61 + 30))
+        << "a >=2-peer, settled, quiesced governance view was not declared complete";
 }
 
 TEST(DashCoinP2PPool, getaddr_is_broadcast_because_discovery_breadth_refills_the_pool)

--- a/test/test_dash_p2p_messages.cpp
+++ b/test/test_dash_p2p_messages.cpp
@@ -239,6 +239,28 @@ TEST(DashP2PMessages, InvTypeNumbersMatchDashcoreProtocol) {
     // dashcore src/protocol.h enum GetDataMsg
     EXPECT_EQ(static_cast<uint32_t>(inventory_type::quorum_final_commitment), 21u);
     EXPECT_EQ(static_cast<uint32_t>(inventory_type::clsig), 29u);   // protocol.h:522
+    // E-SUPERBLOCK governance inv types (dashcore protocol.h:508-509)
+    EXPECT_EQ(static_cast<uint32_t>(inventory_type::govobject), 17u);
+    EXPECT_EQ(static_cast<uint32_t>(inventory_type::govobjectvote), 18u);
+}
+
+// E-SUPERBLOCK feed hook (red-on-master -> green). Before this change the inv
+// handler getdata-pulled only types 21/29/31, so a govsync answer's
+// MSG_GOVERNANCE_OBJECT (17) / _VOTE (18) invs were never requested — the
+// govobj/govobjvote handlers could never fire and the GovernanceStore stayed
+// empty, which is exactly why every superblock height refused to serve
+// daemonlessly. Admitting 17/18 to the pull TYPE predicate is the wire change
+// that lets the store populate (the runtime pull is additionally flag-gated in
+// the inv handler by m_gov_pull_enabled, the is_dstx precedent).
+TEST(DashP2PMessages, InvPullPolicyCoversGovernanceObjectsAndVotes) {
+    EXPECT_TRUE(inv_type_is_pulled(inventory_type::govobject))
+        << "governance objects are inv-announced and served only on getdata; "
+           "without this the govobj handler can never fire and the superblock "
+           "store never populates";
+    EXPECT_TRUE(inv_type_is_pulled(inventory_type::govobjectvote))
+        << "a trigger's funding votes are inv-announced and served only on "
+           "getdata; without this the tally can never reach the funding "
+           "threshold";
 }
 
 TEST(DashP2PMessages, InvPullPolicyCoversChainLocksAndCommitments) {

--- a/test/test_dash_superblock.cpp
+++ b/test/test_dash_superblock.cpp
@@ -661,6 +661,164 @@ TEST(DashSuperblock, TemplateEmitsSuperblockOutputs) {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
+// HISTORICAL BYTE-PARITY (the acceptance gate) — MAINNET superblock 2525632.
+//
+// Ground truth (Mauritius oracle dashd 192.168.86.165:9998, verbosity-2
+// getblock 0000000000000017221e577f37bb5d47a54b403e34ea1c5655e0cdf45b7328a1):
+// the on-chain coinbase txid 79030312ea976c901fa5e0d223ff1edecf71649b7f3e7f8e10f0c356f60ce3e1
+// pays vout[0]=miner, vout[1]=OP_RETURN(platform), vout[2]=MN, and
+// vout[3..16]= the 14 governance/treasury outputs of the funded superblock.
+// This KAT reconstructs the winning trigger's payment schedule from that
+// on-chain payee set (faithful because dashd validates a superblock coinbase
+// against exactly ParsePaymentSchedule(vchData), and address->script is
+// deterministic — the winning-trigger gobject itself is cycle-ephemeral and
+// long since erased network-wide), feeds it through the daemonless pipeline
+// parse_superblock_trigger -> GovernanceStore -> get_superblock_payments ->
+// build_embedded_workdata, and asserts the produced superblock coinbase
+// outputs are BYTE-IDENTICAL to the real vout[3..16] slice: same scripts,
+// same amounts, same ORDER (including the duplicate P2SH 7mUyau75… at
+// positions 4 and 12), same 20% treasury total (6817 DASH), under the
+// getsuperblockbudget cap (6828.26378160 DASH).
+// ═══════════════════════════════════════════════════════════════════════════
+namespace {
+
+// hex scriptPubKey -> raw bytes (the coinbase-serialized script form).
+std::vector<uint8_t> hb(const std::string& hex) {
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return 0;
+    };
+    std::vector<uint8_t> out;
+    out.reserve(hex.size() / 2);
+    for (size_t i = 0; i + 1 < hex.size(); i += 2)
+        out.push_back(static_cast<uint8_t>((nib(hex[i]) << 4) | nib(hex[i + 1])));
+    return out;
+}
+
+// The 14 governance outputs of superblock 2525632 in ON-CHAIN ORDER:
+//   {mainnet payee address, DASH-amount string, on-chain scriptPubKey hex,
+//    duffs}. Note the SAME P2SH payee (7mUyau75…) appears at index 3 and 11.
+struct SbVec { const char* addr; const char* amt; const char* spk; int64_t duffs; };
+const std::vector<SbVec> kSb2525632 = {
+    {"XoLMVTXpDWvLe4yKcj989nZ2vddE2zJQ6q","60",   "76a9148ab9a867903e835e86d0e4f417d968c5c78fa7ba88ac",  6000000000LL},
+    {"XgNfgrEB9n6uCY9Pi1hb2foimxPdtiZ4Z2","350",  "76a9143e60cc82015c846a4ff43fc80e587850dd248e8d88ac", 35000000000LL},
+    {"Xebhp13RsUPU8sqzAPiurHUh1kGCJ7zabs","200",  "76a9142ae7ba2caf2a0578aa1b4ee9431dcaac2c56805388ac", 20000000000LL},
+    {"7mUyau75ATy1c6LoZeG3D57jKBkR4iHJkE","4832", "a914d13bc5c4b8ca8073d08e12baf57690d3eebc6f7987",    483200000000LL},
+    {"Xx1DY36sQjrmvRTPw7kyTZ9Xg9dyVp3h7C","45",   "76a914e9d43ee3ac25faf34f1776f1d1e23e6ea28543ac88ac", 4500000000LL},
+    {"XjRx5Xj9G4kE4gvLT6GQKmvWMrtGPtUjkS","530",  "76a9145fe81b4ddaafdffbd6f70cdb7464b9567e15301d88ac", 53000000000LL},
+    {"XogmURyyvkE8DXdhZGUd1qgYwgvwZ8WCxR","100",  "76a9148e95ff1957118b3209f4b40b8e63f5bc42edd5bb88ac", 10000000000LL},
+    {"XjdnZBUedF4q8EzgWWAGsZrHteEgEUybbo","250",  "76a914622526095b3f27d9b8f7a6f975956d9a63586a9c88ac", 25000000000LL},
+    {"Xhf1d5nmRreWC3YkvQXWswFbPdpGyU6rRB","1",    "76a9144c7038928ca5ad481a348a4dc74270026f82568c88ac", 100000000LL},
+    {"Xr3EjtyMzJRcb5dkshjbjg6zXd2EY1662Y","85",   "76a914a865540d8b036f34b8fd60f328177a4c22f39a4d88ac", 8500000000LL},
+    {"XvQMESjyfJEW2hsSXNRvbXwBVizZgdNXkw","32",   "76a914d843fc6fdfd071c2fab8b94dcd8143cec67dcb1788ac", 3200000000LL},
+    {"7mUyau75ATy1c6LoZeG3D57jKBkR4iHJkE","200",  "a914d13bc5c4b8ca8073d08e12baf57690d3eebc6f7987",     20000000000LL},
+    {"XoccKgfVCBRWqu2GYWctDAdLGRybr2zbhP","82",   "76a9148dccb1a4f3d32a7bdb997d18ff53bea78723ab2488ac", 8200000000LL},
+    {"XcAY5amfZ4qr8WrzppGxLQ3uGpCYFb19zC","50",   "76a9141034f40bf6fe1543f2290d9c3e515b6698dff80f88ac", 5000000000LL},
+};
+
+std::string join_pipe(const std::vector<std::string>& v) {
+    std::string out;
+    for (size_t i = 0; i < v.size(); ++i) { if (i) out += "|"; out += v[i]; }
+    return out;
+}
+
+} // namespace
+
+TEST(DashSuperblockHistorical, Mainnet2525632CoinbaseBytesMatchOnChain) {
+    constexpr int32_t H = 2'525'632;
+    // 1) Reconstruct the winning trigger's plaintext JSON schedule from the
+    //    on-chain payee set (mainnet addresses, chain order). proposal_hashes
+    //    is a well-formed-but-arbitrary per-payee filler (the dashd parser
+    //    requires one valid uint256 hex per payee; it never affects the payee
+    //    math — get_superblock_payments consumes only script+amount).
+    std::vector<std::string> addrs, amts, props;
+    for (const auto& e : kSb2525632) {
+        addrs.emplace_back(e.addr);
+        amts.emplace_back(e.amt);
+        props.emplace_back(kPropHash);
+    }
+    const std::string json =
+        trigger_json(H, join_pipe(addrs), join_pipe(amts), join_pipe(props));
+
+    // 2) Parse via the daemonless dashd-exact parser (MAINNET chain-strict).
+    auto trig = parse_superblock_trigger(json, hash_of(2525632), /*testnet=*/false);
+    ASSERT_TRUE(trig.has_value()) << "mainnet trigger must parse";
+    ASSERT_EQ(trig->event_block_height, H);
+    ASSERT_EQ(trig->payments.size(), kSb2525632.size());
+
+    // 3) Feed the GovernanceStore and resolve the winning schedule under the
+    //    real getsuperblockbudget cap. superblock_budget(2525632, 16616) is
+    //    KAT-pinned below to the oracle's 6828.26378160 DASH.
+    const int64_t budget = superblock_budget(H, DASH_SUPERBLOCK_CYCLE_MAINNET);
+    EXPECT_EQ(budget, 682'826'378'160LL);  // dashd getsuperblockbudget 2525632
+
+    GovernanceStore store;
+    ASSERT_TRUE(store.add_trigger(*trig));
+    store.set_funding_threshold(1);
+    store.set_vote_weight_fn(weight_all_regular);
+    store.add_verified_funding_vote(hash_of(2525632), "mn-0", VOTE_OUTCOME_YES, 1);
+
+    auto sched = get_superblock_payments(store, H, budget);
+    ASSERT_TRUE(sched.has_value()) << "trigger-confident schedule must resolve";
+    ASSERT_EQ(sched->size(), kSb2525632.size());
+
+    // 4) BYTE-PARITY: the resolved (scriptPubKey, amount) vector is exactly the
+    //    on-chain coinbase vout[3..16] slice — order-exact, incl. the duplicate
+    //    P2SH at positions 3 and 11, to the duff.
+    int64_t total = 0;
+    for (size_t i = 0; i < kSb2525632.size(); ++i) {
+        const auto expected_script = hb(kSb2525632[i].spk);
+        EXPECT_EQ((*sched)[i].script, expected_script)
+            << "payee " << i << " (" << kSb2525632[i].addr
+            << ") scriptPubKey diverges from on-chain coinbase";
+        EXPECT_EQ((*sched)[i].amount, kSb2525632[i].duffs)
+            << "payee " << i << " amount diverges from on-chain coinbase";
+        total += kSb2525632[i].duffs;
+    }
+    // 20% treasury total: 6817 DASH, under the 6828.26378160 DASH budget.
+    EXPECT_EQ(total, 681'700'000'000LL);
+    EXPECT_LE(total, budget);
+
+    // 5) TEMPLATE WIRING: the embedded coinbase builder appends those payees as
+    //    ADDED outputs (mainnet address versions 76 / 16) and augments
+    //    coinbasevalue by exactly the treasury total — a valid CreateNewBlock-
+    //    equivalent superblock coinbase built daemonlessly.
+    MnStateMachine mn;   // empty MN set isolates the superblock outputs
+    Mempool mp;
+    DashWorkData base = build_embedded_workdata(
+        static_cast<uint32_t>(H) - 1, uint256::ZERO, mn, mp,
+        /*bits*/0x1a0ffff0, /*mtp*/1'700'000'000u,
+        /*addr_ver*/76, /*addr_p2sh*/16,
+        /*curtime*/1'700'000'100u, /*version*/0x20000000u,
+        /*underfill*/nullptr, /*sml*/nullptr, /*qmgr*/nullptr,
+        /*bestcl_h*/0, k_zero_cl_sig, /*credit_pool*/0,
+        /*qc_commitments*/nullptr, /*quorum_root_override*/nullptr,
+        DASH_MN_RR_HEIGHT_MAINNET, /*superblock_payments*/nullptr);
+    DashWorkData sb = build_embedded_workdata(
+        static_cast<uint32_t>(H) - 1, uint256::ZERO, mn, mp,
+        0x1a0ffff0, 1'700'000'000u, 76, 16,
+        1'700'000'100u, 0x20000000u,
+        nullptr, nullptr, nullptr, 0, k_zero_cl_sig, 0,
+        nullptr, nullptr, DASH_MN_RR_HEIGHT_MAINNET, &*sched);
+
+    EXPECT_EQ(sb.m_coinbase_value,
+              base.m_coinbase_value + static_cast<uint64_t>(total));
+    ASSERT_EQ(sb.m_packed_payments.size(),
+              base.m_packed_payments.size() + kSb2525632.size());
+    // The appended superblock outputs are in schedule order, each carrying the
+    // exact on-chain amount for its position (the duplicate 200-DASH / 4832-DASH
+    // P2SH pair distinguishes an order-preserving append from a set-merge).
+    const size_t off = base.m_packed_payments.size();
+    for (size_t i = 0; i < kSb2525632.size(); ++i) {
+        EXPECT_EQ(sb.m_packed_payments[off + i].amount,
+                  static_cast<uint64_t>(kSb2525632[i].duffs))
+            << "appended superblock output " << i << " amount/order diverges";
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // R5 / R6 — NodeCoinState + CoinStateMaintainer harness
 // ═══════════════════════════════════════════════════════════════════════════
 namespace {


### PR DESCRIPTION
## What

The fully-daemonless DASH node refused to serve **every superblock height**: it built no funded-superblock coinbase template, so miners at a superblock height got no work. Root cause was a dark feed, not missing logic — the winning-trigger resolution and the E-SUPERBLOCK coinbase seam were already on master (`GovernanceStore`, `get_superblock_payments`, `build_embedded_workdata` superblock outputs), but the **store never populated**: the coin-P2P inv handler getdata-pulled only inv types 21/29/31, so a govsync answer's `MSG_GOVERNANCE_OBJECT` (17) and `MSG_GOVERNANCE_OBJECT_VOTE` (18) inventory was never requested and the `govobj`/`govobjvote` handlers could never fire.

## The feed (the only new logic)

- `inventory_type` gains `govobject=17` / `govobjectvote=18` (dashcore `protocol.h:508-509`); `inv_type_is_pulled` admits them as pull-eligible **types**.
- The inv handler pulls gov invs only when armed (`m_gov_pull_enabled`), collecting all admitted gov invs from one inv message into **one batched getdata** — a mainnet govsync answers with thousands of vote invs, so per-inv getdata would be a self-inflicted flood. `InvDedup` still collapses the N-peer fan-in.
- `send_govsync()` now primes **every handshaked peer** (the R5 coverage floor), and a new `send_govsync(prop)` fires per accepted **TRIGGER** to pull that object's votes — dashcore's `SyncSingleObjVotes`: a `nProp=0` sync invs objects only, never their votes.
- The govsync call site records each handshaked peer via `note_govsync_requested` so the R5 completeness gate can reach `min_peers`.

## Arming (default OFF)

- `--embedded-govsync` — observe-only: populate + BLS-verify operator votes + EvoNode-4x weighted tally; the superblock provider stays OFF. Lets a canary prove the store populates on live wire **without** arming serving.
- `--embedded-superblock` — the serve gate (unchanged), implies the feed.

**Both default OFF** ⇒ no gov inv earns a getdata, the store stays empty, every superblock height falls back to dashd — wire and template behaviour byte-identical to before. `EMBED-STATUS` gains `gov_triggers`/`gov_threshold`/`gov_peers`/`gov_complete` so the observe-only soak is grep-provable.

## Proof

**Historical byte-parity KAT (acceptance gate)** — `DashSuperblockHistorical.Mainnet2525632CoinbaseBytesMatchOnChain`. Reconstructs the winning-trigger payment schedule from the real on-chain coinbase of mainnet superblock **2525632** (coinbase `79030312…e1`), feeds it through `parse_superblock_trigger` → `GovernanceStore` → `get_superblock_payments` → `build_embedded_workdata`, and asserts the produced superblock coinbase outputs are **byte-identical** to the on-chain `vout[3..16]` slice: 14 payees, order-exact including the duplicate P2SH `7mUyau75…` at positions 4 and 12, 6817 DASH treasury total under the `getsuperblockbudget` cap of 6828.26378160 DASH.

**Feed hook red→green** — `DashP2PMessages.InvPullPolicyCoversGovernanceObjectsAndVotes` fails with the pre-fix predicate (gov invs not pulled ⇒ store never populates ⇒ superblock heights refuse) and passes with the enum/predicate change.

Builds: `c2pool-dash` links; `test_dash_superblock` (27), `test_dash_p2p_messages` (13), `test_dash_dstx` (13) all green.

## Consensus safety

Trigger-selection and payee math are unchanged ports of dashcore `CGovernanceManager` / `CSuperblockManager` already on master — this PR only adds the wire feed that populates the store. Fail-closed discipline is preserved end-to-end (unverified/sub-threshold/over-budget ⇒ refuse ⇒ dashd fallback). The historical byte-parity KAT is the money-path gate. A live cross-check at the next funded superblock (~19 days out) is planned as belt-and-suspenders soak before any operator arms `--embedded-superblock` on the canary.
