### PR TITLE
dash: embedded template superset/parity of dashd CreateNewBlock (mempool special txs 1-4/8)

### DIFF
--- a/src/impl/dash/coin/embedded_gbt.hpp
+++ b/src/impl/dash/coin/embedded_gbt.hpp
@@ -30,6 +30,7 @@
 
 #include <impl/dash/coin/mn_state_machine.hpp>
 #include <impl/dash/coin/sml_projection.hpp>    // confirmedHash rollover pass + collateral-spend predicate
+#include <impl/dash/coin/sml_special_fold.hpp>  // template-side types 1-4 MN-list fold (merkleRootMNList parity)
 #include <impl/dash/coin/mempool.hpp>
 #include <impl/dash/coin/asset_lock_fold.hpp>   // #107 phase 2: DIP-0027 type-8 credit-pool fold
 #include <impl/dash/coin/asset_unlock_admission.hpp>  // #143 Variant B: verified type-9 set (light bridge struct)
@@ -54,6 +55,7 @@
 #include <array>
 #include <cstdint>
 #include <ctime>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -525,7 +527,21 @@ inline DashWorkData build_embedded_workdata(
     //     term (creditpool.h:98-100) — so the validator's re-derivation from
     //     the block's OWN txs matches (specialtxman.cpp bad-cbtx-assetlocked-
     //     amount otherwise).
