### PR TITLE
dash(share_check): fold donation-keyed finder/PPLNS amount into the donation output (F11 fork fix) [DRAFT — do not merge]

### DIFF
--- a/src/impl/dash/share_check.hpp
+++ b/src/impl/dash/share_check.hpp
@@ -657,11 +657,32 @@ uint256 generate_share_transaction(const DashShare& share, TrackerT& tracker,
     auto finder_script = pubkey_hash_to_script2(share.m_pubkey_hash);
     amounts[finder_script] += worker_payout / 50;
 
-    // Donation: remainder (rounding + donation weight)
+    // Donation: any pre-existing DONATION_SCRIPT-keyed amount MERGED with the
+    // leftover (rounding + donation weight). This mirrors BOTH authors exactly:
+    //   - producer  share_producer.hpp: amounts[donation_script] += (worker_payout - sum)
+    //   - oracle    ref/p2pool-dash data.py:223:
+    //                 amounts[DONATION_SCRIPT] = amounts.get(DONATION_SCRIPT,0) + worker_payout - sum(...)
+    //     (both then emit amounts[DONATION_SCRIPT] as the single donation txout).
+    //
+    // Reachability: DASH's DONATION_SCRIPT is P2PKH (hash160 20cb5c22...,
+    // address XdgF55wEHBRWwbuBniNYH4GvvaoYMgL84u), so pubkey_hash_to_script2 of a
+    // share whose m_pubkey_hash == that hash160 collides with DONATION_SCRIPT and
+    // the finder-fee / PPLNS-weight amount lands in amounts[DONATION_SCRIPT].
+    // The previous code subtracted that amount inside sum_amounts, dropped it
+    // from worker_outputs, and emitted ONLY the residual -- so the reconstructed
+    // coinbase was low by exactly that amount, its txid diverged from the
+    // committed gentx_hash, and a VALID share was falsely rejected. Because
+    // p2pool-dash (the shared sharechain) and our own producer both preserve it,
+    // that was a cross-impl FORK (F11): our nodes orphaned shares the network
+    // accepted. Folding it back in makes the reconstruction byte-identical to
+    // both authors. Non-colliding shares are unaffected (no DONATION_SCRIPT key
+    // in amounts -> donation_amount == residual, exactly as before).
     uint64_t sum_amounts = 0;
     for (auto& [s, a] : amounts)
         sum_amounts += a;
-    uint64_t donation_amount = (worker_payout > sum_amounts) ? (worker_payout - sum_amounts) : 0;
+    uint64_t residual = (worker_payout > sum_amounts) ? (worker_payout - sum_amounts) : 0;
+    auto don_it = amounts.find(DONATION_SCRIPT);
+    uint64_t donation_amount = (don_it != amounts.end() ? don_it->second : 0) + residual;
 
     // ── 4. Build sorted output list ──
     // worker_scripts: sorted, excluding donation

--- a/test/test_dash_share_producer.cpp
+++ b/test/test_dash_share_producer.cpp
@@ -985,6 +985,115 @@ static dash::producer::BuiltShare mint_scene(SyntheticChain& sc,
         sc.chain, params, info, fixture_min_header(), F1_NONCE64, /*check_pow=*/false);
 }
 
