### PR TITLE
config/dash: restore release-package yamls (fix dash cells in release matrix) [DO-NOT-MERGE]

### DIFF
--- a/config/dash/c2pool_mainnet.yaml
+++ b/config/dash/c2pool_mainnet.yaml
@@ -1,0 +1,32 @@
+# C2Pool Dash [DASH] Mainnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 8999                    # p2pool sharechain P2P port (DASH mainnet default)
+stratum_port: 7903            # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   8999 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   7903 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   9999 TCP  — DASH coin P2P (recommended for faster block propagation)
+
+# --- Operating mode ----------------------------------------------------------
+# Default: integrated P2P pool with an EMBEDDED Dash node.
+# Zero-config — no dashd daemon required. The commented dash_rpc_* fields
+# below enable optional external-daemon mode.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (optional external-daemon mode) -------------------------
+# dash_rpc_host: 127.0.0.1
+# dash_rpc_port:                # your DASH daemon's RPC port
+# dash_rpc_user: user
+# dash_rpc_password: pass

--- a/config/dash/c2pool_testnet.yaml
+++ b/config/dash/c2pool_testnet.yaml
@@ -1,0 +1,32 @@
+# C2Pool Dash [DASH] Testnet Configuration
+#
+# Zero-config startup: run ./start.sh (Linux/macOS) or start.bat (Windows).
+# Miners set their payout address as the stratum username (p2pool-style).
+# CLI arguments always override values set here.
+
+# --- Network -----------------------------------------------------------------
+port: 18999                   # p2pool sharechain P2P port (DASH testnet default)
+stratum_port: 17903           # Stratum mining port
+web_port: 8080                 # Web dashboard / JSON-RPC API port
+http_host: "0.0.0.0"           # HTTP bind address
+# external_ip: ""              # Public IP/domain for stratum URL display
+#
+# Port forwarding (if behind NAT/firewall):
+#   18999 TCP  — P2P sharechain (REQUIRED for full p2pool participation)
+#   17903 TCP  — Stratum mining (REQUIRED for miners to connect)
+#   19999 TCP  — DASH coin P2P (recommended for faster block propagation)
+
+# --- Operating mode ----------------------------------------------------------
+# Default: integrated P2P pool with an EMBEDDED Dash node.
+# Zero-config — no dashd daemon required. The commented dash_rpc_* fields
+# below enable optional external-daemon mode.
+
+# --- Bootstrap header checkpoint (optional) ----------------------------------
+# Skip old headers on first sync.  Format: HEIGHT:BLOCK_HASH
+# header_checkpoint: "HEIGHT:BLOCK_HASH"   # set for faster first sync
+
+# --- Coin daemon RPC (optional external-daemon mode) -------------------------
+# dash_rpc_host: 127.0.0.1
+# dash_rpc_port:                # your DASH daemon's RPC port
+# dash_rpc_user: user
+# dash_rpc_password: pass


### PR DESCRIPTION
## DO-NOT-MERGE until integrator review (pre-tag)

### Regression
`b1abd2570` (#1423, control-plane M0) deleted `config/dash/c2pool_mainnet.yaml` and `config/dash/c2pool_testnet.yaml` as unloaded runtime config. That premise is true for `main_dash.cpp` (no yaml cfg loading), **but the release packaging contract still depends on these files**:

- `.github/workflows/release.yml` `cp "config/${COIN}/c2pool_mainnet.yaml" ...` + `c2pool_testnet.yaml` on the Linux (~233-234), macOS (~379-380) and Windows (~670-671) legs.
- Tripwire `head -1 c2pool_mainnet.yaml.example | grep -qi "${COIN}"` (~237).

With `config/dash/` gone, a full-matrix tag fails **every dash cell at the cp** and the release ships without the flagship dash pool. `btc/ltc/dgb/bch` configs are all present on master; only `config/dash/` was missing.

### Fix (files only — release.yml is correct)
Restore both files as the package's documented example. Not a blind revert:

- Structure matches the current `btc`/`ltc` skeleton.
- Ports pinned to `src/impl/dash/config_pool.hpp`: mainnet P2P **8999** / stratum **7903**, testnet **18999** / **17903**; coin P2P **9999** / **19999**.
- Operating-mode prose modernized to the **daemonless default** (embedded Dash node, no dashd required; `dash_rpc_*` commented as optional external mode), replacing the stale "embedded not wired (#738), dashd required" block.
- Testnet coin-P2P forwarding note corrected `9999` -> `19999`.
- No new active yaml keys added (nothing parses this file at runtime); kept the same four the deleted file had for cross-coin example consistency.

### Verification
- `yaml.safe_load` both files: OK.
- `head -1 config/dash/c2pool_mainnet.yaml | grep -qi dash`: passes (first line `# C2Pool Dash [DASH] Mainnet Configuration`).
- `git status`: only the two new files. `release.yml` and other coins untouched.

### Scope
Creates **only** `config/dash/c2pool_mainnet.yaml` + `config/dash/c2pool_testnet.yaml`. Does not modify `release.yml` or any other coin's config.
