### PR TITLE
dash: keep WebServer alive on web-port bind failure (fix receive-path UAF SIGSEGV)

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -3117,7 +3117,12 @@ int main(int argc, char* argv[])
         } else {
             LOG_ERROR << "[BTC-POOL] WebServer FAILED to bind " << http_addr << ":"
                       << http_port << " â dashboard disabled, run-loop continues.";
-            web_server.reset();
+            // Keep the WebServer alive on a failed bind (do NOT reset). A
+            // failed-start server holds no listener and serves nothing; all
+            // later use is `if (web_server)`-guarded. This mirrors the DASH
+            // fix: freeing here would dangle any pre-start raw-pointer capture
+            // into the WebServer / MiningInterface. BTC installs no such capture
+            // today, so this is defensive parity, not a live-bug fix.
         }
         } // if (mi != nullptr)
     } else {

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2295,7 +2295,20 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         } else {
             std::cout << "[run] web dashboard FAILED to bind " << web_host << ":"
                       << web_port << " — dashboard disabled (mining unaffected)\n";
-            web_server.reset();
+            // Do NOT reset() the WebServer here. Pre-start hooks already captured
+            // it by raw pointer — the tracker's m_on_share_difficulty feed
+            // (core::WebServer* ws = web_server.get() above) and the detached
+            // auto_detect_external_info() thread both hold references into this
+            // object AND its MiningInterface. Freeing it on a failed bind left
+            // those pointers dangling; the first verify burst then called
+            // record_share_difficulty() on the freed MiningInterface
+            // (m_hashrate_ring / m_samples[miner]) and SIGSEGV'd during share
+            // ingestion. A failed-start WebServer holds no listener and serves
+            // nothing, so keeping it alive costs nothing: the acceptor never
+            // came up, later use is all `if (web_server)`-guarded, and the
+            // surviving hooks fire safely against an inert MiningInterface that
+            // merely accumulates stats. Every capture stays valid; the
+            // bind-success path (production) is byte-for-byte unchanged.
         }
     } else {
         std::cout << "[run] web dashboard disabled (--web-port 0)\n";

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -2035,7 +2035,12 @@ int run_node(const core::CoinParams& params, bool testnet,
         } else {
             std::cout << "[DGB] WebServer FAILED to bind " << http_addr << ":"
                       << http_port << " — dashboard disabled, run-loop continues" << std::endl;
-            web_server.reset();
+            // Keep the WebServer alive on a failed bind (do NOT reset). A
+            // failed-start server holds no listener and serves nothing; all
+            // later use is `if (web_server)`-guarded. This mirrors the DASH
+            // fix: freeing here would dangle any pre-start raw-pointer capture
+            // into the WebServer / MiningInterface. DGB installs no such capture
+            // today, so this is defensive parity, not a live-bug fix.
         }
     } else {
         std::cout << "[DGB] dashboard disabled (no --http flag)" << std::endl;


### PR DESCRIPTION
## Summary

Fixes a use-after-free SIGSEGV that crashes `c2pool-dash` during live
sharechain ingestion whenever the dashboard web port cannot be bound.

The crash presents as a receive-path crash: it fires on the async-think
thread inside `dash::ShareTracker::attempt_verify` during the first large
share-verification burst (~100 s after start on a fresh store). The root
cause is at startup, not on the wire.

## Root cause

`run_node()` installs two consumers that capture the `WebServer` /
`MiningInterface` by **raw pointer before** `web_server->start()` is
attempted:

- the tracker per-share difficulty feed
  `p2p_node.tracker().m_on_share_difficulty`, built as
  `core::WebServer* ws = web_server.get(); … ws->get_mining_interface()->record_share_difficulty(…)`;
- the detached `auto_detect_external_info()` thread, which writes the
  detected public-IP string into the `MiningInterface`.

When the bind fails, the code logged `web dashboard FAILED to bind` and
then called `web_server.reset()`, destroying the `WebServer` and the
`MiningInterface` it owns. The two captured pointers were left dangling.
The next verified share drove the tracker hook into the freed
`MiningInterface`:

```
record_share_difficulty  ->  HashrateRing::record  ->  m_samples[miner]   (operator[] on a freed std::unordered_map)  ->  SIGSEGV
```

Because verification only runs once the chain is connected, the fault
looks like an ingestion crash even though the sharechain wire/identity
path is not involved.

The condition is deterministic on any host where the web port is already
occupied. It is latent (not introduced by any recent commit): the
reset-on-bind-failure and the raw-pointer hook both predate the current
release line by ~6 weeks, so a binary that happened to bind its web port
never hit it.

## Fix

On a failed bind, do **not** reset the `WebServer`. A failed-start server
holds no listener and serves nothing, and every later use of `web_server`
is already `if (web_server)`-guarded, so keeping it non-null simply lets
the surviving hooks fire harmlessly into an inert `MiningInterface` that
accumulates stats. This keeps every captured pointer valid with **zero
behavior change on the bind-success path** (the production path).

The same `web_server.reset()`-on-bind-failure shape exists in the BTC and
DGB run loops. Neither captures the `WebServer` by raw pointer before the
reset today, so neither has a live use-after-free, but both are changed to
the same keep-alive for defensive parity so a future pre-start capture
cannot regress into the same bug.

## Proof

- Build: Release, SIMD SHA256 backend, startup KAT byte-exact vs scalar.
- Condition: **fresh** sharechain store, deliberately colliding web port
  (bind failure forced — the exact condition that crashed the pre-fix
  binary), live p2pool-dash fleet peers over the `[Pool]` sharechain
  (`83.221.211.116:8999`, `92.53.224.27:8999`, `66.151.242.154:8999`,
  `79.140.31.170:8999`).
- Pre-fix: SIGSEGV reproducibly ~100 s in during the first verify burst.
- Fixed: full session > 30 min with **zero SIGSEGV**; fleet shares
  received and validated, sharechain connected, best share advancing, the
  difficulty hook firing safely throughout.

Scope: the change is outside the sharechain / serve / template paths. The
mainnet identity restore and all daemonless (dashd-cut) features are
untouched.
