### PR TITLE
dashboard: recover found-block network_difficulty so accepted wins fold into the luck trend

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -9684,21 +9684,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // difficulty. backfill_block_fields internally re-derives the luck trend.
         if (header_chain) {
             auto* hc = header_chain.get();
-            cache_mi->backfill_block_fields(
-                [hc](const std::string& block_hash_hex) -> double {
-                    uint256 h;
-                    h.SetHex(block_hash_hex);
-                    auto e = hc->get_header(h);
-                    if (!e) return 0.0;
-                    return chain::target_to_difficulty(
-                        chain::bits_to_target(e->header.m_bits));
-                },
-                [hc](const std::string& block_hash_hex) -> uint32_t {
-                    uint256 h;
-                    h.SetHex(block_hash_hex);
-                    auto e = hc->get_header(h);
-                    return e ? e->header.m_timestamp : 0;
-                });
+            auto diff_lookup = [hc](const std::string& block_hash_hex) -> double {
+                uint256 h;
+                h.SetHex(block_hash_hex);
+                auto e = hc->get_header(h);
+                if (!e) return 0.0;
+                return chain::target_to_difficulty(
+                    chain::bits_to_target(e->header.m_bits));
+            };
+            auto ts_lookup = [hc](const std::string& block_hash_hex) -> uint32_t {
+                uint256 h;
+                h.SetHex(block_hash_hex);
+                auto e = hc->get_header(h);
+                return e ? e->header.m_timestamp : 0;
+            };
+            // One-shot backfill of rows restored from persistence.
+            cache_mi->backfill_block_fields(diff_lookup, ts_lookup);
+            // Retain the same lookups so the record + confirm paths can fill a
+            // missing network_difficulty for blocks won AFTER this backfill runs
+            // (sharechain-replay / relay wins recorded seconds into boot), whose
+            // luck point the one-shot backfill can never reach.
+            cache_mi->set_block_field_lookups(diff_lookup, ts_lookup);
         }
 
         // #159 (G2): the verifier + io_context are now live, so drive a

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -7294,21 +7294,28 @@ int main(int argc, char* argv[]) {
             // using LTC header chain. Exact values from the block header.
             if (embedded_chain) {
                 auto* hc = embedded_chain.get();
+                auto diff_lookup = [hc](const std::string& block_hash_hex) -> double {
+                    uint256 h;
+                    h.SetHex(block_hash_hex);
+                    auto entry = hc->get_header(h);
+                    if (!entry) return 0.0;
+                    auto target = chain::bits_to_target(entry->header.m_bits);
+                    return chain::target_to_difficulty(target);
+                };
+                auto ts_lookup = [hc](const std::string& block_hash_hex) -> uint32_t {
+                    uint256 h;
+                    h.SetHex(block_hash_hex);
+                    auto entry = hc->get_header(h);
+                    return entry ? entry->header.m_timestamp : 0;
+                };
+                // One-shot backfill of rows restored from persistence.
                 web_server.get_mining_interface()->backfill_block_fields(
-                    [hc](const std::string& block_hash_hex) -> double {
-                        uint256 h;
-                        h.SetHex(block_hash_hex);
-                        auto entry = hc->get_header(h);
-                        if (!entry) return 0.0;
-                        auto target = chain::bits_to_target(entry->header.m_bits);
-                        return chain::target_to_difficulty(target);
-                    },
-                    [hc](const std::string& block_hash_hex) -> uint32_t {
-                        uint256 h;
-                        h.SetHex(block_hash_hex);
-                        auto entry = hc->get_header(h);
-                        return entry ? entry->header.m_timestamp : 0;
-                    });
+                    diff_lookup, ts_lookup);
+                // Retain the same lookups so the record + confirm paths can fill
+                // a missing network_difficulty for blocks won AFTER this backfill
+                // runs, whose luck point the one-shot backfill can never reach.
+                web_server.get_mining_interface()->set_block_field_lookups(
+                    diff_lookup, ts_lookup);
             }
 
             // #159 (G2): re-verify any found block that was still pending at the

