### PR TITLE
dash(sharechain): restore live p2pool-dash mainnet identity (revert #1344)

### DIFF
--- a/src/impl/dash/config_pool.hpp
+++ b/src/impl/dash/config_pool.hpp
@@ -80,14 +80,24 @@ struct SharechainConfig
     static uint32_t real_chain_length() { return is_testnet ? TESTNET_REAL_CHAIN_LENGTH : REAL_CHAIN_LENGTH; }
 
     // ISOLATION PRIMITIVES — per-coin AND per-instance, never unified cross-coin.
-    // 2026-08-25: c2pool moved to its OWN sharechain identity, distinct from the inherited legacy
-    // p2pool-dash chain. Identifier + prefix are the sharechain's network isolation keys — nodes
-    // with different values form disjoint sharechains and reject each other, so this cleanly
-    // separates the c2pool sharechain from the old p2pool one. Old values kept commented below.
-    //   OLD (legacy p2pool-dash identity):
-    //     IDENTIFIER_HEX = "7242ef345e1bed6b";  PREFIX_HEX = "3b3e1286f446b891";
-    static inline const std::string IDENTIFIER_HEX         = "ac2785363c0180b8";  // c2pool sharechain
-    static inline const std::string PREFIX_HEX             = "8d8516bac9edd280";  // c2pool sharechain
+    // Identifier + prefix are the sharechain's network isolation keys — they are NOT just
+    // handshake framing: the identifier is committed inside every share's ref_hash (the ref
+    // stream prepends active_identifier_hex()), so it gates BOTH the p2p prefix match AND share
+    // PoW/ref-hash validation. Nodes with different values form disjoint, mutually-rejecting
+    // sharechains, so the default MUST equal the live network's identity.
+    //
+    // Mainnet = the live p2pool-dash fleet identity (oracle p2pool/dash.py:9-10). The single
+    // live DASH sharechain is keyed to 7242ef345e1bed6b / 3b3e1286f446b891.
+    //
+    // RESERVED (future v36 self-identity): ac2785363c0180b8 / 8d8516bac9edd280. A 2026-08-25
+    // switch (#1344) made this the default before any v36 network existed, isolating the node
+    // from the only live network and breaking both handshake AND share validation against the
+    // fleet — reverted here. When a real v36 network launches, reintroduce this identity through
+    // the v36 activation machinery (AutoRatchet / Phase C), not as the plain default.
+    //   RESERVED v36 self-identity:
+    //     IDENTIFIER_HEX = "ac2785363c0180b8";  PREFIX_HEX = "8d8516bac9edd280";
+    static inline const std::string IDENTIFIER_HEX         = "7242ef345e1bed6b";  // live p2pool-dash fleet
+    static inline const std::string PREFIX_HEX             = "3b3e1286f446b891";  // live p2pool-dash fleet
     static inline const std::string TESTNET_IDENTIFIER_HEX = "b6deb1e543fe2427";
     static inline const std::string TESTNET_PREFIX_HEX     = "198b644f6821e3b3";
 

--- a/test/test_dash_conformance.cpp
+++ b/test/test_dash_conformance.cpp
@@ -1314,10 +1314,11 @@ TEST(DashConformanceNetworkParams, MainnetMatchesP2poolDashOracle) {
     EXPECT_EQ(dash::SharechainConfig::TARGET_LOOKBEHIND, 100u);
     EXPECT_EQ(dash::SharechainConfig::SPREAD, 10u);
     EXPECT_EQ(dash::SharechainConfig::MINIMUM_PROTOCOL_VERSION, 1700u);
-    // 2026-08-25: mainnet uses c2pool's OWN sharechain identity (distinct from the legacy p2pool-dash
-    // chain). Testnet (below) still tracks the p2pool oracle. Old p2pool: 7242ef345e1bed6b / 3b3e1286f446b891.
-    EXPECT_EQ(dash::SharechainConfig::identifier_hex(), std::string("ac2785363c0180b8"));
-    EXPECT_EQ(dash::SharechainConfig::prefix_hex(),     std::string("8d8516bac9edd280"));
+    // Mainnet tracks the live p2pool-dash fleet identity (oracle p2pool/dash.py:9-10) — the identifier
+    // is committed inside every share's ref_hash, so it must equal the live network's key. Reserved v36
+    // self-identity ac2785363c0180b8 / 8d8516bac9edd280 activates via the v36 machinery, not by default.
+    EXPECT_EQ(dash::SharechainConfig::identifier_hex(), std::string("7242ef345e1bed6b"));
+    EXPECT_EQ(dash::SharechainConfig::prefix_hex(),     std::string("3b3e1286f446b891"));
     uint256 expect_max;
     expect_max.SetHex("00000000ffff0000000000000000000000000000000000000000000000000000");
     EXPECT_EQ(dash::SharechainConfig::max_target(), expect_max);    // 0xFFFF * 2**208

--- a/test/test_dash_poolnode_messages.cpp
+++ b/test/test_dash_poolnode_messages.cpp
@@ -202,7 +202,7 @@ TEST(DashConnectModePrefix, WirePrefix_NetAware_MainnetVsTestnet) {
     const bool saved = SharechainConfig::is_testnet;
 
     SharechainConfig::is_testnet = false;
-    EXPECT_EQ(SharechainConfig::prefix_hex(), std::string("8d8516bac9edd280"));  // c2pool mainnet chain (was p2pool 3b3e1286f446b891)
+    EXPECT_EQ(SharechainConfig::prefix_hex(), std::string("3b3e1286f446b891"));  // live p2pool-dash fleet chain
     auto main_bytes = ParseHexBytes(SharechainConfig::prefix_hex());
     EXPECT_EQ(main_bytes.size(), size_t(8));
 

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -518,7 +518,7 @@ ProspectiveShareInfo fixture_f1_info() {
 }
 
 const char* F1_REF_STREAM_HEX =
-    "ac2785363c0180b8"                                                  // IDENTIFIER
+    "7242ef345e1bed6b"                                                  // IDENTIFIER
     "0000000000000000000000000000000000000000000000000000000000000000"  // prev None
     "0403010203"                                                        // coinbase VarStr
     "00"                                                                // inner payload None
@@ -539,7 +539,7 @@ const char* F1_REF_STREAM_HEX =
     "01000100010000000000000000000000";                                 // abswork LE (128)
 
 const char* F1_REF_HASH_HEX =
-    "6b97d93ff3b1adad8f4c4d1c0f2fb3cd99ee3ab92a90dd1f83c4faa1a9eaca7e";
+    "ae9fd236e3de3647ce76bf2eb3172ad0ec51d3edba4b231b4b1e2d204771880b";
 
 const char* F1_GENTX_HEX =
     "01000000"                                                          // version 1, type 0
@@ -550,12 +550,12 @@ const char* F1_GENTX_HEX =
     "00e1f50500000000" "066a04deadbeef"                                 // payment 100000000
     "00725d1700000000" "1976a91420cb5c22b1e4d5947e5c112c7696b51ad9af3c6188ac"  // donation 392000000
     "0000000000000000" "2a6a28"
-    "6b97d93ff3b1adad8f4c4d1c0f2fb3cd99ee3ab92a90dd1f83c4faa1a9eaca7e"  // ref_hash
+    "ae9fd236e3de3647ce76bf2eb3172ad0ec51d3edba4b231b4b1e2d204771880b"  // ref_hash
     "0102030405060708"                                                  // last_txout_nonce LE
     "00000000";                                                         // locktime
 
 const char* F1_TXID_HEX =
-    "616583dd0f352b49ef69f04f2b947362bd4d4a9e29a3e7a02654fa095d1e2821";
+    "4cf27aa8726d1df1af549cf905e1b747288dcca9a418f15d052ad45cc0d0b9a0";
 
 constexpr uint64_t F1_NONCE64 = 0x0807060504030201ull;
 
@@ -618,14 +618,14 @@ TEST(DashShareProducerGentx, F2PayloadGolden) {
 
     const uint256 ref_hash = dash::producer::compute_ref_hash(params, info);
     EXPECT_EQ(hex_of(ref_hash),
-              "011b11d0b71be8ab58e2c0bc10c0d0af5ca07a129d2a5879ce695c3db99056b9");
+              "e5efc58b08be49d7bc03b6f1731114d84068346817017465ce07e46c516196e1");
 
     auto gentx = dash::producer::build_gentx(
         info, dash::producer::CumulativeWeights{}, ref_hash, F1_NONCE64, params);
     EXPECT_EQ(gentx.bytes.size(), 194u);
     EXPECT_EQ(gentx.prefix_len, 145u);          // len - 5 (VarStr payload) - 44
     EXPECT_EQ(hex_of(gentx.txid),
-              "cd230eda4487e566d1ea587ff90eee094ef68672ff6c7a1348d92cfe394a68ea");
+              "6835d59cfe4c564b06dc55b3d235fe201869a3aca3c1368eb295a831e8e36239");
     // version int16 / type int16 (dash/data.py:97-98) + payload tail.
     ASSERT_GE(gentx.bytes.size(), 5u);
     EXPECT_EQ(gentx.bytes[0], 0x03); EXPECT_EQ(gentx.bytes[1], 0x00);


### PR DESCRIPTION
## Summary

Reverts the mainnet DASH sharechain identity to the **live p2pool-dash fleet** keys:

| | before (#1344) | after (this PR) |
|---|---|---|
| identifier | `ac2785363c0180b8` | `7242ef345e1bed6b` |
| prefix | `8d8516bac9edd280` | `3b3e1286f446b891` |

Commit #1344 (2026-08-25, `77dabcd4`) switched mainnet to a distinct "own" sharechain identity **before any network using it existed**. There is no live network signalling the `ac2785` identity; the only live DASH sharechain (the p2pool-dash fleet) keys every share to `7242ef`.

## Why this is a defect, not a preference

The identifier is **not just handshake framing** — it is committed inside every share's `ref_hash` (the ref stream prepends `active_identifier_hex()`; `share_check.hpp` / `share_producer.hpp`). A wrong identifier therefore breaks **two** things at once:

1. the p2p **prefix match** (handshake rejected: "prefix doesn't match"), and
2. share **PoW / ref-hash / payout-commitment validation**.

So a default that doesn't match the live network forms a disjoint, mutually rejecting sharechain — the node can neither handshake with, nor validate the shares of, the only network that exists. Both paths read the single SSOT (`config_pool.hpp`), so reverting the default fixes handshake and share consensus coherently in one place.

## v36 roadmap deferred, not dropped

`ac2785363c0180b8 / 8d8516bac9edd280` are retained in `config_pool.hpp` as the **RESERVED** future self-identity. When a real successor network launches, that identity is reintroduced through the existing activation machinery (AutoRatchet / Phase C), **not** as the plain default — a network-forming constant must match the live network.

## Scope

- `src/impl/dash/config_pool.hpp` — mainnet identity constants + rationale comment (testnet identity unchanged).
- `test/test_dash_conformance.cpp`, `test/test_dash_poolnode_messages.cpp`, `test/test_dash_share_producer.cpp` — identity / wire-prefix / ref-hash goldens pinned back to the pre-#1344 (7242ef-keyed) values.

Share **wire format is untouched** and remains byte-identical to p2pool-dash v16. The merged dashd-cut features (govsync, special-tx superset, verack-prime) are orthogonal to the sharechain identity and are **not** touched.

## Live-fleet validation

A node built from this change, run against live fleet peers (`83.221.211.116`, `92.53.224.27`, `66.151.242.154`, `79.140.31.170`, all `:8999`):

- **Handshake**: sessions established with 5 fleet peers, **0** "prefix doesn't match", **0** misbehaving-disconnects/bans.
- **Receive + validate**: downloaded the full 4320-share chain and ran full validation (X11 PoW + hash_link + merkle + ref-hash + version-transition + **payout-commitment**) on **1200+** received v16 shares with **`attempt_verify FAILED = 0`**.
- **Convergence**: the fleet peer's advertised best share became `known`, `best_changed=true`, `verified_heads=1` — the local best share advanced onto the fleet chain head.

This directly refutes the risk that the c2pool sharechain had diverged from v16: received fleet shares validate through the exact producer/verify path our own shares are minted on.

## Tests

- `test_dash_conformance` (Mainnet oracle params): PASS
- `test_dash_poolnode_messages` (wire prefix): PASS
- `test_dash_share_hash_link` (share-producer ref-hash goldens, 37 tests): PASS

## Notes

- Network-forming identity change — **operator merge tap required, no self-merge.**
- Any node persisting a store minted under `ac2785` must discard it on redeploy and resync from the fleet (dash.voidbind already runs the 7242ef chain).