### PR TITLE
dash: drive the govsync coverage prime from the verack handler, not primary election

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -6704,6 +6704,19 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          " no state change).\n";
         }
 
+        // E-SUPERBLOCK R5 coverage reporting seam: the coin-P2P verack handler
+        // primes each handshaked peer with govsync(nProp=0) once per expiry
+        // window (armed only under --embedded-govsync/--embedded-superblock);
+        // whenever it actually primes a peer it reports that peer_key here, so
+        // GovSyncStatus records exactly-the-primed-peer coverage. Fires only on a
+        // real send (never a window-skip), so an already-primed peer never
+        // re-arms the quiescence window — the R5 min_peers (>=2) floor accrues
+        // one DISTINCT primed peer per handshake and can flip completeness TRUE.
+        coin_p2p->set_on_govsync_primed(
+            [maint = maintainer.get()](const std::string& pk) {
+                maint->note_govsync_requested(pk);
+            });
+
         // Kick the initial sync once the version/verack handshake completes:
         // getheaders off our current locator + a mempool prime.
         coin_p2p->set_on_handshake_complete(
@@ -6750,36 +6763,15 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                 // the full cold snapshot; a reconnect after some sync re-requests
                 // from exactly what the SML has applied, never a stranded base.
                 cp->send_getmnlistd(maint ? maint->sml_current_hash() : uint256::ZERO, tip);
-                // E-SUPERBLOCK: prime the governance object sync (triggers +
-                // proposals) so a superblock height can be served daemonlessly.
-                // send_govsync_prime() primes each NOT-YET-PRIMED handshaked peer
-                // EXACTLY ONCE per expiry window (dashd punishes a repeated full
-                // govsync from the same address: CGovernanceManager::SyncObjects
-                // Misbehaving(20)). This callback also re-fires on primary
-                // promotion, where the prime is a deliberate no-op — every peer
-                // is already primed, so nobody is written and no ban score
-                // accrues. Zero nProp + empty filter => request all objects;
-                // dashcore answers with INVENTORY (MSG_GOVERNANCE_OBJECT=17
-                // invs); the inv handler getdata-pulls those (batched) when the
-                // gov arm is armed, the govobj handler fires a per-object vote
-                // sync (govsync nProp=objectHash) for each accepted TRIGGER, and
-                // its MSG_GOVERNANCE_OBJECT_VOTE=18 reply invs are pulled the
-                // same way — so the store populates instead of staying inert.
-                // OFF (no --embedded-govsync/--embedded-superblock) the getdata
-                // is not sent, so the prime is a harmless unanswered request; the
-                // OFF-arm wire is once-per-peer (not loop-all-per-event), which
-                // is itself the fix — the old loop-all leg carried the same
-                // per-repeat ban hazard.
-                //
-                // R5: record govsync peer coverage from the NEWLY primed keys
-                // (never handshaked_peer_keys() — recording an already-primed
-                // peer would spuriously re-arm the quiescence window and delay
-                // completeness). Under --coin-p2p-discover the bounded pool holds
-                // >= 2 peers, so >= 2 distinct keys accumulate across handshakes
-                // and the min_peers (>=2) completeness floor can flip TRUE (the
-                // serve-side R5 gate). With one peer it stays FALSE — reward-safe.
-                for (const auto& pk : cp->send_govsync_prime())
-                    maint->note_govsync_requested(pk);
+                // E-SUPERBLOCK govsync PRIME: NOT driven from here. The prime is
+                // emitted per session by the coin-P2P verack handler, beside its
+                // getsporks leg (routing class 3), so EVERY handshaked peer — the
+                // primary AND every witness — is primed once at its own handshake.
+                // R5 coverage is recorded from that verack site via
+                // set_on_govsync_primed (wired above), which fires only when a peer
+                // was actually primed. Driving it here fired only for the FIRST
+                // verack (the peer that wins primary election), which is exactly
+                // why gov_peers stuck at 1 despite a >=2-peer pool.
             });
 
         std::cout << "[run] E2a live-feed wired: header-chain(" << hdr_db

