### PR TITLE
ci: btc daemonless smoke as required-aggregate member

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -38,10 +38,13 @@ jobs:
   bch-g3b:
     uses: ./.github/workflows/bch-gate-g3b-genuine-activation.yml
     secrets: inherit
+  btc-daemonless-smoke:
+    uses: ./.github/workflows/btc-embedded-standalone-smoke.yml
+    secrets: inherit
 
   aggregate:
     name: aggregate
-    needs: [param-catalog-tripwire, coin-matrix, dash-g1, dash-g3a, dgb-phase-b, bch-g3a, bch-g3b]
+    needs: [param-catalog-tripwire, coin-matrix, dash-g1, dash-g3a, dgb-phase-b, bch-g3a, bch-g3b, btc-daemonless-smoke]
     if: always()
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Wires btc-embedded-standalone-smoke.yml into the ci-required.yml aggregator uses-list and aggregate needs.

Rationale: btc embedded-standalone (daemonless) is a prod-only path today (btc.voidbind.com). A path-filter-only guard misses regressions in unrelated PRs that still ship that path, so it must be a blocking aggregate member on ALL PRs. The smoke already emits a named, logged skip when the coin network is unreachable, so network flake cannot read as green; the aggregate tolerates skipped and fails only on failure/cancel.

Scope: required-aggregate behaviour change (blocking on all PRs). HOLD for operator push-approval — do not self-merge.

The two remaining per-coin daemonless smokes (dash, dgb) stay fenced on peer source not yet on master.