--- a/src/core/test/web_server_dashboard_data_test.cpp
+++ b/src/core/test/web_server_dashboard_data_test.cpp
@@ -934,3 +934,246 @@ TEST(DashboardData, RecentBlocksResidualFieldsHonorHonestNull)
     EXPECT_EQ(arr[0]["blocks_for_luck"].get<uint64_t>(), 0u);
     EXPECT_EQ(arr[0]["single_hashrate_luck_count"].get<uint64_t>(), 0u);
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 8. Header-chain network_difficulty recovery — the luck-less accepted-win bug
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// THE INCIDENT (dash.voidbind, block 2531046, 2026-08-31). An accepted pool
+// win was recorded during startup sharechain replay — before any live template
+// existed and before the first /local_stats poll refreshed the netdiff cache —
+// so record_found_block's template and cache fallbacks were both empty and the
+// row persisted network_difficulty=0. luck needs expected_time needs netdiff,
+// so the row's luck was null forever and the found-block diamond had no matching
+// point on the luck trend. The one-shot startup backfill had already run BEFORE
+// replay created the row, and never re-runs. The block's OWN header carries the
+// exact difficulty in its nBits: the record path must consult it as a final
+// fallback, the confirm lane must repair a row whose header arrived late, the
+// enrichment path must fill it on an already-attributed row, and backfill must
+// PERSIST what it repairs so the fix survives a restart.
+
+namespace {
+// A header lookup that answers a fixed difficulty for every hash (the block's
+// nBits, resolved through the embedded header chain in production). 1.0 keeps
+// the luck arithmetic checkable by eye against a 2^32 H/s pool hashrate.
+MiningInterface::block_diff_lookup_fn fixed_diff_lookup(double d) {
+    return [d](const std::string&) -> double { return d; };
+}
+MiningInterface::block_ts_lookup_fn null_ts_lookup() {
+    return [](const std::string&) -> uint32_t { return 0; };
+}
+} // namespace
+
+// RECORD-PATH fallback: template empty, cache cold, but the block's header is
+// available — netdiff comes from the header and luck is computed. This is the
+// 2531046 replay case reproduced end to end.
+TEST(DashboardData, HeaderLookupFillsNetdiffWhenTemplateAndCacheAreCold)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    // NO template wired (embedded replay arm has none yet); cache is cold.
+    mi.set_pool_hashrate_fn([]() { return 4294967296.0; });   // 2^32 H/s
+    mi.set_block_field_lookups(fixed_diff_lookup(1.0), null_ts_lookup());
+
+    const std::string h1 =
+        "1111111111111111111111111111111111111111111111111111111111110001";
+    const std::string h2 =
+        "1111111111111111111111111111111111111111111111111111111111110002";
+
+    // First (predecessor) block, then the winning block 2 s later — the exact
+    // call shape of the replay hook: netdiff 0, pool_hashrate 0, subsidy 0.
+    mi.record_found_block(2531045, uint256S(h1), /*ts=*/1788182946, "DASH",
+                          "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4", h1,
+                          0.0, 240228.0, 0.0, 0);
+    mi.record_found_block(2531046, uint256S(h2), /*ts=*/1788182948, "DASH",
+                          "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4", h2,
+                          0.0, 240228.0, 0.0, 0);
+
+    auto blk = find_block(mi.rest_recent_blocks(), h2);
+    ASSERT_TRUE(blk.is_object());
+    ASSERT_TRUE(blk["network_difficulty"].is_number())
+        << "netdiff must be recovered from the block header when both the live "
+           "template and the cache are empty at record time";
+    EXPECT_DOUBLE_EQ(blk["network_difficulty"].get<double>(), 1.0);
+    ASSERT_TRUE(blk["luck"].is_number())
+        << "with the header-sourced netdiff the accepted win must carry luck";
+    EXPECT_DOUBLE_EQ(blk["expected_time"].get<double>(), 1.0);
+    EXPECT_DOUBLE_EQ(blk["time_to_find"].get<double>(), 2.0);
+    EXPECT_DOUBLE_EQ(blk["luck"].get<double>(), 50.0);
+    EXPECT_EQ(blk["luck_method"].get<std::string>(), "simple_avg");
+}
+
+// BASELINE for the label split: with NO header lookup available a row that has
+// a predecessor (time_to_find>0) but no measured netdiff is honestly labelled
+// "netdiff_unavailable", NOT "first_block" (which falsely implies it was the
+// pool's first block). Its luck stays null — the trend correctly skips it.
+TEST(DashboardData, NetdiffUnavailableLabelIsDistinctFromFirstBlock)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    mi.set_pool_hashrate_fn([]() { return 4294967296.0; });
+    // No template, no cache, and crucially NO header lookup wired.
+    const std::string h1 =
+        "2222222222222222222222222222222222222222222222222222222222220001";
+    const std::string h2 =
+        "2222222222222222222222222222222222222222222222222222222222220002";
+    mi.record_found_block(2531045, uint256S(h1), 1788182946, "DASH",
+                          "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4", h1,
+                          0.0, 240228.0, 0.0, 0);
+    mi.record_found_block(2531046, uint256S(h2), 1788182948, "DASH",
+                          "XghFtkZ8W3vhEHejUBbD3n387hemVJ6Pt4", h2,
+                          0.0, 240228.0, 0.0, 0);
+
+    auto arr = mi.rest_recent_blocks();
+    auto b1 = find_block(arr, h1);
+    auto b2 = find_block(arr, h2);
+    ASSERT_TRUE(b1.is_object() && b2.is_object());
+    // The genuine first block (no predecessor) keeps "first_block".
+    EXPECT_EQ(b1["luck_method"].get<std::string>(), "first_block");
+    // The second block HAS a predecessor (time_to_find>0) but no netdiff, so
+    // its luck is uncomputable — the old code mislabelled it "first_block".
+    EXPECT_TRUE(b2["time_to_find"].is_number());
+    EXPECT_TRUE(b2["luck"].is_null());
+    EXPECT_EQ(b2["luck_method"].get<std::string>(), "netdiff_unavailable");
+}
+
+// ENRICHMENT path, independent of attribution: an ALREADY-ATTRIBUTED row that
+// carries netdiff=0 (recorded off the fast path) is filled by a later record
+// that carries a real netdiff, and its luck is recomputed. On master the fill
+// lived only inside the unattributed-row branch, so a fully attributed
+// sharechain-peer win could never gain a netdiff after the fact.
+TEST(DashboardData, EnrichmentFillsNetdiffOnAlreadyAttributedRow)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    mi.set_pool_hashrate_fn([]() { return 4294967296.0; });
+    const std::string h1 =
+        "3333333333333333333333333333333333333333333333333333333333330001";
+    const std::string h2 =
+        "3333333333333333333333333333333333333333333333333333333333330002";
+    // Predecessor, then the attributed win with NO netdiff (no header, no
+    // template) — lands attributed but luck-less.
+    mi.record_found_block(2531045, uint256S(h1), 1788182946, "DASH",
+                          "Xminer", h1, 0.0, 240228.0, 0.0, 0);
+    mi.record_found_block(2531046, uint256S(h2), 1788182948, "DASH",
+                          "Xminer", h2, 0.0, 240228.0, 0.0, 0);
+    {
+        auto blk = find_block(mi.rest_recent_blocks(), h2);
+        ASSERT_TRUE(blk["found_locally"].get<bool>());
+        EXPECT_TRUE(blk["network_difficulty"].is_null());
+        EXPECT_TRUE(blk["luck"].is_null());
+    }
+    // A later attributed record for the same block carries the real netdiff.
+    mi.record_found_block(2531046, uint256S(h2), 1788182948, "DASH",
+                          "Xminer", h2, /*network_difficulty=*/1.0,
+                          240228.0, 4294967296.0, 0);
+
+    auto arr = mi.rest_recent_blocks();
+    int copies = 0;
+    for (const auto& b : arr)
+        if (b["hash"].get<std::string>() == h2) ++copies;
+    EXPECT_EQ(copies, 1) << "the fill must upgrade in place, never duplicate";
+    auto blk = find_block(arr, h2);
+    ASSERT_TRUE(blk["network_difficulty"].is_number());
+    EXPECT_DOUBLE_EQ(blk["network_difficulty"].get<double>(), 1.0);
+    ASSERT_TRUE(blk["luck"].is_number())
+        << "filling the netdiff on an attributed row must recompute its luck";
+    EXPECT_DOUBLE_EQ(blk["luck"].get<double>(), 50.0);
+    EXPECT_EQ(blk["luck_method"].get<std::string>(), "simple_avg");
+}
+
+// CONFIRM-LANE repair: a row recorded with no netdiff and no header available
+// AT RECORD TIME gains its netdiff when the confirmation lane flips it to
+// confirmed — by then the header is on-chain by definition. The status change
+// persists the repaired row.
+TEST(DashboardData, ConfirmationRepairsNetdiffAndComputesLuck)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    const std::string h1 =
+        "4444444444444444444444444444444444444444444444444444444444440001";
+    const std::string h2 =
+        "4444444444444444444444444444444444444444444444444444444444440002";
+    // Predecessor + winning block, both with netdiff 0 and NO lookup yet.
+    mi.record_found_block(2531045, uint256S(h1), 1788182946, "DASH",
+                          "Xminer", h1, 0.0, 240228.0, 4294967296.0, 0);
+    mi.record_found_block(2531046, uint256S(h2), 1788182948, "DASH",
+                          "Xminer", h2, 0.0, 240228.0, 4294967296.0, 0);
+    {
+        auto blk = find_block(mi.rest_recent_blocks(), h2);
+        EXPECT_TRUE(blk["network_difficulty"].is_null());
+        EXPECT_TRUE(blk["luck"].is_null());
+    }
+
+    // The header chain is available by the time the confirm lane runs.
+    mi.set_block_field_lookups(fixed_diff_lookup(1.0), null_ts_lookup());
+    mi.set_block_verify_fn([](const std::string&) -> int { return 6; });
+
+    int v = mi.run_block_verification_now(h2);
+    EXPECT_GT(v, 0);
+
+    auto blk = find_block(mi.rest_recent_blocks(), h2);
+    EXPECT_EQ(blk["status"].get<std::string>(), "confirmed");
+    ASSERT_TRUE(blk["network_difficulty"].is_number())
+        << "confirmation must fill the netdiff from the now-on-chain header";
+    EXPECT_DOUBLE_EQ(blk["network_difficulty"].get<double>(), 1.0);
+    ASSERT_TRUE(blk["luck"].is_number());
+    EXPECT_DOUBLE_EQ(blk["luck"].get<double>(), 50.0);
+}
+
+// PERSISTENCE: backfill_block_fields must WRITE BACK the rows it repairs, not
+// only fix them in memory. On master backfill filled the fields in RAM only,
+// so every restart re-derived them transiently and a row whose header was
+// unavailable at record time reverted to netdiff=0 on the next load. Here the
+// restored row starts at netdiff=0; after backfill the persist callback must
+// receive it carrying the header-sourced netdiff.
+TEST(DashboardData, BackfillPersistsRepairedRows)
+{
+    MiningInterface mi(/*testnet=*/false, /*node=*/nullptr,
+                       c2pool::address::Blockchain::DASH);
+    mi.set_pool_hashrate_fn([]() { return 4294967296.0; });
+
+    const std::string h1 =
+        "5555555555555555555555555555555555555555555555555555555555550001";
+    const std::string h2 =
+        "5555555555555555555555555555555555555555555555555555555555550002";
+
+    // Two rows restored from persistence with netdiff=0 (the shipped defect),
+    // pool_hashrate present, attributed. Aggregate init matches FoundBlock's
+    // field order; trailing derived + provenance fields default to 0/false.
+    auto make_row = [](uint64_t height, const std::string& hash, uint64_t ts) {
+        MiningInterface::FoundBlock b{};
+        b.height = height; b.hash = hash; b.ts = ts;
+        b.status = MiningInterface::BlockStatus::confirmed;
+        b.chain = "DASH"; b.confirmations = 300;
+        b.miner = "Xminer"; b.share_hash = hash;
+        b.network_difficulty = 0.0;      // the defect
+        b.share_difficulty = 240228.0;
+        b.pool_hashrate = 4294967296.0;
+        return b;
+    };
+    std::vector<MiningInterface::FoundBlock> restored = {
+        make_row(2531045, h1, 1788182946),
+        make_row(2531046, h2, 1788182948),
+    };
+
+    std::map<std::string, MiningInterface::FoundBlock> persisted;
+    mi.set_found_block_persistence(
+        [&persisted](const MiningInterface::FoundBlock& b) -> bool {
+            persisted[b.hash] = b; return true;
+        },
+        [&restored]() { return restored; });
+    mi.load_persisted_found_blocks();
+
+    // Header chain now available: backfill fills the missing netdiff.
+    mi.backfill_block_fields(fixed_diff_lookup(1.0), null_ts_lookup());
+
+    ASSERT_EQ(persisted.count(h2), 1u)
+        << "backfill must persist the repaired row, not only fix it in memory";
+    EXPECT_DOUBLE_EQ(persisted[h2].network_difficulty, 1.0);
+
+    // And the in-memory row now serves its luck to the trend.
+    auto blk = find_block(mi.rest_recent_blocks(), h2);
+    ASSERT_TRUE(blk["luck"].is_number());
+    EXPECT_DOUBLE_EQ(blk["luck"].get<double>(), 50.0);
+}

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2636,7 +2636,18 @@ nlohmann::json MiningInterface::rest_recent_blocks()
         std::string method;
         if (!have_local_record)                    method = "relayed";
         else if (b.time_to_find > 0 && b.luck > 0) method = "simple_avg";
