### PR TITLE
dashboard: Miners-Block-Value label coin-aware (no MN/treasury framing on Bitcoin-family lanes)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4826,6 +4826,15 @@ nlohmann::json MiningInterface::rest_web_currency_info()
 {
     nlohmann::json result = nlohmann::json::object();
 
+    // Coin capability flag consumed by the dashboard's Miners-Block-Value card.
+    // Only DASH carries protocol lanes deducted from the coinbase before the
+    // miner split (masternode payment + platform/treasury DIP-0027 burn); the
+    // card must NOT claim MN/treasury deductions on a Bitcoin-family coin
+    // (BTC/LTC/DOGE/DGB/BCH/NMC/BIP110), whose block value IS the plain coinbase
+    // subsidy. Default false here; the DASH case flips it true. This is the
+    // authority — the front-end falls back to sym==='DASH' only if it is absent.
+    result["has_treasury"] = false;
+
     // Label-keyed coins that share a Blockchain enum value with another chain
     // resolve their identity from the configured coin label, NOT the enum:
     //   - BCH runs on Blockchain::BITCOIN + set_coin_label("BCH") (it has no
@@ -4943,6 +4952,7 @@ nlohmann::json MiningInterface::rest_web_currency_info()
     case Blockchain::DASH:
         result["symbol"] = "DASH";
         result["name"] = "Dash";
+        result["has_treasury"] = true;  // MN payment + platform/treasury (DIP-0027) lanes
         result["block_period"] = 150;  // 2.5 min average
         if (!m_custom_address_explorer.empty()) {
             result["address_explorer_url_prefix"] = m_custom_address_explorer;

--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -1892,10 +1892,10 @@
                 
                 <!-- Second Row: Miners Block Value -->
                 <div class="stat-card">
-                    <h3><span class="icon">💰</span> Miners Block Value <small style="opacity:0.7;">(after MN + treasury; before pool fee)</small></h3>
+                    <h3><span class="icon">💰</span> Miners Block Value <small id="block_value_subtitle" style="opacity:0.7;">(after MN + treasury; before pool fee)</small></h3>
                     <div class="stat-value warning"><span id="block_value_miner">-</span> <small class="symbol-small" id="block_value_symbol">-</small></div>
                     <div class="stat-sub merged-child-hint" style="color: #c3a634; font-size: 1.1em; margin-top: -4px;">+<span id="merged_block_value">-</span> <span class="merged-child-symbol-hint">DOGE</span></div>
-                    <div class="stat-detail" style="white-space: nowrap;" title="This card headline is the MINERS' share of the block — the DASH subsidy AFTER the masternode payment and the platform/treasury lane (DIP-0027 burn) are deducted. It is chain-truth: a deterministic function of the block HEIGHT, identical on every node, the same split embedded_gbt.hpp uses to build accepted coinbases. 'Gross'/'pre-fee' here means before the POOL fee only; the pool fee is then subtracted to give the NET amount the API reports as block_value_miner.">Fee: <span id="block_value_fee">-</span> &rarr; net <span id="block_value_miner_net">-</span></div>
+                    <div class="stat-detail" id="block_value_headline_hint" style="white-space: nowrap;" title="This card headline is the MINERS' share of the block — the DASH subsidy AFTER the masternode payment and the platform/treasury lane (DIP-0027 burn) are deducted. It is chain-truth: a deterministic function of the block HEIGHT, identical on every node, the same split embedded_gbt.hpp uses to build accepted coinbases. 'Gross'/'pre-fee' here means before the POOL fee only; the pool fee is then subtracted to give the NET amount the API reports as block_value_miner.">Fee: <span id="block_value_fee">-</span> &rarr; net <span id="block_value_miner_net">-</span></div>
                     <!-- #block_value and #block_value_payments were both written
                          by renderLocalStats but had NO elements in this page. The
                          card showed the miner slice with nothing to compare it
@@ -3044,6 +3044,27 @@
             window.currency_info = currency_info;
             var sym = (info && info.symbol) || 'COIN';
             var chainName = (info && info.name) || sym;
+
+            // Coin capability: only DASH (among LTC/BTC/DOGE/DASH/DGB/BCH/NMC/
+            // BIP110) carries protocol lanes — a masternode payment plus the
+            // platform/treasury lane (DIP-0027 burn) — deducted from the
+            // coinbase before the miner split. Bitcoin-family coins have
+            // neither: the block value IS the plain coinbase subsidy. Prefer a
+            // server-declared flag if present, else derive from the symbol so
+            // the Miners-Block-Value card labels one source in one branch and
+            // never claims MN/treasury deductions on a Bitcoin-family lane.
+            var hasTreasury = (currency_info.has_treasury === true)
+                           || (currency_info.has_treasury == null && sym === 'DASH');
+            if (hasTreasury) {
+                d3.select('#block_value_subtitle').text('(after MN + treasury; before pool fee)');
+                d3.select('#block_value_headline_hint').attr('title',
+                    "This card headline is the MINERS' share of the block — the DASH subsidy AFTER the masternode payment and the platform/treasury lane (DIP-0027 burn) are deducted. It is chain-truth: a deterministic function of the block HEIGHT, identical on every node, the same split embedded_gbt.hpp uses to build accepted coinbases. 'Gross'/'pre-fee' here means before the POOL fee only; the pool fee is then subtracted to give the NET amount the API reports as block_value_miner.");
+            } else {
+                d3.select('#block_value_subtitle').text('(block subsidy; before pool fee)');
+                d3.select('#block_value_headline_hint').attr('title',
+                    "This card headline is the MINERS' gross block subsidy — the plain coinbase reward for the block being worked on (e.g. the post-halving BTC-family subsidy). It is chain-truth: a deterministic function of the block HEIGHT, identical on every node. This coin has no masternode or treasury lane, so nothing is deducted before the miner split. 'Gross'/'pre-fee' means before the POOL fee only; the pool fee is then subtracted to give the NET amount the API reports as block_value_miner.");
+            }
+
             d3.selectAll('.symbol-small').text(sym);
             d3.select('#currency-symbol').text(sym);
             d3.selectAll('.parent-symbol-hint').text(sym + '_ADDR');


### PR DESCRIPTION
## Problem

The **Miners Block Value** card in the COIN-GENERIC dashboard hardcoded DASH-specific framing:

- subtitle: `(after MN + treasury; before pool fee)`
- tooltip: *"…the DASH subsidy AFTER the masternode payment and the platform/treasury lane (DIP-0027 burn) are deducted…"*

That is correct for **DASH**, but wrong on **every Bitcoin-family lane** (BTC / LTC / DOGE / DGB / BCH / NMC / **BIP110**), which have **no masternodes and no treasury** — their block value IS the plain coinbase subsidy (e.g. 3.125 BIP110 = post-halving BTC subsidy). The card is coin-generic, so it mislabelled the value on all non-DASH coins. Operator caught it on `bip110.voidbind.com`; the defect is coin-generic. Credibility/correctness bug.

## Fix

Drive the subtitle + tooltip from a single **coin-capability flag**, not scattered per-coin literals:

- **`src/core/web_server.cpp`** `rest_web_currency_info()` now emits `has_treasury` — `true` only for DASH, `false` for every other coin — as the authority.
- **`web-static/dashboard.html`** resolves `has_treasury` from `currency_info` at the existing coin-detection site (the `../web/currency_info` callback) and branches the label **once**:
  - **DASH** keeps the exact MN+treasury subtitle and tooltip, **byte-identical** to before.
  - **Bitcoin-family** gets `(block subsidy; before pool fee)` + a matching generic tooltip (miners' gross block subsidy, chain-truth from block height, before the POOL fee only — **no** MN/treasury claim).
- Front-end falls back to `sym === 'DASH'` only if the flag is absent (older binary), so it is correct even before the backend rebuilds.

## Which coin shows which label

| Coin | subtitle | MN/treasury claimed? |
|---|---|---|
| DASH | `(after MN + treasury; before pool fee)` | yes (unchanged) |
| BTC / LTC / DOGE / DGB / BCH / NMC / BIP110 | `(block subsidy; before pool fee)` | no |

## Safety

- **Label / tooltip text only.** No numeric or chain-truth value changes — the figures still come from `renderLocalStats` / `local_stats` and the protocol split, untouched. DASH block-value split (`#block_value_payments_part` / superblock) is not touched.
- DASH wording preserved **byte-identical** (verified programmatically).
- Coin-generic **shared** dashboard — this is the correct file to edit (not per-coin isolation). The dashboard is not embedded in the binary; it is staged next to each binary at build time (`copy_directory web-static`), so no bundled copy to sync (the small `dashboard-embed.html`/`dashboard-bundled.html` shells do not contain this card).
- **Live only after each coin binary rebuilds + redeploys** — the dashboard is version-coupled to its binary. Benefits all Bitcoin-family lanes.

**DRAFT + do-not-merge** — operator reviews / it rides the next deploy.
