### PR TITLE
bip110: rewrite config_pool.hpp fossil to match params.hpp SSOT (DO NOT MERGE — identity+money-path)

### DIFF
--- a/src/impl/bip110/config_pool.hpp
+++ b/src/impl/bip110/config_pool.hpp
@@ -7,7 +7,7 @@
 #include <btclibs/util/strencodings.h>
 #include <btclibs/crypto/sha256.h>
 #include <core/uint256.hpp>
-#include <core/donation.hpp>
+#include <impl/bip110/params.hpp>
 
 #include <array>
 #include <cstdint>
@@ -17,7 +17,7 @@
 
 namespace bip110
 {
-    
+
 class PoolConfig : protected core::Fileconfig
 {
 protected:
@@ -31,42 +31,46 @@ public:
     }
 
     // -----------------------------------------------------------------------
-    // BTC p2pool network constants (jtoomim/SPB-compat — must match the live
-    // BTC p2pool sharechain at p2p-spb.xyz:9333 + jtoomim-derived peers).
-    // Source: ref/p2pool-btc + p2pool-jtoomim/p2pool/networks/bitcoin.py.
-    // Live network probe 2026-04-28: SPB cluster runs version 77.0.0 with
-    // protocol_version 3502 (one bump above jtoomim master's 3501).
+    // BIP-110 (Bitcoin Knots BLAKE2b hard fork) c2pool sharechain constants.
+    //
+    // SINGLE SOURCE OF TRUTH: every identity value below DERIVES from the
+    // namespace-level SHARECHAIN_* constants in params.hpp (the SSOT), so the
+    // factory (make_coin_params) and this PoolConfig can never drift. BIP-110 is
+    // a NEW sharechain, distinct from the BTC lane: its P2P/worker ports and
+    // identifier/prefix are BIP-110-native (BTC uses 9333 / fc70035c7a81bc6f /
+    // 2472ef181efcd37b), so the sharechain can never merge with, or cross-dial,
+    // the live BTC p2pool network. PREFIX and IDENTIFIER are TWO INDEPENDENT
+    // per-network transport constants (p2pool model) — PREFIX is never derived
+    // from IDENTIFIER. This mirrors the DASH lane's isolation discipline.
     // -----------------------------------------------------------------------
-    static constexpr uint16_t P2P_PORT                  = 9333;  // BTC p2pool sharechain port
-    static constexpr uint32_t SPREAD                    = 3;       // blocks (PPLNS window)
-    static constexpr uint32_t TARGET_LOOKBEHIND         = 200;
-    // MINIMUM 3500 admits jtoomim master (3501) and SPB cluster (3502).
-    // Below that lies forrestv-era v17/v32 — not interoperable with v35.
-    static constexpr uint32_t MINIMUM_PROTOCOL_VERSION  = 3500;
-    // Our capability — match SPB cluster's bump for forward-compat.
-    static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION = 3502;
-    static constexpr uint32_t SEGWIT_ACTIVATION_VERSION = 33;     // jtoomim BTC bitcoin.py:35
-    static constexpr uint32_t BLOCK_MAX_SIZE            = 1000000;
-    static constexpr uint32_t BLOCK_MAX_WEIGHT          = 4000000;
+    static constexpr uint16_t P2P_PORT                  = SHARECHAIN_P2P_PORT;     // 9335 BIP-110 sharechain P2P port
+    static constexpr uint16_t WORKER_PORT               = SHARECHAIN_WORKER_PORT;  // 9336 BIP-110 Stratum port
+    static constexpr uint32_t SPREAD                    = SHARECHAIN_SPREAD;       // blocks (PPLNS window)
+    static constexpr uint32_t TARGET_LOOKBEHIND         = SHARECHAIN_TARGET_LOOKBEHIND;
+    static constexpr uint32_t MINIMUM_PROTOCOL_VERSION  = SHARECHAIN_MINIMUM_PROTOCOL_VERSION;
+    static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION = SHARECHAIN_ADVERTISED_PROTOCOL_VERSION;
+    static constexpr uint32_t SEGWIT_ACTIVATION_VERSION = SHARECHAIN_SEGWIT_ACTIVATION_VERSION;
+    static constexpr uint32_t BLOCK_MAX_SIZE            = SHARECHAIN_BLOCK_MAX_SIZE;
+    // RDTS reduced-data weight cap (800000 WU) while active, until the
+    // 2027-09-01 MTP gate — from params.hpp RDTS_MAX_BLOCK_WEIGHT.
+    static constexpr uint32_t BLOCK_MAX_WEIGHT          = RDTS_MAX_BLOCK_WEIGHT;
 
-    // Mainnet constants — jtoomim BTC bitcoin.py
-    static constexpr uint32_t SHARE_PERIOD              = 30;      // seconds (BTC slower than LTC's 15)
-    static constexpr uint32_t CHAIN_LENGTH              = 8640;    // 24*60*60 / 10
-    static constexpr uint32_t REAL_CHAIN_LENGTH         = 8640;
+    // Mainnet sharechain cadence.
+    static constexpr uint32_t SHARE_PERIOD              = SHARECHAIN_SHARE_PERIOD;   // seconds
+    static constexpr uint32_t CHAIN_LENGTH              = SHARECHAIN_CHAIN_LENGTH;
+    static constexpr uint32_t REAL_CHAIN_LENGTH         = SHARECHAIN_CHAIN_LENGTH;
 
-    // DUST_THRESHOLD: minimum payout per share output.
-    // BTC mainnet: 0.001 BTC = 100000 sat (jtoomim bitcoin/networks/bitcoin.py:32).
-    // Testnet: 1.0 BTC placeholder until jtoomim BTC testnet config is consulted.
-    static constexpr uint64_t DUST_THRESHOLD            = 100000;     // satoshis (BTC mainnet)
-    static constexpr uint64_t TESTNET_DUST_THRESHOLD    = 100000000;  // satoshis placeholder
+    // DUST_THRESHOLD: minimum payout per share output — Bitcoin relay dust floor
+    // (546 sat for a P2PKH output), unchanged by BIP-110. Testnet mirrors mainnet.
+    static constexpr uint64_t DUST_THRESHOLD            = SHARECHAIN_DUST_THRESHOLD;  // satoshis
+    static constexpr uint64_t TESTNET_DUST_THRESHOLD    = SHARECHAIN_DUST_THRESHOLD;
     static uint64_t dust_threshold() { return is_testnet ? TESTNET_DUST_THRESHOLD : DUST_THRESHOLD; }
 
-    // Testnet constants (jtoomim BTC testnet bitcoin/networks/bitcoin_testnet.py
-    // not yet probed; using BTC-mainnet defaults until live testnet network is
-    // selected). Conservative copy of mainnet for now — adjust in B-testnet phase.
-    static constexpr uint32_t TESTNET_SHARE_PERIOD      = 30;
-    static constexpr uint32_t TESTNET_CHAIN_LENGTH      = 8640;
-    static constexpr uint32_t TESTNET_REAL_CHAIN_LENGTH  = 8640;
+    // Testnet constants — BIP-110 testnet mirrors mainnet cadence for now
+    // (adjust in a testnet-bring-up phase). Values still flow from the SSOT.
+    static constexpr uint32_t TESTNET_SHARE_PERIOD      = SHARECHAIN_SHARE_PERIOD;
+    static constexpr uint32_t TESTNET_CHAIN_LENGTH      = SHARECHAIN_CHAIN_LENGTH;
+    static constexpr uint32_t TESTNET_REAL_CHAIN_LENGTH  = SHARECHAIN_CHAIN_LENGTH;
 
     // Runtime testnet flag — set once at startup
     static inline bool is_testnet = false;
@@ -76,52 +80,46 @@ public:
     static uint32_t chain_length()      { return is_testnet ? TESTNET_CHAIN_LENGTH : CHAIN_LENGTH; }
     static uint32_t real_chain_length()  { return is_testnet ? TESTNET_REAL_CHAIN_LENGTH : REAL_CHAIN_LENGTH; }
 
-    // MAX_TARGET: share difficulty floor (easiest allowed share PoW).
-    // BTC mainnet: 2^256 / 2^32 - 1 (≈ 2^224, bdiff 1) — jtoomim BTC bitcoin.py:18
-    //              MAX_TARGET = 2**256//2**32 - 1
-    // Testnet: same as mainnet for now (jtoomim BTC testnet placeholder).
+    // MAX_TARGET: share difficulty floor (easiest allowed share PoW). Bitcoin
+    // powLimit 00000000ffff0000... is unchanged by BIP-110 (CheckProofOfWorkImpl
+    // is untouched); the share floor sits at that limit. From the SSOT hex.
     static uint256 max_target()
     {
         static const uint256 MAINNET_MAX = [] {
             uint256 t;
-            // 2^256 / 2^32 - 1 = 0x00000000ffffffff...ffffffff (224 bits set).
-            t.SetHex("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            t.SetHex(SHARECHAIN_MAX_TARGET_HEX);
             return t;
         }();
         static const uint256 TESTNET_MAX = [] {
             uint256 t;
-            t.SetHex("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            t.SetHex(SHARECHAIN_MAX_TARGET_HEX);
             return t;
         }();
         return is_testnet ? TESTNET_MAX : MAINNET_MAX;
     }
 
     // -----------------------------------------------------------------------
-    // Consensus-critical donation scripts
-    // Must match frstrtr/p2pool-merged-v36 p2pool/data.py exactly.
+    // Donation script — DEPLOY-CONFIG-DRIVEN, never a hardcoded money address in
+    // source. Returns EMPTY here, matching params.hpp's donation_script_func: the
+    // KAT/bring-up lane does not mint, and the deploy config supplies the payout
+    // address at runtime (the BIP-110 lane's bech32 destination is provisioned by
+    // the operator, NEVER a cross-coin address baked into the binary). This is the
+    // per-coin-isolation rule: a source-hardcoded cross-coin donation would ship
+    // one lane's money bytes into another.
     // -----------------------------------------------------------------------
-
-    // Donation script — delegated to the chain-agnostic single source of
-    // truth in core::donation. The bytes are coin-invariant (no network
-    // version byte; uniform v36 redeem hash160), so they are no longer
-    // duplicated per-coin. See core/donation.hpp for provenance (forrestv
-    // P2PK pre-v36; combined P2SH 1-of-2 v36+, operator FLAG6 ruling
-    // 2026-06-17 option-b; bitcoin-agnostic re-scope 2026-06-17).
-    static std::vector<unsigned char> get_donation_script(int64_t share_version)
+    static std::vector<unsigned char> get_donation_script(int64_t /*share_version*/)
     {
-        return core::donation::get_donation_script(share_version);
+        return {};
     }
 
-    // Message framing prefix — BTC mainnet (jtoomim bitcoin.py:14):
-    //   PREFIX = '2472ef181efcd37b'
-    static inline const std::string DEFAULT_PREFIX_HEX          = "2472ef181efcd37b";
-    // Testnet placeholder until jtoomim BTC testnet prefix is probed
-    static inline const std::string TESTNET_PREFIX_HEX          = "2472ef181efcd37b";
-    // Network identifier — BTC mainnet (jtoomim bitcoin.py:13):
-    //   IDENTIFIER = 'fc70035c7a81bc6f'
-    static inline const std::string DEFAULT_IDENTIFIER_HEX      = "fc70035c7a81bc6f";
-    // Testnet placeholder
-    static inline const std::string TESTNET_IDENTIFIER_HEX      = "fc70035c7a81bc6f";
+    // Message framing prefix — BIP-110-native (SSOT: params.hpp SHARECHAIN_PREFIX_HEX).
+    static inline const std::string DEFAULT_PREFIX_HEX          = SHARECHAIN_PREFIX_HEX;
+    // Testnet mirrors mainnet (params testnet identity == mainnet).
+    static inline const std::string TESTNET_PREFIX_HEX          = SHARECHAIN_PREFIX_HEX;
+    // Network identifier — BIP-110-native (SSOT: params.hpp SHARECHAIN_IDENTIFIER_HEX).
+    static inline const std::string DEFAULT_IDENTIFIER_HEX      = SHARECHAIN_IDENTIFIER_HEX;
+    // Testnet mirrors mainnet.
+    static inline const std::string TESTNET_IDENTIFIER_HEX      = SHARECHAIN_IDENTIFIER_HEX;
 
     // Private chain overrides — set once at startup via --network-id
     static inline std::string override_identifier_hex;
@@ -197,29 +195,20 @@ public:
         return fp;
     }
 
-    // BTC mainnet softforks per jtoomim bitcoin.py:33 + post-2021 additions.
-    // jtoomim master pre-dates Taproot activation but the bitcoind we connect
-    // to enforces it; tracking it here keeps the softfork-check pass aligned
-    // with bitcoind's getblockchaininfo.
+    // Softforks the BIP-110 chain requires. segwit stays active; blake2b is the
+    // BIP-110 activation (the pool MUST request the "blake2b" GBT rule against a
+    // Knots 29.4.1 backend). Matches params.hpp p.softforks_required.
     static inline const std::set<std::string> SOFTFORKS_REQUIRED = {
-        "bip65", "csv", "segwit", "taproot"
+        "segwit", "blake2b"
     };
 
-    // Default bootstrap peers — live BTC p2pool network (probed 2026-04-28
-    // via http://p2p-spb.xyz:9334/peer_versions). Mix of the SPB-cluster
-    // 77.0.0 fork + jtoomim-master-derived peers + jtoomim BTC bitcoin.py
-    // BOOTSTRAP_ADDRS defaults.
-    static inline const std::vector<std::string> DEFAULT_BOOTSTRAP_HOSTS = {
-        // SPB cluster (4 nodes RU + USA, version 77.0.0)
-        "p2p-spb.xyz",
-        "ekb.p2p-spb.xyz",
-        "rov.p2p-spb.xyz",
-        "usa.p2p-spb.xyz",
-        // jtoomim-master defaults (BOOTSTRAP_ADDRS in bitcoin.py)
-        "ml.toom.im",
-        "btc-fork.coinpool.pw:9335",
-        "btc.p2pool.leblancnet.us",
-    };
+    // Default bootstrap peers — EMPTY. BIP-110 is a fresh sharechain; nodes come
+    // online via peer discovery (NODE-flagged coin-P2P + explicit --sharechain-
+    // addnode). We deliberately ship NO seed hosts here: the live BTC p2pool seed
+    // list (p2p-spb.xyz etc., port 9333) belongs to the BTC lane and must never
+    // be dialed from BIP-110 (prefix mismatch → handshake refusal + addr-book
+    // poisoning). Populate as BIP-110 c2pool nodes are provisioned.
+    static inline const std::vector<std::string> DEFAULT_BOOTSTRAP_HOSTS = {};
 
     // -----------------------------------------------------------------------
     // Runtime config loaded from pool.yaml
@@ -232,14 +221,13 @@ public:
 // ---------------------------------------------------------------------------
 // Sharechain bootstrap-source selection (pure, testable seam)
 //
-// main_btc must decide which sharechain (pool P2P) peers to bootstrap from.
-// Historically the ELSE branch loaded the PUBLIC BTC p2pool seed list
-// (DEFAULT_BOOTSTRAP_HOSTS, port 9333) EVEN when a custom --network-id/--prefix
-// federation identity was set — so a federation node dialed the open network
-// it can never handshake (prefix mismatch → read_prefix disconnect), poisoning
-// its addr book with public peers. This resolver makes the precedence explicit
-// and unit-testable. Defaults (no custom id, no explicit peers) → PublicDefault,
-// byte-identical to prior behavior.
+// main_bip110 must decide which sharechain (pool P2P) peers to bootstrap from.
+// The ELSE branch loads the PUBLIC seed list (DEFAULT_BOOTSTRAP_HOSTS — empty
+// for BIP-110) only when NO custom --network-id/--prefix federation identity is
+// set; a federation node must never dial the open network it cannot handshake
+// (prefix mismatch → read_prefix disconnect), which would poison its addr book.
+// This resolver makes the precedence explicit and unit-testable. Defaults (no
+// custom id, no explicit peers) → PublicDefault.
 // ---------------------------------------------------------------------------
 enum class SharechainBootstrapMode {
     ExplicitPeers,        // --sharechain-addnode/--p2pool given: dial ONLY those

--- a/src/impl/bip110/params.hpp
+++ b/src/impl/bip110/params.hpp
@@ -53,6 +53,36 @@ inline constexpr const char* GENESIS_HASH =
 // (the RPC rejects the request otherwise); the response reports "!blake2b".
 inline constexpr const char* GBT_RULE = "blake2b";
 
+// --- Sharechain (pool-P2P) identity — SINGLE SOURCE OF TRUTH ------------------
+// These namespace-level constants are the ONE place BIP-110's c2pool sharechain
+// identity and pool-lane parameters are defined. BOTH make_coin_params() (below)
+// and config_pool.hpp's PoolConfig reference them, so the sharechain identity can
+// never drift between the two. Every value is BIP-110-native and distinct from
+// every other lane (BTC = 9333 / fc70035c7a81bc6f / 2472ef181efcd37b) so no
+// cross-lane sharechain handshake can succeed. IDENTIFIER and PREFIX are TWO
+// INDEPENDENT transport constants (p2pool model); PREFIX is never derived from
+// IDENTIFIER. This mirrors the DASH lane's single-definition discipline (one
+// place owns the identity; the factory and PoolConfig both read it).
+inline constexpr uint16_t SHARECHAIN_P2P_PORT    = 9335;  // BIP-110 sharechain P2P port
+inline constexpr uint16_t SHARECHAIN_WORKER_PORT = 9336;  // BIP-110 Stratum/worker port
+inline constexpr const char* SHARECHAIN_IDENTIFIER_HEX = "b1101100b1a4e2bd";
+inline constexpr const char* SHARECHAIN_PREFIX_HEX     = "e2bdb1101100b1a4";
+// Pool-lane tuning constants (BIP-110-native; distinct from the BTC fossil's
+// SPREAD=3 / CHAIN_LENGTH=8640 / ADVERTISED=3502 / SEGWIT_ACTIVATION=33).
+inline constexpr uint32_t SHARECHAIN_SPREAD                    = 30;
+inline constexpr uint32_t SHARECHAIN_CHAIN_LENGTH             = 5760;
+inline constexpr uint32_t SHARECHAIN_TARGET_LOOKBEHIND        = 200;
+inline constexpr uint32_t SHARECHAIN_SHARE_PERIOD            = 30;
+inline constexpr uint32_t SHARECHAIN_MINIMUM_PROTOCOL_VERSION = 3500;
+inline constexpr uint32_t SHARECHAIN_ADVERTISED_PROTOCOL_VERSION = 3501;
+inline constexpr uint32_t SHARECHAIN_SEGWIT_ACTIVATION_VERSION = 4;
+inline constexpr uint32_t SHARECHAIN_BLOCK_MAX_SIZE          = 1000000;
+inline constexpr uint64_t SHARECHAIN_DUST_THRESHOLD          = 546;  // Bitcoin relay dust floor
+// Share difficulty floor (easiest allowed share PoW) == Bitcoin powLimit; BIP-110
+// leaves CheckProofOfWorkImpl untouched, so the share floor sits at that limit.
+inline constexpr const char* SHARECHAIN_MAX_TARGET_HEX =
+    "00000000ffff0000000000000000000000000000000000000000000000000000";
+
 // Standard Bitcoin subsidy: 50 BTC, halving every 210000 blocks. Unchanged by
 // BIP-110 (coinbasevalue at the 961640 era = 3.125 BTC + fees).
 inline uint64_t subsidy(uint32_t height)
@@ -89,44 +119,44 @@ inline core::CoinParams make_coin_params(bool testnet)
     p.subsidy_func = [](uint32_t height) -> uint64_t { return bip110::subsidy(height); };
 
     // Dust: Bitcoin relay-policy dust floor (546 sat for a P2PKH output).
-    p.dust_threshold = 546;
+    p.dust_threshold = SHARECHAIN_DUST_THRESHOLD;
 
     // Softforks / segwit — segwit stays active on the BIP-110 chain.
     p.softforks_required = {"segwit", "blake2b"};  // GBT must request "blake2b"
-    p.segwit_activation_version = 4;
+    p.segwit_activation_version = SHARECHAIN_SEGWIT_ACTIVATION_VERSION;
 
     // Block-size rule: RDTS reduced-data weight cap while active (until the
     // 2027-09-01 MTP gate); the classic 1 MB base-size is unchanged.
-    p.block_max_size   = 1000000;
+    p.block_max_size   = SHARECHAIN_BLOCK_MAX_SIZE;
     p.block_max_weight = RDTS_MAX_BLOCK_WEIGHT;  // 800000 WU (vs Bitcoin 4,000,000)
 
     // ===== Pool-level (net) — c2pool sharechain identity =====
     // BIP-110 is a NEW sharechain, distinct from the BTC lane. p2p/worker ports
     // and identifier/prefix are BIP-110-native so the sharechain can never merge
     // with the BTC p2pool sharechain (which uses 9333 / fc70035c7a81bc6f).
-    p.p2p_port    = 9335;  // BIP-110 p2pool sharechain P2P port
-    p.worker_port = 9336;  // BIP-110 Stratum port
+    p.p2p_port    = SHARECHAIN_P2P_PORT;     // BIP-110 p2pool sharechain P2P port
+    p.worker_port = SHARECHAIN_WORKER_PORT;  // BIP-110 Stratum port
 
-    p.share_period      = 30;
-    p.chain_length      = 5760;
-    p.real_chain_length = 5760;
-    p.target_lookbehind = 200;
-    p.spread            = 30;
-    p.minimum_protocol_version    = 3500;
-    p.advertised_protocol_version = 3501;
+    p.share_period      = SHARECHAIN_SHARE_PERIOD;
+    p.chain_length      = SHARECHAIN_CHAIN_LENGTH;
+    p.real_chain_length = SHARECHAIN_CHAIN_LENGTH;
+    p.target_lookbehind = SHARECHAIN_TARGET_LOOKBEHIND;
+    p.spread            = SHARECHAIN_SPREAD;
+    p.minimum_protocol_version    = SHARECHAIN_MINIMUM_PROTOCOL_VERSION;
+    p.advertised_protocol_version = SHARECHAIN_ADVERTISED_PROTOCOL_VERSION;
 
     // Max target (easiest share difficulty). Bitcoin powLimit
     // 00000000ffff0000... is unchanged by BIP-110 (CheckProofOfWorkImpl is
     // untouched); the share floor sits at that limit.
-    p.max_target = uint256S("00000000ffff0000000000000000000000000000000000000000000000000000");
+    p.max_target = uint256S(SHARECHAIN_MAX_TARGET_HEX);
 
     // Sharechain network identification — BIP-110-native 8-byte values, chosen
     // distinct from every other lane so no cross-lane sharechain handshake can
     // succeed. (Independent transport constants; prefix is not derived from id.)
-    p.identifier_hex         = "b1101100b1a4e2bd";
-    p.prefix_hex             = "e2bdb1101100b1a4";
-    p.testnet_identifier_hex = "b1101100b1a4e2bd";
-    p.testnet_prefix_hex     = "e2bdb1101100b1a4";
+    p.identifier_hex         = SHARECHAIN_IDENTIFIER_HEX;
+    p.prefix_hex             = SHARECHAIN_PREFIX_HEX;
+    p.testnet_identifier_hex = SHARECHAIN_IDENTIFIER_HEX;
+    p.testnet_prefix_hex     = SHARECHAIN_PREFIX_HEX;
 
     // Bootstrap peers — populated as BIP-110 c2pool nodes come online.
     p.bootstrap_addrs = {};


### PR DESCRIPTION
## BIP-110 `config_pool.hpp` fossil rewrite — identity now matches `params.hpp` (SSOT)

`src/impl/bip110/config_pool.hpp` was a **verbatim clone of `src/impl/btc/config_pool.hpp`** (namespace rename only), while `src/impl/bip110/params.hpp` had already been correctly re-stamped for BIP-110. Left as-is, the M3 sharechain/P2P bring-up would have dialed the **live BTC p2pool sharechain** (port 9333, `p2p-spb.xyz` seeds) and shipped a hardcoded cross-coin donation.

This rewrites `config_pool.hpp` so **every identity value derives from `params.hpp`**, applying the DASH lane's single-definition discipline: the BIP-110 sharechain identity + pool-lane tuning are hoisted into named `SHARECHAIN_*` namespace constants in `params.hpp` (**values unchanged**), `make_coin_params()` references them, and `config_pool.hpp` reads the same constants — so the two can never drift.

### Before / after (every changed identity value)

| Field (config_pool.hpp) | Fossil (BTC) | Corrected (params.hpp SSOT) |
|---|---|---|
| `P2P_PORT` | 9333 | **9335** (`SHARECHAIN_P2P_PORT`) |
| `WORKER_PORT` | *absent* | **9336** (`SHARECHAIN_WORKER_PORT`, added) |
| `DEFAULT_IDENTIFIER_HEX` | `fc70035c7a81bc6f` | **`b1101100b1a4e2bd`** |
| `DEFAULT_PREFIX_HEX` | `2472ef181efcd37b` | **`e2bdb1101100b1a4`** |
| `TESTNET_IDENTIFIER_HEX` | `fc70035c7a81bc6f` | **`b1101100b1a4e2bd`** (== mainnet) |
| `TESTNET_PREFIX_HEX` | `2472ef181efcd37b` | **`e2bdb1101100b1a4`** (== mainnet) |
| `DEFAULT_BOOTSTRAP_HOSTS` | 7 live BTC seeds (`p2p-spb.xyz`, `ml.toom.im`, …) | **`{}`** (peer discovery; NO BTC seeds) |
| `get_donation_script` | `core::donation` BTC P2SH bytes | **`{}`** (deploy-config-driven; NEVER a hardcoded cross-coin address) |
| `SOFTFORKS_REQUIRED` | `{bip65,csv,segwit,taproot}` | **`{segwit, blake2b}`** |
| `SPREAD` | 3 | **30** |
| `CHAIN_LENGTH` / `REAL_CHAIN_LENGTH` | 8640 | **5760** |
| `ADVERTISED_PROTOCOL_VERSION` | 3502 | **3501** |
| `SEGWIT_ACTIVATION_VERSION` | 33 | **4** |
| `BLOCK_MAX_WEIGHT` | 4000000 | **800000** (RDTS cap) |
| `DUST_THRESHOLD` (+testnet) | 100000 (+1e8) | **546** |
| `max_target()` | `00000000ffffffff…` (2^224) | **`00000000ffff0000…`** (Bitcoin powLimit) |
| Header comment | BTC/jtoomim/SPB fossil | re-stamped BIP-110 |

Unchanged (already matched): `TARGET_LOOKBEHIND=200`, `MINIMUM_PROTOCOL_VERSION=3500`, `SHARE_PERIOD=30`, `BLOCK_MAX_SIZE=1000000`. `COIN_P2P_PORT=8333` (BTC-fork mainnet coin port) is correct and untouched.

### Guardrails honored
- **Per-coin isolation:** only `src/impl/bip110/` touched (`config_pool.hpp` rewritten; `params.hpp` gains named constants only — **params VALUES unchanged**). No other lane touched.
- **No money address in source:** donation returns `{}`; the BIP-110 bech32 payout is provisioned at deploy time.
- **Builds:** `c2pool-bip110` compiles clean (Release, conan `linux-gcc13` profile). `bip110/coin/rpc.cpp` (the only consumer of `PoolConfig::SOFTFORKS_REQUIRED`) links.

### Base branch note
Targets **`bip110-m2-mineable`** — `config_pool.hpp` does not exist on `master` (bip110 on master = `params.hpp` + `pow.hpp` + `crypto/` only), so a master-based branch would have no file to fix. This is where M3 continues.

⚠️ **DO NOT MERGE without operator tap** — identity + money-path change.
