### PR TITLE
release: c2pool-bip110 first-class binary on all platforms (Linux + macOS universal + Windows)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,13 @@ name: Release matrix
 # (c2pool-<coin>-<version>-<platform>.{tar.gz,zip} + SHA256SUMS).
 #
 # Coins: btc, ltc (carries doge merged-mining aux — no separate doge
-# binary), dgb, dash, bch. Each coin×platform cell gates on source
-# presence (same entrypoint gate as coin-matrix.yml: the real entrypoint
-# src/c2pool/main_<coin>.cpp, not src/impl/<coin>/main — see PR #66) and
-# every matrix is fail-fast:false, so one red coin never blocks the other
-# coins' packages. This implements the ship decouple: a red btc cell
-# still lets ltc/dash/doge/dgb/bch package.
+# binary), dgb, dash, bch, bip110 (Bitcoin Knots BLAKE2b hard fork —
+# standalone lane, no BLS/aux, no per-coin configure flag). Each
+# coin×platform cell gates on source presence (same entrypoint gate as
+# coin-matrix.yml: the real entrypoint src/c2pool/main_<coin>.cpp, not
+# src/impl/<coin>/main — see PR #66) and every matrix is fail-fast:false,
+# so one red coin never blocks the other coins' packages. This implements
+# the ship decouple: a red btc cell still lets ltc/dash/doge/dgb/bch package.
 #
 # macOS: ships UNIVERSAL (arm64+x86_64) at tag time (operator decision
 # 2026-06-11). Each arch builds natively on its own runner — macos-14
@@ -38,7 +39,7 @@ on:
         required: false
         default: ""
       coins:
-        description: "JSON array of coins to build (e.g. [\"ltc\"]). Blank = all five."
+        description: "JSON array of coins to build (e.g. [\"ltc\"]). Blank = all six."
         required: false
         default: ""
 
@@ -67,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch"]') }}
+        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch","bip110"]') }}
     steps:
       - uses: actions/checkout@v6
 
@@ -286,7 +287,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch"]') }}
+        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch","bip110"]') }}
         arch: [arm64, x86_64]
         include:
           - arch: arm64
@@ -403,7 +404,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch"]') }}
+        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch","bip110"]') }}
     steps:
       - uses: actions/checkout@v6
 
@@ -514,7 +515,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch"]') }}
+        coin: ${{ fromJSON(github.event.inputs.coins || '["btc","ltc","dgb","dash","bch","bip110"]') }}
     steps:
       - uses: actions/checkout@v6
 

--- a/config/bip110/c2pool_mainnet.yaml
+++ b/config/bip110/c2pool_mainnet.yaml
@@ -1,0 +1,45 @@
+# C2Pool Bitcoin BIP110 (Knots BLAKE2b fork) Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+#
+# BIP-110 is a minority hard fork of Bitcoin (Bitcoin Knots 29.4.1) that
+# replaces SHA256d proof-of-work with the BLAKE2b commitment pipeline from
+# block 961640 onward. It shares Bitcoin mainnet's address encoding, network
+# magic, and genesis, but runs its own c2pool sharechain (distinct P2P
+# identity) so it never cross-dials the BTC p2pool network.
+
+# --- Network -----------------------------------------------------------------
+port: 9335                     # p2pool sharechain P2P port (BIP-110 mainnet default)
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   9335 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   8333 TCP  — coin P2P (recommended for faster daemon sync)
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL Bitcoin Knots 29.4.1 RPC for block templates
+# (getblocktemplate with the "blake2b" rule). Run a full Knots BIP-110 node
+# and set the rpc fields below. The pool MUST request the "blake2b" GBT rule;
+# a non-BIP-110 backend rejects it.
+
+# --- Fork peers (BIP-110 minority chain) -------------------------------------
+# BIP-110 is a minority fork; seed from known fork nodes with addnode (NOT
+# connect, which would restrict you to only those peers):
+# addnode:
+#   - "<fork-peer-host>:8333"
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# Keys accept the btc_rpc_* aliases (BIP-110 reuses the Bitcoin RPC client).
+# btc_rpc_host: 127.0.0.1
+# btc_rpc_port: 8332           # your Knots BIP-110 daemon's RPC port
+# btc_rpc_user: user
+# btc_rpc_password: pass