+// The 20-byte pubkey hash embedded in dash::DONATION_SCRIPT (76a914 <20> 88ac),
+// i.e. hash160 of the P2PKH donation address XdgF55wEHBRWwbuBniNYH4GvvaoYMgL84u.
+// Sliced from DONATION_SCRIPT itself so byte-order can never drift from the key
+// the verifier / producer actually compare against.
+static uint160 donation_h160() {
+    return uint160(std::vector<unsigned char>(dash::DONATION_SCRIPT.begin() + 3,
+                                              dash::DONATION_SCRIPT.begin() + 23));
+}
+
+// mint_scene's sibling: identical g(A)<-s1(B)<-s2(C) window, but the newly minted
+// share's FINDER (m_pubkey_hash) is the donation address, so pubkey_hash_to_script2
+// of the finder collides with DONATION_SCRIPT and the 2% finder fee lands in
+// amounts[DONATION_SCRIPT]. The PPLNS window {s1(B), g(A)} stays non-colliding, so
+// this isolates the finder-fee collision (F11 "Trigger 1", a single share).
+static dash::producer::BuiltShare mint_scene_finder_is_donation(
+        SyntheticChain& sc, const core::CoinParams& params) {
+    const uint160 A = h160_uniform(0xaa), B = h160_uniform(0xbb), C = h160_uniform(0xcc);
+    uint256 g  = sc.add(0x01, uint256(), BITS_DIFF1, BITS_DIFF1, 1699999900, A, 0,
+                        1, u128_hex(ATA_DIFF1_HEX));
+    uint256 s1 = sc.add(0x02, g,  BITS_DIFF1, BITS_DIFF1, 1699999920, B, 0,
+                        2, u128_hex(ATA_DIFF1_HEX) * 2u);
+    uint256 s2 = sc.add(0x03, s1, BITS_DIFF1, BITS_DIFF1, 1699999940, C, 0,
+                        3, u128_hex(ATA_DIFF1_HEX) * 3u);
+    ProducerJobInputs in;
+    in.prev_share_hash = s2; in.coinbase_scriptSig = {0x03,0x01,0x02,0x03};
+    in.share_nonce = 7; in.pubkey_hash = donation_h160();   // finder == donation addr
+    in.subsidy = 500000000;
+    in.donation = 0; in.desired_version = 16; in.desired_timestamp = 1700000000;
+    in.desired_target = params.max_target;
+    in.packed_payments = { mn_payment(0xd1, 150000000), mn_payment(0xd2, 100000000) };
+    in.payment_amount  = 250000000;
+    in.desired_tx_hashes = { h256_tag(0x71), h256_tag(0x72) };
+    auto info = dash::producer::generate_prospective_share_info(sc.chain, params, in);
+    return dash::producer::build_share(
+        sc.chain, params, info, fixture_min_header(), F1_NONCE64, /*check_pow=*/false);
+}
+
+// ── F11 REGRESSION (donation-keyed finder share) ─────────────────────────────
+// A share whose finder is the P2PKH donation address collides the 2% finder fee
+// onto DONATION_SCRIPT. The producer AND p2pool-dash (ref data.py:223) MERGE that
+// amount into the single donation txout. The verifier MUST do the same; the
+// pre-fix code subtracted it inside sum_amounts, dropped it from worker_outputs,
+// and emitted ONLY the residual -> reconstructed coinbase short by the finder fee
+// -> txid diverges -> a VALID share the shared sharechain accepts is FALSELY
+// REJECTED (cross-impl FORK). This KAT is RED on master (txid mismatch ->
+// verify_payout_commitment throws) and GREEN with the fix (byte-identical).
+TEST(DashPayoutCommitment, DonationKeyedFinderShareAccepted) {
+    const auto params = dash::make_coin_params(false);
+    SyntheticChain sc;
+    auto built = mint_scene_finder_is_donation(sc, params);
+    PayoutTrackerView tv{sc.chain};
+
+    const std::vector<unsigned char> DON(dash::DONATION_SCRIPT.begin(),
+                                         dash::DONATION_SCRIPT.end());
+
+    // Precondition: the collision is REAL -- the finder script IS DONATION_SCRIPT.
+    ASSERT_EQ(dash::pubkey_hash_to_script2(built.share.m_pubkey_hash), DON)
+        << "scene must mint with finder == donation address for the collision";
+
+    // (b) Verifier reconstruction is byte-identical to the producer's committed
+    // gentx. On master the merged finder fee is dropped, so this txid diverges
+    // (RED); with the fix it matches (GREEN). gc exposes the reconstructed bytes.
+    dash::coin::GentxCoinbase gc;
+    uint256 expected = dash::generate_share_transaction(built.share, tv, params, &gc);
+    EXPECT_EQ(hex_of(expected), hex_of(built.gentx_hash))
+        << "F11: verifier must fold the donation-keyed finder fee into the "
+           "donation output exactly like the producer / p2pool-dash";
+    EXPECT_EQ(hex_of(gc.txid), hex_of(built.gentx_hash));
+
+    // Parse the reconstructed coinbase outputs (layout pinned by the F1 golden).
+    struct Out { uint64_t value; std::vector<unsigned char> script; };
+    std::vector<Out> outs;
+    {
+        const auto& v = gc.bytes;
+        size_t p = 4 /*ver+type*/ + 1 /*vin cnt*/ + 32 + 4;
+        p += 1 + v[p];                 // scriptSig VarStr (short)
+        p += 4;                        // sequence
+        size_t n = v[p++];             // vout count (short)
+        for (size_t i = 0; i < n; ++i) {
+            Out o; o.value = 0;
+            for (int k = 0; k < 8; ++k) o.value |= static_cast<uint64_t>(v[p + k]) << (8 * k);
+            p += 8;
+            size_t sl = v[p++];
+            o.script.assign(v.begin() + p, v.begin() + p + sl);
+            p += sl;
+            outs.push_back(std::move(o));
+        }
+    }
+
+    // Exactly one donation output, carrying the merged 2% finder fee
+    // (worker_payout/50 = (5e8 - 2.5e8 payments)/50 = 5000000) + residual (0),
+    // NOT zero -- 5000000 is the exact satoshi master silently drops.
+    uint64_t donation_value = 0; int donation_count = 0;
+    for (auto& o : outs) if (o.script == DON) { donation_value = o.value; ++donation_count; }
+    EXPECT_EQ(donation_count, 1) << "exactly one donation output";
+    EXPECT_EQ(donation_value, 5000000u)
+        << "donation output must include the 2% finder fee master drops";
+
+    // Coinbase value conservation: outputs sum to the subsidy. Master's short
+    // donation would sum to subsidy - 5000000, proving money was destroyed.
+    uint64_t total = 0; for (auto& o : outs) total += o.value;
+    EXPECT_EQ(total, 500000000u) << "reconstructed coinbase must conserve subsidy";
+
+    // (a) The live accept-path gate: RED on master (throws -> valid share falsely
+    // rejected), GREEN with the fix (admitted).
+    EXPECT_NO_THROW(dash::verify_payout_commitment(
+        built.share, tv, params, built.gentx_hash));
+}
+
 // (b)+(c) The accept-path recompute reproduces the EXACT gentx the producer
 // committed to, so verify_payout_commitment admits our own freshly-minted share.
 TEST(DashPayoutCommitment, LocalMintCoinbaseAccepted) {


### PR DESCRIPTION
## F11 fork fix — DASH verifier drops the donation-keyed PPLNS/finder amount

**DO NOT MERGE — live-consensus DASH lane (shared hotel + dash.voidbind sharechain), reward-path. Operator tap required.** Draft for review.

### The fork (CONFIRMED, not a measurement artifact)
The accept-path payout-commitment verifier `generate_share_transaction` → `verify_payout_commitment` (`src/impl/dash/share_check.hpp`) rebuilt the coinbase's **donation output** as *only* the rounding/donation-weight residual `worker_payout - sum(amounts)`, silently dropping any amount already keyed to `DONATION_SCRIPT`.

DASH's `DONATION_SCRIPT` is **P2PKH** (`hash160 = 20cb5c22…`, address `XdgF55wEHBRWwbuBniNYH4GvvaoYMgL84u`). So `pubkey_hash_to_script2` of a share whose finder (`m_pubkey_hash`) or PPLNS window resolves to that hash160 lands its 2% finder fee / weight share in `amounts[DONATION_SCRIPT]`. The verifier subtracted that inside `sum_amounts`, excluded it from `worker_outputs`, and emitted only the residual → reconstructed coinbase **short by exactly that amount** → gentx txid diverged from the committed `gentx_hash` → `GENTX-MISMATCH` → a **valid share was falsely rejected**.

Both authors preserve it, so the divergence is verifier-vs-everyone:
- **producer** `share_producer.hpp` build_gentx: `amounts[donation_script] += (worker_payout - sum)`, emits the merged value;
- **oracle** `ref/p2pool-dash/p2pool/data.py:223`: `amounts[DONATION_SCRIPT] = amounts.get(DONATION_SCRIPT,0) + worker_payout - sum(...)`, emits `amounts[DONATION_SCRIPT]`.

Reachability differs from upstream bitcoin p2pool only because upstream's donation script is P2PK (no P2PKH key collision possible); DASH's is P2PKH so it is reachable — one share mined to the donation address triggers it, and once such a share is in the PPLNS window it poisons the window (weight-derived donation amount) for its whole lifetime.

### The fix (minimal, reward-safe, byte-parity-preserving)
Emit the donation output as `amounts[DONATION_SCRIPT] + residual`, mirroring both authors byte-for-byte:

```cpp
uint64_t residual = (worker_payout > sum_amounts) ? (worker_payout - sum_amounts) : 0;
auto don_it = amounts.find(DONATION_SCRIPT);
uint64_t donation_amount = (don_it != amounts.end() ? don_it->second : 0) + residual;
```

This is **not** "stop rejecting" — the reconstruction is made correct. Non-colliding shares are unaffected (no `DONATION_SCRIPT` key → `donation_amount == residual`, exactly as before), so no other share class changes verdict. **DASH lane only** (`src/impl/dash/*` + the KAT).

### Red→green proof (KAT `DashPayoutCommitment.DonationKeyedFinderShareAccepted`)
Mints a share whose finder is the donation address (finder script == `DONATION_SCRIPT`), non-colliding PPLNS window.

- **RED on master** (fix reverted, KAT kept): `verify_payout_commitment` throws `std::invalid_argument` — `GENTX-MISMATCH: expected 81522c71… committed da772916…`; the parsed donation output is 0 and the coinbase sums to `subsidy − 5000000` (money destroyed).
- **GREEN with fix**: verifier reconstruction byte-identical to the producer's committed gentx (`gc.txid == built.gentx_hash`); donation output carries the merged 2% finder fee `5000000` duff + residual; coinbase conserves the subsidy (`500000000`); the accept gate admits the share.
- **No other class flips**: `LocalMintCoinbaseAccepted` / `WrongCoinbaseRejected` / `FinderTamperRejected` stay green on master and with the fix. Full `test_dash_share_hash_link` binary: **78/78 green**.

### Build
`c2pool-dash` and `test_dash_share_hash_link` both build clean (Release, conan toolchain).

### Adjacent defect (NOT fixed here — flagged for a separate scoped PR)
`share_check.hpp:698` counts `n_outs` using `share.m_packed_payments.size()` **unfiltered**, while the emit loop skips zero-amount / undecodable payees — a share carrying such a payment makes the verifier's output *count* disagree with its emitted outputs (a different false-reject of the same `GENTX-MISMATCH` kind). Left out to keep this fix minimal and the KAT tightly scoped.


### Caller-side lock trace (reward-path requirement)
`verify_payout_commitment` -> `generate_share_transaction` is reached from exactly three call sites, all through `share_tracker::attempt_verify`:

- **`node.cpp:1487`** — local-mint inline verify, immediately after `m_tracker.add(share)`, on the io_context/mint path within the tracker mutation section.
- **`share_tracker.hpp:793`** — `think()` P1 walk (`chain.get_chain(head_hash, ...)` verify loop).
- **`share_tracker.hpp:1076`** — `think()` P2 budgeted walk.

Both `think()` walks run while the tracker's `m_tracker_mutex` is held (the tracker's own invariant — see the release/re-acquire notes at `share_tracker.hpp:341` and the "while holding m_tracker_mutex" walk at `:912`); the mint-path call runs under the same tracker section before the storage batch. The verifier is therefore already a **read-only consumer under the tracker lock** — the PPLNS walk reads `verified` / `chain.get_chain`, and `generate_share_transaction` builds a **function-local `amounts` map**.

The fix is **lock-neutral**: it adds one `amounts.find(DONATION_SCRIPT)` plus an add over that same function-local map — no new shared-state access, no new mutex, no change to lock ordering or hold duration. It cannot introduce a race or deadlock relative to master; the reconstruction math changes, the concurrency surface does not.
