### PR TITLE
[DO-NOT-MERGE] bip110: wire coin-P2P addrman feedback + fork-filtered addr gossip + fix empty ADDRESS

### DIFF
--- a/src/c2pool/main_bip110.cpp
+++ b/src/c2pool/main_bip110.cpp
@@ -485,6 +485,32 @@ int run_embedded(bool coin_p2p_discover,
         const auto st = coin_peer_mgr->peer_stats();
         LOG_INFO << "[EMB-BIP110] NODE_BLAKE2B peer discovery ARMED: peers=" << st.total
                  << " groups=" << st.unique_groups;
+
+        // Wire the ported addrman (core::CoinAddrMan) FEEDBACK loop — the piece
+        // the deployed binary was missing (all discovered peers stayed
+        // in_tried:false because these edges never fired). Mirror of the DASH
+        // p2p_client seam (task #40), adapted to this single-connection lane:
+        // the callbacks are stashed on coin_node and re-applied to every
+        // NodeP2P start_p2p rebuilds on failover.
+        //   • addr crawl  -> add_discovered_peer (fork-filtered in the addr
+        //                    handler to NODE_BLAKE2B entries only)
+        //   • handshake   -> notify_connected (Good() -> tried table + anchors)
+        //   • disconnect  -> notify_disconnected (believed-alive refresh)
+        //   • dial fail   -> notify_dial_failed (Attempt()/backoff penalty)
+        // getaddr is requested post-handshake so the mesh grows fork-peer ->
+        // fork-peer, then persists to addrman_BIP110.json / peers_BIP110.json.
+        auto* mgr = coin_peer_mgr.get();
+        coin_node.set_addr_callback(
+            [mgr](const std::vector<NetService>& addrs) {
+                for (auto& a : addrs) mgr->add_discovered_peer(a);
+            });
+        coin_node.set_on_peer_connected(
+            [mgr](const NetService& s) { mgr->notify_connected(s.to_string()); });
+        coin_node.set_on_peer_disconnected(
+            [mgr](const NetService& s) { mgr->notify_disconnected(s.to_string()); });
+        coin_node.set_on_dial_failed(
+            [mgr](const NetService& s) { mgr->notify_dial_failed(s.to_string()); });
+        coin_node.set_send_getaddr_on_connect(true);
     }
 
     // Round-robin dialer over explicit peers + the discovered set. Redials the