+        else if (b.time_to_find > 0)               method = "netdiff_unavailable";
         else                                       method = "first_block";
+        // "netdiff_unavailable" vs "first_block": the old else-branch collapsed
+        // two distinct rows. A genuine first block has no earlier same-chain row,
+        // so time_to_find is 0 and no luck can exist. A row with time_to_find>0
+        // but no luck HAS a predecessor — its luck was uncomputable only because
+        // network_difficulty was never captured at find time. Labelling the
+        // second case "first_block" made the UI tooltip claim it was the pool's
+        // first block, which is false for any row after the first. The netdiff
+        // repair paths normally fill that difficulty and this row becomes
+        // "simple_avg"; the label survives only for a row whose header is still
+        // unavailable (never synced), where it correctly reads "unavailable".
         // #942 second slice, extended to EVERY unmeasured field (hotel,
         // 2026-08-05): the primary's rows for our own blocks rendered
         // network_difficulty=0.0, subsidy=0, pool_hashrate=0.0 as if they
@@ -3606,6 +3617,21 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
         if (network_difficulty <= 0.0)
             network_difficulty =
                 m_network_difficulty.load(std::memory_order_relaxed);
+        // FINAL fallback: the block's OWN header carries the exact difficulty in
+        // its nBits. The live-template and cache fallbacks above are both empty
+        // when a block is recorded off the fast path — a sharechain-replay or
+        // relayed win recorded early in boot, before the first template exists
+        // and before any /local_stats poll refreshed the cache. That is exactly
+        // the case (block won during a fork/crash window, learned via replay 37s
+        // after restart) that persisted network_difficulty=0 and lost the luck
+        // point for the winning block. Ask the header chain by hash; it is the
+        // authoritative, purely-daemonless source and needs no live state.
+        if (network_difficulty <= 0.0 && m_block_diff_lookup_fn) {
+            try {
+                double d = m_block_diff_lookup_fn(hash_hex);
+                if (d > 0.0) network_difficulty = d;
+            } catch (...) {}
+        }
     }
 
     // Runtime dedup — with ENRICHMENT. Measured (hotel primary): rows for