-    const AssetUnlockAdmission* admitted_asset_unlocks = nullptr)
+    const AssetUnlockAdmission* admitted_asset_unlocks = nullptr,
+    // ── SUPERSET seam: INCLUDE MEMPOOL PROVIDER SPECIAL TXS (types 1-4) ────
+    // --embedded-include-mn-special-txs (default OFF). When true AND the
+    // template-side SML fold is available (sml != nullptr), mempool selection
+    // admits ProRegTx/ProUpServTx/ProUpRegTx/ProUpRevTx (types 1-4) and the
+    // builder folds their effect over a COPY of the projected SML
+    // (sml_special_fold.hpp) so the committed merkleRootMNList matches the list
+    // those txs produce — exactly dashd BuildNewListFromBlock + the CbTx root
+    // it commits. A tx the fold cannot apply exactly is EXCLUDED (never a bad
+    // root). Default false => types 1-4 stay excluded and every existing
+    // positional caller is byte-unchanged (the folded copy is never built).
+    // The type-8 (asset-lock) selection leg rides accrue_pending_asset_locks;
+    // types 5/6/7/9 are never selected (type-6 is builder-generated, type-9 is
+    // admission-path-only via admitted_asset_unlocks).
+    bool include_mn_special_txs = false)
 {
     DashWorkData w;
     w.m_height          = prev_height + 1;
@@ -599,11 +615,36 @@ inline DashWorkData build_embedded_workdata(
         reserved_bytes >= MAX_BLOCK_BYTES
             ? 0u
             : static_cast<uint32_t>(MAX_BLOCK_BYTES - reserved_bytes);
-    // C-3: exclude Dash special txs (tx.type != 0) from the embedded template.
-    // dashd recomputes the CbTx roots + creditPool by applying the block's own
-    // special txs; including one without accounting for it yields bad-cbtx. The
-    // safe-minimal cut keeps the embedded block special-tx-free so the creditPool
-    // accrual below is exactly the platform-reward term.
+    // ── PER-TYPE SPECIAL-TX ADMISSION MASK ────────────────────────────────
+    // dashd's BlockAssembler makes NO ordering distinction for special txs and
+    // recomputes the CbTx roots + creditPool by APPLYING the block's own
+    // special txs. So the embedded template is a SUPERSET/parity of dashd only
+    // when it INCLUDES the special txs dashd would include AND folds their
+    // effect into the CbTx. The mask below is that per-type gate:
+    //   * types 1-4 (ProReg/ProUpServ/ProUpReg/ProUpRev): admitted only when
+    //     the caller armed --embedded-include-mn-special-txs AND the SML fold
+    //     input is present (sml != nullptr) — the builder then folds them over
+    //     a projected-SML COPY and commits the resulting merkleRootMNList
+    //     (sml_special_fold.hpp, dashd BuildNewListFromBlock parity);
+    //   * type 8 (AssetLock): admitted only when accrue_pending_asset_locks is
+    //     armed — the credit-pool lock term is then derived from the SELECTED
+    //     BODY (not the mempool snapshot), matching dashd's
+    //     GetCreditPoolDiffForBlock over the block's own txs;
+    //   * types 5/6/7/9: never selected. Type-5 is the coinbase; type-6 quorum
+    //     commitments are builder-generated (dkg_commitments — a mempool copy
+    //     would duplicate the mandatory commitment, exactly as dashd's miner
+    //     injects its own); type-9 AssetUnlock is admission-path-only
+    //     (admitted_asset_unlocks / credit_pool_idx.hpp, because validity needs
+    //     the index follower).
+    // PER-TYPE DEGRADE: a missing leg masks ONLY its own type — a stale
+    // creditpool seed excludes type-8 while types 1-4 still ride, and a missing
+    // SML fold excludes types 1-4 while type-8 still rides. Default (all legs
+    // off) => admits() rejects every type!=0, byte-identical to the historical
+    // special-tx-free template.
+    Mempool::SpecialTxSelectMask special_mask;
+    special_mask.allow_all_special = false;                 // never the general path here
+    special_mask.allow_mn_types    = include_mn_special_txs && (sml != nullptr);
+    special_mask.allow_locks       = accrue_pending_asset_locks;
     // suppress_mempool_txs: coinbase-only body, total_fees == 0 exactly. The
     // mempool is not even consulted for selection (only, below, for the forgone-
     // fee report), so no partially-warm UTXO view can price anything into this
@@ -622,11 +663,11 @@ inline DashWorkData build_embedded_workdata(
         suppress_mempool_txs
             ? std::pair<std::vector<Mempool::SelectedTx>, uint64_t>{{}, 0ull}
             : mempool.get_sorted_txs_with_fees(selection_budget,
-                                               /*exclude_special=*/true,
+                                               special_mask,
                                                /*next_height=*/w.m_height,
                                                /*lock_time_cutoff=*/mtp_at_tip);
-    // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The C-3
-    // special-tx cut above is NOT sufficient: dashd's verifier removes a
+    // MN-collateral spend filter (sml_projection.hpp, FINDING-2). The per-type
+    // selection mask is NOT sufficient on its own: dashd's verifier removes a
     // masternode from the list when ANY block tx — special or not — spends
     // its collateral outpoint (specialtxman.cpp:457-464, no type guard), and
     // that removal changes the merkleRootMNList the CbTx must commit. A plain
@@ -635,7 +676,10 @@ inline DashWorkData build_embedded_workdata(
     // = a silently lost block). No tx is ever mandatory, so EXCLUDING it is
     // consensus-clean — dashd's own miner folds the removal instead, but the
     // exclusion needs no second root computation. Fee follows the tx out of
-    // the template so block_value / mn_payment below stay exact.
+    // the template so block_value / mn_payment below stay exact. (Kept even
+    // when the types-1-4 fold below is armed: a collateral spend has no ProTx
+    // effect the fold applies, so excluding it stays the simplest safe route —
+    // subsuming it into the fold is a later step, per the frozen design.)
     {
         size_t kept = 0;
         for (size_t i = 0; i < selected.size(); ++i) {
@@ -655,6 +699,77 @@ inline DashWorkData build_embedded_workdata(
             ++kept;
         }
         selected.resize(kept);
+    }
+    // ── TYPES 1-4 MN-LIST FOLD (merkleRootMNList parity) ──────────────────
+    // When the mask admitted provider special txs (types 1-4), fold their
+    // effect over a COPY of the projected SML now, BEFORE body assembly, so
+    // (a) a tx the fold cannot apply exactly is DROPPED from `selected` (its
+    // fee follows it out, exactly like the collateral filter), and (b) the
+    // resulting list's CalcMerkleRoot() is the merkleRootMNList the CbTx below
+    // commits — dashd BuildNewListFromBlock + CalcCbTxMerkleRootMNList parity.
+    // Never mutates any follower state: the fold runs on a projected COPY. When
+    // the mask did not admit types 1-4 (default), this whole block is skipped
+    // and the template is byte-identical to before.
+    std::optional<vendor::CSimplifiedMNList> mn_folded_sml;
+    if (special_mask.allow_mn_types && sml != nullptr) {
+        auto proj_for_fold = project_sml_confirmations(
+            *sml, prev_height, prev_hash, mnstates, mn_min_confirmations);
+        if (proj_for_fold.ok) {
+            std::vector<MutableTransaction> body_for_fold;
+            body_for_fold.reserve(selected.size());
+            for (const auto& s : selected) body_for_fold.push_back(s.tx);
+            auto fold = fold_mn_special_txs(
+                proj_for_fold.sml, body_for_fold,
+                [](const MutableTransaction& t) {
+                    return dash::coin::dash_txid(t);
+                });
+            if (!fold.refused_ids.empty()) {
+                std::set<uint256> drop(fold.refused_ids.begin(),
+                                       fold.refused_ids.end());
+                size_t kept = 0;
+                for (size_t i = 0; i < selected.size(); ++i) {
+                    if (drop.count(dash::coin::dash_txid(selected[i].tx))) {
+                        total_fees -= selected[i].fee;
+                        LOG_WARNING << "[GBT-EMB] excluding provider special tx "
+                                    << dash::coin::dash_txid(selected[i].tx).GetHex().substr(0, 16)
+                                    << " from template h=" << (prev_height + 1)
+                                    << ": MN-list fold refused it (unknown proTxHash"
+                                    << " / dup key / parse failure)";
+                        continue;
+                    }
+                    if (kept != i) selected[kept] = std::move(selected[i]);
+                    ++kept;
+                }
+                selected.resize(kept);
+            }
+            mn_folded_sml = std::move(fold.sml);
+            if (fold.applied > 0)
+                LOG_INFO << "[GBT-EMB] types 1-4 MN-list fold h="
+                         << (prev_height + 1) << " applied=" << fold.applied
+                         << " refused=" << fold.refused
+                         << " — committing folded merkleRootMNList";
+        } else {
+            // Projection unavailable ⇒ degrade leg (b): mask types 1-4 out by
+            // dropping them from the body (the credit-pool / type-8 leg is
+            // independent and unaffected). Fail-closed and loud.
+            size_t kept = 0;
+            unsigned dropped = 0;
+            for (size_t i = 0; i < selected.size(); ++i) {
+                const uint16_t t = selected[i].tx.type;
+                if (t >= 1 && t <= 4) {
+                    total_fees -= selected[i].fee;
+                    ++dropped;
+                    continue;
+                }
+                if (kept != i) selected[kept] = std::move(selected[i]);
+                ++kept;
+            }
+            selected.resize(kept);
+            if (dropped > 0)
+                LOG_WARNING << "[GBT-EMB] SML projection unavailable at h="
+                            << (prev_height + 1) << " — masked " << dropped
+                            << " provider special tx(s) out of the template";
+        }
     }
     // #143: the admitted unlocks' payload fees are ordinary miner fees (dashd
     // GetAssetUnlockFee, assetlocktx.cpp:200-212 — the fee reaches the miner
@@ -680,7 +795,10 @@ inline DashWorkData build_embedded_workdata(
             // against the FULL cap would overstate it — we could not have
             // served more than selection_budget even with serving enabled.
             mempool.get_sorted_txs_with_fees(selection_budget,
-                                             /*exclude_special=*/true,
+                                             // coverage measurement only: keep
+                                             // the conservative special-tx-free
+                                             // baseline (admits nothing != type 0)
+                                             Mempool::SpecialTxSelectMask{/*exclude_special=*/true},
                                              /*next_height=*/w.m_height,
                                              /*lock_time_cutoff=*/mtp_at_tip);
         (void)cand_fees;
@@ -1007,42 +1125,44 @@ inline DashWorkData build_embedded_workdata(
         //                          + platformReward(N)              (locked this block)
         //                          + Σ assetLocks(N) − Σ assetUnlocks(N)
         // last_observed_credit_pool is creditPoolBalance(N-1) (the freshness gate
-        // guarantees the SML/CCbTx seed is current at the tip we build on). The
-        // embedded template excludes special txs (C-3 mempool filter), so the
-        // asset-lock/unlock terms are exactly zero and the accrual reduces to the
-        // platform-reward burn locked this block. Verified byte-exact against a
-        // real testnet dashd getblocktemplate: creditPoolBalance stepped by
-        // exactly the platform reward (66966830 duff) each block — see
-        // test_dash_embedded_cbtx_byte_parity.cpp. When platform_reward is 0
-        // (pre-MN_RR) the balance carries forward unchanged, also correct.
+        // guarantees the SML/CCbTx seed is current at the tip we build on). When
+        // no special txs ride the body (the default posture) the asset-lock and
+        // asset-unlock terms are exactly zero and the accrual reduces to the
+        // platform-reward burn locked this block — verified byte-exact against a
+        // real testnet dashd getblocktemplate (creditPoolBalance stepped by
+        // exactly 66966830 duff each block, test_dash_embedded_cbtx_byte_parity).
         //
-        // #107 PHASE 2: when --embedded-accrue-asset-locks is armed, ADD the
-        // DIP-0027 type-8 (asset-lock) term dashd commits for this block. dashd
-        // builds its template from the pending locks in its mempool and adds,
-        // for each, the value of the lock tx's FIRST OP_RETURN output
-        // (creditpool.cpp:262-276) to GetTotalLocked() (creditpool.h:98-100),
-        // written to the CbTx at miner.cpp:314. We fold the SAME source — the
-        // pending type-8 locks in OUR mempool — with the SAME arithmetic
-        // (asset_lock_fold.hpp), each validated by check_asset_lock_tx
-        // (assetlocktx.cpp:44-95) so only would-be-valid block members count.
-        // Off (default) the term is 0 and the accrual is byte-identical to the
-        // pre-phase-2 template. The emit gate (node_coin_state.hpp
-        // embedded_template_emit_ok) re-derives this SAME term over the SAME
-        // mempool snapshot, so a fresh build cannot trip emit-creditpool-value-
-        // drift (PR body B2).
+        // THE STRUCTURAL CHOICE (frozen design creditpool_accounting): the lock
+        // term is derived from the SELECTED BODY, not the mempool snapshot —
+        // exactly dashd's GetCreditPoolDiffForBlock(*pblock,...), which folds
+        // ProcessLockUnlockTransaction over the block's OWN txs. A type-8 lock
+        // that was pending but did NOT win selection (budget / ancestor / IS
+        // hold) therefore accrues ZERO here, so a won block cannot commit a
+        // creditPoolBalance the validator's re-derivation from the served body
+        // would reject (bad-cbtx-assetlocked-amount). We fold ONLY the type-8
+        // locks actually in `selected`, with the SAME first-OP_RETURN
+        // arithmetic (asset_lock_fold.hpp), each re-validated by
+        // check_asset_lock_tx so only would-be-valid block members count. When
+        // selection admitted no type-8 (mask leg off, or none pending), the
+        // fold is empty and the accrual is byte-identical to the platform-reward
+        // term. The emit gate (node_coin_state.hpp embedded_template_emit_ok)
+        // re-derives this SAME term over the SAME served body, so a fresh build
+        // cannot trip emit-creditpool-value-drift.
         int64_t asset_lock_accrual = 0;
-        if (accrue_pending_asset_locks) {
-            const AssetLockFold f =
-                pending_asset_lock_fold(mempool.pending_asset_lock_txs());
+        {
+            std::vector<MutableTransaction> body_locks;
+            for (const auto& s : selected)
+                if (s.tx.type == vendor::CAssetLockPayload::SPECIALTX_TYPE)
+                    body_locks.push_back(s.tx);
+            const AssetLockFold f = pending_asset_lock_fold(body_locks);
             asset_lock_accrual = f.accrued;
             if (f.count > 0 || f.rejected > 0) {
-                LOG_INFO << "[GBT-EMB] #107 asset-lock accrual h="
+                LOG_INFO << "[GBT-EMB] asset-lock accrual (from SELECTED body) h="
                          << (prev_height + 1) << " folded=" << f.count
                          << " rejected=" << f.rejected
                          << " accrual=" << asset_lock_accrual
-                         << " duff (committed creditPoolBalance now INCLUDES the"
-                            " pending type-8 locks; block is valid ONLY if those"
-                            " same txs ride the served body -- #125/tx-serving)";
+                         << " duff (creditPoolBalance INCLUDES the type-8 locks that"
+                            " ride THIS body — dashd GetCreditPoolDiffForBlock parity)";
             }
         }
         // #143: the admitted unlocks' GROSS amount (Σ vout + fee) LEAVES the
@@ -1083,8 +1203,15 @@ inline DashWorkData build_embedded_workdata(
                      << (prev_height + 1)
                      << " — committing projected merkleRootMNList";
         }
+        // merkleRootMNList source: the types-1-4 fold above (when armed and the
+        // projection was available) has already applied the body's provider
+        // special txs to a projected COPY — commit THAT list's root so the
+        // CbTx matches the list the block's own txs produce (dashd
+        // BuildNewListFromBlock). Otherwise commit the plain projected root.
+        const vendor::CSimplifiedMNList& cbtx_sml =
+            mn_folded_sml.has_value() ? *mn_folded_sml : proj.sml;
         vendor::CCbTx cb = build_embedded_cbtx(
-            prev_height, proj.sml, *qmgr, best_cl_height, best_cl_sig,
+            prev_height, cbtx_sml, *qmgr, best_cl_height, best_cl_sig,
             accrued_credit_pool, quorum_root_override);
         w.m_coinbase_payload = encode_cbtx(cb);
     } else {
@@ -1231,9 +1358,10 @@ inline vendor::CCbTx build_embedded_cbtx(
 
     // creditPoolBalance: the caller (build_embedded_workdata) supplies the
     // ALREADY-ACCRUED balance for THIS block — i.e. creditPoolBalance(N-1) +
-    // platformReward(N) (+ asset lock/unlock, which are zero because the
-    // embedded template excludes special txs). We commit it verbatim. See the
-    // H-4 accrual note in build_embedded_workdata and the byte-parity KAT.
+    // platformReward(N) + Σ type-8 locks − Σ type-9 unlocks OVER THE SELECTED
+    // BODY (zero when no asset-lock/unlock tx rode this template — the default
+    // posture). We commit it verbatim. See the H-4 accrual note in
+    // build_embedded_workdata and the byte-parity KAT.
     c.creditPoolBalance  = last_observed_credit_pool;
     return c;
 }

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -1064,15 +1064,56 @@ public:
     /// miner too — its mempool never admits deeper chains).
     static constexpr size_t MAX_PACKAGE_TXS = 25;
 
-    // exclude_special (C-3): when true, drop every Dash special tx (tx.type != 0
-    // — ProRegTx/ProUpServTx/asset-lock/asset-unlock) from the selection. dashd
-    // recomputes the coinbase CbTx roots (merkleRootMNList/Quorums) and the
-    // DIP-0027 creditPoolBalance by APPLYING the block's own special txs, so
-    // including one in the embedded template WITHOUT folding its effect into the
-    // CbTx yields bad-cbtx and a rejected block. build_embedded_workdata passes
-    // true (safe-minimal: the creditPool accrual then reduces to the platform-
-    // reward term only). Default false preserves the mempool's general pricing +
-    // selection capability (including the asset-unlock fee path) unchanged.
+    // ── PER-TYPE SPECIAL-TX SELECTION MASK ────────────────────────────────
+    // dashd's BlockAssembler builds the coinbase CbTx roots (merkleRootMNList
+    // / merkleRootQuorums) and the DIP-0027 creditPoolBalance by APPLYING the
+    // block's OWN special txs (BuildNewListFromBlock, GetCreditPoolDiffForBlock).
+    // So a special tx may ride the embedded template ONLY when the template
+    // side folds that same effect into the CbTx. Which types the builder can
+    // account for varies at runtime (the SML fold may be unavailable, the
+    // credit-pool seed may be stale), so selection admits special txs PER TYPE
+    // rather than all-or-nothing. This mask is that per-type gate:
+    //
+    //   * types 1-4 (ProRegTx/ProUpServTx/ProUpRegTx/ProUpRevTx) — admitted
+    //     when allow_mn_types (the template folds them into merkleRootMNList,
+    //     sml_special_fold.hpp);
+    //   * type 8 (AssetLock) — admitted when allow_locks (the template accrues
+    //     the credit-pool lock term from the SELECTED body, asset_lock_fold.hpp);
+    //   * types 5/6/7/9 — NEVER admitted through selection: type-5 is the
+    //     coinbase itself, type-6 quorum commitments are builder-generated
+    //     (dkg_commitments), type-9 AssetUnlock is admission-path-only
+    //     (credit_pool_idx.hpp), and any mempool copy of these would duplicate
+    //     or invalidate the mandatory builder-side object.
+    //
+    // Legacy bool compatibility: the historical parameter was `exclude_special`
+    // (true = drop every special tx; false = admit ALL of them, the general
+    // pricing/selection capability). The implicit constructor preserves BOTH
+    // meanings byte-for-byte for every existing caller — `true` masks all
+    // special out, `false`/default admits all — so only the embedded builder,
+    // which now passes an explicit partial mask, changes behaviour.
+    struct SpecialTxSelectMask {
+        bool allow_all_special;   // legacy exclude_special == false
+        bool allow_mn_types;      // types 1-4
+        bool allow_locks;         // type 8
+        // A single user-provided constructor (default exclude_special=false =>
+        // legacy admit-all). No in-class member initializers: those would be
+        // odr-used by the `= {}` default argument on get_sorted_txs_with_fees
+        // while Mempool is still incomplete, which GCC rejects.
+        // NOLINTNEXTLINE(google-explicit-constructor) — the implicit bool path
+        // is exactly the source-compat contract with pre-mask callers.
+        constexpr SpecialTxSelectMask(bool exclude_special = false)
+            : allow_all_special(!exclude_special),
+              allow_mn_types(false),
+              allow_locks(false) {}
+        constexpr bool admits(uint16_t tx_type) const {
+            if (tx_type == 0) return true;              // ordinary tx
+            if (allow_all_special) return true;         // legacy general path
+            if (tx_type >= 1 && tx_type <= 4) return allow_mn_types;
+            if (tx_type == 8) return allow_locks;
+            return false;                               // 5/6/7/9 never here
+        }
+    };
+
     // lock_time_cutoff: dashd m_lock_time_cutoff = MTP(pindexPrev)
     // (miner.cpp:223) for the per-member IsFinalTx re-check
     // (TestPackageTransactions, miner.cpp:377). 0 (legacy/test callers) skips
@@ -1080,7 +1121,8 @@ public:
     // the embedded GBT passes the tip MTP, which closes that argument's reorg
     // edge (height/MTP can REGRESS across a reorg while the tx stays pooled).
     std::pair<std::vector<SelectedTx>, uint64_t>
-    get_sorted_txs_with_fees(uint32_t max_bytes, bool exclude_special = false,
+    get_sorted_txs_with_fees(uint32_t max_bytes,
+                             SpecialTxSelectMask special_mask = {},
                              uint32_t next_height = 0,
                              int64_t lock_time_cutoff = 0) const
     {
@@ -1337,7 +1379,11 @@ public:
                     }
                     if (!scripts_ok) { ok = false; break; }
                 }
-                if (exclude_special && e->tx.type != 0) { ok = false; break; }
+                // PER-TYPE special-tx admission (see SpecialTxSelectMask):
+                // the legacy exclude_special=true collapses to admits()==false
+                // for every type!=0; the partial embedded mask admits types
+                // 1-4 and/or 8 only, and 5/6/7/9 are never selected.
+                if (!special_mask.admits(e->tx.type)) { ok = false; break; }
 
                 // ── dashd TestPackageTransactions (node/miner.cpp:374-391),
                 // member-level; either failure drops the WHOLE package and —

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -351,6 +351,13 @@ public:
     void set_accrue_pending_asset_locks(bool v) { m_accrue_pending_asset_locks = v; }
     bool accrue_pending_asset_locks() const { return m_accrue_pending_asset_locks; }
 
+    /// SUPERSET (--embedded-include-mn-special-txs): admit provider special txs
+    /// (types 1-4) into the served body and fold them into the committed
+    /// merkleRootMNList. Default OFF (canary phase); the emit gate re-derives
+    /// the folded root over the served body and refuses on any mismatch.
+    void set_include_mn_special_txs(bool v) { m_include_mn_special_txs = v; }
+    bool include_mn_special_txs() const { return m_include_mn_special_txs; }
+
     /// Network MN_RR activation height (dashcore Params().GetConsensus()
     /// .MN_RRHeight — per-chainparams). Gates the DIP-0027 platform-share
     /// credit-pool accrual in the template build, the pre-emit value re-check,
@@ -1251,10 +1258,38 @@ public:
             m_sml_root_memo_epoch = m_root_memo_epoch;
             m_sml_root_memo_valid = true;
         }
-        if (cb.merkleRootMNList != m_sml_root_memo)
+        // merkleRootMNList expected value. By default this is the memoized
+        // projected root (no provider special txs in the body). When the
+        // SUPERSET arm (--embedded-include-mn-special-txs) is on, the served
+        // body may carry types 1-4, so the committed root must be the FOLDED
+        // root — re-derive it over w.m_txs on a projected COPY (dashd
+        // BuildNewListFromBlock parity, sml_special_fold.hpp) and refuse the
+        // template if the fold cannot apply the body exactly (fail-closed:
+        // an unfoldable body must never be served with a guessed root).
+        uint256 expected_mn_root = m_sml_root_memo;
+        if (m_include_mn_special_txs) {
+            auto proj = project_sml_confirmations(m_sml, m_prev_height,
+                                                  m_prev_hash, m_mnstates,
+                                                  m_mn_min_confirmations);
+            if (!proj.ok)
+                return reject("emit-mn-confirm-rollover-pending",
+                              "protx=" + proj.unprojectable_protx.GetHex().substr(0, 12),
+                              "known-registration-height");
+            auto fold = fold_mn_special_txs(
+                proj.sml, w.m_txs,
+                [](const Transaction& t) {
+                    return dash::coin::dash_txid(MutableTransaction(t));
+                });
+            if (!fold.clean())
+                return reject("emit-mnlist-fold-refused",
+                              std::to_string(fold.refused),
+                              "0-refused");
+            expected_mn_root = fold.sml.CalcMerkleRoot();
+        }
+        if (cb.merkleRootMNList != expected_mn_root)
             return reject("emit-mnlist-root-drift",
                           cb.merkleRootMNList.GetHex().substr(0, 12),
-                          m_sml_root_memo.GetHex().substr(0, 12));
+                          expected_mn_root.GetHex().substr(0, 12));
         // E1: under a qc plan the committed root must be the WITH-BLOCK root
         // (fold of the plan's commitments over the active set — equal to the
         // plain root while the plan is all-null, diverging only once Phase L
@@ -1301,16 +1336,28 @@ public:
                 m_credit_pool
                 + compute_dash_platform_reward_post_v20_mn_rr(next_h,
                                                               m_mn_rr_height);
-            // #107 PHASE 2 (B2): when the asset-lock fold is armed the builder
-            // ADDED the pending type-8 term to the committed pool. Re-derive it
-            // here from the SAME source (m_mempool's pending type-8 locks) with
-            // the SAME arithmetic (asset_lock_fold.hpp) so the freshness gate
-            // EXPECTS the accrued value instead of rejecting it. Off (default)
-            // this term is 0 and the check is byte-identical to before.
-            if (m_accrue_pending_asset_locks) {
-                expected_credit_pool +=
-                    pending_asset_lock_fold(m_mempool.pending_asset_lock_txs())
-                        .accrued;
+            // BODY re-derivation (frozen design failclosed_gate): dashd derives
+            // the committed creditPoolBalance from the BLOCK'S OWN txs, so the
+            // emit gate re-derives the asset-lock/unlock terms over the SERVED
+            // BODY (w.m_txs) — NOT a mempool snapshot — killing the build-vs-emit
+            // snapshot race the old m_mempool.pending_asset_lock_txs() source
+            // tolerated. Each type-8 adds its first-OP_RETURN value (the SAME
+            // asset_lock_fold.hpp arithmetic the builder used); each type-9 (only
+            // the admitted set can be present) subtracts its gross = payload.fee
+            // + Σvout (dashd GetDataFromUnlockTx). When no special tx rode this
+            // body (the default posture) both terms are 0 and the check is
+            // byte-identical to before. NOTE: the type-9 deduction term is a HARD
+            // prerequisite of arming #143 — without it an admitted-unlock template
+            // would self-reject here.
+            expected_credit_pool += pending_asset_lock_fold(w.m_txs).accrued;
+            for (const auto& t : w.m_txs) {
+                if (t.type != vendor::CAssetUnlockPayload::SPECIALTX_TYPE) continue;
+                vendor::CAssetUnlockPayload upl;
+                if (!vendor::parse_assetunlock_payload(t.extra_payload, upl))
+                    continue;
+                int64_t gross = static_cast<int64_t>(upl.fee);
+                for (const auto& o : t.vout) gross += o.value;
+                expected_credit_pool -= gross;
             }
             if (cb.creditPoolBalance != expected_credit_pool)
                 return reject("emit-creditpool-value-drift",
@@ -1435,6 +1482,9 @@ public:
                                      ? &m_pinned_local_txs : nullptr;
         // #107 phase 2: accrue pending type-8 asset locks into the CbTx pool.
         e.accrue_pending_asset_locks = m_accrue_pending_asset_locks;
+        // SUPERSET: include provider special txs (types 1-4) + fold them into
+        // the committed merkleRootMNList. Default OFF (canary flag).
+        e.include_mn_special_txs = m_include_mn_special_txs;
         // E-SUPERBLOCK: hand the resolved treasury schedule to the builder.
         // Empty at non-superblock heights and confidently-unfunded superblocks
         // (normal block); the winning trigger's payees at a funded superblock.
@@ -1882,6 +1932,13 @@ private:
     // set_accrue_pending_asset_locks. Consumed by make_embedded_work_inputs
     // (builder) and embedded_template_emit_ok (matching emit-gate re-derivation).
     bool m_accrue_pending_asset_locks{false};
+
+    // SUPERSET arm (--embedded-include-mn-special-txs): include provider special
+    // txs (types 1-4) in the served body and fold them into the committed
+    // merkleRootMNList (sml_special_fold.hpp). Default OFF (canary phase).
+    // Consumed by make_embedded_work_inputs (builder) and
+    // embedded_template_emit_ok (matching folded-root emit-gate re-derivation).
+    bool m_include_mn_special_txs{false};
     // Pinned local tx (set_pinned_local_tx): held by value for the lifetime of
     // this state; the bundle exposes a pointer only when the flag is set.
     // MULTIPLE pins: the donation consolidation had to be SPLIT after

--- a/src/impl/dash/coin/sml_special_fold.hpp
+++ b/src/impl/dash/coin/sml_special_fold.hpp
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// Template-side masternode-list fold for the DIP-3 provider special
+/// transactions (types 1-4) a served embedded block includes.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// WHY THIS EXISTS
+/// ─────────────────────────────────────────────────────────────────────────
+/// dashd builds the masternode list a block commits FROM THE BLOCK'S OWN TXS:
+/// `BuildNewListFromBlock(block, pindex->pprev, ...)` (evo/specialtxman.cpp),
+/// then `CalcCbTxMerkleRootMNList` over that POST-diff list, then rejects
+/// `bad-cbtx-mnmerkleroot` when the coinbase's committed root does not match.
+/// So including a ProRegTx / ProUpServTx / ProUpRegTx / ProUpRevTx in the
+/// embedded template WITHOUT recomputing merkleRootMNList over the list those
+/// txs produce is a guaranteed bad-cbtx on a won block.
+///
+/// This header is the template-side analogue of that per-type application. It
+/// runs on a COPY of the PROJECTED SML (sml_projection.hpp's confirmedHash
+/// pass already applied) — it NEVER mutates any follower state — and produces
+/// the post-diff list whose CalcMerkleRoot() is the root the CbTx must commit.
+/// It touches ONLY the DIP-4 simplified-entry fields that feed
+/// CSimplifiedMNListEntry::CalcHash (the merkle leaf): nVersion, proRegTxHash,
+/// confirmedHash, service (netAddress+netPort), pubKeyOperator, keyIDVoting,
+/// isValid, nType, platform fields. scriptPayout / nLastPaidHeight / penalty
+/// counters are NOT hashed into the leaf, so they are deliberately absent.
+///
+/// ─────────────────────────────────────────────────────────────────────────
+/// FAIL-CLOSED CONTRACT
+/// ─────────────────────────────────────────────────────────────────────────
+/// A transaction this fold cannot apply EXACTLY (payload parse failure, an
+/// update naming a proRegTxHash the list does not hold, a registration whose
+/// proRegTxHash or operator key already exists) is REFUSED — the caller
+/// excludes that one tx from the template and logs it, exactly as dashd's own
+/// getblocktemplate would never include a tx that fails BuildNewListFromBlock.
+/// A refusal never mutates the list. The emit gate re-runs this same fold over
+/// the served body and refuses the whole template on any residual mismatch, so
+/// a folded root that is wrong for any reason is caught before it is served.
+
+#include <impl/dash/coin/vendor/simplifiedmns.hpp>
+#include <impl/dash/coin/vendor/providertx.hpp>
+#include <impl/dash/coin/transaction.hpp>
+#include <impl/dash/coin/utxo_adapter.hpp>   // dash_txid
+
+#include <core/uint256.hpp>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// Outcome of applying ONE transaction to the folded list.
+enum class MnFoldOutcome {
+    Ignored,   ///< not a type 1-4 tx (nothing to do)
+    Applied,   ///< a type 1-4 tx whose effect was folded into the list
+    Refused    ///< a type 1-4 tx that could not be applied exactly (exclude it)
+};
+
+namespace detail {
+
+// Is a legacy 18-byte CService "empty" (no address AND no port)? dashd
+// registers/keeps a masternode BANNED while its netInfo is empty; the SML
+// leaf reflects that as isValid=false.
+inline bool net_service_empty(const std::array<uint8_t, vendor::NETADDR_SIZE>& ip,
+                              uint16_t port_be)
+{
+    if (port_be != 0) return false;
+    for (uint8_t b : ip) if (b != 0) return false;
+    return true;
+}
+
+// Find the SML entry for a proRegTxHash. Returns nullptr when absent.
+inline vendor::CSimplifiedMNListEntry*
+find_entry(std::vector<vendor::CSimplifiedMNListEntry>& list, const uint256& pro)
+{
+    for (auto& e : list)
+        if (e.proRegTxHash == pro) return &e;
+    return nullptr;
+}
+
+} // namespace detail
+
+/// Apply one candidate special tx to the working entry list. `list` is the
+/// mutable leaf set of a CSimplifiedMNList copy (the caller re-sorts + hashes
+/// after the whole pass). Types other than 1-4 are Ignored. Returns Refused
+/// (and leaves the list UNCHANGED) when the tx cannot be applied exactly.
+template <typename Tx>
+inline MnFoldOutcome apply_mn_special_tx_to_sml(
+    std::vector<vendor::CSimplifiedMNListEntry>& list, const Tx& tx)
+{
+    switch (tx.type) {
+    // ── type 1 ProRegTx — AddMN ──────────────────────────────────────────
+    case vendor::CProRegTx::SPECIALTX_TYPE: {
+        vendor::CProRegTx pl;
+        if (!vendor::parse_protx_payload(tx.extra_payload, pl))
+            return MnFoldOutcome::Refused;
+
+        // The new registration's proRegTxHash is the ProRegTx's own txid
+        // (dashd: newState->proTxHash = tx.GetHash()).
+        const uint256 pro = dash::coin::dash_txid(::dash::coin::MutableTransaction(tx));
+
+        // dup-proRegTxHash / dup-operator-key refusal (the caller excludes the
+        // tx rather than folding a list dashd's AddMN would reject).
+        for (const auto& e : list) {
+            if (e.proRegTxHash == pro) return MnFoldOutcome::Refused;
+            if (e.pubKeyOperator == pl.pubKeyOperator) return MnFoldOutcome::Refused;
+        }
+
+        vendor::CSimplifiedMNListEntry e;
+        e.nVersion       = pl.nVersion;               // 1=legacy,2=basic,3=extaddr
+        e.proRegTxHash   = pro;
+        e.confirmedHash  = uint256::ZERO;             // registered here, not yet confirmed
+        e.netAddress     = pl.netInfo.ip;
+        e.netPort        = pl.netInfo.port_be;
+        // The ProReg payload's operator key is ALREADY encoded in the scheme
+        // its nVersion dictates (legacy iff nVersion < BASIC_BLS), which is
+        // exactly the scheme the SML leaf hashes for that nVersion — copy the
+        // wire bytes straight through.
+        e.pubKeyOperator = pl.pubKeyOperator;
+        e.keyIDVoting    = pl.keyIDVoting;
+        // Empty netInfo ⇒ registers BANNED (isValid=false), else valid.
+        e.isValid        = !detail::net_service_empty(pl.netInfo.ip, pl.netInfo.port_be);
+        e.nType          = pl.nType;
+        e.platformHTTPPort = pl.platformHTTPPort;
+        e.platformNodeID   = pl.platformNodeID;
+        list.push_back(e);
+        return MnFoldOutcome::Applied;
+    }
+
+    // ── type 2 ProUpServTx — UpdateService (+ revive) ────────────────────
+    case vendor::CProUpServTx::SPECIALTX_TYPE: {
+        vendor::CProUpServTx pl;
+        if (!vendor::parse_protx_payload(tx.extra_payload, pl))
+            return MnFoldOutcome::Refused;
+        auto* e = detail::find_entry(list, pl.proTxHash);
+        if (e == nullptr) return MnFoldOutcome::Refused;
+        e->netAddress = pl.netInfo.ip;
+        e->netPort    = pl.netInfo.port_be;
+        if (e->nType == vendor::CSimplifiedMNListEntry::TYPE_EVO) {
+            e->platformHTTPPort = pl.platformHTTPPort;
+            e->platformNodeID   = pl.platformNodeID;
+        }
+        // dashd revives a banned masternode on a ProUpServTx once its service
+        // is set again (BuildNewListFromBlock Revive). A non-empty netInfo is
+        // the revive trigger the SML leaf can see.
+        if (!detail::net_service_empty(pl.netInfo.ip, pl.netInfo.port_be))
+            e->isValid = true;
+        return MnFoldOutcome::Applied;
+    }
+
+    // ── type 3 ProUpRegTx — UpdateRegistrar ──────────────────────────────
+    case vendor::CProUpRegTx::SPECIALTX_TYPE: {
+        vendor::CProUpRegTx pl;
+        if (!vendor::parse_protx_payload(tx.extra_payload, pl))
+            return MnFoldOutcome::Refused;
+        auto* e = detail::find_entry(list, pl.proTxHash);
+        if (e == nullptr) return MnFoldOutcome::Refused;
+        e->keyIDVoting = pl.keyIDVoting;
+        // Operator-key change ⇒ ResetOperatorFields + ban, exactly as dashd's
+        // BuildNewListFromBlock: the masternode must re-announce service with a
+        // ProUpServTx before it is valid again.
+        if (e->pubKeyOperator != pl.pubKeyOperator) {
+            e->pubKeyOperator = pl.pubKeyOperator;
+            e->netAddress = {};
+            e->netPort    = 0;
+            e->isValid    = false;
+        }
+        return MnFoldOutcome::Applied;
+    }
+
+    // ── type 4 ProUpRevTx — RevokeOperator (ban) ─────────────────────────
+    case vendor::CProUpRevTx::SPECIALTX_TYPE: {
+        vendor::CProUpRevTx pl;
+        if (!vendor::parse_protx_payload(tx.extra_payload, pl))
+            return MnFoldOutcome::Refused;
+        auto* e = detail::find_entry(list, pl.proTxHash);
+        if (e == nullptr) return MnFoldOutcome::Refused;
+        // ResetOperatorFields + ban: operator key cleared, service cleared,
+        // isValid=false until a fresh ProUpRegTx(new key)+ProUpServTx pair.
+        e->pubKeyOperator = {};
+        e->netAddress = {};
+        e->netPort    = 0;
+        e->isValid    = false;
+        return MnFoldOutcome::Applied;
+    }
+
+    default:
+        return MnFoldOutcome::Ignored;
+    }
+    return MnFoldOutcome::Ignored;   // unreachable; silences -Wreturn-type
+}
+
+/// Result of folding a body's type 1-4 txs onto a projected SML copy.
+struct SmlSpecialFold {
+    vendor::CSimplifiedMNList sml;          ///< projected list with types 1-4 applied
+    unsigned applied{0};                    ///< txs whose effect was folded
+    unsigned refused{0};                    ///< txs that could not be applied
+    std::vector<uint256> refused_ids;       ///< txids the caller must exclude
+    bool clean() const { return refused == 0; }
+};
+
+/// Fold every type 1-4 tx in `body_txs` onto a COPY of `base` (a projected
+/// SML). Refusals are recorded but never mutate the list. The returned list is
+/// re-sorted so CalcMerkleRoot() is the committed root.
+template <typename TxRange, typename TxidFn>
+inline SmlSpecialFold fold_mn_special_txs(const vendor::CSimplifiedMNList& base,
+                                          const TxRange& body_txs,
+                                          TxidFn&& txid_of)
+{
+    SmlSpecialFold out;
+    out.sml = base;                         // COPY — never the follower's list
+    for (const auto& tx : body_txs) {
+        const auto r = apply_mn_special_tx_to_sml(out.sml.mnList, tx);
+        if (r == MnFoldOutcome::Applied) {
+            ++out.applied;
+        } else if (r == MnFoldOutcome::Refused) {
+            ++out.refused;
+            out.refused_ids.push_back(txid_of(tx));
+        }
+    }
+    out.sml.sort();                         // dashd memcmp(proRegTxHash) order
+    return out;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/work_source.hpp
+++ b/src/impl/dash/coin/work_source.hpp
@@ -173,6 +173,13 @@ struct EmbeddedWorkInputs {
     // NodeCoinState::make_embedded_work_inputs from set_accrue_pending_asset_locks.
     bool                             accrue_pending_asset_locks{false};
 
+    // SUPERSET (--embedded-include-mn-special-txs): admit provider special txs
+    // (types 1-4) into selection and fold them over the projected SML so the
+    // committed merkleRootMNList matches the list they produce. Default false
+    // => byte-unchanged (types 1-4 excluded). Set by
+    // NodeCoinState::make_embedded_work_inputs from set_include_mn_special_txs.
+    bool                             include_mn_special_txs{false};
+
     bool viable() const {
         return has_state && mnstates != nullptr && mempool != nullptr;
     }
@@ -306,7 +313,13 @@ inline WorkSelection select_dash_work(
                 emb.pinned_local_txs,
                 // #107 phase 2: accrue pending type-8 asset-lock term into the
                 // CbTx creditPoolBalance (default false => byte-unchanged).
-                emb.accrue_pending_asset_locks);
+                emb.accrue_pending_asset_locks,
+                // #143 verified type-9 unlocks: not wired through this arm yet
+                // (admission-path-only; default nullptr => byte-unchanged).
+                /*admitted_asset_unlocks=*/nullptr,
+                // SUPERSET: include provider special txs (types 1-4) + fold
+                // them into merkleRootMNList (default false => byte-unchanged).
+                emb.include_mn_special_txs);
         },
         dashd_fallback);
 }

--- a/test/test_dash_embedded_gbt.cpp
+++ b/test/test_dash_embedded_gbt.cpp
@@ -1914,3 +1914,244 @@ TEST(DashFallbackPinBudget, GateRefusalKeepsItsOwnCause) {
     EXPECT_STREQ(rep.causes[0], "input-missing-or-spent")
         << "the size budget must not relabel a gate refusal";
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// SUPERSET (frozen design): the daemonless template is a SUPERSET/parity of
+// dashd CreateNewBlock — it INCLUDES the mempool special txs dashd would
+// include and folds their effect into the CbTx so the block stays valid.
+//   * type-8 asset-lock: creditPoolBalance = prev + platformReward + Σlocks
+//     derived from the SELECTED BODY (not the mempool snapshot).
+//   * types 1-4 provider txs: merkleRootMNList recomputed from a projected-SML
+//     COPY folded with the block's own txs (dashd BuildNewListFromBlock).
+// ════════════════════════════════════════════════════════════════════════
+
+// A valid DIP-0027 type-8 asset-lock tx locking `lock_value` duff: one bare
+// OP_RETURN output of that value + a payload crediting the same sum.
+static MutableTransaction make_asset_lock_tx(const uint256& prev_utxo,
+                                             int64_t lock_value, uint32_t salt) {
+    MutableTransaction tx;
+    tx.version = 3; tx.type = 8; tx.locktime = salt;
+    TxIn in; in.prevout.hash = prev_utxo; in.prevout.index = 0;
+    in.sequence = 0xffffffffu; tx.vin.push_back(in);
+    TxOut op; op.value = lock_value;
+    op.scriptPubKey.m_data = {0x6a, 0x00};   // bare 2-byte OP_RETURN
+    tx.vout.push_back(op);
+    dash::coin::vendor::CAssetLockPayload pl; pl.nVersion = 1;
+    TxOut credit; credit.value = lock_value;
+    credit.scriptPubKey.m_data = p2pkh_script(0x30);
+    pl.creditOutputs.push_back(credit);
+    auto ps = ::pack(pl); auto sp = ps.get_span();
+    tx.extra_payload.assign(
+        reinterpret_cast<const unsigned char*>(sp.data()),
+        reinterpret_cast<const unsigned char*>(sp.data()) + sp.size());
+    return tx;
+}
+
+// PROOF (2): a template that INCLUDES a type-8 lock byte-validates — the CbTx
+// creditPoolBalance equals prev + platformReward + Σlocks over the block's OWN
+// included txs (the structural change: sessionLocked from the SELECTED body).
+TEST(DashSupersetSpecialTx, Type8LockCreditPoolFromSelectedBody) {
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+    const int64_t LOCK = 50'000, FEE = 10'000;
+    uint256 pv = mint_hash(0x88);
+    utxo.add_coin(::core::coin::Outpoint(pv, 0),
+                  ::core::coin::Coin(LOCK + FEE, {}, 1, false));
+    auto lock_tx = make_asset_lock_tx(pv, LOCK, /*salt=*/88);
+    ASSERT_TRUE(mp.add_tx(lock_tx));
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+    CSimplifiedMNListEntry e;
+    e.proRegTxHash = raw256(0x01); e.confirmedHash = raw256(0x77); e.isValid = true;
+    CSimplifiedMNList sml(std::vector<CSimplifiedMNListEntry>{e});
+    QuorumManager qmgr;
+    const int64_t SEED = 3'000'000'000LL;   // creditPoolBalance(N-1)
+
+    auto w = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp, 0x1b104be3u, 1'700'000'000u,
+        DASH_PUBKEY_VER, DASH_P2SH_VER, /*curtime=*/1'700'000'123u,
+        /*version=*/0x20000000u, /*underfill=*/nullptr, &sml, &qmgr,
+        /*best_cl_height=*/0, dash::coin::k_zero_cl_sig, SEED,
+        /*qc_commitments=*/nullptr, /*quorum_root_override=*/nullptr,
+        dash::coin::DASH_MN_RR_HEIGHT_MAINNET, /*superblock=*/nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress=*/false, /*cause=*/"utxo-immature-serving",
+        /*pinned=*/nullptr, /*accrue_pending_asset_locks=*/true);
+
+    // The lock rode the body (allow_locks admitted it).
+    bool found = false;
+    for (const auto& h : w.m_tx_hashes)
+        if (h == dash::coin::dash_txid(lock_tx)) found = true;
+    ASSERT_TRUE(found) << "type-8 lock must be selected once allow_locks is armed";
+
+    // creditPoolBalance == seed + platformReward + LOCK (from the body).
+    CCbTx cb; ASSERT_TRUE(parse_cbtx(w.m_coinbase_payload, cb));
+    const int64_t platform = compute_dash_platform_reward_post_v20_mn_rr(H);
+    EXPECT_GT(platform, 0);
+    EXPECT_EQ(cb.creditPoolBalance, SEED + platform + LOCK)
+        << "creditPoolBalance must be prev + platformReward + Σlocks (own body)";
+
+    // Control: a lock that fails selection must NOT accrue — prove the source
+    // is the BODY, not the pending snapshot. Add a second pending lock whose
+    // input the UTXO view does not know (unpriced => never selected).
+    Mempool mp2; ::core::coin::UTXOViewCache utxo2(nullptr); mp2.set_utxo(&utxo2);
+    uint256 pv2 = mint_hash(0x99);
+    utxo2.add_coin(::core::coin::Outpoint(pv2, 0),
+                   ::core::coin::Coin(LOCK + FEE, {}, 1, false));
+    ASSERT_TRUE(mp2.add_tx(make_asset_lock_tx(pv2, LOCK, /*salt=*/99)));
+    // A SECOND lock with no known UTXO for its input: pending but unpriced.
+    auto orphan_lock = make_asset_lock_tx(mint_hash(0xAA), 777'000, /*salt=*/100);
+    ASSERT_TRUE(mp2.add_tx(orphan_lock));
+    auto w2 = build_embedded_workdata(
+        H - 1, raw256(0xAB), mnstates, mp2, 0x1b104be3u, 1'700'000'000u,
+        DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u,
+        nullptr, &sml, &qmgr, 0, dash::coin::k_zero_cl_sig, SEED,
+        nullptr, nullptr, dash::coin::DASH_MN_RR_HEIGHT_MAINNET, nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        false, "utxo-immature-serving", nullptr, true);
+    CCbTx cb2; ASSERT_TRUE(parse_cbtx(w2.m_coinbase_payload, cb2));
+    EXPECT_EQ(cb2.creditPoolBalance, SEED + platform + LOCK)
+        << "the unpriced pending lock (777000) must NOT accrue — body, not snapshot";
+}
+
+// PROOF (3, MN-root fold leg): a type-4 ProUpRevTx folded over a projected SML
+// COPY bans the MN and yields a DIFFERENT, independently-reproducible
+// merkleRootMNList — so a template including it commits the right root.
+TEST(DashSupersetSpecialTx, Type4FoldRevokesOperatorAndRecomputesRoot) {
+    namespace v = dash::coin::vendor;
+    CSimplifiedMNListEntry base_e;
+    base_e.nVersion       = CSimplifiedMNListEntry::VER_BASIC_BLS;
+    base_e.proRegTxHash   = raw256(0x01);
+    base_e.confirmedHash  = raw256(0x77);
+    base_e.netAddress     = seq_array<16>(0x11);
+    base_e.netPort        = 9999;
+    base_e.pubKeyOperator = seq_array<48>(0x30);
+    base_e.isValid        = true;
+    base_e.nType          = CSimplifiedMNListEntry::TYPE_REGULAR;
+    CSimplifiedMNList base(std::vector<CSimplifiedMNListEntry>{base_e});
+    const uint256 root_before = base.CalcMerkleRoot();
+
+    v::CProUpRevTx rev;
+    rev.nVersion  = v::ProTxVersion::BASIC_BLS;
+    rev.proTxHash = raw256(0x01);
+    rev.nReason   = v::CProUpRevTx::REASON_COMPROMISED_KEYS;
+    MutableTransaction revtx; revtx.version = 3; revtx.type = 4;
+    { auto ps = ::pack(rev); auto sp = ps.get_span();
+      revtx.extra_payload.assign(
+          reinterpret_cast<const unsigned char*>(sp.data()),
+          reinterpret_cast<const unsigned char*>(sp.data()) + sp.size()); }
+
+    auto fold = dash::coin::fold_mn_special_txs(
+        base, std::vector<MutableTransaction>{revtx},
+        [](const MutableTransaction& t) { return dash::coin::dash_txid(t); });
+    EXPECT_EQ(fold.applied, 1u);
+    EXPECT_EQ(fold.refused, 0u);
+    ASSERT_EQ(fold.sml.mnList.size(), 1u);
+    EXPECT_FALSE(fold.sml.mnList[0].isValid) << "type-4 must ban the MN";
+    std::array<uint8_t, 48> zero{};
+    EXPECT_EQ(fold.sml.mnList[0].pubKeyOperator, zero) << "operator key cleared";
+
+    // Independent expected root (hand-built, never from the fold).
+    CSimplifiedMNListEntry exp = base_e;
+    exp.isValid = false; exp.pubKeyOperator = {};
+    exp.netAddress = {}; exp.netPort = 0;
+    CSimplifiedMNList expsml(std::vector<CSimplifiedMNListEntry>{exp});
+    EXPECT_EQ(fold.sml.CalcMerkleRoot(), expsml.CalcMerkleRoot());
+    EXPECT_NE(fold.sml.CalcMerkleRoot(), root_before)
+        << "the fold must change merkleRootMNList (else bad-cbtx-mnmerkleroot)";
+}
+
+// An update naming a proRegTxHash the list does not hold is REFUSED (never a
+// guessed root); the list is unchanged — fail-closed exclusion.
+TEST(DashSupersetSpecialTx, UnknownProTxHashIsRefusedNotFolded) {
+    namespace v = dash::coin::vendor;
+    CSimplifiedMNListEntry base_e;
+    base_e.proRegTxHash = raw256(0x01); base_e.confirmedHash = raw256(0x77);
+    base_e.isValid = true;
+    CSimplifiedMNList base(std::vector<CSimplifiedMNListEntry>{base_e});
+    const uint256 root_before = base.CalcMerkleRoot();
+
+    v::CProUpRevTx rev; rev.nVersion = v::ProTxVersion::BASIC_BLS;
+    rev.proTxHash = raw256(0xEE);   // not in the list
+    MutableTransaction revtx; revtx.version = 3; revtx.type = 4;
+    { auto ps = ::pack(rev); auto sp = ps.get_span();
+      revtx.extra_payload.assign(
+          reinterpret_cast<const unsigned char*>(sp.data()),
+          reinterpret_cast<const unsigned char*>(sp.data()) + sp.size()); }
+
+    auto fold = dash::coin::fold_mn_special_txs(
+        base, std::vector<MutableTransaction>{revtx},
+        [](const MutableTransaction& t) { return dash::coin::dash_txid(t); });
+    EXPECT_EQ(fold.applied, 0u);
+    EXPECT_EQ(fold.refused, 1u);
+    ASSERT_EQ(fold.refused_ids.size(), 1u);
+    EXPECT_EQ(fold.refused_ids[0], dash::coin::dash_txid(revtx));
+    EXPECT_EQ(fold.sml.CalcMerkleRoot(), root_before)
+        << "a refused tx must not mutate the folded list";
+}
+
+// PROOF (3, end-to-end): a template that INCLUDES a type-1 ProRegTx commits a
+// merkleRootMNList equal to the projected-SML COPY folded with that tx.
+TEST(DashSupersetSpecialTx, Type1IncludedCommitsFoldedMnRoot) {
+    namespace v = dash::coin::vendor;
+    ::core::coin::UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+
+    // A type-1 ProRegTx (fee-known), operator key distinct from the base MN.
+    v::CProRegTx reg;
+    reg.nVersion = v::ProTxVersion::BASIC_BLS; reg.nType = v::MnType::REGULAR;
+    reg.netInfo.ip = seq_array<16>(0x12); reg.netInfo.port_be = 9998;
+    reg.pubKeyOperator = seq_array<48>(0x40);   // != base 0x30
+    reg.inputsHash = raw256(0x71);
+    MutableTransaction regtx; regtx.version = 3; regtx.type = 1;
+    { uint256 pv = mint_hash(0x55);
+      utxo.add_coin(::core::coin::Outpoint(pv, 0),
+                    ::core::coin::Coin(100'000, {}, 1, false));
+      TxIn in; in.prevout.hash = pv; in.prevout.index = 0; in.sequence = 0xffffffffu;
+      regtx.vin.push_back(in);
+      TxOut o; o.value = 90'000; o.scriptPubKey.m_data = p2pkh_script(0x33);
+      regtx.vout.push_back(o);
+      auto ps = ::pack(reg); auto sp = ps.get_span();
+      regtx.extra_payload.assign(
+          reinterpret_cast<const unsigned char*>(sp.data()),
+          reinterpret_cast<const unsigned char*>(sp.data()) + sp.size()); }
+    ASSERT_TRUE(mp.add_tx(regtx));
+
+    auto mnstates = single_mn(p2pkh_script(0x30));
+    CSimplifiedMNListEntry base_e;
+    base_e.proRegTxHash = raw256(0x01); base_e.confirmedHash = raw256(0x77);
+    base_e.pubKeyOperator = seq_array<48>(0x30); base_e.isValid = true;
+    CSimplifiedMNList sml(std::vector<CSimplifiedMNListEntry>{base_e});
+    QuorumManager qmgr;
+    const uint256 prev_hash = raw256(0xAB);
+
+    auto w = build_embedded_workdata(
+        H - 1, prev_hash, mnstates, mp, 0x1b104be3u, 1'700'000'000u,
+        DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u,
+        nullptr, &sml, &qmgr, 0, dash::coin::k_zero_cl_sig, /*credit_pool=*/0,
+        nullptr, nullptr, dash::coin::DASH_MN_RR_HEIGHT_MAINNET, nullptr,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET,
+        /*suppress=*/false, "utxo-immature-serving", /*pinned=*/nullptr,
+        /*accrue_pending_asset_locks=*/false, /*admitted_asset_unlocks=*/nullptr,
+        /*include_mn_special_txs=*/true);
+
+    // The ProRegTx rode the body.
+    bool found = false;
+    for (const auto& h : w.m_tx_hashes)
+        if (h == dash::coin::dash_txid(regtx)) found = true;
+    ASSERT_TRUE(found) << "type-1 must be selected once include_mn_special_txs is armed";
+
+    // Committed merkleRootMNList == projected SML folded with the ProRegTx.
+    auto proj = dash::coin::project_sml_confirmations(
+        sml, H - 1, prev_hash, mnstates,
+        dash::coin::DASH_MN_MIN_CONFIRMATIONS_MAINNET);
+    ASSERT_TRUE(proj.ok);
+    auto fold = dash::coin::fold_mn_special_txs(
+        proj.sml, std::vector<MutableTransaction>{regtx},
+        [](const MutableTransaction& t) { return dash::coin::dash_txid(t); });
+    EXPECT_EQ(fold.applied, 1u);
+    CCbTx cb; ASSERT_TRUE(parse_cbtx(w.m_coinbase_payload, cb));
+    EXPECT_EQ(cb.merkleRootMNList, fold.sml.CalcMerkleRoot())
+        << "committed merkleRootMNList must equal the folded projected-SML root";
+    EXPECT_EQ(fold.sml.mnList.size(), 2u) << "AddMN grew the list by one";
+}


### PR DESCRIPTION
## What

The daemonless DASH block template excluded **every** mempool special tx (`tx.type != 0`), so the served template was a strict *subset* of dashd's `CreateNewBlock` — a good-citizen omission. This makes the template a **superset/parity**: it now includes the mempool special txs dashd would include (ProRegTx1 / ProUpServTx2 / ProUpRegTx3 / ProUpRevTx4 / AssetLockTx8) and folds their effect into the CbTx so the block stays consensus-valid.

Everything is **default-OFF** behind arming flags; with no flag set the template is byte-identical to before.

## How

**`mempool.hpp`** — `get_sorted_txs_with_fees` takes a `SpecialTxSelectMask` (per-type: `allow_mn_types` 1-4, `allow_locks` 8) instead of a bool `exclude_special`. Types 5/6/7/9 are never selected (type-6 is builder-generated; type-9 is admission-path-only). The mask is implicitly constructible from the old bool, so **every existing caller is byte-for-byte unchanged**.

**`embedded_gbt.hpp`** — `build_embedded_workdata` builds the mask from the arming legs and applies dashd's two structural derivations:
- **credit-pool lock term from the SELECTED BODY**, not the pending mempool snapshot — `GetCreditPoolDiffForBlock` parity. A pending type-8 lock that fails selection can no longer over-count the committed `creditPoolBalance` (`bad-cbtx-assetlocked-amount`).
- **types 1-4 folded over a COPY of the projected SML**, and the resulting `merkleRootMNList` is committed — `BuildNewListFromBlock` + `CalcCbTxMerkleRootMNList` parity, so a provider tx no longer yields `bad-cbtx-mnmerkleroot` on a won block.

**`sml_special_fold.hpp`** (new) — the template-side per-type application (AddMN / UpdateService / UpdateRegistrar / RevokeOperator) on a projected-SML copy, touching only the DIP-4 leaf fields that feed the merkle root. **Fail-closed**: a tx it cannot apply exactly (unknown proTxHash / dup key / parse failure) is refused and excluded, never folded into a guessed root.

**`node_coin_state.hpp`** — the pre-emit gate re-derives both quantities over the **served body**: the credit-pool value folds the body's type-8 locks and subtracts the body's type-9 unlock gross (previously absent — a prerequisite of arming the #143 unlock follower), and the `merkleRootMNList` expected value is the folded root when the arm is on. Any residual mismatch **refuses** the template rather than serving an invalid block.

Per-type degrade: a missing SML projection masks only types 1-4; a stale creditpool seed masks only type 8. Stale "special-tx-free" comments on this path are rewritten in the same change.

## Arming flags (all default OFF)

- `--embedded-include-mn-special-txs` — types 1-4 (needs the SML fold input)
- `--embedded-accrue-asset-locks` — type 8 (now sources the accrual from the body)

## Tests

New `DashSupersetSpecialTx` KATs:
- `Type8LockCreditPoolFromSelectedBody` — a type-8 template's `creditPoolBalance == prev + platformReward + Σlocks` over the body, **and** an unpriced pending lock does **not** accrue (proves body-not-snapshot).
- `Type4FoldRevokesOperatorAndRecomputesRoot` — the fold bans the MN and yields an independently-reproducible, changed `merkleRootMNList`.
- `UnknownProTxHashIsRefusedNotFolded` — fail-closed refusal leaves the list unchanged.
- `Type1IncludedCommitsFoldedMnRoot` — an included ProRegTx commits `merkleRootMNList == fold(projected SML, body)`.

Full dash suites green: embedded_gbt 272, mempool 116, node_coin_state 109, dstx 13, isdlock 10.