@@ -669,6 +695,7 @@ int run_embedded(bool coin_p2p_discover,
                 const uint32_t sh = p2p->peer_start_height();
                 if (sh > th) th = sh;
                 peers.push_back({
+                    {"addr", p2p->peer_addr()},   // fixes the empty ADDRESS column
                     {"subver", p2p->peer_subver()},
                     {"startingheight", sh},
                     {"conntime", p2p->peer_uptime_sec()},

--- a/src/impl/bip110/coin/node.hpp
+++ b/src/impl/bip110/coin/node.hpp
@@ -2,6 +2,8 @@
 #pragma once
 
 #include <memory>
+#include <functional>  // std::function (stashed coin-peer-manager callbacks)
+#include <vector>
 #include <limits>       // std::numeric_limits (found-block RPC-fallback sentinel)
 
 #include <boost/asio.hpp>
@@ -32,6 +34,31 @@ class Node : public bip110::interfaces::Node
     std::unique_ptr<NodeRPC> m_rpc;
     std::unique_ptr<NodeP2P<config_t>> m_p2p;
     bool m_request_mempool_on_connect{false};  // BIP 35 pull on (re)connect
+
+    // Coin-peer-manager feedback + addr-crawl callbacks. This lane is
+    // single-connection: start_p2p REBUILDS m_p2p on every failover dial, so
+    // the callbacks are stashed on the node and re-applied to each fresh
+    // NodeP2P — otherwise they would be lost after the first redial and the
+    // ported addrman would never receive connect/disconnect/dial-failed
+    // feedback (its tried table would stay permanently empty).
+    using PeerLifecycleCallback = std::function<void(const NetService&)>;
+    using AddrCallback = std::function<void(const std::vector<NetService>&)>;
+    PeerLifecycleCallback m_on_peer_connected;
+    PeerLifecycleCallback m_on_peer_disconnected;
+    PeerLifecycleCallback m_on_dial_failed;
+    AddrCallback m_addr_callback;
+    bool m_send_getaddr_on_connect{false};
+
+    /// Push the stashed discovery callbacks onto the current NodeP2P.
+    void apply_p2p_callbacks()
+    {
+        if (!m_p2p) return;
+        if (m_on_peer_connected)    m_p2p->set_on_peer_connected(m_on_peer_connected);
+        if (m_on_peer_disconnected) m_p2p->set_on_peer_disconnected(m_on_peer_disconnected);
+        if (m_on_dial_failed)       m_p2p->set_on_dial_failed(m_on_dial_failed);
+        if (m_addr_callback)        m_p2p->set_addr_callback(m_addr_callback);
+        m_p2p->set_send_getaddr_on_connect(m_send_getaddr_on_connect);
+    }
 
     void init_p2p()
     {
@@ -84,9 +111,19 @@ public:
         m_p2p = std::make_unique<NodeP2P<config_t>>(m_context, this, m_config);
         if (m_request_mempool_on_connect)
             m_p2p->enable_mempool_request();
+        apply_p2p_callbacks();   // re-arm discovery/scorer feedback on the fresh peer
         m_p2p->connect(addr);
         LOG_INFO << "Coin P2P broadcaster connecting to " << addr.to_string();
     }
+
+    /// Register coin-peer-manager feedback + addr-crawl callbacks. Stashed so
+    /// start_p2p re-applies them to every NodeP2P it creates; also applied to
+    /// the current peer immediately (idempotent).
+    void set_on_peer_connected(PeerLifecycleCallback cb) { m_on_peer_connected = std::move(cb); apply_p2p_callbacks(); }
+    void set_on_peer_disconnected(PeerLifecycleCallback cb) { m_on_peer_disconnected = std::move(cb); apply_p2p_callbacks(); }
+    void set_on_dial_failed(PeerLifecycleCallback cb) { m_on_dial_failed = std::move(cb); apply_p2p_callbacks(); }
+    void set_addr_callback(AddrCallback cb) { m_addr_callback = std::move(cb); apply_p2p_callbacks(); }
+    void set_send_getaddr_on_connect(bool on) { m_send_getaddr_on_connect = on; apply_p2p_callbacks(); }
 
     /// Opt into the BIP 35 `mempool` request on (re)connect. Without this the
     /// embedded mempool only learns txs announced via `inv` AFTER we connect,

--- a/src/impl/bip110/coin/p2p_node.hpp
+++ b/src/impl/bip110/coin/p2p_node.hpp
@@ -120,6 +120,22 @@ private:
     using RawBlockParser = std::function<BlockType(const uint8_t*, size_t)>;
     RawBlockParser m_raw_block_parser;
 
+    // Coin-peer-manager lifecycle feedback (mirror of the DASH p2p_client seam,
+    // task #40). Without these the ported core::CoinAddrMan never learns which
+    // dialed peers actually completed the NODE_BLAKE2B handshake — its tried
+    // table stays empty and scoring/backoff run blind. Fired on the dial-result
+    // edges: connect_failed (socket never came up) / verack (handshake done) /
+    // error (an established link dropped, or a mid-handshake drop such as the
+    // NODE_BLAKE2B reject). Keys = m_target_addr.to_string() so they match the
+    // manager's stored PeerEndpoint key exactly.
+    using PeerLifecycleCallback = std::function<void(const NetService&)>;
+    PeerLifecycleCallback m_on_peer_connected;
+    PeerLifecycleCallback m_on_peer_disconnected;
+    PeerLifecycleCallback m_on_dial_failed;
+    // When set (discovery mode), request the peer's known-address set once the
+    // handshake completes so gossiped NODE_BLAKE2B peers grow the fork mesh.
+    bool m_send_getaddr_on_connect{false};
+
 public:
     NodeP2P(io::io_context* context, bip110::interfaces::Node* coin, config_t* config,
             const std::string& chain_label = "CoinP2P")
@@ -237,6 +253,11 @@ public:
         NetService svc_copy = service;
         LOG_WARNING << "[" << m_chain_label << "] Peer " << svc_copy.to_string()
                     << " disconnected: " << err;
+        // Capture the pre-reset state so the coin-peer-manager feedback fires at
+        // most once per link and distinguishes a lost established connection from
+        // a mid-handshake drop (e.g. a peer rejected at the NODE_BLAKE2B gate).
+        const bool had_peer = (m_peer != nullptr);
+        const bool was_up   = m_handshake_complete;
         if (m_peer)
         {
             m_peer.reset();
@@ -247,11 +268,36 @@ public:
         stop_timeout_timer();
         m_handshake_complete = false;
         m_idle_gate.reset();
+
+        if (had_peer) {
+            if (was_up) {
+                // An established outbound link dropped — refresh the addrman's
+                // believed-alive stamp (dashd Connected()).
+                if (m_on_peer_disconnected) m_on_peer_disconnected(m_target_addr);
+            } else {
+                // Socket came up but the handshake never completed (non-fork peer
+                // dropped at the version gate, or a broken peer): penalise it
+                // (attempt++/backoff) so the dialer rotates away from it.
+                if (m_on_dial_failed) m_on_dial_failed(m_target_addr);
+            }
+        }
     }
 
     void error(const boost::system::error_code& ec, const NetService& service, const std::source_location where = std::source_location::current()) override
     {
         error(parse_net_error(ec), service, where);
+    }
+
+    // #940 (BIP-110): an outbound dial failed BEFORE the socket came up
+    // (ECONNREFUSED / ETIMEDOUT / DNS-resolve error), so connected() and the
+    // error() disconnect seam never ran. Feed the dead target to the scored
+    // peer manager so its addrman lowers the entry's GetChance() (Attempt())
+    // and the dialer walks to a fresh fork peer instead of re-drawing it.
+    void connect_failed(const ::NetService& addr) override
+    {
+        LOG_WARNING << "[" << m_chain_label << "] dial failed to "
+                    << addr.to_string() << " — feeding peer scorer";
+        if (m_on_dial_failed) m_on_dial_failed(m_target_addr);
     }
 
     void handle(std::unique_ptr<RawMessage> rmsg, const NetService& service) override
@@ -383,6 +429,21 @@ public:
             std::chrono::steady_clock::now() - m_connected_at).count();
     }
     const std::string& chain_label() const { return m_chain_label; }
+    /// Remote address of the connected peer for the dashboard peers panel.
+    /// Prefer the live socket endpoint; fall back to the dialed target before
+    /// the socket is up. (Fixes the empty ADDRESS column: the peers entry never
+    /// carried an "addr" key.)
+    std::string peer_addr() const {
+        if (m_peer) return m_peer->get_addr().to_string();
+        return m_target_addr.to_string();
+    }
+
+    /// Coin-peer-manager feedback wiring (see member docs above).
+    void set_on_peer_connected(PeerLifecycleCallback cb) { m_on_peer_connected = std::move(cb); }
+    void set_on_peer_disconnected(PeerLifecycleCallback cb) { m_on_peer_disconnected = std::move(cb); }
+    void set_on_dial_failed(PeerLifecycleCallback cb) { m_on_dial_failed = std::move(cb); }
+    /// Enable the post-handshake getaddr crawl (fork-mesh discovery).
+    void set_send_getaddr_on_connect(bool on) { m_send_getaddr_on_connect = on; }
 
     /// Set mempool reference for compact block reconstruction.
     void set_mempool(Mempool* mp) { m_mempool = mp; }
@@ -615,6 +676,12 @@ private:
         );
 
         m_handshake_complete = true;
