### PR TITLE
ci: fix CI-Required aggregate red from reusable concurrency-group collision

### DIFF
--- a/.github/workflows/btc-embedded-standalone-smoke.yml
+++ b/.github/workflows/btc-embedded-standalone-smoke.yml
@@ -33,7 +33,7 @@ on:
       - '.github/workflows/btc-embedded-standalone-smoke.yml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: btc-standalone-smoke-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -24,7 +24,7 @@ on:
 # oversubscription root cause, not just queue depth). Per-ref group so
 # distinct PRs/branches never cancel each other.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: coin-matrix-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 


### PR DESCRIPTION
## Problem

On multi-coin PRs the `CI Required / aggregate` check goes red even on a fresh, uncontested head. Root cause: two reusable workflows that `ci-required.yml` calls via `uses:` — `coin-matrix.yml` and `btc-embedded-standalone-smoke.yml` — both keyed their `concurrency` group on `${{ github.workflow }}-${{ github.ref }}`.

Under `workflow_call`, the `github` context is the **caller's**, so `github.workflow` resolves to `CI Required` for both reusables. They collapse into a single shared group `CI Required-<ref>` with `cancel-in-progress: true`. The later-starting lane (btc smoke) evicts the in-flight `coin-matrix` run, which surfaces as a `cancelled` lane and fails the aggregate (correctly intolerant of `cancelled`).

Confirmed deterministically on empty-commit head `8a0640a1` (run 33565599697): all 7 coin-matrix lane jobs started 22:18:12 and were cancelled ~1s later; btc-daemonless-smoke succeeded; aggregate failed with `results="success cancelled success ..."`.

## Fix

Prefix each reusable's concurrency group with a per-file literal so the two are distinct even when `github.workflow` is the shared caller name:

| file | before | after |
|---|---|---|
| `coin-matrix.yml` | `${{ github.workflow }}-${{ github.ref }}` | `coin-matrix-${{ github.workflow }}-${{ github.ref }}` |
| `btc-embedded-standalone-smoke.yml` | `${{ github.workflow }}-${{ github.ref }}` | `btc-standalone-smoke-${{ github.workflow }}-${{ github.ref }}` |

`github.workflow` is **kept** as a component so a workflow's standalone run and its ci-required-called run on the same ref stay in separate groups — btc smoke fires both on a master PR touching its own paths (this PR does), and merging them would re-trigger the exact cancellation we are fixing.

`cancel-in-progress` semantics, the aggregate logic (failing on `cancelled` is correct), and `ci-required.yml`'s own group are all untouched. The other 6 called reusables declare no concurrency block. Distinct PRs/branches still never cancel each other (ref component unchanged).

## Proof

This PR edits `btc-embedded-standalone-smoke.yml`, so it fires that standalone lane too — a built-in test that standalone and called runs no longer collide. Gate: `CI Required / aggregate` green with the coin-matrix lane no longer cancelled.