### PR TITLE
bip110 M3 sharechain: mint seam payout_script parity + scope/PR sequence (DO NOT MERGE)

### DIFF
--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -295,6 +295,7 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
         FreezeEntry e; e.freeze = f;
         e.coinbase       = cb.bytes;        // non-witness (txid/merkle/share source)
         e.coinbase_block = cb.block_bytes;  // BIP144 witness form for the block body
+        e.payout_script  = payout_script;   // M3: the miner the share must pay
         e.at = std::chrono::steady_clock::now();
         freeze_map_[to_hex(f.h2)] = std::move(e);
     }
@@ -413,12 +414,19 @@ nlohmann::json Bip110WorkSource::mining_submit(
     // counted by the core, no mint.
     if (create_share_fn_) {
         std::vector<unsigned char> coinbase;
+        std::vector<unsigned char> payout_script;
         {
             std::lock_guard<std::mutex> lk(freeze_mutex_);
             auto it = freeze_map_.find(to_hex(f.h2));
-            if (it != freeze_map_.end()) coinbase = it->second.coinbase;
+            if (it != freeze_map_.end()) {
+                coinbase      = it->second.coinbase;
+                payout_script = it->second.payout_script;
+            }
         }
-        create_share_fn_(coinbase, hdr, *job);
+        // M3 mint seam: pay the SUBMITTING miner (payout_script), mirroring the
+        // btc create_local_share path (main_btc.cpp:2338-2345). Unset here until
+        // the bip110 sharechain lane exists — see the header note.
+        create_share_fn_(coinbase, hdr, payout_script, *job);
     }
     return nlohmann::json(true);
 }

--- a/src/impl/bip110/stratum/work_source.hpp
+++ b/src/impl/bip110/stratum/work_source.hpp
@@ -51,9 +51,20 @@ public:
     // Sharechain WRITE seam (M3). Called when a share meets sharechain (not
     // block) target. Left unset in M2 => shares are validated + counted but not
     // minted into a p2pool sharechain. Returns the share hash or uint256::ZERO.
+    //
+    // M3 SEAM PARITY (btc reference, main_btc.cpp:2215-2345): the mint must pay
+    // the SUBMITTING miner, so the connection's payout_script — the same bytes
+    // build_connection_coinbase() baked into this job's coinbase outputs — is
+    // handed to the share builder. bip110's freeze (keyed by h2) now carries the
+    // payout_script alongside the coinbase so it is recoverable at submit time
+    // without re-deriving it from the coinbase outputs. Left unset in M2/M3-seam:
+    // installing the fn requires the bip110 sharechain lane (share_types/share/
+    // share_check/share_tracker/pool node — the ~10k-line btc-family port, still
+    // absent on this branch), so shares are validated + counted but not minted.
     using CreateShareFn = std::function<uint256(
         const std::vector<unsigned char>& full_coinbase,
         const std::vector<unsigned char>& header_164b,
+        const std::vector<unsigned char>& payout_script,
         const core::stratum::JobSnapshot&  job)>;
 
     Bip110WorkSource(bip110::coin::HeaderChain& chain,
@@ -170,7 +181,10 @@ private:
     // coinbase_block = BIP144 witness serialization for the BLOCK BODY (carries
     //                  the 1x32-byte witness reserved value the commitment output
     //                  requires; == coinbase when no commitment). See DEFECT 1.
-    struct FreezeEntry { HeaderFreeze freeze; std::vector<unsigned char> coinbase; std::vector<unsigned char> coinbase_block; std::chrono::steady_clock::time_point at; };
+    // payout_script = the submitting connection's payout destination, captured
+    // at build_connection_coinbase() time so the M3 mint (create_share_fn_) can
+    // pay the miner without re-parsing the frozen coinbase outputs (btc parity).
+    struct FreezeEntry { HeaderFreeze freeze; std::vector<unsigned char> coinbase; std::vector<unsigned char> coinbase_block; std::vector<unsigned char> payout_script; std::chrono::steady_clock::time_point at; };
     mutable std::mutex           freeze_mutex_;
     mutable std::map<std::string, FreezeEntry> freeze_map_;   // key = hex(h2)
     static constexpr std::chrono::seconds FREEZE_TTL{360};


### PR DESCRIPTION
## bip110 M3 — sharechain participation: seam groundwork + scope correction

**DO NOT MERGE — operator reviews (money/consensus-adjacent: PPLNS + sharechain genesis).**
Base is `bip110-m2-mineable` (M3 builds on M2; M2 is not yet on master).

### What this PR changes (safe, isolated, non-consensus)
Threads `payout_script` through the M3 mint seam so the future `create_share_fn`
pays the **submitting** miner — btc parity with `main_btc.cpp:2215-2345` →
`create_local_share_v35(... payout_script ...)`. bip110's seam lacked it (design
item 3). The connection's `payout_script` is now captured into the h2-keyed
`HeaderFreeze` at `build_connection_coinbase()` and recovered at submit time.