+        // Feed the coin-peer-manager: this dialed target completed the
+        // NODE_BLAKE2B handshake, so mark it Good() -> its addrman tried table.
+        if (m_on_peer_connected) m_on_peer_connected(m_target_addr);
+        // Fork-mesh growth: pull the peer's known-address set. The addr handler
+        // filters the reply to NODE_BLAKE2B entries before banking them.
+        if (m_send_getaddr_on_connect) send_getaddr();
         m_idle_gate.reset();
         // The idle-progress gate now owns the eviction window. Nothing is pending
         // yet, so it stays disarmed (a synced/idle peer is never evicted); the
@@ -834,12 +901,19 @@ private:
     ADD_P2P_HANDLER(addr)
     {
         if (m_addr_callback && !msg->m_addrs.empty()) {
+            // Fork-mesh filter: a gossiped addr entry carries the advertised
+            // service flags of the peer it describes. Only peers advertising
+            // NODE_BLAKE2B (bit 28) follow the BLAKE2b hard-fork chain, so bank
+            // ONLY those into the addrman — a generic-BTC addr would poison the
+            // fork table with a non-fork peer that the version gate drops anyway.
+            static constexpr uint64_t NODE_BLAKE2B = (uint64_t{1} << 28);
             std::vector<NetService> addrs;
             addrs.reserve(msg->m_addrs.size());
             for (auto& rec : msg->m_addrs) {
+                if (!(rec.m_services & NODE_BLAKE2B)) continue;
                 addrs.push_back(rec.m_endpoint);
             }
-            m_addr_callback(addrs);
+            if (!addrs.empty()) m_addr_callback(addrs);
         }
     }
 