--- a/src/impl/dash/coin/govsync_status.hpp
+++ b/src/impl/dash/coin/govsync_status.hpp
@@ -60,9 +60,11 @@ inline constexpr int64_t DASH_GOVSYNC_SETTLE_SECS_DEFAULT = 60;
 /// hazard. dashcore syncs governance from multiple peers for the same reason.
 /// DEFAULT 2 (fail-closed leaning): a single-peer deployment can NEVER assert
 /// completeness, so it stays on the reward-safe dashd fallback. The multi-peer
-/// govsync leg that primes >= 2 distinct peers is CoinClient::send_govsync_prime()
-/// (each handshaked peer asked for the full object set exactly once per expiry
-/// window); the keys it returns are what feed note_govsync_requested here.
+/// govsync leg that primes >= 2 distinct peers is the coin-P2P verack handler:
+/// per session it asks THAT peer for the full object set exactly once per expiry
+/// window (CoinClient::send_govsync_prime_to), so both the primary and every
+/// witness peer are covered; each real prime reports its peer_key (via
+/// set_on_govsync_primed) into note_govsync_requested here.
 inline constexpr size_t DASH_GOVSYNC_MIN_PEERS_DEFAULT = 2;
 
 /// Tracks daemonless governance-sync progress and answers is_complete(now).

--- a/src/impl/dash/coin/p2p_client.hpp
+++ b/src/impl/dash/coin/p2p_client.hpp
@@ -917,11 +917,12 @@ private:
     // gated. A governance inv is otherwise inert: without the pull the
     // govobj/govobjvote handlers never fire and the GovernanceStore stays
     // empty, so a superblock height can never be served daemonlessly. OFF by
-    // default => the inv answer is not pulled and the store stays inert
-    // (a govsync(nProp=0) is still SENT once per peer at its handshake — the
-    // coverage-prime leg — but with the pull off its reply is ignored). No
-    // budget: gov invs are batched to ONE getdata per inv message, and the
-    // prime is sent to each peer EXACTLY ONCE per expiry window (send_govsync_prime,
+    // default => the inv answer is not pulled, the store stays inert, AND the
+    // govsync(nProp=0) coverage prime is not emitted at all — the verack handler
+    // gates it on m_gov_pull_enabled, so the default-OFF wire is byte-identical
+    // to the pre-feature node (no unanswered off-arm request). ARMED, the prime
+    // is emitted per session from the verack handler beside getsporks — each
+    // handshaked peer asked EXACTLY ONCE per expiry window (send_govsync_prime_to,
     // below) because dashd PUNISHES a repeated full govsync with Misbehaving(20).
     bool     m_gov_pull_enabled{false};
     uint64_t m_gov_inv_offered{0};   // inv(gov) SEEN on the wire, pre-dedup
@@ -1063,6 +1064,13 @@ private:
     PeerHeightCallback m_on_peer_height;
     using HandshakeCallback = std::function<void()>;
     HandshakeCallback m_on_handshake_complete;
+    // E-SUPERBLOCK R5 coverage REPORTING seam (NOT a drive hook): fired with a
+    // peer_key the moment the verack handler ACTUALLY primed that peer (the
+    // helper returned true — window-skips never fire it). The driver is the
+    // already-ported verack handshake-complete point; this only transports the
+    // primed key to GovSyncStatus (owned by CoinStateMaintainer, outside this
+    // class), so an already-primed peer never re-arms the quiescence window.
+    std::function<void(const std::string&)> m_on_govsync_primed;
     // Peer lifecycle seams for the DASH-isolated CoinPeerManager scoring feed
     // (coin/coin_peer_manager.hpp). Fired with the peer's "host:port" key so the
     // manager can score connects/disconnects and persist anchors. Both optional;