- `CreateShareFn` signature: `(full_coinbase, header_164b, payout_script, job)`.
- `FreezeEntry` carries `payout_script`.
- The fn is **still unset** → submits are validated + counted, **not minted**.
  Runtime behaviour unchanged. Lane-local (`src/impl/bip110/stratum/*`); no other
  coin touched. Builds `c2pool-bip110` 100%; BLAKE2b selftest PASS.

### Scope correction (the important part for the reviewer)
The design brief assumed M3 = "attach `create_local_share` to an existing seam".
The live tree says otherwise: **neither master nor `bip110-m2-mineable` has any
bip110 sharechain lane** — no `pool/` family (`share_types`, `share`,
`share_check`, `share_tracker`, pool `node`/`peer`/`protocol`, `messages`). So
the mint substrate (`tracker.add`, `best_share`, PPLNS, `SharechainNode`,
share-p2p broadcast) does not exist to wire yet. Making a share **mint** and the
`best_share` / `/sharechain/*` / `/current_payouts` / `peer_list` endpoints
populate requires building that lane first.

### Truthful M3 status right now
- shares mint: **NO** — no bip110 sharechain lane to mint into.
- endpoints populate: **NO** — same reason.
- `create_share_fn` wired: **seam prepared** (payout parity), consumer absent.
- `SharechainNode` attached: **NO** — needs bip110 Share/ShareChain/Peer types.
- addrman-backed broadcaster: JOB 1 (won-share gossip) is free once the pool node
  exists (shared `pool::BaseNode` + `core::AddrStore`); JOB 2 (robust found-block
  fan-out over the coin core P2P) is a wiring task over `core::CoinAddrMan`
  (already embedded in `BtcCoinPeerManager` on this branch) — not a port.

### Proposed PR sequence (unchanged from design, re-sized against the live tree)
- **PR-A** `bip110 sharechain lane` — copy the btc `pool/` family into
  `src/impl/bip110/pool/` (~10-12k lines, BCH/DGB full-copy precedent) with three
  deltas: (a) `Bip110SmallHeader` (164B v2 minus tx-merkle-root), (b) BLAKE2b
  PoW/identity via `pseudoheader.hpp` rebuild + `bip110::pow`, (c) **fresh**
  network identity constants (never reuse btc's `9333`/`2472ef…` — live-sharechain
  prefix-regression class). Unit KATs; no main wiring. Zero risk to other lanes.
- **PR-B** `mint + endpoints` — install `create_share_fn` (this seam's consumer),
  construct the bip110 pool `Node`, flip `get_best_share_hash_fn`, install the
  MiningInterface feeds (pplns/window/stats/best_share/peer_info/pool_hashrate);
  2-node convergence. **This is where shares mint and endpoints populate.**
- **PR-C** `addrman block fan-out` — `Bip110BlockFanout` over
  `BtcCoinPeerManager`/`CoinAddrMan`: K parallel standing NODE_BLAKE2B conns,
  parallel full-block push, RPC leg always fired, peer-found-block re-broadcast.
- **PR-D** `persistence + soak` — shares.dat + restart re-serve; legion64 soak.

### Consensus sign-offs required before PR-B finalizes (safe default named)
1. **Share format/version** — default v35 PaddingBugfixShare + bip110 header ext,
   version literal 35. Wire genesis; unchangeable without a coordinated fork.
2. **Sharechain identity** — fresh 8B PREFIX + 8B IDENTIFIER + P2P port (proposal
   9337) + bootstrap seeds. **Not committed in this PR** (consensus act).
3. **Share difficulty/retarget** — default btc verbatim (SHARE_PERIOD 30s,
   LOOKBEHIND 200, CHAIN_LENGTH 8640). FLAG: tiny fork hashrate may want a lower
   floor / longer period for a sane single-miner mint cadence.
4. **PPLNS window** — default v35 SPREAD=3. FLAG: fork block cadence ≠ btc.
5. **Donation u16 encoding** — mirror btc lane; per-node fee stays a flag; the u16
   field encoding must be fixed now.
6. **Nonzero flags/xor_key shares** — default fail-closed refuse-to-mint/accept
   (every live fork block is flags=0).
7. **Mint-freshness gate** — copy btc C1 verified-vs-raw gap (STALE_SHARES=30).

### What the Luke Dashjr ecosystem issue can truthfully claim
- **Today (M2):** c2pool mines BIP-110 BLAKE2b blocks coinbase-only, fully
  daemonless, and relays won blocks to fork peers.
- **After PR-A+PR-B:** "c2pool mints and gossips BIP-110 shares on a dedicated
  BLAKE2b sharechain with PPLNS payouts populated end-to-end."
- **After PR-C+PR-D (soak-proven):** "full P2Pool participation with robust
  multi-peer block propagation to the fork network." Do not claim this before C+D.