--- a/config/bip110/c2pool_testnet.yaml
+++ b/config/bip110/c2pool_testnet.yaml
@@ -1,0 +1,27 @@
+# C2Pool Bitcoin BIP110 (Knots BLAKE2b fork) Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+# port:                        # BIP-110 testnet sharechain port — binary default applies; set to override
+# stratum_port:                # Stratum is opt-in for this coin: enable with --stratum [HOST:]PORT
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+
+# --- Operating mode ----------------------------------------------------------
+# Deployment: EXTERNAL Bitcoin Knots BIP-110 RPC for block templates
+# (getblocktemplate with the "blake2b" rule).
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (for non-embedded / daemon mode) ------------------------
+# Keys accept the btc_rpc_* aliases (BIP-110 reuses the Bitcoin RPC client).
+# btc_rpc_host: 127.0.0.1
+# btc_rpc_port:                # your BIP-110 daemon's RPC port
+# btc_rpc_user: user
+# btc_rpc_password: pass


### PR DESCRIPTION
## Summary

Makes `c2pool-bip110` a first-class released binary on every platform the other five coins already ship on: Linux x86_64, macOS universal (arm64 + x86_64 lipo-merged), and Windows x86_64.

`bip110` is the Bitcoin Knots BLAKE2b hard-fork (BIP-110) lane. Its `c2pool-bip110` target is already built and KAT-gated green on Linux in `build.yml`, and the source-presence gate (`main_bip110.cpp && src/impl/bip110/`) passes on master — it was simply absent from `release.yml`'s coin matrix, so no bip110 package was ever produced at tag time.

## Changes (release.yml only, plus one packaging-required config dir)

- Add `"bip110"` to the coin-list default of all four platform legs: `linux`, `macos` (per-arch), `macos-universal` (lipo-merge), and `windows`.
- Update the `workflow_dispatch` `coins` input description ("all five" -> "all six") and the header comment coin roster.
- Add `config/bip110/c2pool_mainnet.yaml` + `config/bip110/c2pool_testnet.yaml`, modeled on `config/btc/` with bip110 network identity (sharechain P2P 9335, coin P2P 8333, Knots `getblocktemplate` `blake2b` rule). The three package steps hard-copy `config/<coin>/*.yaml`, and the Linux packaging tripwire greps the first config line for the coin token — so these files are required for the bip110 cells to package (first line carries the contiguous `BIP110` token).

## No per-coin build flag

Unlike `dash` (`-DC2POOL_DASH_BLS=ON`) or `dgb` (`-DAUX_DOGE=ON`), the `c2pool-bip110` target is **unconditional** in CMake — no configure option gates it. The existing per-coin steps parameterize on `matrix.coin` and resolve `c2pool-bip110` as-is, so no `EXTRA`/ternary wiring was added. BLAKE2b PoW is a standalone SHA-family lane with no BLS/aux needs.

## Cross-platform

`src/impl/bip110/crypto/blake2b.c` is portable RFC-7693 C (byte-wise little-endian, no intrinsics/asm/SIMD); the only POSIX includes in the lane (`sys/socket.h`, `sys/time.h` in `coin/rpc.cpp`) are already under `#ifndef _WIN32`, byte-identical to the release-proven `btc` lane. This PR's `workflow_dispatch` dry-run is the first-ever macOS/Windows compile of the lane — see the linked run for the proof.

## Guardrails

- No behavioral change to the other five coins' matrix cells; `fail-fast: false` preserved on every leg.
- Do NOT merge, do NOT tag — integrator + operator handle the version/tag/publish.

## Out of scope (flagged separately)

Commit `b1abd2570` (#1423) deleted `config/dash/c2pool_{mainnet,testnet}.yaml`; on current master every release.yml `dash` cell now fails at the config-copy step even though its presence gate passes. That is a pre-existing dash regression, not addressed here.