@@ -1316,10 +1324,11 @@ public:
     }
     // NOTE: handshaked_peer_keys() (the HANDSHAKE-COMPLETE peer set) is defined
     // once below, near the bulk-scheduler peer accessors. The R5 govsync
-    // coverage floor is NOT recorded from it — it is recorded from the keys
-    // RETURNED by send_govsync_prime() (the peers actually primed this round),
-    // so an already-primed peer that is re-visited does not spuriously re-arm
-    // the quiescence window / re-count as a fresh request.
+    // coverage floor is NOT recorded from it — it is recorded per session from
+    // the verack handler via m_on_govsync_primed, which fires ONLY for a peer the
+    // prime actually wrote (send_govsync_prime_to returned true), so an
+    // already-primed peer that is re-visited does not spuriously re-arm the
+    // quiescence window / re-count as a fresh request.
     /// Per-peer connection age in seconds, in pool order — durability, direct.
     std::vector<int64_t> peer_ages_sec() const
     {
@@ -1563,6 +1572,12 @@ public:
     /// Fired once per session when the version/verack handshake completes —
     /// the hook E2 uses to kick the initial getheaders/mnlistdiff sync.
     void set_on_handshake_complete(HandshakeCallback cb) { m_on_handshake_complete = std::move(cb); }
+    /// E-SUPERBLOCK R5 coverage reporting seam. Fired with the peer_key each
+    /// time the verack handler primes a peer with govsync(nProp=0), so the
+    /// maintainer that owns GovSyncStatus can record exactly that peer's
+    /// coverage. Reporting only — see m_on_govsync_primed.
+    void set_on_govsync_primed(std::function<void(const std::string&)> fn)
+    { m_on_govsync_primed = std::move(fn); }
     /// Register ONE historical-mnlistdiff consumer. Additive, not a slot: the
     /// Phase-L member source and the MN-checkpoint lane both source historical
     /// snapshots off this client and both must be offered every reply.
@@ -1767,15 +1782,17 @@ public:
     //      unlike getaddr, dashd PUNISHES a repeated full govsync from the same
     //      address inside the netfulfilledman window with Misbehaving(20)
     //      (CGovernanceManager::SyncObjects), so it cannot be a plain broadcast.
-    //      send_govsync_prime() (below) sends it to each handshaked peer AT MOST
-    //      ONCE per expiry window — the requester-side mirror of dashcore's own
-    //      CMasternodeSync + netfulfilledman once-per-peer gate.
+    //      the verack handler (below) primes each peer at its OWN handshake, once
+    //      per expiry window (send_govsync_prime_to) — the requester-side mirror
+    //      of dashcore's own CMasternodeSync + netfulfilledman once-per-peer gate.
     //
     // When the primary is lost, another handshaked peer is promoted and
     // m_on_handshake_complete re-fires — which is exactly the re-ask the
     // single-peer client already performed on every reconnect, so no class-1 leg
-    // silently loses its driver; the class-3 prime is idempotent across the
-    // re-fire (already-primed peers are skipped).
+    // silently loses its driver. The class-3 govsync prime is NOT driven from
+    // that callback (it is emitted per session in the verack handler): the
+    // survivor was already primed at its own verack, so primary re-election
+    // sends no govsync at all.
 
     /// Send a getheaders request (E2 sync driver seam; unused by E1 run_node).
     void send_getheaders(uint32_t version, const std::vector<uint256>& locator, const uint256& stop)
@@ -2320,37 +2337,60 @@ public:
     /// for the whole list multiple times in a short period of time is no good") —
     /// five repeats = score 100 = ban. This is the requester-side mirror of
     /// dashcore's own CMasternodeSync + netfulfilledman
-    /// HasFulfilledRequest("governance-sync") gate. So this primes each handshaked
+    /// HasFulfilledRequest("governance-sync") gate.
+    ///
+    /// PER-SESSION DRIVE: the prime is emitted from the VERACK HANDLER, per
+    /// session, right beside the getsporks leg (routing-class-3, exactly-once):
+    /// each peer is primed once at its own handshake, so both the future primary
+    /// (first verack) and every witness peer (later veracks) get covered —
+    /// mirroring how getsporks reaches every handshaked peer. That drive routes
+    /// through send_govsync_prime_to() below (single source of the window
+    /// discipline). This pool-wide walker is retained as the reprime-after-expiry
+    /// / test seam and a future hourly re-ask primitive: it primes each handshaked
     /// peer whose key is not already in m_govsync_primed (within
-    /// m_govsync_reprime_secs), records it, and RETURNS the vector of NEWLY primed
-    /// keys. Invoked from on_handshake_complete: at each new handshake it writes to
-    /// exactly the one new unprimed peer; on primary promotion / a re-fire it
-    /// writes to NOBODY. The R5 coverage is recorded from the RETURNED keys, so it
-    /// accrues peer-by-peer across handshakes without any single call fanning out.
+    /// m_govsync_reprime_secs) and RETURNS the vector of NEWLY primed keys, so R5
+    /// coverage accrues peer-by-peer without any single call fanning out.
     std::vector<std::string> send_govsync_prime()
     {
         std::vector<std::string> primed;
-        const int64_t now = now_sec();
         for (auto& p : m_pool) {
-            if (!p->handshake.complete()) continue;
-            auto it = m_govsync_primed.find(p->key);
-            if (it != m_govsync_primed.end() &&
-                m_govsync_reprime_secs > 0 &&
-                now - it->second < m_govsync_reprime_secs) {
-                // already primed within the expiry window — a repeat here is
-                // exactly the CGovernanceManager::SyncObjects Misbehaving(20)
-                // hazard, so skip it (dashd's own netfulfilledman once-only gate).
-                continue;
-            }
-            auto m = message_govsync::make_raw(
-                uint256::ZERO,           // nProp = 0 => request all objects
-                std::vector<uint8_t>{},  // empty filter vData
-                /*nHashFuncs=*/0u, /*nTweak=*/0u, /*nFlags=*/uint8_t{0});
-            p->write(m);
-            m_govsync_primed[p->key] = now;
-            primed.push_back(p->key);
+            if (send_govsync_prime_to(p.get()))
+                primed.push_back(p->key);
         }
         return primed;
+    }
+
+    /// Prime EXACTLY this peer with a full govsync(nProp=0), honouring the
+    /// once-per-expiry-window discipline. Returns TRUE iff a govsync was actually
+    /// written (peer handshaked AND not primed within m_govsync_reprime_secs);
+    /// FALSE on a window-skip or an unhandshaked peer. SINGLE SOURCE OF TRUTH for
+    /// the wire discipline: both the per-session verack driver and the pool-wide
+    /// walker route their write through here, so the at-most-once-per-key-per-
+    /// window guarantee holds regardless of caller — the requester-side mirror of
+    /// dashd's netfulfilledman HasFulfilledRequest("governance-sync") gate (a
+    /// repeat inside the window draws Misbehaving(20) in
+    /// CGovernanceManager::SyncObjects). peer_key is addr:port, matching dashd's
+    /// per-address fulfilled-request identity, so the window survives reconnects.
+    bool send_govsync_prime_to(PeerSession* p)
+    {
+        if (!p || !p->handshake.complete()) return false;
+        const int64_t now = now_sec();
+        auto it = m_govsync_primed.find(p->key);
+        if (it != m_govsync_primed.end() &&
+            m_govsync_reprime_secs > 0 &&
+            now - it->second < m_govsync_reprime_secs) {
+            // already primed within the expiry window — a repeat here is exactly
+            // the CGovernanceManager::SyncObjects Misbehaving(20) hazard, so skip
+            // it (dashd's own netfulfilledman once-only gate).
+            return false;
+        }
+        auto m = message_govsync::make_raw(
+            uint256::ZERO,           // nProp = 0 => request all objects
+            std::vector<uint8_t>{},  // empty filter vData
+            /*nHashFuncs=*/0u, /*nTweak=*/0u, /*nFlags=*/uint8_t{0});
+        p->write(m);
+        m_govsync_primed[p->key] = now;
+        return true;
     }
 
     /// TEST/DEPLOYMENT SEAM: the govsync-prime re-ask TTL, seconds. Default 3600
@@ -3624,6 +3664,22 @@ private:
         // N-witness refinement of the assume-active seed.
         auto msg_getsporks = message_getsporks::make_raw();
         p->write(msg_getsporks);
+
+        // E-SUPERBLOCK GOVSYNC PRIME (routing class 3), mirroring getsporks:
+        // ask THIS peer for the full governance object set exactly once, so a
+        // superblock height can be sourced daemonlessly. Like getsporks it is
+        // per-peer — the coverage defence (R5) is that the winning trigger
+        // reaches us even if one peer withholds it, so both the future primary
+        // (this first verack) and every witness peer (later veracks) must be
+        // primed, not just whoever wins primary election below. Only armed under
+        // --embedded-govsync/--embedded-superblock (m_gov_pull_enabled); OFF, the
+        // reply would be unanswered, so the default wire stays byte-identical to
+        // the pre-feature node. send_govsync_prime_to() enforces the at-most-
+        // once-per-peer-per-window discipline (dashd punishes a repeat full
+        // govsync with Misbehaving(20)); the reporting seam fires only when it
+        // actually wrote, so a window-skip never re-arms R5 quiescence.
+        if (m_gov_pull_enabled && send_govsync_prime_to(p) && m_on_govsync_primed)
+            m_on_govsync_primed(p->key);
 
         if (!m_primary)
         {

--- a/test/test_dash_coin_p2p_pool.cpp
+++ b/test/test_dash_coin_p2p_pool.cpp
@@ -914,9 +914,11 @@ TEST(DashCoinP2PPool, govsync_prime_covers_every_handshaked_peer_exactly_once)
 
 TEST(DashCoinP2PPool, govsync_prime_is_incremental_for_late_handshakes)
 {
-    // The prime fires from on_handshake_complete: at each new handshake it must
-    // write to exactly the ONE newly-handshaked (still-unprimed) peer, never
-    // re-touch the peers already primed at earlier handshakes.
+    // The pool-wide walker (send_govsync_prime) primes each not-yet-primed
+    // handshaked peer exactly once: called after a new handshake it writes to
+    // exactly the ONE newly-handshaked (still-unprimed) peer, never re-touch the
+    // peers already primed. (In production the per-session prime is driven from
+    // the verack handler; this exercises the retained walker/test seam directly.)
     PoolRig rig;
     rig.use_fake_clock();
     rig.client.set_max_peers(3);
@@ -1001,6 +1003,164 @@ TEST(DashCoinP2PPool, govsync_prime_returned_keys_drive_R5_to_two_peer_completen
     // >=2-peer view is COMPLETE — the serve path may now trust the store.
     EXPECT_TRUE(gov.is_complete(t0 + 61 + 30))
         << "a >=2-peer, settled, quiesced governance view was not declared complete";
+}
+
+// ── VERACK-DRIVEN PRIME: every handshaked peer covered, once, per session ─────
+// The live-wire failure mode reproduced: with --embedded-govsync armed the
+// govsync prime must fire from the VERACK handler for EVERY peer — the future
+// primary AND every witness — so the R5 >=2-peer coverage floor can flip. On
+// master the prime was driven only from promote_primary -> on_handshake_complete,
+// which primed the first verack alone, so gov_peers stuck at 1 forever.
+
+TEST(DashCoinP2PPool, verack_primes_every_handshaked_peer_for_R5_coverage)
+{
+    using dash::coin::GovSyncStatus;
+
+    // Baseline: an UNARMED rig — set_gov_pull is NEVER called, so the verack path
+    // stays silent and a witness handshake writes NO govsync. This is the
+    // per-handshake message count the armed rig is measured against (+1 govsync).
+    uint64_t unarmed_witness_msgs;
+    {
+        PoolRig base;
+        base.use_fake_clock();
+        base.client.set_max_peers(3);
+        base.handshake(1);
+        base.handshake(2);
+        unarmed_witness_msgs = base.session(2)->msgs_sent;
+    }
+
+    GovSyncStatus gov;   // defaults: min_peers=2, settle=60, quiesce=30
+    const int64_t t0 = 1'000'000;
+
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.fake_now = t0;
+    rig.client.set_max_peers(3);
+    rig.client.set_gov_pull(true);                     // = --embedded-govsync armed
+    rig.client.set_on_govsync_primed(
+        [&](const std::string& pk){ gov.note_govsync_requested(pk, rig.fake_now); });
+
+    // The FUTURE PRIMARY (first verack) is primed at its own handshake — not
+    // gated behind primary election.
+    rig.handshake(1);
+    EXPECT_EQ(gov.requested_peer_count(), 1u)
+        << "the first (primary) peer was not primed at its verack";
+    EXPECT_FALSE(gov.is_complete(t0 + 10'000))
+        << "a single primed peer must never be a complete governance view";
+
+    // The WITNESS peer — the one master NEVER primed — handshakes later and is
+    // primed too. THIS is the coverage gap that kept gov_peers stuck at 1.
+    rig.fake_now = t0 + 5;
+    rig.handshake(2);
+    EXPECT_EQ(gov.requested_peer_count(), 2u)
+        << "the witness peer was not primed at its verack (the live-wire gap)";
+
+    // Per-peer WIRE proof: the witness wrote exactly ONE more message than the
+    // unarmed baseline — a single govsync, no fanout.
+    EXPECT_EQ(rig.session(2)->msgs_sent, unarmed_witness_msgs + 1u)
+        << "the witness prime was not exactly one govsync (fanout or missing)";
+
+    // No residual double-drive: everyone was already primed at their verack, so a
+    // pool-wide walk now returns EMPTY (proves the old promote_primary drive is
+    // gone — nobody is left for it to re-prime).
+    EXPECT_TRUE(rig.client.send_govsync_prime().empty())
+        << "a peer was left unprimed by the verack path (residual drive gap)";
+
+    // >=2 DISTINCT primed peers -> the min_peers=2 floor is crossable; after the
+    // settle floor AND quiescence the view flips COMPLETE -> gov_complete=1.
+    EXPECT_FALSE(gov.is_complete(t0 + 30)) << "settled before the 60s floor";
+    EXPECT_TRUE(gov.is_complete(t0 + 5 + 61 + 30))
+        << "a >=2-peer settled quiesced governance view was not declared complete";
+}
+
+TEST(DashCoinP2PPool, primary_election_does_not_double_prime_the_primary)
+{
+    // KAT-3: promote_primary fires on the first verack (m_on_handshake_complete),
+    // but the govsync drive no longer lives there — so the primary is primed
+    // exactly ONCE, by the same verack-site line as any peer. Armed handshake(1)
+    // writes exactly one govsync to peer 1 (delta vs an unarmed handshake == +1),
+    // and a following pool-wide walk finds nothing to re-prime.
+    uint64_t unarmed_primary_msgs;
+    {
+        PoolRig base;
+        base.use_fake_clock();
+        base.client.set_max_peers(2);
+        base.handshake(1);
+        unarmed_primary_msgs = base.session(1)->msgs_sent;
+    }
+
+    int primed_reports = 0;
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(2);
+    rig.client.set_gov_pull(true);
+    rig.client.set_on_govsync_primed([&](const std::string&){ ++primed_reports; });
+
+    rig.handshake(1);   // triggers promote_primary -> m_on_handshake_complete
+    EXPECT_EQ(rig.session(1)->msgs_sent, unarmed_primary_msgs + 1u)
+        << "the primary was double-primed (or not primed) at its verack";
+    EXPECT_EQ(primed_reports, 1)
+        << "the primary's prime reported other than exactly once";
+    EXPECT_TRUE(rig.client.send_govsync_prime().empty())
+        << "the primary was left unprimed / re-primeable after its verack";
+}
+
+TEST(DashCoinP2PPool, verack_reprime_within_window_does_not_resend_no_ban_vector)
+{
+    // KAT-2: the requester-side mirror of dashd's netfulfilledman once-per-window
+    // gate must survive a RECONNECT. A peer dropped and re-handshaked from the
+    // SAME address inside m_govsync_reprime_secs must NOT be re-sent a full
+    // govsync (that repeat is the CGovernanceManager::SyncObjects Misbehaving(20)
+    // ban vector). Once the window lapses, the re-handshake IS re-primed (TTL).
+    using dash::coin::GovSyncStatus;
+    GovSyncStatus gov;
+    int primed_reports = 0;
+
+    PoolRig rig;
+    rig.use_fake_clock();
+    rig.client.set_max_peers(3);
+    rig.client.set_gov_pull(true);
+    rig.client.set_on_govsync_primed([&](const std::string& pk){
+        ++primed_reports;
+        gov.note_govsync_requested(pk, rig.fake_now);
+    });
+
+    rig.handshake(1);
+    rig.handshake(2);
+    ASSERT_EQ(primed_reports, 2);
+    ASSERT_EQ(gov.requested_peer_count(), 2u);
+
+    // Keep the PRIMARY (peer 1) alive across the reap window by answering its
+    // pings; let the WITNESS (peer 2) go silent so ONLY it is reaped.
+    const auto answer_peer1 = [&](int64_t){
+        const PeerSession* s = rig.session(1);
+        if (s && s->liveness.ping_outstanding())
+            rig.deliver(1, p2p::message_pong::make_raw(s->liveness.ping_nonce()));
+    };
+    rig.run_seconds(rig.client.peer_timeout_sec(), answer_peer1);
+    ASSERT_EQ(rig.session(2), nullptr) << "the witness peer was not reaped";
+    ASSERT_NE(rig.session(1), nullptr) << "the primary was wrongly reaped";
+    // Still well inside the default 3600s reprime window (peer_timeout is 1200s),
+    // so the reconnect below must be treated as an in-window repeat.
+    ASSERT_LT(rig.fake_now - 1'000'000, static_cast<int64_t>(3600));
+
+    // RECONNECT the same address INSIDE the window: a NEW session, same peer_key.
+    rig.handshake(2);
+    EXPECT_EQ(primed_reports, 2)
+        << "a reconnect inside the window re-sent govsync (dashd Misbehaving(20))";
+    EXPECT_EQ(gov.requested_peer_count(), 2u)
+        << "a window-skipped reconnect spuriously re-armed R5 coverage";
+
+    // Collapse the window (TTL semantics), reap the witness again, reconnect: now
+    // the govsync IS re-sent — proving the guard is an EXPIRY window, not a latch,
+    // and that the discipline lives in the shared send-site helper.
+    rig.client.set_govsync_reprime_secs(0);
+    rig.run_seconds(rig.client.peer_timeout_sec(), answer_peer1);
+    ASSERT_EQ(rig.session(2), nullptr) << "the witness peer was not reaped (2nd)";
+    rig.handshake(2);
+    EXPECT_EQ(primed_reports, 3)
+        << "a lapsed reprime window did not permit a verack re-prime";
+    EXPECT_EQ(gov.requested_peer_count(), 2u);   // same key -> still 2 distinct
 }
 
 TEST(DashCoinP2PPool, getaddr_is_broadcast_because_discovery_breadth_refills_the_pool)


### PR DESCRIPTION
## Problem

The daemonless superblock govsync feed pulls governance objects end-to-end (inv 17/18 getdata), but the R5 completeness gate never crossed its `>=2` peer coverage floor: `gov_peers` stayed at **1** even with a `>=2`-peer handshaked pool, so `gov_complete` could never flip TRUE and `--embedded-superblock` could never be armed. That was the last functional gap to 100% superblock serving.

## Root cause

The `govsync(nProp=0)` prime was driven only from `promote_primary -> m_on_handshake_complete` (main_dash's handshake-complete callback). That fires once — for the first peer to verack, the one that wins primary election. Witness peers that verack afterwards were never primed. But the prime belongs beside `getsporks`: a per-peer, idempotent, full-set request whose reply merges into the one `GovernanceStore` regardless of which peer delivered it, so multi-peer coverage is the defence against a single peer withholding the winning trigger.

## Fix

Move the prime to its true per-session point — the **verack handler** — right after the `getsporks` leg and before primary election:

- **Factor `send_govsync_prime_to(PeerSession*)`** out of the pool-wide walker so the at-most-once-per-peer-per-expiry-window discipline lives at the single send site (`peer_key` = `addr:port`, matching dashd's netfulfilledman identity; a repeat inside the window is the `CGovernanceManager::SyncObjects` Misbehaving(20) ban vector). The walker now loops over the helper and is retained as the reprime-after-expiry / test seam.
- **Emit the prime in the verack handler**, gated on `m_gov_pull_enabled` (`--embedded-govsync`/`--embedded-superblock`). OFF, nothing is emitted, so the default wire is byte-identical to the pre-feature node (master emitted an unanswered off-arm prime — a strict tightening).
- **Add an `m_on_govsync_primed` reporting seam** (in the `set_addr_callback` pattern) that fires only when a peer was actually primed; main_dash wires it to `note_govsync_requested`, so R5 coverage records exactly the primed peer and a window-skip never re-arms quiescence. This is a reporting seam, not a new drive hook — the driver is the already-ported verack handshake-complete point.
- **Remove the govsync drive** from main_dash's handshake-complete callback (the old buggy driver). Every other consumer (getheaders kick, BIP35 guard, discover getaddr, cold getmnlistd snapshot) is unchanged. `promote_primary`/`elect_primary` keep firing the callback for the class-1 re-ask legs but no longer prime, so the primary is primed exactly once (at its own verack) and re-election never double-primes.
- **Fix the doc-comments** that described the intended per-handshake firing rather than the shipped promote_primary-only reality.

Only active under `--embedded-govsync` (default OFF). `send_govsync(prop)` per-trigger vote-sync fanout is unchanged (different routing class, no netfulfilledman gate).

## Behaviour delta

Master sends the prime even with the gov arm OFF (the drive was wired unconditionally). Gating at the verack site makes the default-OFF wire byte-identical to the pre-feature node — a strict tightening, and it is what keeps the 5 existing govsync KATs green without edits.

## Tests

New KATs in `test/test_dash_coin_p2p_pool.cpp` (the exact live-wire failure mode, previously uncovered because the old tests only exercised `promote_primary`):

- `verack_primes_every_handshaked_peer_for_R5_coverage` — stable single-primary election, arm on, handshake two peers; the witness (the peer master never primed) IS primed, coverage reaches 2, the witness writes exactly one extra govsync, the pool-wide walk is then empty (no residual double-drive), and `is_complete` flips TRUE after settle+quiesce.
- `primary_election_does_not_double_prime_the_primary` — armed `handshake(1)` writes exactly one govsync to the primary despite `promote_primary` firing.
- `verack_reprime_within_window_does_not_resend_no_ban_vector` — a reconnect from the same address inside the window does NOT resend govsync (no Misbehaving(20) vector); after the window is collapsed a reconnect IS re-primed (TTL preserved through the helper).

The 5 existing govsync KATs pass unchanged (their rigs never arm the pull). Full `test_dash_p2p_node` (168) + `test_dash_p2p_messages` (13) green; isolated `c2pool-dash` build green.