### PR DESCRIPTION
## DO-NOT-MERGE — review pass first

Completes the Bitcoin Core / Knots–style **AddrMan** port in the **bip110** coin-P2P so the NODE_BLAKE2B fork mesh can actually grow, and fixes the empty ADDRESS column in the coin-P2P peers panel. **bip110-isolated** (3 files, no shared-core / web-static / other-coin change).

### Why "Connections 1" on bip110.voidbind

Investigation refuted the prime hypothesis (no seed list): bip110 **already** carries the ported `core::CoinAddrMan` (`BtcCoinPeerManager`) **and** the built-in NODE_BLAKE2B fork-peer seed list (`chain_seeds.hpp` — DNS `x10000009.*` + 7 fixed fork peers). Discovery works: contabo banks 60 addrman / 20 working-set fork peers, 7/7 seeds reachable. The mesh could not grow because three wiring seams were missing:

1. **Manager feedback unwired** — `notify_connected` / `notify_disconnected` / `notify_dial_failed` had zero call sites, so every discovered peer stayed `in_tried:false`, the addrman tried table stayed empty, anchors never formed, scoring/backoff ran blind.
2. **addr/getaddr gossip unwired** — `send_getaddr` / `set_addr_callback` existed but were never called; the addrman only ever learned peers from DNS-seed resolution.
3. **Empty ADDRESS** — the `/broadcaster_status` peers entry carried no `"addr"` key (`dashboard.html` renders `p.addr || '-'` → `–`).

### What this PR does (bip110 lane only)

- **`p2p_node.hpp`** — add `on_peer_connected` / `on_peer_disconnected` / `on_dial_failed` lifecycle callbacks (mirror of the DASH `p2p_client` seam, task #40) and fire them on the dial-result edges: verack (handshake done → `Good()` → tried table), `error()` split into established-drop vs mid-handshake-drop, and a new `connect_failed()` override for pre-socket dial failures (`Attempt()`/backoff). Add `peer_addr()` (live socket endpoint, fall back to dialed target). **Fork-filter** the `addr` handler so only NODE_BLAKE2B (bit 28) gossiped entries are banked (a generic-BTC addr would poison the fork table). Post-handshake `getaddr` crawl gated by a flag.
- **`node.hpp`** — stash the callbacks on the coin node and re-apply them in every `start_p2p` (this lane rebuilds its single `NodeP2P` on each failover dial, so callbacks set once would be lost).
- **`main_bip110.cpp`** — wire the addrman feedback loop to `BtcCoinPeerManager`, enable the getaddr crawl, and emit `"addr"` in the peers entry.

Result: bootstrap seed → getaddr among NODE_BLAKE2B peers → tried/new tables populate via `Good()`/`Attempt()` → persists across restarts (`addrman_BIP110.json` / `peers_BIP110.json` now meaningfully populate `in_tried`). No seed-list change (already correct; `.211` deliberately excluded — LAN-only).

### Scope / classification

- 1-peer verdict: **design gap, not a defect** in discovery. `--coin-p2p-discover` finds the fork fine; the coin arm holds exactly one outbound `NodeP2P` by construction (M1 single-connection SPV follower). This PR completes the addrman wiring so the tried set grows and persists; a **multi-peer outbound mesh** (real `Connections>1`, CConnman analog on `node.hpp`) is a recommended **follow-up PR**, not this one.
- `main_btc.cpp` shares the same empty-ADDRESS omission + unwired gossip/feedback → separate **btc-lane issue** per per-coin isolation (not cross-fixed here).

### Build

`c2pool-bip110` builds clean (EXIT=0) on this branch.

### Files
- `src/impl/bip110/coin/p2p_node.hpp`
- `src/impl/bip110/coin/node.hpp`
- `src/c2pool/main_bip110.cpp`