@@ -3632,9 +3658,13 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
             // found the block, and that is exactly the row this field exists
             // to correct. EnrichmentRaisesAuthorshipAndNeverLowersIt proved
             // this red before the fix.
+            bool row_dirty = false;      // any field changed -> persist once
+            bool luck_input_changed = false;  // netdiff/hashrate -> recompute luck
+
             const bool authorship_raised = authorship > existing.authorship;
             if (authorship_raised) {
                 existing.authorship = authorship;
+                row_dirty = true;
                 LOG_INFO << "[Pool] found-block AUTHORSHIP raised: h="
                          << existing.height << " hash="
                          << hash_hex.substr(0, 16) << " -> "
@@ -3651,30 +3681,63 @@ void MiningInterface::record_found_block(uint64_t height, const uint256& hash, u
                 existing.share_hash = share_hash;
                 if (existing.share_difficulty <= 0.0)
                     existing.share_difficulty = share_difficulty;
-                if (existing.network_difficulty <= 0.0)
+                if (existing.network_difficulty <= 0.0 && network_difficulty > 0.0) {
                     existing.network_difficulty = network_difficulty;
-                if (existing.pool_hashrate <= 0.0)
+                    luck_input_changed = true;
+                }
+                if (existing.pool_hashrate <= 0.0 && pool_hashrate > 0.0) {
                     existing.pool_hashrate = pool_hashrate;
+                    luck_input_changed = true;
+                }
                 if (existing.subsidy == 0) existing.subsidy = subsidy;
+                row_dirty = true;
                 LOG_INFO << "[Pool] found-block row ENRICHED (was recorded"
                             " unattributed): h=" << existing.height
                          << " hash=" << hash_hex.substr(0, 16)
                          << " miner=" << miner;
-                if (m_persist_block_fn) {
-                    try { m_persist_block_fn(existing); }
-                    catch (const std::exception& e) {
-                        LOG_WARNING << "[Pool] Failed to persist enriched"
-                                       " found block: " << e.what();
-                    }
+            }
+
+            // NETWORK-DIFFICULTY REPAIR — independent of attribution state.
+            // A row can be fully attributed (a sharechain-peer win carries both
+            // miner + share_hash) yet still hold network_difficulty=0, because
+            // it was recorded off the fast path with no template/cache/header to
+            // read at that instant. That row loses its luck point permanently:
+            // the enrichment branch above never runs (the row is already
+            // attributed), backfill_block_fields already ran at startup, and
+            // recompute needs a non-zero difficulty. Fill it here from a later
+            // record that carries one, or from the block's own header, whenever
+            // the stored value is still absent. This is the general form of the
+            // enrichment fill, lifted out of the unattributed-only branch.
+            if (existing.network_difficulty <= 0.0) {
+                double nd = network_difficulty > 0.0 ? network_difficulty : 0.0;
+                if (nd <= 0.0 && m_block_diff_lookup_fn) {
+                    try {
+                        double d = m_block_diff_lookup_fn(existing.hash);
+                        if (d > 0.0) nd = d;
+                    } catch (...) {}
                 }
-            } else if (authorship_raised && m_persist_block_fn) {
-                // Authorship changed on a row that needed no other enrichment.
-                // Without this the raise lives only in memory and the restored
-                // row reasserts the wrong finder after every restart.
+                if (nd > 0.0) {
+                    existing.network_difficulty = nd;
+                    row_dirty = true;
+                    luck_input_changed = true;
+                    LOG_INFO << "[Pool] found-block network_difficulty filled: h="
+                             << existing.height << " hash="
+                             << hash_hex.substr(0, 16) << " diff=" << nd;
+                }
+            }
+
+            // A changed luck input means the derived expected_time/luck are now
+            // computable (or stale); recompute the whole series while we hold the
+            // lock. Only fills fields still at 0, so it never clobbers a live
+            // value on any other row.
+            if (luck_input_changed)
+                recompute_found_block_luck_locked();
+
+            if (row_dirty && m_persist_block_fn) {
                 try { m_persist_block_fn(existing); }
                 catch (const std::exception& e) {
-                    LOG_WARNING << "[Pool] Failed to persist raised"
-                                   " authorship: " << e.what();
+                    LOG_WARNING << "[Pool] Failed to persist updated found"
+                                   " block: " << e.what();
                 }
             }
             return;  // already recorded (possibly just enriched)
@@ -3928,30 +3991,62 @@ void MiningInterface::reverify_pending_found_blocks()
              << " restored pending found block(s)";
 }
 
+void MiningInterface::set_block_field_lookups(block_diff_lookup_fn diff_fn, block_ts_lookup_fn ts_fn)
+{
+    m_block_diff_lookup_fn = std::move(diff_fn);
+    m_block_ts_lookup_fn = std::move(ts_fn);
+}
+
 void MiningInterface::backfill_block_fields(block_diff_lookup_fn diff_fn, block_ts_lookup_fn ts_fn)
 {
-    std::lock_guard<std::mutex> lock(m_blocks_mutex);
-    int diff_filled = 0, ts_filled = 0;
-    for (auto& blk : m_found_blocks) {
-        if (!blk.hash.empty()) {
-            if (diff_fn && blk.network_difficulty == 0.0) {
-                double diff = diff_fn(blk.hash);
-                if (diff > 0) { blk.network_difficulty = diff; ++diff_filled; }
+    std::vector<FoundBlock> repaired;   // snapshot rows to persist AFTER unlocking
+    {
+        std::lock_guard<std::mutex> lock(m_blocks_mutex);
+        int diff_filled = 0, ts_filled = 0;
+        for (auto& blk : m_found_blocks) {
+            if (!blk.hash.empty()) {
+                bool changed = false;
+                if (diff_fn && blk.network_difficulty == 0.0) {
+                    double diff = diff_fn(blk.hash);
+                    if (diff > 0) { blk.network_difficulty = diff; ++diff_filled; changed = true; }
+                }
+                if (ts_fn) {
+                    uint32_t ts = ts_fn(blk.hash);
+                    if (ts > 0 && blk.ts != ts) { blk.ts = ts; ++ts_filled; changed = true; }
+                }
+                if (changed) repaired.push_back(blk);
             }
-            if (ts_fn) {
-                uint32_t ts = ts_fn(blk.hash);
-                if (ts > 0 && blk.ts != ts) { blk.ts = ts; ++ts_filled; }
+        }
+        if (diff_filled > 0)
+            LOG_INFO << "[Pool] Backfilled network_difficulty on " << diff_filled << " found block(s)";
+        if (ts_filled > 0)
+            LOG_INFO << "[Pool] Backfilled timestamp on " << ts_filled << " found block(s)";
+        // #159 (G3/G5): a backfilled network_difficulty or timestamp is an input
+        // to the luck series, so recompute the derived fields now that they are
+        // known. Refresh the persist snapshot from the recomputed rows so the
+        // luck/expected_time/time_to_find just derived are written too.
+        if (diff_filled > 0 || ts_filled > 0) {
+            recompute_found_block_luck_locked();
+            for (auto& r : repaired)
+                for (const auto& blk : m_found_blocks)
+                    if (blk.hash == r.hash && blk.chain == r.chain) { r = blk; break; }
+        }
+    }
+    // PERSIST the repaired rows. Previously backfill filled the fields in memory
+    // ONLY, so every restart re-derived them transiently and a row whose header
+    // was unavailable at record time never healed durably — it healed for the
+    // lifetime of each process and reverted to network_difficulty=0 (luck null)
+    // on the next load. Writing them back makes the repair permanent. Done
+    // outside m_blocks_mutex: m_persist_block_fn is the LevelDB writer, which
+    // must not run under the blocks lock.
+    if (m_persist_block_fn) {
+        for (const auto& blk : repaired) {
+            try { m_persist_block_fn(blk); }
+            catch (const std::exception& e) {
+                LOG_WARNING << "[Pool] Failed to persist backfilled found block: " << e.what();
             }
         }
     }
-    if (diff_filled > 0)
-        LOG_INFO << "[Pool] Backfilled network_difficulty on " << diff_filled << " found block(s)";
-    if (ts_filled > 0)
-        LOG_INFO << "[Pool] Backfilled timestamp on " << ts_filled << " found block(s)";
-    // #159 (G3/G5): a backfilled network_difficulty or timestamp is an input to
-    // the luck series, so recompute the derived fields now that they are known.
-    if (diff_filled > 0 || ts_filled > 0)
-        recompute_found_block_luck_locked();
 }
 
 void MiningInterface::set_merged_block_store(std::shared_ptr<void> store) { m_merged_block_store = std::move(store); }
@@ -4004,6 +4099,27 @@ void MiningInterface::verify_found_block(size_t index)
 
     if (result > 0) {
         blk.confirmations = static_cast<uint32_t>(result);
+
+        // VERDICT-TIME LUCK REPAIR. A block confirmed by the header chain has,
+        // by definition, an on-chain header now — so its exact difficulty is
+        // available even if it was not at record time. This closes the case the
+        // record-path fallback cannot: a win learned via replay/relay whose
+        // header had not yet synced when the row was created (network_difficulty
+        // persisted as 0, luck lost). Fill it on confirmation and recompute the
+        // derived luck series; the status change below triggers the persist that
+        // makes it durable.
+        if (blk.network_difficulty <= 0.0 && m_block_diff_lookup_fn) {
+            try {
+                double d = m_block_diff_lookup_fn(blk.hash);
+                if (d > 0.0) {
+                    blk.network_difficulty = d;
+                    recompute_found_block_luck_locked();
+                    LOG_INFO << "[Pool] found-block network_difficulty filled at"
+                                " confirmation: h=" << blk.height << " hash="
+                             << blk.hash.substr(0, 16) << " diff=" << d;
+                }
+            } catch (...) {}
+        }
 
         if (blk.status == BlockStatus::pending) {
             blk.status = BlockStatus::confirmed;

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -1053,6 +1053,17 @@ public:
     using block_ts_lookup_fn = std::function<uint32_t(const std::string& block_hash)>;
     void backfill_block_fields(block_diff_lookup_fn diff_fn, block_ts_lookup_fn ts_fn);
 
+    /// Retain the block-header field lookups so paths OTHER than the one-shot
+    /// startup backfill can re-derive a missing network_difficulty from the
+    /// header chain. backfill_block_fields runs exactly once, before the
+    /// sharechain-replay / relay hooks record blocks won during the process's
+    /// own uptime, so a block learned AFTER backfill (e.g. a peer-relayed win
+    /// replayed 37s into boot) never gets its difficulty filled and its luck is
+    /// lost for the life of the process. record_found_block and the confirm
+    /// lane consult these to close that window. Coin-generic; wire once beside
+    /// backfill_block_fields (same header chain, same lambdas).
+    void set_block_field_lookups(block_diff_lookup_fn diff_fn, block_ts_lookup_fn ts_fn);
+
 private:
     /// #159 (G3): recompute the DERIVED found-block fields (time_to_find,
     /// expected_time, luck) that are never persisted, from the height-ordered
@@ -1422,6 +1433,13 @@ private:
     // Persistent found block storage (Layer +2) — functional callbacks
     block_store_fn_t m_persist_block_fn;   // called on record + status change
     block_load_fn_t  m_load_blocks_fn;     // called on startup
+
+    // Retained block-header field lookups (set_block_field_lookups). Let the
+    // record + confirm paths re-derive a missing network_difficulty by block
+    // hash after the one-shot startup backfill has already run. Guarded by
+    // m_blocks_mutex at the call sites (same discipline as backfill_block_fields).
+    block_diff_lookup_fn m_block_diff_lookup_fn;
+    block_ts_lookup_fn   m_block_ts_lookup_fn;
 
     std::shared_ptr<void> m_merged_block_store;  // MergedBlockStore (opaque)
     coin_peer_info_fn m_ltc_peer_info_fn;


### PR DESCRIPTION
## Problem

On dash.voidbind an accepted pool win (height 2531046, chainlocked, 312 confs) painted a green found-block diamond on the 1D dashboard but the yellow luck trend declined smoothly straight through it with no favourable discontinuity. Verdict: this is a real data-capture bug, not an orphan-misclassification. The block is on the DASH main chain (getblockhash(2531046) matches the pool's recorded hash); the diamond is correct. The luck trend missed it because the row was recorded with `network_difficulty=0`.

## Root cause

The win was found during a fork/crash window and learned by the reverted process via startup sharechain replay ~37s after boot. At that instant `record_found_block`'s netdiff fallback chain (caller value -> live template -> cache refreshed only by `/local_stats` polls) was entirely empty, so `network_difficulty=0` was persisted. `luck` needs `expected_time` needs the network difficulty, so luck stayed null for the life of the process. The one-shot startup header backfill had already run 35s *before* replay created the row, and never re-runs.

## Fix (display-only, coin-generic, no consensus path)

The block's own header carries the exact difficulty in its nBits. Consult it from every path that can hold a luck-less row:

- **record_found_block**: extend the netdiff fallback chain with a header lookup by block hash before accepting 0.
- **verify_found_block**: when the confirm lane flips a row to confirmed its header is on-chain by definition; fill a missing difficulty and recompute luck.
- **enrichment/dedup path**: fill a missing difficulty on an already-attributed row (from a later record or the header), independent of attribution state.
- **backfill_block_fields**: persist the rows it repairs so the fix survives a restart instead of re-deriving transiently every boot.

Retained the header-field lookups via a new `set_block_field_lookups`, wired beside `backfill_block_fields` on the DASH and LTC embedded arms (covers every coin through the shared `MiningInterface`).

Also split the `/recent_blocks` `luck_method` label `first_block` into `first_block` (genuinely no prior same-chain row) vs `netdiff_unavailable` (has a predecessor but the difficulty was never captured).

Frontend unchanged: skipping a null-luck point is correct honest-null behaviour; once the row carries a real difficulty its luck is computed (2531046 lands at ~122%) and the trend gains its point, so the diamond and the trend agree.

## Proof

Five new KATs in `web_server_dashboard_data_test`, each verified **red on master** and **green with the fix**:
- header-sourced netdiff at record time (the exact replay case),
- confirmation-time repair,
- enrichment fill on an already-attributed row,
- backfill persistence of a repaired row,
- `netdiff_unavailable` vs `first_block` label split.

Local build: `core_test` 204/204 green, `test_dash_node` 56/56 green (incl. the confirm-lane and found-block suites), `c2pool-dash` and `c2pool-ltc` compile clean.