### PR TITLE
release.yml: skip sudo-apt system-deps on self-hosted runners (fixes Linux release failure)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,13 +100,19 @@ jobs:
         run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
 
       - name: Install system dependencies
-        if: steps.presence.outputs.exists == '1'
+        # github-hosted ONLY: the c2pool-build self-hosted host has these libs
+        # (and conan, cmake, g++) baked in / persisted from prior runs, exactly
+        # like conan at /usr/local/bin below. Running sudo apt there is both
+        # redundant AND fatal when the runner has no passwordless sudo ("sudo: a
+        # terminal is required to authenticate", run 33596952781) -- so skip apt
+        # on self-hosted entirely and only provision fresh github-hosted VMs.
+        if: steps.presence.outputs.exists == '1' && runner.environment == 'github-hosted'
         # Serialize apt across the concurrent coin package jobs sharing the one
-        # c2pool-build self-hosted host. Without this, the 5 Linux matrix cells
-        # race on /var/lib/apt/lists/lock (and corrupt srcpkgcache.bin), and the
-        # loser fails before the build starts (e.g. LTC on v0.2.0, run
-        # 29148852306). flock on a host-wide lock makes apt atomic; on
-        # github-hosted runners the lock is per-VM and uncontended, so no-op.
+        # host. Without this, the Linux matrix cells race on
+        # /var/lib/apt/lists/lock (and corrupt srcpkgcache.bin), and the loser
+        # fails before the build starts (e.g. LTC on v0.2.0, run 29148852306).
+        # flock on a host-wide lock makes apt atomic; on github-hosted runners
+        # the lock is per-VM and uncontended, so no-op.
         run: |
           exec {lockfd}>/tmp/c2pool-apt.lock
           flock "$lockfd"


### PR DESCRIPTION
## Problem
v0.2.6-alpha release run 33596952781 failed the **btc + dgb Linux** package cells at the *Install system dependencies* step, ~2s after checkout:

```
sudo apt-get update -qq
sudo: a terminal is required to authenticate
##[error]Process completed with exit code 1.
```

The Linux package matrix runs on the **c2pool-build self-hosted host**, which has lost passwordless `sudo`. Not a source/conan issue — no coin source is touched.

## Fix
The self-hosted host already carries `g++ cmake make libleveldb-dev libsecp256k1-dev` (baked in / persisted across runs, exactly like conan at `/usr/local/bin`), so the apt step is **redundant** there. Gate it on `runner.environment == 'github-hosted'` so it only provisions fresh github-hosted fallback VMs and never depends on `sudo` on the self-hosted host.

One-line `if:` guard + comment. No source, no build, no other-coin change. flock/apt logic unchanged for github-hosted.

## Note (separate, pre-existing)
The **dash Windows** cell fails independently on an MSVC portability bug in vendored `dashscript/c2pool_scriptcheck.cpp` (`__attribute__((visibility("default")))` — GCC-ism MSVC rejects). Tracked separately; not addressed here.