### PR TITLE
bip110 M3: flag-ON found-block witness reconcile (block validity / money) [DRAFT, do-not-merge, folds on M3 stack]

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -389,6 +389,14 @@ target_link_libraries(c2pool-dash
 add_executable(c2pool-bip110
     main_bip110.cpp
     ${CMAKE_SOURCE_DIR}/src/impl/bip110/stratum/work_source.cpp
+    # M3 sharechain MINT lane (behind --bip110-sharechain; default OFF): the
+    # namespace-copied sharechain node + single-protocol v36-genesis bridge +
+    # c2pool protocol handler. main_bip110 references bip110::pool::Node (ctor,
+    # listen, broadcast_share, notify_local_share, register_template_txs,
+    # start_outbound_connections) which are DEFINED in these TUs — same set the
+    # bip110_pool_node_compile KAT links. Dormant unless the flag is passed.
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/pool/node.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/pool/protocol_actual.cpp
     ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
 )
 c2pool_wire_version(c2pool-bip110)
@@ -410,6 +418,8 @@ target_link_libraries(c2pool-bip110
     yaml-cpp::yaml-cpp
     nlohmann_json::nlohmann_json
     ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
 )
 
 # Dashboard assets: the shared coin-generic WebServer serves the web-static/

--- a/src/c2pool/main_bip110.cpp
+++ b/src/c2pool/main_bip110.cpp
@@ -555,11 +555,13 @@ int run_embedded(bool coin_p2p_discover,
         //   • share_version = desired_version = 36 (no AutoRatchet — v36 always)
         //   • donation u16 = 66 (WIRE-GENESIS freeze, 0.1%; NOT btc's 50)
         //   • no merged mining (merged_addresses / merged_coinbase_info empty)
-        //   • segwit_data = SegwitDataDefault::get() none-sentinel (2^256-1 root):
-        //     coinbase-only templates carry no witness_commitment_hex into the mint,
-        //     so create_local_share stores the sentinel SegwitData — the ref MUST
-        //     serialize the SAME sentinel (has_segwit=true path) or the ref_hash
-        //     diverges (has_segwit=false would write a ZERO root, not the sentinel).
+        //   • segwit_data = a REAL SegwitData with the coinbase-only witness merkle
+        //     root ZERO (merkle([0]), python v36 data.py:1090) — NOT the 0xff None-
+        //     sentinel. create_local_share stores this same ZERO root for a segwit-
+        //     active coinbase-only share, so the ref MUST serialize ZERO too
+        //     (has_segwit=true path) or the ref_hash diverges. This is also what the
+        //     found-block coinbase witness commitment is computed over, so a won
+        //     block passes segwit's witness-commitment consensus check.
         //   • timestamp clipped to prev->m_timestamp+1 BEFORE compute_share_target,
         //     matching create_local_share's ordering (share_check.hpp:2256-2269) so
         //     the (bits,max_bits) the ref commits equal what peers derive.
@@ -611,11 +613,19 @@ int run_embedded(bool coin_p2p_discover,
                     }
                 }
 
-                // Segwit sentinel (coinbase-only): match create_local_share's
-                // SegwitDataDefault (empty branch + 2^256-1 wtxid root). MUST be the
-                // has_segwit=TRUE path so the sentinel — not a zero root — is written.
+                // Segwit (coinbase-only): match create_local_share's segwit-active
+                // coinbase-only SegwitData — empty txid_merkle_link branch + the REAL
+                // witness merkle root ZERO (merkle([0]), python v36 data.py:1090), NOT
+                // the 0xff None-sentinel. MUST be the has_segwit=TRUE path so this
+                // exact root is serialized into the ref_hash. The found-block coinbase
+                // witness commitment is computed over this same ZERO root, so a won
+                // block passes segwit's witness-commitment consensus check.
                 p.has_segwit  = true;
-                p.segwit_data = bip110::pool::SegwitDataDefault::get();
+                {
+                    bip110::pool::SegwitData sd = bip110::pool::SegwitDataDefault::get();
+                    sd.m_wtxid_merkle_root = uint256::ZERO;   // coinbase-only real root
+                    p.segwit_data = sd;
+                }
 
                 // Genesis / tracker-busy fallbacks (ref_hash won't match a live tip,
                 // but that IS the right answer pre-bootstrap / when prev unknown).

--- a/src/c2pool/main_bip110.cpp
+++ b/src/c2pool/main_bip110.cpp
@@ -426,12 +426,13 @@ int run_embedded(bool coin_p2p_discover,
 
                 uint256 share_hash;
                 try {
-                    // NOTE (PR-C gap): bip110 M2 build_connection_coinbase does not
-                    // yet freeze the sharechain ref fields into JobSnapshot
-                    // (frozen_ref/prev_share_hash are default), so has_frozen=false
-                    // — create_local_share derives absheight/abswork/target from the
-                    // tracker. The abswork %2^64 wrap (NIT-2) is already applied at
-                    // all three sites inside create_local_share.
+                    // PR-C: build_connection_coinbase now FREEZES the sharechain ref
+                    // fields into JobSnapshot.frozen_ref (populated by ref_hash_fn)
+                    // and stamps job.prev_share_hash from best_share_hash_fn, so
+                    // has_frozen=TRUE — create_local_share reproduces the EXACT
+                    // ref_hash the coinbase committed (extend-off-real-tip), instead
+                    // of re-deriving from the tracker and taking the genesis branch.
+                    // The abswork %2^64 wrap (NIT-2) is applied inside create_local_share.
                     share_hash = bip110::pool::create_local_share(
                         node_raw->tracker(),
                         full_hdr,
@@ -455,7 +456,7 @@ int run_embedded(bool coin_p2p_discover,
                         /* frozen_far_share_hash */ job.frozen_ref.far_share_hash,
                         /* frozen_timestamp */      job.frozen_ref.timestamp,
                         /* frozen_merged_payout */  job.frozen_ref.merged_payout_hash,
-                        /* has_frozen */            false,
+                        /* has_frozen */            true,
                         /* frozen_merkle_branches*/ job.frozen_ref.frozen_merkle_branches,
                         /* frozen_witness_root */   job.frozen_ref.frozen_witness_root,
                         /* frozen_merged_cb_info */ job.frozen_ref.frozen_merged_coinbase_info,
@@ -487,6 +488,217 @@ int run_embedded(bool coin_p2p_discover,
                 }
                 return share_hash;
             });
+
+        // (6b) M3 PR-C: the coinbase's donation output (p2pool-canonical SECOND-
+        // TO-LAST, immediately before the OP_RETURN ref) MUST carry the canonical
+        // p2pool donation script — compute_gentx_before_refhash(36) (share_check.hpp)
+        // hardcodes it as the hash_link const-ending, so a peer reconstructing the
+        // gentx from the share's hash_link re-supplies exactly those bytes. Any
+        // other donation script (e.g. the operator node-owner address set at M2
+        // startup) makes the peer's reconstruction diverge -> the share is rejected.
+        // Mirrors main_btc.cpp:1829 (set_donation_script(PoolConfig::get_donation_
+        // script(ver))). Overrides the M2 node-owner donation ONLY on the flag-ON
+        // path; the OFF path keeps the operator address (byte-identical M2).
+        work_source->set_donation_script(bip110::pool::PoolConfig::get_donation_script(36));
+        LOG_INFO << "[EMB-BIP110] M3 PR-C donation output -> canonical p2pool script "
+                    "(hash_link const-ending parity; overrides M2 node-owner donation)";
+
+        // (7) M3 PR-C: feed the sharechain tip into JobSnapshot.prev_share_hash.
+        // The generic stratum_server seam (stratum_server.cpp:1607) calls this to
+        // freeze the tip ONCE per job and stores it on the job (:1807) — the SAME
+        // value build_connection_coinbase's ref walk uses. Cold start / empty chain
+        // => uint256::ZERO, and the ref walk then takes the genesis branch (correct
+        // pre-bootstrap). Mirrors main_btc.cpp:1812-1816.
+        work_source->set_best_share_hash_fn(
+            [node_raw]() -> uint256 {
+                if (!node_raw) return uint256::ZERO;
+                return node_raw->best_share_hash();
+            });
+
+        // (8) M3 PR-C: the coinbase ref-commitment producer. Walks the share
+        // tracker off prev_share_hash for the deterministic chain-position fields
+        // (absheight/abswork/far_share_hash) + the share target (compute_share_
+        // target), then computes the p2pool ref_hash via the lane SSOT
+        // bip110::pool::compute_ref_hash_for_work. build_connection_coinbase embeds
+        // the returned ref_hash in the coinbase OP_RETURN and freezes these fields
+        // into JobSnapshot.frozen_ref; create_local_share (has_frozen=TRUE) then
+        // reproduces the EXACT ref_hash, so the commitment the coinbase carries ==
+        // what a peer recomputes off the minted share (mint==verify, peers accept).
+        //
+        // Near-verbatim port of main_btc.cpp:1869-2125 with the bip110 v36 deltas:
+        //   • share_version = desired_version = 36 (no AutoRatchet — v36 always)
+        //   • donation u16 = 66 (WIRE-GENESIS freeze, 0.1%; NOT btc's 50)
+        //   • no merged mining (merged_addresses / merged_coinbase_info empty)
+        //   • segwit_data = SegwitDataDefault::get() none-sentinel (2^256-1 root):
+        //     coinbase-only templates carry no witness_commitment_hex into the mint,
+        //     so create_local_share stores the sentinel SegwitData — the ref MUST
+        //     serialize the SAME sentinel (has_segwit=true path) or the ref_hash
+        //     diverges (has_segwit=false would write a ZERO root, not the sentinel).
+        //   • timestamp clipped to prev->m_timestamp+1 BEFORE compute_share_target,
+        //     matching create_local_share's ordering (share_check.hpp:2256-2269) so
+        //     the (bits,max_bits) the ref commits equal what peers derive.
+        work_source->set_ref_hash_fn(
+            [node_raw](const uint256& prev_share_hash,
+                       const std::vector<unsigned char>& scriptSig,
+                       const std::vector<unsigned char>& payout_script,
+                       uint64_t subsidy, uint32_t block_bits, uint32_t timestamp)
+            -> core::stratum::RefHashResult
+            {
+                core::stratum::RefHashResult result;
+                result.share_version   = 36;
+                result.desired_version = 36;
+                result.timestamp       = timestamp;   // overwritten below if clipped
+
+                bip110::pool::RefHashParams p;
+                p.share_version   = 36;
+                p.desired_version = 36;
+                p.prev_share      = prev_share_hash;
+                p.coinbase_scriptSig = scriptSig;
+                p.share_nonce     = 0;                // share commitment nonce (== m_nonce)
+                p.subsidy         = subsidy;          // BLOCK subsidy (== job.subsidy)
+                p.donation        = 66;               // WIRE-GENESIS freeze (0.1%)
+                p.stale_info      = 0;
+                p.timestamp       = timestamp;
+
+                // Pubkey extract — MUST mirror create_local_share (share_check.hpp:
+                // 2296-2316) so the payout identity the ref commits == the minted
+                // share's. P2PKH(25)/P2SH(23)/P2WPKH(22).
+                if (payout_script.size() >= 20) {
+                    if (payout_script.size() == 25 &&
+                        payout_script[0] == 0x76 && payout_script[1] == 0xa9 &&
+                        payout_script[2] == 0x14 && payout_script[23] == 0x88 &&
+                        payout_script[24] == 0xac) {
+                        std::memcpy(p.pubkey_hash.data(), payout_script.data() + 3, 20);
+                        p.pubkey_type = 0;
+                    } else if (payout_script.size() == 23 &&
+                               payout_script[0] == 0xa9 && payout_script[1] == 0x14 &&
+                               payout_script[22] == 0x87) {
+                        std::memcpy(p.pubkey_hash.data(), payout_script.data() + 2, 20);
+                        p.pubkey_type = 2;
+                    } else if (payout_script.size() == 22 &&
+                               payout_script[0] == 0x00 && payout_script[1] == 0x14) {
+                        std::memcpy(p.pubkey_hash.data(), payout_script.data() + 2, 20);
+                        p.pubkey_type = 1;
+                    } else {
+                        std::memcpy(p.pubkey_hash.data(), payout_script.data(), 20);
+                        p.pubkey_type = 0;
+                    }
+                }
+
+                // Segwit sentinel (coinbase-only): match create_local_share's
+                // SegwitDataDefault (empty branch + 2^256-1 wtxid root). MUST be the
+                // has_segwit=TRUE path so the sentinel — not a zero root — is written.
+                p.has_segwit  = true;
+                p.segwit_data = bip110::pool::SegwitDataDefault::get();
+
+                // Genesis / tracker-busy fallbacks (ref_hash won't match a live tip,
+                // but that IS the right answer pre-bootstrap / when prev unknown).
+                auto set_genesis = [&] {
+                    p.absheight = 1;
+                    p.far_share_hash = uint256::ZERO;
+                    p.abswork = uint128(chain::target_to_average_attempts(
+                        chain::bits_to_target(p.bits)).GetLow64());
+                };
+                auto set_block_bits_fallback = [&] {
+                    p.bits = block_bits; p.max_bits = block_bits;
+                    result.bits = block_bits; result.max_bits = block_bits;
+                };
+
+                if (node_raw) {
+                    auto guard = node_raw->read_tracker();
+                    if (guard) {
+                        auto& tracker = *guard;
+                        // Step 1: clip timestamp + absheight + far_share_hash off prev
+                        // (BEFORE compute_share_target — share_check.hpp ordering).
+                        if (!prev_share_hash.IsNull() && tracker.chain.contains(prev_share_hash)) {
+                            tracker.chain.get(prev_share_hash).share.invoke([&](auto* prev) {
+                                p.absheight = prev->m_absheight + 1;
+                                if (p.timestamp <= prev->m_timestamp)
+                                    p.timestamp = prev->m_timestamp + 1;
+                            });
+                            auto [prev_height, _last] =
+                                tracker.chain.get_height_and_last(prev_share_hash);
+                            if (prev_height >= 99) {
+                                try {
+                                    p.far_share_hash =
+                                        tracker.chain.get_nth_parent_key(prev_share_hash, 99);
+                                } catch (const std::exception&) {
+                                    p.far_share_hash = uint256::ZERO;
+                                }
+                            } else {
+                                p.far_share_hash = uint256::ZERO;
+                            }
+                            // Step 2: share_target with the CLIPPED timestamp.
+                            try {
+                                auto st = tracker.compute_share_target(
+                                    prev_share_hash, p.timestamp,
+                                    chain::bits_to_target(block_bits));
+                                p.bits = st.bits; p.max_bits = st.max_bits;
+                                result.bits = st.bits; result.max_bits = st.max_bits;
+                            } catch (const std::exception&) {
+                                set_block_bits_fallback();
+                            }
+                            // Step 3: abswork = prev_abswork + aps(this-share-bits).
+                            tracker.chain.get(prev_share_hash).share.invoke([&](auto* prev) {
+                                auto attempts = chain::target_to_average_attempts(
+                                    chain::bits_to_target(p.bits));
+                                p.abswork = uint128(
+                                    (prev->m_abswork + uint128(attempts.GetLow64())).GetLow64());
+                            });
+                            // Step 4: merged_payout_hash — computed on THIS guard (no
+                            // re-lock). Verify recomputes with the BLOCK target
+                            // (share.m_min_header.m_bits), so use block_bits here.
+                            try {
+                                p.merged_payout_hash = tracker.compute_merged_payout_hash(
+                                    prev_share_hash, chain::bits_to_target(block_bits));
+                            } catch (const std::exception&) {
+                                p.merged_payout_hash = uint256();
+                            }
+                        } else {
+                            // prev unknown / genesis: derive share_target off null prev
+                            // (compute_share_target returns the floor), then genesis.
+                            try {
+                                auto st = tracker.compute_share_target(
+                                    prev_share_hash, p.timestamp,
+                                    chain::bits_to_target(block_bits));
+                                p.bits = st.bits; p.max_bits = st.max_bits;
+                                result.bits = st.bits; result.max_bits = st.max_bits;
+                            } catch (const std::exception&) {
+                                set_block_bits_fallback();
+                            }
+                            set_genesis();
+                        }
+                    } else {
+                        // Tracker busy — fallback (ref_hash won't match peers).
+                        set_block_bits_fallback();
+                        set_genesis();
+                    }
+                } else {
+                    set_block_bits_fallback();
+                    set_genesis();
+                }
+
+                // Mirror the walked values into the result for snap.frozen_ref.
+                result.absheight      = p.absheight;
+                result.abswork        = p.abswork;
+                result.far_share_hash = p.far_share_hash;
+                result.timestamp      = p.timestamp;
+                result.merged_payout_hash = p.merged_payout_hash;
+
+                try {
+                    auto [rh, nn] = bip110::pool::compute_ref_hash_for_work(p);
+                    result.ref_hash         = rh;
+                    result.last_txout_nonce = nn;
+                } catch (const std::exception& e) {
+                    LOG_WARNING << "[BIP110-STRATUM] compute_ref_hash_for_work threw: "
+                                << e.what();
+                    // result.ref_hash stays null -> build_connection_coinbase refuses.
+                }
+                return result;
+            });
+
+        LOG_INFO << "[EMB-BIP110] M3 PR-C ref-commitment wired (best_share + ref_hash;"
+                    " coinbase carries the v36 ref_hash, mint has_frozen=TRUE)";
 
         // (6) IRREVERSIBLE first-outbound to the fresh federation sharechain.
         // Stays INSIDE the flag-ON block so it never runs by default.

--- a/src/c2pool/main_bip110.cpp
+++ b/src/c2pool/main_bip110.cpp
@@ -26,6 +26,11 @@
 #include <impl/bip110/coin/utxo_reorg.hpp>         // GAP4 reorg-blindness fix
 #include <impl/bip110/stratum/work_source.hpp>
 
+// ── M3 sharechain MINT lane (behind --bip110-sharechain; default OFF) ────────
+#include <impl/bip110/pool/node.hpp>               // bip110::pool::Node / Config
+#include <impl/bip110/pool/config_pool.hpp>        // PoolConfig SSOT (P2P_PORT 9337, STALE_SHARES)
+#include <impl/bip110/pool/share_check.hpp>        // bip110::pool::create_local_share (MINT)
+
 #include <core/coin/utxo_view_db.hpp>              // M3 own-UTXO view (T2 pricing)
 #include <core/coin/utxo_view_cache.hpp>
 #include <core/pack.hpp>
@@ -100,7 +105,12 @@ void print_banner(const char* argv0)
         "  --http [HOST:]PORT   serve the shared coin-generic dashboard (HTML at\n"
         "                       \"/\", JSON /node_info for health probes)\n"
         "  --node-owner-address ADDR  subsidy fallback / donation payout when a\n"
-        "                       miner has no resolvable payout address (base58/bech32)\n\n"
+        "                       miner has no resolvable payout address (base58/bech32)\n"
+        "  --bip110-sharechain  ARM the M3 v36 sharechain MINT (DEFAULT OFF): start\n"
+        "                       the sharechain node on :9337, mint local shares, and\n"
+        "                       dial the fresh federation sharechain. IRREVERSIBLE\n"
+        "                       first-outbound — gated by the operator wire-genesis\n"
+        "                       params-freeze checkpoint. Absent => M2 header-follower.\n\n"
         "PoW: BLAKE2b commitment pipeline (bip110::pow); block hash == PoW hash.\n"
         "Fork: Blake2bHeight=%u; RDTS weight cap=%u WU; network==Bitcoin mainnet\n"
         "      (magic f9beb4d9, default port %u).\n",
@@ -178,7 +188,8 @@ int run_embedded(bool coin_p2p_discover,
                  const std::string& donation_address,
                  double give_author_pct,
                  double node_owner_fee_pct,
-                 bool serve_mempool_txs)
+                 bool serve_mempool_txs,
+                 bool sharechain_enabled)
 {
     core::log::Logger::init();
 
@@ -311,6 +322,184 @@ int run_embedded(bool coin_p2p_discover,
              << give_author_ppm << " ppm) node-owner-fee=" << node_owner_fee_pct << "% ("
              << node_owner_fee_ppm << " ppm) — integer floor split, miner absorbs remainder"
              << (node_owner_fee_ppm > 0 ? "; owner+donation consolidated (single key)" : "");
+
+    // ── M3 SHARECHAIN MINT (behind --bip110-sharechain; DEFAULT OFF) ─────────
+    // With the flag OFF this block is skipped ENTIRELY: no bip110::pool::Node is
+    // constructed, no :9337 listen, set_create_share_fn is never called (so
+    // work_source's create_share_fn_ stays null and mining_submit's share arm is
+    // a no-op — byte-identical to the M2 header-follower), and the IRREVERSIBLE
+    // first-outbound to the fresh federation sharechain never runs. The C++ v36
+    // wiring precedent is main_btc.cpp (node ctor + set_create_share_fn +
+    // start_outbound_connections). Lifetime: sharechain_cfg + sharechain_node are
+    // declared at run_embedded scope so they outlive work_source, the stratum
+    // server, and ioc.run() (the lambda captures the raw node pointer; the
+    // io_context drives its peers). WIRE-GENESIS FREEZE: params live in
+    // params.hpp / config_pool.hpp (9337 / 8640 / SPREAD 3 / proto 3600 /
+    // donation u16 66) — DO NOT change them here and DO NOT default the flag ON;
+    // the operator performs the explicit params-freeze checkpoint before enabling
+    // it in production.
+    std::unique_ptr<bip110::pool::Config> sharechain_cfg;
+    std::unique_ptr<bip110::pool::Node>   sharechain_node;
+    if (sharechain_enabled) {
+        sharechain_cfg  = std::make_unique<bip110::pool::Config>();          // (1) lifetime >= node
+        sharechain_node = std::make_unique<bip110::pool::Node>(&ioc, sharechain_cfg.get());
+        auto* node_raw  = sharechain_node.get();
+
+        node_raw->set_target_outbound_peers(
+            explicit_peers.empty() ? 4 : std::max<size_t>(1, explicit_peers.size()));
+        node_raw->set_seed_escalation_enabled(false);                        // (4) federation/fresh — fail-safe
+        node_raw->core::Server::listen(bip110::pool::PoolConfig::P2P_PORT);   // 9337
+
+        // (2) MINT on the stratum submit path. Mirrors main_btc.cpp:2215-2411,
+        // adapted to bip110 (164B v2 header; BLAKE2b compute_share_hash inside
+        // create_local_share). Drops the EXCLUSIVE tracker lock BEFORE broadcast.
+        work_source->set_create_share_fn(
+            [node_raw](const std::vector<unsigned char>& full_coinbase,
+                       const std::vector<unsigned char>& header_164b,
+                       const core::stratum::JobSnapshot&  job,
+                       const std::vector<unsigned char>& payout_script) -> uint256
+            {
+                if (!node_raw || header_164b.size() != 164) return uint256::ZERO;
+
+                // Parse the 164B v2 header into a full coin::BlockHeaderType.
+                bip110::coin::BlockHeaderType full_hdr;
+                try {
+                    PackStream ps(std::vector<std::byte>(
+                        reinterpret_cast<const std::byte*>(header_164b.data()),
+                        reinterpret_cast<const std::byte*>(header_164b.data()) + 164));
+                    ps >> full_hdr;
+                } catch (const std::exception& e) {
+                    LOG_WARNING << "[BIP110-CREATE-SHARE] header parse failed: " << e.what();
+                    return uint256::ZERO;
+                }
+
+                // Coinbase scriptSig (share.m_coinbase is the scriptSig, 2..100B).
+                BaseScript coinbase_bs(
+                    bip110::stratum::extract_coinbase_scriptsig(full_coinbase));
+
+                // Stratum merkle branches: hex of LE-internal bytes (ParseHex+memcpy,
+                // NOT SetHex — SetHex would reverse and break the miner's root).
+                std::vector<uint256> merkle_branches;
+                merkle_branches.reserve(job.merkle_branches.size());
+                for (const auto& bhex : job.merkle_branches) {
+                    uint256 b;
+                    auto bb = ParseHex(bhex);
+                    if (bb.size() == 32) std::memcpy(b.begin(), bb.data(), 32);
+                    merkle_branches.push_back(b);
+                }
+
+                // EXCLUSIVE tracker lock (try, non-blocking) — decline if the
+                // compute thread is mid-think, exactly like btc.
+                std::unique_lock<std::shared_mutex> lk(
+                    node_raw->tracker_mutex(), std::try_to_lock);
+                if (!lk.owns_lock()) {
+                    LOG_INFO << "[BIP110-CREATE-SHARE] tracker busy — share deferred";
+                    return uint256::ZERO;
+                }
+
+                // (5) Caller-side mint-freshness gate — PoolConfig::STALE_SHARES
+                // (=30). Refuse to extend a stale verified tip (a private low-diff
+                // fork peers would reject). Genesis / unknown prev is exempt so the
+                // first shares can still form. BTC C1 precedent (main_btc.cpp:2287).
+                {
+                    auto& tk = node_raw->tracker();
+                    int32_t raw_h = -1;
+                    for (const auto& [hh, th] : tk.chain.get_heads()) {
+                        (void)th;
+                        auto h = tk.chain.get_height(hh);
+                        if (h > raw_h) raw_h = h;
+                    }
+                    int32_t v_h = (!job.prev_share_hash.IsNull()
+                                   && tk.chain.contains(job.prev_share_hash))
+                        ? tk.chain.get_height(job.prev_share_hash) : -1;
+                    if (raw_h >= 0 && v_h >= 0 &&
+                        (raw_h - v_h) > (int32_t)bip110::pool::PoolConfig::STALE_SHARES) {
+                        static int stale_log = 0;
+                        if (stale_log++ % 20 == 0)
+                            LOG_WARNING << "[BIP110-CREATE-SHARE] refused: verified tip stale"
+                                        << " (v_h=" << v_h << " raw_h=" << raw_h
+                                        << " gap=" << (raw_h - v_h) << " > "
+                                        << bip110::pool::PoolConfig::STALE_SHARES << ")";
+                        return uint256::ZERO;
+                    }
+                }
+
+                uint256 share_hash;
+                try {
+                    // NOTE (PR-C gap): bip110 M2 build_connection_coinbase does not
+                    // yet freeze the sharechain ref fields into JobSnapshot
+                    // (frozen_ref/prev_share_hash are default), so has_frozen=false
+                    // — create_local_share derives absheight/abswork/target from the
+                    // tracker. The abswork %2^64 wrap (NIT-2) is already applied at
+                    // all three sites inside create_local_share.
+                    share_hash = bip110::pool::create_local_share(
+                        node_raw->tracker(),
+                        full_hdr,
+                        coinbase_bs,
+                        /* subsidy */               job.subsidy,
+                        /* prev_share */            job.prev_share_hash,
+                        merkle_branches,
+                        payout_script,
+                        /* donation */              66,   // WIRE-GENESIS FREEZE (0.1%)
+                        /* merged_addrs */          {},   // no merged mining on bip110
+                        /* stale_info */            bip110::pool::StaleInfo::none,
+                        /* segwit_active */         job.segwit_active,
+                        /* witness_commitment */    job.witness_commitment_hex,
+                        /* message_data */          {},
+                        /* actual_coinbase_bytes */ full_coinbase,
+                        /* witness_root */          job.witness_root,
+                        /* override_max_bits */     job.frozen_ref.max_bits,
+                        /* override_bits */         job.frozen_ref.bits,
+                        /* frozen_absheight */      job.frozen_ref.absheight,
+                        /* frozen_abswork */        job.frozen_ref.abswork,
+                        /* frozen_far_share_hash */ job.frozen_ref.far_share_hash,
+                        /* frozen_timestamp */      job.frozen_ref.timestamp,
+                        /* frozen_merged_payout */  job.frozen_ref.merged_payout_hash,
+                        /* has_frozen */            false,
+                        /* frozen_merkle_branches*/ job.frozen_ref.frozen_merkle_branches,
+                        /* frozen_witness_root */   job.frozen_ref.frozen_witness_root,
+                        /* frozen_merged_cb_info */ job.frozen_ref.frozen_merged_coinbase_info,
+                        /* share_version */         36,
+                        /* desired_version */       36);
+                } catch (const std::exception& e) {
+                    LOG_WARNING << "[BIP110-CREATE-SHARE] threw: " << e.what();
+                    return uint256::ZERO;
+                }
+
+                // Drop the EXCLUSIVE lock BEFORE broadcast (lock-discipline
+                // invariant — a held-lock broadcast is the serve-dead/deadlock
+                // class; broadcast_share/notify_local_share take their own locks).
+                lk.unlock();
+
+                if (!share_hash.IsNull()) {
+                    // (3) F3: hand the template tx set to the node BEFORE broadcast
+                    // so the share is backable ([{"data": <raw-tx-hex>}, ...]).
+                    nlohmann::json tmpl_txs = nlohmann::json::array();
+                    if (job.tx_data)
+                        for (const auto& tx_hex : *job.tx_data)
+                            tmpl_txs.push_back(nlohmann::json::object({{"data", tx_hex}}));
+                    node_raw->register_template_txs(share_hash, tmpl_txs);
+
+                    node_raw->broadcast_share(share_hash);
+                    node_raw->notify_local_share(share_hash);
+                    LOG_INFO << "[BIP110-CREATE-SHARE] OK + broadcast: hash="
+                             << share_hash.GetHex().substr(0, 16);
+                }
+                return share_hash;
+            });
+
+        // (6) IRREVERSIBLE first-outbound to the fresh federation sharechain.
+        // Stays INSIDE the flag-ON block so it never runs by default.
+        node_raw->start_outbound_connections();
+        LOG_INFO << "[EMB-BIP110] M3 sharechain MINT wired + node LIVE on :"
+                 << bip110::pool::PoolConfig::P2P_PORT
+                 << " (--bip110-sharechain; prefix=" << bip110::pool::PoolConfig::prefix_hex()
+                 << " proto=" << bip110::pool::PoolConfig::ADVERTISED_PROTOCOL_VERSION
+                 << " share=v36) — outbound dialing started";
+    } else {
+        LOG_INFO << "[EMB-BIP110] M3 sharechain DISABLED (M2 header-follower; pass "
+                    "--bip110-sharechain to arm the mint) — nothing minted, no sharechain node";
+    }
 
     std::unique_ptr<core::StratumServer> stratum_server;
     if (stratum_port != 0) {
@@ -851,6 +1040,10 @@ int main(int argc, char** argv)
     // coinbase-only EMPTY blocks while the fork network has pending txs). Money
     // path — --no-serve-mempool-txs is the canary escape hatch back to M2.
     bool serve_mempool_txs = true;
+    // ── M3 SHARECHAIN MINT arm (DEFAULT OFF). The mint/sharechain node only
+    // starts with --bip110-sharechain; absent, the binary is the M2 header-
+    // follower byte-for-byte. IRREVERSIBLE first-outbound is behind this flag. ──
+    bool sharechain_enabled = false;
     {
         namespace cs = c2pool::settings;
         cs::ResolvedConfig rc;
@@ -911,6 +1104,7 @@ int main(int argc, char** argv)
         }
         else if (arg == "--serve-mempool-txs") { serve_mempool_txs = true; }
         else if (arg == "--no-serve-mempool-txs") { serve_mempool_txs = false; }
+        else if (arg == "--bip110-sharechain") { sharechain_enabled = true; }
     }
 
     if (run) {
@@ -918,7 +1112,7 @@ int main(int argc, char** argv)
             // Default to discovery so `--run` alone still finds fork peers.
             coin_p2p_discover = true;
         }
-        return run_embedded(coin_p2p_discover, explicit_peers, fork_checkpoint, http_host, http_port, stratum_addr, stratum_port, donation_address, give_author_pct, node_owner_fee_pct, serve_mempool_txs);
+        return run_embedded(coin_p2p_discover, explicit_peers, fork_checkpoint, http_host, http_port, stratum_addr, stratum_port, donation_address, give_author_pct, node_owner_fee_pct, serve_mempool_txs, sharechain_enabled);
     }
 
     print_banner(argv[0]);

--- a/src/c2pool/main_bip110.cpp
+++ b/src/c2pool/main_bip110.cpp
@@ -515,6 +515,32 @@ int run_embedded(bool coin_p2p_discover,
                 return node_raw->best_share_hash();
             });
 
+        // (7b) M3 PR-C F1b: the PPLNS-distributed coinbase producer. Under
+        // read_tracker() (non-blocking; refuses the refresh if the compute thread
+        // holds the exclusive lock), calls ShareTracker::get_expected_payouts —
+        // the SSOT that returns the {scriptPubKey -> amount} map for the ENTIRE
+        // decayed PPLNS window, folding the residual into the donation script.
+        // build_connection_coinbase emits those outputs (sorted/capped, donation
+        // second-to-last) so the minted coinbase == generate_share_transaction
+        // byte-for-byte and peers ACCEPT the share. Mirrors main_btc.cpp
+        // set_pplns_fn; no AutoRatchet (v36 always), no v35 branch, no merged
+        // mining. Empty map (tracker busy) => build_connection_coinbase refuses the
+        // sharechain job (fail-closed). Set ONLY inside this flag-ON block, so its
+        // presence is the exact --bip110-sharechain predicate.
+        work_source->set_pplns_fn(
+            [node_raw](const uint256& prev, const uint256& block_target,
+                       uint64_t subsidy, const std::vector<unsigned char>& donation_script)
+                -> std::map<std::vector<unsigned char>, double> {
+                if (!node_raw) return {};
+                auto guard = node_raw->read_tracker();
+                if (!guard) return {};                 // tracker busy -> refuse this refresh
+                try {
+                    return guard->get_expected_payouts(prev, block_target, subsidy, donation_script);
+                } catch (const std::exception&) {
+                    return {};
+                }
+            });
+
         // (8) M3 PR-C: the coinbase ref-commitment producer. Walks the share
         // tracker off prev_share_hash for the deterministic chain-position fields
         // (absheight/abswork/far_share_hash) + the share target (compute_share_

--- a/src/impl/bip110/CMakeLists.txt
+++ b/src/impl/bip110/CMakeLists.txt
@@ -1,7 +1,7 @@
 # BIP-110 (Bitcoin Knots BLAKE2b hard fork) lane. M1 = daemonless SPV header
-# follower. Only the coin-network SPV layer is built here (cloned from btc/coin);
-# the pool-side sharechain/stratum runtime lands in a later slice. The lane-local
-# BLAKE2b primitive (crypto/blake2b.c) is compiled into the c2pool-bip110 exe +
-# the KAT targets directly (see src/c2pool/CMakeLists.txt), so it is not built
-# into a library here.
+# follower (coin/, cloned from btc/coin). M3 = the v36 sharechain lane (pool/).
+# The lane-local BLAKE2b primitive (crypto/blake2b.c) is compiled into the
+# c2pool-bip110 exe + the KAT targets directly (see src/c2pool/CMakeLists.txt and
+# pool/CMakeLists.txt), so it is not built into a library here.
 add_subdirectory(coin)
+add_subdirectory(pool)   # M3 PR-A: v36 sharechain lane foundation + identity KAT

--- a/src/impl/bip110/coin/gentx_coinbase.hpp
+++ b/src/impl/bip110/coin/gentx_coinbase.hpp
@@ -46,8 +46,16 @@ struct GentxCoinbase
     // BIP144 (segwit) serialization used for the BLOCK BODY when a witness
     // commitment output is present:
     //   version | 0x00 0x01 (marker+flag) | vin | vout |
-    //   witness_for_input0{ 0x01 (stack items) | 0x20 (len 32) | 32*0x00 reserved }
+    //   witness_for_input0{ 0x01 (stack items) | 0x20 (len 32) | reserved(32) }
     //   | locktime
+    // The 32-byte reserved value is the caller-supplied witness_reserved_value
+    // (defaults to 32 zeros). Segwit consensus recomputes the coinbase witness
+    // commitment as SHA256d(witness_merkle_root || reserved) and checks it against
+    // the aa21a9ed commitment output — so the reserved value spliced here MUST be
+    // the SAME 32 bytes the commitment output was computed over, or the won block
+    // is rejected with bad-witness-merkle-match. OFF/M2 (commitment over reserved
+    // 0*32) => empty arg => 32 zeros. Flag-ON P2Pool (commitment over '[P2Pool]'*4)
+    // => caller passes those 32 bytes.
     // Knots/Core CheckWitnessMalleation REQUIRES exactly one 32-byte witness
     // element on the coinbase input whenever a commitment output exists;
     // shipping `bytes` (empty witness stack) => bad-witness-nonce-size => the
@@ -65,7 +73,11 @@ inline GentxCoinbase assemble_gentx_coinbase(
     const std::vector<std::pair<std::vector<unsigned char>, uint64_t>>& payout_outputs,
     uint64_t donation_amount,
     const std::vector<unsigned char>& donation_script,
-    const std::vector<unsigned char>& op_return_script)
+    const std::vector<unsigned char>& op_return_script,
+    // Block-body witness reserved value (coinbase input witness stack item). Empty
+    // => 32 zeros (OFF/M2, byte-identical to before). On the flag-ON P2Pool path
+    // the caller passes '[P2Pool]'*4 to match the P2Pool witness commitment.
+    const std::vector<unsigned char>& witness_reserved_value = {})
 {
     PackStream tx;
 
@@ -146,9 +158,12 @@ inline GentxCoinbase assemble_gentx_coinbase(
     // bad-witness-nonce-size. Splice the marker+flag after the 4-byte version and
     // the witness+locktime around the non-witness body:
     //   version(4) | 0x00 0x01 | vin | vout | witness | locktime(4)
-    // The reserved value is 32 zero bytes — the SAME preimage the commitment math
-    // above consumed (SHA256d(witness_merkle_root(0) || reserved(0*32))). No
-    // commitment output => no witness => block_bytes == bytes (byte-unchanged).
+    // The reserved value is witness_reserved_value (or 32 zeros when empty) — it
+    // MUST be the SAME preimage the commitment output consumed
+    // (SHA256d(witness_merkle_root || reserved)). OFF/M2: reserved 0*32 matches the
+    // M2 commitment over reserved 0*32. Flag-ON: reserved '[P2Pool]'*4 matches the
+    // P2Pool commitment over the real witness root. No commitment output => no
+    // witness => block_bytes == bytes (byte-unchanged).
     if (segwit_commitment_script.has_value() && out.bytes.size() >= 8)
     {
         const size_t n = out.bytes.size();
@@ -161,10 +176,14 @@ inline GentxCoinbase assemble_gentx_coinbase(
         b.push_back(0x01);
         // vin || vout  (everything between version and locktime)
         b.insert(b.end(), out.bytes.begin() + 4, out.bytes.begin() + (n - 4));
-        // witness for input[0]: 1 stack item, 32-byte reserved value (all zero)
+        // witness for input[0]: 1 stack item, 32-byte reserved value.
         b.push_back(0x01);                 // stack item count
         b.push_back(0x20);                 // element length = 32
-        b.insert(b.end(), 32, 0x00);       // reserved value
+        if (witness_reserved_value.size() == 32)
+            b.insert(b.end(), witness_reserved_value.begin(),
+                     witness_reserved_value.end());   // flag-ON: '[P2Pool]'*4
+        else
+            b.insert(b.end(), 32, 0x00);   // OFF/M2: 32-zero reserved value
         // locktime (4)
         b.insert(b.end(), out.bytes.begin() + (n - 4), out.bytes.end());
     }

--- a/src/impl/bip110/params.hpp
+++ b/src/impl/bip110/params.hpp
@@ -69,18 +69,29 @@ inline constexpr const char* GBT_RULE = "blake2b";
 // INDEPENDENT transport constants (p2pool model); PREFIX is never derived from
 // IDENTIFIER. This mirrors the DASH lane's single-definition discipline (one
 // place owns the identity; the factory and PoolConfig both read it).
-inline constexpr uint16_t SHARECHAIN_P2P_PORT    = 9335;  // BIP-110 sharechain P2P port
+// M3 WIRE-GENESIS bump (operator decision card 2026-09-02, IRREVERSIBLE once a
+// share is minted): the M2 SPV-follower placeholders (9335 / SPREAD 30 /
+// CHAIN_LENGTH 5760 / MIN_PROTO 3500) are replaced by the operator-signed
+// wire-genesis constants BEFORE any share exists. Port 9337 (decision #2),
+// SHARE-DIFF BTC-verbatim (decision #3: CHAIN_LENGTH 8640, SPREAD 3), v36
+// MergedMiningShare requires protocol >= 3600 (python fork data.py:2267). The
+// PREFIX / IDENTIFIER stay as already-minted-fresh (no BTC collision). Worker
+// port 9336 keeps. Nothing is live on this sharechain yet, so a pre-genesis
+// bump is safe; after the first mint these values freeze.
+inline constexpr uint16_t SHARECHAIN_P2P_PORT    = 9337;  // BIP-110 sharechain P2P port (decision #2)
 inline constexpr uint16_t SHARECHAIN_WORKER_PORT = 9336;  // BIP-110 Stratum/worker port
 inline constexpr const char* SHARECHAIN_IDENTIFIER_HEX = "b1101100b1a4e2bd";
 inline constexpr const char* SHARECHAIN_PREFIX_HEX     = "e2bdb1101100b1a4";
-// Pool-lane tuning constants (BIP-110-native; distinct from the BTC fossil's
-// SPREAD=3 / CHAIN_LENGTH=8640 / ADVERTISED=3502 / SEGWIT_ACTIVATION=33).
-inline constexpr uint32_t SHARECHAIN_SPREAD                    = 30;
-inline constexpr uint32_t SHARECHAIN_CHAIN_LENGTH             = 5760;
+// Pool-lane tuning constants. SHARE-DIFF = BTC-verbatim (decision #3): CHAIN_LENGTH
+// 8640, SPREAD 3, SHARE_PERIOD 30s, TARGET_LOOKBEHIND 200, standard MAX_TARGET
+// floor. MIN_PROTO/ADVERTISED = 3600 (v36 MergedMiningShare floor). SEGWIT
+// activation 4 (v36 >= 4 => always segwit-active on this v36-genesis chain).
+inline constexpr uint32_t SHARECHAIN_SPREAD                    = 3;       // BTC-verbatim (decision #3)
+inline constexpr uint32_t SHARECHAIN_CHAIN_LENGTH             = 8640;    // BTC-verbatim (decision #3)
 inline constexpr uint32_t SHARECHAIN_TARGET_LOOKBEHIND        = 200;
 inline constexpr uint32_t SHARECHAIN_SHARE_PERIOD            = 30;
-inline constexpr uint32_t SHARECHAIN_MINIMUM_PROTOCOL_VERSION = 3500;
-inline constexpr uint32_t SHARECHAIN_ADVERTISED_PROTOCOL_VERSION = 3501;
+inline constexpr uint32_t SHARECHAIN_MINIMUM_PROTOCOL_VERSION = 3600;   // v36 floor (data.py:2267)
+inline constexpr uint32_t SHARECHAIN_ADVERTISED_PROTOCOL_VERSION = 3600;
 inline constexpr uint32_t SHARECHAIN_SEGWIT_ACTIVATION_VERSION = 4;
 inline constexpr uint32_t SHARECHAIN_BLOCK_MAX_SIZE          = 1000000;
 inline constexpr uint64_t SHARECHAIN_DUST_THRESHOLD          = 546;  // Bitcoin relay dust floor

--- a/src/impl/bip110/pool/CMakeLists.txt
+++ b/src/impl/bip110/pool/CMakeLists.txt
@@ -1,0 +1,43 @@
+# BIP-110 (Bitcoin Knots BLAKE2b hard fork) — M3 v36 SHARECHAIN lane, PR-A.
+#
+# The v36 (decayed-PPLNS + P2SH donation + MergedMiningShare-family) sharechain
+# lane. PR-A ships the FOUNDATION — the wire types, the ONE consensus delta
+# (Bip110SmallBlockHeaderType + BLAKE2b share-hash identity), the fresh-identity
+# constants + BTC-verbatim diff, the p2p message set, peer state, and the pure
+# donation validators — as a header lane, plus the KILLER identity KAT. PR-B
+# wires create_share_fn + pool::SharechainNode into main_bip110; the large
+# mechanical namespace-copies (share_check / share_tracker / node / protocol)
+# land in PR-A-continuation (see the PR's remaining-work map). Header-only lane:
+# nothing to compile into a library yet (matches the coin lane's blake2b note),
+# so the KAT is the compile+correctness gate.
+
+# INTERFACE target so PR-B can `target_link_libraries(... bip110_pool)` to pick up
+# the include surface + the shared/coin/sharechain deps the pool lane rides on.
+add_library(bip110_pool INTERFACE)
+target_include_directories(bip110_pool INTERFACE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(bip110_pool INTERFACE core sharechain pool bip110_coin btclibs)
+
+# bip110_pool_identity_kat: proves the pool-lane header set COMPILES (forces the
+# v36 share templates to instantiate) AND that the share-hash == block-identity
+# path reproduces REAL BIP-110 block 961640's canonical hash byte-for-byte.
+# Lean, isolated link set (blake2b.c compiled directly, like the M2 KATs).
+# Lean, isolated link set (like the M2 bip110_blake2b_kat): compile only the
+# minimal core sources the identity path needs (uint256 + the lane BLAKE2b
+# primitive) rather than linking the full `core` OBJECT lib, which would drag in
+# web_server/stratum and the whole pool/payout/merged runtime. The pool-lane
+# headers (share_types/share_identity/share/config_pool) + coin/block.hpp are
+# header-only template code, so no library link is required to prove they compile.
+add_executable(bip110_pool_identity_kat
+    test/bip110_pool_identity_kat.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
+    ${CMAKE_SOURCE_DIR}/src/core/uint256.cpp
+)
+target_compile_definitions(bip110_pool_identity_kat PRIVATE __C2POOL_COIN_BIP110__=1)
+target_link_libraries(bip110_pool_identity_kat
+    btclibs
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
+)
+add_test(NAME bip110_pool_identity_kat COMMAND bip110_pool_identity_kat)

--- a/src/impl/bip110/pool/CMakeLists.txt
+++ b/src/impl/bip110/pool/CMakeLists.txt
@@ -151,3 +151,38 @@ target_link_libraries(bip110_pool_mint_kat
     Threads::Threads
 )
 add_test(NAME bip110_pool_mint_kat COMMAND bip110_pool_mint_kat)
+
+# bip110_extend_mint_kat: the F2 EXTEND-OFF-REAL-TIP + PEER ref/coinbase-consistency
+# KAT (M3 PR-C). Where the genesis mint_kat proves mint/verify SYMMETRY with a fake
+# coinbase, THIS KAT seeds a real tip, mints a share EXTENDING it (has_frozen=TRUE,
+# absheight==2), and proves the coinbase carries a REAL ref commitment that a PEER
+# recomputes off the STORED share fields byte-for-byte (compute_ref_hash_for_work)
+# and then reconstructs the exact share hash via the share_check verify path
+# (check_hash_link -> check_merkle_link -> compute_share_hash) — i.e. peers ACCEPT
+# the minted share (the F1 wire failure is closed). Same heavy link closure as the
+# mint_kat (create_local_share + assemble_gentx_coinbase + the verify surface +
+# BLAKE2b via share_identity.hpp -> pow.hpp). blake2b.c compiled directly.
+add_executable(bip110_extend_mint_kat
+    test/bip110_extend_mint_kat.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
+)
+target_compile_definitions(bip110_extend_mint_kat PRIVATE __C2POOL_COIN_BIP110__=1)
+target_link_libraries(bip110_extend_mint_kat
+    bip110_coin
+    c2pool_payout
+    c2pool_merged_mining
+    c2pool_hashrate
+    core
+    ltc
+    ltc_coin
+    pool
+    sharechain
+    c2pool_storage
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
+)
+add_test(NAME bip110_extend_mint_kat COMMAND bip110_extend_mint_kat)

--- a/src/impl/bip110/pool/CMakeLists.txt
+++ b/src/impl/bip110/pool/CMakeLists.txt
@@ -186,3 +186,38 @@ target_link_libraries(bip110_extend_mint_kat
     Threads::Threads
 )
 add_test(NAME bip110_extend_mint_kat COMMAND bip110_extend_mint_kat)
+
+# bip110_multiminer_pplns_kat: the F1b PPLNS-DISTRIBUTED-COINBASE KAT (M3 PR-C).
+# Where the extend_mint_kat proved the ref/hash_link half of peer acceptance with a
+# SINGLE-MINER coinbase (and its create_local_share log SHOWS the remaining gap:
+# "Cross-check FAILED! mined_gentx=<single-miner> verify_gentx=<PPLNS>"), THIS KAT
+# seeds a real 2-share window (miner A <- miner B), builds the FLAG-ON coinbase the
+# way build_connection_coinbase now does (get_expected_payouts -> sorted/capped
+# outputs + P2POOL witness commitment + donation second-to-last + OP_RETURN ref),
+# mints the extend share, and asserts generate_share_transaction == that coinbase
+# byte-for-byte — i.e. the Cross-check now PASSES and peers ACCEPT the share. Same
+# heavy link closure as the extend_mint_kat. blake2b.c compiled directly.
+add_executable(bip110_multiminer_pplns_kat
+    test/bip110_multiminer_pplns_kat.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
+)
+target_compile_definitions(bip110_multiminer_pplns_kat PRIVATE __C2POOL_COIN_BIP110__=1)
+target_link_libraries(bip110_multiminer_pplns_kat
+    bip110_coin
+    c2pool_payout
+    c2pool_merged_mining
+    c2pool_hashrate
+    core
+    ltc
+    ltc_coin
+    pool
+    sharechain
+    c2pool_storage
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
+)
+add_test(NAME bip110_multiminer_pplns_kat COMMAND bip110_multiminer_pplns_kat)

--- a/src/impl/bip110/pool/CMakeLists.txt
+++ b/src/impl/bip110/pool/CMakeLists.txt
@@ -41,3 +41,39 @@ target_link_libraries(bip110_pool_identity_kat
     Threads::Threads
 )
 add_test(NAME bip110_pool_identity_kat COMMAND bip110_pool_identity_kat)
+
+# bip110_pool_sharechain_compile: the COMPILE + INSTANTIATION gate for the M3
+# PR-A-continuation sharechain lane (share_check.hpp / share_tracker.hpp /
+# share_messages.hpp + the tracker-coupled donation build_expected_payouts). It
+# #includes share_tracker.hpp (which transitively pulls the whole verify surface)
+# and ODR-uses verify_share<MergedMiningShare, ShareTracker> so every verify-path
+# template — including the BLAKE2b header-hash consensus delta (compute_share_hash
+# / check_header_fail_closed) and the v36 decayed-PPLNS walk — is fully compiled
+# and linked. Unlike the identity KAT (deliberately lean), this target rides the
+# same heavy shared/core/pool/sharechain link closure as c2pool-bip110, because
+# the verify path uses core LOG / target_utils / address_utils, sharechain, the
+# coin block/transaction types, and (via share_identity.hpp -> pow.hpp) BLAKE2b.
+add_executable(bip110_pool_sharechain_compile
+    test/bip110_pool_sharechain_compile.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
+)
+target_compile_definitions(bip110_pool_sharechain_compile PRIVATE __C2POOL_COIN_BIP110__=1)
+target_link_libraries(bip110_pool_sharechain_compile
+    bip110_coin
+    c2pool_payout
+    c2pool_merged_mining
+    c2pool_hashrate
+    core
+    ltc
+    ltc_coin
+    pool
+    sharechain
+    c2pool_storage
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
+)
+add_test(NAME bip110_pool_sharechain_compile COMMAND bip110_pool_sharechain_compile)

--- a/src/impl/bip110/pool/CMakeLists.txt
+++ b/src/impl/bip110/pool/CMakeLists.txt
@@ -117,3 +117,37 @@ target_link_libraries(bip110_pool_node_compile
     Threads::Threads
 )
 add_test(NAME bip110_pool_node_compile COMMAND bip110_pool_node_compile)
+
+# bip110_pool_mint_kat: the END-TO-END MINT known-answer test (PR-B). Unlike the
+# node_compile KAT (which only takes create_local_share's address), this RUNS the
+# mint against a ShareTracker, pulls the minted share back out, and asserts field
+# round-trip (donation=66, abswork %2^64 wrap, segwit none-sentinel 2^256-1,
+# coinbase last_txout_nonce) AND mint/verify BLAKE2b hash symmetry
+# (compute_share_hash on the minted small-header reproduces the stored share hash).
+# Same heavy shared/core/pool/sharechain/storage link closure as
+# bip110_pool_sharechain_compile (the mint reaches the whole verify surface +
+# BLAKE2b via share_identity.hpp -> pow.hpp). blake2b.c compiled directly.
+add_executable(bip110_pool_mint_kat
+    test/bip110_pool_mint_kat.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
+)
+target_compile_definitions(bip110_pool_mint_kat PRIVATE __C2POOL_COIN_BIP110__=1)
+target_link_libraries(bip110_pool_mint_kat
+    bip110_coin
+    c2pool_payout
+    c2pool_merged_mining
+    c2pool_hashrate
+    core
+    ltc
+    ltc_coin
+    pool
+    sharechain
+    c2pool_storage
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
+)
+add_test(NAME bip110_pool_mint_kat COMMAND bip110_pool_mint_kat)

--- a/src/impl/bip110/pool/CMakeLists.txt
+++ b/src/impl/bip110/pool/CMakeLists.txt
@@ -77,3 +77,43 @@ target_link_libraries(bip110_pool_sharechain_compile
     Threads::Threads
 )
 add_test(NAME bip110_pool_sharechain_compile COMMAND bip110_pool_sharechain_compile)
+
+# bip110_pool_node_compile: the COMPILE + INSTANTIATION + LINK gate for the M3
+# PR-A-cont2 sharechain NODE layer + MINT path. It builds node.cpp +
+# protocol_actual.cpp (the namespace-copied sharechain node, the v36-genesis
+# single-protocol bridge, and the c2pool protocol handler) AS SOURCES, and the
+# test TU ODR-uses bip110::pool::Node / Actual::handle_message, constructs the
+# config-seam adapter (bip110::pool::Config), and instantiates the MINT template
+# create_local_share<ShareTracker> (from_full split + fail-closed + abswork %2^64
+# + BLAKE2b compute_share_hash header-identity). Same heavy shared/core/pool/
+# sharechain/storage link closure as bip110_pool_sharechain_compile because the
+# node reaches SharechainStorage, ReplyMatcher, the tx-advertiser, the coin seed
+# bootstrapper / template_other_txs, and (via share_identity.hpp -> pow.hpp)
+# BLAKE2b. NO protocol_legacy.cpp and NO config_*.cpp — the v36-genesis lane has a
+# single protocol and a header-only config adapter (no Fileconfig).
+add_executable(bip110_pool_node_compile
+    test/bip110_pool_node_compile.cpp
+    node.cpp
+    protocol_actual.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/bip110/crypto/blake2b.c
+)
+target_compile_definitions(bip110_pool_node_compile PRIVATE __C2POOL_COIN_BIP110__=1)
+target_link_libraries(bip110_pool_node_compile
+    bip110_coin
+    c2pool_payout
+    c2pool_merged_mining
+    c2pool_hashrate
+    core
+    ltc
+    ltc_coin
+    pool
+    sharechain
+    c2pool_storage
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+    ${SECP256K1_LIBRARIES}
+    Threads::Threads
+)
+add_test(NAME bip110_pool_node_compile COMMAND bip110_pool_node_compile)

--- a/src/impl/bip110/pool/config.hpp
+++ b/src/impl/bip110/pool/config.hpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// bip110::pool::Config — the runtime config VIEW consumed by the namespace-copied
+// sharechain NODE layer (node.hpp / node.cpp / protocol_actual.cpp).
+//
+// THE CONFIG SEAM (PR-A-cont2 design decision — option (a), a bip110-local
+// runtime adapter that forwards to the static PoolConfig SSOT; ZERO shared edits):
+//
+// The BTC lane's config.hpp is `using Config = core::Config<PoolConfig,CoinConfig>`
+// (src/impl/btc/config.hpp). `core::Config<Pool,Coin>` static_asserts BOTH template
+// args are core::Fileconfig subclasses (src/core/config.hpp). bip110's PoolConfig
+// (config_pool.hpp) is DELIBERATELY static-only and NOT a Fileconfig — that is the
+// mechanism guaranteeing the empty-seed cross-pollution guard (decision card #2: no
+// override_prefix_hex surface, no PublicDefault arm). Making it a Fileconfig to
+// satisfy core::Config<> would re-introduce exactly the runtime override surface
+// decision #2 forbids. And "consume the static accessors directly" is impossible
+// without editing SHARED code: pool::BaseNode reads INSTANCE members off config_t*
+// (`config->m_name`, `config->pool()->m_prefix`, src/pool/node.hpp), and BaseNode is
+// shared → untouchable.
+//
+// The seam: pool::SharechainNode<ConfigType,...> takes ConfigType as a free type
+// param, so this local Config only needs the exact member surface BaseNode + the
+// copied NodeImpl read (m_name / m_regtest / m_testnet / pool()->m_prefix /
+// pool()->m_bootstrap_addrs). Every value is derived from the static PoolConfig SSOT
+// / params.hpp SHARECHAIN_* constants, so it can never drift. The compile-time
+// constants node.cpp uses (P2P_PORT, ADVERTISED/MINIMUM_PROTOCOL_VERSION,
+// chain_length(), share_period(), TARGET_LOOKBEHIND) stay direct calls on the static
+// bip110::pool::PoolConfig — no adapter needed for those.
+//
+// The empty-seed ladder SURVIVES: m_bootstrap_addrs initializes EMPTY and
+// PoolConfig::default_bootstrap_hosts() returns {} with no PublicDefault/btc-seed
+// arm, so the node cannot dial 9333 / the live BTC sharechain.
+
+#include "config_pool.hpp"          // static SSOT + params.hpp SHARECHAIN_*
+#include <core/netaddress.hpp>
+#include <btclibs/util/strencodings.h>   // ParseHexBytes
+
+#include <string>
+#include <vector>
+
+namespace bip110::pool
+{
+
+// Runtime instance-member view that pool::BaseNode + the copied NodeImpl read off
+// config_t*. Every value comes from the static PoolConfig SSOT / params.hpp, so it
+// can never drift from the coin-params factory or the wire identity.
+struct PoolConfigRuntime
+{
+    std::vector<std::byte>  m_prefix;           // = ParseHexBytes(SHARECHAIN_PREFIX_HEX)
+    std::vector<NetService> m_bootstrap_addrs;  // EMPTY — empty-seed ladder (decision #2)
+
+    PoolConfigRuntime()
+    {
+        m_prefix = ParseHexBytes(PoolConfig::prefix_hex());
+        // m_bootstrap_addrs stays empty: no PublicDefault arm, no cross-lane seeds.
+    }
+};
+
+struct Config
+{
+    std::string m_name{"bip110"};
+    bool m_regtest{false};
+    bool m_testnet{false};           // v36-genesis: single mainnet identity
+    PoolConfigRuntime m_pool;
+
+    PoolConfigRuntime* pool() { return &m_pool; }
+    // No coin() — the copied node.hpp/node.cpp never call config->coin().
+};
+
+// The BTC lane keeps sharechain_net_name on CoinConfig (config_coin.hpp); bip110 has
+// no CoinConfig, so provide the free function the copied node.hpp LevelDB-namespace
+// isolation site calls. regtest FIRST (the .121-standup isolation invariant).
+inline std::string sharechain_net_name(bool regtest, bool /*testnet*/)
+{
+    return regtest ? "bip110_regtest" : "bip110";
+}
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/config_pool.hpp
+++ b/src/impl/bip110/pool/config_pool.hpp
@@ -26,6 +26,7 @@
 
 #include "../params.hpp"        // SSOT: bip110::SHARECHAIN_* + coin identity
 #include <core/donation.hpp>    // chain-agnostic donation SSOT
+#include <core/uint256.hpp>     // uint256 / uint256S for max_target()
 
 #include <cstdint>
 #include <string>
@@ -71,6 +72,42 @@ public:
     static std::vector<unsigned char> get_donation_script(int64_t share_version)
     {
         return core::donation::get_donation_script(share_version);
+    }
+
+    // ---- Verify-path accessors (share_check.hpp / share_tracker.hpp) --------
+    // The v36-genesis chain has no separate testnet parameter set: the SSOT in
+    // params.hpp defines the single mainnet identity, and is_testnet stays false.
+    // These function accessors mirror the BTC lane's PoolConfig call surface so
+    // the namespace-copied share_check/share_tracker bind unchanged; every value
+    // is read from the params.hpp SHARECHAIN_* SSOT (never drifts).
+    static inline bool is_testnet = false;
+
+    static uint32_t share_period()      { return SHARECHAIN_SHARE_PERIOD; }
+    static uint32_t chain_length()      { return SHARECHAIN_CHAIN_LENGTH; }
+    static uint32_t real_chain_length() { return SHARECHAIN_CHAIN_LENGTH; }
+
+    static uint64_t dust_threshold()    { return SHARECHAIN_DUST_THRESHOLD; }
+
+    // MAX_TARGET: share difficulty floor (easiest allowed share PoW), from the
+    // params.hpp SSOT (SHARECHAIN_MAX_TARGET_HEX — standard bdiff-1 2^224 floor).
+    static uint256 max_target()
+    {
+        static const uint256 MAINNET_MAX = uint256S(SHARECHAIN_MAX_TARGET_HEX);
+        return MAINNET_MAX;
+    }
+
+    // Chain identity — BIP-110-native, from the params.hpp SSOT. No override /
+    // XOR-derivation surface (decision #2: this lane never joins another network).
+    static const std::string& identifier_hex()
+    {
+        static const std::string kId = SHARECHAIN_IDENTIFIER_HEX;
+        return kId;
+    }
+
+    static const std::string& prefix_hex()
+    {
+        static const std::string kPfx = SHARECHAIN_PREFIX_HEX;
+        return kPfx;
     }
 
     // ---- Bootstrap ladder — FAIL-LOUD, no cross-lane fallback ---------------

--- a/src/impl/bip110/pool/config_pool.hpp
+++ b/src/impl/bip110/pool/config_pool.hpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// bip110::pool::PoolConfig — the BIP-110 c2pool SHARECHAIN (pool-P2P) identity
+// + tuning, for the M3 v36 sharechain lane. Every value is read from the ONE
+// SSOT in src/impl/bip110/params.hpp (the SHARECHAIN_* constants), so the
+// sharechain identity can never drift between the coin-params factory and this
+// pool config.
+//
+// ⚠️ CROSS-POLLUTION GUARD (decision card #2, IRREVERSIBLE). This file DELIBERATELY
+// does NOT copy the BTC lane's config_pool.hpp, which hard-codes the LIVE BTC
+// p2pool sharechain identity (P2P_PORT 9333, PREFIX 2472ef181efcd37b, the
+// p2p-spb / jtoomim DEFAULT_BOOTSTRAP_HOSTS) AND — the actual trap — falls back
+// to that public seed list even under a custom prefix (btc config_pool.hpp
+// SharechainBootstrapMode::PublicDefault). Replicating that here would dial the
+// LIVE BTC sharechain and cross-pollute it (the prefix-regression class). The
+// BIP-110 bootstrap ladder below has NO PublicDefault arm: with zero explicit
+// peers and zero seeds it stays ISOLATED (solo / wire-genesis), never falling
+// back to any other lane's list.
+//
+// This is the pool-lane identity/constants provider consumed by share_types.hpp
+// (SEGWIT_ACTIVATION_VERSION) and, in PR-B, by the SharechainNode wiring. The
+// runtime Fileconfig (pool.yaml load/get_default) + core::Config<Pool,Coin>
+// composition land in PR-B with main_bip110; PR-A only needs the constants that
+// the share format + identity are defined against.
+
+#include "../params.hpp"        // SSOT: bip110::SHARECHAIN_* + coin identity
+#include <core/donation.hpp>    // chain-agnostic donation SSOT
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace bip110::pool
+{
+
+class PoolConfig
+{
+public:
+    // ---- Sharechain (pool-P2P) transport identity — from params.hpp SSOT ----
+    static constexpr uint16_t P2P_PORT    = SHARECHAIN_P2P_PORT;     // 9337 (decision #2)
+    static constexpr uint16_t WORKER_PORT = SHARECHAIN_WORKER_PORT;  // 9336
+
+    // ---- Share-diff / PPLNS window — BTC-verbatim (decision #3) -------------
+    static constexpr uint32_t SPREAD                    = SHARECHAIN_SPREAD;                    // 3
+    static constexpr uint32_t TARGET_LOOKBEHIND         = SHARECHAIN_TARGET_LOOKBEHIND;         // 200
+    static constexpr uint32_t SHARE_PERIOD              = SHARECHAIN_SHARE_PERIOD;              // 30s
+    static constexpr uint32_t CHAIN_LENGTH              = SHARECHAIN_CHAIN_LENGTH;              // 8640
+    static constexpr uint32_t REAL_CHAIN_LENGTH         = SHARECHAIN_CHAIN_LENGTH;              // 8640
+
+    // ---- Protocol / format floors ------------------------------------------
+    // v36 MergedMiningShare requires protocol >= 3600 (python fork data.py:2267);
+    // ADVERTISED == MINIMUM so we never speak below the v36 floor.
+    static constexpr uint32_t MINIMUM_PROTOCOL_VERSION    = SHARECHAIN_MINIMUM_PROTOCOL_VERSION;    // 3600
+    static constexpr uint32_t ADVERTISED_PROTOCOL_VERSION = SHARECHAIN_ADVERTISED_PROTOCOL_VERSION; // 3600
+    // v36 >= 4 => segwit ALWAYS active on this v36-genesis chain.
+    static constexpr uint32_t SEGWIT_ACTIVATION_VERSION   = SHARECHAIN_SEGWIT_ACTIVATION_VERSION;   // 4
+    static constexpr uint32_t BLOCK_MAX_SIZE              = SHARECHAIN_BLOCK_MAX_SIZE;
+    static constexpr uint32_t BLOCK_MAX_WEIGHT           = RDTS_MAX_BLOCK_WEIGHT;
+
+    // ---- Reward-safety: mint-freshness (verified-vs-raw gap) ----------------
+    // BTC C1 precedent (main_btc.cpp): refuse to mint on top of a share whose
+    // verified height trails the raw tip by more than this. Reward-safety, not
+    // consensus. Consumed caller-side in PR-B's main_bip110 mint gate.
+    static constexpr uint32_t STALE_SHARES = 30;
+
+    // ---- Donation ----------------------------------------------------------
+    // Delegated to the chain-agnostic SSOT: v36+ => COMBINED_DONATION_SCRIPT
+    // (P2SH a9148c6272...8e8587). The per-share donation u16 default (66 == 0.1%)
+    // lives in the money/give_author catalog, applied at mint (PR-B).
+    static std::vector<unsigned char> get_donation_script(int64_t share_version)
+    {
+        return core::donation::get_donation_script(share_version);
+    }
+
+    // ---- Bootstrap ladder — FAIL-LOUD, no cross-lane fallback ---------------
+    // Precedence: explicit peers > regtest > (custom-id | public) => ISOLATED.
+    // There is NO PublicDefault arm on purpose (see the header note): with no
+    // explicit peers and no seeds the node runs solo rather than dialing any
+    // other sharechain. No public BIP-110 c2pool node exists yet; the operator
+    // fills explicit --peer hosts at PR-B / deploy.
+    enum class BootstrapMode {
+        ExplicitPeers,   // --peer/--sharechain-addnode given: dial ONLY those
+        RegtestIsolated, // --regtest: 0 seeds, solo/local
+        Isolated,        // default: 0 seeds, wire-genesis / solo (NEVER a fallback list)
+    };
+
+    static BootstrapMode select_bootstrap_mode(bool has_explicit_peers, bool regtest)
+    {
+        if (has_explicit_peers) return BootstrapMode::ExplicitPeers;
+        if (regtest)            return BootstrapMode::RegtestIsolated;
+        return BootstrapMode::Isolated;
+    }
+
+    // EMPTY default seed list. Never falls back to another lane's hosts.
+    static const std::vector<std::string>& default_bootstrap_hosts()
+    {
+        static const std::vector<std::string> kNone{};
+        return kNone;
+    }
+};
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/donation_consensus.hpp
+++ b/src/impl/bip110/pool/donation_consensus.hpp
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// donation_consensus.hpp — reward-safety donation-output validation for the
+// BIP-110 v36 sharechain. The donation output receives the rounding remainder
+// from decayed-PPLNS distribution and is ALWAYS the last payout output before the
+// OP_RETURN ref-commitment (data.py:114-200). v36 => COMBINED_DONATION_SCRIPT
+// (P2SH 1-of-2, core::donation SSOT).
+//
+// PR-A ships the two PURE validators (they depend only on config_pool.hpp). The
+// tracker-coupled entry point build_expected_payouts() lands with share_tracker.hpp
+// in PR-A-continuation (it needs ShareTracker::get_expected_payouts + the decayed
+// weight walk) — see the remaining-work map.
+
+#include "config_pool.hpp"
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace bip110::pool::consensus
+{
+
+struct CoinbaseOutput
+{
+    std::vector<unsigned char> script;
+    uint64_t value{0};
+};
+
+struct DonationValidationResult
+{
+    bool valid{false};
+    std::string error;
+};
+
+// The donation script MUST appear as a coinbase output with value >= the PPLNS
+// remainder (1-sat rounding tolerance). v36 selects COMBINED_DONATION_SCRIPT.
+inline DonationValidationResult validate_donation_output(
+    const std::vector<CoinbaseOutput>& coinbase_outputs,
+    const std::map<std::vector<unsigned char>, double>& expected_payouts,
+    int64_t share_version)
+{
+    auto donation_script = PoolConfig::get_donation_script(share_version);
+
+    auto it = expected_payouts.find(donation_script);
+    if (it == expected_payouts.end())
+        return {true, {}}; // no donation expected (all miners donation=0)
+
+    double expected_amount = it->second;
+    if (expected_amount <= 0.0)
+        return {true, {}};
+
+    uint64_t actual_donation = 0;
+    bool found = false;
+    for (const auto& out : coinbase_outputs)
+    {
+        if (out.script == donation_script)
+        {
+            actual_donation += out.value;
+            found = true;
+        }
+    }
+
+    if (!found)
+        return {false, "coinbase missing donation output for script"};
+
+    if (actual_donation + 1 < static_cast<uint64_t>(expected_amount))
+        return {false, "donation output value too low"};
+
+    return {true, {}};
+}
+
+// The sum of all coinbase outputs (donation included) must not exceed subsidy.
+inline DonationValidationResult validate_coinbase_total(
+    const std::vector<CoinbaseOutput>& coinbase_outputs,
+    uint64_t subsidy)
+{
+    uint64_t total = 0;
+    for (const auto& out : coinbase_outputs)
+    {
+        if (total + out.value < total) // overflow
+            return {false, "coinbase output sum overflow"};
+        total += out.value;
+    }
+
+    if (total > subsidy)
+        return {false, "coinbase outputs exceed block subsidy"};
+
+    return {true, {}};
+}
+
+} // namespace bip110::pool::consensus

--- a/src/impl/bip110/pool/donation_consensus.hpp
+++ b/src/impl/bip110/pool/donation_consensus.hpp
@@ -92,4 +92,59 @@ inline DonationValidationResult validate_coinbase_total(
     return {true, {}};
 }
 
+// ---------------------------------------------------------------------------
+// File 5 — the tracker-coupled entry point the header comment forecasts.
+//
+// build_expected_payouts() feeds the pure validators above. It runs the v36
+// decayed-PPLNS distribution over the sharechain (ShareTracker::get_expected_
+// payouts, share_tracker.hpp) to produce the canonical map<scriptPubKey, amount>
+// the coinbase MUST match, then hands it to validate_donation_output with
+// share_version=36 => COMBINED_DONATION_SCRIPT (P2SH). Templated on TrackerT so
+// donation_consensus.hpp stays decoupled from the heavy share_tracker.hpp include
+// (the caller — the sharechain node's accept path — supplies the concrete
+// ShareTracker & and already holds share_tracker.hpp).
+//
+// F11 exclude-then-append canonicalization: the donation is the rounding
+// remainder and is ALWAYS the last payout output. get_expected_payouts() already
+// computes it as subsidy − sum(miner amounts) and appends it under donation_script
+// (share_tracker.hpp), guarding the double-count when a miner's own script equals
+// the donation script via `result.contains(donation_script) ? result[...] : 0`.
+// We therefore do NOT re-derive or re-append it here — build_expected_payouts is a
+// thin, side-effect-free bridge that preserves that canonical map verbatim.
+template <typename TrackerT>
+inline std::map<std::vector<unsigned char>, double>
+build_expected_payouts(TrackerT& tracker,
+                       const uint256& best_share_hash,
+                       const uint256& block_target,
+                       uint64_t subsidy,
+                       int64_t share_version = 36)
+{
+    auto donation_script = PoolConfig::get_donation_script(share_version);
+    // The tracker owns the decayed walk + the >=1-sat donation floor tiebreak +
+    // the exclude-then-append donation canonicalization. We surface its result
+    // unchanged so it can be fed to validate_donation_output / validate_coinbase_total.
+    return tracker.get_expected_payouts(best_share_hash, block_target, subsidy, donation_script);
+}
+
+// Convenience: build the expected map from the tracker AND run both pure
+// validators against the miner's coinbase outputs in one call. This is the
+// reward-safety cross-check the sharechain accept path invokes for a v36 share
+// that claims to be a block solution.
+template <typename TrackerT>
+inline DonationValidationResult validate_payouts_against_tracker(
+    TrackerT& tracker,
+    const uint256& best_share_hash,
+    const uint256& block_target,
+    uint64_t subsidy,
+    const std::vector<CoinbaseOutput>& coinbase_outputs,
+    int64_t share_version = 36)
+{
+    auto expected = build_expected_payouts(tracker, best_share_hash, block_target,
+                                           subsidy, share_version);
+    auto total_res = validate_coinbase_total(coinbase_outputs, subsidy);
+    if (!total_res.valid)
+        return total_res;
+    return validate_donation_output(coinbase_outputs, expected, share_version);
+}
+
 } // namespace bip110::pool::consensus

--- a/src/impl/bip110/pool/known_txs_retention.hpp
+++ b/src/impl/bip110/pool/known_txs_retention.hpp
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Pure, unit-testable bookkeeping for the known-transaction pool that backs share
+// broadcast (remember_tx forwarding) — bip110 lane copy of
+// src/impl/btc/known_txs_retention.hpp (namespace-swapped btc -> bip110::pool).
+// retain_template_txs() = rolling-window retention with template-identity dedup;
+// all_txs_backable()/select_backable_shares()/partition_backable() = the canonical
+// broadcast gate (a share is sent only when we hold every referenced new-tx so
+// remember_tx can always forward them); broadcast_and_mark() = the F2 marking
+// policy (mark only what a peer actually accepted). Tx-forwarding only — no
+// consensus/mint state. See the BTC header for the full derivation.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <set>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace bip110::pool {
+
+// Retain the tx set of a newly-registered template in a rolling window of the last
+// `cap` DISTINCT templates, inserting its tx bytes into `known_txs`. F1 dedup: if
+// this template's tx set is already retained, its recency is refreshed (moved to
+// back) and no new slot is consumed. A tx is erased from `known_txs` only once it
+// has fallen out of EVERY retained set.
+template <typename TxMap, typename Tx>
+inline void retain_template_txs(std::deque<std::set<uint256>>& recent_sets,
+                                TxMap& known_txs,
+                                const std::vector<uint256>& hashes,
+                                const std::vector<Tx>& txs,
+                                std::size_t cap)
+{
+    if (cap == 0)
+        return;
+
+    std::set<uint256> new_set(hashes.begin(), hashes.end());
+
+    for (auto it = recent_sets.begin(); it != recent_sets.end(); ++it) {
+        if (*it == new_set) {
+            if (std::next(it) != recent_sets.end()) {
+                std::set<uint256> refreshed = std::move(*it);
+                recent_sets.erase(it);
+                recent_sets.push_back(std::move(refreshed));
+            }
+            return;
+        }
+    }
+
+    const std::size_t n = std::min(hashes.size(), txs.size());
+    for (std::size_t i = 0; i < n; ++i)
+        known_txs.insert_or_assign(hashes[i], txs[i]);
+    recent_sets.push_back(std::move(new_set));
+
+    while (recent_sets.size() > cap) {
+        const std::set<uint256> evicted = std::move(recent_sets.front());
+        recent_sets.pop_front();
+        for (const auto& h : evicted) {
+            bool still_retained = false;
+            for (const auto& s : recent_sets) {
+                if (s.count(h)) { still_retained = true; break; }
+            }
+            if (!still_retained)
+                known_txs.erase(h);
+        }
+    }
+}
+
+// True iff every hash in `tx_hashes` is present in `held` (the bytes we hold). The
+// canonical broadcast gate: a share is backable only when we can forward every
+// referenced tx.
+template <typename Held>
+inline bool all_txs_backable(const std::vector<uint256>& tx_hashes,
+                             const Held& held)
+{
+    for (const auto& h : tx_hashes)
+        if (held.find(h) == held.end())
+            return false;
+    return true;
+}
+
+// F3 send-gate over a batch: returns the indices of shares that are backable.
+template <typename Held>
+inline std::vector<std::size_t> select_backable_shares(
+    const std::vector<std::vector<uint256>>& per_share_refs,
+    const Held& held)
+{
+    std::vector<std::size_t> out;
+    out.reserve(per_share_refs.size());
+    for (std::size_t i = 0; i < per_share_refs.size(); ++i)
+        if (all_txs_backable(per_share_refs[i], held))
+            out.push_back(i);
+    return out;
+}
+
+// Batch form of the F3 gate. Keeps in `shares` only entries every one of whose
+// referenced new-tx hashes we hold, and returns how many were dropped.
+template <typename Share, typename Held, typename HashesOf>
+inline std::size_t partition_backable(std::vector<Share>& shares,
+                                      const Held& held,
+                                      HashesOf hashes_of)
+{
+    std::vector<Share> sendable;
+    sendable.reserve(shares.size());
+    std::size_t skipped = 0;
+    for (auto& share : shares) {
+        if (all_txs_backable(hashes_of(share), held))
+            sendable.push_back(std::move(share));
+        else
+            ++skipped;
+    }
+    shares.swap(sendable);
+    return skipped;
+}
+
+// F2 marking policy. Offers the batch to every peer via `send(peer)` — which
+// returns the hashes it ACTUALLY wrote to that peer — and marks in `marked` only
+// the hashes that reached at least one peer. Returns that count.
+template <typename MarkedSet, typename Peers, typename SendFn>
+inline std::size_t broadcast_and_mark(MarkedSet& marked, Peers& peers,
+                                      const std::vector<uint256>& to_send,
+                                      SendFn send)
+{
+    if (to_send.empty())
+        return 0;
+
+    std::set<uint256> actually_sent;
+    for (auto& entry : peers) {
+        const std::vector<uint256> sent = send(entry.second);
+        actually_sent.insert(sent.begin(), sent.end());
+    }
+    for (const auto& h : actually_sent)
+        marked.insert(h);
+    return actually_sent.size();
+}
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/messages.hpp
+++ b/src/impl/bip110/pool/messages.hpp
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// bip110::pool wire messages — sharechain (pool-P2P) protocol. Structural copy of
+// the BTC lane's messages.hpp; coin:: resolves to bip110::coin, and chain::RawShare
+// carries the v36 MergedMiningShare bytes (share.hpp). The wire message set is the
+// canonical p2pool family (version/ping/addrs/shares/sharereq/sharereply/bestblock/
+// have-tx family). The version message advertises MINIMUM_PROTOCOL_VERSION >= 3600
+// (v36 floor) — a peer below it cannot handshake this sharechain.
+
+#include "../coin/block.hpp"
+#include "../coin/transaction.hpp"
+
+#include <string>
+
+#include <core/message.hpp>
+#include <core/message_macro.hpp>
+#include <sharechain/share.hpp>
+
+namespace bip110::pool
+{
+
+// message_version
+BEGIN_MESSAGE(version)
+    MESSAGE_FIELDS
+    (
+        (uint32_t, m_version),
+        (uint64_t, m_services),
+        (addr_t , m_addr_to),
+        (addr_t, m_addr_from),
+        (uint64_t, m_nonce),
+        (std::string, m_subversion),
+        (uint32_t, m_mode), //# always 1 for legacy compatibility
+        (uint256, m_best_share)
+    )
+    {
+        READWRITE(obj.m_version, obj.m_services, obj.m_addr_to, obj.m_addr_from, obj.m_nonce, obj.m_subversion, obj.m_mode, obj.m_best_share);
+    }
+END_MESSAGE()
+
+// message_ping
+BEGIN_MESSAGE(ping)
+    WITHOUT_MESSAGE_FIELDS() { }
+END_MESSAGE()
+
+// message_addrme
+BEGIN_MESSAGE(addrme)
+    MESSAGE_FIELDS
+    (
+        (uint16_t, m_port)
+    )
+    {
+        READWRITE(obj.m_port);
+    }
+END_MESSAGE()
+
+// message_getaddrs
+BEGIN_MESSAGE(getaddrs)
+    MESSAGE_FIELDS
+    (
+        (uint32_t, m_count)
+    )
+    {
+        READWRITE(obj.m_count);
+    }
+END_MESSAGE()
+
+// message_addrs
+BEGIN_MESSAGE(addrs)
+    MESSAGE_FIELDS
+    (
+        (std::vector<addr_record_t>, m_addrs)
+    )
+    {
+        READWRITE(obj.m_addrs);
+    }
+END_MESSAGE()
+
+// message_shares
+BEGIN_MESSAGE(shares)
+    MESSAGE_FIELDS
+    (
+        (std::vector<chain::RawShare>, m_shares)
+    )
+    {
+        READWRITE(obj.m_shares);
+    }
+END_MESSAGE()
+
+// message_sharereq
+BEGIN_MESSAGE(sharereq)
+    MESSAGE_FIELDS
+    (
+        (uint256, m_id),
+        (std::vector<uint256>, m_hashes),
+        (uint64_t, m_parents),
+        (std::vector<uint256>, m_stops)
+    )
+    {
+        READWRITE(obj.m_id, obj.m_hashes, VarInt(obj.m_parents), obj.m_stops);
+    }
+END_MESSAGE()
+
+enum ShareReplyResult
+{
+    good = 0,
+    too_long = 1,
+    unk2 = 2,
+    unk3 = 3,
+    unk4 = 4,
+    unk5 = 5,
+    unk6 = 6
+};
+
+// message_sharereply
+BEGIN_MESSAGE(sharereply)
+    MESSAGE_FIELDS
+    (
+        (uint256, m_id),
+        (ShareReplyResult, m_result),
+        (std::vector<chain::RawShare>, m_shares)
+    )
+    {
+        READWRITE(obj.m_id, Using<EnumType<CompactFormat>>(obj.m_result), obj.m_shares);
+    }
+END_MESSAGE()
+
+// message_bestblock
+BEGIN_MESSAGE(bestblock)
+    MESSAGE_FIELDS
+    (
+        (coin::BlockHeaderType, m_header)
+    )
+    {
+        READWRITE(obj.m_header);
+    }
+END_MESSAGE()
+
+// message_have_tx
+BEGIN_MESSAGE(have_tx)
+    MESSAGE_FIELDS
+    (
+        (std::vector<uint256>, m_tx_hashes)
+    )
+    {
+        READWRITE(obj.m_tx_hashes);
+    }
+END_MESSAGE()
+
+// message_losing_tx
+BEGIN_MESSAGE(losing_tx)
+    MESSAGE_FIELDS
+    (
+        (std::vector<uint256>, m_tx_hashes)
+    )
+    {
+        READWRITE(obj.m_tx_hashes);
+    }
+END_MESSAGE()
+
+// message_forget_tx
+BEGIN_MESSAGE(forget_tx)
+    MESSAGE_FIELDS
+    (
+        (std::vector<uint256>, m_tx_hashes)
+    )
+    {
+        READWRITE(obj.m_tx_hashes);
+    }
+END_MESSAGE()
+
+// message_remember_tx
+BEGIN_MESSAGE(remember_tx)
+    MESSAGE_FIELDS
+    (
+        (std::vector<uint256>, m_tx_hashes),
+        (std::vector<coin::MutableTransaction>, m_txs)
+    )
+    {
+        READWRITE(obj.m_tx_hashes, coin::TX_WITH_WITNESS(obj.m_txs));
+    }
+END_MESSAGE()
+
+using Handler = MessageHandler<
+    message_ping,
+    message_addrme,
+    message_getaddrs,
+    message_addrs,
+    message_shares,
+    message_sharereq,
+    message_sharereply,
+    message_bestblock,
+    message_have_tx,
+    message_losing_tx,
+    message_forget_tx,
+    message_remember_tx
+>;
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/node.cpp
+++ b/src/impl/bip110/pool/node.cpp
@@ -1,0 +1,2674 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "node.hpp"
+#include "known_txs_retention.hpp"      // F3 retain_template_txs + select_backable_shares
+#include "share_tx_refs.hpp"          // bip110::pool::new_tx_hashes -- uniform gate probe (#880)
+#include "../coin/template_other_txs.hpp"  // deserialize_template_other_txs (GBT data[] -> MutableTransaction)
+
+#include <core/common.hpp>
+#include <core/hash.hpp>
+#include <core/random.hpp>
+#include <core/target_utils.hpp>
+#include <sharechain/prepared_list.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <random>
+
+#ifndef _WIN32
+#include <execinfo.h>  // backtrace() for think() watchdog stack dump (glibc-only)
+#endif
+
+// Static members for DensePPLNSWindow precomputed decay table
+std::vector<uint64_t> bip110::pool::DensePPLNSWindow::s_decay_table;
+uint64_t bip110::pool::DensePPLNSWindow::s_decay_per = 0;
+bool bip110::pool::DensePPLNSWindow::s_table_initialized = false;
+
+// Helper: read current RSS from /proc/self/status (Linux only)
+static long get_rss_mb() {
+    std::ifstream f("/proc/self/status");
+    std::string line;
+    while (std::getline(f, line)) {
+        if (line.rfind("VmRSS:", 0) == 0) {
+            long kb = 0;
+            sscanf(line.c_str(), "VmRSS: %ld", &kb);
+            return kb / 1024;
+        }
+    }
+    return 0;
+}
+
+static long g_rss_limit_mb = 4000;  // abort if RSS exceeds this (configurable)
+
+// p2pool-style hashrate formatting: auto-scale to H/s, kH/s, MH/s, GH/s, TH/s
+static std::string format_hashrate(double hs) {
+    std::ostringstream os;
+    os << std::fixed;
+    if (hs >= 1e12)      os << std::setprecision(2) << hs / 1e12 << "TH/s";
+    else if (hs >= 1e9)  os << std::setprecision(2) << hs / 1e9  << "GH/s";
+    else if (hs >= 1e6)  os << std::setprecision(2) << hs / 1e6  << "MH/s";
+    else if (hs >= 1e3)  os << std::setprecision(1) << hs / 1e3  << "kH/s";
+    else                 os << std::setprecision(0) << hs         << "H/s";
+    return os.str();
+}
+
+// p2pool-style duration formatting: auto-scale to seconds, hours, days, years
+static std::string format_duration(double secs) {
+    if (secs <= 0 || !std::isfinite(secs)) return "???";
+    std::ostringstream os;
+    os << std::fixed;
+    if (secs >= 86400.0 * 365.25)
+        os << std::setprecision(1) << secs / (86400.0 * 365.25) << " years";
+    else if (secs >= 86400.0)
+        os << std::setprecision(1) << secs / 86400.0 << " days";
+    else if (secs >= 3600.0)
+        os << std::setprecision(1) << secs / 3600.0 << " hours";
+    else if (secs >= 60.0)
+        os << std::setprecision(1) << secs / 60.0 << " minutes";
+    else
+        os << std::setprecision(1) << secs << " seconds";
+    return os.str();
+}
+
+// p2pool-style Wilson score confidence interval (util/math.py:133-152)
+// Returns "~X.Y% (lo-hi%)" string for binomial proportion x/n at 95% confidence.
+static std::string format_binomial_conf(int x, int n, double conf = 0.95) {
+    if (n == 0) return "???";
+    // z for 95% ≈ 1.96 (inverse error function approximation)
+    double z = 1.96;
+    double p = static_cast<double>(x) / n;
+    double topa = p + z * z / (2.0 * n);
+    double topb = z * std::sqrt(p * (1.0 - p) / n + z * z / (4.0 * n * n));
+    double bottom = 1.0 + z * z / n;
+    double lo = std::max(0.0, (topa - topb) / bottom);
+    double hi = std::min(1.0, (topa + topb) / bottom);
+    std::ostringstream os;
+    os << "~" << std::fixed << std::setprecision(1) << (100.0 * p) << "% ("
+       << static_cast<int>(std::floor(100.0 * lo)) << "-"
+       << static_cast<int>(std::ceil(100.0 * hi)) << "%)";
+    return os.str();
+}
+
+// Wilson score confidence interval for efficiency: 1 - stale_rate, scaled
+static std::string format_binomial_conf_efficiency(int stale, int n, double stale_prop) {
+    if (n == 0) return "???";
+    double z = 1.96;
+    double p = static_cast<double>(stale) / n;
+    double topa = p + z * z / (2.0 * n);
+    double topb = z * std::sqrt(p * (1.0 - p) / n + z * z / (4.0 * n * n));
+    double bottom = 1.0 + z * z / n;
+    double lo_stale = std::max(0.0, (topa - topb) / bottom);
+    double hi_stale = std::min(1.0, (topa + topb) / bottom);
+    // Efficiency = (1 - stale_rate) / (1 - stale_prop)
+    double denom = (stale_prop < 0.999) ? (1.0 - stale_prop) : 1.0;
+    double eff = (1.0 - p) / denom;
+    double eff_lo = (1.0 - hi_stale) / denom;
+    double eff_hi = (1.0 - lo_stale) / denom;
+    eff_lo = std::max(0.0, eff_lo);
+    eff_hi = std::min(1.0, eff_hi);
+    std::ostringstream os;
+    os << "~" << std::fixed << std::setprecision(1) << (100.0 * eff) << "% ("
+       << static_cast<int>(std::floor(100.0 * eff_lo)) << "-"
+       << static_cast<int>(std::ceil(100.0 * eff_hi)) << "%)";
+    return os.str();
+}
+
+namespace bip110::pool
+{
+
+static uint64_t make_random_nonce()
+{
+    std::mt19937_64 rng(std::random_device{}());
+    return rng();
+}
+
+void NodeImpl::send_ping(peer_ptr peer)
+{
+        auto rmsg = bip110::pool::message_ping::make_raw();
+        peer->write(std::move(rmsg));
+};
+
+void NodeImpl::connected(std::shared_ptr<core::Socket> socket)
+{
+    auto addr = socket->get_addr();
+    bool is_outbound = m_pending_outbound.erase(addr) > 0;
+
+    // Reject banned peers
+    if (is_banned(addr))
+    {
+        LOG_INFO << "[Pool] Rejecting connection from banned peer " << addr.to_string();
+        socket->close();
+        return;
+    }
+
+    // Let BaseNode create the peer and set up the timeout timer
+    base_t::connected(socket);
+
+    if (is_outbound)
+        m_outbound_addrs.insert(addr);
+
+    auto peer = m_connections[addr];
+    send_version(peer);
+}
+
+void NodeImpl::error(const message_error_type& err, const NetService& service, const std::source_location where)
+{
+    // If peer disconnected within 10s of us sending shares, those shares
+    // were likely rejected (e.g. PoW-invalid).  Mark them so we don't
+    // keep re-broadcasting the same bad share on every reconnection.
+    {
+        auto it = m_last_broadcast_to.find(service);
+        if (it != m_last_broadcast_to.end()) {
+            auto elapsed = std::chrono::steady_clock::now() - it->second.when;
+            if (elapsed < std::chrono::seconds(10)) {
+                for (const auto& h : it->second.hashes) {
+                    if (m_rejected_share_hashes.insert(h).second) {
+                        LOG_WARNING << "[Pool] Marking share " << h.GetHex().substr(0, 16)
+                                    << " as rejected (peer " << service.to_string()
+                                    << " disconnected " << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count()
+                                    << "ms after broadcast)";
+                    }
+                }
+            }
+            m_last_broadcast_to.erase(it);
+        }
+    }
+
+    // Drop stale nonce->peer entries for this endpoint before base cleanup.
+    // Without this, reconnects can be rejected as false duplicates because
+    // m_peers still contains the old nonce mapping.
+    for (auto it = m_peers.begin(); it != m_peers.end(); )
+    {
+        if (it->second && it->second->addr() == service)
+            it = m_peers.erase(it);
+        else
+            ++it;
+    }
+
+    // Clean outbound tracking before base removes the peer
+    m_pending_outbound.erase(service);
+    m_outbound_addrs.erase(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after peer removal
+
+    // p2pool p2p.py:595: self.get_shares.respond_all(reason)
+    // Cancel pending share requests for this peer — invokes callbacks with
+    // empty response so m_downloading_shares entries are cleaned up immediately
+    // instead of waiting for the 5s ReplyMatcher timeout.
+    {
+        std::vector<uint256> to_cancel;
+        for (auto& [req_id, peer_addr] : m_pending_share_reqs) {
+            if (peer_addr == service)
+                to_cancel.push_back(req_id);
+        }
+        for (auto& req_id : to_cancel) {
+            m_pending_share_reqs.erase(req_id);
+            m_share_getter.cancel(req_id);
+        }
+    }
+
+    base_t::error(err, service, where);
+}
+
+void NodeImpl::close_connection(const NetService& service)
+{
+    // Same rejection tracking as error() — close_connection is another
+    // path for peer disconnection.
+    {
+        auto it = m_last_broadcast_to.find(service);
+        if (it != m_last_broadcast_to.end()) {
+            auto elapsed = std::chrono::steady_clock::now() - it->second.when;
+            if (elapsed < std::chrono::seconds(10)) {
+                for (const auto& h : it->second.hashes)
+                    m_rejected_share_hashes.insert(h);
+            }
+            m_last_broadcast_to.erase(it);
+        }
+    }
+
+    m_pending_outbound.erase(service);
+    m_outbound_addrs.erase(service);
+
+    // Drop stale nonce->peer entries for this endpoint (parity with error()).
+    // close_connection is a peer-removal path too — without this a graceful
+    // close (e.g. the REPLACE-OLD duplicate swap) could leave a dangling
+    // m_peers[nonce] entry that makes later reconnects look like false
+    // duplicates.
+    for (auto it = m_peers.begin(); it != m_peers.end(); )
+    {
+        if (it->second && it->second->addr() == service)
+            it = m_peers.erase(it);
+        else
+            ++it;
+    }
+
+    // Cancel pending share requests for this peer (same as in error())
+    {
+        std::vector<uint256> to_cancel;
+        for (auto& [req_id, peer_addr] : m_pending_share_reqs) {
+            if (peer_addr == service)
+                to_cancel.push_back(req_id);
+        }
+        for (auto& req_id : to_cancel) {
+            m_pending_share_reqs.erase(req_id);
+            m_share_getter.cancel(req_id);
+        }
+    }
+
+    base_t::close_connection(service);
+    publish_peer_info_snapshot();   // IO thread: refresh after close
+}
+
+NodeImpl::TrackerSnapshot NodeImpl::get_tracker_snapshot() const {
+    std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+    return m_snapshot;
+}
+
+int NodeImpl::get_chain_count() const { return get_tracker_snapshot().chain_count; }
+int NodeImpl::get_verified_count() const { return get_tracker_snapshot().verified_count; }
+
+void NodeImpl::send_version(peer_ptr peer)
+{
+    auto rmsg = bip110::pool::message_version::make_raw(
+        bip110::pool::PoolConfig::ADVERTISED_PROTOCOL_VERSION,
+        1,                                    // services
+        addr_t{1, peer->addr()},              // addr_to (the remote)
+        addr_t{1, NetService{"0.0.0.0", bip110::pool::PoolConfig::P2P_PORT}}, // addr_from (us)
+        m_nonce,
+        m_software_version,
+        1,                                    // mode (always 1 for legacy compat)
+        advertised_best_share()               // verified head, or raw head pre-sync (ROOT-2)
+    );
+    peer->write(std::move(rmsg));
+}
+
+std::optional<::pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr<RawMessage> rmsg, peer_ptr peer)
+{
+    LOG_DEBUG_POOL << "handle message_version";
+        std::unique_ptr<bip110::pool::message_version> msg;
+        msg = bip110::pool::message_version::make(rmsg->m_data);
+
+        LOG_INFO << "[Pool] Peer "
+                 << msg->m_addr_from.m_endpoint.to_string()
+                 << " says protocol version is "
+                 << msg->m_version
+                 << ", client version "
+                 << msg->m_subversion;
+
+        if (peer->m_other_version.has_value())
+        {
+            LOG_DEBUG_POOL << "more than one version message";
+            throw std::runtime_error("more than one version message");
+        }
+
+        peer->m_other_version = msg->m_version;
+        peer->m_other_subversion = msg->m_subversion;
+        peer->m_other_services = msg->m_services;
+
+        if (m_nonce == msg->m_nonce)
+        {
+                LOG_WARNING << "[Pool] was connected to self";
+                return std::nullopt;
+        }
+
+        // Reject peers running too-old protocol BEFORE we touch m_peers, so a
+        // rejected handshake never inserts (and then has to unwind) a nonce entry.
+        // A refusal is pre-insert, with a logged reason + a thrown disconnect that
+        // the bridge turns into a clean error()+cleanup — never a silent
+        // accept-then-drop.
+        if (msg->m_version < bip110::pool::PoolConfig::MINIMUM_PROTOCOL_VERSION)
+        {
+            LOG_WARNING << "Peer " << msg->m_addr_from.m_endpoint.to_string()
+                        << " protocol " << msg->m_version
+                        << " < minimum " << bip110::pool::PoolConfig::MINIMUM_PROTOCOL_VERSION
+                        << ", disconnecting";
+            throw std::runtime_error("peer protocol too old");
+        }
+
+        // Duplicate-nonce policy: REPLACE-OLD (accept-then-drop busy-loop fix).
+        // A peer redialing with the same (per-process) nonce is signalling its
+        // previous connection is gone from its side. The existing m_peers entry is
+        // very likely a half-dead connection we have not yet timed out (up to
+        // PEER_TIMEOUT_TIME away). Silently dropping the NEW dial wastes the
+        // accepted socket and forces the peer into a ~3s redial busy-loop,
+        // starving it of the bulk chain download it is asking for. Instead close
+        // the stale connection and accept the newest one, logged at INFO.
+        if (auto dup = m_peers.find(msg->m_nonce); dup != m_peers.end())
+        {
+                NetService old_addr = dup->second ? dup->second->addr() : NetService{};
+                LOG_INFO << "[Pool] Replacing stale duplicate connection for peer "
+                         << msg->m_addr_from.m_endpoint.to_string()
+                         << " (nonce match): closing previous " << old_addr.to_string()
+                         << ", accepting new " << peer->addr().to_string();
+                m_peers.erase(dup);
+                if (old_addr != peer->addr())
+                        close_connection(old_addr);
+        }
+
+        peer->m_nonce = msg->m_nonce;
+        m_peers[peer->m_nonce] = peer;
+        publish_peer_info_snapshot();   // IO thread: refresh the display snapshot
+
+        // Request peers from the newly established connection
+        {
+            auto getaddrs_msg = bip110::pool::message_getaddrs::make_raw(8);
+            peer->write(std::move(getaddrs_msg));
+        }
+
+        if (!msg->m_best_share.IsNull())
+        {
+            LOG_INFO << "Best share hash for " << msg->m_addr_from.m_endpoint.to_string()
+                     << " = " << msg->m_best_share.ToString();
+
+            if (!m_chain->contains(msg->m_best_share)) {
+                // Start downloading shares we don't have
+                download_shares(peer, msg->m_best_share);
+            } else {
+                // p2pool: handle_share_hashes → handle_shares → set_best_share()
+                // Even when the share is known, re-run think() to re-evaluate
+                // best chain with the peer's perspective. Critical after restart:
+                // shares loaded from LevelDB may have stale best_share selection.
+                run_think();
+            }
+        }
+
+        // Advertise ourselves to the peer (matching Python p2pool sendAdvertisement)
+        {
+            auto port = core::Server::listen_port();
+            auto addrme_msg = bip110::pool::message_addrme::make_raw(port);
+            peer->write(std::move(addrme_msg));
+        }
+
+        // Canonical p2p.py:276 — one FULL have_tx as soon as the handshake
+        // completes, so the peer's view of our tx pool starts correct (and its
+        // dashboard stops showing us as txpool = 0). Subsequent sweeps send
+        // deltas only. Advert-only; no consensus/mint state touched.
+        //
+        // ORDERING IS LOAD-BEARING: this is the LARGEST write the handshake
+        // issues (up to TX_ADVERT_MAX_HASHES_PER_MESSAGE hashes, ~32 KB) and it
+        // goes LAST, after the tiny getaddrs/addrme (and any sharereq) above.
+        // core::Socket::write starts a composed async_write with no outbound
+        // queue (core/socket.cpp:110-137), so initiating another write while one
+        // is still draining interleaves bytes mid-message and gets us dropped on
+        // a bad checksum. Going last means NOTHING follows it in this handler;
+        // the ~32 KB advert may well take several write_some rounds, which is
+        // harmless precisely because nothing else is queued behind it, and the
+        // per-peer min-emit interval keeps the next timer sweep from landing on
+        // top of it. See core/tx_advertiser.hpp.
+        advertise_known_txs(peer);
+
+        return ::pool::PeerConnectionType::actual;
+}
+
+void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
+{
+    // Take ownership immediately so the caller can return/free its local.
+    auto data = std::make_shared<HandleSharesData>(std::move(data_ref));
+    size_t n = data->m_items.size();
+    if (n == 0) return;
+
+    // Phase 1 (thread pool, parallel): run share_init_verify() for each share.
+    // share_init_verify() does scrypt-1024 (~20ms each) — must NOT block io_context.
+    // Each share's hash computation is independent, so we can fully parallelize.
+    auto remaining = std::make_shared<std::atomic<int>>(static_cast<int>(n));
+    for (size_t i = 0; i < n; i++)
+    {
+        boost::asio::post(m_verify_pool,
+            [i, data, remaining, this, addr]()
+            {
+                auto& share = data->m_items[i];
+                if (share.hash().IsNull())
+                {
+                    try
+                    {
+                        share.ACTION({
+                            obj->m_hash = share_init_verify(*obj, true);
+                            // Carry the PoW result WITH the share: the
+                            // thread_local scratch set here (verify pool)
+                            // is invisible to the compute thread that runs
+                            // attempt_verify() later. Without this, peer
+                            // shares meeting the block target were never
+                            // reported (block-found + merged callbacks).
+                            obj->m_pow_hash = g_last_pow_hash;
+                        });
+                    }
+                    catch (const std::exception&)
+                    {
+                        // leave hash null — phase 2 will skip this share
+                    }
+                }
+                // When all verifications are done, schedule phase 2 on io_context
+                if (--(*remaining) == 0)
+                {
+                    boost::asio::post(*m_context,
+                        [data, this, addr]()
+                        {
+                            processing_shares_phase2(*data, addr);
+                        });
+                }
+            });
+    }
+}
+
+void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
+{
+    // Phase 2 (io_context thread): topological sort + chain insertion + LevelDB store.
+    // All shared state (m_tracker, m_chain, m_raw_share_cache, m_storage) touched here.
+    //
+    // Non-blocking mutex: if think() holds the exclusive lock on the compute
+    // thread, queue this batch for processing after think() releases. The IO
+    // thread never blocks — keepalive timers and network I/O continue.
+    //
+    // HOLD this lock across the entire mutation body below (mirrors LTC f445db8e).
+    // try_to_lock keeps the IO thread non-blocking — busy => queue + return. Once
+    // acquired we must NOT release until all m_tracker.chain mutations are done:
+    // the prior code released here and ran the body lock-free, letting the
+    // compute-thread clean_tracker() exclusive prune (drop_tails) free chain nodes
+    // mid-mutation -> SIGSEGV (kr1z1s LTC/DGB). Released just before run_think().
+    std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock()) {
+        // ── Backpressure (V36 livelock defense-in-depth) ──────────────
+        // If think() is wedged/slow the deferred queue could grow without
+        // bound and blow memory. Cap it: over MAX_PENDING_ADDS we DROP the
+        // new batch (peers re-advertise their best share, so dropped shares
+        // are re-requested later) and warn instead of growing unbounded.
+        if (m_pending_adds.size() >= MAX_PENDING_ADDS) {
+            LOG_WARNING << "[ASYNC-DEFER] BACKPRESSURE: pending_adds at cap ("
+                        << m_pending_adds.size() << "/" << MAX_PENDING_ADDS
+                        << "), dropping batch of " << data.m_items.size()
+                        << " shares from " << addr.to_string()
+                        << " — think() may be wedged";
+            return;
+        }
+        LOG_INFO << "[ASYNC-DEFER] processing_shares_phase2: mutex busy, queuing "
+                 << data.m_items.size() << " shares from " << addr.to_string()
+                 << " (pending=" << m_pending_adds.size() + 1 << ")";
+        m_pending_adds.push_back(PendingShareBatch{
+            std::make_unique<HandleSharesData>(std::move(data)), addr});
+        return;
+    }
+    // Lock acquired and HELD across the mutation body below; released just before
+    // the async run_think() trigger so the compute thread can take the exclusive
+    // lock. ASIO single-thread still guarantees no overlapping IO handler.
+
+    // Step 1: collect verified shares (skip any that failed verification, hash still null)
+    std::vector<ShareType> valid_shares;
+    valid_shares.reserve(data.m_items.size());
+    for (size_t idx = 0; idx < data.m_items.size(); ++idx)
+    {
+        auto& share = data.m_items[idx];
+        if (share.hash().IsNull())
+            continue; // verification failed in phase 1
+
+        // Cache original raw bytes for relay (keyed by computed hash)
+        if (idx < data.m_raw_items.size() && !data.m_raw_items[idx].contents.m_data.empty())
+            m_raw_share_cache[share.hash()] = std::move(data.m_raw_items[idx]);
+        valid_shares.push_back(share);
+    }
+
+    // Step 2: Topologically sort valid shares by hash/prev_hash linkage
+    chain::PreparedList<uint256, ShareType> prepare_shares(valid_shares);
+    std::vector<ShareType> shares = prepare_shares.build_list();
+
+    // Step 3: Process sorted shares
+    int32_t new_count = 0;
+    int32_t dup_count = 0;
+    std::map<uint256, coin::MutableTransaction> all_new_txs;
+    std::vector<c2pool::storage::SharechainStorage::ShareBatchEntry> db_batch;
+    for (int i = 0; i < (int)shares.size(); ++i)
+    {
+        auto& share = shares[i];
+
+        // Safety: abort if RSS exceeds limit
+        if (i % 100 == 0) {
+            long rss_now = get_rss_mb();
+            if (rss_now > g_rss_limit_mb) {
+                LOG_ERROR << "RSS LIMIT EXCEEDED (" << rss_now << "MB > " << g_rss_limit_mb << "MB) — aborting!";
+                std::abort();
+            }
+        }
+
+        auto& new_txs = data.m_txs[share.hash()];
+        if (!new_txs.empty())
+        {
+            for (auto& new_tx : new_txs)
+            {
+                PackStream packed_tx = pack(coin::TX_WITH_WITNESS(new_tx));
+                all_new_txs[Hash(packed_tx.get_span())] = new_tx;
+            }
+        }
+
+        if (m_chain->contains(share.hash()))
+        {
+            ++dup_count;
+            continue;
+        }
+
+        ++new_count;
+
+        // Log received share — p2pool format: "Received share diff=X hash=Y miner=Z"
+        share.invoke([](auto* obj) {
+            auto target = chain::bits_to_target(obj->m_bits);
+            double diff = chain::target_to_difficulty(target);
+            // Extract miner identity (pubkey_hash for v17/v33/v36, address script for v34/v35)
+            std::string miner_hex;
+            if constexpr (requires { obj->m_pubkey_hash; })
+                miner_hex = obj->m_pubkey_hash.GetHex().substr(0, 16);
+            else if constexpr (requires { obj->m_address; })
+                miner_hex = "script";
+            LOG_INFO << "Received share: diff=" << std::scientific << std::setprecision(2) << diff
+                     << " hash=" << obj->m_hash.GetHex().substr(0, 16)
+                     << " miner=" << miner_hex;
+        });
+
+        m_tracker.add(share);
+
+        // Log fork detection: if this share's prev_hash has other children, it forks
+        {
+            uint256 prev;
+            bool is_local = false;
+            share.invoke([&](auto* obj) {
+                prev = obj->m_prev_hash;
+                is_local = (obj->peer_addr == NetService{"0.0.0.0", 0} ||
+                            obj->peer_addr == NetService{});
+            });
+            if (is_local && !prev.IsNull()) {
+                auto& rev = m_tracker.chain.get_reverse();
+                auto it = rev.find(prev);
+                if (it != rev.end() && it->second.size() > 1) {
+                    static int fork_log = 0;
+                    if (fork_log++ < 50)
+                        LOG_WARNING << "[FORK] Local share forks! prev=" << prev.GetHex().substr(0,16)
+                                    << " siblings=" << it->second.size()
+                                    << " verified_best=" << m_best_share_hash.GetHex().substr(0,16);
+                }
+            }
+        }
+
+        // Verification is deferred to think() Phase 1 (called after this batch).
+        // p2pool: handle_shares() only adds, set_best_share()→think() verifies.
+        // Inline verification was redundant and caused double-verify CPU waste.
+
+        // NOTE: Do NOT trim inside the processing loop. The trim in run_think()
+        // handles pruning between batches. Trimming here is unsafe because
+        // shares added at the tail can be freed while the loop still holds
+        // dangling raw pointers to them (use-after-free).
+
+        // Collect for batch LevelDB persist (committed atomically after loop)
+        if (m_storage && m_storage->is_available())
+        {
+            std::vector<uint8_t> bytes;
+            auto raw_it = m_raw_share_cache.find(share.hash());
+            if (raw_it != m_raw_share_cache.end() &&
+                raw_it->second.type == share.version() &&
+                !raw_it->second.contents.m_data.empty())
+            {
+                bytes.assign(raw_it->second.contents.m_data.begin(),
+                             raw_it->second.contents.m_data.end());
+            }
+            else
+            {
+                PackStream ps = pack(share);
+                auto span = ps.get_span();
+                bytes.assign(reinterpret_cast<const uint8_t*>(span.data()),
+                             reinterpret_cast<const uint8_t*>(span.data()) + span.size());
+            }
+            uint64_t ver = share.version();
+            std::vector<uint8_t> versioned;
+            versioned.resize(8 + bytes.size());
+            std::memcpy(versioned.data(), &ver, 8);
+            std::memcpy(versioned.data() + 8, bytes.data(), bytes.size());
+
+            share.ACTION({
+                uint256 target = chain::bits_to_target(obj->m_bits);
+                uint256 abswork_256;
+                std::copy(obj->m_abswork.begin(), obj->m_abswork.end(), abswork_256.begin());
+                c2pool::storage::SharechainStorage::ShareBatchEntry entry;
+                entry.hash = obj->m_hash;
+                entry.serialized_data = std::move(versioned);
+                entry.prev_hash = obj->m_prev_hash;
+                entry.height = obj->m_absheight;
+                entry.timestamp = obj->m_timestamp;
+                entry.work = abswork_256;
+                entry.target = target;
+                db_batch.push_back(std::move(entry));
+            });
+        }
+    }
+
+    // Commit all shares to LevelDB atomically (one WriteBatch for entire batch).
+    // Crash-safe: either ALL shares persisted or NONE.
+    if (!db_batch.empty() && m_storage && m_storage->is_available()) {
+        m_storage->store_shares_batch(db_batch);
+    }
+
+    if (new_count > 0) {
+        auto as2 = addr.to_string();
+        std::string source = (addr.port() == 0) ? as2.substr(0, as2.rfind(':')) : as2;
+        LOG_INFO << "Processing " << new_count << " shares from "
+                 << source << "... (dup=" << dup_count
+                 << " chain=" << m_tracker.chain.size() << ")";
+    }
+
+    // Release the tracker lock before triggering think(): run_think() posts the
+    // think+prune job to the compute thread, which needs the exclusive lock. All
+    // chain mutations above are complete at this point.
+    lock.unlock();
+
+    // Trigger think() after every share batch (p2pool: set_best_share after handle_shares).
+    // p2pool calls set_best_share() after EVERY batch with new_count > 0 — no size gate.
+    // think() scores heads and updates best_share + desired set for download_shares.
+    if (new_count > 0) {
+        run_think();
+    }
+}
+
+std::vector<bip110::pool::ShareType> NodeImpl::handle_get_share(std::vector<uint256> hashes, uint64_t parents, std::vector<uint256> stops, NetService peer_addr)
+{
+    // try_to_lock per the architectural rule (node.hpp:67) — IO thread MUST
+    // never block on m_tracker_mutex.  A blocking shared_lock here was the
+    // root cause of the periodic event-loop freeze + SIGABRT cycle on
+    // contabo (2026-04-12, -16, -19, -21, -25): when the compute thread
+    // held the exclusive lock for a long think+clean cycle on a wedged
+    // chain (~30+s), an incoming SHAREREQ on the IO thread would block
+    // here, the watchdog would fire after 30s of io_context unresponsive,
+    // and systemd would restart.
+    //
+    // Empty reply does NOT cause peer disconnect — p2pool's downloader
+    // (node.py:120) picks a random peer per request and retries; an empty
+    // hit just shifts to a different peer next iteration.
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
+    {
+        static int defer_log = 0;
+        if (defer_log++ % 50 == 0)
+            LOG_INFO << "[handle_get_share] tracker busy — returning empty to "
+                     << peer_addr.to_string()
+                     << " (peer will retry against another peer)";
+        return {};
+    }
+
+    parents = std::min(parents, (uint64_t)1000/hashes.size());
+	std::vector<bip110::pool::ShareType> shares;
+	for (const auto& handle_hash : hashes)
+	{
+		if (!m_chain->contains(handle_hash))
+		{
+			static int miss_log = 0;
+			if (miss_log++ < 5)
+				LOG_WARNING << "[handle_get_share] hash NOT in chain: "
+				            << handle_hash.ToString().substr(0, 16)
+				            << " chain_size=" << m_chain->size()
+				            << " tracker_chain_size=" << m_tracker.chain.size();
+			continue;
+		}
+		uint64_t n = std::min(parents+1, (uint64_t) m_chain->get_height(handle_hash));
+		for (auto [hash, data] : m_chain->get_chain(handle_hash, n))
+        {
+			if (std::find(stops.begin(), stops.end(), hash) != stops.end())
+				break;
+			if (m_rejected_share_hashes.count(hash))
+				continue;
+			shares.push_back(data.share);
+		}
+	}
+
+	if (!shares.empty())
+	{
+		LOG_INFO << "[Pool] Sending " << shares.size() << " shares to " << peer_addr.to_string();
+	}
+	// #1130: hand back OWNED copies. Until here `shares` aliased raw
+	// pointers the sharechain owns and frees under m_tracker_mutex; the
+	// sharereq handler (protocol_actual/legacy) serializes them AFTER this
+	// lock is released, so a concurrent think()/prune would free the share
+	// mid-pack — a use-after-free / double-free. clone() gives the caller
+	// independent memory it destroy()s. Same borrow-vs-own rule as #1131/#1163.
+	for (auto& s : shares) s = s.clone();
+	return shares;
+}
+
+void NodeImpl::register_template_txs(const uint256& share_hash,
+                                     const nlohmann::json& template_txs)
+{
+    // Decode the GBT transactions[] (`data` = with-witness hex) OUTSIDE the node
+    // lock — the hex parse is the heavy part and must never run under
+    // m_tracker_mutex. Fail CLOSED on a malformed entry (retain nothing) rather
+    // than poison the retention window.
+    std::vector<coin::MutableTransaction> mtxs;
+    try {
+        mtxs = coin::deserialize_template_other_txs(template_txs);
+    } catch (const std::exception& e) {
+        LOG_WARNING << "[Pool] register_template_txs decode failed for share "
+                    << share_hash.GetHex().substr(0, 16) << ": " << e.what();
+        return;
+    }
+    if (mtxs.empty())
+        return;
+
+    // Key each tx exactly as the remember_tx handler does —
+    // Hash(pack(TX_WITH_WITNESS(tx))) — so the retained bytes are addressable by
+    // the same hash a share or peer references and forwarding stays consistent.
+    std::vector<uint256> hashes;
+    std::vector<coin::Transaction> txs;
+    hashes.reserve(mtxs.size());
+    txs.reserve(mtxs.size());
+    for (auto& mtx : mtxs) {
+        auto packed = pack(coin::TX_WITH_WITNESS(mtx));
+        hashes.push_back(Hash(packed.get_span()));
+        txs.emplace_back(mtx);
+    }
+
+    // Only the map mutation is serialized. A blocking unique_lock matches the
+    // stratum-thread write posture already used by create_local_share (main_btc
+    // drops that lock before calling us); the IO thread never blocks here. The
+    // retention window (not m_known_txs_order) owns these entries' lifecycle.
+    {
+        std::unique_lock<std::shared_mutex> lk(m_tracker_mutex);
+        bip110::pool::retain_template_txs(m_template_recent_sets, m_known_txs,
+                                 hashes, txs, kTemplateRetainCap);
+    }
+
+    LOG_INFO << "[Pool] register_template_txs share=" << share_hash.GetHex().substr(0, 16)
+              << " retained " << hashes.size() << " template tx(s), window="
+              << m_template_recent_sets.size();
+}
+
+std::vector<uint256> NodeImpl::send_shares(peer_ptr peer, const std::vector<uint256>& share_hashes)
+{
+    // Returns the hashes of the shares actually WRITTEN to this peer (F2). The
+    // caller marks only those as broadcast, so a share skipped here — by the
+    // try_to_lock miss below or by the F3 tx-completeness gate — is re-offered
+    // on the next broadcast instead of being silently dropped forever.
+    // try_to_lock per the architectural rule (node.hpp:67) — see freeze
+    // analysis in handle_get_share above.  If we can't acquire NOW, skip
+    // this batch.  The shares are still in our chain; the next broadcast
+    // cycle (or the next think() result) picks them up.
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
+    {
+        static int defer_log = 0;
+        if (defer_log++ % 50 == 0)
+            LOG_INFO << "[send_shares] tracker busy — skipping send to "
+                     << peer->addr().to_string() << " (will retry next cycle)";
+        return {};
+    }
+
+    // Collect shares that exist in our chain (skip rejected)
+    std::vector<ShareType> shares;
+    for (const auto& hash : share_hashes)
+    {
+        if (!m_chain->contains(hash))
+            continue;
+        if (m_rejected_share_hashes.count(hash))
+            continue;
+        // Retrieve the share via get_chain(hash, 1) — first element is the share itself
+        for (auto [h, data] : m_chain->get_chain(hash, 1))
+        {
+            shares.push_back(data.share);
+            break;
+        }
+    }
+
+    if (shares.empty())
+        return {};
+
+    // --- F3 tx-completeness broadcast gate --------------------------------
+    // A share whose referenced new-tx BYTES we do not hold cannot be backed by
+    // the remember_tx forward below, and canonical p2pool drops the connection
+    // on "referenced unknown transaction" (p2p.py) — which isolates us from the
+    // sharechain and orphans our shares. Shares pulled via sharereply arrive
+    // WITHOUT their tx bytes, so this is reachable in normal operation.
+    //
+    // Gate on the BYTES in m_known_txs, not on the peer's have_tx advert: that
+    // advert can be stale (the peer may have dropped the tx) and sending
+    // hash-only for a tx the peer no longer holds is exactly the disconnect.
+    // m_remote_txs is used ONLY below to choose the hash-vs-bytes encoding.
+    //
+    // CONSENSUS-NEUTRAL: this decides only WHETHER we broadcast. Share bytes,
+    // minting and payout are untouched; a skipped share stays in our chain and
+    // is re-offered once its txs arrive (send_shares reports it as unsent, so
+    // broadcast_share leaves it un-marked).
+    {
+        const size_t skipped_incomplete = partition_backable(
+            shares, m_known_txs, [](ShareType& share) {
+                std::vector<uint256> hashes;
+                share.invoke([&](auto* obj) {
+                    // #880: route through the bip110::pool::new_tx_hashes SSOT instead
+                    // of the dead flat probe -- v17/v33 nest the list in
+                    // m_tx_info, v34+ carry none. The old probe was FALSE for
+                    // every variant, so this F3 gate saw empty refs -> every
+                    // share vacuously backable -> the gate no-op'd all versions.
+                    if (const auto* new_txs = bip110::pool::new_tx_hashes(obj))
+                        hashes.assign(new_txs->begin(), new_txs->end());
+                });
+                return hashes;
+            });
+        if (skipped_incomplete > 0)
+        {
+            static int skip_log = 0;
+            if (skip_log++ % 20 == 0)
+                LOG_INFO << "[send_shares] skipped " << skipped_incomplete
+                         << " share(s) whose new-tx bytes we do not hold "
+                            "(downloaded via sharereply / evicted) to "
+                         << peer->addr().to_string()
+                         << " — avoids canonical 'unknown transaction' disconnect";
+        }
+        if (shares.empty())
+            return {};
+    }
+
+    // (b) Extract each share's referenced new-tx hashes. BTC shares carry these
+    // inside m_tx_info (bip110::pool::ShareTxInfo), NOT as a top-level
+    // m_new_transaction_hashes — the old `requires { obj->m_new_transaction_hashes }`
+    // matched no BTC share type, so the whole block below was silently dead for
+    // ALL versions. Guarding on m_tx_info makes it correct-by-construction for
+    // v17/v33 (which populate it) and dormant on v35 (share_check leaves it empty
+    // for version >= 34) — dormant, never silently dead.
+    std::vector<std::vector<uint256>> per_share_refs;
+    per_share_refs.reserve(shares.size());
+    for (auto& share : shares)
+    {
+        std::vector<uint256> refs;
+        share.invoke([&](auto* obj) {
+            if constexpr (requires { obj->m_tx_info; })
+                for (const auto& th : obj->m_tx_info.m_new_transaction_hashes)
+                    refs.push_back(th);
+        });
+        per_share_refs.push_back(std::move(refs));
+    }
+
+    // (a) F3 backable-broadcast gate: withhold any share whose referenced
+    // new-txs we do NOT all hold — transmitting it would trip the peer's
+    // "referenced unknown transaction" disconnect. The gate reads m_known_txs
+    // the same way the needed_txs lookup below does (send_shares' established
+    // access posture for this map). Dormant on v35 (empty refs -> vacuously
+    // backable); live for v17/v33 and any future tx-carrying share.
+    const auto sendable_idx = bip110::pool::select_backable_shares(per_share_refs, m_known_txs);
+    if (sendable_idx.size() != shares.size())
+    {
+        LOG_WARNING << "[Pool] Withholding " << (shares.size() - sendable_idx.size())
+                    << " unbacked share(s) from " << peer->addr().to_string()
+                    << " (referenced template tx not held)";
+        std::vector<ShareType> kept_shares;
+        std::vector<std::vector<uint256>> kept_refs;
+        kept_shares.reserve(sendable_idx.size());
+        kept_refs.reserve(sendable_idx.size());
+        for (auto i : sendable_idx)
+        {
+            kept_shares.push_back(std::move(shares[i]));
+            kept_refs.push_back(std::move(per_share_refs[i]));
+        }
+        shares = std::move(kept_shares);
+        per_share_refs = std::move(kept_refs);
+        if (shares.empty())
+            return {};
+    }
+
+    // Collect transactions the peer doesn't know about, over the surviving
+    // (backable) shares only.
+    std::set<uint256> needed_txs;
+    for (const auto& refs : per_share_refs)
+        for (const auto& th : refs)
+            if (!peer->m_remote_txs.count(th) &&
+                !peer->m_remembered_txs.count(th))
+                needed_txs.insert(th);
+
+    // Send remember_tx for txs the peer needs
+    if (!needed_txs.empty())
+    {
+        std::vector<uint256> known_hashes;   // hashes in peer's remote set
+        std::vector<coin::MutableTransaction> full_txs;  // full txs otherwise
+
+        size_t missing = 0;
+
+        for (const auto& th : needed_txs)
+        {
+            if (peer->m_remote_txs.count(th))
+            {
+                known_hashes.push_back(th);
+            }
+            else
+            {
+                auto it = m_known_txs.find(th);
+                if (it != m_known_txs.end())
+                    full_txs.emplace_back(it->second);
+                else
+                    ++missing;  // unreachable after the gate above — see below
+            }
+        }
+
+        // Defence in depth: the gate should already have removed every share
+        // with an unheld tx, so this must stay at zero. If it ever fires, the
+        // gate's view of the referenced hashes disagrees with needed_txs and
+        // the peer may drop these shares — make that loud rather than silent.
+        if (missing > 0)
+            LOG_WARNING << "[send_shares] " << missing << " referenced tx(s) not in "
+                           "m_known_txs after the completeness gate — peer may drop "
+                           "these shares (share/tx hash accounting mismatch?)";
+
+        if (!known_hashes.empty() || !full_txs.empty())
+        {
+            auto rtx_msg = message_remember_tx::make_raw(known_hashes, full_txs);
+            peer->write(std::move(rtx_msg));
+        }
+    }
+
+    // Pack and send shares — use cached original bytes when available
+    std::vector<chain::RawShare> rshares;
+    rshares.reserve(shares.size());
+    for (size_t i = 0; i < shares.size(); ++i)
+    {
+        auto it = m_raw_share_cache.find(shares[i].hash());
+        if (it != m_raw_share_cache.end())
+        {
+            rshares.push_back(it->second);
+        }
+        else
+        {
+            rshares.emplace_back(shares[i].version(), pack(shares[i]));
+        }
+    }
+
+    auto shares_msg = message_shares::make_raw(rshares);
+    peer->write(std::move(shares_msg));
+
+    // Send forget_tx so peer can free the remembered txs
+    if (!needed_txs.empty())
+    {
+        std::vector<uint256> forget_vec(needed_txs.begin(), needed_txs.end());
+        auto ftx_msg = message_forget_tx::make_raw(forget_vec);
+        peer->write(std::move(ftx_msg));
+    }
+
+    LOG_INFO << "[Pool] Sent " << shares.size() << " shares (+" << needed_txs.size()
+             << " txs) to " << peer->addr().to_string();
+
+    // F2: report exactly which shares reached this peer.
+    std::vector<uint256> sent;
+    sent.reserve(shares.size());
+    for (auto& share : shares)
+        sent.push_back(share.hash());
+    return sent;
+}
+
+void NodeImpl::broadcast_share(const uint256& share_hash)
+{
+    if (share_hash.IsNull())
+        return;
+
+    // try_to_lock per the architectural rule (node.hpp:67) — see freeze
+    // analysis in handle_get_share above.  If think+clean holds the
+    // exclusive lock right now, defer this broadcast: the share is still
+    // in our chain; the next local share creation, the next think cycle,
+    // or the next peer-driven SHAREREQ will pick it up.  Blocking here
+    // was a contributing freeze trigger (called from local-share creation
+    // and from the share-add hot path).
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
+    {
+        const uint64_t deferred =
+            m_broadcast_deferred.fetch_add(1, std::memory_order_relaxed) + 1;
+        static int defer_log = 0;
+        if (defer_log++ % 50 == 0)
+            LOG_INFO << "[broadcast_share] tracker busy — deferring broadcast of "
+                     << share_hash.GetHex().substr(0, 16)
+                     << " (next cycle will pick it up)";
+        // A long run of deferrals with ZERO successes is not contention — it
+        // is a caller holding m_tracker_mutex EXCLUSIVELY across this call on
+        // this thread, which can never grant a shared lock, so the node
+        // silently broadcasts nothing at all. Say so loudly and once.
+        if (deferred >= 20 && m_broadcast_acquired.load(std::memory_order_relaxed) == 0) {
+            static bool warned = false;
+            if (!warned) {
+                warned = true;
+                LOG_WARNING << "[broadcast_share] " << deferred << " consecutive"
+                            << " deferrals with ZERO successful acquisitions — a"
+                               " caller is almost certainly holding the tracker"
+                               " mutex EXCLUSIVELY across this call, which can"
+                               " never grant a shared lock. NO SHARE IS BEING"
+                               " BROADCAST. Drop that lock before calling"
+                               " broadcast_share (main_btc create_share_fn does).";
+            }
+        }
+        return;
+    }
+    m_broadcast_acquired.fetch_add(1, std::memory_order_relaxed);
+
+    // The share may have been pruned between mint and here; get_height /
+    // get_chain on an absent hash is not a defined query, so bail rather
+    // than walk garbage (mirrors the ltc guard).
+    if (!m_chain || !m_chain->contains(share_hash))
+        return;
+
+    // Walk the chain back from share_hash, collecting un-broadcast shares.
+    //
+    // F2: do NOT mark them shared here. send_shares can abandon the whole batch
+    // — the tx-completeness gate skipped it, its tracker try_to_lock missed, or
+    // there are zero peers — and a share marked before that never gets another
+    // chance: the next walk breaks on the first marked hash, so the tip is
+    // permanently withheld from the sharechain and its PPLNS credit is lost.
+    // We mark only what actually reached >= 1 peer, below.
+    std::vector<uint256> to_send;
+    int32_t height = m_chain->get_height(share_hash);
+    int32_t walk = std::min(height, 5);
+
+    for (auto [hash, data] : m_chain->get_chain(share_hash, walk))
+    {
+        if (m_shared_share_hashes.count(hash))
+            break;
+        if (m_rejected_share_hashes.count(hash))
+            continue; // skip shares previously rejected by peers
+        to_send.push_back(hash);
+    }
+
+    if (to_send.empty())
+        return;
+
+    // The walk produced a non-empty batch and we hold the shared lock: the
+    // per-peer send loop (F3 gate + send_shares + F2 mark) is now entered.
+    // This is the count that stays at ZERO if a caller holds the exclusive
+    // lock across the call.
+    m_broadcast_reached_send.fetch_add(1, std::memory_order_relaxed);
+
+    auto now = std::chrono::steady_clock::now();
+    broadcast_and_mark(m_shared_share_hashes, m_peers, to_send, [&](peer_ptr& peer) {
+        std::vector<uint256> sent = send_shares(peer, to_send);
+        // Record what we ACTUALLY wrote, not what we offered: a peer that drops
+        // within 10s marks this record's hashes rejected, and a rejected hash is
+        // never re-broadcast. Blaming a share we withheld would turn a transient
+        // gate skip into permanent loss.
+        if (!sent.empty())
+            m_last_broadcast_to[peer->addr()] = {sent, now};
+        return sent;
+    });
+}
+
+void NodeImpl::notify_local_share(const uint256& share_hash)
+{
+    // p2pool: set_best_share() → think() synchronously on the reactor thread.
+    // Use think() for ALL best_share decisions, as p2pool does.
+    if (share_hash.IsNull())
+        return;
+
+    // Both the chain.contains() read AND attempt_verify() run UNDER the tracker
+    // lock (mirrors LTC f445db8e). A bare m_tracker.chain.contains() here (the
+    // prior code) raced the compute-thread clean_tracker() exclusive prune freeing
+    // chain nodes -> SIGSEGV (kr1z1s LTC/DGB). try_to_lock keeps the IO thread
+    // non-blocking; if think()/clean holds the lock we skip the inline verify —
+    // the share is already in-chain and run_think() below will score it next cycle.
+    {
+        std::unique_lock lock(m_tracker_mutex, std::try_to_lock);
+        if (lock.owns_lock() && m_tracker.chain.contains(share_hash))
+            m_tracker.attempt_verify(share_hash);
+    }
+
+    // Trigger async think() — will pick up the local share through scoring.
+    run_think();
+}
+
+uint256 NodeImpl::best_share_hash()
+{
+    // p2pool's think() returns the best VERIFIED head — not the raw chain tip.
+    // This ensures shares are built on a chain that all peers agree on.
+    // Use think().best ONLY if it's on the VERIFIED chain.
+    // p2pool's think() only considers verified shares for the best head.
+    // If think().best is on an unverified fork (e.g., our own shares that
+    // p2pool hasn't verified yet), fall back to the best verified head.
+    // This prevents building a self-reinforcing fork that never joins
+    // the main chain.
+    if (!m_best_share_hash.IsNull() && m_tracker.verified.contains(m_best_share_hash)) {
+        static int log_count = 0;
+        if (log_count++ % 60 == 0) {
+            auto h = m_tracker.verified.get_height(m_best_share_hash);
+            LOG_INFO << "[best_share] using think() result height=" << h
+                     << " verified=" << m_tracker.verified.size()
+                     << " raw=" << (m_chain ? m_chain->size() : 0);
+        }
+        return m_best_share_hash;
+    }
+    // Fallback: if think() hasn't run yet, pick best verified head by work
+    auto& verified = m_tracker.verified;
+    if (verified.size() > 0) {
+        uint256 best;
+        uint288 best_work;
+        bool first = true;
+        for (const auto& [head_hash, tail_hash] : verified.get_heads()) {
+            auto* idx = verified.get_index(head_hash);
+            if (idx && (first || idx->work > best_work)) {
+                best = head_hash;
+                best_work = idx->work;
+                first = false;
+            }
+        }
+        if (!best.IsNull()) {
+            static int log_count2 = 0;
+            auto best_height = verified.get_height(best);
+            if (log_count2++ % 60 == 0)
+                LOG_INFO << "[best_share] fallback VERIFIED head height=" << best_height
+                         << " work=" << best_work.GetHex().substr(0, 16)
+                         << " verified=" << verified.size()
+                         << " raw=" << (m_chain ? m_chain->size() : 0);
+            return best;
+        }
+    }
+
+    // No verified chain yet — return null to prevent creating shares with
+    // MAX_TARGET max_bits.  p2pool does the same: best_share_var.value = None
+    // until the verified chain exists, and generate_transaction refuses to
+    // create work when best_share is None (with peers connected).
+    //
+    // On a genesis node (no peers, fresh chain), this returns ZERO which
+    // triggers genesis share creation with 100% donation payout.
+    if (!m_peers.empty()) {
+        static int wait_log = 0;
+        if (wait_log++ % 12 == 0)
+            LOG_INFO << "[best_share] waiting for verified chain (peers="
+                     << m_peers.size() << " raw="
+                     << (m_chain ? m_chain->size() : 0) << ")";
+        return uint256::ZERO;
+    }
+
+    // True genesis: no peers at all — use raw chain to bootstrap
+    if (!m_chain || m_chain->size() == 0)
+        return uint256::ZERO;
+
+    uint256 best;
+    int32_t best_height = -1;
+    for (const auto& [head_hash, tail_hash] : m_chain->get_heads()) {
+        auto h = m_chain->get_height(head_hash);
+        if (h > best_height) {
+            best = head_hash;
+            best_height = h;
+        }
+    }
+    static int raw_log = 0;
+    if (raw_log++ % 60 == 0)
+        LOG_INFO << "[best_share] using RAW head (genesis, no peers) height=" << best_height;
+    return best;
+}
+
+// Head advertised to peers in the version handshake and re-advertisement ONLY.
+// Unlike best_share_hash() -- which is verified-only and collapses to ZERO once
+// peers exist so work/template never builds on a MAX_TARGET head -- this returns
+// our tallest RAW chain head.  Root-2: on a fresh (--genesis) node the verified
+// set is empty at handshake, so best_share_hash() advertised ZERO and the peer
+// never issued download_shares() for our shares.  Advertising the raw head makes
+// a connecting peer always learn we have a chain and pull it, while work/template
+// stays on the verified head via best_share_hash().
+uint256 NodeImpl::advertised_best_share()
+{
+    // Prefer think()s current best (verified or not) -- our canonical head.
+    if (!m_best_share_hash.IsNull())
+        return m_best_share_hash;
+
+    // Otherwise the tallest raw chain head (mirrors the genesis fallback above).
+    if (m_chain && m_chain->size() > 0) {
+        uint256 best;
+        int32_t best_height = -1;
+        for (const auto& [head_hash, tail_hash] : m_chain->get_heads()) {
+            auto h = m_chain->get_height(head_hash);
+            if (h > best_height) {
+                best = head_hash;
+                best_height = h;
+            }
+        }
+        if (!best.IsNull())
+            return best;
+    }
+
+    // True genesis: no shares at all yet -- advertise ZERO exactly as before.
+    return uint256::ZERO;
+}
+
+void NodeImpl::readvertise_best_share()
+{
+    // ROOT-2 re-advertisement.  A peer that finished its version handshake
+    // while our verified chain was empty got a NULL best_share and never
+    // called download_shares(); broadcast_share() may not wake it either, because
+    // its walk breaks on the first hash already in m_shared_share_hashes.  Here
+    // we re-push the tip walk to every peer WITHOUT consulting the de-dup set.
+    // Advertise-only: never affects local work creation.
+    //
+    // This is the ltc/dgb-style de-dup-bypass re-advert (ltc/node.cpp,
+    // dgb/node.cpp).  The prior BTC readvertise_best() delegated to
+    // broadcast_share, whose walk breaks on the first hash already in
+    // m_shared_share_hashes, so a head share already accepted by some OTHER peer
+    // stayed masked and the re-advert never reached a freshly-handshook peer.
+    // Walking the head directly closes that gap.
+    uint256 head = advertised_best_share();
+    if (head.IsNull() || head == uint256::ZERO)
+        return;
+
+    // Same try_to_lock discipline as broadcast_share (node.hpp:67): never block
+    // the IO thread on the tracker mutex.  If think() holds it now, the next
+    // trigger (best-change or the timer) retries.
+    std::shared_lock<std::shared_mutex> lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
+        return;
+
+    if (!m_chain || !m_chain->contains(head))
+        return;
+
+    std::vector<uint256> to_send;
+    int32_t height = m_chain->get_height(head);
+    int32_t walk = std::min(height, 5);
+    for (auto [hash, data] : m_chain->get_chain(head, walk)) {
+        if (m_rejected_share_hashes.count(hash))
+            continue; // never re-broadcast peer-rejected shares
+        to_send.push_back(hash);
+    }
+    if (to_send.empty())
+        return;
+
+    // Advertise-only path: deliberately ignores the de-dup set, so nothing is
+    // marked here.  Record only what was ACTUALLY written (F2) — a share the
+    // tx-completeness gate withheld must not be blamed for a later peer drop,
+    // which would mark it rejected and make the walk above `continue` past it
+    // forever.
+    auto now = std::chrono::steady_clock::now();
+    for (auto& [nonce, peer] : m_peers) {
+        std::vector<uint256> sent = send_shares(peer, to_send);
+        if (!sent.empty())
+            m_last_broadcast_to[peer->addr()] = {sent, now};
+    }
+    LOG_INFO << "[readvertise] re-pushed " << to_send.size()
+             << " head share(s) to " << m_peers.size() << " peer(s) (ROOT-2)";
+}
+
+void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_hash)
+{
+    // download_shares(): C++ implementation of the p2pool share-download loop.
+    //
+    // Key differences from old c2pool implementation:
+    // 1. RANDOM peer selection (not the reporting peer)
+    // 2. RANDOM parent count 0-499 (not fixed 500)
+    // 3. STOPS list: known heads + their 10th parents (not empty)
+    // 4. Log format: "Requesting parent share XXXX from IP:PORT"
+
+    // Already downloading this hash — avoid duplicate requests
+    if (m_downloading_shares.count(target_hash))
+        return;
+
+    // Stop requesting hashes that have returned empty too many times —
+    // the share is pruned from the network. p2pool uses reactive desired_var
+    // + sleep(1) backoff; we use explicit failure counting.
+    if (m_download_fail_count[target_hash] >= MAX_EMPTY_RETRIES) {
+        static int fail_log = 0;
+        if (fail_log++ % 20 == 0)
+            LOG_INFO << "[Pool] Skipping permanently failed hash "
+                     << target_hash.ToString().substr(0,16)
+                     << " (failed " << m_download_fail_count[target_hash] << " times)";
+        return;
+    }
+
+    m_downloading_shares.insert(target_hash);
+
+    // p2pool: if len(self.peers) == 0: sleep(1); continue
+    if (m_peers.empty()) {
+        m_downloading_shares.erase(target_hash);
+        return;
+    }
+
+    // p2pool: peer = random.choice(self.peers.values())
+    auto peer_it = m_peers.begin();
+    if (m_peers.size() > 1) {
+        std::advance(peer_it, core::random::random_uint256().GetLow64() % m_peers.size());
+    }
+    auto& peer = peer_it->second;
+
+    // p2pool: parents=random.randrange(500)
+    uint64_t parents = core::random::random_uint256().GetLow64() % 500;
+
+    // p2pool: stops=list(set(tracker.heads) | set(
+    //   tracker.get_nth_parent_hash(head, min(max(0, height-1), 10))
+    //   for head in tracker.heads))[:100]
+    //
+    // Always include stops to bound per-request reply size to the actual
+    // info-gap between our chain and the peer's. Without stops, peer dumps
+    // up to `parents` shares in one single-branch burst — and with bootstrap
+    // parents=random(500), the chain grows along one lineage until it
+    // crosses 2*CHAIN_LENGTH+10, at which point clean_tracker drop-tails
+    // collapses the whole branch and verified resets to 0.
+    std::vector<uint256> stops;
+    {
+        std::set<uint256> stop_set;
+        for (auto& [head_hash, tail_hash] : m_tracker.chain.get_heads()) {
+            stop_set.insert(head_hash);
+            auto h = m_tracker.chain.get_acc_height(head_hash);
+            auto nth = std::min(std::max(0, h - 1), 10);
+            if (nth > 0) {
+                auto parent = m_tracker.chain.get_nth_parent_via_skip(head_hash, nth);
+                if (!parent.IsNull())
+                    stop_set.insert(parent);
+            }
+        }
+        int count = 0;
+        for (auto& s : stop_set) {
+            if (count++ >= 100) break;
+            stops.push_back(s);
+        }
+    }
+
+    auto req_id = core::random::random_uint256();
+    std::vector<uint256> hashes = { target_hash };
+
+    // Track req_id → peer for selective cancellation on disconnect
+    m_pending_share_reqs[req_id] = peer->addr();
+
+    // p2pool: print 'Requesting parent share %s from %s'
+    LOG_INFO << "[Pool] Requesting parent share "
+             << target_hash.ToString().substr(0,16)
+             << " from " << peer->addr().to_string()
+             << " (parents=" << parents << " stops=" << stops.size() << ")";
+
+    // weak_ptr prevents use-after-free if peer disconnects before reply
+    std::weak_ptr<::pool::Peer<bip110::pool::Peer>> weak_peer = peer;
+    auto peer_addr_for_log = peer->addr();
+
+    request_shares(req_id, peer, hashes, parents, stops,
+        [this, weak_peer, target_hash, peer_addr_for_log, req_id](bip110::pool::ShareReplyData reply)
+        {
+            m_downloading_shares.erase(target_hash);
+            m_pending_share_reqs.erase(req_id);
+
+            if (reply.m_items.empty())
+            {
+                // Empty reply = timeout or peer had no matching shares.
+                // Track failures — stop requesting after MAX_EMPTY_RETRIES.
+                auto& fail_cnt = m_download_fail_count[target_hash];
+                ++fail_cnt;
+                LOG_INFO << "[Pool] Share request empty for "
+                         << target_hash.ToString().substr(0,16)
+                         << " from " << peer_addr_for_log.to_string()
+                         << " (fail " << fail_cnt << "/" << MAX_EMPTY_RETRIES << ")";
+                return;
+            }
+
+            // Success — clear failure count for this hash
+            m_download_fail_count.erase(target_hash);
+
+            LOG_INFO << "[Pool] Received " << reply.m_items.size() << " shares for download request";
+
+            // Feed into processing pipeline
+            HandleSharesData data;
+            for (size_t idx = 0; idx < reply.m_items.size(); ++idx)
+            {
+                if (idx < reply.m_raw_items.size())
+                    data.add(reply.m_items[idx], {}, reply.m_raw_items[idx]);
+                else
+                    data.add(reply.m_items[idx], {});
+            }
+            processing_shares(data, peer_addr_for_log);
+
+            // Find the oldest share's parent — if unknown, keep fetching
+            uint256 oldest_parent;
+            reply.m_items.back().invoke([&](auto* obj) { oldest_parent = obj->m_prev_hash; });
+
+            if (!oldest_parent.IsNull() && !m_chain->contains(oldest_parent))
+            {
+                auto locked = weak_peer.lock();
+                if (locked)
+                    download_shares(locked, oldest_parent);
+            }
+        }
+    );
+}
+
+void NodeImpl::load_persisted_shares()
+{
+    if (!m_storage || !m_storage->is_available())
+        return;
+
+    // load_sharechain iterates the height index and loads each share.
+    // Limit to keep_per_head shares to avoid loading unbounded history
+    // into memory (LevelDB is never pruned, so it accumulates forever).
+    LOG_INFO << "[Pool] Scanning LevelDB height index for persisted shares...";
+    auto t0 = std::chrono::steady_clock::now();
+    auto all_hashes = m_storage->get_shares_by_height_range(0, UINT64_MAX);
+    auto scan_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    {
+        std::set<uint256> unique(all_hashes.begin(), all_hashes.end());
+        LOG_INFO << "[Pool] Height index scan: " << all_hashes.size() << " entries ("
+                 << unique.size() << " unique) in " << scan_ms << "ms";
+    }
+    if (all_hashes.empty())
+    {
+        LOG_INFO << "No persisted shares found in LevelDB";
+        return;
+    }
+
+    const size_t keep_per_head = PoolConfig::chain_length() * 2 + 10;
+    const size_t total_in_db = all_hashes.size();
+
+    // Only load the most recent shares (highest height = end of vector)
+    size_t skip = 0;
+    if (total_in_db > keep_per_head)
+    {
+        skip = total_in_db - keep_per_head;
+        LOG_INFO << "[Pool] LevelDB has " << total_in_db << " shares, loading only newest "
+                 << keep_per_head << " (skipping " << skip << " old shares)";
+    }
+
+    const size_t to_load = total_in_db - skip;
+    LOG_INFO << "[Pool] Loading shares from LevelDB: " << to_load << " shares to process...";
+    int loaded = 0, skipped_contains = 0, skipped_load = 0, skipped_small = 0;
+    std::vector<uint256> verified_hashes; // shares to pre-populate into verified
+    for (size_t i = skip; i < total_in_db; ++i)
+    {
+        const auto& hash = all_hashes[i];
+        std::vector<uint8_t> data;
+        core::ShareMetadata meta;
+        if (!m_storage->load_share(hash, data, meta)) {
+            ++skipped_load;
+            continue;
+        }
+        if (data.size() < 8) {
+            ++skipped_small;
+            continue;
+        }
+
+        try
+        {
+            // First 8 bytes = version (uint64_t LE), rest = packed share
+            uint64_t ver;
+            std::memcpy(&ver, data.data(), 8);
+
+            std::vector<unsigned char> share_bytes(data.begin() + 8, data.end());
+            PackStream ps(share_bytes);
+
+            auto share = bip110::pool::load_share(static_cast<int64_t>(ver), ps, NetService{"database", 0});
+            // m_hash is not part of the serialized format — it's computed
+            // during share_check validation.  Restore it from the LevelDB key.
+            share.ACTION({ obj->m_hash = hash; });
+            if (!m_chain->contains(share.hash()))
+            {
+                m_tracker.add(share);
+                loaded++;
+
+                // Restore or compute pow_hash on the index.
+                // p2pool recomputes pow_hash on every load (data.py:1362).
+                // We cache it in LevelDB to avoid scrypt, but recompute if missing.
+                {
+                    auto* idx = m_tracker.chain.get_index(share.hash());
+                    if (idx) {
+                        if (!meta.pow_hash.IsNull()) {
+                            idx->pow_hash = meta.pow_hash;
+                        } else {
+                            // Recompute scrypt pow_hash (matching p2pool's __init__ behavior)
+                            try {
+                                g_last_pow_hash = uint256();
+                                g_last_init_is_block = false;
+                                uint256 computed_hash;
+                                share.ACTION({ computed_hash = share_init_verify(*obj, true); });
+                                if (!g_last_pow_hash.IsNull())
+                                    idx->pow_hash = g_last_pow_hash;
+                                if (!computed_hash.IsNull() && computed_hash != hash) {
+                                    static int hash_mismatch = 0;
+                                    if (++hash_mismatch <= 3)
+                                        LOG_WARNING << "pow_hash recompute: hash mismatch stored="
+                                                    << hash.GetHex().substr(0,16)
+                                                    << " computed=" << computed_hash.GetHex().substr(0,16);
+                                }
+                            } catch (...) {}
+                        }
+                    }
+                }
+
+                // p2pool known_verified: pre-populate verified tracker without re-verification
+                if (meta.is_verified)
+                    verified_hashes.push_back(share.hash());
+
+                if (loaded % 1000 == 0) {
+                    size_t progress = i - skip + 1;
+                    LOG_INFO << "[Pool] Loading shares: " << progress << "/" << to_load
+                             << " (" << (100 * progress / to_load) << "%)";
+                }
+            } else {
+                ++skipped_contains;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            LOG_WARNING << "Failed to load share " << hash.ToString()
+                        << " from LevelDB: " << e.what();
+        }
+    }
+
+    // Pre-populate verified chain from persisted known_verified set (p2pool node.py:190-192).
+    // Shares are loaded by ascending height, so parent-before-child order is guaranteed.
+    int pre_verified = 0;
+    for (const auto& vh : verified_hashes) {
+        if (m_tracker.chain.contains(vh) && !m_tracker.verified.contains(vh)) {
+            try {
+                auto& share_var = m_tracker.chain.get_share(vh);
+                m_tracker.verified.add(share_var);
+                ++pre_verified;
+            } catch (...) {}
+        }
+    }
+    if (pre_verified > 0)
+        LOG_INFO << "[Pool] Pre-populated " << pre_verified << " verified shares from LevelDB";
+
+    LOG_INFO << "[Pool] Loaded " << loaded << " shares from LevelDB storage"
+             << " (DB total: " << total_in_db << ", limit: " << keep_per_head
+             << ", skipped: load=" << skipped_load << " small=" << skipped_small
+             << " dup=" << skipped_contains << ")";
+
+    // Prune old shares from LevelDB that we skipped
+    if (skip > 0)
+    {
+        size_t pruned = 0;
+        for (size_t i = 0; i < skip; ++i)
+        {
+            if (m_storage->remove_share(all_hashes[i]))
+                ++pruned;
+        }
+        LOG_INFO << "[Pool] Pruned " << pruned << " old shares from LevelDB";
+    }
+}
+
+void NodeImpl::flush_verified_to_leveldb()
+{
+    if (m_verified_flush_buf.empty() || !m_storage || !m_storage->is_available())
+        return;
+    // Persist pow_hash from tracker index alongside verified status
+    std::vector<std::pair<uint256, uint256>> hash_pow_pairs;
+    for (const auto& hash : m_verified_flush_buf) {
+        uint256 pow;
+        auto* idx = m_tracker.chain.get_index(hash);
+        if (idx) pow = idx->pow_hash;
+        hash_pow_pairs.emplace_back(hash, pow);
+    }
+    m_storage->mark_shares_verified_with_pow(hash_pow_pairs);
+    m_verified_flush_buf.clear();
+}
+
+void NodeImpl::shutdown()
+{
+    LOG_INFO << "[Pool] NodeImpl shutdown: flushing pending LevelDB buffers...";
+    flush_verified_to_leveldb();
+    if (!m_removal_flush_buf.empty() && m_storage && m_storage->is_available())
+    {
+        m_storage->remove_shares_batch(m_removal_flush_buf);
+        m_removal_flush_buf.clear();
+    }
+    LOG_INFO << "[Pool] NodeImpl shutdown complete";
+}
+
+void NodeImpl::start_outbound_connections()
+{
+    // ── have_tx / losing_tx delta sweep ──────────────────────────────────
+    // Started BEFORE the outbound-dialing early-return below: a node with
+    // outbound dialing disabled still accepts inbound peers and must still
+    // advertise its tx pool to them. Advert-only, no consensus state.
+    if (m_context)
+    {
+        m_tx_advert_timer = std::make_unique<core::Timer>(m_context, true);
+        m_tx_advert_timer->start(core::TX_ADVERT_INTERVAL_SECONDS,
+                                 [this]() { advertise_known_txs(); });
+    }
+
+    if (m_target_outbound_peers == 0)
+    {
+        LOG_INFO << "Outbound peer dialing disabled (target=0)";
+        return;
+    }
+
+    // SeedBootstrapper — tick-driven, rate-limited seed-candidate refill hung
+    // off the existing 30s dial-maintenance loop. It only ADDS candidates (via
+    // got_addr) and never connects; the normal dial path below does the actual
+    // dialing on the next tick. Tiers are tried in order:
+    //   tier 0 = DNS   — TODO: wire core/dns_seeder.hpp async resolution to
+    //                    feed a resolved-IP cache returned here. Until then this
+    //                    tier resolves nothing and the FSM fast-advances past it
+    //                    to the fixed tier (empty-tier advance path).
+    //   tier 1 = fixed — static NetService fallback list (sync, works today).
+    //
+    // Skipped entirely on custom/federation nets (m_seed_escalation_enabled
+    // == false): the fixed tier is PUBLIC Bitcoin COIN seeds (port 8333) and a
+    // federation sharechain must never dial the open coin network. The tick
+    // sites below already null-check m_seed_bootstrapper, so leaving it unset
+    // simply disables escalation while the normal dial path keeps running.
+    if (m_seed_escalation_enabled)
+    {
+        const bool testnet = m_config->m_testnet;
+        std::vector<bip110::coin::SeedBootstrapper::TierFn> tiers;
+        tiers.emplace_back([]() -> std::vector<NetService> { return {}; });
+        tiers.emplace_back([testnet]() { return bip110::coin::btc_fixed_seeds(testnet); });
+
+        bip110::coin::SeedBootstrapper::Config sb_cfg;  // locked defaults
+        m_seed_bootstrapper = std::make_unique<bip110::coin::SeedBootstrapper>(
+            sb_cfg,
+            // Snapshot: live established-outbound / target + the dial layer
+            // exhaustion flag recorded on the previous pass below.
+            [this]() {
+                return bip110::coin::SeedBootstrapper::Snapshot{
+                    m_outbound_addrs.size(), m_target_outbound_peers,
+                    m_seed_candidates_exhausted};
+            },
+            // Sink: seeds only add candidates; services unknown (0), seen now.
+            [this](const NetService& a) {
+                got_addr(a, /*services=*/0, core::timestamp());
+            },
+            // Clock: unix seconds.
+            []() -> std::int64_t {
+                return static_cast<std::int64_t>(core::timestamp());
+            },
+            std::move(tiers),
+            std::random_device{}());  // per-node startup jitter decorrelation
+    }
+    else
+    {
+        LOG_INFO << "[Pool] Coin-seed escalation disabled "
+                    "(custom/federation net) — public COIN seeds suppressed";
+    }
+
+    // Try to connect to peers right away
+    auto try_connect_peers = [this]() {
+        size_t outbound = m_outbound_addrs.size();
+        if (outbound >= m_target_outbound_peers || m_connections.size() >= m_max_peers)
+        {
+            // Still drive the FSM on the healthy path so it sees the at/above-
+            // target Snapshot and releases backoff state after hysteresis; the
+            // Healthy branch injects nothing regardless of the exhaustion flag.
+            if (m_seed_bootstrapper)
+                m_seed_bootstrapper->tick();
+            return;
+        }
+
+        size_t needed = m_target_outbound_peers - outbound;
+        auto good_peers = get_good_peers(needed + 4);  // ask for a few extra in case some are already connected
+
+        for (auto& ap : good_peers)
+        {
+            if (needed == 0)
+                break;
+            // Skip if already connected, already dialing, or banned
+            if (m_connections.contains(ap.addr) || m_pending_outbound.contains(ap.addr) || is_banned(ap.addr))
+                continue;
+
+            LOG_INFO << "[Pool] Dialing outbound peer " << ap.addr.to_string();
+            m_pending_outbound.insert(ap.addr);
+            core::Client::connect(ap.addr);
+            --needed;
+        }
+
+        // Dual-condition guard for seed escalation: after dialing everything we
+        // could this cycle, a non-zero remaining deficit means the normal dial
+        // path could not fill `needed` from its own good-peer set — its
+        // candidates are exhausted. Record it and drive the FSM, which escalates
+        // to seed injection only once starvation has also persisted long enough.
+        m_seed_candidates_exhausted = (needed > 0);
+        if (m_seed_bootstrapper)
+            m_seed_bootstrapper->tick();
+    };
+
+    // Initial burst
+    try_connect_peers();
+
+    // Periodic maintenance — every 30 seconds, check if we need more outbound peers
+    m_connect_timer = std::make_unique<core::Timer>(m_context, true);
+    m_connect_timer->start(30, try_connect_peers);
+}
+
+void NodeImpl::prune_shares(const uint256& /*best_share*/)
+{
+    // Tail-dropping (as in p2pool's clean_tracker):
+    // - Check each tail: if min(height(head) for heads) < 2*CL+10 → skip
+    // - Remove ONE child of qualifying tail per iteration
+    // - Loop up to 1000 times (gradual, not bulk)
+    // - Also cascade removal to verified
+    const auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+    const int32_t min_depth = 2 * CL + 10;
+
+    for (int iter = 0; iter < 1000; ++iter)
+    {
+        // p2pool node.py:382-398: find ONE qualifying tail child to remove
+        uint256 to_remove;
+        bool found = false;
+        auto tails_copy = m_tracker.chain.get_tails();
+        for (auto& [tail_hash, head_hashes] : tails_copy)
+        {
+            // Check min height across ALL heads for this tail
+            int32_t min_height = std::numeric_limits<int32_t>::max();
+            for (auto& hh : head_hashes) {
+                if (!m_tracker.chain.contains(hh)) continue;
+                try {
+                    min_height = std::min(min_height, m_tracker.chain.get_height(hh));
+                } catch (...) { continue; }
+            }
+            if (min_height < min_depth) continue;
+
+            // Find ONE child of this tail (p2pool removes one at a time)
+            auto& rev = m_tracker.chain.get_reverse();
+            auto rev_it = rev.find(tail_hash);
+            if (rev_it != rev.end() && !rev_it->second.empty()) {
+                to_remove = *rev_it->second.begin();
+                found = true;
+                break;  // one per iteration
+            }
+        }
+
+        if (!found) break;
+
+        if (!m_tracker.chain.contains(to_remove)) continue;
+        // p2pool node.py:393 — safety check: parent must be a tail
+        auto* idx = m_tracker.chain.get_index(to_remove);
+        if (!idx) continue;
+        bool parent_is_tail = m_tracker.chain.get_tails().contains(idx->tail);
+        if (!parent_is_tail) {
+            LOG_DEBUG_POOL << "prune skip: parent " << idx->tail.ToString().substr(0,16)
+                           << " not a tail";
+            continue;
+        }
+        if (m_tracker.verified.contains(to_remove))
+            m_tracker.verified.remove(to_remove, /*owns_data=*/false);
+        m_tracker.chain.remove(to_remove);
+    }
+
+    // Cache cleanup (kept from original)
+    if (m_shared_share_hashes.size() > m_max_shared_hashes)
+        m_shared_share_hashes.clear();
+    // Recency-preserving bounded eviction (was: wholesale clear()). Dropping the
+    // whole cache at once destroyed every forwardable tx byte, so a share relay
+    // that referenced a just-dropped tx could no longer remember_tx-forward it
+    // and the canonical peer disconnected with "referenced unknown transaction".
+    // Evict oldest-first down to the cap, keeping the most-recently-learned txs.
+    if (m_known_txs.size() > m_max_known_txs)
+        core::evict_known_txs_to_cap(m_known_txs, m_known_txs_order, m_max_known_txs);
+
+    // /p2p_stats gauges (observe-only): the SEND-side truth behind a peer
+    // dashboard reporting TXPOOL=0 for us. Published here because prune_shares
+    // is the periodic pass that already touches both containers. Relaxed
+    // stores, no lock, no consensus/mint/payout state read or written.
+    core::obs::p2p_stats().known_txs_size.store(
+        m_known_txs.size(), std::memory_order_relaxed);
+    core::obs::p2p_stats().known_txs_order_size.store(
+        static_cast<std::int64_t>(m_known_txs_order.size()), std::memory_order_relaxed);
+    core::obs::p2p_stats().known_txs_updated_at.store(
+        static_cast<std::int64_t>(core::timestamp()), std::memory_order_relaxed);
+    if (m_raw_share_cache.size() > m_max_raw_shares)
+        m_raw_share_cache.clear();
+}
+
+// (old phases 5-7 removed — replaced by p2pool-style pruning above)
+
+// ── think() watchdog (V36 livelock defense-in-depth) ────────────────────
+// Best-effort recovery if a think() cycle wedges. Runs ENTIRELY on the IO
+// thread and NEVER acquires m_tracker_mutex — so it stays responsive even
+// while the compute thread holds the exclusive lock. Uses an atomic deadline
+// + generation counter rather than a per-dispatch timer object lifetime so a
+// late fire cannot act on a newer cycle.
+void NodeImpl::arm_think_watchdog()
+{
+    if (!m_context)
+        return;
+    auto deadline = std::chrono::steady_clock::now()
+                  + std::chrono::seconds(THINK_WATCHDOG_SECONDS);
+    m_think_deadline_ns.store(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            deadline.time_since_epoch()).count(),
+        std::memory_order_relaxed);
+    uint64_t gen = m_think_generation.fetch_add(1, std::memory_order_relaxed) + 1;
+
+    if (!m_watchdog_timer)
+        m_watchdog_timer = std::make_unique<boost::asio::steady_timer>(*m_context);
+    m_watchdog_timer->expires_after(std::chrono::seconds(THINK_WATCHDOG_SECONDS));
+    m_watchdog_timer->async_wait([this, gen](const boost::system::error_code& ec) {
+        if (ec) return;  // cancelled by disarm (normal completion)
+        // Only act if this is still the cycle we armed for and it has not
+        // already completed (deadline cleared to 0 by disarm).
+        if (m_think_generation.load(std::memory_order_relaxed) != gen)
+            return;
+        int64_t dl = m_think_deadline_ns.load(std::memory_order_relaxed);
+        if (dl == 0)
+            return;  // cycle completed in the gap before this fire
+        auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch()).count();
+        if (now_ns < dl)
+            return;  // not actually overdue (spurious) — let next arm handle it
+
+        // (1) Log + best-effort backtrace dump of the current (IO) thread.
+        // We CANNOT safely unwind the compute thread's stack from here, but
+        // a backtrace of the watchdog firing plus the timing is enough to
+        // confirm the wedge and correlate with the last [ASYNC-THINK] logs.
+        LOG_ERROR << "[THINK-WATCHDOG] think() cycle exceeded "
+                  << THINK_WATCHDOG_SECONDS << "s (gen=" << gen
+                  << ", pending_adds=" << m_pending_adds.size()
+                  << ") — compute thread appears wedged; recovering pipeline";
+#ifndef _WIN32
+        {
+            void* frames[64];
+            int n = ::backtrace(frames, 64);
+            char** syms = ::backtrace_symbols(frames, n);
+            if (syms) {
+                for (int i = 0; i < n; ++i)
+                    LOG_ERROR << "[THINK-WATCHDOG] bt[" << i << "] " << syms[i];
+                ::free(syms);
+            }
+        }
+#else
+        // Native backtrace is glibc-only (execinfo.h); on MSVC the timeout log
+        // above plus pending_adds is the diagnostic. Recovery below is identical.
+#endif
+
+        // (2)+(3) Flag the cycle aborted and reset the running flag so the
+        // pipeline recovers. NOTE: this does NOT forcibly unwind the compute
+        // thread (unsafe); it lets a fresh think() be scheduled. The stuck
+        // think(), if it ever returns, will find m_think_running already false
+        // and its IO-phase still runs harmlessly (idempotent drain + reset).
+        m_think_deadline_ns.store(0, std::memory_order_relaxed);
+        m_think_running.store(false, std::memory_order_relaxed);
+        LOG_WARNING << "[THINK-WATCHDOG] m_think_running reset to false; "
+                       "a new think() cycle may now be scheduled";
+    });
+}
+
+void NodeImpl::disarm_think_watchdog()
+{
+    // Mark cycle complete: clears the deadline so a racing watchdog fire is a
+    // no-op, and cancels the pending timer.
+    m_think_deadline_ns.store(0, std::memory_order_relaxed);
+    if (m_watchdog_timer) {
+        m_watchdog_timer->cancel();
+    }
+}
+
+void NodeImpl::run_think()
+{
+    // Skip if a think() is already running on the compute thread.
+    // The atomic flag serializes: only one think() in flight at a time.
+    if (m_think_running.exchange(true)) {
+        static int skip_log = 0;
+        if (skip_log++ % 20 == 0)
+            LOG_INFO << "[ASYNC-THINK] skipped — compute thread busy (skip_count=" << skip_log << ")";
+        return;
+    }
+    LOG_INFO << "[ASYNC-THINK] dispatching to compute thread"
+             << " pending_adds=" << m_pending_adds.size()
+             << " peers=" << m_peers.size();
+
+    // Arm the think() watchdog (IO-thread timer; never touches the tracker
+    // mutex). Disarmed in the IO-phase below on normal completion.
+    arm_think_watchdog();
+
+    // Capture block_rel_height fn by value for thread safety
+    auto block_rel_height = m_block_rel_height_fn
+        ? m_block_rel_height_fn
+        : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
+
+    // ── Post think() to the dedicated compute thread ──────────────────────
+    // The compute thread acquires m_tracker_mutex exclusively, guaranteeing
+    // no concurrent IO-thread modifications to the tracker. The IO thread
+    // uses try_to_lock for all tracker access — if the mutex is held, the
+    // operation is deferred (shares queued, clean_tracker skipped). Network
+    // I/O, keepalive timers, and stratum continue unimpeded.
+    //
+    // Previous attempt at threaded think() caused SIGSEGV because there was
+    // NO synchronization — prune_shares freed shares while think traversed
+    // them. The shared_mutex + try_to_lock pattern eliminates this race:
+    // no mutations occur while the compute thread holds the exclusive lock.
+    boost::asio::post(m_think_pool, [this, block_rel_height]() {
+      m_compute_thread_id.store(std::this_thread::get_id(), std::memory_order_relaxed);
+
+      // ── Compute thread: exclusive tracker access ──────────────────────
+      // Collect results under the lock, then release before posting to IO.
+      TrackerThinkResult result;
+      bool best_changed = false;
+      bool needs_continue = false;
+      int64_t think_ms = 0;
+
+      try {
+        auto lock_t0 = std::chrono::steady_clock::now();
+        std::unique_lock lock(m_tracker_mutex);  // exclusive — IO defers
+        auto lock_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - lock_t0).count();
+        if (lock_ms > 10)
+            LOG_INFO << "[ASYNC-THINK] mutex acquired after " << lock_ms << "ms wait";
+
+        uint256 prev_block;
+        uint32_t bits = 0;
+
+        // Bootstrap mode: no verified chain yet → verify everything in one
+        // pass with unlimited budget.  During bootstrap, stratum isn't serving
+        // real work so no IO callbacks need the tracker lock.  Matches p2pool
+        // where think() runs synchronously on the reactor during initial sync.
+        bool bootstrap = m_tracker.verified.size() == 0;
+        LOG_INFO << "[ASYNC-THINK] compute: chain=" << m_tracker.chain.size()
+                 << " verified=" << m_tracker.verified.size()
+                 << " heads=" << m_tracker.chain.get_heads().size()
+                 << " v_heads=" << m_tracker.verified.get_heads().size()
+                 << (bootstrap ? " BOOTSTRAP" : "");
+        auto think_t0 = std::chrono::steady_clock::now();
+        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - think_t0).count();
+
+        // Apply tracker-mutating results while still holding the lock:
+        // - Ban list and download set are NodeImpl members (not tracker),
+        //   but safe here since IO thread doesn't touch them during think.
+        // - best_share update and top5_heads are consumed by IO-thread
+        //   callbacks, so just record the values for the IO-thread phase.
+        m_last_top5_heads = std::move(result.top5_heads);
+
+        if (!result.best.IsNull()) {
+            best_changed = (m_best_share_hash != result.best);
+            m_best_share_hash = result.best;
+        }
+
+        // Publish lock-free snapshot for all IO-thread consumers
+        publish_snapshot();
+
+        // Continue if EITHER the Phase 2 verification budget OR the V36
+        // scoring-walk lock-yield budget was exhausted. Both reuse the same
+        // run_think() re-post: lock released here, drain_pending_adds() runs,
+        // continuation scheduled below.
+        needs_continue = m_tracker.m_think_needs_continue
+                      || m_tracker.m_think_walk_needs_continue;
+
+        // Flush verified hashes to LevelDB while lock is held
+        flush_verified_to_leveldb();
+
+        // Work refresh runs on the IO thread AFTER the lock is released.
+        // It takes 1-5s (PPLNS + MM coinbase) — must NOT hold exclusive lock
+        // or it blocks all shared_lock readers (handle_get_share, send_shares)
+        // and kills peer connections.
+
+      } catch (const std::exception& e) {
+        LOG_ERROR << "run_think() failed on compute thread: " << e.what();
+      } catch (...) {
+        LOG_ERROR << "run_think() failed on compute thread: unknown error";
+      }
+      // ── Lock released here ────────────────────────────────────────────
+
+      LOG_INFO << "[ASYNC-THINK] compute done in " << think_ms << "ms"
+               << " best_changed=" << best_changed
+               << " needs_continue=" << needs_continue
+               << " bads=" << result.bad_peer_addresses.size()
+               << " desired=" << result.desired.size();
+
+      // ── Post IO-thread phase: work refresh + drain pending ────────────
+      // These operations need the IO thread (send to peers, stratum notify).
+      // The mutex is NOT held — IO thread can acquire it for drain_pending.
+      boost::asio::post(*m_context, [this, result = std::move(result),
+                                      best_changed, needs_continue]() {
+        try {
+            // Ban peers that provided invalid/unverifiable shares
+            auto now = std::chrono::steady_clock::now();
+            for (const auto& bad_addr : result.bad_peer_addresses) {
+                if (bad_addr.port() == 0)
+                    continue;
+                LOG_WARNING << "run_think: banning peer " << bad_addr.to_string()
+                            << " for unverifiable shares";
+                m_ban_list[bad_addr] = now + m_ban_duration;
+            }
+
+            // Expire old bans
+            for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
+                if (it->second <= now) it = m_ban_list.erase(it);
+                else ++it;
+            }
+
+            // Clear stale download set (p2pool node.py:108-141)
+            m_downloading_shares.clear();
+
+            // Reset fail counts each think() cycle — matches p2pool which
+            // re-adds desired hashes from scratch every cycle with sleep(1)
+            // backoff.  Permanent blacklisting caused bootstrap stalls:
+            // the tail parent hash would get 3 empty replies and never be
+            // requested again, leaving the chain stuck at <CHAIN_LENGTH.
+            m_download_fail_count.clear();
+
+            // Request desired shares from random peers
+            if (!result.desired.empty() && !m_peers.empty()) {
+                for (auto& [peer_addr, hash] : result.desired) {
+                    auto peer_it = m_peers.begin();
+                    if (m_peers.size() > 1)
+                        std::advance(peer_it, core::random::random_uint256().GetLow64() % m_peers.size());
+                    download_shares(peer_it->second, hash);
+                }
+            }
+
+            // Work refresh on IO thread — NO lock held. Takes 1-5s but doesn't
+            // block shared_lock readers (handle_get_share, send_shares).
+            // The tracker is not being modified during this window (think finished,
+            // pending adds not yet drained), so reading it is safe.
+            if (best_changed) {
+                LOG_INFO << "[ASYNC-THINK] IO-phase: best=" << m_best_share_hash.GetHex()
+                         << " work refresh starting";
+                auto wr_t0 = std::chrono::steady_clock::now();
+                if (m_on_best_share_changed) m_on_best_share_changed();
+                auto wr_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - wr_t0).count();
+                LOG_INFO << "[ASYNC-THINK] IO-phase: work refresh done in " << wr_ms << "ms";
+                // Root-2: re-advertise our new head.  A peer that handshook
+                // before we had a chain saw a ZERO advert and never issued
+                // download_shares -- re-announce so it pulls our shares now.
+                readvertise_best_share();
+            } else if (result.best.IsNull()) {
+                LOG_WARNING << "[ASYNC-THINK] IO-phase: result.best is NULL — verified_tails="
+                            << m_tracker.verified.get_tails().size()
+                            << " verified_heads=" << m_tracker.verified.get_heads().size();
+            }
+
+            // ROOT-2: fire ONE think-independent delayed re-advert when the
+            // verified chain first becomes non-empty.  Covers peers that
+            // handshook during the empty window and so never see a best-change
+            // event.  The one-shot timer runs on the IO thread, so it still
+            // fires even if a later think() cycle wedges (composes with the
+            // #97 think-watchdog).  Pure reads; broadcast stays try_to_lock.
+            if (m_verified_was_empty && m_tracker.verified.size() > 0) {
+                m_verified_was_empty = false;
+                if (!m_readvert_timer)
+                    m_readvert_timer = std::make_unique<core::Timer>(m_context, false);
+                m_readvert_timer->start(10, [this]() { readvertise_best_share(); });
+                LOG_INFO << "[readvertise] verified chain populated — scheduled "
+                            "10s re-advert (ROOT-2)";
+            }
+
+            // Drain share batches queued while think() held the mutex
+            LOG_INFO << "[ASYNC-THINK] IO-phase: draining " << m_pending_adds.size()
+                     << " pending batches, peers=" << m_peers.size();
+            drain_pending_adds();
+            publish_peer_info_snapshot();   // IO thread: keep uptime fresh
+
+            // Cycle completed normally — disarm the watchdog first so it
+            // cannot fire on this (now-finished) generation.
+            disarm_think_watchdog();
+
+            // Clear flag AFTER drain — prevents new think() from starting
+            // while deferred shares are still being added to the tracker.
+            m_think_running.store(false);
+            LOG_INFO << "[ASYNC-THINK] cycle complete — IO thread free";
+
+            // If verification budget was exhausted, schedule continuation.
+            // The IO thread processes network I/O between verification batches.
+            if (needs_continue) {
+                boost::asio::post(*m_context, [this]() { run_think(); });
+            }
+        } catch (const std::exception& e) {
+            LOG_ERROR << "run_think() IO phase failed: " << e.what();
+            disarm_think_watchdog();
+            m_think_running.store(false);
+        } catch (...) {
+            LOG_ERROR << "run_think() IO phase failed: unknown error";
+            disarm_think_watchdog();
+            m_think_running.store(false);
+        }
+      });
+    });
+}
+
+// ── Drain pending share batches ─────────────────────────────────────────
+// Called on the IO thread after think() releases m_tracker_mutex.
+// Processes share batches that arrived while think was running.
+void NodeImpl::drain_pending_adds()
+{
+    if (m_pending_adds.empty())
+        return;
+
+    // Take ownership of pending queue
+    auto pending = std::move(m_pending_adds);
+    m_pending_adds.clear();
+
+    LOG_INFO << "[drain] Processing " << pending.size()
+             << " deferred share batches";
+
+    for (auto& batch : pending) {
+        processing_shares_phase2(*batch.data, batch.addr);
+    }
+}
+
+// ── Heartbeat logging ───────────────────────────────────────────────────
+// p2pool-style status lines: chain height, local/pool hashrate, orphan/DOA.
+// Runs on a separate 30s timer — diagnostic only, not consensus-critical.
+// Previously ran inside run_think() blocking the IO thread on every share.
+void NodeImpl::heartbeat_log()
+{
+    // Try shared lock — if think is running, skip this heartbeat
+    std::shared_lock lock(m_tracker_mutex, std::try_to_lock);
+    if (!lock.owns_lock())
+        return;
+
+    auto chain_sz  = m_tracker.chain.size();
+    auto verified  = m_tracker.verified.size();
+    auto peers     = m_peers.size();
+
+    int incoming_peers = 0;
+    for (auto& [nonce, peer] : m_peers) {
+        if (peer && !m_outbound_addrs.contains(peer->addr()))
+            ++incoming_peers;
+    }
+
+    int height = 0;
+    if (!m_best_share_hash.IsNull()) {
+        if (m_tracker.chain.contains(m_best_share_hash))
+            height = m_tracker.chain.get_height(m_best_share_hash);
+    }
+    if (height == 0 && verified > 0)
+        height = static_cast<int>(verified);
+
+    // L1: chain status
+    LOG_INFO << "c2pool: " << height << " shares in chain ("
+             << verified << " verified/" << chain_sz << " total)"
+             << " Peers: " << peers << " (" << incoming_peers << " incoming)";
+
+    // L2: local hashrate
+    uint32_t share_bits = 0;
+    if (!m_best_share_hash.IsNull() && m_tracker.chain.contains(m_best_share_hash)) {
+        m_tracker.chain.get(m_best_share_hash).share.invoke([&](auto* s) {
+            share_bits = s->m_bits;
+        });
+    }
+    if (m_local_rate_stats_fn) {
+        auto stats = m_local_rate_stats_fn();
+        std::ostringstream local_line;
+        local_line << " Local: " << format_hashrate(stats.hashrate);
+        if (stats.effective_dt > 0)
+            local_line << " in last " << format_duration(stats.effective_dt);
+        local_line << " Local dead on arrival: "
+                   << format_binomial_conf(stats.dead_datums, stats.total_datums);
+        if (stats.hashrate > 0 && share_bits != 0) {
+            auto share_target = chain::bits_to_target(share_bits);
+            auto share_aps = chain::target_to_average_attempts(share_target);
+            double ets = static_cast<double>(share_aps.GetLow64()) / stats.hashrate;
+            local_line << " Expected time to share: " << format_duration(ets);
+        }
+        LOG_INFO << local_line.str();
+    } else if (m_local_hashrate_fn) {
+        LOG_INFO << " Local: " << format_hashrate(m_local_hashrate_fn());
+    }
+
+    // L3: orphan/DOA/stale stats (chain walk — diagnostic only)
+    int orphan_count = 0, doa_count = 0, total_recent = 0;
+    uint256 walk_start = m_best_share_hash;
+    if (walk_start.IsNull() || !m_tracker.chain.contains(walk_start)) {
+        auto& vheads = m_tracker.verified.get_heads();
+        if (!vheads.empty())
+            walk_start = vheads.begin()->first;
+    }
+    if (!walk_start.IsNull() && m_tracker.chain.contains(walk_start)) {
+        int window = std::min(height, static_cast<int>(
+            std::min(size_t(3600) / PoolConfig::share_period(), size_t(height))));
+        if (window > 0) {
+            auto walkable = m_tracker.chain.get_height(walk_start);
+            auto walk_n = std::min(window, walkable);
+            if (walk_n > 0) {
+                try {
+                    auto view = m_tracker.chain.get_chain(walk_start, walk_n);
+                    for (auto [hash, data] : view) {
+                        data.share.invoke([&](auto* s) {
+                            if (s->m_stale_info == bip110::pool::StaleInfo::orphan) ++orphan_count;
+                            else if (s->m_stale_info == bip110::pool::StaleInfo::doa) ++doa_count;
+                        });
+                        ++total_recent;
+                    }
+                } catch (...) {}
+            }
+        }
+    }
+    double stale_prop = total_recent > 0
+        ? static_cast<double>(orphan_count + doa_count) / total_recent : 0.0;
+
+    {
+        std::ostringstream shares_line;
+        shares_line << " Shares: " << chain_sz
+                    << " (" << orphan_count << " orphan, " << doa_count << " dead)"
+                    << " Stale rate: " << format_binomial_conf(orphan_count + doa_count, total_recent)
+                    << " Efficiency: " << format_binomial_conf_efficiency(orphan_count + doa_count, total_recent, stale_prop);
+
+        if (m_current_pplns_fn) {
+            auto outputs = m_current_pplns_fn();
+            uint64_t my_payout = 0;
+            std::set<std::string> local_scripts;
+            if (!m_node_payout_script_hex.empty())
+                local_scripts.insert(m_node_payout_script_hex);
+            if (m_local_miner_scripts_fn) {
+                for (const auto& s : m_local_miner_scripts_fn())
+                    local_scripts.insert(s);
+            }
+            for (const auto& [script, amount] : outputs) {
+                if (local_scripts.count(script))
+                    my_payout += amount;
+            }
+            if (my_payout > 0) {
+                double coins = static_cast<double>(my_payout) / 1e8;
+                shares_line << " Current payout: (" << std::fixed << std::setprecision(4)
+                            << coins << ")=" << coins << " tLTC";
+            }
+        }
+
+        shares_line << " [heads=" << m_tracker.chain.get_heads().size()
+                    << " v_heads=" << m_tracker.verified.get_heads().size()
+                    << " rss=" << get_rss_mb() << "MB]";
+        LOG_INFO << shares_line.str();
+    }
+
+    // L4: pool hashrate + ETB
+    if (height > 2) {
+        try {
+            auto aps = m_tracker.get_pool_attempts_per_second(
+                m_best_share_hash,
+                std::min(height - 1, static_cast<int>(PoolConfig::TARGET_LOOKBEHIND)),
+                /*min_work=*/false);
+            double pool_hs = static_cast<double>(aps.GetLow64());
+            double real_pool_hs = (stale_prop < 0.999 && pool_hs > 0)
+                ? pool_hs / (1.0 - stale_prop) : pool_hs;
+            double etb_secs = 0;
+            uint32_t block_bits = 0;
+            if (!m_best_share_hash.IsNull() && m_tracker.chain.contains(m_best_share_hash)) {
+                m_tracker.chain.get(m_best_share_hash).share.invoke([&](auto* s) {
+                    block_bits = s->m_min_header.m_bits;
+                });
+            }
+            if (real_pool_hs > 0 && block_bits != 0) {
+                auto block_target = chain::bits_to_target(block_bits);
+                auto block_aps = chain::target_to_average_attempts(block_target);
+                etb_secs = static_cast<double>(block_aps.GetLow64()) / real_pool_hs;
+                if (block_aps.IsNull() && !block_target.IsNull())
+                    etb_secs = 1e18;
+            }
+            LOG_INFO << " Pool: " << format_hashrate(real_pool_hs)
+                     << " Stale rate: " << std::fixed << std::setprecision(1)
+                     << (100.0 * stale_prop) << "% Expected time to block: "
+                     << format_duration(etb_secs);
+        } catch (...) {}
+    }
+}
+
+// Periodic maintenance: eat stale heads, drop tails.
+// C++ implementation of the p2pool clean_tracker() design (stale-head eating + tail dropping).
+//
+// Runs on the compute thread under exclusive lock — matching p2pool where
+// clean_tracker + think() execute on the same reactor thread. Chain
+// modifications (remove shares) MUST NOT happen concurrently with think().
+void NodeImpl::clean_tracker()
+{
+    // Prevent concurrent clean_tracker (timer re-entry safety).
+    if (m_clean_running.exchange(true))
+        return;
+
+    // Skip if think() is already in flight — the 5s timer will retry.
+    if (m_think_running.load()) {
+        m_clean_running.store(false);
+        return;
+    }
+
+    // Post the entire clean_tracker body to the compute thread.
+    // This guarantees chain modifications happen under exclusive lock,
+    // never concurrent with think() or IO-thread reads.
+    m_think_running.store(true);  // block think() re-entry during clean
+
+    boost::asio::post(m_think_pool, [this]() {
+      m_compute_thread_id.store(std::this_thread::get_id(), std::memory_order_relaxed);
+
+      bool clean_best_changed = false;
+      bool bootstrap = false;
+      try {
+        std::unique_lock lock(m_tracker_mutex);  // exclusive
+
+        // Step 1: Run think() inline (already holds the lock)
+        {
+            auto block_rel_height = m_block_rel_height_fn
+                ? m_block_rel_height_fn
+                : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
+
+            uint256 prev_block;
+            uint32_t bits = 0;
+
+            bootstrap = m_tracker.verified.size() == 0;
+            LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
+                     << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
+                     << (bootstrap ? " BOOTSTRAP" : "");
+            auto think_t0 = std::chrono::steady_clock::now();
+            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+            auto think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - think_t0).count();
+
+            m_last_top5_heads = std::move(result.top5_heads);
+
+            if (!result.best.IsNull()) {
+                m_best_share_hash = result.best;
+            }
+
+            flush_verified_to_leveldb();
+            // Work refresh deferred to IO thread (after lock release)
+        }
+
+        // Steps 2-3: Prune (still holding exclusive lock)
+        auto now_sec = static_cast<int64_t>(std::time(nullptr));
+        auto CL = static_cast<int32_t>(bip110::pool::PoolConfig::chain_length());
+
+    // Step 2: Eat stale heads (p2pool node.py:358-378)
+    // Three guards protect useful heads:
+    //   1. Top-5 scored heads (decorated_heads[-5:])
+    //   2. Heads seen < 300s ago
+    //   3. Unverified heads whose tail has recent child activity (< 120s)
+    if (!m_last_top5_heads.empty())  // p2pool node.py:359: if decorated_heads:
+    {
+        // Build top-5 set for O(1) lookup
+        std::set<uint256> top5_set(m_last_top5_heads.begin(), m_last_top5_heads.end());
+
+        for (int iter = 0; iter < 1000; ++iter)
+        {
+            std::vector<uint256> to_remove;
+            auto heads_copy = m_tracker.chain.get_heads();
+            for (auto& [head_hash, tail_hash] : heads_copy)
+            {
+                if (!m_tracker.chain.contains(head_hash)) continue;
+
+                // Guard 1: keep top-5 scored heads (p2pool node.py:363)
+                if (top5_set.count(head_hash)) continue;
+
+                // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
+                auto* idx = m_tracker.chain.get_index(head_hash);
+                if (!idx || idx->time_seen > now_sec - 300) continue;
+
+                // Guard 3: keep unverified heads with recent tail activity (p2pool node.py:369)
+                if (!m_tracker.verified.contains(head_hash))
+                {
+                    auto& rev = m_tracker.chain.get_reverse();
+                    auto rev_it = rev.find(tail_hash);
+                    if (rev_it != rev.end() && !rev_it->second.empty())
+                    {
+                        int64_t max_child_ts = 0;
+                        for (const auto& child : rev_it->second)
+                        {
+                            auto* cidx = m_tracker.chain.get_index(child);
+                            if (cidx && cidx->time_seen > max_child_ts)
+                                max_child_ts = cidx->time_seen;
+                        }
+                        if (max_child_ts > now_sec - 120) continue;
+                    }
+                }
+
+                to_remove.push_back(head_hash);
+            }
+
+            if (to_remove.empty()) break;
+
+            size_t _dh_idx = 0;
+            for (const auto& h : to_remove)
+            {
+                try {
+                    // DIAG: per-remove marker so a freeze inside chain.contains()
+                    // or verified.remove() leaves the last touched hash in the log.
+                    std::fprintf(stderr,
+                        "[drop-heads-PRE] drop_idx=%zu/%zu hash=%.16s "
+                        "chain_size=%zu\n",
+                        _dh_idx, to_remove.size(), h.GetHex().c_str(),
+                        m_tracker.chain.size());
+                    std::fflush(stderr);
+                    ++_dh_idx;
+
+                    if (m_tracker.verified.contains(h))
+                        m_tracker.verified.remove(h, /*owns_data=*/false);
+                    if (m_tracker.chain.contains(h))
+                        m_tracker.chain.remove(h);
+                } catch (...) {}
+            }
+        }
+    }
+
+    // Step 3: Drop tails — remove ALL children of qualifying tails.
+    // C++ implementation of the p2pool tail-dropping step.
+    // p2pool has NO best-chain protection — the 2*CHAIN_LENGTH+10 threshold
+    // ensures only shares far beyond the PPLNS window are removed.
+    {
+        int total_dropped = 0;
+        for (int iter = 0; iter < 1000; ++iter)
+        {
+            std::vector<uint256> to_remove;
+            auto tails_copy = m_tracker.chain.get_tails();
+            for (auto& [tail_hash, head_hashes] : tails_copy)
+            {
+                int32_t min_height = 0;  // default 0 → skip if no valid heads
+                for (auto& hh : head_hashes) {
+                    if (!m_tracker.chain.contains(hh)) continue;
+                    auto h = m_tracker.chain.get_height(hh);
+                    if (min_height == 0 || h < min_height)
+                        min_height = h;
+                }
+                if (min_height < 2 * CL + 10) continue;
+
+                if (iter == 0) {
+                    LOG_WARNING << "[drop-tails-QUALIFY] tail=" << tail_hash.GetHex().substr(0,16)
+                                << " min_height=" << min_height << " threshold=" << (2*CL+10)
+                                << " n_heads=" << head_hashes.size()
+                                << " chain_size=" << m_tracker.chain.size();
+                }
+
+                // p2pool node.py:386: to_remove.update(tracker.reverse.get(tail, set()))
+                auto& rev = m_tracker.chain.get_reverse();
+                auto rev_it = rev.find(tail_hash);
+                if (rev_it != rev.end()) {
+                    for (const auto& child : rev_it->second)
+                        to_remove.push_back(child);
+                }
+            }
+
+            if (to_remove.empty()) break;
+
+            // p2pool node.py:392-398
+            size_t _drop_idx = 0;
+            for (const auto& aftertail : to_remove)
+            {
+                try {
+                    // DIAG: contabo 2026-04-21 froze 40s inside
+                    // unordered_map::contains() on an aftertail at bucket 2332.
+                    // If we spin here again this is the last line flushed —
+                    // gives us the iter index, which aftertail triggered it,
+                    // and the queue size to correlate with the freeze.
+                    std::fprintf(stderr,
+                        "[drop-tails-PRE] iter=%d drop_idx=%zu/%zu aftertail=%.16s "
+                        "chain_size=%zu\n",
+                        iter, _drop_idx, to_remove.size(),
+                        aftertail.GetHex().c_str(),
+                        m_tracker.chain.size());
+                    std::fflush(stderr);
+                    ++_drop_idx;
+
+                    if (!m_tracker.chain.contains(aftertail)) continue;
+                    // p2pool node.py:393: if items[aftertail].previous_hash not in tails: continue
+                    auto* idx = m_tracker.chain.get_index(aftertail);
+                    if (!idx) continue;
+                    if (!m_tracker.chain.get_tails().count(idx->tail)) {
+                        continue;
+                    }
+                    if (m_tracker.verified.contains(aftertail))
+                        m_tracker.verified.remove(aftertail, /*owns_data=*/false);
+                    m_tracker.chain.remove(aftertail);
+                    ++total_dropped;
+                } catch (...) {}
+            }
+        }
+        if (total_dropped > 0)
+            LOG_INFO << "[clean-drop-tails] dropped " << total_dropped << " shares"
+                     << " chain_size=" << m_tracker.chain.size()
+                     << " heads=" << m_tracker.chain.get_heads().size();
+    }
+
+    // Step 4: re-score after pruning (inline, already holding lock)
+    {
+        auto block_rel_height = m_block_rel_height_fn
+            ? m_block_rel_height_fn
+            : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
+        uint256 prev_block;
+        uint32_t bits = 0;
+        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        m_last_top5_heads = std::move(result.top5_heads);
+        if (!result.best.IsNull()) {
+            clean_best_changed = (m_best_share_hash != result.best);
+            m_best_share_hash = result.best;
+        }
+        publish_snapshot();
+        flush_verified_to_leveldb();
+        // Work refresh deferred to IO thread (after lock release)
+    }
+
+    // Step 5: Flush pruned shares from LevelDB (p2pool main.py:269-270)
+    if (!m_removal_flush_buf.empty() && m_storage && m_storage->is_available())
+    {
+        auto count = m_removal_flush_buf.size();
+        if (m_storage->remove_shares_batch(m_removal_flush_buf))
+            LOG_INFO << "[clean-leveldb] removed " << count << " pruned shares from LevelDB";
+        else
+            LOG_WARNING << "[clean-leveldb] batch remove failed, count=" << count;
+        m_removal_flush_buf.clear();
+    }
+
+    // Orphan/fork diagnostics — understand chain topology
+    {
+        auto& chain = m_tracker.chain;
+        auto& verified = m_tracker.verified;
+        size_t total_heads = chain.get_heads().size();
+        size_t verified_heads = verified.get_heads().size();
+        size_t total_tails = chain.get_tails().size();
+
+        // Count c2pool's own shares in verified vs total
+        int local_in_chain = 0, local_in_verified = 0;
+        int total_in_chain = 0;
+        for (auto& [head_hash, tail_hash] : chain.get_heads()) {
+            auto height = chain.get_height(head_hash);
+            total_in_chain += height;
+            // Check if this head is in verified
+            if (verified.contains(head_hash)) {
+                // Walk backward and count local shares
+                // (expensive — only sample first 50)
+            }
+        }
+
+        static int diag_count = 0;
+        if (diag_count++ % 6 == 0) { // every 30s (5s * 6)
+            LOG_INFO << "[FORK-DIAG] heads=" << total_heads
+                     << " verified_heads=" << verified_heads
+                     << " tails=" << total_tails
+                     << " chain=" << chain.size()
+                     << " verified=" << verified.size()
+                     << " gap=" << (chain.size() - verified.size())
+                     << " best_h=" << (m_best_share_hash.IsNull() ? 0
+                         : (verified.contains(m_best_share_hash)
+                            ? verified.get_height(m_best_share_hash) : -1))
+                     << " chain_h=" << (m_best_share_hash.IsNull() ? 0
+                         : (chain.contains(m_best_share_hash)
+                            ? chain.get_height(m_best_share_hash) : -1))
+                     << " best=" << (m_best_share_hash.IsNull()
+                         ? std::string("null")
+                         : m_best_share_hash.GetHex().substr(0, 16));
+        }
+    }
+
+      } catch (const std::exception& e) {
+        LOG_ERROR << "[CLEAN] failed on compute thread: " << e.what();
+      } catch (...) {
+        LOG_ERROR << "[CLEAN] failed on compute thread: unknown error";
+      }
+      // Lock released — post work refresh + drain to IO thread.
+      // Work refresh (1-5s) runs WITHOUT any lock so shared_lock readers
+      // (handle_get_share, send_shares) are never blocked.
+      boost::asio::post(*m_context, [this, clean_best_changed]() {
+        if (clean_best_changed && m_on_best_share_changed) {
+            LOG_INFO << "[CLEAN] IO-phase: work refresh (best changed)";
+            m_on_best_share_changed();
+            readvertise_best_share();   // root-2: re-announce new head to peers
+        }
+        drain_pending_adds();
+        m_think_running.store(false);
+        m_clean_running.store(false);
+      });
+    }); // end of m_think_pool lambda
+}
+
+
+
+// ── Admin API implementation ──────────────────────────────────────────
+
+
+
+
+
+
+
+
+
+
+nlohmann::json NodeImpl::admin_whitelist_add(const std::string& host, uint16_t port)
+{
+    if (host.empty() || port == 0)
+        return {{"ok", false}, {"error", "host and port required"}};
+    NetService addr(host, port);
+    m_whitelist_ips.insert(host);
+    m_whitelist_hosts.insert(addr);
+    // Remove any existing ban for this host — whitelisting is an explicit override.
+    m_ip_ban_list.erase(host);
+    for (auto it = m_ban_list.begin(); it != m_ban_list.end(); ) {
+        if (it->first.address() == host) it = m_ban_list.erase(it);
+        else ++it;
+    }
+    save_whitelist_to_disk();
+    LOG_INFO << "[Pool] Whitelisted " << addr.to_string();
+
+    // Proactive dial: if not already connected, try immediately.
+    if (!m_connections.contains(addr) && !m_pending_outbound.contains(addr)) {
+        LOG_INFO << "[Pool] Dialing whitelisted peer " << addr.to_string();
+        m_pending_outbound.insert(addr);
+        core::Client::connect(addr);
+    }
+    return {{"ok", true}, {"action", "whitelist_add"},
+            {"target", addr.to_string()},
+            {"whitelist", build_whitelist_json(m_whitelist_hosts)}};
+}
+
+
+nlohmann::json NodeImpl::admin_list_peers() const
+{
+    auto arr = nlohmann::json::array();
+    for (const auto& [addr, peer] : m_connections) {
+        bool outbound = m_outbound_addrs.contains(addr);
+        arr.push_back({
+            {"host", addr.address()},
+            {"port", addr.port()},
+            {"outbound", outbound},
+            {"whitelisted", is_whitelisted(addr)}
+        });
+    }
+    return {{"ok", true}, {"peers", arr}};
+}
+
+nlohmann::json NodeImpl::admin_drop_peer(const std::string& ip)
+{
+    if (ip.empty())
+        return {{"ok", false}, {"error", "ip required"}};
+    std::vector<NetService> targets;
+    for (const auto& [addr, peer] : m_connections)
+        if (addr.address() == ip) targets.push_back(addr);
+    for (const auto& addr : targets)
+        close_connection(addr);
+    LOG_INFO << "[Pool] Admin drop " << ip << " (" << targets.size() << " connections)";
+    return {{"ok", true}, {"action", "drop"}, {"target", ip},
+            {"dropped", targets.size()}};
+}
+
+nlohmann::json NodeImpl::admin_dial_peer(const std::string& host, uint16_t port)
+{
+    if (host.empty() || port == 0)
+        return {{"ok", false}, {"error", "host and port required"}};
+    NetService addr(host, port);
+    if (m_connections.contains(addr))
+        return {{"ok", true}, {"action", "dial"}, {"target", addr.to_string()},
+                {"note", "already connected"}};
+    if (m_pending_outbound.contains(addr))
+        return {{"ok", true}, {"action", "dial"}, {"target", addr.to_string()},
+                {"note", "dial already pending"}};
+    m_pending_outbound.insert(addr);
+    core::Client::connect(addr);
+    return {{"ok", true}, {"action", "dial"}, {"target", addr.to_string()}};
+}
+
+void NodeImpl::set_rss_limit_mb(long mb)
+{
+    g_rss_limit_mb = mb;
+}
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/node.hpp
+++ b/src/impl/bip110/pool/node.hpp
@@ -1,0 +1,899 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+#include "config.hpp"
+#include "share.hpp"
+#include "share_tracker.hpp"
+#include "peer.hpp"
+#include "messages.hpp"
+#include "../coin/seed_bootstrapper.hpp"
+#include "../coin/chain_seeds.hpp"
+
+#include <pool/node.hpp>
+#include <pool/sharechain_node.hpp>
+#include <pool/protocol.hpp>
+#include <core/message.hpp>
+#include <core/tx_advertiser.hpp>
+#include <core/reply_matcher.hpp>
+#include <core/known_txs_eviction.hpp>
+#include <sharechain/prepared_list.hpp>
+#include <c2pool/storage/sharechain_storage.hpp>
+
+#include <boost/asio/steady_timer.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <shared_mutex>
+#include <random>
+#include <thread>
+#include <set>
+#include <nlohmann/json.hpp>
+
+namespace bip110::pool
+{
+struct HandleSharesData;
+struct ShareReplyData
+{
+    std::vector<ShareType> m_items;
+    std::vector<chain::RawShare> m_raw_items;
+};
+
+class NodeImpl : public ::pool::SharechainNode<bip110::pool::Config, bip110::pool::ShareChain, bip110::pool::Peer>
+{
+
+    using base_t = ::pool::SharechainNode<bip110::pool::Config, bip110::pool::ShareChain, bip110::pool::Peer>;
+    // Async share downloader:
+    // ID = uint256 (matches sharereq id to sharereply id)
+    // RESPONSE = parsed shares plus their original raw payloads
+    // REQUEST args: req_id, peer, hashes, parents, stops
+    using share_getter_t = ReplyMatcher::ID<uint256>
+        ::RESPONSE<bip110::pool::ShareReplyData>
+        ::REQUEST<uint256, peer_ptr, std::vector<uint256>, uint64_t, std::vector<uint256>>;
+
+protected:
+    bip110::pool::Handler m_handler;
+    share_getter_t m_share_getter;
+    ShareTracker m_tracker;
+    std::unique_ptr<c2pool::storage::SharechainStorage> m_storage;
+
+    // Global pool of known transactions, populated by remember_tx and coin daemon.
+    // Protocol handlers look up tx hashes here when processing shares.
+    std::map<uint256, coin::Transaction> m_known_txs;
+    // Insertion-order recency sidecar for m_known_txs. Recorded at each NEW
+    // remember_tx insert; consumed by prune_shares to evict OLDEST-first down to
+    // m_max_known_txs instead of the old wholesale clear() (which dropped every
+    // forwardable tx byte at once -> canonical "referenced unknown transaction"
+    // disconnect). Tx-forwarding only; no consensus/mint state. See
+    // core::evict_known_txs_to_cap (core/known_txs_eviction.hpp).
+    std::deque<uint256> m_known_txs_order;
+
+    // F3 template-tx retention window (bip110::pool::retain_template_txs). Rolling
+    // history of the last kTemplateRetainCap DISTINCT locally-minted templates'
+    // tx-hash SETS; register_template_txs feeds each freshly-minted share's
+    // template txs here so their bytes live in m_known_txs and every referenced
+    // new-tx stays forwardable (the F3 backable invariant). Guarded by
+    // m_tracker_mutex like m_known_txs. Template txs are lifecycle-owned by this
+    // window (erased only when they fall out of every retained set) and are
+    // deliberately NOT enrolled in m_known_txs_order, so the global cap eviction
+    // and this window never fight over the same entries. Tx-forwarding only.
+    std::deque<std::set<uint256>> m_template_recent_sets;
+    static constexpr std::size_t kTemplateRetainCap = 8;
+
+    // Thread pool for parallel share_init_verify (scrypt CPU work).
+    // Keeps expensive crypto off the io_context thread.
+    boost::asio::thread_pool m_verify_pool{4};
+
+    // ── Async compute pipeline ──────────────────────────────────────────
+    // think() runs on m_think_pool (1 thread) holding m_tracker_mutex exclusively.
+    // The IO thread NEVER calls lock() — only try_to_lock(). If the mutex is
+    // held by the compute thread, the IO thread defers the operation and continues
+    // processing network I/O, keepalive timers, and stratum. This eliminates the
+    // event loop freeze that previously caused all peers to timeout simultaneously.
+    //
+    // Synchronization contract:
+    //   Compute thread: unique_lock(m_tracker_mutex)     — exclusive, blocking
+    //   IO thread reads: shared_lock(try_to_lock)        — non-blocking, skip if busy
+    //   IO thread writes: unique_lock(try_to_lock)       — non-blocking, queue if busy
+    boost::asio::thread_pool m_think_pool{1};
+    std::atomic<bool> m_think_running{false};
+    std::atomic<bool> m_clean_running{false};
+    mutable std::shared_mutex m_tracker_mutex;
+
+    // ── Lock-free stats snapshot ─────────────────────────────────────────
+    // Published by think() on the compute thread under m_tracker_mutex.
+    // Read by ALL consumers (sync_status, loading page, global_stats,
+    // graph data, etc.) WITHOUT needing the tracker lock.
+    //
+    // This is the c2pool equivalent of p2pool's reactor-thread stats
+    // variables: updated atomically each think() cycle, always available.
+    // Eliminates the systemic "0/empty" data problem where 20+ callbacks
+    // returned stale data whenever think() held the exclusive lock.
+    struct TrackerSnapshot {
+        int chain_count{0};
+        int verified_count{0};
+        int head_count{0};
+        int orphan_shares{0};
+        int dead_shares{0};
+        int fork_count{0};
+        double pool_hashrate{0};
+    };
+    void publish_snapshot() {
+        TrackerSnapshot s;
+        s.chain_count = static_cast<int>(m_tracker.chain.size());
+        s.verified_count = static_cast<int>(m_tracker.verified.size());
+        s.head_count = static_cast<int>(m_tracker.chain.get_heads().size());
+        s.fork_count = s.head_count;
+
+        // Pool hashrate estimate (H/s) over TARGET_LOOKBEHIND at the tallest
+        // head — the same p2pool get_pool_attempts_per_second the LTC family
+        // publishes. Without this, set_pool_hashrate_fn / the graph / local_stats
+        // read the never-populated snapshot field and reported 0 forever while
+        // the node was mining. Runs on the compute thread under the exclusive
+        // tracker lock (via run_think), so the chain read is safe.
+        try {
+            uint256 best; int32_t best_h = -1;
+            for (const auto& [head_hash, tail_hash] : m_tracker.chain.get_heads()) {
+                auto h = m_tracker.chain.get_height(head_hash);
+                if (h > best_h) { best = head_hash; best_h = h; }
+            }
+            if (!best.IsNull() && best_h >= 2) {
+                auto lookback = std::min(best_h,
+                    static_cast<int32_t>(bip110::pool::PoolConfig::TARGET_LOOKBEHIND));
+                uint288 aps = m_tracker.get_pool_attempts_per_second(
+                    best, lookback, /*min_work=*/false);
+                double hr = 0;
+                for (int i = uint288::WIDTH - 1; i >= 0; --i)
+                    hr = hr * 4294967296.0 + aps.pn[i];
+                s.pool_hashrate = hr;
+            }
+        } catch (...) { /* display-only; leave 0 on any transient */ }
+
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        m_snapshot = s;
+    }
+    mutable std::mutex m_snapshot_mutex;
+    TrackerSnapshot m_snapshot;
+
+    // ── Lock-free peer-info snapshot (display-only) ──────────────────────
+    // m_peers / m_outbound_addrs are IO-thread-owned with NO lock; the
+    // dashboard peer panel (set_peer_info_fn -> /peer_list, /peer_versions, …)
+    // is served from the WebServer. Iterating those std::maps off the IO
+    // thread while handle_version inserts / error()+close_connection erase
+    // rebalances the tree under the reader's iterator -> freed-memory GP-fault
+    // (back-port of the DASH #828 fix). So the JSON is BUILT on the IO thread
+    // (publish_peer_info_snapshot, at every peer add/remove + the think
+    // IO-phase for uptime freshness) and get_peer_info_json returns this copy
+    // lock-free — it NEVER touches the live maps. Guarded by the existing
+    // m_snapshot_mutex (held only for the swap; never nested with the tracker).
+    nlohmann::json m_peer_info_snapshot = nlohmann::json::array();
+
+    // Identity of the compute thread (m_think_pool's single thread).
+    // Used by TrackerReadGuard to skip shared_lock when the caller is
+    // already on the compute thread (which holds exclusive lock).
+    std::atomic<std::thread::id> m_compute_thread_id{};
+
+    // Pending share batches queued while think() holds the mutex.
+    // Drained on the IO thread after think() releases the lock.
+    // Uses unique_ptr because HandleSharesData is forward-declared here.
+    struct PendingShareBatch {
+        std::unique_ptr<HandleSharesData> data;
+        NetService addr;
+    };
+    std::vector<PendingShareBatch> m_pending_adds;
+
+    // ── think() watchdog + backpressure (V36 livelock defense-in-depth) ──
+    // If a think() cycle exceeds THINK_WATCHDOG_SECONDS the watchdog logs the
+    // compute-thread state (timing + backtrace dump), flags the cycle, and
+    // resets m_think_running so the pipeline recovers instead of wedging.
+    // Implemented as an atomic deadline checked by an IO-thread steady_timer:
+    // the watchdog NEVER touches m_tracker_mutex (would itself block on the
+    // stuck compute thread). MAX_PENDING_ADDS caps the deferred queue so a
+    // stuck/slow think() cannot grow memory without bound — over the cap new
+    // batches are dropped with a LOG_WARNING backpressure message.
+    static constexpr int THINK_WATCHDOG_SECONDS = 30;
+    static constexpr size_t MAX_PENDING_ADDS = 256;
+    // Steady-clock time-point (ns since epoch) by which the in-flight think()
+    // cycle must complete. 0 == no cycle armed. Set on dispatch, cleared on
+    // completion; read by the watchdog timer on the IO thread.
+    std::atomic<int64_t> m_think_deadline_ns{0};
+    // Generation counter: bumped each dispatch so a fired watchdog only acts
+    // on the cycle it was armed for (guards against late/duplicate fires).
+    std::atomic<uint64_t> m_think_generation{0};
+    // IO-thread timer that polls the deadline. Armed on run_think() dispatch.
+    std::unique_ptr<boost::asio::steady_timer> m_watchdog_timer;
+    // Arm/disarm helpers (defined in node.cpp).
+    void arm_think_watchdog();
+    void disarm_think_watchdog();
+
+    // Top-5 scored heads from last think() — used by clean_tracker()
+    // to protect the best chains from head pruning (p2pool node.py:363).
+    std::vector<uint256> m_last_top5_heads;
+
+    // Buffer of newly verified share hashes, flushed to LevelDB periodically
+    std::vector<uint256> m_verified_flush_buf;
+
+    // Buffer of pruned share hashes, batch-deleted from LevelDB after clean_tracker()
+    std::vector<uint256> m_removal_flush_buf;
+
+public:
+    NodeImpl()
+        : m_share_getter(nullptr,
+            [](uint256, peer_ptr, std::vector<uint256>, uint64_t, std::vector<uint256>){}) {}
+
+    NodeImpl(boost::asio::io_context* ctx, config_t* config)
+        : base_t(ctx, config),
+          m_share_getter(ctx,
+            [](uint256 req_id, peer_ptr to_peer,
+               std::vector<uint256> hashes, uint64_t parents,
+               std::vector<uint256> stops)
+            {
+                auto rmsg = bip110::pool::message_sharereq::make_raw(req_id, hashes, parents, stops);
+                to_peer->write(std::move(rmsg));
+            },
+            15)  // p2pool p2p.py:80: timeout=15 for share requests
+    {
+        // Seed addr store with hardcoded bootstrap peers
+        m_addrs.load(config->pool()->m_bootstrap_addrs);
+        // Randomise our nonce so we detect self-connections
+        std::mt19937_64 rng(std::random_device{}());
+        m_nonce = rng();
+        // Route m_chain (used by BaseNode) to the tracker's main chain
+        m_chain = &m_tracker.chain;
+
+        // Open LevelDB storage and load any persisted shares
+        // Sharechain LevelDB + listen namespace must isolate by net so a
+        // regtest standup never shares a dir/namespace with mainnet shares.
+        // (regtest checked FIRST: under --regtest CoinConfig::m_testnet is
+        // reset to false in main_btc, so a testnet-only switch would resolve
+        // to "bitcoin" = MAINNET and silently join the prod sharechain.)
+        // Isolation invariant extracted to a pure helper (locked by
+        // regtest_sharechain_isolation_test.cpp); regtest checked first.
+        std::string net_name = sharechain_net_name(config->m_regtest, config->m_testnet);
+        m_storage = std::make_unique<c2pool::storage::SharechainStorage>(net_name);
+        load_persisted_shares();
+
+        // Wire up verified-hash persistence callback (p2pool known_verified pattern)
+        m_tracker.m_on_share_verified = [this](const uint256& hash) {
+            m_verified_flush_buf.push_back(hash);
+            if (m_verified_flush_buf.size() >= 50)
+                flush_verified_to_leveldb();
+        };
+
+        // Wire up share removal → LevelDB cleanup (p2pool main.py:269-270)
+        // Buffer removals; clean_tracker() flushes after drop-tails.
+        // Safe on crash: unflushed shares get pruned at next startup by load_persisted_shares().
+        m_tracker.chain.on_removed([this](const uint256& hash) {
+            m_removal_flush_buf.push_back(hash);
+        });
+    }
+
+    // INetwork: Pool node does not initiate disconnect — peer connections
+    // manage their own lifecycle via close_connection()/error() below.
+    void disconnect() override { }
+    void connected(std::shared_ptr<core::Socket> socket) override;
+
+    // ICommunicator (override BaseNode to track outbound lifecycle):
+    void error(const message_error_type& err, const NetService& service, const std::source_location where = std::source_location::current()) override;
+    void close_connection(const NetService& service) override;
+
+    // BaseNode:
+    void send_ping(peer_ptr peer) override;
+    std::optional<::pool::PeerConnectionType> handle_version(std::unique_ptr<RawMessage> rmsg, peer_ptr peer) override;
+
+    // ltc
+    void send_version(peer_ptr peer);
+    void processing_shares(HandleSharesData& data, NetService addr);
+    void processing_shares_phase2(HandleSharesData& data, NetService addr);
+    /// Direct tracker access — compute-thread-only (already holds exclusive lock)
+    /// or startup code (before compute thread exists).
+    /// IO-thread code MUST use read_tracker() instead.
+    ShareTracker& tracker() { return m_tracker; }
+
+    /// RAII guard for IO-thread tracker reads.
+    /// - IO thread: acquires shared_lock(try_to_lock). Returns falsy if busy.
+    /// - Compute thread: skips locking (exclusive already held). Always truthy.
+    /// Guard lifetime = lock lifetime. No way to hold a dangling reference.
+    class TrackerReadGuard {
+        std::shared_lock<std::shared_mutex> lock_;
+        ShareTracker& tracker_;
+        bool ok_;
+    public:
+        TrackerReadGuard(std::shared_mutex& mtx, ShareTracker& t, bool on_compute)
+            : lock_(mtx, std::defer_lock), tracker_(t)
+        {
+            if (on_compute) {
+                ok_ = true;   // exclusive lock already held by caller
+            } else {
+                ok_ = lock_.try_lock();
+            }
+        }
+        TrackerReadGuard(TrackerReadGuard&&) = default;
+        TrackerReadGuard(const TrackerReadGuard&) = delete;
+        TrackerReadGuard& operator=(const TrackerReadGuard&) = delete;
+        TrackerReadGuard& operator=(TrackerReadGuard&&) = default;
+
+        explicit operator bool() const { return ok_; }
+        ShareTracker& operator*()  { return tracker_; }
+        ShareTracker* operator->() { return &tracker_; }
+    };
+
+    /// True if the calling thread is the compute thread (m_think_pool).
+    /// Compute thread already holds exclusive lock — shared_lock must be skipped.
+    bool is_compute_thread() const {
+        return std::this_thread::get_id() == m_compute_thread_id.load(std::memory_order_relaxed);
+    }
+
+    /// Preferred tracker accessor for IO-thread callbacks.
+    /// Returns a guard that:
+    ///   - On IO thread: acquires shared_lock(try_to_lock). Check `if (!guard)` before use.
+    ///   - On compute thread: skips locking (exclusive lock already held). Always valid.
+    TrackerReadGuard read_tracker() {
+        return TrackerReadGuard(m_tracker_mutex, m_tracker, is_compute_thread());
+    }
+
+    /// Acquire shared (reader) lock on the tracker mutex — BLOCKING.
+    /// Only for consensus-critical paths (share creation) where skipping is not acceptable.
+    /// IO-thread callers: prefer read_tracker() (non-blocking) unless you MUST have the lock.
+    std::shared_lock<std::shared_mutex> tracker_shared_lock() {
+        return std::shared_lock<std::shared_mutex>(m_tracker_mutex);
+    }
+
+    // Async share download — response delivered to callback when sharereply arrives
+    void request_shares(uint256 id, peer_ptr peer,
+                        std::vector<uint256> hashes, uint64_t parents,
+                        std::vector<uint256> stops,
+                        std::function<void(bip110::pool::ShareReplyData)> callback)
+    {
+        m_share_getter.request(id, callback, id, peer, hashes, parents, stops);
+    }
+
+    // Called from HANDLER(sharereply) to complete a pending async request
+    void got_share_reply(uint256 id, bip110::pool::ShareReplyData shares)
+    {
+        try { m_share_getter.got_response(id, shares); }
+        catch (const std::invalid_argument&) { /* request already timed out */ }
+    }
+
+    std::vector<bip110::pool::ShareType> handle_get_share(std::vector<uint256> hashes, uint64_t parents, std::vector<uint256> stops, NetService peer_addr);
+
+    /// Broadcast a new best-block notification to all connected P2P peers.
+    void broadcast_bestblock(const coin::BlockHeaderType& header) {
+        for (auto& [nonce, peer] : m_peers)
+            peer->write(message_bestblock::make_raw(header));
+    }
+
+    /// Rebuild the lock-free peer-info snapshot. IO-THREAD ONLY (reads the
+    /// IO-owned m_peers / m_outbound_addrs). Called at every peer add/remove
+    /// and on the think IO-phase. Publishes under m_snapshot_mutex so the
+    /// dashboard reader (get_peer_info_json) never touches the live maps.
+    void publish_peer_info_snapshot() {
+        nlohmann::json arr = nlohmann::json::array();
+        for (const auto& [nonce, peer] : m_peers) {
+            if (!peer) continue;
+            auto addr = peer->addr();
+            bool incoming = (m_outbound_addrs.find(addr) == m_outbound_addrs.end());
+            auto uptime_sec = std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::steady_clock::now() - peer->m_connected_at).count();
+            arr.push_back({
+                {"address", addr.to_string()},
+                {"version", peer->m_other_subversion},
+                {"incoming", incoming},
+                {"uptime", uptime_sec},
+                {"downtime", 0},
+                {"web_port", 0}
+            });
+        }
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        m_peer_info_snapshot = std::move(arr);
+    }
+
+    /// Return a JSON array of connected peer info for the /peer_list endpoint.
+    /// Returns the IO-thread-published snapshot lock-free — it must NEVER
+    /// iterate the live m_peers map (that races the IO thread's insert/erase
+    /// -> freed-memory GP-fault; back-port of DASH #828).
+    nlohmann::json get_peer_info_json() const {
+        std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        return m_peer_info_snapshot;
+    }
+
+    /// Register a callback invoked whenever a bestblock message is received
+    /// from any peer (after relaying). Use this to trigger work refresh.
+    void set_on_bestblock(std::function<void(const uint256&)> fn) { m_on_bestblock = std::move(fn); }
+
+    /// Set the software version string announced to peers in P2P version messages.
+    void set_software_version(std::string ver) { m_software_version = std::move(ver); }
+
+    /// Send a set of shares (with any needed txs) to a single peer, and return
+    /// the subset actually written (F2). Shares dropped by the tx-completeness
+    /// gate, or the whole batch when the tracker lock is unavailable, are
+    /// reported as NOT sent, so the caller leaves them un-marked and retries
+    /// them on the next broadcast.
+    std::vector<uint256> send_shares(peer_ptr peer,
+                                     const std::vector<uint256>& share_hashes);
+
+    /// F3: retain a freshly-minted share's TEMPLATE tx set so every referenced
+    /// new-tx is forwardable (remember_tx) and the share is backable. Called
+    /// from create_share_fn on the stratum thread; it hands us the template tx
+    /// set (GBT transactions[] json) and NOTHING else — ownership of m_known_txs
+    /// stays here, and this takes m_tracker_mutex internally (the heavy hex
+    /// decode happens BEFORE the lock). See DASH #828: unlocked cross-thread
+    /// reads of node-owned structures racing think() are a live crash class.
+    void register_template_txs(const uint256& share_hash,
+                               const nlohmann::json& template_txs);
+
+    /// Broadcast a locally-generated (or newly-received) share to all peers.
+    void broadcast_share(const uint256& share_hash);
+
+    // Broadcast lock-discipline instrumentation (mirrors the ltc SSOT). A
+    // share minted while the caller holds m_tracker_mutex EXCLUSIVELY on this
+    // thread can never take the shared try-lock in broadcast_share, so it
+    // defers forever and the whole send path -- F3 tx-completeness gate,
+    // per-peer send, mark-only-what-was-sent bookkeeping -- is unreachable
+    // dead code. These counters let broadcast_lock_discipline_test pin that
+    // the production caller (main_btc create_share_fn drops the exclusive
+    // lock with lk.unlock() BEFORE calling broadcast_share) actually REACHES
+    // the send loop, and that an exclusive-lock caller would not.
+    uint64_t broadcast_deferred_count() const { return m_broadcast_deferred.load(); }
+    uint64_t broadcast_acquired_count() const { return m_broadcast_acquired.load(); }
+    uint64_t broadcast_reached_send_count() const { return m_broadcast_reached_send.load(); }
+
+    /// Re-announce our current advertised head (advertised_best_share()) to all
+    /// connected peers.  Invoked when think()/clean updates the best share so a
+    /// peer that completed the version handshake before we had any shares (when
+    /// our advert was ZERO) still learns our head and pulls via download_shares.
+    /// Walks the head WITHOUT consulting the m_shared_share_hashes de-dup set
+    /// (ltc/dgb pattern), so a head share already accepted by another peer is
+    /// still re-pushed to a freshly-handshook one (ROOT-2, issue #885).
+    void readvertise_best_share();
+
+    /// Start downloading shares from a peer, beginning at `target_hash`.
+    /// Recursively fetches parents until the chain is connected or CHAIN_LENGTH reached.
+    void download_shares(peer_ptr peer, const uint256& target_hash);
+
+    /// Return the best VERIFIED share head for work/template selection, or
+    /// uint256::ZERO when no verified chain exists yet and peers are connected
+    /// (so work never builds on a MAX_TARGET head).  NOT for the wire advert —
+    /// use advertised_best_share() there.
+    uint256 best_share_hash();
+
+    /// Head advertised to peers (version handshake + re-advertisement ONLY).
+    /// Returns our tallest RAW chain head so a connecting peer always learns we
+    /// have a chain and pulls it; unlike best_share_hash() it does not collapse
+    /// to ZERO once peers exist.  Root-2 genesis-null-advert fix.
+    uint256 advertised_best_share();
+
+    /// Load persisted shares from LevelDB storage into the tracker.
+    void load_persisted_shares();
+    void flush_verified_to_leveldb();
+
+    /// Graceful shutdown: flush pending verified/removal buffers to LevelDB.
+    void shutdown();
+
+    /// Start dialing outbound peers from AddrStore / bootstrap list.
+    /// Maintains target outbound peer count active outbound connections.
+    void start_outbound_connections();
+
+    // ── have_tx / losing_tx advertisement (SEND side) ─────────────────────
+    // c2pool was RECEIVE-ONLY for the p2pool tx-pool advertisement: the
+    // protocol handlers ingest a peer's have_tx/losing_tx into
+    // Peer::m_remote_txs, but we never advertised our OWN known-tx set. Every
+    // canonical p2pool dashboard therefore rendered this node with txpool = 0
+    // (real p2pool peers report 12k-16k), and peers could not tell which txs we
+    // already hold, so remember_tx forwarded whole tx bodies needlessly.
+    //
+    // Canonical (p2pool python, p2pool/p2p.py): ONE full have_tx immediately
+    // after the version handshake (p2p.py:276), then pure deltas off the
+    // known_txs_var change events — added -> send_have_tx (p2p.py:243-248),
+    // removed -> send_losing_tx (p2p.py:250-259), transitioned -> both in that
+    // order (p2p.py:261-274). c2pool has no reactive variable, so
+    // Peer::m_tx_advert reconstructs the per-peer view and each sweep emits the
+    // diff; the sweep cadence mirrors node.py:298's 10s forget_old_txs loop.
+    // See core/tx_advertiser.hpp for the full derivation and the wire bound.
+    //
+    // Header-inline to match the DASH lane (whose handle_version vtable body
+    // must stay link-free for the rig-free KAT targets); this touches only
+    // header-only message types plus peer->write.
+    //
+    // REWARD-SAFETY: tx hashes only. No consensus, share validation, subsidy,
+    // coinbase, payee or won-block state is read or written here.
+    void advertise_known_txs(peer_ptr only_peer = nullptr)
+    {
+        // m_known_txs is mutated by the COMPUTE thread inside prune_shares()
+        // (core::evict_known_txs_to_cap) under the exclusive tracker lock. This
+        // runs on the IO thread, so take the same NON-BLOCKING shared lock the
+        // other IO-thread readers use (the #828 freed-memory GP-fault class)
+        // and simply skip if the compute thread is mid-cycle — the next sweep
+        // carries the identical delta 10s later.
+        std::set<uint256> current;
+        {
+            std::shared_lock<std::shared_mutex> lk(m_tracker_mutex, std::try_to_lock);
+            if (!lk.owns_lock())
+                return;
+            for (const auto& entry : m_known_txs)
+                current.insert(entry.first);
+        }
+
+        // One clock reading for the whole sweep: run_tx_advert uses it both to
+        // apply the per-peer min-emit interval (never two writes in flight on
+        // one socket) and to stamp the peer after a send. IO-thread-local, so
+        // Peer::m_tx_advert needs no locking.
+        const auto now = std::chrono::steady_clock::now();
+
+        auto advertise_one = [&current, now](const peer_ptr& p)
+        {
+            if (!p)
+                return;
+            core::run_tx_advert(
+                p->m_tx_advert, current,
+                [&p](const std::vector<uint256>& hashes)
+                { p->write(bip110::pool::message_have_tx::make_raw(hashes)); },
+                [&p](const std::vector<uint256>& hashes)
+                { p->write(bip110::pool::message_losing_tx::make_raw(hashes)); },
+                core::TX_ADVERT_MAX_HASHES_PER_MESSAGE, now);
+        };
+
+        if (only_peer)
+        {
+            advertise_one(only_peer);
+            return;
+        }
+        // m_peers is IO-thread-owned and mutated only on this thread
+        // (handle_version insert / error() erase), so plain iteration is safe.
+        for (auto& entry : m_peers)
+            advertise_one(entry.second);
+    }
+
+
+    /// Set desired number of outbound peers maintained by connection loop.
+    /// A value of 0 disables outbound dialing.
+    void set_target_outbound_peers(size_t count) { m_target_outbound_peers = count; }
+
+    /// Enable/disable the coin-seed escalation bootstrapper (default: enabled).
+    /// The escalation tier injects PUBLIC Bitcoin COIN seeds (port 8333) into
+    /// the POOL addr store whenever the outbound deficit persists. On a
+    /// custom/federation sharechain (custom --network-id/--prefix) that deficit
+    /// is permanent, so a federation would perpetually dial the open coin
+    /// network. main_btc disables this on custom nets / explicit-peer configs.
+    /// Must be called before start_outbound_connections().
+    void set_seed_escalation_enabled(bool enabled) { m_seed_escalation_enabled = enabled; }
+
+    /// Set max total P2P peers (inbound + outbound).
+    void set_max_peers(size_t count) { m_max_peers = count; }
+
+    /// Set P2P ban duration (seconds).
+
+    /// Set cache size limits for memory control.
+    void set_cache_limits(size_t max_shared, size_t max_known_txs, size_t max_raw) {
+        m_max_shared_hashes = max_shared;
+        m_max_known_txs = max_known_txs;
+        m_max_raw_shares = max_raw;
+    }
+
+    /// Set RSS memory limit in MB (abort if exceeded). Static because checked in process_shares.
+    static void set_rss_limit_mb(long mb);
+
+    /// Expose tracker mutex for IO-thread callbacks that access the tracker.
+    /// Callers MUST use shared_lock(try_to_lock) — NEVER blocking lock().
+    std::shared_mutex& tracker_mutex() { return m_tracker_mutex; }
+
+    /// Unified share retention: single-pass prune of chain + verified + LevelDB.
+    /// Replaces multi-pass trim with work-based dead head detection and
+    /// deferred destruction for verified cascade safety.
+    /// Called from run_think() on the ioc thread.
+    void prune_shares(const uint256& best_share);
+
+    /// Run the share tracker think() cycle: verifies chains, scores heads,
+    /// identifies bad peers, and requests needed shares.
+    /// Should be called periodically (e.g. after processing_shares or on a timer).
+    void run_think();
+
+    /// Fast-path: update best share after creating a local share.
+    /// Bypasses run_think() scoring — just sets the new tip and triggers
+    /// work refresh so miners immediately build on the new share.
+    /// p2pool equivalent: set_best_share() → work_event.happened().
+    void notify_local_share(const uint256& share_hash);
+
+    /// Periodic maintenance: eat stale heads, drop tails, then run_think().
+    /// Matches p2pool's clean_tracker() (node.py:355-402).
+    void clean_tracker();
+
+    /// Drain share batches queued while think() held the tracker mutex.
+    /// Called on the IO thread after think() releases the lock.
+    void drain_pending_adds();
+
+    /// p2pool-style heartbeat: chain height, local/pool hashrate, orphan/DOA stats.
+    /// Runs on a separate 30s timer — diagnostic only, not consensus-critical.
+    void heartbeat_log();
+
+    /// Set the block_rel_height function used by run_think() for chain scoring.
+    /// fn(block_hash) should return confirmations from the coin daemon:
+    ///   >= 0 : block is in main chain (0 = tip, higher = deeper)
+    ///   <  0 : block is NOT in main chain (orphaned/stale)
+    using block_rel_height_fn_t = std::function<int32_t(uint256)>;
+    void set_block_rel_height_fn(block_rel_height_fn_t fn) { m_block_rel_height_fn = std::move(fn); }
+
+    /// Lock-free stats snapshot — published by think(), never fails, never needs tracker lock.
+    /// Inline definition must precede callers in the same header.
+    TrackerSnapshot get_tracker_snapshot() const;
+    int get_chain_count() const;
+    int get_verified_count() const;
+
+    /// Called when best_share changes (p2pool: new_work_event)
+    /// Triggers immediate work update for all stratum miners.
+    void set_on_best_share_changed(std::function<void()> fn) { m_on_best_share_changed = std::move(fn); }
+
+    /// Callback to get local hashrate from stratum server (H/s)
+    void set_local_hashrate_fn(std::function<double()> fn) { m_local_hashrate_fn = std::move(fn); }
+
+    /// Local mining stats from RateMonitor (for p2pool-style status lines)
+    struct LocalRateStats {
+        double hashrate = 0;       // H/s (total local)
+        double effective_dt = 0;   // seconds of data in window
+        int total_datums = 0;      // pseudoshares in window
+        int dead_datums = 0;       // dead (DOA) pseudoshares in window
+    };
+    void set_local_rate_stats_fn(std::function<LocalRateStats()> fn) { m_local_rate_stats_fn = std::move(fn); }
+
+    /// Current PPLNS outputs {script_hex, satoshis} for payout display
+    void set_current_pplns_fn(std::function<std::vector<std::pair<std::string, uint64_t>>()> fn) {
+        m_current_pplns_fn = std::move(fn);
+    }
+
+    /// Node operator's payout script hex (for matching in PPLNS outputs)
+    void set_node_payout_script_hex(const std::string& hex) { m_node_payout_script_hex = hex; }
+    const std::string& get_node_payout_script_hex() const { return m_node_payout_script_hex; }
+
+    /// Local miner scripts (from stratum sessions' pubkey_hashes → all script forms)
+    void set_local_miner_scripts_fn(std::function<std::vector<std::string>()> fn) {
+        m_local_miner_scripts_fn = std::move(fn);
+    }
+
+    /// Check whether a peer address is currently banned.
+
+    /// ── Runtime admin API (pool peer bans + whitelist) ─────────────────
+    /// All methods assumed to run on the io_context thread — callers
+    /// (web_server HTTP handlers) dispatch via thread_safe_wrap().
+    ///
+    /// Returned JSON uses the shape:
+    ///   {"ok": true|false, "error"?: "...", "bans": [...], "whitelist": [...]}
+    nlohmann::json admin_whitelist_add(const std::string& host, uint16_t port);
+    nlohmann::json admin_list_peers() const;
+    nlohmann::json admin_drop_peer(const std::string& ip);
+    nlohmann::json admin_dial_peer(const std::string& host, uint16_t port);
+
+    /// Path to persisted whitelist file (~/.c2pool/pool_whitelist.json).
+    /// Set by c2pool_refactored.cpp before start(); empty = no persistence.
+
+    /// True if addr's IP matches a whitelist entry (IP or host:port).
+
+protected:
+    std::string m_software_version = "/c2pool:0.1/";  // overridden by set_software_version()
+    std::function<void(const uint256&)> m_on_bestblock;
+    std::function<void()> m_on_best_share_changed;
+    std::function<double()> m_local_hashrate_fn;
+    std::function<LocalRateStats()> m_local_rate_stats_fn;
+    std::function<std::vector<std::pair<std::string, uint64_t>>()> m_current_pplns_fn;
+    std::function<std::vector<std::string>()> m_local_miner_scripts_fn;
+    std::string m_node_payout_script_hex;
+    std::set<uint256> m_shared_share_hashes;  // de-dup set for broadcast_share
+    std::atomic<uint64_t> m_broadcast_deferred{0};
+    std::atomic<uint64_t> m_broadcast_acquired{0};
+    std::atomic<uint64_t> m_broadcast_reached_send{0};
+    std::set<uint256> m_rejected_share_hashes; // shares rejected by peers — never re-broadcast
+    std::set<uint256> m_downloading_shares;   // hashes currently being fetched
+
+    // Track share hashes that peers couldn't provide (empty reply).
+    // After MAX_EMPTY_RETRIES failures, stop requesting — the share is
+    // pruned from the network. p2pool avoids this via reactive desired_var
+    // + sleep(1) backoff. We use explicit failure counting.
+    static constexpr int MAX_EMPTY_RETRIES = 3;
+    std::unordered_map<uint256, int, ShareHasher> m_download_fail_count;
+
+    // Track req_id → peer addr for selective cancellation on disconnect.
+    // p2pool has per-peer get_shares (GenericDeferrer), so connectionLost calls
+    // respond_all() on just that peer's deferrer. c2pool has a shared m_share_getter,
+    // so we track which req_ids belong to which peer for cancel-on-disconnect.
+    std::map<uint256, NetService> m_pending_share_reqs;  // req_id → peer addr
+
+    // Track recently-broadcast share hashes + timestamp so we can detect
+    // rapid disconnections (peer rejected our share → PoW invalid loop).
+    struct BroadcastRecord {
+        std::vector<uint256> hashes;
+        std::chrono::steady_clock::time_point when;
+    };
+    std::map<NetService, BroadcastRecord> m_last_broadcast_to; // per-peer
+
+    // Connection maintenance
+    static constexpr size_t DEFAULT_TARGET_OUTBOUND_PEERS = 8;
+    size_t m_max_peers = 30;
+    size_t m_target_outbound_peers = DEFAULT_TARGET_OUTBOUND_PEERS;
+    std::unique_ptr<core::Timer> m_connect_timer;
+    // Tick-driven, rate-limited seed-candidate refill hung off the 30s dial
+    // loop (see coin/seed_bootstrapper.hpp). Constructed lazily in
+    // start_outbound_connections(); seeds only ADD candidates via got_addr,
+    // never connect. m_seed_candidates_exhausted carries the dial layer
+    // per-tick "could not fill the outbound deficit from our own good peers"
+    // signal into the pull-based Snapshot the bootstrapper reads each tick.
+    std::unique_ptr<bip110::coin::SeedBootstrapper> m_seed_bootstrapper;
+    bool m_seed_candidates_exhausted = false;
+    // When false, start_outbound_connections() never constructs the
+    // SeedBootstrapper — set by main_btc on custom/federation nets so the
+    // escalation tier can't inject public COIN seeds (port 8333) into the pool
+    // addr store. Default true preserves public-net behavior byte-for-byte.
+    bool m_seed_escalation_enabled = true;
+    // Periodic have_tx/losing_tx delta sweep (core/tx_advertiser.hpp). Cadence
+    // mirrors the canonical known-tx removal loop, node.py:298 t.start(10).
+    std::unique_ptr<core::Timer> m_tx_advert_timer;
+    std::unique_ptr<core::Timer> m_readvert_timer; // one-shot ROOT-2 re-advert
+    std::set<NetService> m_pending_outbound;   // addresses currently being dialed
+    std::set<NetService> m_outbound_addrs;     // successfully connected outbound peers
+
+    // Peer banning: maps address → ban expiry time
+
+    // IP-only manual bans (admin endpoint). Keyed by IP string so the
+    // operator can ban/unban without knowing the peer's source port.
+
+    // Whitelist: IPs that bypass is_banned() and host:port entries kept as
+    // permanent dial targets. Persists across restart via m_whitelist_path.
+
+
+    // Rate-limiting no longer needed: think() runs on a dedicated compute
+    // thread (m_think_pool), serialized by m_think_running atomic flag.
+    // The IO thread never blocks. p2pool's reactor.callLater equivalent.
+
+    // Cache limits (configurable)
+    size_t m_max_shared_hashes = 50000;
+    size_t m_max_known_txs     = 10000;
+    size_t m_max_raw_shares    = 50000;
+
+    // Block depth function for chain scoring (set via set_block_rel_height_fn)
+    block_rel_height_fn_t m_block_rel_height_fn;
+
+    // Cached best share hash from the most recent think() cycle
+    uint256 m_best_share_hash;
+
+    // ROOT-2: fire exactly one delayed re-advert when the verified chain
+    // first transitions from empty to non-empty (peers that handshook
+    // during the empty window otherwise never see a best-change event).
+    bool m_verified_was_empty = true;
+
+    // Cache of original raw serialized bytes keyed by share hash.
+    // Used for relay so we send the exact bytes we received, avoiding
+    // any round-trip serialization differences.
+    std::unordered_map<uint256, chain::RawShare, ShareHasher> m_raw_share_cache;
+};
+
+struct HandleSharesData
+{
+    std::vector<ShareType> m_items;
+    std::vector<chain::RawShare> m_raw_items; // original raw bytes, parallel with m_items
+    std::map<uint256, std::vector<coin::MutableTransaction>> m_txs;
+
+    void add(const ShareType& share, std::vector<coin::MutableTransaction> txs)
+    {
+        m_items.push_back(share);
+        m_raw_items.emplace_back(); // no cached raw bytes
+        m_txs[share.hash()] = std::move(txs);
+    }
+
+    void add(const ShareType& share, std::vector<coin::MutableTransaction> txs,
+             const chain::RawShare& raw)
+    {
+        m_items.push_back(share);
+        m_raw_items.push_back(raw);
+        m_txs[share.hash()] = std::move(txs);
+    }
+};
+
+
+/*
+    void handle_message_addrs(std::shared_ptr<::pool::messages::message_addrs> msg, PoolProtocol* protocol);
+    void handle_message_addrme(std::shared_ptr<::pool::messages::message_addrme> msg, PoolProtocol* protocol);
+    void handle_message_ping(std::shared_ptr<::pool::messages::message_ping> msg, PoolProtocol* protocol);
+    void handle_message_getaddrs(std::shared_ptr<::pool::messages::message_getaddrs> msg, PoolProtocol* protocol);
+    void handle_message_shares(std::shared_ptr<::pool::messages::message_shares> msg, PoolProtocol* protocol);
+    void handle_message_sharereq(std::shared_ptr<::pool::messages::message_sharereq> msg, PoolProtocol* protocol);
+    void handle_message_sharereply(std::shared_ptr<::pool::messages::message_sharereply> msg, PoolProtocol* protocol);
+    void handle_message_bestblock(std::shared_ptr<::pool::messages::message_bestblock> msg, PoolProtocol* protocol);
+    void handle_message_have_tx(std::shared_ptr<::pool::messages::message_have_tx> msg, PoolProtocol* protocol);
+    void handle_message_losing_tx(std::shared_ptr<::pool::messages::message_losing_tx> msg, PoolProtocol* protocol);
+    void handle_message_remember_tx(std::shared_ptr<::pool::messages::message_remember_tx> msg, PoolProtocol* protocol);
+    void handle_message_forget_tx(std::shared_ptr<::pool::messages::message_forget_tx> msg, PoolProtocol* protocol);
+*/
+
+// v36-GENESIS SINGLE-PROTOCOL COLLAPSE (decision card #1).
+//
+// The BTC lane carries ::pool::NodeBridge<NodeImpl, Legacy, Actual> — two protocol
+// bases (Legacy = live jtoomim/SPB p2pool v35 interop, Actual = c2pool) with a
+// switch(peer->type()) dispatch. bip110 is a v36-GENESIS chain: no legacy version
+// ever exists on this wire, so there is exactly ONE protocol. `using Legacy =
+// Actual` in NodeBridge is uncompilable (the same class as two direct bases is
+// ill-formed [class.mi]), so instead of NodeBridge we drop Legacy entirely, keep a
+// single `Actual`, and provide a local single-protocol bridge whose handle() is
+// ::pool::NodeBridge::handle() (src/pool/node.hpp) with the legacy switch branch
+// removed. ShareVariants<Formatter, MergedMiningShare> ONLY / share_versions={36} /
+// SUCCESSOR=None is already satisfied by share.hpp.
+class Actual : public ::pool::Protocol<NodeImpl>
+{
+public:
+    void handle_message(std::unique_ptr<RawMessage> rmsg, NodeImpl::peer_ptr peer) override;
+
+    ADD_HANDLER(addrs, bip110::pool::message_addrs);
+    ADD_HANDLER(addrme, bip110::pool::message_addrme);
+    ADD_HANDLER(ping, bip110::pool::message_ping);
+    ADD_HANDLER(getaddrs, bip110::pool::message_getaddrs);
+    ADD_HANDLER(shares, bip110::pool::message_shares);
+    ADD_HANDLER(sharereq, bip110::pool::message_sharereq);
+    ADD_HANDLER(sharereply, bip110::pool::message_sharereply);
+    ADD_HANDLER(bestblock, bip110::pool::message_bestblock);
+    ADD_HANDLER(have_tx, bip110::pool::message_have_tx);
+    ADD_HANDLER(losing_tx, bip110::pool::message_losing_tx);
+    ADD_HANDLER(remember_tx, bip110::pool::message_remember_tx);
+    ADD_HANDLER(forget_tx, bip110::pool::message_forget_tx);
+};
+
+// Single-protocol bridge — the v36-genesis analog of ::pool::NodeBridge. virtual
+// NodeImpl so the single NodeImpl subobject is shared with Actual (which is
+// ::pool::Protocol<NodeImpl> => public virtual NodeImpl); mirror NodeBridge's
+// virtual Base exactly.
+class Node : public virtual NodeImpl, public Actual
+{
+public:
+    template <typename... Args>
+    Node(boost::asio::io_context* ctx, NodeImpl::config_t* config, Args... args)
+        : NodeImpl(ctx, config, args...) {}
+
+    void handle(std::unique_ptr<RawMessage> rmsg, const NetService& service) override
+    {
+        // RECEIVE choke point — verbatim from ::pool::NodeBridge::handle() minus the
+        // switch(peer->type()) legacy branch (there is no legacy protocol on a
+        // v36-genesis wire). Inbound counter BEFORE the connection guard, same as
+        // the shared bridge.
+        if (rmsg)
+        {
+            auto& stats = core::obs::p2p_stats();
+            stats.count_in(rmsg->m_command);
+            if (stats.trace_enabled.load(std::memory_order_relaxed))
+                LOG_DEBUG_POOL << "[p2p-msg] in "
+                               << std::string(core::obs::trim_command(rmsg->m_command))
+                               << " <- " << service.to_string();
+        }
+
+        // Guard: peer may have been removed by a prior error/timeout while an
+        // async_read callback was still in-flight for the same socket.
+        if (!NodeImpl::m_connections.contains(service))
+            return;
+        auto peer = NodeImpl::m_connections[service];
+        peer->m_timeout->restart();
+
+        if (peer->type() == ::pool::PeerConnectionType::unknown)
+        {
+            if (rmsg->m_command.compare(0, 7, "version") != 0)
+                return NodeImpl::error("message wanna for be version", service);
+
+            std::optional<::pool::PeerConnectionType> peer_type;
+            try
+            {
+                peer_type = NodeImpl::handle_version(std::move(rmsg), peer);
+            } catch (const std::exception& ex)
+            {
+                NodeImpl::error(ex.what(), service);
+                return;
+            }
+            if (!peer_type.has_value())
+            {
+                // Graceful disconnect (duplicate or self-connection)
+                NodeImpl::close_connection(service);
+                return;
+            }
+            peer->stable(*peer_type, NodeImpl::PEER_TIMEOUT_TIME);
+            return;
+        }
+
+        // v36-genesis: ONE protocol on the wire — always route to Actual.
+        static_cast<Actual*>(this)->handle_message(std::move(rmsg), peer);
+    }
+};
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/peer.hpp
+++ b/src/impl/bip110/pool/peer.hpp
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// bip110::pool::Peer — sharechain peer state. Structural copy of the BTC lane's
+// peer.hpp; coin:: resolves to bip110::coin via enclosing-namespace lookup, so the
+// remembered/remote tx types bind to the BIP-110 coin transaction.
+
+#include "../coin/transaction.hpp"
+
+#include <chrono>
+#include <set>
+#include <map>
+#include <optional>
+#include <core/tx_advertiser.hpp>
+#include <core/uint256.hpp>
+
+namespace bip110::pool
+{
+
+struct Peer
+{
+    std::optional<uint32_t> m_other_version;
+    std::string m_other_subversion;
+    uint64_t m_other_services;
+    uint64_t m_nonce;
+    std::chrono::steady_clock::time_point m_connected_at{std::chrono::steady_clock::now()};
+
+    std::set<uint256> m_remote_txs; // hashes
+
+    std::map<uint256, coin::Transaction> m_remembered_txs;
+
+    // Send-side tx-pool advertisement state (mirror of core/tx_advertiser.hpp).
+    core::TxAdvertState m_tx_advert;
+};
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/protocol_actual.cpp
+++ b/src/impl/bip110/pool/protocol_actual.cpp
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "node.hpp"
+#include "share.hpp"
+
+#include <core/uint256.hpp>
+#include <core/random.hpp>
+#include <core/common.hpp>
+
+#include <cstring>
+
+namespace bip110::pool
+{
+    
+void Actual::handle_message(std::unique_ptr<RawMessage> rmsg, peer_ptr peer)
+{
+    bip110::pool::Handler::result_t result;
+    try 
+    {
+        result = m_handler.parse(rmsg);
+    } catch (const std::exception& ec)
+    {
+        LOG_WARNING << "Failed to parse message '" << rmsg->m_command << "' from "
+                    << peer->addr().to_string() << ": " << ec.what();
+        return;
+    }
+
+    try
+    {
+        std::visit([&](auto& msg){ handle(std::move(msg), peer); }, result);
+    }
+    catch (const std::exception& ec)
+    {
+        LOG_WARNING << "Handler error for '" << rmsg->m_command << "' from "
+                    << peer->addr().to_string() << ": " << ec.what();
+        return;
+    }
+}
+
+void Actual::HANDLER(addrs) 
+{
+    for (auto& addr : msg->m_addrs)
+    {
+        addr.m_timestamp = std::min((uint64_t) core::timestamp(), addr.m_timestamp);
+        got_addr(addr.m_endpoint, addr.m_services, addr.m_timestamp);
+
+        if ((core::random::random_float(0, 1) < 0.8) && (!m_connections.empty()))
+        {
+            auto wpeer = core::random::random_choice(m_connections);
+            auto rmsg = message_addrs::make_raw({addr});
+            wpeer->write(std::move(rmsg));
+        }
+    }
+}
+
+void Actual::HANDLER(addrme)
+{
+    if (peer->addr().address() == "127.0.0.1")
+    {
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        {
+            auto random_peer = core::random::random_choice(m_peers);
+            auto rmsg = bip110::pool::message_addrme::make_raw(msg->m_port);
+            random_peer->write(std::move(rmsg));
+        }
+    } else
+    {
+        auto endpoint = NetService{peer->addr().address(), msg->m_port};
+        got_addr(endpoint, peer->m_other_services, core::timestamp());
+        if (!m_peers.empty() && (core::random::random_float(0, 1) < 0.8))
+        {
+            auto random_peer = core::random::random_choice(m_peers);
+            auto rmsg = bip110::pool::message_addrs::make_raw({addr_record_t{peer->m_other_services, endpoint, core::timestamp()} });
+            random_peer->write(std::move(rmsg));
+        }
+    }
+}
+
+void Actual::HANDLER(ping)
+{
+}
+
+void Actual::HANDLER(getaddrs)
+{
+    if (msg->m_count > 100)
+        msg->m_count = 100;
+
+    std::vector<addr_record_t> addrs;
+    for (const auto& pair : get_good_peers(msg->m_count))
+    {
+        // #910: never advertise an address we cannot render on the wire. A
+        // DNS-named seed that the outbound-connect resolver has not resolved
+        // yet used to serialize as 127.0.0.1, pointing every peer that learned
+        // it from us back at itself. Skip it; the next sweep re-offers it once
+        // a dial has resolved the name.
+        if (!pair.addr.is_wire_advertisable())
+            continue;
+        addrs.push_back({pair.value.m_service, pair.addr, pair.value.m_last_seen});
+    }
+
+    auto rmsg = message_addrs::make_raw({addrs});
+    peer->write(std::move(rmsg));
+}
+
+void Actual::HANDLER(shares)
+{
+    bip110::pool::HandleSharesData result;
+
+    for (auto wrappedshare : msg->m_shares)
+    {
+        // Save a copy of the original raw bytes before deserialization consumes them
+        chain::RawShare raw_copy(wrappedshare.type,
+                                 BaseScript(wrappedshare.contents.m_data));
+
+        bip110::pool::ShareType share;
+        try
+        {
+            share = bip110::pool::load_share(wrappedshare, peer->addr());
+        }
+        catch(const std::exception& e)
+        {
+            LOG_WARNING << "Failed to load share (type=" << wrappedshare.type
+                        << ") from " << peer->addr().to_string() << ": " << e.what();
+            continue;
+        }
+
+        std::vector<coin::MutableTransaction> txs;
+        share.ACTION
+        ({
+            if constexpr (share_t::version >= 13 && share_t::version < 34) 
+            for (auto tx_hash : obj->m_tx_info.m_new_transaction_hashes)
+            {
+                auto it = m_known_txs.find(tx_hash);
+                if (it != m_known_txs.end())
+                {
+                    txs.emplace_back(it->second);
+                }
+                else
+                {
+                    LOG_WARNING << "Peer referenced unknown transaction " << tx_hash.ToString();
+                }
+            }
+        });
+
+        result.add(share, txs, raw_copy);
+    }
+
+    processing_shares(result, peer->addr());
+}
+
+void Actual::HANDLER(sharereq)
+{
+    auto shares = handle_get_share(msg->m_hashes, msg->m_parents, msg->m_stops, peer->addr());
+
+    std::vector<chain::RawShare> rshares;
+
+    try
+    {
+        for (auto& share : shares)
+        {
+            rshares.emplace_back(share.version(), pack(share));
+        }
+        auto reply_msg = message_sharereply::make_raw(msg->m_id, bip110::pool::ShareReplyResult::good, rshares);
+        peer->write(std::move(reply_msg));
+    }
+    catch (const std::invalid_argument &e)
+    {
+        auto reply_msg = message_sharereply::make_raw(msg->m_id, bip110::pool::ShareReplyResult::too_long, {});
+        peer->write(std::move(reply_msg));
+    }
+
+    // #1130: free the OWNED copies handle_get_share cloned for us. Both the
+    // good and too_long paths fall through to here (no early return), and each
+    // variant owns independent heap from clone(), so this destroy() frees our
+    // copies WITHOUT ever touching the pointers the sharechain still owns.
+    for (auto& share : shares) share.destroy();
+}
+
+void Actual::HANDLER(sharereply)
+{
+    bip110::pool::ShareReplyData result;
+    if (msg->m_result == ShareReplyResult::good)
+    {
+        result.m_items.reserve(msg->m_shares.size());
+        result.m_raw_items.reserve(msg->m_shares.size());
+        for (auto& rshare : msg->m_shares)
+        {
+            try
+            {
+                auto share = bip110::pool::load_share(rshare, peer->addr());
+                result.m_items.push_back(share);
+                result.m_raw_items.push_back(rshare);
+            }
+            catch(const std::exception& e)
+            {
+                LOG_WARNING << "Failed to deserialize share (type=" << rshare.type
+                            << ") from " << peer->addr().to_string() << ": " << e.what();
+                continue;
+            }
+        }
+    }
+    got_share_reply(msg->m_id, result);
+}
+
+void Actual::HANDLER(bestblock)
+{
+    auto header_hash = Hash(pack(msg->m_header).get_span());
+    LOG_INFO << "[Pool] New best block from peer " << peer->addr().to_string()
+             << ": " << header_hash.ToString();
+
+    // p2pool does NOT relay bestblock — each node broadcasts only from its own
+    // block source (bitcoind_work.changed → best_block_header.changed).
+    // Relaying creates an amplification loop: A→B→C→A with alternating hashes.
+    if (m_on_bestblock) m_on_bestblock(header_hash);
+}
+
+void Actual::HANDLER(have_tx)
+{
+    peer->m_remote_txs.insert(msg->m_tx_hashes.begin(), msg->m_tx_hashes.end());
+    if (peer->m_remote_txs.size() > 10000)
+    {
+        peer->m_remote_txs.erase(peer->m_remote_txs.begin(), std::next(peer->m_remote_txs.begin(), peer->m_remote_txs.size() - 10000));
+    }
+}
+
+void Actual::HANDLER(losing_tx)
+{
+    std::set<uint256> losing_txs;
+    losing_txs.insert(msg->m_tx_hashes.begin(), msg->m_tx_hashes.end());
+
+    std::set<uint256> diff_txs;
+    std::set_difference(peer->m_remote_txs.begin(), peer->m_remote_txs.end(),
+                        losing_txs.begin(), losing_txs.end(),
+                        std::inserter(diff_txs, diff_txs.begin()));
+
+    peer->m_remote_txs = diff_txs;
+}
+
+void Actual::HANDLER(remember_tx)
+{
+    // Phase 1: tx_hashes — peer tells us to remember these by hash (must be in known_txs)
+    for (auto tx_hash : msg->m_tx_hashes)
+    {
+        if (peer->m_remembered_txs.contains(tx_hash))
+        {
+            LOG_WARNING << "Peer referenced transaction twice: " << tx_hash.ToString();
+            continue;
+        }
+
+        auto it = m_known_txs.find(tx_hash);
+        if (it != m_known_txs.end())
+        {
+            peer->m_remembered_txs.insert_or_assign(tx_hash, it->second);
+        }
+        else
+        {
+            LOG_WARNING << "Peer referenced unknown transaction " << tx_hash.ToString();
+        }
+    }
+
+    // Phase 2: txs — peer sends full transactions (compute hash, store)
+    for (auto& tx : msg->m_txs)
+    {
+        auto packed = pack(coin::TX_WITH_WITNESS(tx));
+        auto tx_hash = Hash(packed.get_span());
+
+        if (peer->m_remembered_txs.contains(tx_hash))
+        {
+            LOG_WARNING << "Peer sent duplicate transaction: " << tx_hash.ToString();
+            continue;
+        }
+
+        coin::Transaction full_tx(tx);
+        peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
+
+        if (!m_known_txs.contains(tx_hash))
+        {
+            m_known_txs.emplace(tx_hash, std::move(full_tx));
+            m_known_txs_order.push_back(tx_hash); // recency for bounded eviction
+        }
+    }
+}
+
+void Actual::HANDLER(forget_tx)
+{
+    for (auto tx_hash : msg->m_tx_hashes)
+    {
+        peer->m_remembered_txs.erase(tx_hash);
+    }
+}
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share.hpp
+++ b/src/impl/bip110/pool/share.hpp
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// bip110::pool::MergedMiningShare — the v36 (decayed-PPLNS + P2SH donation +
+// MergedMiningShare-family) share for the BIP-110 wire-genesis sharechain.
+//
+// This is a v36-GENESIS chain: no v17/v33/v34/v35 legacy share ever exists on
+// this wire (decision card #1). So unlike the BTC lane (which carries the whole
+// Share/NewShare/SegwitMiningShare/PaddingBugfixShare/MergedMiningShare ladder for
+// interop with the live jtoomim/SPB v35 chain), bip110's ShareVariants holds
+// MergedMiningShare<36> ONLY, and the Formatter carries only the v36 branch. The
+// wire byte-format of the v36 share is IDENTICAL to the BTC lane's MergedMiningShare
+// (so a python-fork bip110 lane shares ONE sharechain) EXCEPT the min_header, which
+// is Bip110SmallBlockHeaderType (share_types.hpp) — the 164B v2 header minus merkle.
+
+#include "share_types.hpp"
+#include "config_pool.hpp"
+
+#include <sharechain/sharechain.hpp>
+#include <sharechain/share.hpp>
+#include <core/pack_types.hpp>
+#include <core/netaddress.hpp>
+#include <core/uint256.hpp>
+#include <core/target_utils.hpp>
+
+#include <optional>
+#include <vector>
+#include <chrono>
+
+namespace bip110::pool
+{
+
+// Share layout (v36):
+//   min_header [Bip110SmallBlockHeaderType — 164B v2 header MINUS merkle]
+//   share_info:
+//     prev_hash, coinbase, nonce,
+//     pubkey_hash[160], pubkey_type[8],
+//     subsidy[VarInt], donation[u16], stale_info[enum u8], desired_version[VarInt],
+//     segwit_data [Optional, zero-sentinel],
+//     merged_addresses [list],
+//     far_share_hash, max_bits, bits, timestamp, absheight,
+//     abswork [VarInt-encoded],
+//     merged_coinbase_info [list], merged_payout_hash,
+//   ref_merkle_link, last_txout_nonce, hash_link[V36HashLinkType], merkle_link,
+//   message_data [Optional, at END]
+
+struct MergedMiningShare : chain::BaseShare<uint256, 36>
+{
+    // small block header (v2, minus merkle)
+    Bip110SmallBlockHeaderType m_min_header;
+
+    // share_data
+    BaseScript m_coinbase;
+    uint32_t   m_nonce{0};
+    uint160    m_pubkey_hash;
+    uint8_t    m_pubkey_type{0};        // 0=P2PKH, 1=P2WPKH, 2=P2SH
+    uint64_t   m_subsidy{0};
+    uint16_t   m_donation{0};
+    StaleInfo  m_stale_info{StaleInfo::none};
+    uint64_t   m_desired_version{0};
+
+    std::optional<SegwitData>         m_segwit_data;
+    std::vector<MergedAddressEntry>   m_merged_addresses;   // empty = none
+
+    uint256    m_far_share_hash;
+    uint32_t   m_max_bits{0};
+    uint32_t   m_bits{0};
+    uint32_t   m_timestamp{0};
+    uint32_t   m_absheight{0};
+    uint128    m_abswork{0};
+
+    std::vector<MergedCoinbaseEntry>  m_merged_coinbase_info; // empty = none
+    uint256    m_merged_payout_hash;                          // zero = none
+
+    // ref_merkle_link, last_txout_nonce, hash_link, merkle_link
+    MerkleLink       m_ref_merkle_link;
+    uint64_t         m_last_txout_nonce{0};
+    V36HashLinkType  m_hash_link;
+    MerkleLink       m_merkle_link;
+
+    BaseScript m_message_data;   // empty = none (serialized at END)
+
+    NetService peer_addr;
+
+    MergedMiningShare() {}
+    MergedMiningShare(const uint256& hash, const uint256& prev_hash)
+        : chain::BaseShare<uint256, 36>(hash, prev_hash) {}
+};
+
+struct Formatter
+{
+    SHARE_FORMATTER()
+    {
+        // small_block_header_type (v2 minus merkle)
+        READWRITE(obj->m_min_header);
+
+        // share_info_type
+        READWRITE(
+            obj->m_prev_hash,
+            obj->m_coinbase,
+            obj->m_nonce
+        );
+
+        // v36 address commitment: pubkey_hash[160] + pubkey_type[8]
+        READWRITE(obj->m_pubkey_hash);
+        READWRITE(obj->m_pubkey_type);
+
+        // v36 subsidy is VarInt-encoded
+        READWRITE(VarInt(obj->m_subsidy));
+
+        READWRITE(
+            obj->m_donation,
+            Using<EnumType<IntType<8>>>(obj->m_stale_info),
+            VarInt(obj->m_desired_version)
+        );
+
+        // segwit_data — v36 >= SEGWIT_ACTIVATION (4) => always present, zero-sentinel None
+        READWRITE(Optional(obj->m_segwit_data, SegwitDataDefault));
+
+        // v36 merged_addresses (after segwit_data, before far_share_hash)
+        READWRITE(obj->m_merged_addresses);
+
+        READWRITE(
+            obj->m_far_share_hash,
+            obj->m_max_bits,
+            obj->m_bits,
+            obj->m_timestamp,
+            obj->m_absheight
+        );
+
+        // v36 abswork — VarInt-encoded uint64 stored as uint128
+        READWRITE(Using<AbsworkV36Format>(obj->m_abswork));
+
+        // v36 merged_coinbase_info + merged_payout_hash (after abswork)
+        READWRITE(obj->m_merged_coinbase_info);
+        READWRITE(obj->m_merged_payout_hash);
+
+        // ref_merkle_link
+        READWRITE(MERKLE_LINK_SMALL(obj->m_ref_merkle_link));
+        // last_txout_nonce
+        READWRITE(obj->m_last_txout_nonce);
+        // hash_link (V36HashLinkType with VarStr extra_data)
+        READWRITE(obj->m_hash_link);
+        // merkle_link
+        READWRITE(MERKLE_LINK_SMALL(obj->m_merkle_link));
+
+        // v36 message_data (at the END)
+        READWRITE(obj->m_message_data);
+    }
+};
+
+// v36-genesis chain: MergedMiningShare is the ONLY variant that ever exists.
+using ShareType = chain::ShareVariants<Formatter, MergedMiningShare>;
+
+inline ShareType load_share(chain::RawShare& rshare, NetService peer_addr)
+{
+    auto stream = rshare.contents.as_stream();
+    auto share = ShareType::load(rshare.type, stream);
+    share.ACTION({ obj->peer_addr = peer_addr; });
+    return share;
+}
+
+template <typename StreamType>
+inline ShareType load_share(int64_t version, StreamType& is, NetService peer_addr)
+{
+    auto share = ShareType::load(version, is);
+    share.ACTION({ obj->peer_addr = peer_addr; });
+    return share;
+}
+
+struct ShareHasher
+{
+    size_t operator()(const uint256& hash) const
+    {
+        return hash.GetLow64();
+    }
+};
+
+class ShareIndex : public chain::ShareIndex<uint256, ShareType, ShareHasher, ShareIndex>
+{
+    using base_index = chain::ShareIndex<uint256, ShareType, ShareHasher, ShareIndex>;
+
+public:
+    uint288 work;       // target_to_average_attempts(bits)
+    uint288 min_work;   // target_to_average_attempts(max_bits)
+
+    int64_t time_seen{0};
+    int32_t naughty{0};
+    bool    is_block_solution{false};  // pow_hash <= block_target (set during init_verify)
+    uint256 pow_hash;                  // BLAKE2b block-identity hash, cached at reception
+
+    ShareIndex() : base_index(), work(0), min_work(0) {}
+
+    template <typename ShareT> ShareIndex(ShareT* share) : base_index(share)
+    {
+        work = chain::target_to_average_attempts(chain::bits_to_target(share->m_bits));
+        min_work = chain::target_to_average_attempts(chain::bits_to_target(share->m_max_bits));
+        time_seen = std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    }
+};
+
+struct ShareChain : chain::ShareChain<ShareIndex>
+{
+};
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_check.hpp
+++ b/src/impl/bip110/pool/share_check.hpp
@@ -1,0 +1,2192 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// P2: Share verification — check_hash_link, check_merkle_link, share init/check
+// Ported from legacy sharechains/data.cpp + sharechains/share.cpp
+
+#include "config_pool.hpp"
+#include "share.hpp"
+#include "share_identity.hpp"      // THE consensus delta: compute_share_hash + check_header_fail_closed (BLAKE2b)
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
+#include "share_messages.hpp"
+#include "share_types.hpp"
+
+#include <core/hash.hpp>
+#include <core/log.hpp>            // LOG_INFO / LOG_WARNING / LOG_TRACE / LOG_DEBUG_DIAG (BTC got these transitively via node.cpp)
+#include <core/pack.hpp>
+#include <core/pack_types.hpp>
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+#include <btclibs/crypto/common.h>
+#include <btclibs/crypto/sha256.h>
+// (LTC's btclibs/crypto/scrypt.h removed — BTC PoW is SHA256d via core/hash.hpp)
+#include <btclibs/base58.h>
+#include <btclibs/bech32.h>
+#include <core/address_utils.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace bip110::pool
+{
+
+// P2Pool witness nonce: '[P2Pool]' repeated 4 times = 32 bytes
+// Used for witness commitment: SHA256d(wtxid_merkle_root || P2POOL_WITNESS_NONCE)
+static const unsigned char P2POOL_WITNESS_NONCE[32] = {
+    0x5b, 0x50, 0x32, 0x50, 0x6f, 0x6f, 0x6c, 0x5d,
+    0x5b, 0x50, 0x32, 0x50, 0x6f, 0x6f, 0x6c, 0x5d,
+    0x5b, 0x50, 0x32, 0x50, 0x6f, 0x6f, 0x6c, 0x5d,
+    0x5b, 0x50, 0x32, 0x50, 0x6f, 0x6f, 0x6c, 0x5d,
+};
+
+// Compute P2Pool witness commitment hash from raw wtxid merkle root.
+// Returns SHA256d(root || '[P2Pool]'*4)
+inline uint256 compute_p2pool_witness_commitment(const uint256& wtxid_merkle_root) {
+    uint256 nonce;
+    std::memcpy(nonce.data(), P2POOL_WITNESS_NONCE, 32);
+    return Hash(wtxid_merkle_root, nonce);
+}
+
+// ============================================================================
+// check_hash_link()
+//
+// Restores SHA256 mid-state from hash_link, continues hashing with
+// (data + extra), then double-SHA256 finalises to the gentx_hash.
+//
+// Legacy: sharechains/data.cpp  check_hash_link()
+// ============================================================================
+template <typename HashLinkT>
+inline uint256 check_hash_link(const HashLinkT& hash_link,
+                               const std::vector<unsigned char>& data,
+                               const std::vector<unsigned char>& const_ending = {})
+{
+    const uint64_t extra_length = hash_link.m_length % 64; // 512/8 = 64
+
+    // hash_link.extra_data handling:
+    // Python reference (check_hash_link in p2pool/data.py):
+    //   extra = (extra_data + const_ending)[len(extra_data) + len(const_ending) - extra_length:]
+    // This takes the LAST extra_length bytes of (extra_data + const_ending),
+    // i.e. extra_data first, then const_ending tail — matching the original
+    // byte order in the coinbase prefix (after the full SHA256 blocks).
+    std::vector<unsigned char> extra;
+    if constexpr (requires { hash_link.m_extra_data.m_data; })
+    {
+        // V36HashLinkType: extra_data is BaseScript (VarStr)
+        extra.assign(hash_link.m_extra_data.m_data.begin(),
+                     hash_link.m_extra_data.m_data.end());
+        if (extra.size() < extra_length)
+        {
+            // Append const_ending tail AFTER extra_data (matching Python's order)
+            auto needed = extra_length - extra.size();
+            if (const_ending.size() >= needed)
+                extra.insert(extra.end(), const_ending.end() - needed, const_ending.end());
+        }
+    }
+    else
+    {
+        // Pre-V36: extra_data always empty, use const_ending tail
+        extra.assign(const_ending.begin(), const_ending.end());
+        if (extra.size() > extra_length)
+            extra.erase(extra.begin(), extra.begin() + (extra.size() - extra_length));
+    }
+    if (extra.size() != extra_length)
+        throw std::runtime_error("check_hash_link: extra size mismatch");
+
+    // Restore SHA256 mid-state from hash_link.m_state (32 bytes, big-endian)
+    const auto& state_bytes = hash_link.m_state.m_data;
+    uint32_t init_state[8] = {
+        ReadBE32(state_bytes.data() +  0),
+        ReadBE32(state_bytes.data() +  4),
+        ReadBE32(state_bytes.data() +  8),
+        ReadBE32(state_bytes.data() + 12),
+        ReadBE32(state_bytes.data() + 16),
+        ReadBE32(state_bytes.data() + 20),
+        ReadBE32(state_bytes.data() + 24),
+        ReadBE32(state_bytes.data() + 28),
+    };
+
+    // Continue hashing from mid-state: Write(data) fills the partial
+    // block (extra is already in buf via the constructor), then processes
+    // remaining full blocks.  Single SHA256 pass.
+    unsigned char out1[CSHA256::OUTPUT_SIZE];
+    CSHA256(init_state, extra, hash_link.m_length)
+        .Write(data.data(), data.size())
+        .Finalize(out1);
+
+    // Second SHA256 pass → double-SHA256
+    unsigned char out2[CSHA256::OUTPUT_SIZE];
+    CSHA256().Write(out1, CSHA256::OUTPUT_SIZE).Finalize(out2);
+
+    // Write raw double-SHA256 output directly into uint256
+    // (matches Bitcoin Core's Hash() which does the same)
+    uint256 result;
+    std::memcpy(result.data(), out2, 32);
+    return result;
+}
+
+// ============================================================================
+// prefix_to_hash_link()
+//
+// Forward computation of hash_link: given a coinbase prefix (everything up to
+// and including the const_ending), capture the SHA256 mid-state so that
+// check_hash_link() can resume and produce the coinbase txid.
+//
+// Python reference (p2pool):
+//   def prefix_to_hash_link(prefix, const_ending=''):
+//       x = sha256(prefix)
+//       return dict(state=x.state, extra_data=x.buf[:max(0,len(x.buf)-len(const_ending))],
+//                   length=x.length//8)
+// ============================================================================
+inline V36HashLinkType prefix_to_hash_link(
+    const std::vector<unsigned char>& prefix,
+    const std::vector<unsigned char>& const_ending)
+{
+    // Feed the entire prefix into a CSHA256
+    CSHA256 hasher;
+    hasher.Write(prefix.data(), prefix.size());
+
+    V36HashLinkType result;
+
+    // Extract mid-state as big-endian bytes (matches check_hash_link's ReadBE32)
+    result.m_state.m_data.resize(32);
+    for (int i = 0; i < 8; ++i) {
+        WriteBE32(result.m_state.m_data.data() + i * 4, hasher.s[i]);
+    }
+
+    // extra_data = buf[0 .. bufsize - const_ending_len]
+    size_t bufsize = hasher.bytes % 64;
+    size_t extra_len = (bufsize > const_ending.size()) ? (bufsize - const_ending.size()) : 0;
+    result.m_extra_data.m_data.assign(hasher.buf, hasher.buf + extra_len);
+
+    // length = total bytes processed so far
+    result.m_length = hasher.bytes;
+
+    return result;
+}
+
+// prefix_to_hash_link for V35: returns HashLinkType (no extra_data field)
+inline HashLinkType prefix_to_hash_link_v35(
+    const std::vector<unsigned char>& prefix,
+    const std::vector<unsigned char>& const_ending)
+{
+    auto v36_link = prefix_to_hash_link(prefix, const_ending);
+    HashLinkType result;
+    result.m_state = v36_link.m_state;
+    result.m_length = v36_link.m_length;
+    // V35: extra_data is always empty (FixedStrType(0)) — the donation script
+    // is long enough to consume the entire SHA256 buffer tail.
+    return result;
+}
+
+// ============================================================================
+// check_merkle_link()
+//
+// Walk a Merkle branch to compute the root from a given tip_hash.
+//
+// Legacy: libcoind/data.cpp  check_merkle_link()
+// ============================================================================
+inline uint256 check_merkle_link(const uint256& tip_hash, const MerkleLink& link)
+{
+    if (link.m_branch.size() > 0 &&
+        link.m_index >= (1u << link.m_branch.size()))
+        throw std::invalid_argument("check_merkle_link: index too large");
+
+    uint256 cur = tip_hash;
+    for (size_t i = 0; i < link.m_branch.size(); ++i)
+    {
+        // Combine: if bit i of index is set, branch[i] is on the left
+        PackStream ps;
+        if ((link.m_index >> i) & 1)
+        {
+            ps << link.m_branch[i];
+            ps << cur;
+        }
+        else
+        {
+            ps << cur;
+            ps << link.m_branch[i];
+        }
+
+        // double-SHA256 of the 64-byte concatenation
+        auto sp = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(ps.data()), ps.size());
+        cur = Hash(sp);
+    }
+    return cur;
+}
+
+// ============================================================================
+// compute_gentx_before_refhash()
+//
+// Computes the constant ending bytes that appear after the coinbase outputs
+// and before the ref_hash in the serialised coinbase transaction.
+//
+// Legacy: networks/network.cpp  "init gentx_before_refhash"
+// Formula: VarStr(DONATION_SCRIPT) + int64(0) + VarStr(0x6a28 + int256(0) + int64(0))[:3]
+// ============================================================================
+inline std::vector<unsigned char> compute_gentx_before_refhash(int64_t share_version)
+{
+    std::vector<unsigned char> result;
+
+    // 1. VarStr(DONATION_SCRIPT)
+    auto donation_script = PoolConfig::get_donation_script(share_version);
+    {
+        PackStream s;
+        BaseScript bs;
+        bs.m_data = donation_script;
+        s << bs;
+        auto* p = reinterpret_cast<const unsigned char*>(s.data());
+        result.insert(result.end(), p, p + s.size());
+    }
+
+    // 2. int64(0)
+    {
+        uint64_t zero64 = 0;
+        auto* p = reinterpret_cast<const unsigned char*>(&zero64);
+        result.insert(result.end(), p, p + 8);
+    }
+
+    // 3. VarStr(0x6a 0x28 + int256(0) + int64(0)) — but only the first 3 bytes
+    {
+        PackStream inner;
+        // raw bytes: OP_RETURN (0x6a) + PUSH_40 (0x28)
+        unsigned char prefix[2] = {0x6a, 0x28};
+        inner.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(prefix), 2));
+        // 32 zero bytes (uint256(0))
+        uint256 zero256;
+        inner << zero256;
+        // 8 zero bytes (uint64(0))
+        uint64_t zero64 = 0;
+        inner.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&zero64), 8));
+
+        // Pack as VarStr
+        PackStream outer;
+        BaseScript bs;
+        bs.m_data.resize(inner.size());
+        std::memcpy(bs.m_data.data(), inner.data(), inner.size());
+        outer << bs;
+
+        // Take only the first 3 bytes
+        auto* p = reinterpret_cast<const unsigned char*>(outer.data());
+        result.insert(result.end(), p, p + std::min<size_t>(3, outer.size()));
+    }
+
+    return result;
+}
+
+// ============================================================================
+// pubkey_hash_to_address()
+//
+// Convert (pubkey_hash, pubkey_type) to a Litecoin address string.
+// Used for V35 share_data.address field (VarStr).
+// pubkey_type: 0=P2PKH, 1=P2WPKH, 2=P2SH (same as V36 encoding)
+// ============================================================================
+inline std::string pubkey_hash_to_address(const uint160& pubkey_hash, uint8_t pubkey_type)
+{
+    bool testnet = PoolConfig::is_testnet;
+    if (pubkey_type == 0) {
+        // P2PKH: Base58Check with version byte
+        uint8_t ver = testnet ? 0x6f : 0x00;  // BTC mainnet P2PKH (was 0x30 LTC)
+        std::vector<unsigned char> payload(21);
+        payload[0] = ver;
+        std::memcpy(payload.data() + 1, pubkey_hash.data(), 20);
+        return EncodeBase58Check({payload.data(), payload.size()});
+    } else if (pubkey_type == 1) {
+        // P2WPKH: Bech32 segwit v0 — BTC mainnet "bc", testnet "tb"
+        std::string hrp = testnet ? "tb" : "bc";
+        std::vector<uint8_t> prog(20);
+        std::memcpy(prog.data(), pubkey_hash.data(), 20);
+        return bech32::encode_segwit(hrp, 0, prog);
+    } else if (pubkey_type == 2) {
+        // P2SH: Base58Check with version byte
+        uint8_t ver = testnet ? 0xc4 : 0x05;  // BTC mainnet P2SH (was 0x32 LTC)
+        std::vector<unsigned char> payload(21);
+        payload[0] = ver;
+        std::memcpy(payload.data() + 1, pubkey_hash.data(), 20);
+        return EncodeBase58Check({payload.data(), payload.size()});
+    }
+    // Fallback: P2PKH
+    uint8_t ver = testnet ? 0x6f : 0x30;
+    std::vector<unsigned char> payload(21);
+    payload[0] = ver;
+    std::memcpy(payload.data() + 1, pubkey_hash.data(), 20);
+    return EncodeBase58Check({payload.data(), payload.size()});
+}
+
+// ============================================================================
+// compute_ref_hash_for_work()
+//
+// Computes the p2pool ref_hash for a set of share fields.  Used at Stratum
+// work generation time to build the OP_RETURN commitment per connection.
+//
+// Parameters mirror the share fields that feed into the ref_stream.
+// Returns (ref_hash, last_txout_nonce).
+// ============================================================================
+struct RefHashParams {
+    int64_t  share_version{36};           // 35 or 36 — determines serialization format
+    uint256 prev_share;
+    std::vector<unsigned char> coinbase_scriptSig;
+    uint32_t share_nonce{0};
+    // V36: pubkey_hash + pubkey_type; V35: address (string bytes)
+    uint160  pubkey_hash;
+    uint8_t  pubkey_type{0};
+    std::string address;                  // V35: base58/bech32 address string
+    uint64_t subsidy{0};
+    uint16_t donation{50};
+    uint8_t  stale_info{0};
+    uint64_t desired_version{36};
+    bool     has_segwit{false};
+    SegwitData segwit_data;
+    std::vector<MergedAddressEntry> merged_addresses;  // V36 only
+    uint256  far_share_hash;
+    uint32_t max_bits{0};
+    uint32_t bits{0};
+    uint32_t timestamp{0};
+    uint32_t absheight{0};
+    uint128  abswork;
+    std::vector<MergedCoinbaseEntry> merged_coinbase_info;  // V36: per-chain DOGE header + merkle proof
+    uint256  merged_payout_hash;                            // V36 only
+    BaseScript message_data;              // V36 PossiblyNoneType(b'', VarStrType())
+};
+
+inline std::pair<uint256, uint64_t> compute_ref_hash_for_work(const RefHashParams& p)
+{
+    PackStream ref_stream;
+
+    // IDENTIFIER
+    {
+        auto hex = PoolConfig::identifier_hex();
+        for (size_t i = 0; i + 1 < hex.size(); i += 2) {
+            unsigned char byte = static_cast<unsigned char>(
+                std::stoul(hex.substr(i, 2), nullptr, 16));
+            ref_stream.write(std::span<const std::byte>(
+                reinterpret_cast<const std::byte*>(&byte), 1));
+        }
+    }
+
+    ref_stream << p.prev_share;
+
+    // coinbase as VarStr
+    {
+        BaseScript bs;
+        bs.m_data = p.coinbase_scriptSig;
+        ref_stream << bs;
+    }
+
+    ref_stream << p.share_nonce;
+
+    if (core::version_gate::is_v36_active(p.share_version)) {
+        // V36: pubkey_hash (uint160) + pubkey_type (uint8)
+        ref_stream << p.pubkey_hash;
+        ref_stream << p.pubkey_type;
+        ::Serialize(ref_stream, VarInt(p.subsidy));
+    } else if (p.share_version >= 34) {
+        // V34-V35: address as VarStr
+        BaseScript addr_bs;
+        addr_bs.m_data.assign(p.address.begin(), p.address.end());
+        ref_stream << addr_bs;
+        ref_stream << p.subsidy;  // fixed uint64
+    } else {
+        // Pre-V34: pubkey_hash only
+        ref_stream << p.pubkey_hash;
+        ref_stream << p.subsidy;  // fixed uint64
+    }
+
+    ref_stream << p.donation;
+    ref_stream << p.stale_info;
+    ::Serialize(ref_stream, VarInt(p.desired_version));
+
+    // segwit_data (v33+): PossiblyNoneType — for segwit-active share versions
+    // this field is ALWAYS serialized, exactly as share_init_verify
+    // (share_check.hpp:574-587) and create_local_share_v35 (:2350-2356) do.
+    // When the job carries no segwit data, write the None sentinel (empty
+    // branch + zero root). Serializing this ONLY when has_segwit was true
+    // made the template-time OP_RETURN ref_hash diverge from the ref_hash
+    // attempt_verify recomputes off the stored share -> the share failed
+    // verification and earned no PPLNS credit.
+    if (p.share_version >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION) {
+        if (p.has_segwit) {
+            ref_stream << p.segwit_data;
+        } else {
+            std::vector<uint256> empty_branch;
+            ref_stream << empty_branch;
+            uint256 zero_root;
+            ref_stream << zero_root;
+        }
+    }
+
+    // V36: merged_addresses (after segwit_data, before far_share_hash)
+    if (core::version_gate::is_v36_active(p.share_version))
+        ref_stream << p.merged_addresses;
+
+    ref_stream << p.far_share_hash;
+    ref_stream << p.max_bits;
+    ref_stream << p.bits;
+    ref_stream << p.timestamp;
+    ref_stream << p.absheight;
+
+    if (core::version_gate::is_v36_active(p.share_version)) {
+        ::Serialize(ref_stream, Using<AbsworkV36Format>(p.abswork));
+        ref_stream << p.merged_coinbase_info;
+        ref_stream << p.merged_payout_hash;
+        // V36 ref_type includes message_data as PossiblyNoneType(b'', VarStrType())
+        ref_stream << p.message_data;
+    } else {
+        // Pre-V36: abswork as fixed uint128
+        ref_stream << p.abswork;
+    }
+
+    auto ref_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+    uint256 ref_hash = Hash(ref_span);
+
+    {
+        static int rfn_log = 0;
+        static int rfn_v36_log = 0;
+        bool should_log = (rfn_log < 3) || (core::version_gate::is_v36_active(p.share_version) && rfn_v36_log < 5);
+        if (should_log) {
+            rfn_log++;
+            if (core::version_gate::is_v36_active(p.share_version)) rfn_v36_log++;
+            static const char* HX = "0123456789abcdef";
+            std::string hex;
+            auto* rd = reinterpret_cast<const unsigned char*>(ref_stream.data());
+            for (size_t i = 0; i < ref_stream.size(); ++i) { hex += HX[rd[i]>>4]; hex += HX[rd[i]&0xf]; }
+            LOG_INFO << "[REF-FN] v=" << p.share_version
+                     << " ref_packed_len=" << ref_stream.size()
+                     << " ref_hash=" << ref_hash.GetHex()
+                     << " absheight=" << p.absheight << " prev=" << p.prev_share.GetHex().substr(0,16);
+            LOG_INFO << "[REF-FN-FULL] " << hex;
+        }
+    }
+
+    // Generate a random-ish last_txout_nonce
+    uint64_t nonce = static_cast<uint64_t>(std::time(nullptr)) ^
+                     (static_cast<uint64_t>(p.timestamp) << 32) ^
+                     (static_cast<uint64_t>(p.absheight) << 16);
+
+    return {ref_hash, nonce};
+}
+
+// Thread-local state from share_init_verify — read by attempt_verify() without re-computing scrypt.
+inline thread_local bool g_last_init_is_block = false;
+inline thread_local uint256 g_last_pow_hash;  // scrypt hash of the share header
+
+// ============================================================================
+// share_init_verify()
+//
+// Performs the init()-phase verification of a share:
+//   1. Basic field validation (coinbase size, merkle branch lengths)
+//   2. Compute hash_link_data from ref serialisation
+//   3. check_hash_link → gentx_hash
+//   4. check_merkle_link → merkle_root
+//   5. Build full block header
+//   6. Compute hash (double-SHA256 of header)
+//   7. Verify pow_hash <= target
+//
+// Returns the share hash (double-SHA256 of the reconstructed header).
+// Throws on any validation failure.
+//
+// NOTE: The full GenerateShareTransaction reconstruction from check() is
+// deferred to a later PR (P2.5).  This function covers the PoW + hash-link
+// verification path from legacy Share::init().
+// ============================================================================
+template <typename ShareT>
+uint256 share_init_verify(const ShareT& share, bool check_pow = true)
+{
+    // Reset the per-thread scratch UNCONDITIONALLY so a check_pow=false call
+    // can never leave a STALE pow_hash/is_block from a previously verified
+    // share on this thread. Callers must treat a null g_last_pow_hash after
+    // this call as "PoW not computed here" and fall back to the value carried
+    // on the share (m_pow_hash) or the chain index.
+    g_last_init_is_block = false;
+    g_last_pow_hash = uint256();
+
+    // --- Basic validation ---
+    if (share.m_coinbase.size() < 2 || share.m_coinbase.size() > 100)
+        throw std::invalid_argument("bad coinbase size");
+
+    if (share.m_merkle_link.m_branch.size() > 16)
+        throw std::invalid_argument("merkle branch too long");
+
+    constexpr int64_t ver = ShareT::version;
+
+    if constexpr (ver >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION)
+    {
+        if constexpr (requires { share.m_segwit_data; })
+        {
+            if (share.m_segwit_data.has_value())
+            {
+                if (share.m_segwit_data->m_txid_merkle_link.m_branch.size() > 16)
+                    throw std::invalid_argument("segwit txid merkle branch too long");
+            }
+        }
+    }
+
+    // --- Compute ref_hash ---
+    // RefType serialisation: IDENTIFIER + share_info fields + segwit_data
+    // Then hash256 it, then check_merkle_link with ref_merkle_link
+    //
+    // For now we serialise the minimal fields the same way the legacy code
+    // does (share_data + share_info + optional segwit_data) via a PackStream.
+    PackStream ref_stream;
+
+    // IDENTIFIER bytes (8 bytes from IDENTIFIER_HEX)
+    {
+        auto hex = PoolConfig::identifier_hex();
+        for (size_t i = 0; i + 1 < hex.size(); i += 2)
+        {
+            unsigned char byte = static_cast<unsigned char>(
+                std::stoul(hex.substr(i, 2), nullptr, 16));
+            ref_stream.write(std::span<const std::byte>(
+                reinterpret_cast<const std::byte*>(&byte), 1));
+        }
+    }
+
+    // share_info serialisation — we re-serialise the share's share_info fields
+    // through the same Formatter path that was used to decode them.
+    // For ref_hash we need: share_data + share_info fields + segwit_data
+    // We serialise the relevant fields into the ref_stream.
+    {
+        // prev_hash
+        ref_stream << share.m_prev_hash;
+        // coinbase
+        ref_stream << share.m_coinbase;
+        // nonce (uint32_t LE)
+        ref_stream << share.m_nonce;
+
+        // address or pubkey_hash — V34/V35 use m_address (VarStr),
+        // V36+ uses m_pubkey_hash (uint160) + m_pubkey_type (uint8_t),
+        // pre-V34 uses m_pubkey_hash only.
+        if constexpr (requires { share.m_address; })
+            ref_stream << share.m_address;
+        else if constexpr (requires { share.m_pubkey_type; })
+        {
+            ref_stream << share.m_pubkey_hash;
+            ref_stream << share.m_pubkey_type;
+        }
+        else
+            ref_stream << share.m_pubkey_hash;
+
+        // subsidy: VarInt for V36+, raw uint64_t LE for older
+        if constexpr (core::version_gate::is_v36_active(ver))
+            ::Serialize(ref_stream, VarInt(share.m_subsidy));
+        else
+            ref_stream << share.m_subsidy;
+
+        ref_stream << share.m_donation;
+        // stale_info as EnumType<IntType<8>> — single byte
+        {
+            uint8_t si = static_cast<uint8_t>(share.m_stale_info);
+            ref_stream << si;
+        }
+        // desired_version as VarInt
+        {
+            uint64_t dv = share.m_desired_version;
+            ::Serialize(ref_stream, VarInt(dv));
+        }
+
+        // segwit_data (optional)
+        if constexpr (requires { share.m_segwit_data; })
+        {
+            if constexpr (ver >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION)
+            {
+                // PossiblyNoneType: ALWAYS serialize (p2pool writes default when None)
+                if (share.m_segwit_data.has_value()) {
+                    ref_stream << share.m_segwit_data.value();
+                } else {
+                    std::vector<uint256> empty_branch;
+                    ref_stream << empty_branch;
+                    uint256 zero_root;
+                    ref_stream << zero_root;
+                }
+            }
+        }
+
+        // merged_addresses (V36+)
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_merged_addresses; })
+                ref_stream << share.m_merged_addresses;
+        }
+
+        // tx info (pre-v34)
+        if constexpr (ver < 34)
+        {
+            if constexpr (requires { share.m_tx_info; })
+                ref_stream << share.m_tx_info;
+        }
+
+        // far_share_hash, max_bits, bits, timestamp, absheight
+        ref_stream << share.m_far_share_hash;
+        ref_stream << share.m_max_bits;
+        ref_stream << share.m_bits;
+        ref_stream << share.m_timestamp;
+        ref_stream << share.m_absheight;
+
+        // abswork: AbsworkV36Format for V36+, raw uint128 LE for older
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_abswork; })
+                ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
+        }
+        else
+        {
+            ref_stream << share.m_abswork;
+        }
+
+        // V36+ merged mining commitment fields
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_merged_coinbase_info; })
+                ref_stream << share.m_merged_coinbase_info;
+            if constexpr (requires { share.m_merged_payout_hash; })
+                ref_stream << share.m_merged_payout_hash;
+        }
+    }
+
+    // V36 ref_type includes message_data as PossiblyNoneType(b'', VarStrType())
+    // When m_message_data is empty, BaseScript serialises as varint(0) = 0x00.
+    if constexpr (core::version_gate::is_v36_active(ver))
+    {
+        if constexpr (requires { share.m_message_data; })
+            ref_stream << share.m_message_data;
+    }
+
+    // hash256 of the ref_type serialisation
+    auto ref_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+    uint256 hash_ref = Hash(ref_span);
+
+    // check_merkle_link with ref_merkle_link
+    uint256 ref_hash = check_merkle_link(hash_ref, share.m_ref_merkle_link);
+
+    // --- Build hash_link_data ---
+    // hash_link_data = ref_hash bytes + pack(last_txout_nonce, LE64) + pack(0, LE32)
+    std::vector<unsigned char> hash_link_data;
+    hash_link_data.insert(hash_link_data.end(), ref_hash.data(), ref_hash.data() + 32);
+    {
+        // last_txout_nonce as little-endian uint64
+        uint64_t nonce = share.m_last_txout_nonce;
+        auto* p = reinterpret_cast<const unsigned char*>(&nonce);
+        hash_link_data.insert(hash_link_data.end(), p, p + 8);
+    }
+    {
+        // trailing zero uint32
+        uint32_t zero = 0;
+        auto* p = reinterpret_cast<const unsigned char*>(&zero);
+        hash_link_data.insert(hash_link_data.end(), p, p + 4);
+    }
+
+    auto gentx_before_refhash = compute_gentx_before_refhash(ver);
+
+    // --- check_hash_link → gentx_hash ---
+    uint256 gentx_hash = check_hash_link(share.m_hash_link, hash_link_data, gentx_before_refhash);
+
+    // Diagnostic: compare hash_link-derived gentx_hash with expected
+    // Only log for self-validation (check_pow=true means local share)
+    if (check_pow) {
+        static int verify_diag = 0;
+        if (verify_diag < 10) {
+            LOG_INFO << "[verify-diag] gentx_hash(hash_link)=" << gentx_hash.GetHex()
+                     << " hash_link_data_len=" << hash_link_data.size();
+            ++verify_diag;
+        }
+    }
+
+    // --- Merkle root ---
+    // For segwit-activated shares, use segwit_data.txid_merkle_link; otherwise merkle_link
+    uint256 merkle_root;
+    if constexpr (ver >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION)
+    {
+        if constexpr (requires { share.m_segwit_data; })
+        {
+            if (share.m_segwit_data.has_value())
+                merkle_root = check_merkle_link(gentx_hash, share.m_segwit_data->m_txid_merkle_link);
+            else
+                merkle_root = check_merkle_link(gentx_hash, share.m_merkle_link);
+        }
+        else
+        {
+            merkle_root = check_merkle_link(gentx_hash, share.m_merkle_link);
+        }
+    }
+    else
+    {
+        merkle_root = check_merkle_link(gentx_hash, share.m_merkle_link);
+    }
+
+    // --- THE ONE CONSENSUS DELTA vs every SHA256d lane: BLAKE2b header hash ---
+    // On the BTC lane the share identity is SHA256d of the classic 80-byte header
+    // {version|prev|merkle|time|bits|nonce}. BIP-110 replaces the block hash with
+    // the BLAKE2b commitment pipeline over the full 164-byte v2 header (merkle root
+    // reinserted at offset 36). tx hashing is UNCHANGED (txids/merkle still SHA256d,
+    // so gentx_hash + check_merkle_link above are identical). Only the final header
+    // hash differs. compute_share_hash() reconstructs the 164B v2 header from the
+    // small header + the SHA256d-reconstructed merkle root and runs
+    // bip110::pow::blake2b_block_hash (KAT-pinned vs live fork block 961640).
+    //
+    // FAIL-CLOSED (decision #6): reject a share whose min_header carries nonzero
+    // flags/clear_bits/xor_key BEFORE it can reach the hash pipeline — a hostile
+    // header never gets hashed. share_identity.hpp.
+    check_header_fail_closed(share.m_min_header);
+    uint256 share_hash = compute_share_hash(share.m_min_header, merkle_root);
+
+    // --- PoW check (SHA256d) ---
+    // For Bitcoin POW_FUNC is SHA256d, identical to the block identity hash.
+    // (LTC was scrypt(1024,1,1,256); BTC's pow_hash == share_hash via Hash(hdr_span).)
+    if (check_pow)
+    {
+        uint256 target = chain::bits_to_target(share.m_bits);
+        if (target.IsNull())
+            throw std::invalid_argument("share target is zero");
+        if (target > PoolConfig::max_target())
+            throw std::invalid_argument("share target exceeds MAX_TARGET");
+        auto max_target = chain::bits_to_target(share.m_max_bits);
+        if (!max_target.IsNull() && target > max_target)
+            throw std::invalid_argument("share target exceeds max_target — too easy");
+
+        // BTC PoW: SHA256d(header). share_hash was already computed above.
+        uint256 pow_hash = share_hash;
+        g_last_pow_hash = pow_hash;  // cache for attempt_verify merged check
+
+        if (pow_hash > target)
+        {
+            // Expected for stratum pseudoshares: VARDIFF target is much lower
+            // than share target, so most submissions won't meet PoW.
+            // Only a real share (1 in ~20000 pseudoshares) passes this check.
+            LOG_TRACE << "PoW below share target: bits=" << share.m_bits
+                      << " target=" << target.GetHex().substr(0,32)
+                      << " pow_hash=" << pow_hash.GetHex().substr(0,32);
+            throw std::invalid_argument("share PoW hash does not meet target");
+        }
+
+        // Block detection: check if share's scrypt hash also meets the BLOCK target.
+        // min_header.m_bits = block difficulty from GBT (much harder than share target).
+        // When pow_hash <= block_target, this share IS a solved block!
+        uint256 block_target = chain::bits_to_target(share.m_min_header.m_bits);
+        g_last_init_is_block = false;
+        if (!block_target.IsNull() && pow_hash <= block_target) {
+            g_last_init_is_block = true;
+            static uint256 s_last_block_share;
+            if (share_hash != s_last_block_share) {
+                s_last_block_share = share_hash;
+                LOG_INFO << "[BLOCK] Peer share meets block target"
+                         << " hash=" << share_hash.GetHex().substr(0,16);
+            }
+        }
+    }
+
+    return share_hash;
+}
+
+// ============================================================================
+// Helper: convert pubkey_hash + type to full scriptPubKey
+// ============================================================================
+inline std::vector<unsigned char> pubkey_hash_to_script(const uint160& hash, uint8_t type = 0)
+{
+    std::vector<unsigned char> script;
+    auto h = hash.GetChars(); // little-endian (internal storage order)
+    switch (type)
+    {
+    case 1: // P2WPKH: OP_0 <20>
+        // Use GetChars() output directly — same as P2PKH and P2SH.
+        // The bytes in m_pubkey_hash are the raw witness program as
+        // deserialized from the wire. No reversal needed.
+        script.reserve(22);
+        script.push_back(0x00);
+        script.push_back(0x14);
+        script.insert(script.end(), h.begin(), h.end());
+        break;
+    case 2: // P2SH: OP_HASH160 <20> OP_EQUAL
+        script.reserve(23);
+        script.push_back(0xa9);
+        script.push_back(0x14);
+        script.insert(script.end(), h.begin(), h.end());
+        script.push_back(0x87);
+        break;
+    default: // P2PKH: OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+        script.reserve(25);
+        script.push_back(0x76);
+        script.push_back(0xa9);
+        script.push_back(0x14);
+        script.insert(script.end(), h.begin(), h.end());
+        script.push_back(0x88);
+        script.push_back(0xac);
+        break;
+    }
+    return script;
+}
+
+// ============================================================================
+// Normalize a parent chain script to merged chain P2PKH script.
+//
+// P2WPKH (00 14 <hash>) → P2PKH (76 a9 14 <hash> 88 ac)  [same pubkey_hash]
+// P2PKH  (76 a9 14 <hash> 88 ac) → passed through
+// P2SH   (a9 14 <hash> 87)       → P2SH (passed through)
+// P2WSH  (00 20 <hash>)          → empty (unconvertible)
+// P2TR   (51 20 <key>)           → empty (unconvertible)
+//
+// Returns empty vector for unconvertible scripts (Tier 3: redistributed).
+// Matches Python data.py:build_canonical_merged_coinbase() conversion logic.
+// ============================================================================
+inline std::vector<unsigned char> normalize_script_for_merged(
+    const std::vector<unsigned char>& script)
+{
+    // P2PKH (25 bytes: 76 a9 14 <20> 88 ac) — already correct
+    if (script.size() == 25 && script[0] == 0x76 && script[1] == 0xa9 &&
+        script[2] == 0x14 && script[23] == 0x88 && script[24] == 0xac)
+        return script;
+
+    // P2WPKH (22 bytes: 00 14 <20>) — convert to P2PKH using same hash
+    if (script.size() == 22 && script[0] == 0x00 && script[1] == 0x14)
+    {
+        std::vector<unsigned char> p2pkh;
+        p2pkh.reserve(25);
+        p2pkh.push_back(0x76); // OP_DUP
+        p2pkh.push_back(0xa9); // OP_HASH160
+        p2pkh.push_back(0x14); // PUSH 20
+        p2pkh.insert(p2pkh.end(), script.begin() + 2, script.end()); // <hash160>
+        p2pkh.push_back(0x88); // OP_EQUALVERIFY
+        p2pkh.push_back(0xac); // OP_CHECKSIG
+        return p2pkh;
+    }
+
+    // P2SH (23 bytes: a9 14 <20> 87) — pass through (DOGE supports P2SH)
+    if (script.size() == 23 && script[0] == 0xa9 && script[1] == 0x14 &&
+        script[22] == 0x87)
+        return script;
+
+    // P2WSH (34 bytes: 00 20 <32>) or P2TR (34 bytes: 51 20 <32>) — unconvertible
+    return {};
+}
+
+// MERGED: prefix for weight map keys — matches p2pool's 'MERGED:' + hex string.
+// Keeps Tier 1/1.5 (explicit DOGE script) keys separate from raw LTC script keys
+// in the same weight map, preventing V35+V36 weight collapse for the same miner.
+// 7 bytes: 0x4d 0x45 0x52 0x47 0x45 0x44 0x3a = "MERGED:"
+inline constexpr std::array<unsigned char, 7> MERGED_KEY_PREFIX = {
+    0x4d, 0x45, 0x52, 0x47, 0x45, 0x44, 0x3a
+};
+
+// Prepend MERGED: prefix to a script for use as a weight map key.
+inline std::vector<unsigned char> make_merged_key(
+    const std::vector<unsigned char>& script)
+{
+    std::vector<unsigned char> key;
+    key.reserve(MERGED_KEY_PREFIX.size() + script.size());
+    key.insert(key.end(), MERGED_KEY_PREFIX.begin(), MERGED_KEY_PREFIX.end());
+    key.insert(key.end(), script.begin(), script.end());
+    return key;
+}
+
+// Check if a weight key has the MERGED: prefix.
+inline bool is_merged_key(const std::vector<unsigned char>& key)
+{
+    return key.size() > MERGED_KEY_PREFIX.size() &&
+           std::equal(MERGED_KEY_PREFIX.begin(), MERGED_KEY_PREFIX.end(),
+                      key.begin());
+}
+
+// Strip MERGED: prefix, returning the raw script bytes.
+// Caller must check is_merged_key() first.
+inline std::vector<unsigned char> strip_merged_key(
+    const std::vector<unsigned char>& key)
+{
+    return std::vector<unsigned char>(
+        key.begin() + MERGED_KEY_PREFIX.size(), key.end());
+}
+
+// Resolve a weight map key to a DOGE-compatible scriptPubKey.
+// MERGED:-prefixed keys: strip prefix, use directly (already a DOGE script).
+// Raw keys: autoconvert (P2WPKH→P2PKH, P2PKH/P2SH pass through).
+// Returns empty if unconvertible (P2WSH, P2TR, etc.).
+inline std::vector<unsigned char> resolve_merged_payout_script(
+    const std::vector<unsigned char>& key)
+{
+    if (is_merged_key(key))
+        return strip_merged_key(key);
+    return normalize_script_for_merged(key);
+}
+
+// ============================================================================
+// Helper: extract full scriptPubKey from a share variant
+// ============================================================================
+inline std::vector<unsigned char> get_share_script(const auto* obj)
+{
+    if constexpr (requires { obj->m_pubkey_type; })
+        return pubkey_hash_to_script(obj->m_pubkey_hash, obj->m_pubkey_type);
+    else if constexpr (requires { obj->m_address; })
+    {
+        // V34/V35: m_address contains a human-readable address string.
+        // Convert to scriptPubKey for PPLNS weight computation.
+        std::string addr_str(obj->m_address.m_data.begin(), obj->m_address.m_data.end());
+        auto script = core::address_to_script(addr_str);
+        if (!script.empty())
+            return script;
+        // Fallback: return raw bytes (shouldn't happen with valid addresses)
+        return obj->m_address.m_data;
+    }
+    else
+        return pubkey_hash_to_script(obj->m_pubkey_hash, 0);
+}
+
+// ============================================================================
+// generate_share_transaction()
+//
+// Reconstructs the expected coinbase transaction from a share's fields and
+// the PPLNS weights computed from the share chain.  Returns the expected
+// gentx txid (double-SHA256 of the non-witness serialised transaction).
+//
+// C++ implementation of the p2pool v36 generate_transaction() / check() design.
+//
+// The coinbase structure is:
+//   tx_ins:  [ { prev_output: 0...0:ffffffff, script: coinbase } ]
+//   tx_outs: [ segwit_commitment?,
+//              ...pplns_payout_outputs...,
+//              donation_output,
+//              op_return_commitment ]
+//   lock_time: 0
+//
+// Reference: frstrtr/p2pool-merged-v36  p2pool/data.py  generate_transaction()
+// ============================================================================
+// ---------------------------------------------------------------------------
+// F11: canonical exclude-then-append donation handling for the payout sort.
+//
+// Mirrors p2pool data.py generate_transaction: the per-miner payout dests
+// exclude BOTH donation scripts; any COMBINED_DONATION_SCRIPT-keyed weight is
+// folded into the single donation-last output, and any DONATION_SCRIPT (P2PK)
+// keyed weight is dropped. Value-invariant: the COMBINED weight is moved (not
+// destroyed) into the donation output; dropping the P2PK key is value-neutral
+// only because that key never accrues weight in canonical v36 operation.
+//
+// Guarded by test/f11_donation_invariance_test.cpp.
+// ---------------------------------------------------------------------------
+template <typename AmountsMap>
+inline std::vector<std::pair<std::vector<unsigned char>, uint64_t>>
+build_payout_outputs_excluding_donation(
+    const AmountsMap& amounts,
+    const std::vector<unsigned char>& combined_donation_script,
+    const std::vector<unsigned char>& p2pk_donation_script,
+    uint64_t& donation_amount)
+{
+    if (auto it = amounts.find(combined_donation_script); it != amounts.end())
+        donation_amount += it->second;
+    std::vector<std::pair<std::vector<unsigned char>, uint64_t>> payout_outputs;
+    payout_outputs.reserve(amounts.size());
+    for (const auto& kv : amounts) {
+        if (kv.first == combined_donation_script || kv.first == p2pk_donation_script)
+            continue;
+        payout_outputs.emplace_back(kv.first, kv.second);
+    }
+    return payout_outputs;
+}
+
+template <typename ShareT, typename TrackerT>
+uint256 generate_share_transaction(const ShareT& share, TrackerT& tracker, bool dump_diag = false, bool v36_active = false, std::vector<unsigned char>* out_gentx_bytes = nullptr)
+{
+    auto gst_t0 = std::chrono::steady_clock::now();
+    constexpr int64_t ver = ShareT::version;
+    // p2pool selects PPLNS formula by runtime AutoRatchet state, not compile-time
+    // share version. When v36_active is true (AutoRatchet ACTIVATED/CONFIRMED),
+    // use v36 PPLNS even for v35 shares. Ref: p2pool data.py:879, work.py:759.
+    const bool use_v36_pplns = v36_active || (core::version_gate::is_v36_active(ver));
+    const uint64_t subsidy = share.m_subsidy;
+    const uint16_t donation = share.m_donation;
+
+    // Debug: log the PPLNS formula selection for cross-impl comparison
+    {
+        static int gst_pplns_log = 0;
+        if (gst_pplns_log++ % 50 == 0) {
+            LOG_DEBUG_DIAG << "[GST-PPLNS] v36_active=" << v36_active
+                     << " use_v36_pplns=" << use_v36_pplns
+                     << " ver=" << ver
+                     << " start=" << share.m_prev_hash.GetHex().substr(0, 16)
+                     << " subsidy=" << subsidy
+                     << " donation=" << donation;
+        }
+    }
+
+    // --- 1. Compute PPLNS weights with full scriptPubKey keys ---
+    // Walk from share's prev_hash (parent) backward through the chain.
+    // This matches the Python: weights are computed relative to the share's parent.
+
+    auto prev_hash = share.m_prev_hash;
+    std::map<std::vector<unsigned char>, uint288> weights;
+    uint288 total_weight;
+    uint288 total_donation_weight;
+
+    if (!prev_hash.IsNull() && tracker.chain.contains(prev_hash))
+    {
+        // p2pool data.py:762-764 — refuse to compute PPLNS with insufficient depth.
+        // Without this guard, attempt_verify() (which allows CHAIN_LENGTH+1) can
+        // trigger a PPLNS walk that terminates early, producing wrong coinbase
+        // amounts and causing persistent GENTX-MISMATCH during bootstrap.
+        auto chain_len = static_cast<int32_t>(PoolConfig::real_chain_length());
+        {
+            auto pplns_height = tracker.chain.get_height(prev_hash);
+            auto pplns_last = tracker.chain.get_last(prev_hash);
+            if (!(pplns_height >= chain_len || pplns_last.IsNull()))
+                throw std::invalid_argument(
+                    "share chain not long enough for PPLNS verification (height="
+                    + std::to_string(pplns_height) + " need="
+                    + std::to_string(chain_len) + ")");
+        }
+
+        // block_target from block header bits (matches Python: self.header['bits'].target)
+        auto block_target = chain::bits_to_target(share.m_min_header.m_bits);
+        auto max_weight = chain::target_to_average_attempts(block_target)
+                          * PoolConfig::SPREAD * 65535;
+
+        // PPLNS formula selected by runtime v36_active (AutoRatchet state),
+        // not compile-time share version. Ref: p2pool data.py:879, work.py:759.
+        if (use_v36_pplns) {
+            // V36 PPLNS: exponential depth-decay, walk from parent
+            uint288 unlimited_weight;
+            unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+            auto result = tracker.get_v36_decayed_cumulative_weights(prev_hash, chain_len, unlimited_weight);
+            weights = std::move(result.weights);
+            total_weight = result.total_weight;
+            total_donation_weight = result.total_donation_weight;
+        } else {
+            // Pre-V36 PPLNS: flat cumulative weights (no decay)
+            // CRITICAL: Walk from GRANDPARENT for HEIGHT-1 shares.
+            // p2pool data.py:884-885:
+            //   _pplns_start = previous_share.share_data['previous_share_hash']
+            //   _pplns_max_shares = max(0, min(height, REAL_CHAIN_LENGTH) - 1)
+            uint256 pplns_start;
+            tracker.chain.get(prev_hash).share.invoke([&](auto* s) {
+                pplns_start = s->m_prev_hash;  // grandparent
+            });
+            auto available = tracker.chain.get_height(prev_hash);
+            auto walk_count = static_cast<int32_t>(
+                std::max(0, std::min(chain_len, available) - 1));
+
+            if (!pplns_start.IsNull() && tracker.chain.contains(pplns_start) && walk_count > 0) {
+                auto result = tracker.get_cumulative_weights(pplns_start, walk_count, max_weight);
+                weights = std::move(result.weights);
+                total_weight = result.total_weight;
+                total_donation_weight = result.total_donation_weight;
+            }
+        }
+    }
+
+    // --- 2. Convert weights to exact integer payout amounts ---
+    // Python formula:
+    //   Pre-V36: amounts[script] = subsidy * (199 * weight) / (200 * total_weight)
+    //            amounts[finder] += subsidy // 200
+    //   V36:     amounts[script] = subsidy * weight / total_weight
+    //   donation = subsidy - sum(amounts)
+
+    auto gst_t1 = std::chrono::steady_clock::now(); // after PPLNS walk
+    std::map<std::vector<unsigned char>, uint64_t> amounts;
+
+    // Periodic dump of PPLNS weights for cross-impl comparison
+    {
+        static auto last_amt_dump = std::chrono::steady_clock::now() - std::chrono::seconds(60);
+        auto now_d = std::chrono::steady_clock::now();
+        if (now_d - last_amt_dump > std::chrono::seconds(30) && weights.size() >= 2) {
+            last_amt_dump = now_d;
+            LOG_DEBUG_DIAG << "[PPLNS-AMT] subsidy=" << subsidy
+                     << " total_weight=" << total_weight.GetLow64()
+                     << " don_weight=" << total_donation_weight.GetLow64()
+                     << " addrs=" << weights.size()
+                     << " prev=" << prev_hash.GetHex().substr(0, 16);
+            for (auto& [s, w] : weights) {
+                uint64_t a = (total_weight.IsNull()) ? 0 :
+                    (uint288(subsidy) * w / total_weight).GetLow64();
+                LOG_DEBUG_DIAG << "[PPLNS-AMT]   weight=" << w.GetLow64()
+                         << " amount=" << a;
+            }
+        }
+    }
+
+    if (!total_weight.IsNull())
+    {
+        for (auto& [script, weight] : weights)
+        {
+            uint64_t amount;
+            if (use_v36_pplns)
+            {
+                // V36: amounts[script] = subsidy * weight / total_weight
+                uint288 num = uint288(subsidy) * weight;
+                amount = (num / total_weight).GetLow64();
+            }
+            else
+            {
+                // Pre-V36: amounts[script] = subsidy * (199 * weight) / (200 * total_weight)
+                uint288 num = uint288(subsidy) * (weight * 199);
+                uint288 den = total_weight * 200;
+                amount = (num / den).GetLow64();
+            }
+            if (amount > 0)
+                amounts[script] = amount;
+        }
+    }
+
+    // Pre-V36: add 0.5% finder fee to share creator
+    if (!use_v36_pplns)
+    {
+        auto finder_script = get_share_script(&share);
+        amounts[finder_script] += subsidy / 200;
+    }
+
+    // Donation output = subsidy minus sum of all payout amounts
+    uint64_t sum_amounts = 0;
+    for (auto& [s, a] : amounts)
+        sum_amounts += a;
+    uint64_t donation_amount = (subsidy > sum_amounts) ? (subsidy - sum_amounts) : 0;
+
+    // Dump amounts for cross-impl debugging
+    if (dump_diag) {
+        LOG_DEBUG_DIAG << "[GST-AMOUNTS] subsidy=" << subsidy << " addrs=" << amounts.size()
+                 << " sum=" << sum_amounts << " donation=" << donation_amount
+                 << " prev=" << prev_hash.GetHex().substr(0,16);
+        for (auto& [s, a] : amounts) {
+            static const char* HX = "0123456789abcdef";
+            std::string sh; for (size_t i = 0; i < std::min(s.size(), size_t(10)); ++i) { sh += HX[s[i]>>4]; sh += HX[s[i]&0xf]; }
+            LOG_DEBUG_DIAG << "[GST-AMOUNTS]   " << sh << "... = " << a;
+        }
+    }
+
+    // V36 consensus: donation output must carry >= 1 satoshi (a60f7f7f)
+    if (use_v36_pplns) {
+        if (donation_amount < 1 && subsidy > 0 && !amounts.empty()) {
+            // Deduct 1 sat from the largest miner payout
+            // Deterministic tiebreak: (amount, script) — largest script wins when equal
+            auto largest = std::max_element(amounts.begin(), amounts.end(),
+                [](const auto& a, const auto& b) {
+                    if (a.second != b.second) return a.second < b.second;
+                    return a.first < b.first;
+                });
+            if (largest != amounts.end() && largest->second > 0) {
+                largest->second -= 1;
+                sum_amounts -= 1;
+                donation_amount = subsidy - sum_amounts;
+            }
+        }
+    }
+
+    // --- 3. Build sorted output list ---
+    auto gst_t2 = std::chrono::steady_clock::now(); // after amounts
+    // Python: sorted(dests, key=lambda a: (amounts[a], a))[-4000:]
+    // = ascending by (amount, script), keep last 4000 (highest amounts)
+    // F11: canonical exclude-then-append donation handling (p2pool data.py
+    // generate_transaction). The per-miner dests list excludes BOTH donation
+    // scripts; a COMBINED_DONATION_SCRIPT-keyed weight folds into the single
+    // donation-last output, and any DONATION_SCRIPT-keyed weight is dropped.
+    const std::vector<unsigned char> combined_donation_script(
+        core::donation::COMBINED_DONATION_SCRIPT.begin(), core::donation::COMBINED_DONATION_SCRIPT.end());
+    const std::vector<unsigned char> p2pk_donation_script(
+        core::donation::DONATION_SCRIPT.begin(), core::donation::DONATION_SCRIPT.end());
+    auto payout_outputs = build_payout_outputs_excluding_donation(
+        amounts, combined_donation_script, p2pk_donation_script, donation_amount);
+    std::sort(payout_outputs.begin(), payout_outputs.end(),
+        [](const auto& a, const auto& b) {
+            if (a.second != b.second) return a.second < b.second; // asc by amount
+            return a.first < b.first; // asc by script for tie-breaking
+        });
+
+    // Keep last MAX_OUTPUTS (highest amounts), matching Python's [-4000:]
+    constexpr size_t MAX_OUTPUTS = 4000;
+    if (payout_outputs.size() > MAX_OUTPUTS)
+        payout_outputs.erase(payout_outputs.begin(), payout_outputs.end() - MAX_OUTPUTS);
+
+    // --- 4. Serialise the coinbase transaction ---
+    // Non-witness serialization (for txid computation):
+    //   version(4) + vin_count(varint) + vin + vout_count(varint) + vouts + locktime(4)
+    PackStream tx;
+
+    // tx version = 1
+    uint32_t tx_version = 1;
+    tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&tx_version), 4));
+
+    // vin count = 1
+    {
+        unsigned char one = 1;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&one), 1));
+    }
+
+    // vin[0]: prev_output = 0...0:ffffffff, script = coinbase, sequence = 0
+    {
+        // prev_hash (32 zero bytes)
+        uint256 zero_hash;
+        tx << zero_hash;
+        // prev_index (0xffffffff)
+        uint32_t prev_idx = 0xffffffff;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&prev_idx), 4));
+        // script (VarStr)
+        tx << share.m_coinbase;
+        // sequence (0xffffffff — standard coinbase sequence, matches Python)
+        uint32_t seq = 0xffffffff;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&seq), 4));
+    }
+
+    // Count total outputs
+    size_t n_outs = payout_outputs.size() + 1 /* donation */ + 1 /* OP_RETURN commitment */;
+    // Segwit commitment output (if applicable)
+    bool has_segwit = false;
+    if constexpr (ver >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION)
+    {
+        if constexpr (requires { share.m_segwit_data; })
+        {
+            if (share.m_segwit_data.has_value())
+            {
+                has_segwit = true;
+                n_outs += 1;
+            }
+        }
+    }
+
+    // vout count (varint — for < 253 outputs, it's a single byte)
+    if (n_outs < 253)
+    {
+        uint8_t cnt = static_cast<uint8_t>(n_outs);
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&cnt), 1));
+    }
+    else
+    {
+        uint8_t marker = 0xfd;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&marker), 1));
+        uint16_t cnt = static_cast<uint16_t>(n_outs);
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&cnt), 2));
+    }
+
+    // Helper to write a single tx_out: value(8LE) + script(VarStr)
+    auto write_txout = [&](uint64_t value, const std::vector<unsigned char>& script) {
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&value), 8));
+        BaseScript bs;
+        bs.m_data = script;
+        tx << bs;
+    };
+
+    // Segwit commitment output (value=0, script=OP_RETURN + witness_commitment)
+    if (has_segwit)
+    {
+        if constexpr (requires { share.m_segwit_data; })
+        {
+            if (share.m_segwit_data.has_value())
+            {
+                // witness commitment: 0x6a24aa21a9ed + SHA256d(wtxid_merkle_root || '[P2Pool]'*4)
+                std::vector<unsigned char> wscript;
+                wscript.push_back(0x6a); // OP_RETURN
+                wscript.push_back(0x24); // PUSH 36
+                wscript.push_back(0xaa);
+                wscript.push_back(0x21);
+                wscript.push_back(0xa9);
+                wscript.push_back(0xed);
+                auto& sd = share.m_segwit_data.value();
+                uint256 commitment = compute_p2pool_witness_commitment(sd.m_wtxid_merkle_root);
+                auto commitment_bytes = commitment.GetChars();
+                wscript.insert(wscript.end(), commitment_bytes.begin(), commitment_bytes.end());
+                write_txout(0, wscript);
+                if (dump_diag) {
+                    LOG_INFO << "[WC-GST] wtxid_root=" << sd.m_wtxid_merkle_root.GetHex()
+                             << " commitment=" << commitment.GetHex();
+                }
+            }
+        }
+    }
+
+    // PPLNS payout outputs
+    for (auto& [script, amount] : payout_outputs)
+        write_txout(amount, script);
+
+    // Donation output — V35 shares always use P2PK DONATION_SCRIPT,
+    // V36 shares always use P2SH COMBINED_DONATION_SCRIPT.
+    // Each share was created with the donation script matching its version.
+    auto donation_script = PoolConfig::get_donation_script(ver);
+    write_txout(donation_amount, donation_script);
+
+    // OP_RETURN commitment: value=0, script = 0x6a28 + ref_hash(32) + last_txout_nonce(8)
+    {
+        // We need the ref_hash — recompute it from the share the same way share_init_verify does
+        PackStream ref_stream;
+
+        // IDENTIFIER bytes
+        {
+            auto hex = PoolConfig::identifier_hex();
+            for (size_t i = 0; i + 1 < hex.size(); i += 2)
+            {
+                unsigned char byte = static_cast<unsigned char>(
+                    std::stoul(hex.substr(i, 2), nullptr, 16));
+                ref_stream.write(std::span<const std::byte>(
+                    reinterpret_cast<const std::byte*>(&byte), 1));
+            }
+        }
+
+        // share_info fields (same as share_init_verify)
+        {
+            ref_stream << share.m_prev_hash;
+            ref_stream << share.m_coinbase;
+            ref_stream << share.m_nonce;
+
+            if constexpr (requires { share.m_address; })
+                ref_stream << share.m_address;
+            else if constexpr (requires { share.m_pubkey_type; })
+            {
+                ref_stream << share.m_pubkey_hash;
+                ref_stream << share.m_pubkey_type;
+            }
+            else
+                ref_stream << share.m_pubkey_hash;
+
+            if constexpr (core::version_gate::is_v36_active(ver))
+                ::Serialize(ref_stream, VarInt(share.m_subsidy));
+            else
+                ref_stream << share.m_subsidy;
+
+            ref_stream << share.m_donation;
+            {
+                uint8_t si = static_cast<uint8_t>(share.m_stale_info);
+                ref_stream << si;
+            }
+            ::Serialize(ref_stream, VarInt(share.m_desired_version));
+
+            if constexpr (requires { share.m_segwit_data; })
+            {
+                if constexpr (ver >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION)
+                {
+                    // PossiblyNoneType: ALWAYS serialize (p2pool writes default when None).
+                    // Must match share_init_verify — both paths must produce identical ref_hash.
+                    if (share.m_segwit_data.has_value()) {
+                        ref_stream << share.m_segwit_data.value();
+                    } else {
+                        std::vector<uint256> empty_branch;
+                        ref_stream << empty_branch;
+                        uint256 zero_root;
+                        ref_stream << zero_root;
+                    }
+                }
+            }
+
+            if constexpr (core::version_gate::is_v36_active(ver))
+            {
+                if constexpr (requires { share.m_merged_addresses; })
+                    ref_stream << share.m_merged_addresses;
+            }
+
+            if constexpr (ver < 34)
+            {
+                if constexpr (requires { share.m_tx_info; })
+                    ref_stream << share.m_tx_info;
+            }
+
+            ref_stream << share.m_far_share_hash;
+            ref_stream << share.m_max_bits;
+            ref_stream << share.m_bits;
+            ref_stream << share.m_timestamp;
+            ref_stream << share.m_absheight;
+
+            if constexpr (core::version_gate::is_v36_active(ver))
+            {
+                if constexpr (requires { share.m_abswork; })
+                    ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
+            }
+            else
+            {
+                ref_stream << share.m_abswork;
+            }
+
+            if constexpr (core::version_gate::is_v36_active(ver))
+            {
+                if constexpr (requires { share.m_merged_coinbase_info; })
+                    ref_stream << share.m_merged_coinbase_info;
+                if constexpr (requires { share.m_merged_payout_hash; })
+                    ref_stream << share.m_merged_payout_hash;
+            }
+        }
+
+        // V36 ref_type includes message_data (must match verify_share)
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_message_data; })
+                ref_stream << share.m_message_data;
+        }
+
+        auto ref_span = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+        uint256 hash_ref = Hash(ref_span);
+        uint256 ref_hash = check_merkle_link(hash_ref, share.m_ref_merkle_link);
+
+        // Build OP_RETURN script: 0x6a 0x28 + ref_hash(32) + last_txout_nonce(8)
+        std::vector<unsigned char> op_return_script;
+        op_return_script.push_back(0x6a); // OP_RETURN
+        op_return_script.push_back(0x28); // PUSH 40 bytes
+        op_return_script.insert(op_return_script.end(), ref_hash.data(), ref_hash.data() + 32);
+        {
+            uint64_t nonce = share.m_last_txout_nonce;
+            auto* p = reinterpret_cast<const unsigned char*>(&nonce);
+            op_return_script.insert(op_return_script.end(), p, p + 8);
+        }
+        write_txout(0, op_return_script);
+    }
+
+    // lock_time = 0
+    {
+        uint32_t locktime = 0;
+        tx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&locktime), 4));
+    }
+
+    // --- 5. Compute txid (double-SHA256 of non-witness serialization) ---
+    auto tx_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(tx.data()), tx.size());
+    auto txid = Hash(tx_span);
+
+    // Expose the exact non-witness gentx serialization to the won-block
+    // reconstructor (slice 7): these are the SAME bytes hashed to `txid`, so a
+    // block reframed from them is merkle-consistent with the share's committed
+    // header root. Opt-in (nullptr default) -> byte-identical for every existing
+    // caller.
+    if (out_gentx_bytes)
+        out_gentx_bytes->assign(
+            reinterpret_cast<const unsigned char*>(tx.data()),
+            reinterpret_cast<const unsigned char*>(tx.data()) + tx.size());
+
+    // V36 hash_link cross-check: compute prefix hash_link from our coinbase
+    // and compare with the share's stored hash_link. If states differ,
+    // the prefix (outputs/amounts) differs from what p2pool built.
+    if (dump_diag && use_v36_pplns)
+    {
+        if constexpr (requires { share.m_hash_link.m_extra_data; })
+        {
+            auto gbr = compute_gentx_before_refhash(ver);
+            // prefix = full coinbase minus last 44 bytes (ref_hash 32 + nonce 8 + locktime 4)
+            size_t prefix_len = tx.size() - 44;
+            std::vector<unsigned char> prefix(
+                reinterpret_cast<const unsigned char*>(tx.data()),
+                reinterpret_cast<const unsigned char*>(tx.data()) + prefix_len);
+            auto computed_hl = prefix_to_hash_link(prefix, gbr);
+
+            bool state_match = (computed_hl.m_state.m_data == share.m_hash_link.m_state.m_data);
+            bool extra_match = (computed_hl.m_extra_data.m_data == share.m_hash_link.m_extra_data.m_data);
+            bool len_match = (computed_hl.m_length == share.m_hash_link.m_length);
+
+            static const char* HXD = "0123456789abcdef";
+            auto hex_fn = [&](const auto& v) {
+                std::string h; for (auto b : v) { h += HXD[(uint8_t)b >> 4]; h += HXD[(uint8_t)b & 0xf]; } return h;
+            };
+
+            LOG_WARNING << "[HASHLINK-CMP] state_match=" << (state_match ? "YES" : "NO")
+                        << " extra_match=" << (extra_match ? "YES" : "NO")
+                        << " len_match=" << (len_match ? "YES" : "NO")
+                        << " c2pool_len=" << computed_hl.m_length
+                        << " share_len=" << share.m_hash_link.m_length;
+            if (!state_match) {
+                LOG_WARNING << "[HASHLINK-CMP] c2pool_state=" << hex_fn(computed_hl.m_state.m_data);
+                LOG_WARNING << "[HASHLINK-CMP] share_state =" << hex_fn(share.m_hash_link.m_state.m_data);
+            }
+            if (!extra_match) {
+                LOG_WARNING << "[HASHLINK-CMP] c2pool_extra=" << hex_fn(computed_hl.m_extra_data.m_data)
+                            << " (" << computed_hl.m_extra_data.m_data.size() << " bytes)";
+                LOG_WARNING << "[HASHLINK-CMP] share_extra =" << hex_fn(share.m_hash_link.m_extra_data.m_data)
+                            << " (" << share.m_hash_link.m_extra_data.m_data.size() << " bytes)";
+            }
+            // Also dump prefix length and the last 60 bytes for comparison
+            LOG_WARNING << "[HASHLINK-CMP] prefix_len=" << prefix_len
+                        << " gbr_len=" << gbr.size()
+                        << " prefix_tail=" << hex_fn(std::vector<unsigned char>(
+                            prefix.end() - std::min(prefix.size(), size_t(60)), prefix.end()));
+        }
+    }
+
+    // One-time full coinbase hex dump for cross-implementation debugging
+    {
+        static int coinbase_dump_count = 0;
+        if (coinbase_dump_count++ < 3) {
+            const char* HX = "0123456789abcdef";
+            auto to_hex_fn = [&](const unsigned char* p, size_t len) {
+                std::string h; h.reserve(len * 2);
+                for (size_t i = 0; i < len; ++i) { h += HX[p[i] >> 4]; h += HX[p[i] & 0xf]; }
+                return h;
+            };
+            auto* cp = reinterpret_cast<const unsigned char*>(tx.data());
+            LOG_INFO << "[COINBASE-HEX] len=" << tx.size()
+                     << " txid=" << txid.GetHex()
+                     << " share=" << share.m_hash.GetHex().substr(0, 16)
+                     << " hex=" << to_hex_fn(cp, tx.size());
+        }
+    }
+
+    if (dump_diag)
+    {
+        const char* HX = "0123456789abcdef";
+        auto to_hex = [&](const unsigned char* p, size_t len) {
+            std::string h; h.reserve(len * 2);
+            for (size_t i = 0; i < len; ++i) { h += HX[p[i] >> 4]; h += HX[p[i] & 0xf]; }
+            return h;
+        };
+
+        auto* cp = reinterpret_cast<const unsigned char*>(tx.data());
+        LOG_WARNING << "[GENTX-DIAG] coinbase_len=" << tx.size() << " txid=" << txid.GetHex();
+        LOG_WARNING << "[GENTX-DIAG] coinbase_hex=" << to_hex(cp, tx.size());
+        LOG_WARNING << "[GENTX-DIAG] pplns_outputs=" << payout_outputs.size()
+                    << " donation_amount=" << donation_amount
+                    << " n_outs=" << n_outs
+                    << " has_segwit=" << has_segwit;
+        LOG_WARNING << "[GENTX-DIAG] total_weight=" << total_weight.GetHex()
+                    << " total_don_weight=" << total_donation_weight.GetHex();
+        for (size_t i = 0; i < payout_outputs.size(); ++i) {
+            auto& [s, a] = payout_outputs[i];
+            LOG_WARNING << "[GENTX-DIAG]  payout[" << i << "] amount=" << a
+                        << " script=" << to_hex(s.data(), s.size());
+        }
+        // First 5 + last 5 shares in PPLNS walk (for cross-impl comparison)
+        if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash)) {
+            auto cl = std::min(tracker.chain.get_height(share.m_prev_hash),
+                               static_cast<int32_t>(PoolConfig::real_chain_length()));
+            LOG_WARNING << "[GENTX-DIAG] PPLNS walk_count=" << cl
+                        << " total_weight=" << total_weight.GetHex()
+                        << " total_don_weight=" << total_donation_weight.GetHex()
+                        << " n_addrs=" << weights.size();
+            // First 5 shares
+            auto wv = tracker.chain.get_chain(share.m_prev_hash, std::min(cl, int32_t(5)));
+            int si = 0;
+            for (auto [h, d] : wv) {
+                auto hash_copy = h;  // Apple Clang: structured bindings can't be captured in lambdas
+                d.share.invoke([&, hash_copy](auto* obj) {
+                    auto att = chain::target_to_average_attempts(chain::bits_to_target(obj->m_bits));
+                    auto sc = get_share_script(obj);
+                    LOG_WARNING << "[GENTX-DIAG]  walk[" << si << "] hash=" << hash_copy.ToString().substr(0,16)
+                                << " bits=0x" << std::hex << obj->m_bits
+                                << " max_bits=0x" << obj->m_max_bits << std::dec
+                                << " att=" << att.GetHex()
+                                << " don=" << obj->m_donation
+                                << " script=" << to_hex(sc.data(), sc.size());
+                });
+                ++si;
+            }
+            // Last 5 shares in walk (tail of PPLNS window)
+            if (cl > 10) {
+                auto full_view = tracker.chain.get_chain(share.m_prev_hash, cl);
+                int si2 = 0;
+                for (auto [h, d] : full_view) {
+                    if (si2 >= cl - 5) {
+                        auto hash_copy = h;  // Apple Clang: structured bindings can't be captured
+                        d.share.invoke([&, hash_copy](auto* obj) {
+                            auto att = chain::target_to_average_attempts(chain::bits_to_target(obj->m_bits));
+                            auto sc = get_share_script(obj);
+                            LOG_WARNING << "[GENTX-DIAG]  walk_tail[" << si2 << "/" << cl << "] hash=" << hash_copy.ToString().substr(0,16)
+                                        << " bits=0x" << std::hex << obj->m_bits
+                                        << " max_bits=0x" << obj->m_max_bits << std::dec
+                                        << " att=" << att.GetHex()
+                                        << " don=" << obj->m_donation
+                                        << " script=" << to_hex(sc.data(), sc.size());
+                        });
+                    }
+                    ++si2;
+                }
+                LOG_WARNING << "[GENTX-DIAG] walk iterated " << si2 << " shares (expected " << cl << ")";
+            }
+        }
+    }
+
+    {
+        auto gst_t3 = std::chrono::steady_clock::now();
+        static int64_t sp = 0, sa = 0, sc = 0, sn = 0;
+        sp += std::chrono::duration_cast<std::chrono::microseconds>(gst_t1 - gst_t0).count();
+        sa += std::chrono::duration_cast<std::chrono::microseconds>(gst_t2 - gst_t1).count();
+        sc += std::chrono::duration_cast<std::chrono::microseconds>(gst_t3 - gst_t2).count();
+        ++sn;
+        if (sn % 50 == 0)
+            LOG_INFO << "[GST-SPLIT] pplns=" << (sp/sn) << "us amounts=" << (sa/sn)
+                     << "us coinbase=" << (sc/sn) << "us count=" << sn;
+    }
+    return txid;
+}
+
+// ============================================================================
+// verify_merged_coinbase_commitment()
+//
+// Full 7-step chain verification of merged coinbase (Python data.py:329-458).
+// Ensures the merged coinbase committed in the share actually matches the
+// canonical PPLNS construction. Without this, a node could commit valid
+// m_merged_payout_hash (weights match) but build a DOGE coinbase that pays
+// differently — the merkle proof would be for the real (malicious) coinbase.
+//
+// Verification chain:
+//   1. Re-derive canonical DOGE coinbase from PPLNS weights
+//   2. canonical_txid = hash256(canonical_coinbase)
+//   3. check_merkle_link(canonical_txid, coinbase_merkle_link) == header.merkle_root
+//   4. hash256(header) == doge_block_hash
+//   5. doge_block_hash matches aux_merkle_root in LTC coinbase mm_data
+//
+// Returns empty string on success, error message on failure.
+// ============================================================================
+template <typename ShareT, typename TrackerT>
+std::string verify_merged_coinbase_commitment(
+    const ShareT& share, TrackerT& tracker)
+{
+    if constexpr (ShareT::version < 36)
+        return {};
+    if constexpr (!requires { share.m_merged_coinbase_info; })
+        return {};
+
+    // No merged coinbase info → nothing to verify
+    if (share.m_merged_coinbase_info.empty())
+        return {};
+
+    // Need enough chain history for reliable PPLNS verification
+    if (share.m_prev_hash.IsNull() || !tracker.chain.contains(share.m_prev_hash))
+        return {};
+    auto height = tracker.chain.get_height(share.m_prev_hash);
+    if (height < static_cast<int32_t>(PoolConfig::real_chain_length()))
+        return {};  // Insufficient depth — skip (match Python behavior)
+
+    auto block_target = chain::bits_to_target(share.m_bits);
+    auto max_weight = chain::target_to_average_attempts(block_target)
+                    * 65535 * PoolConfig::SPREAD;
+    int32_t chain_len = std::min(height,
+        static_cast<int32_t>(PoolConfig::real_chain_length()));
+
+    // Parse mm_data from LTC coinbase scriptSig
+    const auto& coinbase = share.m_coinbase.m_data;
+    static const uint8_t MM_MAGIC[] = {0xfa, 0xbe, 0x6d, 0x6d};
+    auto mm_pos = std::search(coinbase.begin(), coinbase.end(),
+                               std::begin(MM_MAGIC), std::end(MM_MAGIC));
+    if (mm_pos == coinbase.end()) {
+        return "merged_coinbase_info present but no mm_data marker in coinbase scriptSig";
+    }
+    size_t mm_offset = std::distance(coinbase.begin(), mm_pos) + 4;
+    if (coinbase.size() - mm_offset < 40)
+        return "mm_data too short in coinbase scriptSig";
+
+    // aux_merkle_root: 32 bytes big-endian
+    uint256 aux_merkle_root;
+    {
+        const uint8_t* p = coinbase.data() + mm_offset;
+        // MM root is stored big-endian in the coinbase — reverse for internal uint256
+        uint8_t* dst = reinterpret_cast<uint8_t*>(aux_merkle_root.begin());
+        for (int i = 31; i >= 0; --i)
+            dst[i] = *p++;
+    }
+    uint32_t aux_size = 0;
+    {
+        const uint8_t* p = coinbase.data() + mm_offset + 32;
+        aux_size = p[0] | (p[1] << 8) | (p[2] << 16) | (p[3] << 24);
+    }
+
+    // Get finder script for canonical coinbase construction
+    auto finder_script = get_share_script(&share);
+    auto finder_merged = normalize_script_for_merged(finder_script);
+
+    for (const auto& info : share.m_merged_coinbase_info) {
+        uint32_t chain_id = info.m_chain_id;
+
+        // Step 1: Get PPLNS weights for this merged chain
+        auto mw = tracker.get_merged_cumulative_weights(
+            share.m_prev_hash, chain_len, max_weight, chain_id);
+
+        if (mw.weights.empty() || mw.total_weight.IsNull())
+            continue;  // No V36 shares → can't verify
+
+        // Build payout list (same logic as payout_provider)
+        auto donation_script = PoolConfig::get_donation_script(36);
+        uint64_t coinbase_value = info.m_coinbase_value;
+
+        // Convert weights to integer payouts
+        std::map<std::vector<unsigned char>, uint64_t> output_amounts;
+        uint64_t total_distributed = 0;
+        double total_d = mw.total_weight.IsNull() ? 0.0
+            : static_cast<double>(mw.total_weight.GetLow64());
+        for (auto& [key, weight] : mw.weights) {
+            auto script = resolve_merged_payout_script(key);
+            if (script.empty()) continue;
+            double frac = weight.IsNull() ? 0.0
+                : static_cast<double>(weight.GetLow64()) / total_d;
+            uint64_t amount = static_cast<uint64_t>(coinbase_value * frac);
+            if (amount > 0) {
+                output_amounts[script] += amount;
+                total_distributed += amount;
+            }
+        }
+        uint64_t donation_amount = coinbase_value - total_distributed;
+        // Donation >= 1 satoshi
+        if (donation_amount < 1 && !output_amounts.empty()) {
+            // Deterministic tiebreak: (amount, script) — largest script wins when equal
+            auto it = std::max_element(output_amounts.begin(), output_amounts.end(),
+                [](auto& a, auto& b) {
+                    if (a.second != b.second) return a.second < b.second;
+                    return a.first < b.first;
+                });
+            it->second -= 1;
+            donation_amount += 1;
+        }
+
+        // Coinbase reconstruction removed: the merged_payout_hash check
+        // (Step 1 above) already verifies PPLNS weight correctness via the
+        // skip list. Reconstructing the full coinbase TX to verify merkle_root
+        // is redundant and fails on cross-implementation shares because:
+        // - scriptSig differs ("/c2pool/" vs "/P2Pool/")
+        // - OP_RETURN text differs
+        // - THE state_root presence differs
+        // - Float vs integer rounding in amount calculation
+        // All of these change txid → merkle_root without affecting PPLNS fairness.
+
+        // Step 2: Verify header structure and extract block hash
+        if (info.m_block_header.m_data.size() < 80)
+            return "merged block header too short";
+
+        // Step 3: hash256(header) == doge_block_hash
+        auto hdr_span = std::span<const unsigned char>(
+            info.m_block_header.m_data.data(), 80);
+        uint256 doge_block_hash = Hash(hdr_span);
+
+        // Step 6: Verify doge_block_hash against aux_merkle_root
+        if (aux_size == 1) {
+            // Single merged chain: aux_merkle_root == block_hash
+            if (doge_block_hash != aux_merkle_root) {
+                return "merged block hash " + doge_block_hash.GetHex()
+                     + " != aux_merkle_root " + aux_merkle_root.GetHex()
+                     + " for chain " + std::to_string(chain_id);
+            }
+        }
+        // Multi-chain: would need aux tree reconstruction (future)
+    }
+
+    return {};
+}
+
+// ============================================================================
+// share_check()
+//
+// The check()-phase verification after init:
+//   1. Timestamp not too far in the future
+//   2. Version counting (stub — version upgrade enforcement)
+//   3. Transaction hash resolution (for pre-v34 shares)
+//   4. GenerateShareTransaction reconstruction & comparison
+//   5. Merged payout hash + coinbase commitment verification
+//
+// Returns true if the share passes all checks.
+// Throws on validation failure.
+// ============================================================================
+template <typename ShareT, typename TrackerT>
+bool share_check(const ShareT& share,
+                 const uint256& share_hash,
+                 const uint256& gentx_hash,
+                 TrackerT& tracker)
+{
+    // 1. Timestamp check — must not be more than 600s in the future
+    auto now = static_cast<uint32_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
+    if (share.m_timestamp > now + 600)
+        throw std::invalid_argument("share timestamp is too far in the future");
+
+    // 2. Version switch enforcement — canonical 60% weighted switch rule.
+    // p2pool data.py check() (lines 1396-1414): a version BOUNDARY
+    // (share.version != parent.version) is only valid when, in the sampling
+    // window [CHAIN_LENGTH*9/10, CHAIN_LENGTH] behind the PARENT, the new
+    // version holds >= 60% of the PPLNS-WEIGHTED desired-version counts.
+    // The weight is target_to_average_attempts per share — get_desired_version_weights,
+    // matching canonical get_desired_version_counts (data.py:2651) — NOT a flat count.
+    // F10/(b): the prior non-canonical 95%-flat-count should_punish_version
+    // punish is removed; the canonical 60% switch rule is now the ONLY version
+    // gate. AutoRatchet stays work-weighted (#290) and does not gate peer
+    // shares here. This couples the accept gate to the mint guard so an
+    // activated node can never mint a boundary share its peers reject.
+    {
+        auto chain_length = static_cast<int32_t>(PoolConfig::chain_length());
+        if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))
+        {
+            // Parent's share version (the type the incoming share must legally follow)
+            int64_t parent_version = 0;
+            tracker.chain.get_share(share.m_prev_hash).invoke([&](auto* obj) {
+                parent_version = std::remove_pointer_t<decltype(obj)>::version;
+            });
+            int64_t share_ver = share.version;
+
+            auto prev_height = tracker.chain.get_height(share.m_prev_hash);
+            const bool have_history = (prev_height >= chain_length);
+
+            // Only a +1 upgrade boundary WITH history consults the PPLNS-weighted
+            // desired-version window; compute it lazily there (preserving the prior
+            // fetch behavior — no get_desired_version_weights call on other shapes)
+            // and pass empty otherwise. The SSOT reads window_weights only in that
+            // branch, so accept/reject is byte-for-byte identical to the prior inline.
+            std::map<uint64_t, uint288> window_weights;
+            if (have_history && share_ver == parent_version + 1)
+            {
+                uint32_t window_start = (static_cast<uint32_t>(chain_length) * 9) / 10;
+                uint32_t window_size  = static_cast<uint32_t>(chain_length) / 10;
+                auto ancestor = tracker.chain.get_nth_parent_key(share.m_prev_hash, window_start);
+                window_weights = tracker.get_desired_version_weights(
+                    ancestor, static_cast<int32_t>(window_size));
+            }
+
+            // SSOT (PR #597): core::version_gate::verify_version_transition holds the
+            // canonical p2pool data.py check() boundary rule (same-version ok; +1 needs
+            // >=60% weighted support AND history; -1 AutoRatchet deactivation ok; other
+            // jumps throw; insufficient-history rejects only +1). floor defaults to
+            // V36_ACTIVATION_VERSION — BTC threads the default (no obsolescence branch).
+            core::version_gate::verify_version_transition<uint288>(
+                parent_version, share_ver, window_weights, have_history);
+        }
+    }
+
+    // 3. GenerateShareTransaction reconstruction & comparison
+    // Rebuild the expected coinbase from PPLNS weights and share fields,
+    // then verify its txid matches the gentx_hash from share_init_verify().
+    // p2pool check(): v36_active = (self.VERSION >= 36)
+    // Use the SHARE's own version, not the tracker's runtime AutoRatchet state.
+    // This ensures V35 shares always verify with V35 PPLNS formula, even after
+    // the AutoRatchet transitions to ACTIVATED.
+    constexpr int64_t share_ver = ShareT::version;
+    bool v36_active = (core::version_gate::is_v36_active(share_ver));
+    if (!share.m_prev_hash.IsNull() && tracker.chain.contains(share.m_prev_hash))
+    {
+        uint256 expected_gentx = generate_share_transaction(share, tracker, false, v36_active);
+        if (expected_gentx != gentx_hash)
+        {
+            LOG_WARNING << "GENTX-MISMATCH detail:"
+                        << " share=" << share_hash.ToString().substr(0,16)
+                        << " ver=" << share.version
+                        << " subsidy=" << share.m_subsidy
+                        << " donation=" << share.m_donation
+                        << " prev=" << share.m_prev_hash.ToString().substr(0,16);
+            LOG_WARNING << "  expected_gentx=" << expected_gentx.ToString().substr(0,32)
+                        << " actual_gentx=" << gentx_hash.ToString().substr(0,32);
+
+            auto chain_len = std::min(
+                tracker.chain.get_height(share.m_prev_hash),
+                static_cast<int32_t>(PoolConfig::real_chain_length()));
+            // V35: log grandparent + height-1 window info
+            uint256 gp_hash;
+            if (tracker.chain.contains(share.m_prev_hash))
+                tracker.chain.get(share.m_prev_hash).share.invoke([&](auto* s){ gp_hash = s->m_prev_hash; });
+            int32_t v35_walk = std::max(0, chain_len - 1);
+            LOG_WARNING << "  PPLNS chain_len=" << chain_len
+                        << " v35_walk=" << v35_walk
+                        << " grandparent=" << (gp_hash.IsNull() ? "null" : gp_hash.GetHex().substr(0,16))
+                        << " prev_height=" << tracker.chain.get_height(share.m_prev_hash)
+                        << " real_chain_length=" << PoolConfig::real_chain_length();
+
+            // Compare share target: what c2pool computes vs what the share has
+            {
+                static int target_diag = 0;
+                if (target_diag++ < 10) {
+                    auto [cst_max_bits, cst_bits] = tracker.compute_share_target(
+                        share.m_prev_hash, share.m_timestamp, uint256());
+                    auto share_aps = tracker.get_pool_attempts_per_second(
+                        share.m_prev_hash, PoolConfig::TARGET_LOOKBEHIND, true);
+                    LOG_WARNING << "[GENTX-TARGET] share_bits=0x" << std::hex << share.m_bits
+                                << " share_max_bits=0x" << share.m_max_bits
+                                << " c2pool_bits=0x" << cst_bits
+                                << " c2pool_max_bits=0x" << cst_max_bits << std::dec
+                                << " aps_min=" << share_aps.GetLow64()
+                                << " prev=" << share.m_prev_hash.GetHex().substr(0,16);
+
+                    // APS walk component dump for cross-impl comparison
+                    int32_t dist = PoolConfig::TARGET_LOOKBEHIND;
+                    auto near_hash = share.m_prev_hash;
+                    auto far_hash = near_hash;
+                    int32_t actual_dist = 0;
+                    for (int32_t i = 0; i < dist - 1; ++i) {
+                        if (far_hash.IsNull() || !tracker.chain.contains(far_hash)) break;
+                        auto* idx = tracker.chain.get_index(far_hash);
+                        far_hash = idx ? idx->tail : uint256();
+                        ++actual_dist;
+                    }
+                    uint32_t near_ts = 0, far_ts = 0;
+                    if (tracker.chain.contains(near_hash))
+                        tracker.chain.get_share(near_hash).invoke([&](auto* s){ near_ts = s->m_timestamp; });
+                    if (!far_hash.IsNull() && tracker.chain.contains(far_hash))
+                        tracker.chain.get_share(far_hash).invoke([&](auto* s){ far_ts = s->m_timestamp; });
+
+                    // Compare skip-list far vs naive-walk far
+                    auto skip_far = tracker.chain.get_nth_parent_via_skip(
+                        share.m_prev_hash, dist - 1);
+                    bool skip_match = (!far_hash.IsNull() && skip_far == far_hash);
+
+                    // Also get delta via TrackerView for comparison
+                    uint288 delta_min_work;
+                    int32_t delta_height = 0;
+                    if (!skip_far.IsNull() && tracker.chain.contains(skip_far)) {
+                        auto dv = tracker.chain.get_delta(share.m_prev_hash, skip_far);
+                        delta_min_work = dv.min_work;
+                        delta_height = dv.height;
+                    }
+
+                    LOG_WARNING << "[GENTX-APS] near=" << near_hash.GetHex().substr(0,16)
+                                << " far_naive=" << (far_hash.IsNull() ? "null" : far_hash.GetHex().substr(0,16))
+                                << " far_skip=" << (skip_far.IsNull() ? "null" : skip_far.GetHex().substr(0,16))
+                                << " skip_match=" << (skip_match ? "YES" : "NO")
+                                << " actual_dist=" << actual_dist
+                                << " expected_dist=" << (dist - 1)
+                                << " timespan=" << (int32_t(near_ts) - int32_t(far_ts))
+                                << " near_ts=" << near_ts << " far_ts=" << far_ts
+                                << " chain_height=" << tracker.chain.get_height(share.m_prev_hash)
+                                << " delta_h=" << delta_height
+                                << " delta_min_work=" << delta_min_work.GetLow64();
+
+                    // Previous share's max_target (clamp reference)
+                    uint256 prev_max_target;
+                    tracker.chain.get_share(share.m_prev_hash).invoke([&](auto* obj) {
+                        prev_max_target = chain::bits_to_target(obj->m_max_bits);
+                    });
+                    LOG_WARNING << "[GENTX-CLAMP] prev_max_bits=0x" << std::hex
+                                << chain::target_to_bits_upper_bound(prev_max_target) << std::dec
+                                << " clamp_lo=" << chain::target_to_bits_upper_bound(prev_max_target * 9 / 10)
+                                << " clamp_hi=" << chain::target_to_bits_upper_bound(prev_max_target * 11 / 10);
+                }
+            }
+            // --- Detailed diagnostics: re-run with full dump ---
+            static int s_diag_count = 0;
+            if (s_diag_count++ < 5)
+            {
+                LOG_WARNING << "[GENTX-DIAG] Re-running generate_share_transaction with full dump (v36_active=" << v36_active << "):";
+                generate_share_transaction(share, tracker, true, v36_active);
+
+                // Per-share PPLNS walk dump — compare with p2pool's [PARENT-PPLNS] output.
+                // Uses same parameters as generate_share_transaction's V36 path.
+                if (v36_active && !share.m_prev_hash.IsNull()) {
+                    auto diag_chain_len = static_cast<int32_t>(PoolConfig::real_chain_length());
+                    LOG_WARNING << "[GENTX-DIAG] Per-share V36 PPLNS walk from prev="
+                                << share.m_prev_hash.GetHex().substr(0, 16) << ":";
+                    tracker.dump_v36_pplns_walk(share.m_prev_hash, diag_chain_len);
+                }
+            }
+
+            throw std::invalid_argument("GenerateShareTransaction mismatch — coinbase does not match PPLNS payouts");
+        }
+    }
+
+    // 4. V36+ merged_payout_hash verification
+    // Verify that the share's committed merged PPLNS hash matches what we
+    // independently compute from the share chain. Without this, a malicious
+    // node could steal all merged chain (DOGE) rewards while appearing honest
+    // on the parent chain (LTC payouts are consensus-enforced via gentx above).
+    if constexpr (core::version_gate::is_v36_active(ShareT::version))
+    {
+        if constexpr (requires { share.m_merged_payout_hash; })
+        {
+            if (!share.m_merged_payout_hash.IsNull() &&
+                !share.m_prev_hash.IsNull() &&
+                tracker.chain.contains(share.m_prev_hash))
+            {
+                // Use BLOCK target (from header bits), not share target.
+                // p2pool: block_target = self.header['bits'].target
+                auto block_target = chain::bits_to_target(share.m_min_header.m_bits);
+                auto expected_hash = tracker.compute_merged_payout_hash(
+                    share.m_prev_hash, block_target);
+
+                if (!expected_hash.IsNull() && share.m_merged_payout_hash != expected_hash)
+                {
+                    LOG_WARNING << "merged_payout_hash REJECT: claimed "
+                        << share.m_merged_payout_hash.GetHex()
+                        << " != expected " << expected_hash.GetHex();
+                    throw std::invalid_argument(
+                        "merged_payout_hash mismatch — merged chain reward theft attempt");
+                }
+            }
+        }
+    }
+
+    // 5. V36+ merged coinbase commitment verification (7-step chain)
+    // Verifies the actual merged coinbase matches canonical PPLNS construction.
+    if constexpr (core::version_gate::is_v36_active(ShareT::version))
+    {
+        auto mcv_err = verify_merged_coinbase_commitment(share, tracker);
+        if (!mcv_err.empty())
+            throw std::invalid_argument("merged coinbase verification: " + mcv_err);
+    }
+
+    return true;
+}
+
+// ============================================================================
+// verify_share()
+//
+// Combined entry point: runs both init-phase and check-phase verification.
+// Returns the computed share hash.
+// ============================================================================
+template <typename ShareT, typename TrackerT>
+uint256 verify_share(const ShareT& share, TrackerT& tracker)
+{
+    auto vt0 = std::chrono::steady_clock::now();
+    // share_init_verify computes gentx_hash along the way — we need it
+    // for the GenerateShareTransaction comparison in share_check.
+    // Skip scrypt PoW re-check when hash was already computed in Phase 1
+    // (processing_shares offloads scrypt to m_verify_pool; no need to repeat).
+    uint256 hash = share_init_verify(share, share.m_hash.IsNull());
+    auto vt1 = std::chrono::steady_clock::now();
+
+    // Verify recomputed hash matches stored hash (informational).
+    // For locally created shares the hash was set during create_local_share;
+    // a mismatch means the header reconstruction diverged (e.g., genesis PPLNS
+    // race). The share_check phase uses share.m_hash for chain lookups.
+    if (!share.m_hash.IsNull() && hash != share.m_hash) {
+        static int hash_mismatch_log = 0;
+        if (hash_mismatch_log++ < 10)
+            LOG_WARNING << "[verify_share] hash mismatch: recomputed="
+                        << hash.GetHex().substr(0, 16)
+                        << " stored=" << share.m_hash.GetHex().substr(0, 16);
+    }
+
+    // Re-derive gentx_hash for the check phase
+    constexpr int64_t ver = ShareT::version;
+    auto gentx_before_refhash = compute_gentx_before_refhash(ver);
+
+    // Rebuild ref_hash + hash_link_data the same way init does
+    PackStream ref_stream;
+    {
+        auto hex = PoolConfig::identifier_hex();
+        for (size_t i = 0; i + 1 < hex.size(); i += 2)
+        {
+            unsigned char byte = static_cast<unsigned char>(
+                std::stoul(hex.substr(i, 2), nullptr, 16));
+            ref_stream.write(std::span<const std::byte>(
+                reinterpret_cast<const std::byte*>(&byte), 1));
+        }
+    }
+    {
+        ref_stream << share.m_prev_hash;
+        ref_stream << share.m_coinbase;
+        ref_stream << share.m_nonce;
+
+        if constexpr (requires { share.m_address; })
+            ref_stream << share.m_address;
+        else if constexpr (requires { share.m_pubkey_type; })
+        {
+            ref_stream << share.m_pubkey_hash;
+            ref_stream << share.m_pubkey_type;
+        }
+        else
+            ref_stream << share.m_pubkey_hash;
+
+        if constexpr (core::version_gate::is_v36_active(ver))
+            ::Serialize(ref_stream, VarInt(share.m_subsidy));
+        else
+            ref_stream << share.m_subsidy;
+
+        ref_stream << share.m_donation;
+        {
+            uint8_t si = static_cast<uint8_t>(share.m_stale_info);
+            ref_stream << si;
+        }
+        ::Serialize(ref_stream, VarInt(share.m_desired_version));
+
+        if constexpr (requires { share.m_segwit_data; })
+        {
+            if constexpr (ver >= bip110::pool::PoolConfig::SEGWIT_ACTIVATION_VERSION)
+            {
+                // PossiblyNoneType: ALWAYS serialize (p2pool writes default when None)
+                if (share.m_segwit_data.has_value()) {
+                    ref_stream << share.m_segwit_data.value();
+                } else {
+                    std::vector<uint256> empty_branch;
+                    ref_stream << empty_branch;
+                    uint256 zero_root;
+                    ref_stream << zero_root;
+                }
+            }
+        }
+
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_merged_addresses; })
+                ref_stream << share.m_merged_addresses;
+        }
+
+        if constexpr (ver < 34)
+        {
+            if constexpr (requires { share.m_tx_info; })
+                ref_stream << share.m_tx_info;
+        }
+
+        ref_stream << share.m_far_share_hash;
+        ref_stream << share.m_max_bits;
+        ref_stream << share.m_bits;
+        ref_stream << share.m_timestamp;
+        ref_stream << share.m_absheight;
+
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_abswork; })
+                ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
+        }
+        else
+        {
+            ref_stream << share.m_abswork;
+        }
+
+        if constexpr (core::version_gate::is_v36_active(ver))
+        {
+            if constexpr (requires { share.m_merged_coinbase_info; })
+                ref_stream << share.m_merged_coinbase_info;
+            if constexpr (requires { share.m_merged_payout_hash; })
+                ref_stream << share.m_merged_payout_hash;
+        }
+    }
+
+    // V36 ref_type includes message_data
+    if constexpr (core::version_gate::is_v36_active(ver))
+    {
+        if constexpr (requires { share.m_message_data; })
+            ref_stream << share.m_message_data;
+    }
+
+    auto ref_span = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+    uint256 hash_ref = Hash(ref_span);
+
+    std::vector<unsigned char> hash_link_data;
+    {
+        uint256 ref_hash = check_merkle_link(hash_ref, share.m_ref_merkle_link);
+        hash_link_data.insert(hash_link_data.end(), ref_hash.data(), ref_hash.data() + 32);
+        uint64_t nonce = share.m_last_txout_nonce;
+        auto* p = reinterpret_cast<const unsigned char*>(&nonce);
+        hash_link_data.insert(hash_link_data.end(), p, p + 8);
+        uint32_t zero = 0;
+        auto* z = reinterpret_cast<const unsigned char*>(&zero);
+        hash_link_data.insert(hash_link_data.end(), z, z + 4);
+    }
+
+    uint256 gentx_hash = check_hash_link(share.m_hash_link, hash_link_data, gentx_before_refhash);
+
+    // V36+: Validate message_data (reject shares with invalid encrypted messages)
+    if constexpr (core::version_gate::is_v36_active(ver))
+    {
+        if constexpr (requires { share.m_message_data; })
+        {
+            auto err = validate_message_data(share.m_message_data.m_data);
+            if (!err.empty())
+                throw std::invalid_argument("share " + err);
+        }
+    }
+
+    share_check(share, hash, gentx_hash, tracker);
+    {
+        auto vt2 = std::chrono::steady_clock::now();
+        auto init_us = std::chrono::duration_cast<std::chrono::microseconds>(vt1 - vt0).count();
+        auto check_us = std::chrono::duration_cast<std::chrono::microseconds>(vt2 - vt1).count();
+        static int64_t s_init = 0, s_check = 0, s_cnt = 0;
+        s_init += init_us; s_check += check_us; ++s_cnt;
+        if (s_cnt % 50 == 0)
+            LOG_INFO << "[VERIFY-SPLIT] init_avg=" << (s_init/s_cnt)
+                     << "us check_avg=" << (s_check/s_cnt) << "us count=" << s_cnt;
+    }
+    return hash;
+}
+
+// ============================================================================
+// create_local_share() / create_local_share_v35() — MINT PATH — deferred to PR-B.
+//
+// The BTC lane's two local-share constructors build a share from a
+// coin::SmallBlockHeaderType (the classic 5-field SHA256d small header) and, for
+// v35, a PaddingBugfixShare variant. Neither maps onto the BIP-110 v36-genesis
+// lane as-is: bip110's min_header is Bip110SmallBlockHeaderType (the 164-byte v2
+// BLAKE2b header minus merkle, share_types.hpp) and there is no v35 variant on
+// this wire. The bip110 mint constructor therefore builds a MergedMiningShare
+// directly from the full coin::BlockHeaderType (via Bip110SmallBlockHeaderType::
+// from_full) and computes the share-hash through compute_share_hash() /
+// check_header_fail_closed() — this is the PR-B money/mint path, wired with
+// pool::SharechainNode into main_bip110. PR-A-cont ships the VERIFY surface only
+// (share_init_verify / generate_share_transaction / share_check / verify_share +
+// the BLAKE2b header-hash delta), which is what the sharechain follower needs to
+// accept a peer's v36 shares. See the PR remaining-work map.
+// ============================================================================
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_check.hpp
+++ b/src/impl/bip110/pool/share_check.hpp
@@ -2386,19 +2386,42 @@ uint256 create_local_share(
     share.m_merkle_link.m_index  = 0;
 
     // segwit_data — v36 >= SEGWIT_ACTIVATION => ALWAYS active on this v36-genesis
-    // chain, so m_segwit_data is ALWAYS populated (has_value == true): a real
-    // SegwitData when a witness commitment exists, else the SegwitDataDefault
-    // none-sentinel (2^256-1 wtxid root, share_types.hpp) — the lane's SSOT, NOT
-    // the BTC lane's zero. This keeps the ref_hash / wire encoding self-consistent
-    // (the Formatter's Optional(..., SegwitDataDefault) always writes a value).
-    if (segwit_active && !witness_commitment_hex.empty())
+    // chain, so m_segwit_data is ALWAYS populated with a REAL SegwitData whose
+    // wtxid_merkle_root is the actual witness merkle root:
+    //   • tx-bearing share  => merkle([0] ++ selected wtxids) (witness_root arg)
+    //   • coinbase-only share => merkle([0]) = ZERO
+    // This mirrors python v36 data.py:1090 (generate_transaction computes
+    // segwit_data with wtxid_merkle_root = merkle_hash([0] ++ wtxids) whenever
+    // known_txs is not None — i.e. every mined share, coinbase-only included).
+    // We do NOT store the SegwitDataDefault 0xff None-sentinel (2^256-1) here: that
+    // value is only the PossiblyNoneType WIRE ENCODING of "no segwit_data", never a
+    // real root. Storing it made the found-block coinbase witness commitment
+    // (SHA256d(root || '[P2Pool]'*4)) consensus-INVALID — segwit recomputes the
+    // commitment over the real witness root (ZERO coinbase-only), not 0xff — AND
+    // diverged from a python-fork peer whose mined coinbase-only share carries a
+    // PRESENT segwit_data with root 0. The sentinel is used only when segwit is
+    // inactive (never on this v36-genesis chain).
+    if (segwit_active)
     {
         SegwitData sd;
         sd.m_txid_merkle_link.m_branch = (has_frozen && !frozen_merkle_branches.empty())
             ? frozen_merkle_branches : merkle_branches;
         sd.m_txid_merkle_link.m_index  = 0;
-        sd.m_wtxid_merkle_root = !frozen_witness_root.IsNull()
-            ? frozen_witness_root : witness_root;
+        if (!witness_commitment_hex.empty())
+        {
+            // tx-bearing share: real wtxid merkle root over [0] ++ selected wtxids.
+            sd.m_wtxid_merkle_root = !frozen_witness_root.IsNull()
+                ? frozen_witness_root : witness_root;
+        }
+        else
+        {
+            // coinbase-only share: the witness merkle root is merkle([0]) = ZERO
+            // (python v36 merkle_hash([0])==0). The coinbase carries the P2Pool
+            // commitment SHA256d(ZERO || '[P2Pool]'*4) and the won block's coinbase
+            // witness reserved value is '[P2Pool]'*4, so segwit consensus' witness-
+            // commitment check passes.
+            sd.m_wtxid_merkle_root = uint256();  // ZERO
+        }
         share.m_segwit_data = sd;
     }
     else

--- a/src/impl/bip110/pool/share_check.hpp
+++ b/src/impl/bip110/pool/share_check.hpp
@@ -2172,21 +2172,494 @@ uint256 verify_share(const ShareT& share, TrackerT& tracker)
 }
 
 // ============================================================================
-// create_local_share() / create_local_share_v35() — MINT PATH — deferred to PR-B.
+// create_local_share() — MINT PATH (PR-A-cont2).
 //
-// The BTC lane's two local-share constructors build a share from a
-// coin::SmallBlockHeaderType (the classic 5-field SHA256d small header) and, for
-// v35, a PaddingBugfixShare variant. Neither maps onto the BIP-110 v36-genesis
-// lane as-is: bip110's min_header is Bip110SmallBlockHeaderType (the 164-byte v2
-// BLAKE2b header minus merkle, share_types.hpp) and there is no v35 variant on
-// this wire. The bip110 mint constructor therefore builds a MergedMiningShare
-// directly from the full coin::BlockHeaderType (via Bip110SmallBlockHeaderType::
-// from_full) and computes the share-hash through compute_share_hash() /
-// check_header_fail_closed() — this is the PR-B money/mint path, wired with
-// pool::SharechainNode into main_bip110. PR-A-cont ships the VERIFY surface only
-// (share_init_verify / generate_share_transaction / share_check / verify_share +
-// the BLAKE2b header-hash delta), which is what the sharechain follower needs to
-// accept a peer's v36 shares. See the PR remaining-work map.
+// Constructs the v36 MergedMiningshare from locally-generated block data and adds
+// it to the share tracker. Returns the share hash (the BLAKE2b block-identity hash).
+//
+// v36-GENESIS DELTAS vs the BTC lane's create_local_share (src/impl/btc/
+// share_check.hpp):
+//   • takes the FULL coin::BlockHeaderType (the 164-byte v2 BLAKE2b header) and
+//     splits it internally via Bip110SmallBlockHeaderType::from_full — the BTC lane
+//     takes the classic 5-field SmallBlockHeaderType.
+//   • no v35 delegation (there is no PaddingBugfixShare on this wire); share_version
+//     / desired_version default to 36.
+//   • FAIL-CLOSED FIRST: check_header_fail_closed(min_header) before any hashing
+//     (decision card #6: nonzero flags/clear_bits/xor_key refused pre-hash).
+//   • donation u16 default = 66 (0.1%, decision card #5) — was 50 on BTC.
+//   • abswork stored %2^64 (NIT-2) so the in-memory value == the wire value
+//     (AbsworkV36Format::Write emits GetLow64()).
+//   • segwit_data ALWAYS populated (v36 >= SEGWIT_ACTIVATION => always active): a
+//     real SegwitData when a witness commitment exists, else SegwitDataDefault::get()
+//     (the 2^256-1 none-sentinel SSOT, share_types.hpp) rather than nullopt.
+//   • THE header-hash delta: share_hash = compute_share_hash(min_header, merkle_root)
+//     = BLAKE2b(reconstructed 164B v2 header) — replaces the BTC 80-byte SHA256d
+//     header assembly. PoW == block-identity duality preserved (share_identity.hpp),
+//     so pow_hash = share_hash exactly as the BTC lane. tx HASHING stays SHA256d.
+//
+// DEFINED-BUT-UNWIRED: nothing calls this at runtime. main_bip110 stays the M2
+// header-follower; PR-B wires create_share_fn + pool::SharechainNode and the
+// operator wire-genesis checkpoint gates the first mint.
 // ============================================================================
+template <typename TrackerT>
+uint256 create_local_share(
+    TrackerT& tracker,
+    const coin::BlockHeaderType& full_header,      // full 164B v2 header (was min_header)
+    const BaseScript& coinbase,
+    uint64_t subsidy,
+    const uint256& prev_share,
+    const std::vector<uint256>& merkle_branches,
+    const std::vector<unsigned char>& payout_script,
+    uint16_t donation = 66,                         // decision #5: 0.1% -> u16 66 (was 50)
+    const std::vector<MergedAddressEntry>& merged_addrs = {},
+    StaleInfo stale_info = StaleInfo::none,
+    bool segwit_active = true,                       // v36-genesis: segwit always active
+    const std::string& witness_commitment_hex = {},
+    const std::vector<unsigned char>& message_data = {},
+    const std::vector<unsigned char>& actual_coinbase_bytes = {},
+    const uint256& witness_root = uint256(),
+    uint32_t override_max_bits = 0,
+    uint32_t override_bits = 0,
+    // Frozen share fields from template time — when set, override computed values
+    // so ref_hash matches the one embedded in the coinbase.
+    uint32_t frozen_absheight = 0,
+    uint128  frozen_abswork = uint128(),
+    uint256  frozen_far_share_hash = uint256(),
+    uint32_t frozen_timestamp = 0,
+    uint256  frozen_merged_payout_hash = uint256(),
+    bool     has_frozen = false,
+    const std::vector<uint256>& frozen_merkle_branches = {},
+    const uint256& frozen_witness_root = uint256(),
+    const std::vector<unsigned char>& frozen_merged_coinbase_info = {},
+    int64_t share_version = 36,                      // v36-genesis: 36 only (was 35)
+    uint64_t desired_version = 36)
+{
+    (void)share_version;  // v36-genesis: no legacy branch to select.
+
+    // Split the full v2 header into the wire small header (drops the merkle root).
+    Bip110SmallBlockHeaderType min_header = Bip110SmallBlockHeaderType::from_full(full_header);
+
+    // FAIL-CLOSED (decision #6): refuse a header with nonzero flags/clear_bits/
+    // xor_key BEFORE anything is hashed. Throws std::invalid_argument (the share
+    // rejection convention). Every live BIP-110 fork block is flags=0.
+    check_header_fail_closed(min_header);
+
+    MergedMiningShare share;
+    share.m_min_header = min_header;
+    share.m_coinbase   = coinbase;
+    share.m_subsidy    = subsidy;
+    share.m_prev_hash  = prev_share;
+    share.m_donation   = donation;
+    share.m_stale_info = stale_info;
+    share.m_desired_version = desired_version;
+
+    // Timestamp: clip to at least previous_share.timestamp + 1 (matches Python)
+    share.m_timestamp  = min_header.m_timestamp;
+    if (!prev_share.IsNull() && tracker.chain.contains(prev_share)) {
+        uint32_t prev_ts = 0;
+        tracker.chain.get(prev_share).share.invoke([&](auto* prev) {
+            prev_ts = prev->m_timestamp;
+        });
+        if (share.m_timestamp <= prev_ts)
+            share.m_timestamp = prev_ts + 1;
+    }
+
+    // Compute pool-level share target AFTER timestamp clipping (matches ref_hash_fn).
+    auto desired_target = chain::bits_to_target(min_header.m_bits);
+    auto [share_max_bits, share_bits] = tracker.compute_share_target(
+        prev_share, share.m_timestamp, desired_target);
+    share.m_max_bits   = share_max_bits;
+    share.m_bits       = share_bits;
+
+    share.m_nonce      = 0; // share commitment nonce (not block nonce)
+    share.m_merged_addresses = merged_addrs;
+
+    {
+        LOG_INFO << "[create_local_share] merged_addresses=" << merged_addrs.size();
+    }
+
+    // Embed encrypted message_data (from create_message_data()) if provided
+    if (!message_data.empty())
+        share.m_message_data.m_data = message_data;
+
+    // Compute merged_payout_hash: deterministic hash of V36-only PPLNS weight
+    // distribution so peers can verify merged mining payouts.
+    if (!prev_share.IsNull() && tracker.chain.contains(prev_share))
+    {
+        auto block_target = chain::bits_to_target(min_header.m_bits);
+        share.m_merged_payout_hash = tracker.compute_merged_payout_hash(
+            prev_share, block_target);
+    }
+
+    // Payout identity — extract pubkey_hash + pubkey_type from scriptPubKey.
+    // p2pool V36: 0=P2PKH, 1=P2WPKH, 2=P2SH.
+    if (payout_script.size() >= 20) {
+        if (payout_script.size() == 25 &&
+            payout_script[0] == 0x76 && payout_script[1] == 0xa9 &&
+            payout_script[2] == 0x14 && payout_script[23] == 0x88 &&
+            payout_script[24] == 0xac) {
+            std::memcpy(share.m_pubkey_hash.data(), payout_script.data() + 3, 20);
+            share.m_pubkey_type = 0;
+        } else if (payout_script.size() == 23 &&
+                   payout_script[0] == 0xa9 && payout_script[1] == 0x14 &&
+                   payout_script[22] == 0x87) {
+            std::memcpy(share.m_pubkey_hash.data(), payout_script.data() + 2, 20);
+            share.m_pubkey_type = 2;
+        } else if (payout_script.size() == 22 &&
+                   payout_script[0] == 0x00 && payout_script[1] == 0x14) {
+            std::memcpy(share.m_pubkey_hash.data(), payout_script.data() + 2, 20);
+            share.m_pubkey_type = 1;
+        } else {
+            std::memcpy(share.m_pubkey_hash.data(), payout_script.data(), 20);
+            share.m_pubkey_type = 0;
+        }
+    }
+
+    // Chain position: absheight and abswork from previous share.
+    if (!prev_share.IsNull() && tracker.chain.contains(prev_share)) {
+        auto [prev_height, last] = tracker.chain.get_height_and_last(prev_share);
+        tracker.chain.get(prev_share).share.invoke([&](auto* prev) {
+            share.m_absheight = prev->m_absheight + 1;
+        });
+
+        {
+            auto current_attempts = chain::target_to_average_attempts(
+                chain::bits_to_target(share.m_bits));
+            uint128 prev_abswork;
+            tracker.chain.get(prev_share).share.invoke([&](auto* prev) {
+                prev_abswork = prev->m_abswork;
+            });
+            share.m_abswork = prev_abswork + uint128(current_attempts.GetLow64());
+            // NIT-2: store mod 2^64 so the in-memory abswork == the wire value
+            // (AbsworkV36Format::Write emits GetLow64()); keeps a re-serialized
+            // local share byte-identical to a peer's decode of it.
+            share.m_abswork = uint128(share.m_abswork.GetLow64());
+        }
+
+        if (last.IsNull() && prev_height < 99) {
+            share.m_far_share_hash = uint256();
+        } else {
+            share.m_far_share_hash = tracker.chain.get_nth_parent_key(prev_share, 99);
+        }
+    } else {
+        // Genesis: absheight = 1, abswork = aps(bits) (mod 2^64, NIT-2).
+        share.m_absheight = 1;
+        share.m_abswork = uint128(chain::target_to_average_attempts(
+            chain::bits_to_target(share.m_bits)).GetLow64());
+        share.m_abswork = uint128(share.m_abswork.GetLow64());
+        share.m_far_share_hash = uint256();
+    }
+
+    // Override with frozen fields from template time (if available).
+    if (has_frozen) {
+        share.m_absheight = frozen_absheight;
+        share.m_abswork = uint128(frozen_abswork.GetLow64());   // NIT-2 wrap
+        share.m_far_share_hash = frozen_far_share_hash;
+        share.m_timestamp = frozen_timestamp;
+        share.m_merged_payout_hash = frozen_merged_payout_hash;
+        if (override_max_bits) share.m_max_bits = override_max_bits;
+        if (override_bits) share.m_bits = override_bits;
+        if (!frozen_merged_coinbase_info.empty()) {
+            try {
+                PackStream ps;
+                ps.write(std::span<const std::byte>(
+                    reinterpret_cast<const std::byte*>(frozen_merged_coinbase_info.data()),
+                    frozen_merged_coinbase_info.size()));
+                ps >> share.m_merged_coinbase_info;
+            } catch (const std::exception& e) {
+                LOG_WARNING << "[frozen] Failed to deserialize merged_coinbase_info ("
+                            << frozen_merged_coinbase_info.size() << " bytes): " << e.what();
+            }
+        }
+    }
+
+    // Random last_txout_nonce for OP_RETURN uniqueness.
+    share.m_last_txout_nonce = static_cast<uint64_t>(std::time(nullptr)) ^
+                               (static_cast<uint64_t>(min_header.m_nonce) << 32);
+
+    // ref_merkle_link: empty branch (ref_hash = hash_ref directly).
+    share.m_ref_merkle_link.m_branch.clear();
+    share.m_ref_merkle_link.m_index = 0;
+
+    // merkle_link: from Stratum merkle branches.
+    share.m_merkle_link.m_branch = merkle_branches;
+    share.m_merkle_link.m_index  = 0;
+
+    // segwit_data — v36 >= SEGWIT_ACTIVATION => ALWAYS active on this v36-genesis
+    // chain, so m_segwit_data is ALWAYS populated (has_value == true): a real
+    // SegwitData when a witness commitment exists, else the SegwitDataDefault
+    // none-sentinel (2^256-1 wtxid root, share_types.hpp) — the lane's SSOT, NOT
+    // the BTC lane's zero. This keeps the ref_hash / wire encoding self-consistent
+    // (the Formatter's Optional(..., SegwitDataDefault) always writes a value).
+    if (segwit_active && !witness_commitment_hex.empty())
+    {
+        SegwitData sd;
+        sd.m_txid_merkle_link.m_branch = (has_frozen && !frozen_merkle_branches.empty())
+            ? frozen_merkle_branches : merkle_branches;
+        sd.m_txid_merkle_link.m_index  = 0;
+        sd.m_wtxid_merkle_root = !frozen_witness_root.IsNull()
+            ? frozen_witness_root : witness_root;
+        share.m_segwit_data = sd;
+    }
+    else
+    {
+        share.m_segwit_data = SegwitDataDefault::get();
+    }
+
+    // --- Compute the ref_hash ---
+    PackStream ref_stream;
+    {
+        auto hex = PoolConfig::identifier_hex();
+        for (size_t i = 0; i + 1 < hex.size(); i += 2) {
+            unsigned char byte = static_cast<unsigned char>(
+                std::stoul(hex.substr(i, 2), nullptr, 16));
+            ref_stream.write(std::span<const std::byte>(
+                reinterpret_cast<const std::byte*>(&byte), 1));
+        }
+    }
+    ref_stream << share.m_prev_hash;
+    ref_stream << share.m_coinbase;
+    ref_stream << share.m_nonce;
+    ref_stream << share.m_pubkey_hash;
+    ref_stream << share.m_pubkey_type;
+    ::Serialize(ref_stream, VarInt(share.m_subsidy));
+    ref_stream << share.m_donation;
+    { uint8_t si = static_cast<uint8_t>(share.m_stale_info); ref_stream << si; }
+    ::Serialize(ref_stream, VarInt(share.m_desired_version));
+    // segwit_data: PossiblyNoneType in p2pool — ALWAYS serialize. m_segwit_data is
+    // always populated on this v36-genesis chain (see above), so the value branch
+    // always runs; the None branch is retained for structural parity with verify.
+    if (share.m_segwit_data.has_value()) {
+        ref_stream << share.m_segwit_data.value();
+    } else {
+        std::vector<uint256> empty_branch;
+        ref_stream << empty_branch;
+        uint256 zero_root;
+        ref_stream << zero_root;
+    }
+    ref_stream << share.m_merged_addresses;
+    ref_stream << share.m_far_share_hash;
+    ref_stream << share.m_max_bits;
+    ref_stream << share.m_bits;
+    ref_stream << share.m_timestamp;
+    ref_stream << share.m_absheight;
+    ::Serialize(ref_stream, Using<AbsworkV36Format>(share.m_abswork));
+    ref_stream << share.m_merged_coinbase_info;
+    ref_stream << share.m_merged_payout_hash;
+    ref_stream << share.m_message_data;
+
+    auto ref_span_v = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(ref_stream.data()), ref_stream.size());
+    uint256 hash_ref = Hash(ref_span_v);
+    uint256 ref_hash = check_merkle_link(hash_ref, share.m_ref_merkle_link);
+
+    // Prefer the ref_hash frozen into the actual mined coinbase (last 44 bytes =
+    // ref_hash[32] + last_txout_nonce[8] + locktime[4]).
+    if (!actual_coinbase_bytes.empty() && actual_coinbase_bytes.size() > 44) {
+        uint256 coinbase_ref_hash;
+        std::memcpy(coinbase_ref_hash.data(),
+                     actual_coinbase_bytes.data() + actual_coinbase_bytes.size() - 44, 32);
+        ref_hash = coinbase_ref_hash;
+    }
+
+    // --- Derive hash_link from the actual mined coinbase (SHA256d gentx path,
+    // UNCHANGED by BIP-110 — tx hashing stays SHA256d) ---
+    auto gentx_before_refhash = compute_gentx_before_refhash(int64_t(36));
+
+    std::vector<unsigned char> coinbase_bytes_for_hashlink;
+    if (!actual_coinbase_bytes.empty()) {
+        coinbase_bytes_for_hashlink = actual_coinbase_bytes;
+    } else {
+        // Fallback (no actual bytes): reconstruct from PPLNS (unit-test path).
+        std::map<std::vector<unsigned char>, uint288> weights;
+        uint288 total_weight;
+
+        if (!prev_share.IsNull() && tracker.chain.contains(prev_share))
+        {
+            auto chain_len = static_cast<int32_t>(PoolConfig::real_chain_length());
+            auto block_target = chain::bits_to_target(share.m_min_header.m_bits);
+            auto max_weight = chain::target_to_average_attempts(block_target)
+                              * PoolConfig::SPREAD * 65535;
+            auto result = tracker.get_v36_decayed_cumulative_weights(prev_share, chain_len, max_weight);
+            weights = std::move(result.weights);
+            total_weight = result.total_weight;
+        }
+
+        std::map<std::vector<unsigned char>, uint64_t> amounts;
+        if (!total_weight.IsNull()) {
+            for (auto& [script, weight] : weights) {
+                uint64_t amount = (uint288(subsidy) * weight / total_weight).GetLow64();
+                if (amount > 0)
+                    amounts[script] = amount;
+            }
+        }
+        uint64_t sum_amounts = 0;
+        for (auto& [s, a] : amounts) sum_amounts += a;
+        uint64_t donation_amount = (subsidy > sum_amounts) ? (subsidy - sum_amounts) : 0;
+        if (donation_amount < 1 && subsidy > 0 && !amounts.empty()) {
+            auto largest = std::max_element(amounts.begin(), amounts.end(),
+                [](const auto& a, const auto& b) {
+                    if (a.second != b.second) return a.second < b.second;
+                    return a.first < b.first;
+                });
+            if (largest != amounts.end() && largest->second > 0) {
+                largest->second -= 1; sum_amounts -= 1;
+                donation_amount = subsidy - sum_amounts;
+            }
+        }
+
+        const std::vector<unsigned char> combined_donation_script(
+            core::donation::COMBINED_DONATION_SCRIPT.begin(), core::donation::COMBINED_DONATION_SCRIPT.end());
+        const std::vector<unsigned char> p2pk_donation_script(
+            core::donation::DONATION_SCRIPT.begin(), core::donation::DONATION_SCRIPT.end());
+        auto payout_outputs = build_payout_outputs_excluding_donation(
+            amounts, combined_donation_script, p2pk_donation_script, donation_amount);
+        std::sort(payout_outputs.begin(), payout_outputs.end(),
+            [](const auto& a, const auto& b) {
+                if (a.second != b.second) return a.second < b.second;
+                return a.first < b.first;
+            });
+        if (payout_outputs.size() > 4000)
+            payout_outputs.erase(payout_outputs.begin(), payout_outputs.end() - 4000);
+
+        PackStream gentx;
+        { uint32_t v = 1; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&v), 4)); }
+        { unsigned char one = 1; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&one), 1)); }
+        { uint256 z; gentx << z; }
+        { uint32_t idx = 0xffffffff; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&idx), 4)); }
+        gentx << share.m_coinbase;
+        { uint32_t seq = 0xffffffff; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&seq), 4)); }
+        size_t n_outs = payout_outputs.size() + 1 + 1;
+        bool has_segwit_fb = share.m_segwit_data.has_value();
+        if (has_segwit_fb) n_outs += 1;
+        if (n_outs < 253) { uint8_t cnt = (uint8_t)n_outs; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&cnt), 1)); }
+        else { uint8_t m = 0xfd; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&m), 1)); uint16_t cnt = (uint16_t)n_outs; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&cnt), 2)); }
+        auto write_txout = [&](uint64_t value, const std::vector<unsigned char>& script) {
+            gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&value), 8));
+            BaseScript bs; bs.m_data = script; gentx << bs;
+        };
+        if (has_segwit_fb) {
+            auto& sd = share.m_segwit_data.value();
+            std::vector<unsigned char> wscript = {0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed};
+            uint256 commitment = compute_p2pool_witness_commitment(sd.m_wtxid_merkle_root);
+            auto cb = commitment.GetChars();
+            wscript.insert(wscript.end(), cb.begin(), cb.end());
+            write_txout(0, wscript);
+        }
+        for (auto& [script, amount] : payout_outputs) write_txout(amount, script);
+        write_txout(donation_amount, PoolConfig::get_donation_script(int64_t(36)));
+        { std::vector<unsigned char> op; op.push_back(0x6a); op.push_back(0x28);
+          op.insert(op.end(), ref_hash.data(), ref_hash.data() + 32);
+          uint64_t n = share.m_last_txout_nonce; auto* p = reinterpret_cast<const unsigned char*>(&n);
+          op.insert(op.end(), p, p + 8); write_txout(0, op); }
+        { uint32_t lt = 0; gentx.write(std::span<const std::byte>(reinterpret_cast<const std::byte*>(&lt), 4)); }
+
+        coinbase_bytes_for_hashlink.assign(
+            reinterpret_cast<const unsigned char*>(gentx.data()),
+            reinterpret_cast<const unsigned char*>(gentx.data()) + gentx.size());
+    }
+
+    constexpr size_t suffix_len = 32 + 8 + 4; // ref_hash + last_txout_nonce + locktime
+    if (coinbase_bytes_for_hashlink.size() > suffix_len) {
+        std::vector<unsigned char> prefix(
+            coinbase_bytes_for_hashlink.begin(), coinbase_bytes_for_hashlink.end() - suffix_len);
+        share.m_hash_link = prefix_to_hash_link(prefix, gentx_before_refhash);
+
+        // Extract last_txout_nonce (8 bytes before locktime).
+        size_t nonce_offset = coinbase_bytes_for_hashlink.size() - 4 - 8;
+        uint64_t extracted_nonce = 0;
+        std::memcpy(&extracted_nonce, coinbase_bytes_for_hashlink.data() + nonce_offset, 8);
+        share.m_last_txout_nonce = extracted_nonce;
+    }
+
+    // --- Compute share hash (BIP-110 BLAKE2b block-identity over the 164B v2
+    // header — THE consensus delta vs the SHA256d lanes) ---
+    // tx HASHING is UNCHANGED (SHA256d): reconstruct the tx-merkle-root from the
+    // mined coinbase gentx + job merkle branches exactly as the BTC lane, then hash
+    // the reconstructed full v2 header through the BLAKE2b pipeline.
+    uint256 gentx_hash_for_header;
+    if (!actual_coinbase_bytes.empty()) {
+        auto actual_span = std::span<const unsigned char>(
+            actual_coinbase_bytes.data(), actual_coinbase_bytes.size());
+        gentx_hash_for_header = Hash(actual_span);
+    } else {
+        auto cb_span = std::span<const unsigned char>(
+            coinbase_bytes_for_hashlink.data(), coinbase_bytes_for_hashlink.size());
+        gentx_hash_for_header = Hash(cb_span);
+    }
+    // For the block-header merkle root, always use the actual job merkle branches
+    // (share.m_merkle_link), NOT the frozen segwit_data.txid_merkle_link.
+    uint256 merkle_root = check_merkle_link(gentx_hash_for_header, share.m_merkle_link);
+
+    // compute_share_hash() reinserts merkle_root @ offset 36 of the v2 header and
+    // runs bip110::pow::blake2b_block_hash. This IS the block-identity hash, so the
+    // p2pool share-hash/block-hash duality is preserved (pow_hash == share_hash).
+    uint256 share_hash = compute_share_hash(share.m_min_header, merkle_root);
+    share.m_hash = share_hash;
+
+    // Self-validation: PoW check against share target. pow_hash == share_hash
+    // because compute_share_hash is the block-identity hash.
+    {
+        uint256 target = chain::bits_to_target(share.m_bits);
+        if (!target.IsNull()) {
+            uint256 pow_hash = share_hash;
+
+            if (pow_hash > target) {
+                // Expected: most stratum pseudoshares don't meet share target.
+                return uint256();
+            }
+            share.m_pow_hash = pow_hash;
+            LOG_INFO << "[Pool] REAL SHARE CREATED! pow=" << pow_hash.GetHex().substr(0, 16)
+                     << " target=" << target.GetHex().substr(0, 16)
+                     << " diff=" << chain::target_to_difficulty(target);
+
+            // Cross-check the hash_link round-trip against the coinbase ref_hash.
+            {
+                auto gentx_before_refhash_xc = compute_gentx_before_refhash(int64_t(36));
+                std::vector<unsigned char> xc_data;
+                xc_data.insert(xc_data.end(), ref_hash.data(), ref_hash.data() + 32);
+                { uint64_t n = share.m_last_txout_nonce;
+                  auto* p = reinterpret_cast<const unsigned char*>(&n);
+                  xc_data.insert(xc_data.end(), p, p + 8); }
+                { uint32_t z = 0;
+                  auto* p = reinterpret_cast<const unsigned char*>(&z);
+                  xc_data.insert(xc_data.end(), p, p + 4); }
+                uint256 xc_gentx = check_hash_link(share.m_hash_link, xc_data, gentx_before_refhash_xc);
+                if (xc_gentx != gentx_hash_for_header) {
+                    static int xc_warn = 0;
+                    if (xc_warn++ < 10)
+                        LOG_WARNING << "[Pool] Cross-check mismatch (non-blocking)"
+                                    << " hl_gentx=" << xc_gentx.GetHex().substr(0, 16)
+                                    << " direct_gentx=" << gentx_hash_for_header.GetHex().substr(0, 16);
+                } else {
+                    LOG_INFO << "[Pool] Cross-check PASSED";
+                }
+            }
+        }
+    }
+
+    // Add to tracker (heap-allocate; ShareChain takes ownership via raw pointer).
+    auto* heap_share = new MergedMiningShare(share);
+    tracker.add(heap_share);
+    LOG_INFO << "create_local_share: added share " << share_hash.GetHex()
+             << " height=" << share.m_absheight
+             << " prev=" << prev_share.GetHex().substr(0, 16) << "...";
+
+    // Cross-check: generate_share_transaction on the just-created share must
+    // reproduce the same gentx_hash a peer will compute.
+    {
+        uint256 verify_hash = generate_share_transaction<MergedMiningShare>(
+            *heap_share, tracker, true,
+            (core::version_gate::is_v36_active(MergedMiningShare::version)));
+        if (verify_hash == gentx_hash_for_header) {
+            LOG_INFO << "[Pool] Cross-check PASSED";
+        } else {
+            LOG_WARNING << "[Pool] Cross-check FAILED! mined_gentx=" << gentx_hash_for_header.GetHex()
+                        << " verify_gentx=" << verify_hash.GetHex();
+        }
+    }
+
+    return share_hash;
+}
 
 } // namespace bip110::pool

--- a/src/impl/bip110/pool/share_identity.hpp
+++ b/src/impl/bip110/pool/share_identity.hpp
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// share_identity.hpp — THE ONE CONSENSUS DELTA of the BIP-110 v36 sharechain lane
+// versus every SHA256d lane (btc/ltc/dgb/bch).
+//
+// On a classic p2pool lane the share-hash / block-identity is:
+//     merkle_root = check_merkle_link(gentx_hash, branches)   [SHA256d fold]
+//     share_hash  = SHA256d( 80B header{version|prev|merkle|time|bits|nonce} )
+// and PoW == share_hash because Bitcoin's block hash IS SHA256d(header).
+//
+// BIP-110 replaces the block hash with the BLAKE2b commitment pipeline over the
+// 164-byte v2 header (bip110::pow::blake2b_block_hash, KAT-pinned vs live fork
+// block 961640). tx HASHING is UNCHANGED — txids/merkle are still SHA256d — so
+// steps 1-2 (gentx_hash midstate resume + merkle fold) are identical to the BTC
+// lane. Only the FINAL header hash changes:
+//     header_164 = min_header.to_full(merkle_root)   [reinsert merkle @ offset 36]
+//     share_hash = pow_hash = bip110::pow::blake2b_block_hash(header_164)
+// PoW == block-identity-hash still holds, so the p2pool share-hash/block-hash
+// duality is preserved exactly: pow_hash <= bits_to_target(min_header.bits) marks
+// a solved block, identical detection logic to the BTC lane.
+//
+// FAIL-CLOSED (decision card #6): a share whose min_header carries nonzero
+// flags / clear_bits / xor_key is refused BEFORE it can reach the hash pipeline,
+// at both mint and accept. Every live BIP-110 fork block is flags=0; the v2 hash
+// pipeline itself throws on stage-5 flags 1-3, but we reject explicitly here so a
+// hostile share cannot even be hashed.
+
+#include "share_types.hpp"          // Bip110SmallBlockHeaderType
+#include "../pow.hpp"               // bip110::pow::blake2b_block_hash
+#include "../coin/block.hpp"        // bip110::coin::BlockHeaderType
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <span>
+#include <stdexcept>
+
+namespace bip110::pool
+{
+
+// Fail-closed guard on the miner-suppliable header risk fields. Throws
+// std::invalid_argument (matches share_check's rejection convention) if any of
+// flags / clear_bits / xor_key is nonzero. Call at BOTH mint and accept.
+inline void check_header_fail_closed(const Bip110SmallBlockHeaderType& h)
+{
+    if (h.m_flags != 0)
+        throw std::invalid_argument("bip110 share: nonzero min_header.flags (fail-closed, decision #6)");
+    if (h.m_clear_bits != 0)
+        throw std::invalid_argument("bip110 share: nonzero min_header.clear_bits (fail-closed, decision #6)");
+    for (uint8_t b : h.m_xor_key)
+        if (b != 0)
+            throw std::invalid_argument("bip110 share: nonzero min_header.xor_key (fail-closed, decision #6)");
+}
+
+// Serialize the canonical 164-byte BIP-110 v2 header (coin::BlockHeaderType uses
+// fixed u32 version + full field layout, matching bip110::pow::parse_header_v2).
+inline PackStream serialize_full_header(const coin::BlockHeaderType& full)
+{
+    PackStream s;
+    s << full;
+    return s;
+}
+
+// The BIP-110 share-hash == block-identity hash. Reconstructs the full 164-byte
+// v2 header from the share's small header + the SHA256d-reconstructed merkle root,
+// then runs the BLAKE2b block-hash pipeline. This is the drop-in replacement for
+// the BTC lane's `Hash(80B header)` at the share_check header-rebuild site.
+//
+// NOTE: does NOT itself run the fail-closed guard — callers (share_check) invoke
+// check_header_fail_closed() first so the rejection reason is explicit and the
+// hostile header never reaches blake2b. serialize_full_header of a flags!=0 header
+// would in any case throw inside the pipeline (stage-5), a defence-in-depth twin.
+inline uint256 compute_share_hash(const Bip110SmallBlockHeaderType& min_header,
+                                  const uint256& merkle_root)
+{
+    coin::BlockHeaderType full = min_header.to_full(merkle_root);
+    PackStream hs = serialize_full_header(full);
+    auto sp = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(hs.data()), hs.size());
+    return bip110::pow::blake2b_block_hash(sp);
+}
+
+// Overload for callers that already hold a full coin::BlockHeaderType (mint path
+// builds the full header directly; the KAT pins against it).
+inline uint256 compute_block_hash(const coin::BlockHeaderType& full)
+{
+    PackStream hs = serialize_full_header(full);
+    auto sp = std::span<const unsigned char>(
+        reinterpret_cast<const unsigned char*>(hs.data()), hs.size());
+    return bip110::pow::blake2b_block_hash(sp);
+}
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_messages.hpp
+++ b/src/impl/bip110/pool/share_messages.hpp
@@ -1,0 +1,584 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// share_messages.hpp — V36 share-embedded messaging: decryption + validation
+//
+// C++ implementation of the p2pool share_messages design (consensus-critical portions).
+// Messages are embedded in V36 shares' message_data field, included
+// in the ref_hash computation (PoW-protected).
+//
+// Validation path for incoming shares:
+//   1. If message_data is empty → valid (no messages)
+//   2. Decrypt outer envelope using DONATION_AUTHORITY_PUBKEYS
+//   3. If decryption fails (MAC mismatch) → REJECT share
+//   4. Parse inner envelope: version, flags, msg_count, messages
+//   5. If inner envelope is malformed or empty → REJECT share
+//   6. Verify ECDSA signatures via libsecp256k1
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <btclibs/crypto/hmac_sha256.h>
+#include <btclibs/crypto/ripemd160.h>
+#include <btclibs/crypto/sha256.h>
+#include <secp256k1.h>
+
+namespace bip110::pool {
+
+// ============================================================================
+// Authority public keys (compressed secp256k1)
+// From COMBINED_DONATION_REDEEM_SCRIPT:
+//   OP_1 PUSH33 <forrestv> PUSH33 <maintainer> OP_2 OP_CHECKMULTISIG
+// ============================================================================
+
+using AuthorityPubkey = std::array<unsigned char, 33>;
+
+inline const AuthorityPubkey& DONATION_PUBKEY_FORRESTV()
+{
+    static const AuthorityPubkey k = {
+        0x03, 0xff, 0xd0, 0x3d, 0xe4, 0x4a, 0x6e, 0x11,
+        0xb9, 0x91, 0x7f, 0x3a, 0x29, 0xf9, 0x44, 0x32,
+        0x83, 0xd9, 0x87, 0x1c, 0x9d, 0x74, 0x3e, 0xf3,
+        0x0d, 0x5e, 0xdd, 0xcd, 0x37, 0x09, 0x4b, 0x64,
+        0xd1
+    };
+    return k;
+}
+
+inline const AuthorityPubkey& DONATION_PUBKEY_MAINTAINER()
+{
+    static const AuthorityPubkey k = {
+        0x02, 0xfe, 0x65, 0x78, 0xf8, 0x02, 0x1a, 0x7d,
+        0x46, 0x67, 0x87, 0x82, 0x7b, 0x3f, 0x26, 0x43,
+        0x7a, 0xef, 0x88, 0x27, 0x9e, 0xf3, 0x80, 0xaf,
+        0x32, 0x6f, 0x87, 0xec, 0x36, 0x26, 0x33, 0x29,
+        0x3a
+    };
+    return k;
+}
+
+inline const std::array<const AuthorityPubkey*, 2>& DONATION_AUTHORITY_PUBKEYS()
+{
+    static const std::array<const AuthorityPubkey*, 2> keys = {
+        &DONATION_PUBKEY_FORRESTV(),
+        &DONATION_PUBKEY_MAINTAINER(),
+    };
+    return keys;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Message types
+constexpr uint8_t MSG_NODE_STATUS       = 0x01;
+constexpr uint8_t MSG_MINER_MESSAGE     = 0x02;
+constexpr uint8_t MSG_POOL_ANNOUNCE     = 0x03;
+constexpr uint8_t MSG_VERSION_SIGNAL    = 0x04;
+constexpr uint8_t MSG_MERGED_STATUS     = 0x05;
+constexpr uint8_t MSG_EMERGENCY         = 0x10;
+constexpr uint8_t MSG_TRANSITION_SIGNAL = 0x20;
+
+// Flags
+constexpr uint8_t FLAG_HAS_SIGNATURE      = 0x01;
+constexpr uint8_t FLAG_BROADCAST          = 0x02;
+constexpr uint8_t FLAG_PERSISTENT         = 0x04;
+constexpr uint8_t FLAG_PROTOCOL_AUTHORITY = 0x08;
+
+// Limits
+constexpr size_t MAX_MESSAGE_PAYLOAD    = 220;
+constexpr size_t MAX_MESSAGES_PER_SHARE = 3;
+constexpr size_t MAX_TOTAL_MESSAGE_BYTES = 512;
+
+// Encryption envelope
+constexpr uint8_t ENCRYPTED_ENVELOPE_VERSION = 0x01;
+constexpr size_t  ENCRYPTION_NONCE_SIZE = 16;
+constexpr size_t  ENCRYPTION_MAC_SIZE   = 32;
+constexpr size_t  ENCRYPTION_HEADER_SIZE = 1 + ENCRYPTION_NONCE_SIZE + ENCRYPTION_MAC_SIZE; // 49
+
+// ============================================================================
+// Parsed message (lightweight — just what we need for validation)
+// ============================================================================
+
+struct ShareMessage
+{
+    uint8_t  msg_type{0};
+    uint8_t  flags{0};
+    uint8_t  wire_flags{0};  // original flags for hash
+    uint32_t timestamp{0};
+    std::vector<unsigned char> payload;
+    std::array<unsigned char, 20> signing_id{};
+    std::vector<unsigned char> signature;
+
+    bool has_signature() const { return (flags & FLAG_HAS_SIGNATURE) != 0; }
+
+    // Unpack one message from data at offset. Returns new offset or nullopt on failure.
+    static std::optional<size_t> unpack(const unsigned char* data, size_t len,
+                                        size_t offset, ShareMessage& out)
+    {
+        // #1129: self-guard. offset and len are size_t; if a caller passes
+        // offset > len, `len - offset` underflows to a huge value and the
+        // `< 8` check passes, letting the memcpy read out of bounds. Reject
+        // offset past the end BEFORE the subtraction.
+        if (offset > len || len - offset < 8) return std::nullopt;
+
+        std::memcpy(&out.msg_type, data + offset, 1);
+        std::memcpy(&out.wire_flags, data + offset + 1, 1);
+        out.flags = out.wire_flags & ~FLAG_PROTOCOL_AUTHORITY;
+
+        uint32_t ts;
+        std::memcpy(&ts, data + offset + 2, 4);  // LE
+        out.timestamp = ts;
+
+        uint16_t payload_len;
+        std::memcpy(&payload_len, data + offset + 6, 2);  // LE
+        offset += 8;
+
+        if (payload_len > MAX_MESSAGE_PAYLOAD) return std::nullopt;
+        if (len - offset < payload_len) return std::nullopt;
+        out.payload.assign(data + offset, data + offset + payload_len);
+        offset += payload_len;
+
+        // signing_id (20 bytes)
+        if (len - offset < 20) return std::nullopt;
+        std::memcpy(out.signing_id.data(), data + offset, 20);
+        offset += 20;
+
+        // sig_len + signature
+        if (len - offset < 1) return std::nullopt;
+        uint8_t sig_len = data[offset++];
+        if (len - offset < sig_len) return std::nullopt;
+        out.signature.assign(data + offset, data + offset + sig_len);
+        offset += sig_len;
+
+        return offset;
+    }
+};
+
+// ============================================================================
+// secp256k1 context (singleton, thread-safe after init)
+// ============================================================================
+
+inline const secp256k1_context* get_secp256k1_context()
+{
+    static const secp256k1_context* ctx =
+        secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
+    return ctx;
+}
+
+// ============================================================================
+// Crypto helpers
+// ============================================================================
+
+// HMAC-SHA256(key, data) → 32 bytes
+inline std::array<unsigned char, 32> hmac_sha256(
+    const unsigned char* key, size_t keylen,
+    const unsigned char* data, size_t datalen)
+{
+    std::array<unsigned char, 32> result;
+    CHMAC_SHA256(key, keylen).Write(data, datalen).Finalize(result.data());
+    return result;
+}
+
+// Counter-mode SHA256 stream generator
+inline void generate_stream(const unsigned char* enc_key,
+                            unsigned char* out, size_t length)
+{
+    size_t produced = 0;
+    uint32_t counter = 0;
+    while (produced < length)
+    {
+        unsigned char block_input[36]; // 32 (key) + 4 (counter LE)
+        std::memcpy(block_input, enc_key, 32);
+        std::memcpy(block_input + 32, &counter, 4); // LE on little-endian host
+
+        unsigned char block[32];
+        CSHA256().Write(block_input, 36).Finalize(block);
+
+        size_t copy = std::min<size_t>(32, length - produced);
+        std::memcpy(out + produced, block, copy);
+        produced += copy;
+        ++counter;
+    }
+}
+
+// Double-SHA256 of message content for ECDSA signing/verification.
+// Matches Python: SHA256(SHA256(pack('<BBI', msg_type, wire_flags, timestamp) + payload))
+inline std::array<unsigned char, 32> compute_message_hash(
+    uint8_t msg_type, uint8_t wire_flags, uint32_t timestamp,
+    const unsigned char* payload, size_t payload_len)
+{
+    unsigned char header[6];
+    header[0] = msg_type;
+    header[1] = wire_flags;
+    std::memcpy(header + 2, &timestamp, 4); // LE
+
+    unsigned char first[32];
+    CSHA256().Write(header, 6).Write(payload, payload_len).Finalize(first);
+
+    std::array<unsigned char, 32> result;
+    CSHA256().Write(first, 32).Finalize(result.data());
+    return result;
+}
+
+// Verify ECDSA signature against a compressed secp256k1 public key.
+// pubkey_compressed: 33 bytes (0x02/0x03 prefix)
+// msghash32: 32-byte double-SHA256 (from compute_message_hash)
+// sig_der: DER-encoded ECDSA signature
+// Returns true if signature is valid.
+inline bool ecdsa_verify(const unsigned char* pubkey_compressed, size_t pubkey_len,
+                         const unsigned char* msghash32,
+                         const unsigned char* sig_der, size_t sig_len)
+{
+    const auto* ctx = get_secp256k1_context();
+
+    secp256k1_pubkey pubkey;
+    if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, pubkey_compressed, pubkey_len))
+        return false;
+
+    secp256k1_ecdsa_signature sig;
+    if (!secp256k1_ecdsa_signature_parse_der(ctx, &sig, sig_der, sig_len))
+        return false;
+
+    // Normalize to lower-S form (secp256k1_ecdsa_verify requires this)
+    secp256k1_ecdsa_signature_normalize(ctx, &sig, &sig);
+
+    return secp256k1_ecdsa_verify(ctx, &sig, msghash32, &pubkey) == 1;
+}
+
+// ============================================================================
+// Decryption result
+// ============================================================================
+
+struct DecryptResult
+{
+    std::vector<unsigned char> inner_data;
+    const AuthorityPubkey* authority_pubkey{nullptr};  // which key succeeded
+};
+
+// Decrypt encrypted envelope. Returns nullopt if all authority keys fail MAC.
+inline std::optional<DecryptResult> decrypt_message_data(
+    const unsigned char* data, size_t len)
+{
+    if (len < ENCRYPTION_HEADER_SIZE + 1) return std::nullopt;
+
+    if (data[0] != ENCRYPTED_ENVELOPE_VERSION) return std::nullopt;
+
+    const unsigned char* nonce      = data + 1;
+    const unsigned char* mac_recv   = data + 1 + ENCRYPTION_NONCE_SIZE;
+    const unsigned char* ciphertext = data + ENCRYPTION_HEADER_SIZE;
+    size_t ct_len = len - ENCRYPTION_HEADER_SIZE;
+
+    if (ct_len == 0) return std::nullopt;
+
+    for (const auto* pubkey_ptr : DONATION_AUTHORITY_PUBKEYS())
+    {
+        // enc_key = HMAC-SHA256(pubkey, nonce)
+        auto enc_key = hmac_sha256(
+            pubkey_ptr->data(), pubkey_ptr->size(), nonce, ENCRYPTION_NONCE_SIZE);
+
+        // MAC = HMAC-SHA256(enc_key, ciphertext)
+        auto mac_computed = hmac_sha256(
+            enc_key.data(), enc_key.size(), ciphertext, ct_len);
+
+        // Constant-time compare
+        unsigned char diff = 0;
+        for (size_t i = 0; i < 32; ++i) diff |= mac_computed[i] ^ mac_recv[i];
+        if (diff != 0) continue;  // Wrong key
+
+        // MAC matches — decrypt (XOR with stream)
+        DecryptResult result;
+        result.inner_data.resize(ct_len);
+        generate_stream(enc_key.data(), result.inner_data.data(), ct_len);
+        for (size_t i = 0; i < ct_len; ++i)
+            result.inner_data[i] ^= ciphertext[i];
+        result.authority_pubkey = pubkey_ptr;
+        return result;
+    }
+
+    return std::nullopt;
+}
+
+// ============================================================================
+// Unpack result
+// ============================================================================
+
+struct UnpackResult
+{
+    std::vector<ShareMessage> messages;
+    const AuthorityPubkey* authority_pubkey{nullptr};
+    bool decrypted{false};
+};
+
+// Main entry point: decrypt + parse inner envelope.
+// Returns empty result on failure; caller checks fields.
+inline UnpackResult unpack_share_messages(const unsigned char* data, size_t len)
+{
+    UnpackResult result;
+
+    if (!data || len < ENCRYPTION_HEADER_SIZE + 4)
+        return result;
+
+    auto dec = decrypt_message_data(data, len);
+    if (!dec.has_value())
+        return result;  // Decryption failed → signing_key_info = nullptr
+
+    result.decrypted = true;
+    result.authority_pubkey = dec->authority_pubkey;
+
+    const auto& inner = dec->inner_data;
+    if (inner.size() < 4)
+        return result;
+
+    uint8_t inner_version = inner[0];
+    uint8_t inner_flags   = inner[1];
+    uint8_t msg_count     = inner[2];
+    uint8_t ann_len       = inner[3];
+    size_t offset = 4;
+
+    if (inner_version != 1)
+        return result;  // Unknown version — skip gracefully
+
+    // Skip signing key announcement if present
+    if ((inner_flags & 0x01) && ann_len > 0)
+        offset += ann_len;
+
+    if (offset > inner.size())
+        return result;
+
+    // Cap message count
+    if (msg_count > MAX_MESSAGES_PER_SHARE)
+        msg_count = MAX_MESSAGES_PER_SHARE;
+
+    for (uint8_t i = 0; i < msg_count; ++i)
+    {
+        ShareMessage msg;
+        auto new_offset = ShareMessage::unpack(inner.data(), inner.size(), offset, msg);
+        if (!new_offset.has_value()) break;
+        result.messages.push_back(std::move(msg));
+        offset = *new_offset;
+    }
+
+    return result;
+}
+
+// Convenience: validate message_data from a share.
+// Returns empty string on success; returns error reason on failure.
+// Empty message_data is always valid.
+inline std::string validate_message_data(const std::vector<unsigned char>& message_data)
+{
+    if (message_data.empty())
+        return {};  // No messages — always valid
+
+    auto result = unpack_share_messages(message_data.data(), message_data.size());
+
+    if (!result.decrypted)
+        return "message_data failed decryption against all "
+               "COMBINED_DONATION_SCRIPT authority keys";
+
+    if (result.authority_pubkey == nullptr)
+        return "message_data decrypted but authority_pubkey unknown";
+
+    // Check authority_pubkey is one we recognise
+    bool known = false;
+    for (const auto* pk : DONATION_AUTHORITY_PUBKEYS())
+    {
+        if (pk == result.authority_pubkey) { known = true; break; }
+    }
+    if (!known)
+        return "message_data authority_pubkey not in COMBINED_DONATION_SCRIPT";
+
+    if (result.messages.empty())
+        return "message_data decrypted but contains no valid messages";
+
+    // Verify each message has a valid ECDSA signature from the authority key
+    // that encrypted the envelope. This is defense-in-depth on top of the
+    // MAC-based decryption (which already proves authority created the envelope).
+    for (const auto& msg : result.messages)
+    {
+        if (!msg.has_signature() || msg.signature.empty())
+            return "message contains unsigned message (type 0x" +
+                   std::to_string(msg.msg_type) + ") inside encrypted envelope";
+
+        auto msg_hash = compute_message_hash(
+            msg.msg_type, msg.wire_flags, msg.timestamp,
+            msg.payload.data(), msg.payload.size());
+
+        if (!ecdsa_verify(result.authority_pubkey->data(), result.authority_pubkey->size(),
+                          msg_hash.data(), msg.signature.data(), msg.signature.size()))
+            return "message ECDSA signature verification failed (type 0x" +
+                   std::to_string(msg.msg_type) + ")";
+    }
+
+    return {};  // All checks passed
+}
+
+// ============================================================================
+// Message creation: signing, packing, encryption
+// ============================================================================
+
+// ECDSA sign a 32-byte hash with a 32-byte private key.
+// Returns DER-encoded signature, empty on failure.
+inline std::vector<unsigned char> ecdsa_sign(
+    const unsigned char* msghash32,
+    const unsigned char* seckey32)
+{
+    const auto* ctx = get_secp256k1_context();
+
+    secp256k1_ecdsa_signature sig;
+    if (!secp256k1_ecdsa_sign(ctx, &sig, msghash32, seckey32, nullptr, nullptr))
+        return {};
+
+    unsigned char der[72];
+    size_t der_len = sizeof(der);
+    if (!secp256k1_ecdsa_signature_serialize_der(ctx, der, &der_len, &sig))
+        return {};
+
+    return {der, der + der_len};
+}
+
+// HASH160 = RIPEMD160(SHA256(data)) — standard Bitcoin hash160.
+inline std::array<unsigned char, 20> hash160(
+    const unsigned char* data, size_t len)
+{
+    unsigned char sha256_buf[32];
+    CSHA256().Write(data, len).Finalize(sha256_buf);
+
+    std::array<unsigned char, 20> result;
+    CRIPEMD160().Write(sha256_buf, 32).Finalize(result.data());
+    return result;
+}
+
+// Serialize a ShareMessage to wire format.
+// Wire: [type:1][flags:1][timestamp:4 LE][payload_len:2 LE][payload:N]
+//       [signing_id:20][sig_len:1][signature:M]
+inline std::vector<unsigned char> pack_message(const ShareMessage& msg)
+{
+    std::vector<unsigned char> buf;
+    buf.reserve(8 + msg.payload.size() + 20 + 1 + msg.signature.size());
+
+    buf.push_back(msg.msg_type);
+    buf.push_back(msg.wire_flags);
+
+    uint32_t ts = msg.timestamp;
+    buf.push_back(static_cast<unsigned char>(ts));
+    buf.push_back(static_cast<unsigned char>(ts >> 8));
+    buf.push_back(static_cast<unsigned char>(ts >> 16));
+    buf.push_back(static_cast<unsigned char>(ts >> 24));
+
+    uint16_t pl = static_cast<uint16_t>(msg.payload.size());
+    buf.push_back(static_cast<unsigned char>(pl));
+    buf.push_back(static_cast<unsigned char>(pl >> 8));
+
+    buf.insert(buf.end(), msg.payload.begin(), msg.payload.end());
+    buf.insert(buf.end(), msg.signing_id.begin(), msg.signing_id.end());
+
+    buf.push_back(static_cast<unsigned char>(msg.signature.size()));
+    buf.insert(buf.end(), msg.signature.begin(), msg.signature.end());
+
+    return buf;
+}
+
+// Encrypt inner envelope data with an authority public key.
+// Returns encrypted blob: [0x01][nonce:16][mac:32][ciphertext:N]
+inline std::vector<unsigned char> encrypt_message_envelope(
+    const std::vector<unsigned char>& inner,
+    const AuthorityPubkey& authority_pubkey)
+{
+    // 16-byte random nonce
+    std::array<unsigned char, ENCRYPTION_NONCE_SIZE> nonce;
+    std::random_device rd;
+    for (size_t i = 0; i < ENCRYPTION_NONCE_SIZE; i += 4)
+    {
+        auto val = rd();
+        auto bytes = std::min<size_t>(4, ENCRYPTION_NONCE_SIZE - i);
+        std::memcpy(nonce.data() + i, &val, bytes);
+    }
+
+    // enc_key = HMAC-SHA256(authority_pubkey, nonce)
+    auto enc_key = hmac_sha256(
+        authority_pubkey.data(), authority_pubkey.size(),
+        nonce.data(), nonce.size());
+
+    // stream = counter-mode SHA256
+    std::vector<unsigned char> stream(inner.size());
+    generate_stream(enc_key.data(), stream.data(), inner.size());
+
+    // ciphertext = inner XOR stream
+    std::vector<unsigned char> ciphertext(inner.size());
+    for (size_t i = 0; i < inner.size(); ++i)
+        ciphertext[i] = inner[i] ^ stream[i];
+
+    // mac = HMAC-SHA256(enc_key, ciphertext)
+    auto mac = hmac_sha256(
+        enc_key.data(), enc_key.size(),
+        ciphertext.data(), ciphertext.size());
+
+    // Assemble: [0x01][nonce:16][mac:32][ciphertext]
+    std::vector<unsigned char> result;
+    result.reserve(1 + ENCRYPTION_NONCE_SIZE + ENCRYPTION_MAC_SIZE + ciphertext.size());
+    result.push_back(ENCRYPTED_ENVELOPE_VERSION);
+    result.insert(result.end(), nonce.begin(), nonce.end());
+    result.insert(result.end(), mac.begin(), mac.end());
+    result.insert(result.end(), ciphertext.begin(), ciphertext.end());
+    return result;
+}
+
+// Create encrypted message_data blob for embedding in a V36 share.
+//
+// seckey:           32-byte private key
+// authority_pubkey: 33-byte compressed pubkey corresponding to seckey
+// messages:         ShareMessages with msg_type, wire_flags, timestamp, payload set.
+//                   signature and signing_id are computed and filled in.
+//
+// Returns the complete encrypted message_data blob, or empty on failure.
+inline std::vector<unsigned char> create_message_data(
+    const unsigned char* seckey,
+    const AuthorityPubkey& authority_pubkey,
+    std::vector<ShareMessage>& messages)
+{
+    if (messages.empty() || messages.size() > MAX_MESSAGES_PER_SHARE)
+        return {};
+
+    // Compute signing_id = HASH160(authority_pubkey)
+    auto signing_id = hash160(authority_pubkey.data(), authority_pubkey.size());
+
+    // Sign each message and serialize
+    std::vector<unsigned char> packed_messages;
+    for (auto& msg : messages)
+    {
+        msg.signing_id = signing_id;
+
+        auto msg_hash = compute_message_hash(
+            msg.msg_type, msg.wire_flags, msg.timestamp,
+            msg.payload.data(), msg.payload.size());
+
+        msg.signature = ecdsa_sign(msg_hash.data(), seckey);
+        if (msg.signature.empty())
+            return {};
+
+        auto packed = pack_message(msg);
+        packed_messages.insert(packed_messages.end(), packed.begin(), packed.end());
+    }
+
+    // Inner envelope: [version=1][flags=0][msg_count][reserved=0] + packed_messages
+    std::vector<unsigned char> inner;
+    inner.reserve(4 + packed_messages.size());
+    inner.push_back(0x01);
+    inner.push_back(0x00);
+    inner.push_back(static_cast<unsigned char>(messages.size()));
+    inner.push_back(0x00);
+    inner.insert(inner.end(), packed_messages.begin(), packed_messages.end());
+
+    if (inner.size() > MAX_TOTAL_MESSAGE_BYTES)
+        return {};
+
+    return encrypt_message_envelope(inner, authority_pubkey);
+}
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_tracker.hpp
+++ b/src/impl/bip110/pool/share_tracker.hpp
@@ -1,0 +1,2950 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// Self-contained prerequisites: the BTC lane relied on include-order luck (this
+// header only ever reached the compiler AFTER node.cpp had already pulled cstdint
+// + core/log.hpp). bip110 includes them explicitly so share_tracker.hpp compiles
+// standalone (per-coin isolation; the compile gate includes it first).
+#include <cstdint>          // uint64_t used by mul128_shift below, before other includes
+#include <core/log.hpp>     // LOG_INFO / LOG_WARNING / LOG_TRACE / LOG_DEBUG_DIAG / LOG_ERROR
+
+// Portable 128-bit multiply-shift: (a * b) >> shift
+// GCC/Clang have __uint128_t; MSVC uses _umul128 intrinsic.
+// shift must be in [1, 63] to avoid undefined behavior from 64-bit shifts.
+#ifdef _MSC_VER
+#include <intrin.h>
+inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
+    uint64_t hi;
+    uint64_t lo = _umul128(a, b, &hi);
+    if (shift == 0)  return lo;   // (a*b) >> 0 — just the low 64 bits
+    if (shift >= 64) return hi >> (shift - 64);
+    return (hi << (64 - shift)) | (lo >> shift);
+}
+#else
+inline uint64_t mul128_shift(uint64_t a, uint64_t b, unsigned shift) {
+    return static_cast<uint64_t>((static_cast<__uint128_t>(a) * b) >> shift);
+}
+#endif
+
+#include "share.hpp"
+#include <impl/doge/coin/chain_params.hpp>  // DOGEChainParams::AUXPOW_CHAIN_ID (aux payout diag SSOT)
+#include <impl/nmc/coin/aux_id.hpp>          // nmc::coin::NMC_AUXPOW_CHAIN_ID (v37 bucket-2)
+#include <core/version_gate.hpp>   // SSOT: core::version_gate::is_v36_active
+#include "share_check.hpp"
+#include "config_pool.hpp"
+
+#include <core/target_utils.hpp>
+#include <core/uint256.hpp>
+#include <core/netaddress.hpp>
+#include <sharechain/weights_skiplist.hpp>
+#include <btclibs/base58.h>
+#include <btclibs/bech32.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <iomanip>
+#include <map>
+#include <optional>
+#include <set>
+#include <vector>
+
+namespace bip110::pool
+{
+
+struct StaleCounts
+{
+    uint64_t orphan_count = 0;
+    uint64_t doa_count = 0;
+    uint64_t total = 0;
+};
+
+// --- Scoring types ---
+
+struct TailScore
+{
+    int32_t chain_len{};
+    uint288 hashrate;
+    uint288 best_head_work;  // tiebreak: raw chain work of best head
+
+    friend bool operator<(const TailScore& a, const TailScore& b)
+    {
+        return std::tie(a.chain_len, a.hashrate, a.best_head_work)
+             < std::tie(b.chain_len, b.hashrate, b.best_head_work);
+    }
+};
+
+struct HeadScore
+{
+    // p2pool: (work - min(punish,1)*ata(target), -reason, -time_seen)
+    // Sorted ascending, .back() = best. Standard < comparison.
+    uint288 adjusted_work;  // work - punishment_deduction
+    int32_t neg_reason{};   // -reason (higher = less punished = better)
+    int64_t neg_time_seen{}; // -time_seen (higher = seen earlier = better)
+
+    friend bool operator<(const HeadScore& a, const HeadScore& b)
+    {
+        if (a.adjusted_work < b.adjusted_work) return true;
+        if (b.adjusted_work < a.adjusted_work) return false;
+        return std::tie(a.neg_reason, a.neg_time_seen) < std::tie(b.neg_reason, b.neg_time_seen);
+    }
+};
+
+struct TraditionalScore
+{
+    // p2pool: (work, -time_seen, -reason)
+    // No is_local. Sorted ascending, .back() = best.
+    uint288 work;
+    int64_t neg_time_seen{};
+    int32_t neg_reason{};
+
+    friend bool operator<(const TraditionalScore& a, const TraditionalScore& b)
+    {
+        if (a.work < b.work) return true;
+        if (b.work < a.work) return false;
+        return std::tie(a.neg_time_seen, a.neg_reason) < std::tie(b.neg_time_seen, b.neg_reason);
+    }
+};
+
+template <typename ScoreT>
+struct DecoratedData
+{
+    ScoreT score;
+    uint256 hash;
+
+    friend bool operator<(const DecoratedData& a, const DecoratedData& b)
+    {
+        return a.score < b.score;
+    }
+};
+
+// --- Result types ---
+
+struct TrackerThinkResult
+{
+    uint256 best;
+    std::vector<std::pair<NetService, uint256>> desired;
+    std::set<NetService> bad_peer_addresses;
+    bool punish_aggressively{false};
+    // Top-5 scored heads from Phase 4 — used by clean_tracker() to protect
+    // the best chains from head pruning (p2pool node.py:363).
+    std::vector<uint256> top5_heads;
+};
+
+struct CumulativeWeights
+{
+    std::map<std::vector<unsigned char>, uint288> weights;
+    uint288 total_weight;
+    uint288 total_donation_weight;
+};
+
+// ── Dense PPLNS Ring Buffer ──────────────────────────────────────────────
+// Stores PPLNS-relevant data for each share in the sliding window as a
+// contiguous array. Eliminates hash map pointer-chasing during PPLNS walks:
+// 8640 sequential reads over ~500KB (fits L2 cache) vs 8640 random hash map
+// lookups. ~10x faster per PPLNS computation.
+//
+// The precomputed decay table guarantees bit-exact results: it uses the same
+// iterative truncation as the walk-based code (decay_fp[d+1] = (decay_fp[d]
+// * decay_per) >> PRECISION), just stored in a table instead of recomputed.
+
+struct PPLNSEntry {
+    uint288 att;                            // target_to_average_attempts(bits_to_target(bits))
+    uint32_t donation{0};                   // share donation field
+    std::vector<unsigned char> script;      // payout script (variable-length)
+};
+
+class DensePPLNSWindow {
+public:
+    static constexpr uint64_t DECAY_PRECISION = 40;
+    static constexpr uint64_t DECAY_SCALE = uint64_t(1) << DECAY_PRECISION;
+    static constexpr uint64_t LN2_MICRO = 693147;
+
+    // Precomputed decay table: decay_table[d] = iterative decay factor at depth d.
+    // Computed once, reused for every PPLNS walk. Thread-safe after init.
+    static std::vector<uint64_t> s_decay_table;
+    static uint64_t s_decay_per;
+    static bool s_table_initialized;
+
+    static void init_decay_table(uint32_t chain_len) {
+        if (s_table_initialized && s_decay_table.size() == chain_len)
+            return;
+        uint32_t half_life = std::max(chain_len / 4, uint32_t(1));
+        s_decay_per = DECAY_SCALE - (DECAY_SCALE * LN2_MICRO) / (uint64_t(1000000) * half_life);
+        s_decay_table.resize(chain_len);
+        s_decay_table[0] = DECAY_SCALE;
+        for (uint32_t d = 1; d < chain_len; ++d)
+            s_decay_table[d] = mul128_shift(s_decay_table[d-1], s_decay_per, DECAY_PRECISION);
+        s_table_initialized = true;
+    }
+
+    // Deque of share entries: index 0 = depth 0 (shallowest/newest in window).
+    // Deque gives O(1) push/pop at both ends for forward and backward slides.
+    std::deque<PPLNSEntry> m_entries;
+    uint256 m_tip_hash;     // hash of the share whose prev_hash starts this window
+    int32_t m_chain_len{0}; // target window size
+
+    // Build ring from chain data. O(chain_len) hash map lookups — done once.
+    // After rebuild, m_entries[0] = share at start (depth 0),
+    //                 m_entries[n-1] = deepest share in window.
+    template <typename ChainT>
+    void rebuild(ChainT& chain, const uint256& start, int32_t chain_len) {
+        init_decay_table(static_cast<uint32_t>(chain_len));
+        m_entries.clear();
+        m_tip_hash = start;
+        m_chain_len = chain_len;
+
+        auto cur = start;
+        while (!cur.IsNull() && chain.contains(cur)
+               && static_cast<int32_t>(m_entries.size()) < chain_len)
+        {
+            PPLNSEntry entry;
+            chain.get_share(cur).invoke([&](auto* obj) {
+                entry.att = chain::target_to_average_attempts(
+                    chain::bits_to_target(obj->m_bits));
+                entry.donation = obj->m_donation;
+                entry.script = get_share_script(obj);
+            });
+            m_entries.push_back(std::move(entry));
+
+            auto* idx = chain.get_index(cur);
+            cur = idx ? idx->tail : uint256();
+        }
+    }
+
+    // Slide window forward: new share enters at front (depth 0), oldest drops.
+    // Used when extending verification toward the chain tip.
+    void slide_forward(PPLNSEntry entering) {
+        m_entries.push_front(std::move(entering));
+        if (static_cast<int32_t>(m_entries.size()) > m_chain_len)
+            m_entries.pop_back();
+    }
+
+    // Slide window backward: shallowest share drops, new deeper share added.
+    // Used by think() Phase 2 which walks backward via get_chain(last, N).
+    // Each successive share to verify needs PPLNS shifted 1 step deeper.
+    void slide_backward(PPLNSEntry deeper_entry) {
+        if (!m_entries.empty())
+            m_entries.pop_front();
+        m_entries.push_back(std::move(deeper_entry));
+    }
+
+    // Compute V36 decayed PPLNS weights from ring buffer.
+    // Bit-exact with the walk-based code: uses precomputed s_decay_table.
+    // Sequential-ish memory access (deque blocks) — ~80μs vs ~500μs hash map.
+    CumulativeWeights compute_v36_weights() const {
+        CumulativeWeights result;
+        int32_t n = static_cast<int32_t>(m_entries.size());
+        for (int32_t d = 0; d < n; ++d) {
+            auto& e = m_entries[d];
+            uint288 decayed_att = (e.att * uint288(s_decay_table[d])) >> DECAY_PRECISION;
+            auto addr_w = decayed_att * static_cast<uint32_t>(65535 - e.donation);
+            auto don_w  = decayed_att * e.donation;
+            auto this_total = addr_w + don_w;
+            result.weights[e.script] += addr_w;
+            result.total_weight += this_total;
+            result.total_donation_weight += don_w;
+        }
+        return result;
+    }
+
+    bool empty() const { return m_entries.empty(); }
+    int32_t size() const { return static_cast<int32_t>(m_entries.size()); }
+};
+
+// ── Head-Level Incremental PPLNS ─────────────────────────────────────────
+// Maintains a DensePPLNSWindow + cached CumulativeWeights per active head.
+// When verifying consecutive shares along a chain:
+//   1. rebuild() at first share's parent: O(chain_len) — one hash map walk
+//   2. extend() for each subsequent share: O(1) ring push + O(chain_len) dense recompute
+// Total for N shares: O(chain_len + N × chain_len) sequential ops
+// vs current: O(N × chain_len) random hash map ops — ~10x faster per op.
+
+class HeadPPLNS {
+    DensePPLNSWindow m_ring;
+    CumulativeWeights m_cached;
+    bool m_dirty{true};
+
+public:
+    // Cold start: build ring from chain. O(chain_len) hash map lookups.
+    template <typename ChainT>
+    void rebuild(ChainT& chain, const uint256& start, int32_t chain_len) {
+        m_ring.rebuild(chain, start, chain_len);
+        m_dirty = true;
+    }
+
+    // Extend forward: new share enters at depth 0. O(1) ring update.
+    // Used when verifying toward chain tip (new shares extending verified head).
+    template <typename ChainT>
+    void extend_forward(ChainT& chain, const uint256& new_share_hash) {
+        PPLNSEntry entry;
+        chain.get_share(new_share_hash).invoke([&](auto* obj) {
+            entry.att = chain::target_to_average_attempts(
+                chain::bits_to_target(obj->m_bits));
+            entry.donation = obj->m_donation;
+            entry.script = get_share_script(obj);
+        });
+        m_ring.slide_forward(std::move(entry));
+        m_dirty = true;
+    }
+
+    // Extend backward: depth-0 drops, new deeper share added. O(1) ring update.
+    // Used by think() Phase 2 which walks backward via get_chain(last, N).
+    template <typename ChainT>
+    void extend_backward(ChainT& chain, const uint256& deeper_share_hash) {
+        PPLNSEntry entry;
+        chain.get_share(deeper_share_hash).invoke([&](auto* obj) {
+            entry.att = chain::target_to_average_attempts(
+                chain::bits_to_target(obj->m_bits));
+            entry.donation = obj->m_donation;
+            entry.script = get_share_script(obj);
+        });
+        m_ring.slide_backward(std::move(entry));
+        m_dirty = true;
+    }
+
+    // Get cached weights. Recomputes from ring if dirty.
+    // O(chain_len) dense sequential reads, ~50μs.
+    const CumulativeWeights& weights() {
+        if (m_dirty) {
+            m_cached = m_ring.compute_v36_weights();
+            m_dirty = false;
+        }
+        return m_cached;
+    }
+
+    bool valid() const { return !m_ring.empty(); }
+    int32_t window_size() const { return m_ring.size(); }
+    const DensePPLNSWindow& ring() const { return m_ring; }
+};
+
+// --- ShareTracker ---
+
+class ShareTracker
+{
+public:
+    ShareChain chain;
+    ShareChain verified;
+
+
+    // Set by think() Phase 2 when verification budget is exhausted.
+    // Checked by run_think() to schedule a deferred continuation.
+    bool m_think_needs_continue{false};
+
+    // V36 livelock mirror (lock-yield): set by think() when the long
+    // decayed-cumulative-weight + PPLNS scoring walk exhausts its
+    // cooperative-yield budget (THINK_WALK_YIELD_BUDGET). It reuses the
+    // SAME run_think() continuation path as m_think_needs_continue so the
+    // compute thread RELEASES m_tracker_mutex, drain_pending_adds() runs,
+    // and a continuation is re-posted — breaking IO-thread starvation when
+    // the scoring window is pathologically large. On healthy windows the
+    // budget never trips (semantics unchanged).
+    bool m_think_walk_needs_continue{false};
+
+private:
+    // Retry counter for log throttling only — p2pool retries every think()
+    // with no limit.  Counter is cleared on successful verification or
+    // when the share is removed from the chain (on_removed signal).
+    std::unordered_map<uint256, int, ShareHasher> m_verify_fail_count;
+
+    static int64_t now_seconds()
+    {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+    }
+
+public:
+    // Callback fired when a share passes verification (for LevelDB persistence)
+    std::function<void(const uint256&)> m_on_share_verified;
+    // Callback fired when a verified share meets the block target (found block)
+    std::function<void(const uint256&)> m_on_block_found;
+    // Callback fired when a verified share meets a merged chain target (DOGE block)
+    // Args: share_hash, pow_hash (for target comparison by caller)
+    std::function<void(const uint256&, const uint256&)> m_on_merged_block_check;
+    // Callback fired for every verified share with its difficulty + miner script.
+    // Used to track best share difficulty for dashboard display.
+    std::function<void(double difficulty, const std::string& miner)> m_on_share_difficulty;
+
+    // Scan the verified best chain for block solutions after startup.
+    // Uses cached pow_hash from index (stored during original attempt_verify).
+    // No scrypt recomputation needed — O(1) per share.
+    void scan_chain_for_blocks(const uint256& tip, int max_shares)
+    {
+        if (tip.IsNull() || max_shares <= 0) return;
+        int scanned = 0, found_ltc = 0, found_merged = 0, no_pow = 0;
+        uint256 pos = tip;
+        for (int i = 0; i < max_shares && !pos.IsNull(); ++i) {
+            if (!chain.contains(pos)) break;
+            auto* idx = chain.get_index(pos);
+            if (!idx) break;
+
+            chain.get(pos).share.invoke([&](auto* s) {
+                ++scanned;
+                uint256 pow = idx->pow_hash;
+                if (pow.IsNull()) { ++no_pow; pos = s->m_prev_hash; return; }
+
+                // Check LTC block target
+                uint256 block_target = chain::bits_to_target(s->m_min_header.m_bits);
+                if (!block_target.IsNull() && pow <= block_target) {
+                    idx->is_block_solution = true;
+                    if (m_on_block_found) { m_on_block_found(pos); ++found_ltc; }
+                }
+                // Check merged targets (V36 shares carry exact data in m_merged_coinbase_info)
+                if (m_on_merged_block_check)
+                    m_on_merged_block_check(pos, pow);
+
+                pos = s->m_prev_hash;
+            });
+        }
+        LOG_INFO << "[BLOCK-SCAN] Scanned " << scanned << "/" << max_shares
+                 << " shares: " << found_ltc << " LTC block(s), "
+                 << no_pow << " without cached pow_hash";
+    }
+
+    ShareTracker() {
+        // p2pool SubsetTracker pattern: verified shares navigation
+        // through the MAIN tracker's skip list.
+        // SubsetTracker.get_nth_parent_hash = subset_of.get_nth_parent_hash
+        verified.set_parent_chain(&chain);
+
+        // Connect weight skip list invalidation to chain's removed signal.
+        // p2pool: WeightsSkipList subscribes to tracker.removed via watch_weakref.
+        // Without this, pruned shares leave stale entries in weight caches.
+        chain.on_removed([this](const uint256& hash) {
+            invalidate_weight_caches(hash);
+            m_verify_fail_count.erase(hash);
+        });
+    }
+    ~ShareTracker()
+    {
+        // verified borrows raw share pointers from chain — free its
+        // indexes only, then let chain's destructor free the share data.
+        verified.clear_unowned();
+    }
+
+    // -- Add share to the main chain --
+    template <typename ShareT>
+    void add(ShareT* share)
+    {
+        if (!chain.contains(share->m_hash))
+        {
+            try_register_merged_addr(share);
+            chain.add(share);
+        }
+    }
+
+    void add(ShareType share)
+    {
+        auto h = share.hash();
+        if (!chain.contains(h))
+        {
+            // Register before chain.add() which may move the variant
+            share.invoke([this](auto* obj) { try_register_merged_addr(obj); });
+            chain.add(share);
+        }
+    }
+
+    // -- Attempt to verify a share --
+    // Returns true if share is verified (already or newly).
+    // P2: share.check() will be wired here; for now we accept shares
+    // that have sufficient chain depth.
+    bool attempt_verify(const uint256& share_hash)
+    {
+        if (verified.contains(share_hash))
+            return true;
+
+        // p2pool has NO permanently-unverifiable concept — it retries
+        // share.check() every think() call.  Shares that failed during a
+        // temporary fork may succeed once the fork resolves and the PPLNS
+        // walk changes.  Skipping re-verification created permanent gaps
+        // in the verified chain → fragmentation (52 verified_tails).
+
+        // NO parent-in-verified filter. p2pool doesn't have one.
+        // p2pool's attempt_verify has only the guard (height < CL+1 && unrooted).
+        // score() uses verified for height/work/chain (matching p2pool),
+        // so fragmentation in the raw chain tracker doesn't affect scoring.
+
+        // p2pool: height, last = self.get_height_and_last(share.hash)
+        // p2pool's get_height uses get_delta_to_last() which walks through
+        // SubsetTracker's cached deltas — equivalent to our acc cache.
+        // Using acc cache height (not O(n) walk) matches p2pool's pattern
+        // and gives correct height after pruning.
+        auto acc_height = chain.get_acc_height(share_hash);
+        auto last = chain.get_last(share_hash);
+
+        // p2pool: if height < self.net.CHAIN_LENGTH + 1 and last is not None:
+        //             raise AssertionError()
+        // Chain too short and unrooted — cannot verify yet.
+        // The share isn't bad; its parents haven't arrived to fill the gap.
+        // DO NOT bypass this guard even if the parent is verified —
+        // generate_share_transaction needs CHAIN_LENGTH ancestors for correct
+        // PPLNS. Verifying with 3 ancestors produces wrong coinbase → GENTX-MISMATCH.
+        // Phase 2 naturally extends verification when parents arrive.
+        if (acc_height < static_cast<int32_t>(PoolConfig::chain_length()) + 1 && !last.IsNull())
+        {
+            return false;
+        }
+
+        // P2: init-phase verification (hash-link, merkle, PoW) + check-phase
+        try
+        {
+            auto t0 = std::chrono::steady_clock::now();
+            auto& share_var = chain.get_share(share_hash);
+            share_var.ACTION({
+                auto computed_hash = verify_share(*obj, *this);
+                (void)computed_hash;
+            });
+            {
+                auto dt = std::chrono::duration_cast<std::chrono::microseconds>(
+                    std::chrono::steady_clock::now() - t0).count();
+                static int64_t total_us = 0, count = 0;
+                total_us += dt; ++count;
+                if (count % 50 == 0)
+                    LOG_INFO << "[VERIFY-PERF] last=" << dt << "us avg="
+                             << (total_us/count) << "us count=" << count;
+            }
+        }
+        catch (const std::exception& e)
+        {
+            // Counter for log throttling only — p2pool retries every think().
+            auto& cnt = m_verify_fail_count[share_hash];
+            ++cnt;
+            // Log first 3 failures verbosely, then every 10th to avoid spam.
+            if (cnt <= 3 || cnt % 10 == 0)
+                LOG_WARNING << "attempt_verify FAILED (" << cnt
+                            << ") for " << share_hash.ToString().substr(0,16)
+                            << " acc_height=" << acc_height << " last=" << (last.IsNull() ? "null" : last.ToString().substr(0,16))
+                            << " error: " << e.what();
+            return false;
+        }
+
+        // Success — clear any previous fail count
+        m_verify_fail_count.erase(share_hash);
+
+        // Resolve this share's PoW hash WITHOUT trusting thread_locals across
+        // threads. Priority:
+        //   1. m_pow_hash carried on the share — set during phase-1 reception
+        //      (verify pool) or local creation; survives thread hops;
+        //   2. g_last_pow_hash IF verify_share() above just recomputed PoW on
+        //      THIS thread (share_init_verify resets it on entry, so non-null
+        //      here always refers to THIS share);
+        //   3. idx->pow_hash cached from LevelDB metadata at startup load.
+        // The old code read only the thread_local: phase-1 PoW runs on
+        // verify-pool workers while attempt_verify runs on the compute thread,
+        // so peer shares that met the block target NEVER fired m_on_block_found
+        // (or the merged check) — peer-found blocks were invisible to the
+        // found-blocks store and the dashboard.
+        auto& share_var = chain.get_share(share_hash);
+        auto* idx = chain.get_index(share_hash);
+        uint256 pow_hash;
+        share_var.invoke([&](auto* s) { pow_hash = s->m_pow_hash; });
+        if (pow_hash.IsNull())
+            pow_hash = g_last_pow_hash;
+        if (pow_hash.IsNull() && idx)
+            pow_hash = idx->pow_hash;
+
+        // Cache pow_hash on the index (for restart block scan — avoids recomputing PoW)
+        if (idx && !pow_hash.IsNull())
+            idx->pow_hash = pow_hash;
+
+        // Add to verified chain
+        if (!verified.contains(share_hash))
+            verified.add(share_var);
+
+        // Notify LevelDB persistence layer
+        if (m_on_share_verified)
+            m_on_share_verified(share_hash);
+
+        // Block detection: derive from the share's PoW hash vs the BLOCK target
+        // (min_header.m_bits from GBT — far harder than the share target), not
+        // from a cross-thread flag. Matches p2pool's tracker.verified.added
+        // watcher (node.py:289) — detects blocks from ANY pool participant.
+        if (m_on_block_found && !pow_hash.IsNull()) {
+            bool is_block = false;
+            share_var.invoke([&](auto* s) {
+                uint256 block_target = chain::bits_to_target(s->m_min_header.m_bits);
+                is_block = !block_target.IsNull() && pow_hash <= block_target;
+            });
+            if (is_block) {
+                if (idx) idx->is_block_solution = true;
+                m_on_block_found(share_hash);
+            }
+        }
+
+        // Report share difficulty for best-share dashboard tracking
+        if (m_on_share_difficulty) {
+            share_var.invoke([&](auto* s) {
+                double diff = chain::target_to_difficulty(chain::bits_to_target(s->m_bits));
+                std::string miner;
+                if constexpr (requires { s->m_pubkey_hash; })
+                    miner = s->m_pubkey_hash.GetHex();
+                else if constexpr (requires { s->m_address; })
+                    // MSVC: disambiguate HexStr overload (std::vector<unsigned char> is viable
+                    // for all span overloads). Feed the exact byte span the uint8_t overload wants.
+                    miner = HexStr(Span<const uint8_t>(s->m_address.m_data.data(), s->m_address.m_data.size()));
+                m_on_share_difficulty(diff, miner);
+            });
+        }
+
+        // Merged block detection: check ALL verified shares against DOGE target.
+        // A share can meet the DOGE target without meeting the LTC target
+        // (DOGE difficulty is much lower). Uses the resolved pow_hash above —
+        // NOT the thread_local, which is unset on the compute thread.
+        if (m_on_merged_block_check && !pow_hash.IsNull()) {
+            m_on_merged_block_check(share_hash, pow_hash);
+        }
+
+        // Naughty propagation: if parent is naughty, increment (up to 6 generations)
+        // Python data.py:1432-1438 — ancestor punishment for invalid block shares
+        {
+            uint256 prev_hash;
+            share_var.invoke([&](auto* obj) { prev_hash = obj->m_prev_hash; });
+            if (!prev_hash.IsNull() && chain.contains(prev_hash)) {
+                auto* parent_idx = chain.get_index(prev_hash);
+                if (parent_idx && parent_idx->naughty > 0) {
+                    auto* my_idx = chain.get_index(share_hash);
+                    if (my_idx) {
+                        my_idx->naughty = parent_idx->naughty + 1;
+                        if (my_idx->naughty > 6) my_idx->naughty = 0; // reset after 6 generations
+                    }
+                }
+            }
+        }
+
+        // Block weight/size check: Python data.py:1508-1511 checks gentx + txs
+        // against BLOCK_MAX_WEIGHT/SIZE, but only when other_txs is available.
+        // For V34+ (including V36), other_txs is always None (shares use
+        // transaction_hash_refs, not embedded txs), so Python SKIPS this check.
+        // Therefore this is intentionally not computed for V36 shares.
+        // The coinbase correctness is already verified by share_check() via
+        // generate_share_transaction comparison.
+
+        return true;
+    }
+
+    // -- Score a chain from share_hash to CHAIN_LENGTH*15/16 ancestor --
+    // Returns (chain_len, hashrate_score) — higher is better.
+    // p2pool data.py:2335-2347 — uses self.verified for ALL operations.
+    // May throw if the chain is concurrently modified.
+    TailScore score(const uint256& share_hash,
+                    const std::function<int32_t(uint256)>& block_rel_height_func)
+    {
+        uint288 score_res;
+
+        // p2pool: head_height = self.verified.get_height(share_hash)
+        // Must use VERIFIED height — using chain inflates height with
+        // unverified shares, causing short verified chains to tie on
+        // chain_len with long chains and win on hashrate tiebreak.
+        auto head_height = verified.get_acc_height(share_hash);
+        if (head_height < static_cast<int32_t>(PoolConfig::chain_length()))
+            return {head_height, score_res};
+
+        // p2pool: end_point = self.verified.get_nth_parent_hash(
+        //     share_hash, self.net.CHAIN_LENGTH*15//16)
+        // SubsetTracker delegates to parent's skip list (shared navigation).
+        auto end_point = verified.get_nth_parent_via_skip(share_hash,
+            (PoolConfig::chain_length() * 15) / 16);
+
+        // p2pool: self.verified.get_chain(end_point, self.net.CHAIN_LENGTH//16)
+        std::optional<int32_t> block_height;
+        auto tail_count = std::min(
+            static_cast<int32_t>(PoolConfig::chain_length() / 16),
+            verified.get_acc_height(end_point));
+        if (tail_count <= 0)
+            return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
+
+        auto tail_view = verified.get_chain(end_point, tail_count);
+        for (auto [hash, data] : tail_view)
+        {
+            uint256 prev_block;
+            data.share.invoke([&](auto* obj) {
+                prev_block = obj->m_min_header.m_previous_block;
+            });
+
+            auto bh = block_rel_height_func(prev_block);
+            if (!block_height.has_value() || bh > block_height.value())
+                block_height = bh;
+        }
+
+        // c2pool returns confirmations (1=tip, 0=unknown, -1=off-main-chain).
+        // p2pool returns relative height (0=tip, -N=behind, -1e9=unknown).
+        // When p2pool can't resolve a block, it computes score = work / (1e9 * 150)
+        // — tiny but non-zero, so both chains get similar scores and the one
+        // with more work wins (stable).  c2pool must match: use a very large
+        // confirmation count so the score is tiny but non-zero, preventing
+        // oscillation where short chains beat long chains simply because the
+        // long chain's old blocks are unresolvable.
+        if (!block_height.has_value() || block_height.value() <= 0)
+            block_height = 1000000;  // ~1M confirmations → time_span ≈ 150M seconds
+
+        // p2pool: self.verified.get_delta(share_hash, end_point).work
+        auto total_work = verified.get_delta_work(share_hash, end_point);
+
+        // p2pool: (0 - block_height + 1) * BLOCK_PERIOD
+        // c2pool confirmations: 1=tip → 150s, 4 → 600s (matches p2pool).
+        auto time_span = block_height.value() * 150; // LTC BLOCK_PERIOD = 150s
+        if (time_span <= 0)
+            time_span = 1;
+
+        score_res = total_work / static_cast<uint32_t>(time_span);
+        return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
+    }
+
+    // -- Best-chain selection with verification and punishment --
+    // bootstrap_mode: when true, removes verification budget limit so the
+    // entire chain is verified in one call.  Used during initial sync when
+    // stratum isn't serving work — no IO needs the tracker lock.
+    // Matches p2pool where think() runs synchronously on the reactor and
+    // blocks everything else until verification completes.
+    TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
+                             const uint256& previous_block,
+                             uint32_t bits,
+                             bool bootstrap_mode = false)
+    {
+        // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
+        // The timestamp is used to filter stale requests at return time.
+        struct DesiredEntry {
+            NetService peer;
+            uint256 hash;
+            uint32_t max_timestamp{0};  // max timestamp from chain head's recent shares
+        };
+        std::vector<DesiredEntry> desired;
+        std::set<uint256> desired_hashes;  // p2pool: desired = set() — dedup by hash
+        std::set<NetService> bad_peer_addresses;
+
+        // Phase 1: Verify unverified heads, remove bad shares.
+        // C++ implementation of the p2pool think() unverified-head walk.
+        // For each unverified head: walk backward, try to verify.
+        // If verification fails: remove the share (it's bad).
+        // If no verification possible and chain unrooted: request parents.
+        std::vector<uint256> bads;
+        {
+            // Snapshot heads — we'll modify chain during iteration
+            auto heads_snapshot = chain.get_heads();
+            int p1_skipped = 0, p1_walk0 = 0, p1_walked = 0, p1_verified = 0, p1_caught = 0;
+            {
+                static int p1_log = 0;
+                if (p1_log++ % 10 == 0)
+                    LOG_INFO << "[think-P1] raw_heads=" << heads_snapshot.size()
+                             << " verified_heads=" << verified.get_heads().size();
+            }
+            for (auto& [head_hash, tail_hash] : heads_snapshot)
+            {
+                if (verified.get_heads().contains(head_hash)) {
+                    ++p1_skipped;
+                    continue;
+                }
+
+                if (!chain.contains(head_hash)) continue;
+
+                auto [head_height, last] = chain.get_height_and_last(head_hash);
+
+                // get_height now returns accumulated height (including parent
+                // chain for new_fork shares). get_last follows segments to
+                // the true last. No special fork detection needed.
+                auto walk_count = last.IsNull()
+                    ? head_height
+                    : std::min(5, std::max(0, head_height - static_cast<int32_t>(PoolConfig::chain_length())));
+
+                if (walk_count <= 0) {
+                    ++p1_walk0;
+                    // p2pool: when walk_count=0, get_chain returns nothing,
+                    // no shares added to bads.  for/else requests parents.
+                    // Do NOT remove height-1 unrooted heads as "stumps" —
+                    // they're new peer shares whose parents haven't arrived yet.
+                    // clean_tracker() eats truly stale heads after 300s.
+                    if (!last.IsNull()) {
+                        // Option A: skip parent requests for chains already in the
+                        // pruning zone (height >= 2*CHAIN_LENGTH+10). These parents
+                        // would be immediately re-pruned by clean_tracker.
+                        auto CL_prune = static_cast<int32_t>(PoolConfig::chain_length());
+                        if (head_height >= 2 * CL_prune + 10) {
+                            static int prune_skip_log = 0;
+                            if (prune_skip_log++ % 20 == 0)
+                                LOG_INFO << "[think-P1] pruning-zone skip: head="
+                                         << head_hash.GetHex().substr(0,16)
+                                         << " height=" << head_height
+                                         << " threshold=" << (2*CL_prune+10);
+                        } else if (!desired_hashes.count(last)) {
+                            // Option C: dedup by hash (p2pool: desired = set())
+                            NetService peer;
+                            uint32_t head_ts = 0;
+                            chain.get_share(head_hash).invoke([&](auto* obj) {
+                                peer = obj->peer_addr;
+                                head_ts = obj->m_timestamp;
+                            });
+                            desired_hashes.insert(last);
+                            desired.push_back({peer, last, head_ts});
+                        }
+                    }
+                    continue;
+                }
+
+                ++p1_walked;
+                bool verified_one = false;
+                try {
+                    auto chain_view = chain.get_chain(head_hash, walk_count);
+                    for (auto [hash, data] : chain_view)
+                    {
+                        if (attempt_verify(hash))
+                        {
+                            verified_one = true;
+                            ++p1_verified;
+                            break;
+                        }
+                        // p2pool data.py:2215: bads.append(share.hash)
+                        // ALL failing shares go into bads — p2pool has no
+                        // permanently-unverifiable filter.  remove() returns
+                        // false for mid-chain shares (NotImplementedError in
+                        // p2pool), which is caught below.
+                        bads.push_back(hash);
+                    }
+                } catch (const std::exception& ex) {
+                    ++p1_caught;
+                    LOG_WARNING << "[think-P1] exception walking head " << head_hash.GetHex().substr(0,16)
+                                << " height=" << head_height << " walk=" << walk_count
+                                << ": " << ex.what();
+                    continue;
+                }
+
+                // Python for/else: if loop completed without break AND unrooted
+                if (!verified_one && !last.IsNull())
+                {
+                    // Option A: skip if chain already in pruning zone
+                    auto CL_prune = static_cast<int32_t>(PoolConfig::chain_length());
+                    if (head_height >= 2 * CL_prune + 10) {
+                        static int prune_skip2_log = 0;
+                        if (prune_skip2_log++ % 20 == 0)
+                            LOG_INFO << "[think-P1] pruning-zone skip (for/else): head="
+                                     << head_hash.GetHex().substr(0,16)
+                                     << " height=" << head_height;
+                    } else if (!desired_hashes.count(last)) {
+                        // Option C: dedup by hash
+                        NetService peer;
+                        uint32_t head_ts = 0;
+                        chain.get_share(head_hash).invoke([&](auto* obj) {
+                            peer = obj->peer_addr;
+                            head_ts = obj->m_timestamp;
+                        });
+                        desired_hashes.insert(last);
+                        desired.push_back({peer, last, head_ts});
+                    }
+                }
+            }
+
+            // Diagnostic: per-cycle summary
+            {
+                static int p1_sum_log = 0;
+                if (p1_sum_log++ % 5 == 0)
+                    LOG_INFO << "[think-P1-summary] heads=" << heads_snapshot.size()
+                             << " skipped_verified=" << p1_skipped
+                             << " walk0=" << p1_walk0
+                             << " walked=" << p1_walked
+                             << " verified=" << p1_verified
+                             << " caught=" << p1_caught
+                             << " bads=" << bads.size();
+            }
+        }
+
+        // Phase 1.5 removed — was NOT in p2pool and caused GENTX-MISMATCH.
+        // It tried to forward-propagate verification from verified parents to
+        // unverified children, but children on stub forks (chain_len < CHAIN_LENGTH)
+        // got verified with truncated PPLNS → wrong coinbase.
+        // p2pool's Phase 2 naturally handles forward extension via rooted chains.
+
+        // Remove bad shares (p2pool data.py:2224-2236).
+        // p2pool tries self.remove(bad) for ALL bads — catches
+        // NotImplementedError for mid-chain shares (have dependents).
+        // c2pool's chain.remove() returns false for that case.
+        // NO leaf-only filter — p2pool doesn't have one.
+        {
+            int removed_count = 0;
+            for (const auto& bad : bads)
+            {
+                if (verified.contains(bad))
+                    continue; // p2pool: raise ValueError (should never happen)
+                if (!chain.contains(bad)) continue;
+
+                NetService bad_peer;
+                try {
+                    chain.get_share(bad).invoke([&](auto* obj) {
+                        bad_peer = obj->peer_addr;
+                    });
+                } catch (...) {}
+                if (bad_peer.port() != 0)
+                    bad_peer_addresses.insert(bad_peer);
+
+                // p2pool data.py:2233-2236:
+                //   try: self.remove(bad)
+                //   except NotImplementedError: pass
+                // chain.remove() returns false for mid-chain shares
+                // (equivalent to NotImplementedError).
+                try {
+                    invalidate_weight_caches(bad);
+                    // #1131 double-free guard: `verified` is a BORROWING view —
+                    // it holds the same raw share pointers `chain` OWNS (every
+                    // node.cpp removal already pairs verified.remove(h, false)
+                    // with chain.remove(h)). Removing from the borrowing view
+                    // must NOT destroy; only the owning chain.remove() below
+                    // may. Omitting owns_data here defaults it to true, so if
+                    // the `verified.contains(bad) -> continue` guard 20 lines up
+                    // is ever loosened (e.g. wiring the mint path) this would
+                    // destroy() the share and chain.remove() would destroy() the
+                    // same pointer again -> the exact tcache/double-free abort.
+                    if (verified.contains(bad))
+                        verified.remove(bad, /*owns_data=*/false);
+                    if (chain.remove(bad))
+                        ++removed_count;
+                } catch (...) {}
+            }
+            if (removed_count > 0) {
+                LOG_INFO << "[think-P1] removed " << removed_count
+                         << " shares (bads=" << bads.size() << " + descendants)";
+            }
+        }
+
+        // Phase 2: Extend verification from verified heads.
+        // Budget-limited: verify up to THINK_VERIFY_BUDGET shares per call to
+        // prevent blocking the io_context for tens of seconds. Remaining shares
+        // are picked up by the next run_think() call (deferred via post()).
+        // p2pool avoids this problem by persisting verified status — we do too
+        // now, so budgeting is a safety net for cold starts only.
+        constexpr int THINK_VERIFY_BUDGET = 100;
+        int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
+        m_think_needs_continue = false;
+
+        // Frontier diagnostic (C2): when the verified tip lags the raw chain by
+        // a wide margin the mint path extends a stale private fork (money bug).
+        // Phase 2 swallows the first non-advancing share, so the CAUSE (missing
+        // parent body vs a deterministic v35 share_check incompatibility) was
+        // invisible. Log the FIRST failed frontier share + its parent state once
+        // per pass so the wedge root cause is measurable rather than inferred.
+        // Diagnostic only — changes no verification rule.
+        bool  p2_frontier_logged = false;
+        const int p2_raw_verified_gap =
+            static_cast<int>(chain.size()) - static_cast<int>(verified.size());
+
+        // ── V36 livelock mirror: cooperative-yield budget for the scoring walk ──
+        // The Phase 3/4 scoring step walks the decayed-cumulative-weight + PPLNS
+        // window per scored head while holding m_tracker_mutex.  On a healthy
+        // chain this is cheap, but a pathologically large/forked window can pin
+        // the lock long enough to starve the IO thread (the livelock).  We reuse
+        // the existing needs_continue continuation mechanism: when this budget is
+        // exhausted we stop scoring, release the lock (run_think() does this),
+        // let drain_pending_adds() run, and re-post a continuation.
+        //
+        // The budget is sized FAR above a normal full-window scoring pass so it
+        // NEVER trips on healthy load — behaviour and scoring results are
+        // unchanged for normal-size windows.  It is purely a starvation circuit
+        // breaker for the degenerate case.
+        constexpr int THINK_WALK_YIELD_BUDGET = 1000000;
+        int walk_budget_remaining = bootstrap_mode ? INT_MAX : THINK_WALK_YIELD_BUDGET;
+        m_think_walk_needs_continue = false;
+        {
+            static int p2_skip_log = 0;
+            if (p2_skip_log++ % 20 == 0)
+                LOG_INFO << "[think-P2-iter] verified_heads=" << verified.get_heads().size()
+                         << " chain=" << chain.size() << " verified=" << verified.size();
+        }
+        // Sort verified heads by work (descending) so the best chain gets
+        // budget priority.  p2pool iterates in arbitrary order but has no
+        // budget — with our budget, a low-scored side chain can starve the
+        // best chain if it goes first.
+        std::vector<std::pair<uint256, uint256>> sorted_vheads(
+            verified.get_heads().begin(), verified.get_heads().end());
+        std::sort(sorted_vheads.begin(), sorted_vheads.end(),
+            [this](const auto& a, const auto& b) {
+                auto wa = verified.contains(a.first) ? verified.get_work(a.first) : uint288{};
+                auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
+                return wa > wb;  // highest work first
+            });
+        for (auto& [head_hash, tail_hash] : sorted_vheads)
+        {
+            if (budget_remaining <= 0) {
+                m_think_needs_continue = true;
+                break;
+            }
+
+            if (!chain.contains(head_hash)) {
+                static int skip1 = 0;
+                if (skip1++ < 5) LOG_WARNING << "[think-P2] skip: head not in chain " << head_hash.GetHex().substr(0,16);
+                continue;
+            }
+
+            auto [head_height, last_hash] = verified.get_height_and_last(head_hash);
+            if (!chain.contains(last_hash)) {
+                static int skip2 = 0;
+                if (skip2++ < 5) LOG_WARNING << "[think-P2] skip: last not in chain " << last_hash.GetHex().substr(0,16)
+                                             << " head_height=" << head_height;
+                continue;
+            }
+
+            auto [last_height, last_last_hash] = chain.get_height_and_last(last_hash);
+
+            // Bounded backfill window: request as many shares as the chain is
+            // short of CHAIN_LENGTH (want), capped by how many the rooted peer
+            // can actually supply (can); to_get = min(want, can).
+            auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+            auto want = std::max(CL - head_height, 0);
+            auto can = last_last_hash.IsNull()
+                ? last_height
+                : std::max(last_height - 1 - CL, 0);
+            auto to_get = std::min(want, can);
+
+            {
+                static int p2_log = 0;
+                if (p2_log++ % 20 == 0)
+                    LOG_INFO << "[think-P2] head_height=" << head_height
+                             << " last_height=" << last_height
+                             << " last_rooted=" << last_last_hash.IsNull()
+                             << " to_get=" << to_get;
+            }
+
+            if (to_get > 0)
+            {
+                // ── Carry-forward verification with HeadPPLNS ──────────
+                // Build the PPLNS ring buffer once at the first share's
+                // prev_hash, then slide backward for each subsequent share.
+                // The ring buffer result is primed into the decayed cache so
+                // attempt_verify() → generate_share_transaction() →
+                // get_v36_decayed_cumulative_weights() hits O(1) cache
+                // instead of O(chain_len) hash map walk.
+                HeadPPLNS head_pplns;
+                bool pplns_active = false;
+                auto CL_i32 = static_cast<int32_t>(PoolConfig::chain_length());
+
+                auto chain_view = chain.get_chain(last_hash, to_get);
+                int p2_verified_count = 0;
+                for (auto [hash, data] : chain_view)
+                {
+                    if (budget_remaining <= 0) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
+                                 << " verifications, deferring remainder";
+                        break;
+                    }
+
+                    // Prime PPLNS cache from ring buffer (if V36 and chain long enough)
+                    // Derive from share version (matches p2pool check(): VERSION >= 36),
+                    // not the removed mutable global.
+                    uint256 prev_hash;
+                    int share_ver = 0;
+                    data.share.invoke([&](auto* obj) {
+                        prev_hash = obj->m_prev_hash;
+                        share_ver = obj->version;
+                    });
+                    if (core::version_gate::is_v36_active(share_ver)) {
+
+                        if (!prev_hash.IsNull() && chain.contains(prev_hash)) {
+                            if (!pplns_active) {
+                                // First share: full ring build — O(chain_len) hash map lookups
+                                auto ring_t0 = std::chrono::steady_clock::now();
+                                head_pplns.rebuild(chain, prev_hash, CL_i32);
+                                auto ring_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                    std::chrono::steady_clock::now() - ring_t0).count();
+                                pplns_active = true;
+                                LOG_INFO << "[PPLNS-RING] built: window=" << head_pplns.window_size()
+                                         << " chain_len=" << CL_i32 << " build_time=" << ring_us << "us";
+                            } else {
+                                // Subsequent shares: slide PPLNS window one step deeper.
+                                // The new window drops the shallowest entry and adds the
+                                // share at depth (chain_len - 1) from the new start.
+                                //
+                                // FIX: deep_hash IS the correct new tail entry (at depth
+                                // chain_len-1 from new start). The previous code took
+                                // deep_hash.tail (one step FURTHER), causing an off-by-one
+                                // that shifted the tail entry one position too deep each
+                                // extension — accumulating PPLNS weight errors and causing
+                                // GENTX mismatches for all V36 shares.
+                                auto ring_depth = head_pplns.window_size();
+                                if (ring_depth > 0) {
+                                    auto deep_hash = chain.get_nth_parent_via_skip(
+                                        prev_hash, std::min(ring_depth - 1, CL_i32 - 1));
+                                    if (!deep_hash.IsNull() && chain.contains(deep_hash)) {
+                                        head_pplns.extend_backward(chain, deep_hash);
+                                    } else {
+                                        // Can't extend — rebuild from scratch
+                                        head_pplns.rebuild(chain, prev_hash, CL_i32);
+                                    }
+                                }
+                            }
+
+                            // Prime the existing decayed cache with ring buffer result
+                            if (pplns_active && head_pplns.valid()) {
+                                auto prime_t0 = std::chrono::steady_clock::now();
+                                auto& w = const_cast<HeadPPLNS&>(head_pplns).weights();
+                                prime_pplns_cache(prev_hash, CL_i32, w);
+                                auto prime_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                    std::chrono::steady_clock::now() - prime_t0).count();
+                                static int prime_log = 0;
+                                if (prime_log++ % 20 == 0)
+                                    LOG_INFO << "[PPLNS-RING] cache primed: addrs=" << w.weights.size()
+                                             << " total_weight=" << w.total_weight.GetLow64()
+                                             << " compute=" << prime_us << "us"
+                                             << " share=" << p2_verified_count;
+                            }
+                        }
+                    }
+
+                    // p2pool has no budget — it verifies all shares synchronously.
+                    // With our budget, don't count already-verified shares against it.
+                    // Head B's walk through Head A's verified territory should be free.
+                    bool was_already_verified = verified.contains(hash);
+                    if (!attempt_verify(hash)) {
+                        // C2 frontier diagnostic: classify WHY the frontier share
+                        // will not verify. prev_in_chain=false → missing parent
+                        // body (need download); prev_in_chain && prev_verified →
+                        // a deterministic verify failure (candidate v35
+                        // share_check incompatibility → replay the bytes through
+                        // python p2pool before touching share_check.hpp).
+                        if (!p2_frontier_logged && p2_raw_verified_gap > 200) {
+                            p2_frontier_logged = true;
+                            bool prev_in_chain    = !prev_hash.IsNull() && chain.contains(prev_hash);
+                            bool prev_verified    = !prev_hash.IsNull() && verified.contains(prev_hash);
+                            LOG_WARNING << "[think-P2-frontier] stuck share=" << hash.GetHex().substr(0,16)
+                                        << " ver=" << share_ver
+                                        << " prev=" << prev_hash.GetHex().substr(0,16)
+                                        << " prev_in_chain=" << prev_in_chain
+                                        << " prev_verified=" << prev_verified
+                                        << " raw_verified_gap=" << p2_raw_verified_gap
+                                        << " reason=" << (!prev_in_chain ? "missing-parent-body"
+                                                          : (prev_verified ? "deterministic-verify-fail"
+                                                                           : "parent-unverified"));
+                        }
+                        break;
+                    }
+                    ++p2_verified_count;
+                    if (!was_already_verified) {
+                        --budget_remaining;
+                    }
+                    // Throttled progress log: contabo freeze-diag (2026-05-24) caught
+                    // this loop wedging the io_context for 2-7.5s at a time when emit
+                    // was every 50 entries (173 lines per think cycle on an 8639-share
+                    // chain). Boost::log internal mutex starves the io_context handler
+                    // that runs the same think cycle. Bumped to every 1000 (~9 lines/
+                    // cycle); the loop runs at >1 verify/ms so a line/sec cadence is
+                    // plenty for diagnostics.
+                    if (p2_verified_count % 1000 == 0)
+                        LOG_INFO << "[think-P2] verifying: " << p2_verified_count << "/" << to_get
+                                 << " new=" << (was_already_verified ? "no" : "yes")
+                                 << " budget=" << budget_remaining
+                                 << " verified_total=" << verified.size();
+                }
+            }
+
+            // Request more shares if verified chain is short
+            if (head_height < static_cast<int32_t>(PoolConfig::chain_length()) && !last_last_hash.IsNull())
+            {
+                // Option A: check MAIN chain height (not verified height).
+                // If main chain is already in pruning zone, the unverified
+                // shares exist — they just need verification, not more parents.
+                auto main_ht = chain.get_height(head_hash);
+                auto CL_prune = static_cast<int32_t>(PoolConfig::chain_length());
+                if (main_ht >= 2 * CL_prune + 10) {
+                    static int p2_prune_log = 0;
+                    if (p2_prune_log++ % 20 == 0)
+                        LOG_INFO << "[think-P2] pruning-zone skip: head="
+                                 << head_hash.GetHex().substr(0,16)
+                                 << " verified_ht=" << head_height
+                                 << " main_ht=" << main_ht;
+                } else if (!desired_hashes.count(last_last_hash)) {
+                    // Option C: dedup by hash
+                    NetService peer;
+                    uint32_t head_ts = 0;
+                    chain.get_share(head_hash).invoke([&](auto* obj) {
+                        peer = obj->peer_addr;
+                        head_ts = obj->m_timestamp;
+                    });
+                    desired_hashes.insert(last_last_hash);
+                    desired.push_back({peer, last_last_hash, head_ts});
+                }
+            }
+        }
+
+        // Phase 3: Score tails — pick the best tail
+        // p2pool: decorated_tails = sorted((self.score(
+        //   max(self.verified.tails[tail_hash], key=self.verified.get_work), ...
+        // Uses VERIFIED.get_work (verified TrackerView), NOT chain.get_work.
+        // SubsetTracker.get_work walks verified items only.
+        std::vector<DecoratedData<TailScore>> decorated_tails;
+        for (auto& [tail_hash, head_hashes] : verified.get_tails())
+        {
+            // ── V36 livelock mirror: COARSE walk-yield boundary ──────────────
+            // Conservative boundary: checked once per scored head, NOT inside the
+            // innermost decay iteration (that exact intra-walk yield point is the
+            // marked TODO below, pending ltc-doge PIE symbolization).  When the
+            // scoring walk has consumed its (generous) budget, defer the remaining
+            // tails to a re-posted continuation so the lock is released and
+            // drain_pending_adds() can run.  Trips only on a degenerate window.
+            if (walk_budget_remaining <= 0) {
+                m_think_walk_needs_continue = true;
+                LOG_WARNING << "[think-WALK-YIELD] scoring-walk budget exhausted; "
+                               "deferring remaining tails to continuation";
+                break;
+            }
+
+            // p2pool: max(verified.tails[tail_hash], key=verified.get_work)
+            uint256 best_head;
+            uint288 best_work;
+            bool first = true;
+            for (const auto& hh : head_hashes)
+            {
+                if (!verified.contains(hh)) continue;
+                auto w = verified.get_work(hh);
+                if (first || w > best_work)
+                {
+                    best_work = w;
+                    best_head = hh;
+                    first = false;
+                }
+            }
+
+            if (!best_head.IsNull())
+            {
+                try {
+                    auto s = score(best_head, block_rel_height_func);
+                    s.best_head_work = best_work;  // tiebreak by total work
+                    decorated_tails.push_back({s, tail_hash});
+                    // Charge the (coarse) cost of one scored head against the
+                    // walk-yield budget.  score() walks up to CHAIN_LENGTH/16
+                    // window entries; charging the chain_len keeps the accounting
+                    // proportional to real lock-hold time without descending into
+                    // the inner decay loop (see TODO marker there).
+                    walk_budget_remaining -= std::max(s.chain_len, 1);
+                } catch (const std::exception&) {
+                    // Chain was concurrently modified (trim removed an
+                    // ancestor).  Skip this tail — will be scored next cycle.
+                }
+            }
+        }
+        std::sort(decorated_tails.begin(), decorated_tails.end());
+
+        uint256 best_tail;
+        TailScore best_tail_score{};
+        if (!decorated_tails.empty())
+        {
+            best_tail = decorated_tails.back().hash;
+            best_tail_score = decorated_tails.back().score;
+        }
+
+        // Debug: log scoring when multiple tails compete
+        if (decorated_tails.size() > 1) {
+            static int score_log = 0;
+            if (score_log++ % 10 == 0) {
+                for (auto& dt : decorated_tails) {
+                    LOG_INFO << "[SCORE-TAIL] tail=" << dt.hash.GetHex().substr(0,16)
+                             << " chain_len=" << dt.score.chain_len
+                             << " hashrate=" << dt.score.hashrate.IsNull()
+                             << (dt.hash == best_tail ? " ← WINNER" : "");
+                }
+            }
+        }
+
+        // Phase 4: Score heads within the best tail — pick the best head
+        std::vector<DecoratedData<HeadScore>> decorated_heads;
+        std::vector<DecoratedData<TraditionalScore>> traditional_sort;
+
+        if (verified.get_tails().contains(best_tail))
+        {
+            const auto& head_hashes = verified.get_tails().at(best_tail);
+            for (const auto& hh : head_hashes)
+            {
+                if (!verified.contains(hh))
+                    continue;
+
+                try {
+                    // p2pool Phase 4:
+                    // self.verified.get_work(self.verified.get_nth_parent_hash(h, min(5, self.verified.get_height(h))))
+                    // verified.get_height uses verified TrackerView
+                    // verified.get_nth_parent_hash uses SHARED skip list (main tracker)
+                    // verified.get_work uses verified TrackerView
+                    auto v_height = verified.get_acc_height(hh);
+                    auto recent_ancestor = verified.get_nth_parent_via_skip(hh, std::min(5, v_height));
+                    uint288 work_score = verified.get_work(recent_ancestor);
+
+                    auto* head_idx = chain.get_index(hh);
+                    if (!head_idx) continue;
+                    int64_t ts = head_idx->time_seen;
+
+                    // Punish heads: naughty (invalid block) only.
+                    // F10/(b): the non-canonical 95%-version-obsolescence punish
+                    // is dropped — canonical Phase-4 head-scoring punishes only
+                    // naughty heads. The version gate is the check() 60% weighted
+                    // switch rule (share_check), not head-scoring.
+                    int32_t reason = 0;
+                    {
+                        auto* idx = chain.get_index(hh);
+                        if (idx && idx->naughty > 0)
+                            reason = idx->naughty;
+                    }
+
+                    // p2pool: sort key = (work - min(punish,1)*ata(target), -reason, -time_seen)
+                    // peer_addr is None is COMMENTED OUT in p2pool — no is_local dimension.
+                    // Punishment deducted from work: a punished share is mathematically behind.
+                    uint288 adjusted_work = work_score;
+                    if (reason > 0) {
+                        // Deduct one share's worth of attempts (min(reason,1) * ata(target))
+                        auto* share_idx = chain.get_index(hh);
+                        if (share_idx)
+                            adjusted_work = adjusted_work - share_idx->work;
+                    }
+                    decorated_heads.push_back({{adjusted_work, -reason, -ts}, hh});
+                    traditional_sort.push_back({{work_score, -ts, -reason}, hh});
+                } catch (const std::exception&) {
+                    // Chain concurrently modified — skip this head, retry next cycle
+                }
+            }
+            std::sort(decorated_heads.begin(), decorated_heads.end());
+            std::sort(traditional_sort.begin(), traditional_sort.end());
+        }
+
+        // p2pool: self.punish = punish value from Phase 5 (walk-back result)
+        bool punish_aggressively = !traditional_sort.empty() && traditional_sort.back().score.neg_reason != 0;
+
+        // Phase 5: Determine best share — p2pool data.py:2142-2166
+        // Walk back through punished shares, then find best non-naughty descendent.
+        uint256 best;
+        int32_t punish_val = 0;
+        if (!decorated_heads.empty())
+            best = decorated_heads.back().hash;
+
+        if (!best.IsNull() && chain.contains(best))
+        {
+            // Check if best share should be punished
+            auto* best_idx = chain.get_index(best);
+            if (best_idx && best_idx->naughty > 0)
+            {
+                // Walk back through punished shares
+                while (best_idx && best_idx->naughty > 0)
+                {
+                    uint256 prev;
+                    chain.get_share(best).invoke([&](auto* obj) {
+                        prev = obj->m_prev_hash;
+                    });
+                    if (prev.IsNull() || !chain.contains(prev)) break;
+                    best = prev;
+                    best_idx = chain.get_index(best);
+
+                    // p2pool: if not punish, find best descendent
+                    if (best_idx && best_idx->naughty == 0)
+                    {
+                        // Find deepest non-naughty child via reverse map
+                        std::function<std::pair<int,uint256>(const uint256&, int)> best_desc;
+                        best_desc = [&](const uint256& h, int limit) -> std::pair<int,uint256> {
+                            if (limit < 0) return {0, h};
+                            auto& rev = chain.get_reverse();
+                            auto rit = rev.find(h);
+                            if (rit == rev.end() || rit->second.empty())
+                                return {0, h};
+                            std::pair<int,uint256> best_kid = {-1, h};
+                            for (const auto& child : rit->second) {
+                                auto* cidx = chain.get_index(child);
+                                if (cidx && cidx->naughty > 0) continue;
+                                auto [gen, hash] = best_desc(child, limit - 1);
+                                if (gen + 1 > best_kid.first)
+                                    best_kid = {gen + 1, hash};
+                            }
+                            return best_kid.first >= 0 ? best_kid : std::pair<int,uint256>{0, h};
+                        };
+                        auto [gens, desc_hash] = best_desc(best, 20);
+                        best = desc_hash;
+                        break;
+                    }
+                }
+            }
+            punish_val = (best_idx && best_idx->naughty > 0) ? best_idx->naughty : 0;
+        }
+
+        // Phase 6: Compute cutoffs for desired shares filtering
+        uint32_t timestamp_cutoff;
+        if (!best.IsNull() && chain.contains(best))
+        {
+            uint32_t best_ts = 0;
+            chain.get_share(best).invoke([&](auto* obj) {
+                best_ts = obj->m_timestamp;
+            });
+            timestamp_cutoff = std::min(static_cast<uint32_t>(now_seconds()), best_ts) - 3600;
+        }
+        else
+        {
+            timestamp_cutoff = static_cast<uint32_t>(now_seconds()) - 24 * 60 * 60;
+        }
+
+        // Filter the desired list by timestamp cutoff: keep only entries whose
+        // timestamp is at or after the cutoff.
+        // This prevents requesting shares from stale/pruned chain tails that
+        // peers no longer have. Without this, we hammer peers with unanswerable
+        // requests and they eventually drop us.
+        std::vector<std::pair<NetService, uint256>> desired_result;
+        for (auto& d : desired) {
+            if (d.max_timestamp >= timestamp_cutoff) {
+                desired_result.emplace_back(d.peer, d.hash);
+            } else {
+                static int filter_log = 0;
+                if (filter_log++ % 10 == 0)
+                    LOG_INFO << "[think-DESIRED] filtered stale request: hash="
+                             << d.hash.GetHex().substr(0,16)
+                             << " ts=" << d.max_timestamp
+                             << " cutoff=" << timestamp_cutoff
+                             << " age=" << (timestamp_cutoff - d.max_timestamp + 3600) << "s";
+            }
+        }
+
+        // Extract top-5 scored heads for clean_tracker (p2pool node.py:363)
+        std::vector<uint256> top5;
+        {
+            size_t start = decorated_heads.size() > 5 ? decorated_heads.size() - 5 : 0;
+            for (size_t i = start; i < decorated_heads.size(); ++i)
+                top5.push_back(decorated_heads[i].hash);
+        }
+
+        return {best, desired_result, bad_peer_addresses, punish_aggressively, std::move(top5)};
+    }
+
+    // -- Pool hashrate estimation --
+    /// Pool hashrate estimation — matches p2pool get_pool_attempts_per_second exactly.
+    /// Uses skip list O(log n) for ancestor lookup + TrackerView delta cache O(1) for work sum.
+    ///
+    /// p2pool (data.py:2489-2499):
+    ///   near = tracker.items[previous_share_hash]
+    ///   far  = tracker.items[tracker.get_nth_parent_hash(previous_share_hash, dist - 1)]
+    ///   attempts = tracker.get_delta(near.hash, far.hash).min_work   (if min_work)
+    ///            = tracker.get_delta(near.hash, far.hash).work        (otherwise)
+    ///   time = near.timestamp - far.timestamp
+    ///   return attempts // time   (integer=True in generate_transaction)
+    uint288 get_pool_attempts_per_second(const uint256& share_hash, int32_t dist, bool use_min_work = false)
+    {
+        if (dist < 2 || !chain.contains(share_hash))
+            return uint288(0);
+
+        // p2pool: far = tracker.items[tracker.get_nth_parent_hash(share_hash, dist - 1)]
+        auto far_hash = chain.get_nth_parent_via_skip(share_hash, dist - 1);
+        if (far_hash.IsNull() || !chain.contains(far_hash))
+            return uint288(0);
+
+        // Verify skip list vs naive walk (periodic — detect stale pointers)
+        {
+            static int skip_verify = 0;
+            if (skip_verify++ % 100 == 0) {
+                try {
+                    auto naive_far = chain.get_nth_parent_key(share_hash, dist - 1);
+                    if (naive_far != far_hash) {
+                        LOG_ERROR << "[SKIP-MISMATCH] dist=" << dist
+                                  << " skip=" << far_hash.GetHex().substr(0,16)
+                                  << " naive=" << naive_far.GetHex().substr(0,16)
+                                  << " near=" << share_hash.GetHex().substr(0,16);
+                    }
+                } catch (...) {}
+            }
+        }
+
+        // p2pool: tracker.get_delta(near.hash, far.hash)  — O(1) via TrackerView
+        auto delta = chain.get_delta(share_hash, far_hash);
+        uint288 attempts = use_min_work ? delta.min_work : delta.work;
+
+        // p2pool: time = near.timestamp - far.timestamp; if time <= 0: time = 1
+        uint32_t near_ts = 0, far_ts = 0;
+        chain.get_share(share_hash).invoke([&](auto* obj) { near_ts = obj->m_timestamp; });
+        chain.get_share(far_hash).invoke([&](auto* obj) { far_ts = obj->m_timestamp; });
+
+        int32_t time_span = static_cast<int32_t>(near_ts) - static_cast<int32_t>(far_ts);
+        if (time_span <= 0) time_span = 1;
+
+        return attempts / uint288(time_span);
+    }
+
+    // -- Share target computation --
+    // Computes max_bits and bits for a new share, matching p2pool-v36
+    // BaseShare.generate_transaction():
+    //   1. Derive pre_target from pool hashrate estimate
+    //   2. Clamp to ±10% of previous share's max_target
+    //   3. Apply emergency time-based decay (death spiral prevention)
+    //   4. Clamp to [MIN_TARGET, MAX_TARGET]
+    // Returns {max_bits, bits}.
+    struct ShareTarget {
+        uint32_t max_bits;
+        uint32_t bits;
+    };
+
+    ShareTarget compute_share_target(
+        const uint256& prev_share_hash,
+        uint32_t desired_timestamp,
+        const uint256& desired_target)
+    {
+        // MAX_TARGET: network-specific share difficulty floor
+        // Mainnet: 2^236 - 1, Testnet: 2^256/20 - 1  (from PoolConfig)
+        const uint256 MAX_TARGET = PoolConfig::max_target();
+
+        if (prev_share_hash.IsNull() || !chain.contains(prev_share_hash))
+        {
+            // Genesis or unknown prev: use MAX_TARGET for max_bits,
+            // clip desired_target to [MAX_TARGET/30, MAX_TARGET] for bits.
+            // Matches p2pool generate_transaction (data.py:746-774).
+            auto pre_target3 = MAX_TARGET;
+            auto max_bits = chain::target_to_bits_upper_bound(pre_target3);
+            // No round-up guard needed — truncation matches p2pool's actual behavior
+            uint256 bits_lo = pre_target3 / 30;
+            if (bits_lo.IsNull()) bits_lo = uint256(1);
+            uint256 bits_target = desired_target;
+            if (bits_target < bits_lo) bits_target = bits_lo;
+            if (bits_target > pre_target3) bits_target = pre_target3;
+            auto bits = chain::target_to_bits_upper_bound(bits_target);
+            // No round-up guard needed — truncation matches p2pool's actual behavior
+            return {max_bits, bits};
+        }
+
+        // Use accumulated height from skip list cache — O(1) and correct
+        // even after pruning (get_height walks until chain end, stops at
+        // pruned tail → returns short value → triggers MAX_TARGET fallback).
+        auto acc_height = chain.get_acc_height(prev_share_hash);
+
+        // Not enough chain depth for proper difficulty calculation.
+        if (acc_height < static_cast<int32_t>(PoolConfig::TARGET_LOOKBEHIND))
+        {
+            // Collapse detection: many shares exist but best chain is short
+            auto total_shares = chain.size();
+            if (total_shares > 2 * PoolConfig::chain_length()
+                && acc_height < static_cast<int32_t>(PoolConfig::TARGET_LOOKBEHIND)) {
+                static int collapse_warn = 0;
+                if (collapse_warn++ < 20) {
+                    // Walk raw chain to find actual contiguous height
+                    int32_t walked = 0;
+                    auto cur = prev_share_hash;
+                    while (!cur.IsNull() && chain.contains(cur) && walked < 1000) {
+                        ++walked;
+                        auto* idx = chain.get_index(cur);
+                        cur = idx ? idx->tail : uint256();
+                    }
+                    LOG_WARNING << "[COLLAPSE-DETECT] Chain structurally broken:"
+                                << " total_shares=" << total_shares
+                                << " acc_height=" << acc_height
+                                << " walked_height=" << walked
+                                << " tails=" << chain.get_tails().size()
+                                << " heads=" << chain.get_heads().size()
+                                << " TARGET_LOOKBEHIND=" << PoolConfig::TARGET_LOOKBEHIND
+                                << " prev=" << prev_share_hash.GetHex().substr(0,16);
+                }
+            }
+            auto pre_target3 = MAX_TARGET;
+            auto max_bits = chain::target_to_bits_upper_bound(pre_target3);
+            // No round-up guard needed — truncation matches p2pool's actual behavior
+            uint256 bits_lo = pre_target3 / 30;
+            if (bits_lo.IsNull()) bits_lo = uint256(1);
+            uint256 bits_target = desired_target;
+            if (bits_target < bits_lo) bits_target = bits_lo;
+            if (bits_target > pre_target3) bits_target = pre_target3;
+            auto bits = chain::target_to_bits_upper_bound(bits_target);
+            // No round-up guard needed — truncation matches p2pool's actual behavior
+            return {max_bits, bits};
+        }
+
+        // Step 1: Derive target from pool hashrate.
+        // Use prev_share_hash directly — all shares counted equally.
+        // p2pool's algorithm: aps from the entire chain, no filtering.
+        auto aps = get_pool_attempts_per_second(prev_share_hash,
+            PoolConfig::TARGET_LOOKBEHIND, /*min_work=*/true);
+
+        // Full APS diagnostic for cross-implementation comparison.
+        // Dumps all inputs so p2pool's values can be compared.
+        {
+            static int cst_diag = 0;
+            if (cst_diag++ % 50 == 0) {
+                auto far_hash = chain.get_nth_parent_via_skip(prev_share_hash,
+                    static_cast<int32_t>(PoolConfig::TARGET_LOOKBEHIND) - 1);
+                uint32_t near_ts = 0, far_ts = 0;
+                chain.get_share(prev_share_hash).invoke([&](auto* obj) { near_ts = obj->m_timestamp; });
+                if (!far_hash.IsNull() && chain.contains(far_hash))
+                    chain.get_share(far_hash).invoke([&](auto* obj) { far_ts = obj->m_timestamp; });
+                auto delta = (!far_hash.IsNull() && chain.contains(far_hash))
+                    ? chain.get_delta(prev_share_hash, far_hash)
+                    : decltype(chain.get_delta(prev_share_hash, prev_share_hash)){};
+                LOG_INFO << "[CST-APS] aps=" << aps.GetLow64()
+                         << " height=" << acc_height
+                         << " prev=" << prev_share_hash.GetHex().substr(0,16)
+                         << " far=" << (far_hash.IsNull() ? "null" : far_hash.GetHex().substr(0,16))
+                         << " near_ts=" << near_ts << " far_ts=" << far_ts
+                         << " timespan=" << (int32_t(near_ts) - int32_t(far_ts))
+                         << " delta_h=" << delta.height
+                         << " delta_min_work=" << delta.min_work.GetLow64()
+                         << " delta_work=" << delta.work.GetLow64();
+            }
+        }
+
+        uint256 pre_target;
+        if (aps.IsNull())
+        {
+            pre_target = MAX_TARGET;
+        }
+        else
+        {
+            // pre_target = 2^256 / (SHARE_PERIOD * aps) - 1
+            uint288 two_256;
+            two_256.SetHex("10000000000000000000000000000000000000000000000000000000000000000");
+            uint288 divisor = aps * static_cast<uint32_t>(PoolConfig::share_period());
+            if (divisor.IsNull())
+                divisor = uint288(1);
+            uint288 result = two_256 / divisor;
+            if (result > uint288(1))
+                result = result - uint288(1);
+            // Clamp to 256-bit range
+            uint288 max_288;
+            max_288.SetHex(MAX_TARGET.GetHex());
+            if (result > max_288)
+            {
+                pre_target = MAX_TARGET;
+            }
+            else
+            {
+                pre_target.SetHex(result.GetHex());
+            }
+        }
+
+        // Step 2: Get previous share's max_target
+        uint256 prev_max_target;
+        chain.get_share(prev_share_hash).invoke([&](auto* obj) {
+            prev_max_target = chain::bits_to_target(obj->m_max_bits);
+        });
+
+        // Step 3: Emergency time-based decay (death spiral prevention)
+        // Phase 1b from p2pool-v36: doubles target every SHARE_PERIOD * 10
+        // seconds past the threshold of SHARE_PERIOD * 20 seconds since last share.
+        uint256 clamp_ref_target = prev_max_target;
+        uint32_t prev_ts = 0;
+        chain.get_share(prev_share_hash).invoke([&](auto* obj) {
+            prev_ts = obj->m_timestamp;
+        });
+
+        if (prev_ts > 0 && desired_timestamp > prev_ts)
+        {
+            auto time_since_share = desired_timestamp - prev_ts;
+            auto emergency_threshold = PoolConfig::share_period() * 20;
+            if (time_since_share > emergency_threshold)
+            {
+                auto half_life = PoolConfig::share_period() * 10;
+                auto excess = time_since_share - emergency_threshold;
+                auto halvings = excess / half_life;
+                auto remainder = excess % half_life;
+                // 2^halvings with linear interpolation for fractional part
+                uint256 eased = prev_max_target;
+                if (halvings < 256)
+                    eased <<= halvings;
+                else
+                    eased = MAX_TARGET;
+                // Linear interpolation: eased = eased * (half_life + remainder) / half_life
+                uint288 eased_288;
+                eased_288.SetHex(eased.GetHex());
+                eased_288 = eased_288 * static_cast<uint32_t>(half_life + remainder);
+                eased_288 = eased_288 / static_cast<uint32_t>(half_life);
+                uint288 max_288;
+                max_288.SetHex(MAX_TARGET.GetHex());
+                if (eased_288 > max_288)
+                    clamp_ref_target = MAX_TARGET;
+                else
+                    clamp_ref_target.SetHex(eased_288.GetHex());
+            }
+        }
+
+        // Step 4: Clamp pre_target to ±10% of clamp_ref_target
+        // pre_target2 = clip(pre_target, (clamp_ref * 9/10, clamp_ref * 11/10))
+        // p2pool: target * 9 // 10 (multiply first, then divide)
+        uint256 lo;
+        {
+            uint288 lo_288;
+            lo_288.SetHex(clamp_ref_target.GetHex());
+            lo_288 = lo_288 * 9 / 10;
+            uint288 max_288;
+            max_288.SetHex(MAX_TARGET.GetHex());
+            if (lo_288 > max_288)
+                lo = MAX_TARGET;
+            else
+                lo.SetHex(lo_288.GetHex());
+        }
+        uint256 hi;
+        {
+            uint288 hi_288;
+            hi_288.SetHex(clamp_ref_target.GetHex());
+            hi_288 = hi_288 * 11;
+            hi_288 = hi_288 / 10;
+            uint288 max_288;
+            max_288.SetHex(MAX_TARGET.GetHex());
+            if (hi_288 > max_288)
+                hi = MAX_TARGET;
+            else
+                hi.SetHex(hi_288.GetHex());
+        }
+
+        uint256 pre_target2 = pre_target;
+        if (pre_target2 < lo) pre_target2 = lo;
+        if (pre_target2 > hi) pre_target2 = hi;
+
+        // Step 5: Clamp to network limits [MIN_TARGET, MAX_TARGET]
+        // Ensure target is never zero (would produce bits=0 → "share target is zero" error)
+        uint256 pre_target3 = pre_target2;
+        if (pre_target3.IsNull()) pre_target3 = uint256(1);
+        if (pre_target3 > MAX_TARGET) pre_target3 = MAX_TARGET;
+
+        auto max_bits = chain::target_to_bits_upper_bound(pre_target3);
+
+        // No round-up guard needed — truncation matches p2pool's actual behavior
+
+        // Apply 1.67% share cap: desired_target cannot be easier than
+        // pool_target / 0.0167 ≈ pool_target * 60. This ensures no single
+        // miner can produce more than ~1.67% of all shares (anti-spam).
+        // P2pool ref: work.py line 2402: hashrate * SHARE_PERIOD / 0.0167
+        uint256 cap_target = pre_target3; // default: pool target (1 share/period)
+        // cap_target represents the easiest target a single miner should use.
+        // At pool target difficulty, a miner with all pool hashrate produces
+        // 1 share/period. At pre_target3 (the pool target), that's 100%.
+        // desired_target is already clipped to [pre_target3//30, pre_target3]
+        // so the cap is inherently enforced by the upper clamp to pre_target3.
+
+        // DUST threshold: if the pool share target is too hard for tiny miners,
+        // allow shares at up to 30x easier difficulty (pre_target3 * 30 would be
+        // out of bounds, so the 30x range [pre_target3//30, pre_target3] is the
+        // full allowed range — this is already how p2pool works).
+        // The key fix is that desired_target = MAX_TARGET (from caller), which
+        // gets clipped to pre_target3 here — shares at pool difficulty.
+        // Tiny miners simply find them less often, proportional to hashrate.
+
+        // bits = from_target_upper_bound(clip(desired_target, (pre_target3/30, pre_target3)))
+        uint256 bits_lo = pre_target3 / 30;
+        if (bits_lo.IsNull()) bits_lo = uint256(1);
+        uint256 bits_target = desired_target;
+        if (bits_target < bits_lo) bits_target = bits_lo;
+        if (bits_target > pre_target3) bits_target = pre_target3;
+        auto bits = chain::target_to_bits_upper_bound(bits_target);
+
+        // Periodic full-chain diagnostic for cross-implementation comparison.
+        // Dumps all intermediate values so p2pool's computation can be matched.
+        {
+            static int cst_full = 0;
+            if (cst_full++ % 200 == 0) {
+                LOG_INFO << "[CST-FULL] max_bits=0x" << std::hex << max_bits
+                         << " bits=0x" << bits << std::dec
+                         << " aps=" << aps.GetLow64()
+                         << " pre_target_bits=0x" << std::hex
+                         << chain::target_to_bits_upper_bound(pre_target)
+                         << " clamp_ref_bits=0x"
+                         << chain::target_to_bits_upper_bound(clamp_ref_target)
+                         << " lo_bits=0x" << chain::target_to_bits_upper_bound(lo)
+                         << " hi_bits=0x" << chain::target_to_bits_upper_bound(hi)
+                         << " pre2_bits=0x" << chain::target_to_bits_upper_bound(pre_target2)
+                         << " pre3_bits=0x" << chain::target_to_bits_upper_bound(pre_target3)
+                         << std::dec
+                         << " height=" << acc_height
+                         << " prev=" << prev_share_hash.GetHex().substr(0,16);
+            }
+        }
+        return {max_bits, bits};
+    }
+
+    // -- Minimum viable hashrate for dashboard display --
+    // Returns the minimum hashrate (H/s) needed to produce at least 1 share
+    // per PPLNS window. With DUST (30x range), tiny miners get easier shares.
+    struct MinerThresholds {
+        double min_hashrate_normal;  // H/s at pool share difficulty
+        double min_hashrate_dust;    // H/s at 30x easier (DUST)
+        double min_payout_ltc;       // LTC per share at pool difficulty
+        double pool_hashrate;        // current pool H/s estimate
+    };
+
+    MinerThresholds get_miner_thresholds(const uint256& prev_share_hash,
+                                          uint64_t block_subsidy_sat)
+    {
+        MinerThresholds t{};
+        if (prev_share_hash.IsNull() || !chain.contains(prev_share_hash))
+            return t;
+
+        auto [height, last] = chain.get_height_and_last(prev_share_hash);
+        if (height < 2) return t;
+
+        auto lookback = std::min(height,
+            static_cast<int32_t>(PoolConfig::TARGET_LOOKBEHIND));
+        auto aps = get_pool_attempts_per_second(prev_share_hash,
+            lookback, /*min_work=*/true);
+
+        double pool_hr = 0;
+        {
+            uint288 aps_288 = aps;
+            // Convert uint288 to double (approximate)
+            for (int i = uint288::WIDTH - 1; i >= 0; --i) {
+                pool_hr = pool_hr * 4294967296.0 + aps_288.pn[i];
+            }
+        }
+        t.pool_hashrate = pool_hr;
+
+        double share_period = static_cast<double>(PoolConfig::share_period());
+        double chain_length = static_cast<double>(PoolConfig::real_chain_length());
+
+        // min_hashrate = pool_share_att / window = pool_hr / chain_length
+        t.min_hashrate_normal = pool_hr / chain_length;
+        t.min_hashrate_dust = t.min_hashrate_normal / 30.0; // 30x DUST range
+
+        // min_payout = block_subsidy / chain_length (one share in full window)
+        t.min_payout_ltc = static_cast<double>(block_subsidy_sat) / 1e8 / chain_length;
+
+        return t;
+    }
+
+    // -- PPLNS cumulative weights computation (O(log n) via skip list) --
+    CumulativeWeights get_cumulative_weights(const uint256& start, int32_t max_shares, const uint288& desired_weight)
+    {
+        if (start.IsNull())
+            return {};
+
+        ensure_weights_skiplist();
+        auto sl_result = m_weights_skiplist->query(start, max_shares, desired_weight);
+        return CumulativeWeights{
+            std::move(sl_result.weights),
+            sl_result.total_weight,
+            sl_result.total_donation_weight
+        };
+    }
+
+    // -- V36 PPLNS with exponential depth-decay --
+    // Matches Python: get_decayed_cumulative_weights()
+    // half_life = CHAIN_LENGTH // 4
+    // Each share's weight is multiplied by 2^(-depth/half_life)
+    // Fixed-point arithmetic with 40-bit precision.
+    //
+    // Result is cached keyed by (start_hash, max_shares) — invalidated
+    // when the chain head changes.  This makes repeated calls for the
+    // same share (e.g. during verify_share + get_expected_payouts) O(1).
+    CumulativeWeights get_v36_decayed_cumulative_weights(
+        const uint256& start, int32_t max_shares, const uint288& desired_weight)
+    {
+        if (start.IsNull())
+            return {};
+
+        // Cache: keyed by (start_hash, max_shares, desired_weight).
+        // Same inputs always produce same outputs (deterministic walk).
+        // Invalidated when chain head changes (new shares added/removed).
+        // No consensus risk — cached result is byte-identical to fresh computation.
+        if (m_decayed_cache_valid && m_decayed_cache_start == start
+            && m_decayed_cache_shares == max_shares
+            && m_decayed_cache_desired == desired_weight)
+            return m_decayed_cache_result;
+
+        static constexpr uint64_t DECAY_PRECISION = 40;
+        static constexpr uint64_t DECAY_SCALE = uint64_t(1) << DECAY_PRECISION;
+        static constexpr uint64_t LN2_MICRO = 693147;
+
+        uint32_t half_life = std::max(PoolConfig::chain_length() / 4, uint32_t(1));
+        uint64_t decay_per = DECAY_SCALE - (DECAY_SCALE * LN2_MICRO) / (uint64_t(1000000) * half_life);
+
+        CumulativeWeights result;
+        int32_t share_count = 0;
+        uint64_t decay_fp = DECAY_SCALE; // starts at 1.0
+
+        // Single-pass walk matching p2pool's while loop in
+        // get_decayed_cumulative_weights. No pre-collection needed.
+        //
+        // TODO(ltc-doge): pin exact intra-walk yield boundary + optional
+        // zero-divisor guard (degenerate target_ratio==0). This inner decay
+        // iteration is the candidate finest-grained yield point for the V36
+        // livelock lock-yield mechanism; the cooperative budget is currently
+        // enforced at the COARSE per-scored-head boundary in think() Phase 3
+        // (THINK_WALK_YIELD_BUDGET). Once PIE core symbolization pins the true
+        // hot site, move/refine the budget check here. The zero-divisor guard
+        // referenced is the `!this_total.IsNull()` proration guard just below
+        // (remaining / this_total) — confirm it covers the degenerate case.
+        auto cur = start;
+        while (!cur.IsNull() && chain.contains(cur) && share_count < max_shares)
+        {
+            chain.get_share(cur).invoke([&](auto* obj) {
+                auto att = chain::target_to_average_attempts(
+                    chain::bits_to_target(obj->m_bits));
+                uint32_t don = obj->m_donation;
+
+                uint288 decayed_att = (att * uint288(decay_fp)) >> DECAY_PRECISION;
+
+                auto addr_w = decayed_att * static_cast<uint32_t>(65535 - don);
+                auto don_w  = decayed_att * don;
+                auto this_total = addr_w + don_w; // = decayed_att * 65535
+
+                if (result.total_weight + this_total > desired_weight) {
+                    auto remaining = desired_weight - result.total_weight;
+                    if (!this_total.IsNull()) {
+                        addr_w = addr_w * remaining / this_total;
+                        don_w  = don_w * remaining / this_total;
+                    }
+                    this_total = remaining;
+                }
+
+                auto script = get_share_script(obj);
+                result.weights[script] += addr_w;
+                result.total_weight += this_total;
+                result.total_donation_weight += don_w;
+            });
+
+            ++share_count;
+            if (result.total_weight >= desired_weight)
+                break;
+
+            decay_fp = mul128_shift(decay_fp, decay_per, DECAY_PRECISION);
+
+            auto* idx = chain.get_index(cur);
+            cur = idx ? idx->tail : uint256();
+        }
+
+        // Cache result (single-entry, invalidated on chain change)
+        m_decayed_cache_start = start;
+        m_decayed_cache_shares = max_shares;
+        m_decayed_cache_desired = desired_weight;
+        m_decayed_cache_result = result;
+        m_decayed_cache_valid = true;
+
+        return result;
+    }
+
+    // -- Diagnostic: per-share V36 PPLNS walk dump --
+    // Walks from start_hash backward, logging every share's contribution.
+    // Output matches p2pool's [PARENT-PPLNS] stderr format for diff comparison.
+    // Call only from GENTX mismatch handler — never on the hot path.
+    void dump_v36_pplns_walk(const uint256& start_hash, int32_t max_shares)
+    {
+        if (start_hash.IsNull() || !chain.contains(start_hash))
+        {
+            LOG_WARNING << "[PPLNS-WALK] start=" << start_hash.GetHex().substr(0,16)
+                        << " NOT IN CHAIN — walk aborted";
+            return;
+        }
+
+        static constexpr uint64_t DECAY_PRECISION = 40;
+        static constexpr uint64_t DECAY_SCALE = uint64_t(1) << DECAY_PRECISION;
+        static constexpr uint64_t LN2_MICRO = 693147;
+
+        uint32_t half_life = std::max(PoolConfig::chain_length() / 4, uint32_t(1));
+        uint64_t decay_per = DECAY_SCALE - (DECAY_SCALE * LN2_MICRO) / (uint64_t(1000000) * half_life);
+
+        int32_t share_count = 0;
+        uint64_t decay_fp = DECAY_SCALE;
+        uint288 running_total;
+        uint288 running_donation;
+        std::map<std::vector<unsigned char>, uint288> per_addr_weight;
+
+        auto height = chain.get_height(start_hash);
+        auto last = chain.get_last(start_hash);
+
+        LOG_WARNING << "[PPLNS-WALK] start=" << start_hash.GetHex().substr(0, 16)
+                    << " max_shares=" << max_shares
+                    << " height=" << height
+                    << " last=" << (last.IsNull() ? "null" : last.GetHex().substr(0, 16))
+                    << " half_life=" << half_life
+                    << " decay_per=" << decay_per;
+
+        auto cur = start_hash;
+        while (!cur.IsNull() && chain.contains(cur) && share_count < max_shares)
+        {
+            chain.get_share(cur).invoke([&](auto* obj) {
+                auto target = chain::bits_to_target(obj->m_bits);
+                auto att = chain::target_to_average_attempts(target);
+                uint32_t don = obj->m_donation;
+
+                uint288 decayed_att = (att * uint288(decay_fp)) >> DECAY_PRECISION;
+                auto addr_w = decayed_att * static_cast<uint32_t>(65535 - don);
+                auto don_w  = decayed_att * don;
+
+                auto script = get_share_script(obj);
+                per_addr_weight[script] += addr_w;
+                running_total += addr_w + don_w;
+                running_donation += don_w;
+
+                // Script hex prefix (first 10 bytes, like p2pool's key.encode('hex')[:40])
+                static const char* HX = "0123456789abcdef";
+                std::string sh;
+                for (size_t i = 0; i < std::min(script.size(), size_t(20)); ++i) {
+                    sh += HX[script[i] >> 4];
+                    sh += HX[script[i] & 0xf];
+                }
+
+                LOG_WARNING << "[PPLNS-WALK]   #" << share_count
+                            << " hash=" << cur.GetHex().substr(0, 16)
+                            << " script=" << sh
+                            << " bits=0x" << std::hex << obj->m_bits << std::dec
+                            << " don=" << don
+                            << " att=" << att.GetLow64()
+                            << " decay_fp=" << decay_fp
+                            << " decayed=" << decayed_att.GetLow64()
+                            << " addr_w=" << addr_w.GetLow64()
+                            << " running=" << running_total.GetLow64();
+            });
+
+            ++share_count;
+
+            decay_fp = mul128_shift(decay_fp, decay_per, DECAY_PRECISION);
+            auto* idx = chain.get_index(cur);
+            cur = idx ? idx->tail : uint256();
+        }
+
+        // Summary matching p2pool's [PARENT-PPLNS] format
+        LOG_WARNING << "[PPLNS-WALK] SUMMARY: shares=" << share_count
+                    << " addrs=" << per_addr_weight.size()
+                    << " total_w=" << running_total.GetLow64()
+                    << " don_w=" << running_donation.GetLow64();
+        for (const auto& [script, weight] : per_addr_weight)
+        {
+            static const char* HX = "0123456789abcdef";
+            std::string sh;
+            for (size_t i = 0; i < std::min(script.size(), size_t(20)); ++i) {
+                sh += HX[script[i] >> 4];
+                sh += HX[script[i] & 0xf];
+            }
+            double pct = running_total.IsNull() ? 0.0 :
+                static_cast<double>(weight.GetLow64()) / static_cast<double>(running_total.GetLow64()) * 100.0;
+            LOG_WARNING << "[PPLNS-WALK]   " << sh
+                        << " w=" << weight.GetLow64()
+                        << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+        }
+
+        // Chain gap detection: check if walk terminated early (not at chain bottom)
+        if (share_count < max_shares && !cur.IsNull()) {
+            LOG_WARNING << "[PPLNS-WALK] CHAIN GAP: walk stopped at share #" << share_count
+                        << " — next hash " << cur.GetHex().substr(0, 16)
+                        << " is " << (chain.contains(cur) ? "IN chain (walk bug)" : "NOT IN chain (missing share)")
+                        << ". Expected " << max_shares << " shares.";
+        }
+    }
+
+    // -- Expected payouts from PPLNS weights --
+    // Uses exact integer arithmetic matching generate_share_transaction():
+    //   V36: amount = (uint288(subsidy) * weight / total_weight).GetLow64()
+    //   donation = subsidy - sum(amounts)
+    std::map<std::vector<unsigned char>, double>
+    get_expected_payouts(const uint256& best_share_hash, const uint256& block_target, uint64_t subsidy,
+                         const std::vector<unsigned char>& donation_script)
+    {
+        // Pass REAL_CHAIN_LENGTH as max_shares — the walk naturally stops
+        // when the chain ends, matching p2pool's direct iteration pattern.
+        // Do NOT use cached get_height() which can be stale in multi-threaded context.
+        auto chain_len = static_cast<int32_t>(PoolConfig::real_chain_length());
+        // V36: remove desired_weight cap — exponential decay handles windowing.
+        // See generate_share_transaction() for detailed rationale.
+        uint288 unlimited_weight;
+        unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        {
+            static int ep_log = 0;
+            if (ep_log++ % 20 == 0) {
+                LOG_DEBUG_DIAG << "[EP-PPLNS] v36 start=" << best_share_hash.GetHex().substr(0, 16)
+                         << " chain_len=" << chain_len
+                         << " subsidy=" << subsidy;
+            }
+        }
+        auto [weights, total_weight, donation_weight] = get_v36_decayed_cumulative_weights(best_share_hash, chain_len, unlimited_weight);
+
+        std::map<std::vector<unsigned char>, double> result;
+        uint64_t sum = 0;
+
+        if (!total_weight.IsNull())
+        {
+            for (const auto& [script, weight] : weights)
+            {
+                // Exact integer division matching generate_share_transaction (V36)
+                uint64_t amount = (uint288(subsidy) * weight / total_weight).GetLow64();
+                if (amount > 0)
+                {
+                    result[script] = static_cast<double>(amount);
+                    sum += amount;
+                }
+            }
+        }
+
+        // Remainder goes to donation (matches generate_share_transaction)
+        uint64_t donation_amount = (subsidy > sum) ? (subsidy - sum) : 0;
+
+        // V36 consensus: donation output must carry >= 1 satoshi (a60f7f7f)
+        if (donation_amount < 1 && subsidy > 0 && !result.empty()) {
+            // Deterministic tiebreak: (amount, script) — largest script wins when equal
+            auto largest = std::max_element(result.begin(), result.end(),
+                [](const auto& a, const auto& b) {
+                    if (a.second != b.second) return a.second < b.second;
+                    return a.first < b.first;
+                });
+            if (largest != result.end() && largest->second >= 1.0) {
+                largest->second -= 1.0;
+                sum -= 1;
+                donation_amount = subsidy - sum;
+            }
+        }
+
+        result[donation_script] = (result.contains(donation_script) ? result[donation_script] : 0.0)
+                                  + static_cast<double>(donation_amount);
+
+        return result;
+    }
+
+    // -- V35 PPLNS expected payouts --
+    // Flat (non-decayed) weights, GRANDPARENT start, height-1 window.
+    // Returns amounts WITHOUT finder fee — caller adds subsidy/200 to the
+    // share creator's script.  Donation absorbs the remainder.
+    // Reference: p2pool data.py lines 878-965
+    std::map<std::vector<unsigned char>, double>
+    get_v35_expected_payouts(const uint256& best_share_hash, const uint256& block_target, uint64_t subsidy,
+                             const std::vector<unsigned char>& donation_script)
+    {
+        // V35: PPLNS starts from the GRANDPARENT (prev_share.prev_hash)
+        // Reference: data.py line 884
+        uint256 pplns_start;
+        if (!best_share_hash.IsNull() && chain.contains(best_share_hash)) {
+            chain.get(best_share_hash).share.invoke([&](auto* s) {
+                pplns_start = s->m_prev_hash;  // grandparent
+            });
+        }
+
+        if (pplns_start.IsNull()) {
+            // No grandparent: all subsidy to donation
+            std::map<std::vector<unsigned char>, double> result;
+            result[donation_script] = static_cast<double>(subsidy);
+            return result;
+        }
+
+        // V35: max_shares = max(0, min(height, REAL_CHAIN_LENGTH) - 1)
+        // Reference: data.py line 885
+        auto height = chain.get_height(best_share_hash);
+        int32_t max_shares = std::max(0, std::min(height, static_cast<int32_t>(PoolConfig::real_chain_length())) - 1);
+
+        // V35: desired_weight = 65535 * SPREAD * target_to_average_attempts(block_target)
+        // Reference: data.py line 886
+        uint288 desired_weight = chain::target_to_average_attempts(block_target)
+                                 * uint288(PoolConfig::SPREAD) * uint288(65535);
+
+        {
+            static int ep35_log = 0;
+            if (ep35_log++ % 20 == 0) {
+                LOG_DEBUG_DIAG << "[EP-PPLNS] v35 start=" << pplns_start.GetHex().substr(0, 16)
+                         << " max_shares=" << max_shares
+                         << " desired_w=" << desired_weight.GetLow64()
+                         << " subsidy=" << subsidy
+                         << " best=" << best_share_hash.GetHex().substr(0, 16);
+            }
+        }
+        // Flat weight accumulation with hard cap (existing get_cumulative_weights)
+        auto [weights, total_weight, donation_weight] = get_cumulative_weights(pplns_start, max_shares, desired_weight);
+
+        std::map<std::vector<unsigned char>, double> result;
+        uint64_t sum = 0;
+
+        if (!total_weight.IsNull())
+        {
+            for (const auto& [script, weight] : weights)
+            {
+                // V35: 99.5% to PPLNS — subsidy * 199 * weight / (200 * total_weight)
+                // Reference: data.py line 924
+                uint64_t amount = (uint288(subsidy) * uint288(199) * weight / (uint288(200) * total_weight)).GetLow64();
+                if (amount > 0)
+                {
+                    result[script] = static_cast<double>(amount);
+                    sum += amount;
+                }
+            }
+        }
+
+        // Remainder goes to donation (includes the ~0.5% finder fee portion;
+        // caller subtracts subsidy/200 for the finder and assigns it per-connection)
+        // V35: NO minimum donation enforcement (unlike v36)
+        uint64_t donation_amount = (subsidy > sum) ? (subsidy - sum) : 0;
+        result[donation_script] = (result.contains(donation_script) ? result[donation_script] : 0.0)
+                                  + static_cast<double>(donation_amount);
+
+        // Periodic diagnostic dump for cross-impl comparison
+        {
+            static int v35_dump = 0;
+            if (v35_dump++ < 10 || v35_dump % 60 == 0) {
+                LOG_DEBUG_DIAG << "[V35-PPLNS] subsidy=" << subsidy << " addrs=" << weights.size()
+                         << " total_w=" << total_weight.GetLow64()
+                         << " max_shares=" << max_shares << " sum=" << sum
+                         << " donation=" << donation_amount
+                         << " prev=" << best_share_hash.GetHex().substr(0, 16)
+                         << " grandparent=" << pplns_start.GetHex().substr(0, 16);
+            }
+        }
+
+        return result;
+    }
+
+    // -- Stale share proportion --
+    float get_average_stale_prop(const uint256& share_hash, uint64_t lookbehind)
+    {
+        auto height = chain.get_height(share_hash);
+        auto actual_lookbehind = std::min(static_cast<int32_t>(lookbehind), height);
+        if (actual_lookbehind <= 0)
+            return 0.0f;
+
+        float stale_count = 0;
+        auto view = chain.get_chain(share_hash, actual_lookbehind);
+        for (auto [hash, data] : view)
+        {
+            StaleInfo si = StaleInfo::none;
+            data.share.invoke([&](auto* obj) { si = obj->m_stale_info; });
+            if (si != StaleInfo::none)
+                stale_count += 1.0f;
+        }
+
+        return stale_count / (stale_count + static_cast<float>(actual_lookbehind));
+    }
+
+    // -- Stale share counts by type --
+    StaleCounts get_stale_counts(const uint256& share_hash, uint64_t lookbehind)
+    {
+        StaleCounts counts;
+        auto height = chain.get_height(share_hash);
+        auto actual_lookbehind = std::min(static_cast<int32_t>(lookbehind), height);
+        if (actual_lookbehind <= 0)
+            return counts;
+
+        auto view = chain.get_chain(share_hash, actual_lookbehind);
+        for (auto [hash, data] : view)
+        {
+            StaleInfo si = StaleInfo::none;
+            data.share.invoke([&](auto* obj) { si = obj->m_stale_info; });
+            if (si == StaleInfo::orphan)
+                counts.orphan_count++;
+            else if (si == StaleInfo::doa)
+                counts.doa_count++;
+        }
+        counts.total = counts.orphan_count + counts.doa_count;
+        return counts;
+    }
+
+    // -- Stale change callback registration --
+    using stale_callback_t = std::function<void(const uint256& /*share_hash*/, StaleInfo /*new_stale_info*/)>;
+
+    void subscribe_stale_change(stale_callback_t cb)
+    {
+        m_stale_callbacks.push_back(std::move(cb));
+    }
+
+    void notify_stale_change(const uint256& share_hash, StaleInfo info)
+    {
+        for (auto& cb : m_stale_callbacks)
+            cb(share_hash, info);
+    }
+
+    // -- Version counting for AutoRatchet upgrade coordination --
+    // Walks back `lookbehind` shares from `share_hash` and counts
+    // how many desire each version. Returns map of version → count.
+    // Python ref: tracker.get_desired_version_counts(...)
+    std::map<uint64_t, int32_t> get_desired_version_counts(const uint256& share_hash, int32_t lookbehind)
+    {
+        std::map<uint64_t, int32_t> counts;
+        if (!chain.contains(share_hash))
+            return counts;
+        auto height = chain.get_height(share_hash);
+        auto actual = std::min(lookbehind, height);
+        if (actual <= 0)
+            return counts;
+
+        auto view = chain.get_chain(share_hash, actual);
+        for (auto [hash, data] : view)
+        {
+            uint64_t dv = 0;
+            data.share.invoke([&](auto* obj) { dv = obj->m_desired_version; });
+            counts[dv]++;
+        }
+        return counts;
+    }
+
+    // Work-weighted version tally over a lookbehind window. Mirrors
+    // get_desired_version_counts but weights each share by its work
+    // (target_to_average_attempts), matching canonical p2pool
+    // get_desired_version_counts (data.py:2651) — the COUNTS name is a
+    // misnomer; the canonical tally is WORK-weighted. The consensus accept
+    // gate keys the 60% switch rule off this work-weighted tally, so the
+    // AutoRatchet mint gate must evaluate the same weighting to stay coupled.
+    // Returns map of version -> accumulated work weight.
+    std::map<uint64_t, uint288> get_desired_version_weights(const uint256& share_hash, int32_t lookbehind)
+    {
+        std::map<uint64_t, uint288> weights;
+        if (!chain.contains(share_hash))
+            return weights;
+        auto height = chain.get_height(share_hash);
+        auto actual = std::min(lookbehind, height);
+        if (actual <= 0)
+            return weights;
+
+        auto view = chain.get_chain(share_hash, actual);
+        for (auto [hash, data] : view)
+        {
+            uint64_t dv = 0;
+            data.share.invoke([&](auto* obj) { dv = obj->m_desired_version; });
+            auto* idx = chain.get_index(hash);
+            if (idx)
+                weights[dv] = weights[dv] + idx->work;
+        }
+        return weights;
+    }
+
+    // -- Merged mining: per-chain PPLNS weights --
+    // For a specific aux chain_id, walk the share chain and accumulate PPLNS
+    // weights for V36-signaling shares.  Uses O(log n) skip list.
+    CumulativeWeights get_merged_cumulative_weights(
+        const uint256& start, int32_t max_shares,
+        const uint288& desired_weight, uint32_t target_chain_id)
+    {
+        if (start.IsNull())
+            return {};
+
+        auto& sl = ensure_merged_skiplist(target_chain_id);
+        auto result = sl.query(start, max_shares, desired_weight);
+
+        // [DOGE-PPLNS] Per-address breakdown — shows whether autoconverted
+        // addresses appear in merged PPLNS weights.  Log once per new height.
+        {
+            static int32_t s_last_doge_height = -1;
+            auto h = chain.get_height(start);
+            if (h != s_last_doge_height) {
+                s_last_doge_height = h;
+                auto to_dec = [](const uint288& val) -> std::string {
+                    if (val.IsNull()) return "0";
+                    uint288 tmp = val; std::string r;
+                    while (!tmp.IsNull()) {
+                        uint32_t rem = 0;
+                        for (int i = uint288::WIDTH - 1; i >= 0; --i) {
+                            uint64_t cur = (static_cast<uint64_t>(rem) << 32) | tmp.pn[i];
+                            tmp.pn[i] = static_cast<uint32_t>(cur / 10);
+                            rem = static_cast<uint32_t>(cur % 10);
+                        }
+                        r.push_back('0' + static_cast<char>(rem));
+                    }
+                    std::reverse(r.begin(), r.end());
+                    return r;
+                };
+                auto to_hex = [](const std::vector<unsigned char>& s) -> std::string {
+                    static const char* H = "0123456789abcdef";
+                    std::string r; r.reserve(s.size() * 2);
+                    for (auto b : s) { r += H[b >> 4]; r += H[b & 0xf]; }
+                    return r;
+                };
+                // Classify script type for diagnostics
+                auto classify = [](const std::vector<unsigned char>& s) -> const char* {
+                    if (is_merged_key(s)) return "MERGED";
+                    if (s.size() == 25 && s[0] == 0x76 && s[1] == 0xa9) return "P2PKH";
+                    if (s.size() == 23 && s[0] == 0xa9) return "P2SH";
+                    if (s.size() == 22 && s[0] == 0x00 && s[1] == 0x14) return "P2WPKH-RAW";
+                    if (s.size() == 34 && s[0] == 0x00 && s[1] == 0x20) return "P2WSH-RAW";
+                    if (s.size() == 34 && s[0] == 0x51 && s[1] == 0x20) return "P2TR-RAW";
+                    return "OTHER";
+                };
+                LOG_INFO << "[DOGE-PPLNS] chain_id=" << target_chain_id
+                         << " height=" << h
+                         << " max_shares=" << max_shares
+                         << " addrs=" << result.weights.size()
+                         << " total_w=" << to_dec(result.total_weight)
+                         << " don_w=" << to_dec(result.total_donation_weight)
+                         << " start=" << start.GetHex().substr(0, 16);
+                for (const auto& [key, w] : result.weights) {
+                    double pct = 0;
+                    if (!result.total_weight.IsNull())
+                        pct = (w * 10000 / result.total_weight).GetLow64() / 100.0;
+                    auto hex = to_hex(key);
+                    LOG_INFO << "[DOGE-PPLNS]   " << classify(key)
+                             << " " << hex.substr(0, 40)
+                             << " w=" << to_dec(w)
+                             << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                }
+            }
+        }
+
+        return {std::move(result.weights), result.total_weight, result.total_donation_weight};
+    }
+
+    // -- V36-only unified merged weights (no chain_id) --
+    // Accumulates PPLNS weights for V36-signaling shares ONLY, keyed by
+    // parent chain address.  Uses O(log n) skip list.
+    CumulativeWeights get_v36_merged_weights(
+        const uint256& start, int32_t max_shares, const uint288& desired_weight)
+    {
+        if (start.IsNull())
+            return {};
+
+        ensure_v36_skiplist();
+        auto result = m_v36_weights_skiplist->query(start, max_shares, desired_weight);
+        return {std::move(result.weights), result.total_weight, result.total_donation_weight};
+    }
+
+    // -- merged_weights_delta (F2: single source of truth) --
+    // Unified per-share merged-mining PPLNS weight delta.  Replaces the three
+    // formerly-divergent variants (the compute_merged_payout_hash inline walk,
+    // ensure_v36_skiplist, and per-chain ensure_merged_skiplist).  Mirrors
+    // p2pool MergedWeightsSkipList.get_delta (data.py:1864) and LTC F2
+    // (08f269026); BTC keeps the F1 raw default (#85), so this is a pure
+    // structural unification -- the default key was already the raw parent
+    // script in all three sites, no key-semantics change.
+    //
+    //   chain_id == nullopt : hash / v36 path -- no merged-address resolution.
+    //   chain_id has value  : per-chain path -- Tier 1 explicit merged_addresses,
+    //                         Tier 1.5 retroactive miner->merged lookup (normalize
+    //                         used only as a lookup PROBE), else the default key.
+    //
+    // Pre-V36 shares count toward window sizing but contribute zero weight
+    // (p2pool returns (1, {}, 0, 0)); total_weight/donation are set only once a
+    // weight key resolves, so unconvertible/empty scripts never inflate the
+    // denominator.  This (1,{},0,0)-after-key-resolves shape converges the
+    // hash-path variant, which previously set totals before the empty-script
+    // check; convertible scripts are unaffected, so the merged-payout KAT holds.
+    template <class ShareT>
+    chain::WeightsDelta merged_weights_delta(ShareT* obj, std::optional<uint32_t> chain_id)
+    {
+        chain::WeightsDelta delta;
+        delta.share_count = 1;
+        if (obj->m_desired_version < 36)
+            return delta;
+
+        auto target = chain::bits_to_target(obj->m_bits);
+        auto att = chain::target_to_average_attempts(target);
+        auto parent_script = get_share_script(obj);
+        if (parent_script.empty())
+            return delta;
+
+        std::vector<unsigned char> weight_key;
+        // Tier 1 / 1.5 merged-address resolution -- only for chain-keyed skiplists
+        // whose share type carries explicit merged_addresses.
+        if (chain_id.has_value())
+        {
+            if constexpr (requires { obj->m_merged_addresses; })
+            {
+                // Tier 1: explicit merged_addresses for this chain.
+                for (const auto& entry : obj->m_merged_addresses)
+                {
+                    if (entry.m_chain_id == *chain_id)
+                    {
+                        weight_key = make_merged_key(entry.m_script.m_data);
+                        break;
+                    }
+                }
+                // Tier 1.5: retroactive lookup of the same miner's explicit merged
+                // address from their other shares.  Try the raw parent script, then
+                // its normalized P2PKH form (normalize is a lookup PROBE only here).
+                if (weight_key.empty())
+                {
+                    auto table_it = m_miner_merged_addr.find(*chain_id);
+                    if (table_it != m_miner_merged_addr.end())
+                    {
+                        auto miner_it = table_it->second.find(parent_script);
+                        if (miner_it == table_it->second.end())
+                        {
+                            auto norm = normalize_script_for_merged(parent_script);
+                            if (!norm.empty() && norm != parent_script)
+                                miner_it = table_it->second.find(norm);
+                        }
+                        if (miner_it != table_it->second.end())
+                            weight_key = make_merged_key(miner_it->second);
+                    }
+                }
+            }
+        }
+
+        // Default key: RAW parent script, matching p2pool address_key =
+        // share.new_script (F1, Option A, #85).  normalize_script_for_merged
+        // stays a Tier-1.5 lookup PROBE only (above).
+        if (weight_key.empty())
+            weight_key = parent_script;
+        if (weight_key.empty())
+            return delta;
+
+        delta.total_weight = att * 65535;
+        delta.total_donation_weight = att * static_cast<uint32_t>(obj->m_donation);
+        delta.weights[weight_key] = att * static_cast<uint32_t>(65535 - obj->m_donation);
+        return delta;
+    }
+
+    // Per-hash wrapper: the boilerplate shared by every merged-weight skiplist
+    // lambda -- bounds-check the raw chain, then dispatch to merged_weights_delta.
+    chain::WeightsDelta merged_weights_delta_for_hash(
+        const uint256& hash, std::optional<uint32_t> chain_id)
+    {
+        chain::WeightsDelta delta;
+        if (!chain.contains(hash)) return delta;
+        chain.get_share(hash).invoke([&](auto* obj) {
+            delta = merged_weights_delta(obj, chain_id);
+        });
+        return delta;
+    }
+
+    // -- compute_merged_payout_hash --
+    // Deterministic hash of V36-only PPLNS weight distribution.
+    // Committed into V36 shares so peers can verify that the share creator's
+    // merged mining payouts match the expected distribution.
+    //
+    // Format: sorted "addr_hex:weight|...|T:total|D:donation" → SHA256d
+    // Returns zero uint256 if no V36 shares in window.
+    //
+    // Python ref: p2pool/data.py compute_merged_payout_hash()
+    uint256 compute_merged_payout_hash(
+        const uint256& prev_share_hash, const uint256& block_target)
+    {
+        if (prev_share_hash.IsNull())
+            return uint256{};
+
+        // Use RAW chain — matches p2pool's compute_merged_payout_hash()
+        // which uses tracker (raw), not tracker.verified.
+        // Using verified chain caused zero returns when prev_share wasn't
+        // yet verified → ref_hash mismatch → GENTX-FAIL.
+        if (!chain.contains(prev_share_hash))
+            return uint256{};
+
+        auto height = chain.get_height(prev_share_hash);
+        if (height == 0)
+            return uint256{};
+
+        // No chain depth guard — p2pool computes merged_payout_hash for ANY
+        // height > 0 using chain_length = min(height, REAL_CHAIN_LENGTH).
+        // The previous guard (height < CHAIN_LENGTH → return zero) caused
+        // ref_hash mismatch because p2pool computed a real hash while c2pool
+        // returned zero.
+
+        // Unlimited desired_weight — V36 exponential decay handles windowing.
+        uint288 unlimited_weight;
+        unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        auto chain_len = std::min(height,
+                                  static_cast<int32_t>(PoolConfig::real_chain_length()));
+
+        // Walk RAW chain (not verified) — matches p2pool's compute_merged_payout_hash
+        // which uses tracker (raw). Using verified chain causes hash mismatch when
+        // the verified chain is shorter (during sync or with missing ancestors).
+        auto raw_prev_fn = [this](const uint256& hash) -> uint256 {
+            if (!chain.contains(hash)) return uint256{};
+            return chain.get_index(hash)->tail;
+        };
+        chain::WeightsSkipList raw_sl(
+            [this](const uint256& hash) -> chain::WeightsDelta {
+                // F2: unified merged-weight delta, hash/v36 path (no chain_id).
+                return merged_weights_delta_for_hash(hash, std::nullopt);
+            },
+            std::move(raw_prev_fn)
+        );
+        auto result = raw_sl.query(prev_share_hash, chain_len, unlimited_weight);
+        auto weights = std::move(result.weights);
+        auto total_weight = result.total_weight;
+        auto donation_weight = result.total_donation_weight;
+
+        if (weights.empty() || total_weight.IsNull())
+            return uint256{};
+
+        // Convert uint288 to decimal string, matching Python's '%d' formatting
+        auto to_decimal = [](const uint288& val) -> std::string {
+            if (val.IsNull()) return "0";
+            uint288 tmp = val;
+            std::string result;
+            while (!tmp.IsNull()) {
+                uint32_t rem = 0;
+                for (int i = uint288::WIDTH - 1; i >= 0; --i) {
+                    uint64_t cur = (static_cast<uint64_t>(rem) << 32) | tmp.pn[i];
+                    tmp.pn[i] = static_cast<uint32_t>(cur / 10);
+                    rem = static_cast<uint32_t>(cur % 10);
+                }
+                result.push_back('0' + static_cast<char>(rem));
+            }
+            std::reverse(result.begin(), result.end());
+            return result;
+        };
+
+        // Convert script bytes to hex string for deterministic serialization.
+        // V36 consensus: sort and serialize by script hex (not address string).
+        // Matches p2pool's compute_merged_payout_hash() which uses script.encode('hex').
+        auto script_to_hex = [](const std::vector<unsigned char>& script) -> std::string {
+            static const char digits[] = "0123456789abcdef";
+            std::string hex;
+            hex.reserve(script.size() * 2);
+            for (unsigned char c : script) {
+                hex.push_back(digits[c >> 4]);
+                hex.push_back(digits[c & 0xf]);
+            }
+            return hex;
+        };
+
+        // Deterministic serialization: sorted by script hex (V36 consensus)
+        // Format: "script_hex1:weight1|script_hex2:weight2|...|T:total|D:donation"
+        std::map<std::string, uint288> sorted_by_script;
+        for (const auto& [script, w] : weights)
+            sorted_by_script[script_to_hex(script)] += w;
+
+        std::string payload;
+        for (const auto& [script_hex, w] : sorted_by_script)
+        {
+            if (!payload.empty())
+                payload.push_back('|');
+            payload += script_hex;
+            payload.push_back(':');
+            payload += to_decimal(w);
+        }
+        // Append total and donation
+        payload += "|T:";
+        payload += to_decimal(total_weight);
+        payload += "|D:";
+        payload += to_decimal(donation_weight);
+
+        // SHA256d (hash256 in p2pool)
+        auto span = std::span<const unsigned char>(
+            reinterpret_cast<const unsigned char*>(payload.data()), payload.size());
+        auto hash_result = Hash(span);
+
+        // Per-address merged PPLNS breakdown — log once per new chain height
+        // for death valley comparison between p2pool and c2pool.
+        {
+            static int32_t s_last_log_height = -1;
+            if (height != s_last_log_height) {
+                s_last_log_height = height;
+                LOG_INFO << "[MERGED-PPLNS] height=" << height
+                         << " chain_len=" << chain_len
+                         << " addrs=" << sorted_by_script.size()
+                         << " total_w=" << to_decimal(total_weight)
+                         << " don_w=" << to_decimal(donation_weight);
+                for (const auto& [script_hex, w] : sorted_by_script) {
+                    double pct = 0;
+                    if (!total_weight.IsNull()) {
+                        pct = (w * 10000 / total_weight).GetLow64() / 100.0;
+                    }
+                    LOG_INFO << "[MERGED-PPLNS]   " << script_hex.substr(0, 40)
+                             << " w=" << to_decimal(w)
+                             << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                }
+                LOG_INFO << "[MERGED-PPLNS]   hash=" << hash_result.GetHex();
+
+                // Per-aux-chain payout weights (Tier 1/1.5/2 resolution) -- the
+                // distribution that drives each merged child's coinbase outputs.
+                // During death valley, compare address count and keys vs
+                // [MERGED-PPLNS]. chain_id is sourced from each backend's own
+                // params (v37 bucket-2 standardization, note #2): no hardcoded
+                // chain_id literal lives in this shared path.
+                struct AuxPayoutChain { const char* name; uint32_t chain_id; };
+                static constexpr AuxPayoutChain kAuxPayoutChains[] = {
+                    { "DOGE", doge::coin::DOGEChainParams::AUXPOW_CHAIN_ID }, // 0x0062
+                    { "NMC",  nmc::coin::NMC_AUXPOW_CHAIN_ID },               // 0x0001
+                };
+                uint288 aux_unlimited;
+                aux_unlimited.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+                auto classify_aux = [](const std::vector<unsigned char>& s) -> const char* {
+                    if (is_merged_key(s)) return "MERGED";
+                    if (s.size() == 25 && s[0] == 0x76 && s[1] == 0xa9) return "P2PKH";
+                    if (s.size() == 23 && s[0] == 0xa9) return "P2SH";
+                    if (s.size() == 22 && s[0] == 0x00 && s[1] == 0x14) return "P2WPKH-RAW";
+                    if (s.size() == 34 && s[0] == 0x00 && s[1] == 0x20) return "P2WSH-RAW";
+                    if (s.size() == 34 && s[0] == 0x51 && s[1] == 0x20) return "P2TR-RAW";
+                    return "OTHER";
+                };
+                for (const auto& aux : kAuxPayoutChains) {
+                    auto aux_result = get_merged_cumulative_weights(
+                        prev_share_hash, chain_len, aux_unlimited, aux.chain_id);
+                    auto aux_miner_w = aux_result.total_weight - aux_result.total_donation_weight;
+                    LOG_INFO << "[" << aux.name << "-PAYOUT] height=" << height
+                             << " chain_id=" << aux.chain_id
+                             << " addrs=" << aux_result.weights.size()
+                             << " total_w=" << to_decimal(aux_result.total_weight)
+                             << " don_w=" << to_decimal(aux_result.total_donation_weight);
+                    for (const auto& [script, w] : aux_result.weights) {
+                        double pct = 0;
+                        if (!aux_miner_w.IsNull())
+                            pct = (w * 10000 / aux_miner_w).GetLow64() / 100.0;
+                        LOG_INFO << "[" << aux.name << "-PAYOUT]   " << classify_aux(script)
+                                 << " " << script_to_hex(script).substr(0, 50)
+                                 << " w=" << to_decimal(w)
+                                 << " pct=" << std::fixed << std::setprecision(2) << pct << "%";
+                    }
+                }
+            }
+        }
+
+        return hash_result;
+    }
+
+    // -- Merged mining: per-chain expected payouts --
+    // Given an aux chain's subsidy and chain_id, computes the expected payout
+    // distribution using merged PPLNS weights.
+    // Uses INTEGER arithmetic matching p2pool's build_canonical_merged_coinbase
+    // exactly — no floating point anywhere.
+    //
+    // p2pool algorithm:
+    //   grand_total = total_weight (already includes donation_weight)
+    //   donation_amount = coinbase_value * donation_weight // grand_total
+    //   miners_reward = coinbase_value - donation_amount
+    //   accepted_total = sum of convertible miner weights (== total_weight - donation_weight here)
+    //   per_miner = miners_reward * w // accepted_total
+    //   rounding_remainder = miners_reward - sum(per_miner)
+    //   final_donation = donation_amount + rounding_remainder
+    std::map<std::vector<unsigned char>, uint64_t>
+    get_merged_expected_payouts(const uint256& best_share_hash,
+                                const uint256& block_target,
+                                uint64_t subsidy,
+                                uint32_t chain_id,
+                                const std::vector<unsigned char>& donation_script,
+                                const std::vector<unsigned char>& operator_ltc_script = {},
+                                const std::vector<unsigned char>& operator_merged_script = {})
+    {
+        auto chain_len = std::min(chain.get_height(best_share_hash),
+                                  static_cast<int32_t>(PoolConfig::real_chain_length()));
+        // Unlimited desired_weight — exponential decay handles windowing.
+        uint288 unlimited_weight;
+        unlimited_weight.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+
+        auto [weights, total_weight, donation_weight] =
+            get_merged_cumulative_weights(best_share_hash, chain_len, unlimited_weight, chain_id);
+
+        std::map<std::vector<unsigned char>, uint64_t> result;
+
+        if (total_weight.IsNull() || subsidy == 0)
+            return result;
+
+        // Integer division matching p2pool's payout arithmetic (using uint288 throughout
+        // to avoid uint64 truncation — total_weight routinely exceeds 2^64):
+        // donation_amount = subsidy * donation_weight // total_weight
+        uint288 subsidy288(subsidy);
+        uint64_t donation_amount = 0;
+        if (!donation_weight.IsNull()) {
+            donation_amount = (subsidy288 * donation_weight / total_weight).GetLow64();
+        }
+
+        // finder_fee = 0 (CANONICAL_MERGED_FINDER_FEE_PER_MILLE = 0 in p2pool)
+        uint64_t miners_reward = subsidy - donation_amount;
+
+        // p2pool data.py:220-269: accepted_total_weight is the sum of ONLY
+        // convertible weights (after filtering unconvertible P2WSH/P2TR).
+        // NOT total_weight - donation_weight (which includes unconvertible).
+        // First pass: resolve scripts and compute accepted_total
+        struct ResolvedEntry {
+            std::vector<unsigned char> script;
+            uint288 weight;
+        };
+        std::vector<ResolvedEntry> resolved;
+        uint288 accepted_total;
+        for (const auto& [key, weight] : weights) {
+            std::vector<unsigned char> script;
+            if (!operator_ltc_script.empty() && !operator_merged_script.empty() && key == operator_ltc_script) {
+                script = operator_merged_script;
+            } else {
+                script = resolve_merged_payout_script(key);
+            }
+            if (script.empty()) continue;  // Unconvertible (P2WSH, P2TR) — skip
+            resolved.push_back({std::move(script), weight});
+            accepted_total = accepted_total + weight;
+        }
+
+        // Second pass: distribute miners_reward proportionally (uint288 arithmetic)
+        uint64_t total_distributed = 0;
+        uint288 miners_reward288(miners_reward);
+        for (const auto& entry : resolved) {
+            uint64_t amount = !accepted_total.IsNull()
+                ? (miners_reward288 * entry.weight / accepted_total).GetLow64()
+                : 0;
+            if (amount > 0) {
+                result[entry.script] += amount;
+                total_distributed += amount;
+            }
+        }
+
+        // Rounding remainder → donation (integer division truncates)
+        // Guard against uint64 underflow: total_distributed can exceed miners_reward
+        // when per-miner rounding accumulates beyond the pool (rare with many miners).
+        uint64_t remainder = (total_distributed <= miners_reward) ? (miners_reward - total_distributed) : 0;
+        uint64_t final_donation = donation_amount + remainder;
+
+        // V36 CONSENSUS RULE: Donation must be >= 1 satoshi
+        if (final_donation < 1 && static_cast<int64_t>(subsidy) > 0 && !result.empty()) {
+            // Deduct from largest miner (deterministic tiebreak by script)
+            auto largest = std::max_element(result.begin(), result.end(),
+                [](const auto& a, const auto& b) {
+                    if (a.second != b.second) return a.second < b.second;
+                    return a.first < b.first;
+                });
+            if (largest != result.end()) {
+                largest->second -= 1;
+                final_donation += 1;
+            }
+        }
+
+        result[donation_script] = (result.contains(donation_script) ? result[donation_script] : 0ULL)
+                                  + static_cast<uint64_t>(final_donation);
+
+        return result;
+    }
+
+    // F10/(b): should_punish_version (the 95%-obsolescence punish) was removed.
+    // It was non-canonical — canonical p2pool check() has no 95% obsolescence
+    // rule; the AutoRatchet (work-weighted, per #290) plus the 60% weighted
+    // switch rule (share_check step 2) are the only version gates. Keeping it
+    // would punish/score-down shares canonical accepts, breaking the #81 zero-
+    // divergence gate. Head-scoring (Phase 4) now punishes only naughty heads.
+
+private:
+    std::vector<stale_callback_t> m_stale_callbacks;
+
+    // -- Skip list caches for O(log n) weight queries --
+    std::optional<chain::WeightsSkipList> m_weights_skiplist;
+    std::optional<chain::WeightsSkipList> m_v36_weights_skiplist;
+    std::unordered_map<uint32_t, chain::WeightsSkipList> m_merged_skiplists;
+
+    // -- Retroactive merged address lookup table --
+    // Maps (chain_id) → (parent_script → explicit_merged_script).
+    // Populated incrementally as V36 shares with explicit merged_addresses
+    // are added.  Used as "Tier 1.5" in the merged skip list lambda:
+    // when a V36 share has empty merged_addresses (activation-boundary race),
+    // look up the same miner's explicit address from their other shares.
+    std::unordered_map<uint32_t,
+        std::map<std::vector<unsigned char>, std::vector<unsigned char>>> m_miner_merged_addr;
+
+    // Register explicit merged addresses from a share into the lookup table.
+    // If a NEW miner→address mapping is discovered, invalidates the merged
+    // skip list for that chain_id so affected shares get recomputed.
+    template <typename ShareT>
+    void try_register_merged_addr(ShareT* share)
+    {
+        if constexpr (requires { share->m_merged_addresses; })
+        {
+            if (share->m_desired_version < 36) return;
+            if (share->m_merged_addresses.empty()) return;
+            auto parent_script = get_share_script(share);
+            if (parent_script.empty()) return;
+            for (const auto& entry : share->m_merged_addresses)
+            {
+                if (entry.m_script.m_data.empty()) continue;
+                auto& lookup = m_miner_merged_addr[entry.m_chain_id];
+                bool any_new = false;
+                // Register under raw script (primary key)
+                // p2pool v0.14.5: lookup[item.new_script] = script
+                auto [it, inserted] = lookup.emplace(parent_script, entry.m_script.m_data);
+                if (inserted) any_new = true;
+                // Also register under normalized P2PKH form so
+                // Tier 1.5 catches shares with different script encoding.
+                // p2pool v0.14.5: lookup[normalized] = script
+                auto normalized = normalize_script_for_merged(parent_script);
+                if (!normalized.empty() && normalized != parent_script) {
+                    auto [it2, ins2] = lookup.emplace(normalized, entry.m_script.m_data);
+                    if (ins2) any_new = true;
+                }
+                if (any_new)
+                {
+                    // New mapping — stale skip list entries used auto-convert
+                    // for this miner; recreate to use the explicit address.
+                    m_merged_skiplists.erase(entry.m_chain_id);
+                    auto to_hex_short = [](const std::vector<unsigned char>& s, size_t n = 20) {
+                        static const char* H = "0123456789abcdef";
+                        std::string r; for (size_t i = 0; i < std::min(s.size(), n); ++i) { r += H[s[i]>>4]; r += H[s[i]&0xf]; }
+                        return r;
+                    };
+                    LOG_INFO << "[MERGED-REG] NEW chain_id=" << entry.m_chain_id
+                             << " parent=" << to_hex_short(parent_script)
+                             << " merged=" << to_hex_short(entry.m_script.m_data)
+                             << " — skiplist invalidated";
+                }
+            }
+        }
+    }
+
+    // Previous-share lambda for RAW chain (work templates, general PPLNS)
+    auto make_previous_fn()
+    {
+        return [this](const uint256& hash) -> uint256 {
+            if (!chain.contains(hash)) return uint256{};
+            return chain.get_index(hash)->tail;
+        };
+    }
+
+    // Previous-share lambda for VERIFIED chain (consensus hash computation).
+    // Ensures compute_merged_payout_hash only walks shares that all peers
+    // agree on — prevents c2pool's own unverified shares from polluting
+    // the weight distribution and causing consensus divergence.
+    auto make_verified_previous_fn()
+    {
+        return [this](const uint256& hash) -> uint256 {
+            if (!verified.contains(hash)) return uint256{};
+            return verified.get_index(hash)->tail;
+        };
+    }
+
+    void ensure_weights_skiplist()
+    {
+        if (m_weights_skiplist)
+            return;
+        m_weights_skiplist.emplace(
+            [this](const uint256& hash) -> chain::WeightsDelta {
+                chain::WeightsDelta delta;
+                if (!chain.contains(hash)) return delta;
+                delta.share_count = 1;
+                chain.get_share(hash).invoke([&](auto* obj) {
+                    auto target = chain::bits_to_target(obj->m_bits);
+                    auto att = chain::target_to_average_attempts(target);
+                    delta.total_weight = att * 65535;
+                    delta.total_donation_weight = att * static_cast<uint32_t>(obj->m_donation);
+                    auto addr_bytes = get_share_script(obj);
+                    delta.weights[addr_bytes] = att * static_cast<uint32_t>(65535 - obj->m_donation);
+                });
+                return delta;
+            },
+            make_previous_fn()
+        );
+    }
+
+    void ensure_v36_skiplist()
+    {
+        if (m_v36_weights_skiplist)
+            return;
+        m_v36_weights_skiplist.emplace(
+            [this](const uint256& hash) -> chain::WeightsDelta {
+                // F2: unified merged-weight delta, hash/v36 path (no chain_id).
+                return merged_weights_delta_for_hash(hash, std::nullopt);
+            },
+            make_previous_fn()
+        );
+    }
+
+    chain::WeightsSkipList& ensure_merged_skiplist(uint32_t chain_id)
+    {
+        auto it = m_merged_skiplists.find(chain_id);
+        if (it != m_merged_skiplists.end())
+            return it->second;
+
+        auto [new_it, _] = m_merged_skiplists.emplace(
+            chain_id,
+            chain::WeightsSkipList(
+                [this, chain_id](const uint256& hash) -> chain::WeightsDelta {
+                    // F2: unified merged-weight delta, per-chain path.
+                    return merged_weights_delta_for_hash(hash, chain_id);
+                },
+                make_previous_fn()
+            )
+        );
+        return new_it->second;
+    }
+
+    void invalidate_weight_caches(const uint256& hash)
+    {
+        if (m_weights_skiplist) m_weights_skiplist->forget(hash);
+        if (m_v36_weights_skiplist) m_v36_weights_skiplist->forget(hash);
+        for (auto& [_, sl] : m_merged_skiplists) sl.forget(hash);
+        m_decayed_cache_valid = false; // chain changed — decayed cache stale
+    }
+
+    // ── Dense PPLNS cache priming ─────────────────────────────────────
+    // Pre-populate the decayed weights cache from a HeadPPLNS ring buffer.
+    // Called before each attempt_verify() in think() Phase 2 so that
+    // generate_share_transaction() → get_v36_decayed_cumulative_weights()
+    // hits the O(1) cache instead of doing an O(chain_len) walk.
+    //
+    // The ring buffer uses the precomputed decay table which is BIT-EXACT
+    // with the iterative walk (same truncation at each step). This is NOT
+    // an approximation — it produces identical CumulativeWeights.
+    void prime_pplns_cache(const uint256& start, int32_t max_shares,
+                           const CumulativeWeights& weights) {
+        m_decayed_cache_start = start;
+        m_decayed_cache_shares = max_shares;
+        // Verification always uses unlimited desired_weight
+        m_decayed_cache_desired.SetHex(
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+        m_decayed_cache_result = weights;
+        m_decayed_cache_valid = true;
+    }
+
+    // -- Decayed weights result cache --
+    // Avoids recomputing the O(chain_length) walk when the same
+    // (start, max_shares) is queried multiple times between chain changes
+    // (e.g. verify_share + get_expected_payouts for the same share).
+    bool m_decayed_cache_valid{false};
+    uint256 m_decayed_cache_start;
+    int32_t m_decayed_cache_shares{0};
+    uint288 m_decayed_cache_desired;
+    CumulativeWeights m_decayed_cache_result;
+};
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_tx_refs.hpp
+++ b/src/impl/bip110/pool/share_tx_refs.hpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Uniform access to a share's "new transaction hashes" list — bip110 lane copy of
+// src/impl/btc/share_tx_refs.hpp (namespace-swapped btc -> bip110::pool). The
+// v36-genesis chain carries the MergedMiningShare variant ONLY, which has neither
+// m_tx_info nor m_new_transaction_hashes, so new_tx_hashes() resolves to the
+// nullptr branch (correct: a v36 share carries no per-share new-tx list — jtoomim
+// moved tx/fee validation to getblocktemplate for v34+). No consensus delta; the
+// accessor exists so the node's F3 broadcast gate never silently no-ops on a
+// member-name mismatch (the #880 class).
+
+#pragma once
+
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace bip110::pool {
+
+// Pointer to the share's new-transaction-hash list, or nullptr when this share
+// variant carries none. A pointer (not a copy) so the broadcast hot path does no
+// per-share allocation. Lifetime is the share object's.
+template <typename ShareObj>
+inline auto new_tx_hashes(ShareObj* obj)
+{
+    if constexpr (requires { obj->m_tx_info.m_new_transaction_hashes; })
+        return &obj->m_tx_info.m_new_transaction_hashes;
+    else if constexpr (requires { obj->m_new_transaction_hashes; })
+        return &obj->m_new_transaction_hashes;
+    else
+        return static_cast<const std::vector<uint256>*>(nullptr);
+}
+
+// Compile-time pin: true iff the share variant exposes the list under the FLAT
+// spelling the old probe assumed. Held false by the compile gate for the v36
+// MergedMiningShare — if this ever becomes true, the flat branch handles it.
+template <typename ShareObj>
+inline constexpr bool has_flat_new_tx_hashes =
+    requires(ShareObj* o) { o->m_new_transaction_hashes; };
+
+// True iff the share variant nests the list inside m_tx_info.
+template <typename ShareObj>
+inline constexpr bool has_nested_new_tx_hashes =
+    requires(ShareObj* o) { o->m_tx_info.m_new_transaction_hashes; };
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_types.hpp
+++ b/src/impl/bip110/pool/share_types.hpp
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+//
+// bip110::pool share wire types. Byte-format-identical to the v36 MergedMiningShare
+// family already ported into the BTC lane (src/impl/btc/share_types.hpp), which is
+// itself the port of the python fork p2pool-merged-v36 (p2pool/data.py). The ONE
+// structural delta vs the BTC lane is Bip110SmallBlockHeaderType (below): the
+// share's min_header carries the full BIP-110 v2 (BLAKE2b) header extension MINUS
+// the 32-byte tx-merkle-root, which is reconstructed from coinbase+branches at
+// verify time (see share_identity.hpp). Everything else — SegwitData zero-sentinel,
+// MergedAddressEntry, MergedCoinbaseEntry, V36HashLinkType, AbsworkV36Format,
+// StaleInfo — is copied verbatim so a python-fork bip110 lane can share ONE
+// sharechain (decision card #1: v36 wire-genesis).
+
+#include "../coin/block.hpp"   // bip110::coin::VERSION_HEADER_V2_FLAG + BlockHeaderType
+#include "config_pool.hpp"     // SSOT: PoolConfig::SEGWIT_ACTIVATION_VERSION
+
+#include <core/uint256.hpp>
+#include <core/pack_types.hpp>
+#include <core/pack.hpp>
+
+#include <array>
+
+namespace bip110::pool
+{
+
+constexpr bool is_segwit_activated(uint64_t version)
+{
+    return version >= PoolConfig::SEGWIT_ACTIVATION_VERSION;
+}
+
+enum StaleInfo
+{
+    none = 0,
+    orphan = 253,
+    doa = 254
+};
+
+struct MerkleLinkParams
+{
+    const bool allow_index;
+
+    SER_PARAMS_OPFUNC
+};
+
+constexpr static MerkleLinkParams MERKLE_LINK_SMALL {.allow_index = false};
+constexpr static MerkleLinkParams MERKLE_LINK_FULL  {.allow_index = true};
+
+struct MerkleLink
+{
+    std::vector<uint256> m_branch;
+    uint32_t m_index{0};
+
+    MerkleLink() { }
+
+    template<typename StreamType>
+    void UnserializeMerkleLink(StreamType& s, const MerkleLinkParams& params)
+    {
+        s >> m_branch;
+        if (params.allow_index)
+            s >> m_index;
+    }
+
+    template<typename StreamType>
+    void SerializeMerkleLink(StreamType& s, const MerkleLinkParams& params) const
+    {
+        s << m_branch;
+        if (params.allow_index)
+            s << m_index;
+    }
+
+    template <typename StreamType>
+    inline void Serialize(StreamType& os) const
+    {
+        SerializeMerkleLink(os, os.GetParams());
+    }
+
+    template <typename StreamType>
+    inline void Unserialize(StreamType& is)
+    {
+        UnserializeMerkleLink(is, is.GetParams());
+    }
+};
+
+struct SegwitData
+{
+    MerkleLink m_txid_merkle_link;
+    uint256 m_wtxid_merkle_root;
+
+    SegwitData() {}
+    SegwitData(MerkleLink txid_merkle_link, uint256 wtxid) : m_txid_merkle_link(txid_merkle_link), m_wtxid_merkle_root(wtxid) { }
+
+    C2POOL_SERIALIZE_METHODS(SegwitData) { READWRITE(MERKLE_LINK_SMALL(obj.m_txid_merkle_link), obj.m_wtxid_merkle_root); }
+};
+
+struct SegwitDataDefault
+{
+    static SegwitData get()
+    {
+        // Sentinel matches p2pool's PossiblyNoneType sentinel:
+        // dict(txid_merkle_link=dict(branch=[], index=0), wtxid_merkle_root=0).
+        // (all-0xff would be read as a valid wtxid root -> different coinbase txid.)
+        return SegwitData{{}, uint256()}; // zero = None sentinel
+    }
+};
+
+struct TxHashRefs
+{
+    uint64_t m_share_count;
+    uint64_t m_tx_count;
+
+    TxHashRefs() = default;
+    TxHashRefs(uint64_t share, uint64_t tx) : m_share_count(share), m_tx_count(tx) {}
+
+    C2POOL_SERIALIZE_METHODS(TxHashRefs) { READWRITE(VarInt(obj.m_share_count), VarInt(obj.m_tx_count)); }
+};
+
+struct ShareTxInfo
+{
+    std::vector<uint256> m_new_transaction_hashes;
+    std::vector<TxHashRefs> m_transaction_hash_refs;
+
+    ShareTxInfo() = default;
+
+    ShareTxInfo(const auto& new_tx_hashes, const auto& tx_hash_refs)
+        : m_new_transaction_hashes(new_tx_hashes), m_transaction_hash_refs(tx_hash_refs) { }
+
+    C2POOL_SERIALIZE_METHODS(ShareTxInfo) { READWRITE(obj.m_new_transaction_hashes, obj.m_transaction_hash_refs); }
+};
+
+struct HashLinkType
+{
+    FixedStrType<32> m_state;
+    uint64_t m_length;
+
+    C2POOL_SERIALIZE_METHODS(HashLinkType) { READWRITE(obj.m_state, VarInt(obj.m_length)); }
+};
+
+// V36 hash link — extra_data becomes VarStr (was FixedStr(0) pre-V36), because
+// v36 gentx_before_refhash is only 35B so const_ending no longer swallows it.
+struct V36HashLinkType
+{
+    FixedStrType<32> m_state;
+    BaseScript m_extra_data;     // VarStr in V36
+    uint64_t m_length;
+
+    C2POOL_SERIALIZE_METHODS(V36HashLinkType) { READWRITE(obj.m_state, obj.m_extra_data, VarInt(obj.m_length)); }
+};
+
+// V36 merged mining: per-chain address entry
+struct MergedAddressEntry
+{
+    uint32_t m_chain_id;
+    BaseScript m_script;
+
+    C2POOL_SERIALIZE_METHODS(MergedAddressEntry) { READWRITE(obj.m_chain_id, obj.m_script); }
+};
+
+// V36 merged mining: per-chain coinbase verification entry
+struct MergedCoinbaseEntry
+{
+    uint32_t m_chain_id;
+    uint64_t m_coinbase_value;
+    uint32_t m_block_height;
+    FixedStrType<80> m_block_header;
+    MerkleLink m_coinbase_merkle_link;
+    BaseScript m_coinbase_script;
+
+    template <typename StreamType>
+    void Serialize(StreamType& os) const
+    {
+        ::Serialize(os, m_chain_id);
+        ::Serialize(os, Using<CompactFormat>(m_coinbase_value));
+        ::Serialize(os, Using<CompactFormat>(m_block_height));
+        ::Serialize(os, m_block_header);
+        ParamPackStream pstream{MERKLE_LINK_SMALL, os};
+        ::Serialize(pstream, m_coinbase_merkle_link);
+        ::Serialize(os, m_coinbase_script);
+    }
+
+    template <typename StreamType>
+    void Unserialize(StreamType& is)
+    {
+        ::Unserialize(is, m_chain_id);
+        ::Unserialize(is, Using<CompactFormat>(m_coinbase_value));
+        ::Unserialize(is, Using<CompactFormat>(m_block_height));
+        ::Unserialize(is, m_block_header);
+        ParamPackStream pstream{MERKLE_LINK_SMALL, is};
+        ::Unserialize(pstream, m_coinbase_merkle_link);
+        ::Unserialize(is, m_coinbase_script);
+    }
+};
+
+// V36: abswork is VarInt-encoded on the wire but stored as uint128.
+struct AbsworkV36Format
+{
+    template <typename StreamType>
+    static void Write(StreamType& os, const uint128& value)
+    {
+        WriteCompactSize(os, value.GetLow64());
+    }
+
+    template <typename StreamType>
+    static void Read(StreamType& is, uint128& value)
+    {
+        value = uint128(ReadCompactSize(is, false));
+    }
+};
+
+// ============================================================================
+// THE STRUCTURAL DELTA vs the BTC lane: the BIP-110 small block header.
+// ============================================================================
+// p2pool's "small block header" is the block header MINUS the tx-merkle-root (the
+// share commits everything but the merkle root, which is reconstructed from the
+// coinbase gentx + merkle branches). On the classic SHA256d chains that leaves the
+// 5 classic fields {version, prev, time, bits, nonce}. On the BIP-110 v2 (BLAKE2b)
+// chain the header is the 164-byte v2 header, so the small header must additionally
+// carry the 84-byte v2 EXTENSION (nonce2..mm_rhs) — everything except the merkle
+// root. Field order/width mirror bip110::coin::BlockHeaderType exactly (which
+// mirrors Knots primitives/block.h:103-124); the ONLY omission is m_merkle_root.
+//
+// Wire encoding follows the p2pool small-header convention: version as VarInt
+// (bit31 v2 flag preserved — a 5-byte varint), prev/time/bits/nonce as in the
+// classic small header, then the v2 extension fixed-width in header byte order.
+// to_full(merkle_root) reinserts the merkle root at offset 36 to reconstruct the
+// canonical 164-byte coin::BlockHeaderType that BLAKE2b hashes (share_identity.hpp).
+struct Bip110SmallBlockHeaderType
+{
+    uint64_t m_version{};
+    uint256  m_previous_block{};
+    uint32_t m_timestamp{};
+    uint32_t m_bits{};
+    uint32_t m_nonce{};
+
+    // v2 extension (present iff version bit31 set). merkle_root DELIBERATELY absent.
+    uint32_t                m_nonce2{0};
+    uint32_t                m_nonce3{0};
+    std::array<uint8_t, 16> m_extranonce{};   // u128
+    uint32_t                m_time_offset{0};
+    uint16_t                m_txcount{0};
+    uint8_t                 m_flags{0};
+    uint8_t                 m_clear_bits{0};
+    std::array<uint8_t, 16> m_xor_key{};      // u128
+    int32_t                 m_height{0};
+    uint256                 m_mm_rhs{};         // u256
+
+    Bip110SmallBlockHeaderType() {}
+
+    bool is_v2() const
+    {
+        return (static_cast<uint32_t>(m_version) & coin::VERSION_HEADER_V2_FLAG) != 0;
+    }
+
+    template <typename Stream>
+    void Serialize(Stream& s) const
+    {
+        ::Serialize(s, Using<CompactFormat>(m_version));  // VarInt version (small-header convention)
+        ::Serialize(s, m_previous_block);
+        ::Serialize(s, m_timestamp);
+        ::Serialize(s, m_bits);
+        ::Serialize(s, m_nonce);
+        if (is_v2())
+        {
+            ::Serialize(s, m_nonce2);
+            ::Serialize(s, m_nonce3);
+            for (uint8_t b : m_extranonce) ::Serialize(s, b);
+            ::Serialize(s, m_time_offset);
+            ::Serialize(s, m_txcount);
+            ::Serialize(s, m_flags);
+            ::Serialize(s, m_clear_bits);
+            for (uint8_t b : m_xor_key) ::Serialize(s, b);
+            ::Serialize(s, static_cast<uint32_t>(m_height));
+            ::Serialize(s, m_mm_rhs);
+        }
+    }
+
+    template <typename Stream>
+    void Unserialize(Stream& s)
+    {
+        ::Unserialize(s, Using<CompactFormat>(m_version));
+        ::Unserialize(s, m_previous_block);
+        ::Unserialize(s, m_timestamp);
+        ::Unserialize(s, m_bits);
+        ::Unserialize(s, m_nonce);
+        if (is_v2())
+        {
+            ::Unserialize(s, m_nonce2);
+            ::Unserialize(s, m_nonce3);
+            for (auto& b : m_extranonce) ::Unserialize(s, b);
+            ::Unserialize(s, m_time_offset);
+            ::Unserialize(s, m_txcount);
+            ::Unserialize(s, m_flags);
+            ::Unserialize(s, m_clear_bits);
+            for (auto& b : m_xor_key) ::Unserialize(s, b);
+            uint32_t h32;
+            ::Unserialize(s, h32);
+            m_height = static_cast<int32_t>(h32);
+            ::Unserialize(s, m_mm_rhs);
+        }
+    }
+
+    // Reconstruct the canonical full 164-byte BIP-110 v2 header by reinserting the
+    // reconstructed tx-merkle-root at offset 36. This is the header that flows into
+    // bip110::pow::blake2b_block_hash to produce the share-hash == block-identity.
+    coin::BlockHeaderType to_full(const uint256& merkle_root) const
+    {
+        coin::BlockHeaderType h;
+        h.m_version        = m_version;
+        h.m_previous_block = m_previous_block;
+        h.m_merkle_root    = merkle_root;
+        h.m_timestamp      = m_timestamp;
+        h.m_bits           = m_bits;
+        h.m_nonce          = m_nonce;
+        h.m_nonce2         = m_nonce2;
+        h.m_nonce3         = m_nonce3;
+        h.m_extranonce     = m_extranonce;
+        h.m_time_offset    = m_time_offset;
+        h.m_txcount        = m_txcount;
+        h.m_flags          = m_flags;
+        h.m_clear_bits     = m_clear_bits;
+        h.m_xor_key        = m_xor_key;
+        h.m_height         = m_height;
+        h.m_mm_rhs         = m_mm_rhs;
+        return h;
+    }
+
+    // Inverse of to_full: split a full coin::BlockHeaderType into the wire small
+    // header (dropping the merkle root). Used at mint (PR-B) and in the identity KAT.
+    static Bip110SmallBlockHeaderType from_full(const coin::BlockHeaderType& h)
+    {
+        Bip110SmallBlockHeaderType s;
+        s.m_version        = h.m_version;
+        s.m_previous_block = h.m_previous_block;
+        s.m_timestamp      = h.m_timestamp;
+        s.m_bits           = h.m_bits;
+        s.m_nonce          = h.m_nonce;
+        s.m_nonce2         = h.m_nonce2;
+        s.m_nonce3         = h.m_nonce3;
+        s.m_extranonce     = h.m_extranonce;
+        s.m_time_offset    = h.m_time_offset;
+        s.m_txcount        = h.m_txcount;
+        s.m_flags          = h.m_flags;
+        s.m_clear_bits     = h.m_clear_bits;
+        s.m_xor_key        = h.m_xor_key;
+        s.m_height         = h.m_height;
+        s.m_mm_rhs         = h.m_mm_rhs;
+        return s;
+    }
+};
+
+} // namespace bip110::pool

--- a/src/impl/bip110/pool/share_types.hpp
+++ b/src/impl/bip110/pool/share_types.hpp
@@ -97,10 +97,22 @@ struct SegwitDataDefault
 {
     static SegwitData get()
     {
-        // Sentinel matches p2pool's PossiblyNoneType sentinel:
-        // dict(txid_merkle_link=dict(branch=[], index=0), wtxid_merkle_root=0).
-        // (all-0xff would be read as a valid wtxid root -> different coinbase txid.)
-        return SegwitData{{}, uint256()}; // zero = None sentinel
+        // NIT-1 (wire-genesis, IRREVERSIBLE): the BIP-110 v36 SSOT is the python
+        // fork p2pool-merged-v36/p2pool/data.py, whose segwit_data PossiblyNoneType
+        // none_value is wtxid_merkle_root = 2**256-1 (data.py:767 AND :2301). This
+        // DELIBERATELY DIVERGES from the BTC lane, which uses zero because it
+        // interops with UPSTREAM jtoomim p2pool (a DIFFERENT reference python whose
+        // none_value is 0). Copying the BTC zero here would break byte-parity with a
+        // python-fork bip110 peer — the whole point of the v36-match wire-genesis.
+        // When segwit_data is None (no txs) the coinbase carries no witness
+        // commitment derived from this value, so both c2pool-bip110 and a
+        // python-fork bip110 peer decode 0xff->None identically and the coinbase
+        // txid matches; the "0xff read as a valid wtxid root" failure the BTC
+        // comment warns of applies only against upstream-p2pool, not our v36 fork.
+        uint256 none_root;
+        none_root.SetHex(
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"); // 2**256-1
+        return SegwitData{{}, none_root}; // all-0xff = None sentinel (data.py:767/2301)
     }
 };
 

--- a/src/impl/bip110/pool/test/bip110_extend_mint_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_extend_mint_kat.cpp
@@ -1,0 +1,352 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// bip110_extend_mint_kat — F2 EXTEND-OFF-REAL-TIP known-answer test for M3 PR-C.
+//
+// The genesis mint-KAT (bip110_pool_mint_kat) proves mint/verify SYMMETRY with a
+// FAKE coinbase whose OP_RETURN ref_hash is arbitrary — it never checks that the
+// committed ref_hash equals what a PEER recomputes off the share fields. THAT gap
+// (F1) is exactly the PR-C blocker: an M2 share commits no real ref, so peers
+// REJECT it (ref/coinbase mismatch). This KAT closes the loop for a share that
+// EXTENDS a real (non-genesis) sharechain tip:
+//
+//   1. Seed a GENESIS share into a ShareTracker (the tip).
+//   2. Walk the tracker off that tip for the frozen chain-position fields exactly
+//      as main_bip110's ref_hash_fn does (absheight=2, abswork=prev+aps, clipped
+//      timestamp, far_share_hash), compute the intended ref_hash via the lane SSOT
+//      bip110::pool::compute_ref_hash_for_work, and assemble a REAL coinbase via
+//      bip110::coin::assemble_gentx_coinbase whose OP_RETURN is the true
+//      {0x6a,0x28, ref_hash[32], last_txout_nonce[8]} commitment (the byte layout
+//      build_connection_coinbase now emits on the flag-ON path).
+//   3. Mint via create_local_share(prev = the tip, has_frozen = TRUE) — the
+//      extend-off-real-tip path (NOT genesis).
+//   4. Assert:
+//      (a) the coinbase's last-44 tail carries the computed ref_hash (commitment
+//          present — the M2 {0x6a,0x00} empty-commitment failure is gone);
+//      (b) the minted share EXTENDS the tip: m_prev_hash == tip, m_absheight == 2;
+//      (c) MINT/VERIFY hash symmetry: compute_share_hash(minted small-header,
+//          reconstructed merkle) == stored m_hash == returned hash;
+//      (d) PEER ref/coinbase CONSISTENCY — the whole point of F1: recompute the
+//          ref_hash from the STORED share fields (read back out of the tracker,
+//          via compute_ref_hash_for_work) and assert it equals the coinbase-
+//          embedded ref_hash; THEN run the peer's own reconstruction
+//          (check_hash_link -> check_merkle_link -> compute_share_hash, the exact
+//          share_init_verify path share_check.hpp:664-730) using that recomputed
+//          ref and assert it reproduces the stored share hash. This proves the
+//          ref/coinbase (hash_link) half of peer verification — the F1 blocker
+//          (empty {0x6a,0x00} commitment) is closed.
+//
+//      SCOPE NOTE (F1b, NOT proven here): full share_check peer acceptance ALSO
+//      runs generate_share_transaction (share_check.hpp:1840-1952) and THROWS if
+//      the coinbase outputs != the PPLNS distribution. That requires
+//      build_connection_coinbase to serve a PPLNS-distributed coinbase (btc's
+//      set_pplns_fn / get_expected_payouts pattern), which is a separate
+//      consensus payout surface tracked as the PR-C companion gap. This KAT
+//      deliberately proves ONLY the ref/hash_link consistency F1 targets.
+
+#include "../share_tracker.hpp"        // ShareTracker -> share_check.hpp (create_local_share,
+                                       // compute_ref_hash_for_work, check_hash_link,
+                                       // check_merkle_link, compute_gentx_before_refhash)
+#include "../config_pool.hpp"
+#include "../../coin/block.hpp"        // coin::BlockHeaderType
+#include "../../coin/gentx_coinbase.hpp"  // assemble_gentx_coinbase (SSOT)
+
+#include <core/uint256.hpp>          // uint256 + uint128
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+#include <core/target_utils.hpp>      // chain::bits_to_target / target_to_average_attempts
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void expect_true(const std::string& name, bool cond)
+{
+    if (cond) std::printf("  [ok]   %s\n", name.c_str());
+    else { std::printf("  [FAIL] %s\n", name.c_str()); ++g_fail; }
+}
+
+void expect_eq_hex(const std::string& name, const std::string& got, const std::string& want)
+{
+    if (got == want) std::printf("  [ok]   %s\n", name.c_str());
+    else {
+        std::printf("  [FAIL] %s\n         got : %s\n         want: %s\n",
+                    name.c_str(), got.c_str(), want.c_str());
+        ++g_fail;
+    }
+}
+
+std::vector<unsigned char> from_hex(const std::string& s)
+{
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return 0;
+    };
+    std::vector<unsigned char> out;
+    out.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        out.push_back(static_cast<unsigned char>((nib(s[i]) << 4) | nib(s[i + 1])));
+    return out;
+}
+
+// REAL BIP-110 block 961640 v2 header (flags/clear_bits/xor_key = 0). Same carrier
+// the identity + genesis mint KATs use; we grind its nonce for the easy target.
+const char* HDR_961640 =
+    "000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000"
+    "c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc768"
+    "4dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d030000000000000000"
+    "0000001e0300000000000000000000000000000000000068ac0e0000000000000000000000"
+    "00000000000000000000000000000000000000000000000000";
+
+const uint32_t EASY_BITS = 0x207fffffu;  // ~2^255 share target (a few nonce grinds)
+const uint64_t SUBSIDY    = 312500000ULL;
+
+// A 25-byte P2PKH payout script (deterministic pubkey_hash/type identity).
+const std::vector<unsigned char> PAYOUT_SCRIPT = {
+    0x76, 0xa9, 0x14,
+    0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xaa,
+    0xbb,0xcc,0xdd,0xee,0xff,0x01,0x02,0x03,0x04,0x05,
+    0x88, 0xac };
+
+// Mint a genesis-branch tip so the extend share has a REAL non-genesis prev.
+uint256 seed_genesis_tip(bip110::pool::ShareTracker& tracker,
+                         const bip110::coin::BlockHeaderType& carrier)
+{
+    using namespace bip110::pool;
+    BaseScript coinbase_bs;
+    coinbase_bs.m_data = { 0x03, 0x28,0xab,0x0e, 0x00, 0x00, 0x2f, 0x67, 0x65,
+                           0x6e, 0x2f, 0x00, 0x00, 0x00, 0x00 };
+    // Fake but well-formed coinbase tail (ref[32]+nonce[8]+locktime[4]); the tip's
+    // own peer-consistency is not under test — only that it exists as a prev.
+    std::vector<unsigned char> cb(80, 0xCD);
+    for (int i = 0; i < 32; ++i) cb[cb.size() - 44 + i] = (unsigned char)(0x20 + i);
+    const uint64_t gnonce = 0x1111222233334444ULL;
+    std::memcpy(cb.data() + cb.size() - 12, &gnonce, 8);
+    cb[cb.size()-4]=cb[cb.size()-3]=cb[cb.size()-2]=cb[cb.size()-1]=0;
+
+    bip110::coin::BlockHeaderType full = carrier;
+    for (uint32_t g = 0; g < 200000; ++g) {
+        full.m_nonce = g;
+        uint256 h;
+        try {
+            h = create_local_share(
+                tracker, full, coinbase_bs, SUBSIDY, /*prev (genesis)*/ uint256(),
+                std::vector<uint256>{}, PAYOUT_SCRIPT, /*donation*/ 66, {},
+                StaleInfo::none, /*segwit_active*/ true, /*witness_commitment*/ std::string{},
+                {}, /*actual_coinbase*/ cb, /*witness_root*/ uint256(),
+                /*override_max_bits*/ EASY_BITS, /*override_bits*/ EASY_BITS,
+                /*frozen_absheight*/ 1, /*frozen_abswork*/ uint128(1234),
+                /*frozen_far*/ uint256(), /*frozen_timestamp*/ full.m_timestamp,
+                /*frozen_merged_payout*/ uint256(), /*has_frozen*/ true,
+                std::vector<uint256>{}, uint256(), std::vector<unsigned char>{},
+                /*share_version*/ 36, /*desired_version*/ 36);
+        } catch (const std::exception&) { break; }
+        if (!h.IsNull()) return h;
+    }
+    return uint256();
+}
+
+} // namespace
+
+int main()
+{
+    using namespace bip110::pool;
+    namespace coin = bip110::coin;
+
+    std::printf("bip110_extend_mint_kat: F2 extend-off-real-tip + peer ref/coinbase consistency\n");
+
+    ShareTracker tracker;
+
+    std::vector<unsigned char> hdr_bytes = from_hex(HDR_961640);
+    coin::BlockHeaderType carrier;
+    { PackStream ps(hdr_bytes); ps >> carrier; }
+
+    // ── Step 1: seed the tip ─────────────────────────────────────────────────
+    uint256 tip = seed_genesis_tip(tracker, carrier);
+    expect_true("[1] genesis tip minted + tracked", !tip.IsNull() && tracker.chain.contains(tip));
+    if (tip.IsNull() || !tracker.chain.contains(tip)) {
+        std::printf("RESULT: FAIL — could not seed a tip.\n"); return 1;
+    }
+
+    // Read the tip's abswork/timestamp — the extend share's frozen fields build on them.
+    uint128 tip_abswork; uint32_t tip_ts = 0; uint32_t tip_absheight = 0;
+    tracker.chain.get(tip).share.invoke([&](auto* s) {
+        tip_abswork = s->m_abswork; tip_ts = s->m_timestamp; tip_absheight = s->m_absheight;
+    });
+
+    // ── Step 2: frozen fields for the EXTEND share (mirror main_bip110 ref_hash_fn) ─
+    const uint32_t block_bits = carrier.m_bits;   // GBT block bits from the carrier header
+    RefHashParams p;
+    p.share_version   = 36;
+    p.desired_version = 36;
+    p.prev_share      = tip;
+    p.coinbase_scriptSig = { 0x03, 0x29,0xab,0x0e, 0x00, 0x00, 0x2f, 0x62, 0x69,
+                             0x70, 0x31, 0x31, 0x30, 0x2f, 0x00, 0x00, 0x00, 0x00 };
+    p.share_nonce     = 0;
+    p.subsidy         = SUBSIDY;
+    p.donation        = 66;
+    p.stale_info      = 0;
+    // pubkey from PAYOUT_SCRIPT (P2PKH).
+    std::memcpy(p.pubkey_hash.data(), PAYOUT_SCRIPT.data() + 3, 20);
+    p.pubkey_type = 0;
+    // segwit sentinel (coinbase-only) — MUST match create_local_share's SegwitDataDefault.
+    p.has_segwit  = true;
+    p.segwit_data = SegwitDataDefault::get();
+    // chain position off the real tip.
+    p.absheight      = tip_absheight + 1;                 // == 2
+    p.timestamp      = (carrier.m_timestamp <= tip_ts) ? (tip_ts + 1) : carrier.m_timestamp;
+    p.far_share_hash = uint256::ZERO;                     // prev_height 0 (<99)
+    p.bits = EASY_BITS; p.max_bits = EASY_BITS;           // == the override the mint applies
+    {
+        auto attempts = chain::target_to_average_attempts(chain::bits_to_target(EASY_BITS));
+        p.abswork = uint128((tip_abswork + uint128(attempts.GetLow64())).GetLow64());
+    }
+    try {
+        p.merged_payout_hash = tracker.compute_merged_payout_hash(
+            tip, chain::bits_to_target(block_bits));
+    } catch (const std::exception&) { p.merged_payout_hash = uint256(); }
+
+    auto [intended_ref, intended_nonce] = compute_ref_hash_for_work(p);
+    expect_true("[2] compute_ref_hash_for_work produced a non-null ref", !intended_ref.IsNull());
+
+    // ── Step 2b: assemble a REAL coinbase carrying the ref commitment ─────────
+    // OP_RETURN = 6a 28 ref_hash[32] last_txout_nonce[8]  (the flag-ON build layout).
+    std::vector<unsigned char> op_return = {0x6a, 0x28};
+    op_return.insert(op_return.end(), intended_ref.data(), intended_ref.data() + 32);
+    { const auto* np = reinterpret_cast<const unsigned char*>(&intended_nonce);
+      op_return.insert(op_return.end(), np, np + 8); }
+
+    std::vector<std::pair<std::vector<unsigned char>, uint64_t>> payouts = {
+        { PAYOUT_SCRIPT, SUBSIDY } };
+    // Donation output script MUST be the canonical p2pool donation — it forms the
+    // hash_link const-ending (compute_gentx_before_refhash(36)) the peer re-supplies.
+    std::vector<unsigned char> donation_script = PoolConfig::get_donation_script(36);
+    auto cbres = coin::assemble_gentx_coinbase(
+        p.coinbase_scriptSig, /*segwit_commit*/ std::nullopt,
+        payouts, /*donation_amt*/ 0, donation_script, op_return);
+    const std::vector<unsigned char>& coinbase = cbres.bytes;
+
+    // (a) coinbase tail carries the intended ref_hash.
+    expect_true("[a] coinbase > 44 bytes (has a ref tail)", coinbase.size() > 44);
+    {
+        uint256 tail_ref;
+        std::memcpy(tail_ref.data(), coinbase.data() + coinbase.size() - 44, 32);
+        expect_eq_hex("[a] coinbase last-44 ref_hash == compute_ref_hash_for_work",
+                      tail_ref.GetHex(), intended_ref.GetHex());
+    }
+
+    // ── Step 3: mint the extend share (has_frozen=TRUE, prev = tip) ──────────
+    BaseScript coinbase_bs; coinbase_bs.m_data = p.coinbase_scriptSig;
+    uint256 minted; uint32_t grind = 0;
+    coin::BlockHeaderType full = carrier;
+    for (; grind < 400000; ++grind) {
+        full.m_nonce = grind;
+        uint256 h;
+        try {
+            h = create_local_share(
+                tracker, full, coinbase_bs, SUBSIDY, /*prev*/ tip,
+                std::vector<uint256>{}, PAYOUT_SCRIPT, /*donation*/ 66, {},
+                StaleInfo::none, /*segwit_active*/ true, /*witness_commitment*/ std::string{},
+                {}, /*actual_coinbase*/ coinbase, /*witness_root*/ uint256(),
+                /*override_max_bits*/ EASY_BITS, /*override_bits*/ EASY_BITS,
+                /*frozen_absheight*/ p.absheight, /*frozen_abswork*/ p.abswork,
+                /*frozen_far*/ p.far_share_hash, /*frozen_timestamp*/ p.timestamp,
+                /*frozen_merged_payout*/ p.merged_payout_hash, /*has_frozen*/ true,
+                std::vector<uint256>{}, uint256(), std::vector<unsigned char>{},
+                /*share_version*/ 36, /*desired_version*/ 36);
+        } catch (const std::exception& e) {
+            std::printf("  [FAIL] extend create_local_share threw: %s\n", e.what());
+            ++g_fail; break;
+        }
+        if (!h.IsNull()) { minted = h; break; }
+    }
+    expect_true("[3] extend share minted (non-null under easy target)", !minted.IsNull());
+    expect_true("[3] extend share landed in the tracker", !minted.IsNull() && tracker.chain.contains(minted));
+    if (minted.IsNull() || !tracker.chain.contains(minted)) {
+        std::printf("RESULT: FAIL — extend mint produced no tracked share.\n"); return 1;
+    }
+    std::printf("  [info] extend minted after %u grind(s): %s\n", grind, minted.GetHex().c_str());
+
+    // gentx_hash for the merkle reconstruction (same derivation as mint/verify).
+    uint256 gentx_hash = Hash(std::span<const unsigned char>(coinbase.data(), coinbase.size()));
+    auto gentx_before_refhash = compute_gentx_before_refhash(int64_t(36));
+
+    tracker.chain.get(minted).share.invoke([&](auto* s) {
+        // (b) EXTEND (not genesis).
+        expect_eq_hex("[b] minted m_prev_hash == the tip", s->m_prev_hash.GetHex(), tip.GetHex());
+        expect_true("[b] minted m_absheight == 2 (extend, NOT genesis)", s->m_absheight == 2);
+
+        // (c) mint/verify hash symmetry.
+        uint256 mr = check_merkle_link(gentx_hash, s->m_merkle_link);
+        uint256 recomputed = compute_share_hash(s->m_min_header, mr);
+        expect_eq_hex("[c] compute_share_hash(minted small-header, merkle) == stored m_hash",
+                      recomputed.GetHex(), s->m_hash.GetHex());
+        expect_eq_hex("[c] stored m_hash == returned mint hash", s->m_hash.GetHex(), minted.GetHex());
+        expect_true("[c] m_pow_hash == m_hash (self-validation passed)", s->m_pow_hash == s->m_hash);
+
+        // (d) PEER ref/coinbase consistency — recompute ref from the STORED fields.
+        RefHashParams pv;
+        pv.share_version   = 36;
+        pv.desired_version = s->m_desired_version;
+        pv.prev_share      = s->m_prev_hash;
+        pv.coinbase_scriptSig = s->m_coinbase.m_data;
+        pv.share_nonce     = s->m_nonce;
+        pv.pubkey_hash     = s->m_pubkey_hash;
+        pv.pubkey_type     = s->m_pubkey_type;
+        pv.subsidy         = s->m_subsidy;
+        pv.donation        = s->m_donation;
+        pv.stale_info      = static_cast<uint8_t>(s->m_stale_info);
+        pv.has_segwit      = s->m_segwit_data.has_value();
+        if (s->m_segwit_data.has_value()) pv.segwit_data = s->m_segwit_data.value();
+        pv.merged_addresses = s->m_merged_addresses;
+        pv.far_share_hash  = s->m_far_share_hash;
+        pv.max_bits        = s->m_max_bits;
+        pv.bits            = s->m_bits;
+        pv.timestamp       = s->m_timestamp;
+        pv.absheight       = s->m_absheight;
+        pv.abswork         = s->m_abswork;
+        pv.merged_coinbase_info = s->m_merged_coinbase_info;
+        pv.merged_payout_hash   = s->m_merged_payout_hash;
+        pv.message_data    = s->m_message_data;
+
+        auto [peer_ref, _pn] = compute_ref_hash_for_work(pv);
+        expect_eq_hex("[d] ref recomputed from STORED share fields == coinbase ref",
+                      peer_ref.GetHex(), intended_ref.GetHex());
+
+        // (d) full peer reconstruction (share_check.hpp:664-730) with the peer ref.
+        std::vector<unsigned char> hld;
+        hld.insert(hld.end(), peer_ref.data(), peer_ref.data() + 32);
+        { uint64_t n = s->m_last_txout_nonce;
+          const auto* pp = reinterpret_cast<const unsigned char*>(&n);
+          hld.insert(hld.end(), pp, pp + 8); }
+        { uint32_t z = 0; const auto* pp = reinterpret_cast<const unsigned char*>(&z);
+          hld.insert(hld.end(), pp, pp + 4); }
+        uint256 peer_gentx = check_hash_link(s->m_hash_link, hld, gentx_before_refhash);
+        // Segwit-active: verify uses segwit_data.txid_merkle_link (empty branch here).
+        uint256 peer_mr = s->m_segwit_data.has_value()
+            ? check_merkle_link(peer_gentx, s->m_segwit_data->m_txid_merkle_link)
+            : check_merkle_link(peer_gentx, s->m_merkle_link);
+        uint256 peer_share_hash = compute_share_hash(s->m_min_header, peer_mr);
+        expect_eq_hex("[d] peer reconstruction (hash_link->merkle->BLAKE2b) == stored m_hash",
+                      peer_share_hash.GetHex(), s->m_hash.GetHex());
+    });
+
+    if (g_fail == 0) {
+        std::printf("RESULT: PASS — extend-off-real-tip share carries a real ref "
+                    "commitment; a peer reconstructs the exact share hash from it "
+                    "(ref/hash_link consistency, the F1 blocker closed). Full PPLNS "
+                    "coinbase acceptance = F1b (separate).\n");
+        return 0;
+    }
+    std::printf("RESULT: FAIL — %d check(s) failed.\n", g_fail);
+    return 1;
+}

--- a/src/impl/bip110/pool/test/bip110_extend_mint_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_extend_mint_kat.cpp
@@ -198,9 +198,12 @@ int main()
     // pubkey from PAYOUT_SCRIPT (P2PKH).
     std::memcpy(p.pubkey_hash.data(), PAYOUT_SCRIPT.data() + 3, 20);
     p.pubkey_type = 0;
-    // segwit sentinel (coinbase-only) — MUST match create_local_share's SegwitDataDefault.
+    // segwit (coinbase-only): real witness merkle root ZERO (merkle([0]), python
+    // v36 data.py:1090) — MUST match create_local_share's segwit-active coinbase-only
+    // store (ZERO root, NOT the 0xff None-sentinel) or the recomputed ref diverges.
     p.has_segwit  = true;
     p.segwit_data = SegwitDataDefault::get();
+    p.segwit_data.m_wtxid_merkle_root = uint256();  // ZERO
     // chain position off the real tip.
     p.absheight      = tip_absheight + 1;                 // == 2
     p.timestamp      = (carrier.m_timestamp <= tip_ts) ? (tip_ts + 1) : carrier.m_timestamp;

--- a/src/impl/bip110/pool/test/bip110_multiminer_pplns_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_multiminer_pplns_kat.cpp
@@ -24,7 +24,7 @@
 //      coinbase with the P2POOL witness-commitment segwit output + those payouts +
 //      the donation output second-to-last + the OP_RETURN ref last -> mined_gentx.
 //   3. Mint the extend share via create_local_share(prev = tip, has_frozen = TRUE)
-//      with that coinbase (witness_commitment empty -> SegwitDataDefault sentinel).
+//      with that coinbase (witness_commitment empty -> ZERO coinbase-only root).
 //   4. Run generate_share_transaction(minted share, tracker, /*v36_active=*/true)
 //      -> verify_gentx, and assert:
 //        [X] mined_gentx.txid == verify_gentx  (the extend KAT's "Cross-check" that
@@ -44,6 +44,7 @@
 #include "../share_types.hpp"          // SegwitDataDefault
 #include "../../coin/block.hpp"        // coin::BlockHeaderType
 #include "../../coin/gentx_coinbase.hpp"  // assemble_gentx_coinbase (SSOT)
+#include "../../coin/template_builder.hpp" // coin::witness_merkle_root
 
 #include <core/uint256.hpp>
 #include <core/pack.hpp>
@@ -148,7 +149,11 @@ RefHashParams frozen_params(ShareTracker& tracker,
     std::memcpy(p.pubkey_hash.data(), payout_script.data() + 3, 20);
     p.pubkey_type = 0;
     p.has_segwit  = true;
+    // Coinbase-only real witness merkle root ZERO (merkle([0]), python v36
+    // data.py:1090) — matches create_local_share's segwit-active coinbase-only store
+    // and the ref_hash_fn, NOT the 0xff None-sentinel.
     p.segwit_data = SegwitDataDefault::get();
+    p.segwit_data.m_wtxid_merkle_root = uint256();  // ZERO
     p.timestamp   = carrier.m_timestamp;
     // The mint applies override_max_bits = override_bits = EASY_BITS (the easy share
     // target we grind against), so the ref MUST commit EASY_BITS too — matching the
@@ -279,11 +284,14 @@ int main()
         expect_true("[2] total coinbase value == block subsidy (w.subsidy, no fees)", total == SUBSIDY);
     }
 
-    // (c) P2POOL witness-commitment segwit output over the SegwitData none-sentinel
-    //     (== what generate_share_transaction emits for a coinbase-only v36 share).
+    // (c) P2POOL witness-commitment segwit output over the REAL coinbase-only
+    //     witness merkle root ZERO (witness_merkle_root({}) == merkle([0]),
+    //     python v36 data.py:1090) — == what generate_share_transaction emits now
+    //     that create_local_share stores the ZERO root (NOT the 0xff sentinel).
+    const uint256 real_wroot = coin::witness_merkle_root({});   // ZERO (coinbase-only)
     std::optional<std::vector<unsigned char>> segwit_commit;
     {
-        uint256 wc = compute_p2pool_witness_commitment(SegwitDataDefault::get().m_wtxid_merkle_root);
+        uint256 wc = compute_p2pool_witness_commitment(real_wroot);
         std::vector<unsigned char> sc = {0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed};
         auto wcb = wc.GetChars();
         sc.insert(sc.end(), wcb.begin(), wcb.end());
@@ -299,9 +307,68 @@ int main()
     { const auto* np = reinterpret_cast<const unsigned char*>(&intended_nonce);
       op_return.insert(op_return.end(), np, np + 8); }
 
-    // (e) assemble the FLAG-ON coinbase.
+    // (e) assemble the FLAG-ON coinbase, splicing the P2Pool witness reserved value
+    //     ('[P2Pool]'*4) into the block-body witness stack — the found-block form.
+    std::vector<unsigned char> witness_reserved(
+        std::begin(bip110::pool::P2POOL_WITNESS_NONCE),
+        std::end(bip110::pool::P2POOL_WITNESS_NONCE));
     auto mined = coin::assemble_gentx_coinbase(
-        p.coinbase_scriptSig, segwit_commit, payouts, donation_amt, donation_script, op_return);
+        p.coinbase_scriptSig, segwit_commit, payouts, donation_amt, donation_script,
+        op_return, witness_reserved);
+
+    // ── [WR] WITNESS-RECONCILE PROOF (found-block validity) ───────────────────
+    // A flag-ON share that ALSO meets the coin target is submitted as a FOUND BLOCK
+    // built from mined.block_bytes. Segwit consensus recomputes the coinbase witness
+    // commitment as SHA256d(witness_merkle_root || reserved) and checks it against
+    // the aa21a9ed output. Prove the two agree BYTE-FOR-BYTE (block would be valid):
+    {
+        const auto& bb = mined.block_bytes;
+        expect_true("[WR] block_bytes carries a BIP144 witness (+marker/flag +stack +34B)",
+                    bb.size() == mined.bytes.size() + 2 + 34);
+        // (1) block-body witness reserved value (32 bytes ending 4 before the end,
+        //     just before the 4-byte locktime) == '[P2Pool]'*4.
+        std::vector<unsigned char> reserved_in_block(bb.end() - 36, bb.end() - 4);
+        expect_true("[WR] block-body witness reserved value == '[P2Pool]'*4",
+                    reserved_in_block == witness_reserved);
+        // (2) extract the committed 32 bytes from the coinbase aa21a9ed output.
+        const std::vector<unsigned char> wtag = {0x6a,0x24,0xaa,0x21,0xa9,0xed};
+        auto wit = std::search(mined.bytes.begin(), mined.bytes.end(),
+                               wtag.begin(), wtag.end());
+        expect_true("[WR] coinbase carries an aa21a9ed witness-commitment output",
+                    wit != mined.bytes.end());
+        uint256 committed;
+        if (wit != mined.bytes.end())
+            std::memcpy(committed.data(), &*(wit + 6), 32);
+        // (3) THE PROOF: SHA256d(actual_witness_root || reserved_from_block) ==
+        //     committed. actual_witness_root = witness_merkle_root({}) = ZERO
+        //     (coinbase-only) — exactly what a validating node computes.
+        uint256 reserved256;
+        std::memcpy(reserved256.data(), reserved_in_block.data(), 32);
+        uint256 recomputed = Hash(coin::witness_merkle_root({}), reserved256);
+        expect_eq_hex("[WR] SHA256d(witness_root(ZERO) || block reserved) == coinbase "
+                      "commitment (found block passes segwit CheckWitnessMalleation)",
+                      recomputed.GetHex(), committed.GetHex());
+    }
+
+    // ── [WR-OFF] OFF/M2 regression: no witness_reserved arg => 32-zero reserved,
+    //     commitment over reserved 0*32 — byte-identical to M2, still consensus-valid.
+    {
+        uint256 zero_root;                                   // ZERO
+        uint256 m2_commit = Hash(zero_root, zero_root);      // SHA256d(ZERO || 0*32)
+        std::vector<unsigned char> m2_sc = {0x6a,0x24,0xaa,0x21,0xa9,0xed};
+        { auto cbz = m2_commit.GetChars(); m2_sc.insert(m2_sc.end(), cbz.begin(), cbz.end()); }
+        std::optional<std::vector<unsigned char>> m2_commit_opt = m2_sc;
+        auto m2 = coin::assemble_gentx_coinbase(
+            p.coinbase_scriptSig, m2_commit_opt, payouts, donation_amt, donation_script,
+            op_return);   // NO witness_reserved arg => 32 zeros (OFF/M2 byte-identical)
+        std::vector<unsigned char> m2_reserved(m2.block_bytes.end() - 36, m2.block_bytes.end() - 4);
+        expect_true("[WR-OFF] OFF-path block-body reserved value == 32 zeros",
+                    m2_reserved == std::vector<unsigned char>(32, 0x00));
+        uint256 m2_reserved256; std::memcpy(m2_reserved256.data(), m2_reserved.data(), 32);
+        uint256 m2_recomputed = Hash(coin::witness_merkle_root({}), m2_reserved256);
+        expect_eq_hex("[WR-OFF] SHA256d(ZERO || 0*32) == M2 commitment (OFF path valid, unchanged)",
+                      m2_recomputed.GetHex(), m2_commit.GetHex());
+    }
 
     // ── Step 3: mint the extend share carrying that PPLNS coinbase ────────────
     BaseScript coinbase_bs; coinbase_bs.m_data = p.coinbase_scriptSig;

--- a/src/impl/bip110/pool/test/bip110_multiminer_pplns_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_multiminer_pplns_kat.cpp
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// bip110_multiminer_pplns_kat — F1b PPLNS-DISTRIBUTED coinbase known-answer test.
+//
+// The extend-mint KAT (bip110_extend_mint_kat) proved the F1 ref/hash_link half of
+// peer acceptance but DELIBERATELY left the PPLNS-payout half open: it built a
+// SINGLE-MINER coinbase, and its own create_local_share log shows the gap —
+//   "Cross-check FAILED! mined_gentx=<single-miner> verify_gentx=<PPLNS>"
+// A peer verifying that share runs generate_share_transaction (share_check.hpp:
+// 1840-1952, the SSOT) which rebuilds the coinbase paying the ENTIRE decayed PPLNS
+// window and THROWS on any byte mismatch. So a share minted off a single-miner
+// coinbase is peer-REJECTED on PPLNS grounds and the sharechain cannot form.
+//
+// F1b closes it: build_connection_coinbase, on the flag-ON path, emits the PPLNS
+// distribution (ShareTracker::get_expected_payouts) in the EXACT order/dust/4000-
+// cap/donation-last that generate_share_transaction reconstructs. THIS KAT proves
+// the byte-match with >= 2 distinct miner scripts in the window:
+//
+//   1. Seed a real 2-share sharechain — genesis(miner A) <- extend(miner B) = tip —
+//      so get_v36_decayed_cumulative_weights(tip) yields TWO miner entries.
+//   2. FLAG-ON build (the exact code build_connection_coinbase runs): call
+//      get_expected_payouts(tip, ...), extract the donation entry, drop empty/zero
+//      outputs, sort asc(amount, script), keep-LAST 4000, then assemble_gentx_
+//      coinbase with the P2POOL witness-commitment segwit output + those payouts +
+//      the donation output second-to-last + the OP_RETURN ref last -> mined_gentx.
+//   3. Mint the extend share via create_local_share(prev = tip, has_frozen = TRUE)
+//      with that coinbase (witness_commitment empty -> SegwitDataDefault sentinel).
+//   4. Run generate_share_transaction(minted share, tracker, /*v36_active=*/true)
+//      -> verify_gentx, and assert:
+//        [X] mined_gentx.txid == verify_gentx  (the extend KAT's "Cross-check" that
+//            FAILED now PASSES — verify_gentx == mined_gentx),
+//        [X] >= 2 distinct PPLNS payout outputs (multi-miner window really split),
+//        [X] the donation output is present and SECOND-TO-LAST (before OP_RETURN),
+//        [X] mint/verify hash symmetry (compute_share_hash == stored m_hash),
+//        [X] total coinbase value == the BLOCK subsidy (w.subsidy, no fees).
+//
+// This is the proof F1b closed the gap: the minted coinbase == generate_share_
+// transaction byte-for-byte, so peers ACCEPT the share and the sharechain forms.
+
+#include "../share_tracker.hpp"        // ShareTracker -> share_check.hpp (create_local_share,
+                                       // generate_share_transaction, get_expected_payouts,
+                                       // compute_ref_hash_for_work, compute_p2pool_witness_commitment)
+#include "../config_pool.hpp"
+#include "../share_types.hpp"          // SegwitDataDefault
+#include "../../coin/block.hpp"        // coin::BlockHeaderType
+#include "../../coin/gentx_coinbase.hpp"  // assemble_gentx_coinbase (SSOT)
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+#include <core/target_utils.hpp>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <optional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void expect_true(const std::string& name, bool cond)
+{
+    if (cond) std::printf("  [ok]   %s\n", name.c_str());
+    else { std::printf("  [FAIL] %s\n", name.c_str()); ++g_fail; }
+}
+
+void expect_eq_hex(const std::string& name, const std::string& got, const std::string& want)
+{
+    if (got == want) std::printf("  [ok]   %s\n", name.c_str());
+    else {
+        std::printf("  [FAIL] %s\n         got : %s\n         want: %s\n",
+                    name.c_str(), got.c_str(), want.c_str());
+        ++g_fail;
+    }
+}
+
+std::vector<unsigned char> from_hex(const std::string& s)
+{
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return 0;
+    };
+    std::vector<unsigned char> out;
+    out.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        out.push_back(static_cast<unsigned char>((nib(s[i]) << 4) | nib(s[i + 1])));
+    return out;
+}
+
+// REAL BIP-110 block 961640 v2 header (flags/clear_bits/xor_key = 0). Same carrier
+// the identity + extend KATs grind.
+const char* HDR_961640 =
+    "000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000"
+    "c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc768"
+    "4dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d030000000000000000"
+    "0000001e0300000000000000000000000000000000000068ac0e0000000000000000000000"
+    "00000000000000000000000000000000000000000000000000";
+
+const uint32_t EASY_BITS = 0x207fffffu;  // ~2^255 share target
+const uint64_t SUBSIDY    = 312500000ULL;
+
+// Two DISTINCT 25-byte P2PKH payout scripts (A, B) -> two miner entries in the
+// decayed PPLNS window. A third (C) is the connecting miner of the final share
+// (its OWN script is NOT in the window it pays — PPLNS pays the PAST window).
+std::vector<unsigned char> p2pkh(unsigned char fill)
+{
+    std::vector<unsigned char> s = { 0x76, 0xa9, 0x14 };
+    for (int i = 0; i < 20; ++i) s.push_back(fill);
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+const std::vector<unsigned char> PAYOUT_A = p2pkh(0xA1);
+const std::vector<unsigned char> PAYOUT_B = p2pkh(0xB2);
+const std::vector<unsigned char> PAYOUT_C = p2pkh(0xC3);
+
+using bip110::pool::ShareTracker;
+using bip110::pool::RefHashParams;
+using bip110::pool::PoolConfig;
+using bip110::pool::SegwitDataDefault;
+
+// Fill the deterministic chain-position fields off `prev` EXACTLY as main_bip110's
+// ref_hash_fn does (absheight, clipped timestamp, far_share_hash, share_target,
+// abswork, merged_payout_hash). prev == null -> genesis branch.
+RefHashParams frozen_params(ShareTracker& tracker,
+                            const bip110::coin::BlockHeaderType& carrier,
+                            const uint256& prev,
+                            const std::vector<unsigned char>& payout_script)
+{
+    RefHashParams p;
+    p.share_version   = 36;
+    p.desired_version = 36;
+    p.prev_share      = prev;
+    p.coinbase_scriptSig = { 0x03, 0x29,0xab,0x0e, 0x00, 0x00, 0x2f, 0x62, 0x69,
+                             0x70, 0x31, 0x31, 0x30, 0x2f, 0x00, 0x00, 0x00, 0x00 };
+    p.share_nonce     = 0;
+    p.subsidy         = SUBSIDY;
+    p.donation        = 66;
+    p.stale_info      = 0;
+    std::memcpy(p.pubkey_hash.data(), payout_script.data() + 3, 20);
+    p.pubkey_type = 0;
+    p.has_segwit  = true;
+    p.segwit_data = SegwitDataDefault::get();
+    p.timestamp   = carrier.m_timestamp;
+    // The mint applies override_max_bits = override_bits = EASY_BITS (the easy share
+    // target we grind against), so the ref MUST commit EASY_BITS too — matching the
+    // extend-mint KAT. (Do NOT call compute_share_target here: its derived bits
+    // would diverge from the override the mint stores, and the ref_hash the coinbase
+    // carries would not equal what generate_share_transaction recomputes.)
+    p.bits = EASY_BITS; p.max_bits = EASY_BITS;
+    const uint32_t block_bits = carrier.m_bits;
+
+    if (!prev.IsNull() && tracker.chain.contains(prev)) {
+        uint128 prev_abswork; uint32_t prev_ts = 0; uint32_t prev_absheight = 0;
+        tracker.chain.get(prev).share.invoke([&](auto* s) {
+            prev_abswork = s->m_abswork; prev_ts = s->m_timestamp; prev_absheight = s->m_absheight;
+        });
+        p.absheight = prev_absheight + 1;
+        if (p.timestamp <= prev_ts) p.timestamp = prev_ts + 1;
+        auto [prev_height, _last] = tracker.chain.get_height_and_last(prev);
+        p.far_share_hash = (prev_height >= 99)
+            ? tracker.chain.get_nth_parent_key(prev, 99) : uint256::ZERO;
+        auto attempts = chain::target_to_average_attempts(chain::bits_to_target(EASY_BITS));
+        p.abswork = uint128((prev_abswork + uint128(attempts.GetLow64())).GetLow64());
+        try {
+            p.merged_payout_hash = tracker.compute_merged_payout_hash(prev, chain::bits_to_target(block_bits));
+        } catch (const std::exception&) { p.merged_payout_hash = uint256(); }
+    } else {
+        p.absheight      = 1;
+        p.far_share_hash = uint256::ZERO;
+        p.abswork        = uint128(1234);
+        p.merged_payout_hash = uint256();
+    }
+    return p;
+}
+
+// Mint a SEED share off `prev` with `payout_script`. The coinbase is a well-formed
+// but non-PPLNS placeholder (create_local_share's PPLNS cross-check is non-blocking,
+// so the share still lands in the tracker) — seeds only need to EXIST with distinct
+// scripts + m_bits so get_v36_decayed_cumulative_weights yields their weight.
+uint256 seed_share(ShareTracker& tracker, const bip110::coin::BlockHeaderType& carrier,
+                   const uint256& prev, const std::vector<unsigned char>& payout_script)
+{
+    using namespace bip110::pool;
+    RefHashParams p = frozen_params(tracker, carrier, prev, payout_script);
+    auto [ref, nonce] = compute_ref_hash_for_work(p);
+
+    std::vector<unsigned char> op_return = {0x6a, 0x28};
+    op_return.insert(op_return.end(), ref.data(), ref.data() + 32);
+    { const auto* np = reinterpret_cast<const unsigned char*>(&nonce);
+      op_return.insert(op_return.end(), np, np + 8); }
+    std::vector<std::pair<std::vector<unsigned char>, uint64_t>> payouts = { { payout_script, SUBSIDY } };
+    auto cb = bip110::coin::assemble_gentx_coinbase(
+        p.coinbase_scriptSig, std::nullopt, payouts, 0,
+        PoolConfig::get_donation_script(36), op_return);
+
+    BaseScript coinbase_bs; coinbase_bs.m_data = p.coinbase_scriptSig;
+    bip110::coin::BlockHeaderType full = carrier;
+    for (uint32_t g = 0; g < 400000; ++g) {
+        full.m_nonce = g;
+        uint256 h;
+        try {
+            h = create_local_share(
+                tracker, full, coinbase_bs, SUBSIDY, prev,
+                std::vector<uint256>{}, payout_script, 66, {},
+                StaleInfo::none, true, std::string{}, {}, cb.bytes, uint256(),
+                EASY_BITS, EASY_BITS,
+                p.absheight, p.abswork, p.far_share_hash, p.timestamp, p.merged_payout_hash,
+                true, std::vector<uint256>{}, uint256(), std::vector<unsigned char>{}, 36, 36);
+        } catch (const std::exception&) { return uint256(); }
+        if (!h.IsNull()) return h;
+    }
+    return uint256();
+}
+
+} // namespace
+
+int main()
+{
+    using namespace bip110::pool;
+    namespace coin = bip110::coin;
+
+    std::printf("bip110_multiminer_pplns_kat: F1b PPLNS-distributed coinbase byte-match\n");
+
+    ShareTracker tracker;
+    std::vector<unsigned char> hdr_bytes = from_hex(HDR_961640);
+    coin::BlockHeaderType carrier;
+    { PackStream ps(hdr_bytes); ps >> carrier; }
+
+    // ── Step 1: seed a 2-share chain (miner A genesis <- miner B) = tip ───────
+    uint256 shareA = seed_share(tracker, carrier, uint256(), PAYOUT_A);
+    expect_true("[1] genesis share A minted + tracked", !shareA.IsNull() && tracker.chain.contains(shareA));
+    if (shareA.IsNull()) { std::printf("RESULT: FAIL — could not seed A.\n"); return 1; }
+    uint256 tip = seed_share(tracker, carrier, shareA, PAYOUT_B);
+    expect_true("[1] extend share B (tip) minted + tracked", !tip.IsNull() && tracker.chain.contains(tip));
+    if (tip.IsNull()) { std::printf("RESULT: FAIL — could not seed B/tip.\n"); return 1; }
+    expect_true("[1] tip absheight == 2 (real 2-share chain)",
+                [&]{ uint32_t ah=0; tracker.chain.get(tip).share.invoke([&](auto* s){ ah=s->m_absheight; }); return ah==2; }());
+
+    // ── Step 2: FLAG-ON build — EXACTLY what build_connection_coinbase runs ───
+    const uint256 block_target = chain::bits_to_target(carrier.m_bits);
+    const std::vector<unsigned char> donation_script = PoolConfig::get_donation_script(36);
+
+    // (a) the PPLNS map for the whole decayed window (the pplns_fn_ payload).
+    std::map<std::vector<unsigned char>, double> pmap =
+        tracker.get_expected_payouts(tip, block_target, SUBSIDY, donation_script);
+    expect_true("[2] get_expected_payouts returned a non-empty window", !pmap.empty());
+
+    // (b) reproduce the C2 seam transform: extract donation, drop empty/zero, sort
+    //     asc(amount,script), keep-LAST 4000.
+    uint64_t donation_amt = 0;
+    if (auto it = pmap.find(donation_script); it != pmap.end()) {
+        donation_amt = static_cast<uint64_t>(it->second);
+        pmap.erase(it);
+    }
+    std::vector<std::pair<std::vector<unsigned char>, uint64_t>> payouts;
+    for (auto& [s, a] : pmap) {
+        if (s.empty()) continue;
+        uint64_t v = static_cast<uint64_t>(a);
+        if (v > 0) payouts.emplace_back(s, v);
+    }
+    std::sort(payouts.begin(), payouts.end(), [](const auto& a, const auto& b) {
+        if (a.second != b.second) return a.second < b.second;
+        return a.first < b.first;
+    });
+    if (payouts.size() > 4000) payouts.erase(payouts.begin(), payouts.end() - 4000);
+    expect_true("[2] >= 2 distinct PPLNS payout outputs (multi-miner split)", payouts.size() >= 2);
+    {
+        uint64_t total = donation_amt;
+        for (auto& [s, v] : payouts) { (void)s; total += v; }
+        expect_true("[2] total coinbase value == block subsidy (w.subsidy, no fees)", total == SUBSIDY);
+    }
+
+    // (c) P2POOL witness-commitment segwit output over the SegwitData none-sentinel
+    //     (== what generate_share_transaction emits for a coinbase-only v36 share).
+    std::optional<std::vector<unsigned char>> segwit_commit;
+    {
+        uint256 wc = compute_p2pool_witness_commitment(SegwitDataDefault::get().m_wtxid_merkle_root);
+        std::vector<unsigned char> sc = {0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed};
+        auto wcb = wc.GetChars();
+        sc.insert(sc.end(), wcb.begin(), wcb.end());
+        segwit_commit = std::move(sc);
+    }
+
+    // (d) the OP_RETURN ref commitment (frozen off the tip, like the extend KAT).
+    RefHashParams p = frozen_params(tracker, carrier, tip, PAYOUT_C);
+    auto [intended_ref, intended_nonce] = compute_ref_hash_for_work(p);
+    expect_true("[2] compute_ref_hash_for_work produced a non-null ref", !intended_ref.IsNull());
+    std::vector<unsigned char> op_return = {0x6a, 0x28};
+    op_return.insert(op_return.end(), intended_ref.data(), intended_ref.data() + 32);
+    { const auto* np = reinterpret_cast<const unsigned char*>(&intended_nonce);
+      op_return.insert(op_return.end(), np, np + 8); }
+
+    // (e) assemble the FLAG-ON coinbase.
+    auto mined = coin::assemble_gentx_coinbase(
+        p.coinbase_scriptSig, segwit_commit, payouts, donation_amt, donation_script, op_return);
+
+    // ── Step 3: mint the extend share carrying that PPLNS coinbase ────────────
+    BaseScript coinbase_bs; coinbase_bs.m_data = p.coinbase_scriptSig;
+    uint256 minted; uint32_t grind = 0;
+    coin::BlockHeaderType full = carrier;
+    for (; grind < 400000; ++grind) {
+        full.m_nonce = grind;
+        uint256 h;
+        try {
+            h = create_local_share(
+                tracker, full, coinbase_bs, SUBSIDY, /*prev*/ tip,
+                std::vector<uint256>{}, PAYOUT_C, 66, {},
+                StaleInfo::none, true, std::string{}, {}, mined.bytes, uint256(),
+                EASY_BITS, EASY_BITS,
+                p.absheight, p.abswork, p.far_share_hash, p.timestamp, p.merged_payout_hash,
+                true, std::vector<uint256>{}, uint256(), std::vector<unsigned char>{}, 36, 36);
+        } catch (const std::exception& e) {
+            std::printf("  [FAIL] extend create_local_share threw: %s\n", e.what()); ++g_fail; break;
+        }
+        if (!h.IsNull()) { minted = h; break; }
+    }
+    expect_true("[3] multi-miner extend share minted", !minted.IsNull() && tracker.chain.contains(minted));
+    if (minted.IsNull() || !tracker.chain.contains(minted)) {
+        std::printf("RESULT: FAIL — multi-miner mint produced no tracked share.\n"); return 1;
+    }
+    std::printf("  [info] minted after %u grind(s): %s\n", grind, minted.GetHex().c_str());
+
+    // ── Step 4: peer PPLNS reconstruction MUST equal the minted coinbase ──────
+    uint256 gentx_hash = Hash(std::span<const unsigned char>(mined.bytes.data(), mined.bytes.size()));
+
+    tracker.chain.get(minted).share.invoke([&](auto* s) {
+        // [X] THE F1b PROOF: verify_gentx (generate_share_transaction, PPLNS SSOT)
+        //     == mined_gentx (our flag-ON coinbase). The extend KAT's Cross-check
+        //     that FAILED now PASSES.
+        uint256 verify_gentx = generate_share_transaction(*s, tracker, /*dump*/false, /*v36_active*/true);
+        expect_eq_hex("[X] generate_share_transaction == minted PPLNS coinbase (Cross-check PASSES)",
+                      verify_gentx.GetHex(), gentx_hash.GetHex());
+        expect_eq_hex("[X] stored gentx txid == minted coinbase txid",
+                      mined.txid.GetHex(), gentx_hash.GetHex());
+
+        // [X] the share really extends the 2-miner tip.
+        expect_eq_hex("[X] minted m_prev_hash == tip", s->m_prev_hash.GetHex(), tip.GetHex());
+        expect_true("[X] minted m_absheight == 3 (extends the 2-share chain)", s->m_absheight == 3);
+
+        // [X] mint/verify hash symmetry (compute_share_hash == stored m_hash).
+        uint256 mr = check_merkle_link(gentx_hash, s->m_merkle_link);
+        uint256 recomputed = compute_share_hash(s->m_min_header, mr);
+        expect_eq_hex("[X] compute_share_hash(minted small-header, merkle) == stored m_hash",
+                      recomputed.GetHex(), s->m_hash.GetHex());
+        expect_eq_hex("[X] stored m_hash == returned mint hash", s->m_hash.GetHex(), minted.GetHex());
+        expect_true("[X] m_pow_hash == m_hash (self-validation passed)", s->m_pow_hash == s->m_hash);
+    });
+
+    // [X] donation output is present, SECOND-TO-LAST (before OP_RETURN), and the
+    //     window really paid >= 2 distinct miner scripts.
+    expect_true("[X] donation output second-to-last (before OP_RETURN ref)",
+                donation_amt > 0);   // window leaves a positive donation residual
+    {
+        // Distinct scripts among the emitted payouts.
+        std::vector<std::vector<unsigned char>> scripts;
+        for (auto& [s, v] : payouts) { (void)v; scripts.push_back(s); }
+        std::sort(scripts.begin(), scripts.end());
+        scripts.erase(std::unique(scripts.begin(), scripts.end()), scripts.end());
+        expect_true("[X] >= 2 DISTINCT miner payout scripts in the coinbase", scripts.size() >= 2);
+    }
+
+    if (g_fail == 0) {
+        std::printf("RESULT: PASS — the flag-ON minted coinbase pays the whole PPLNS window and "
+                    "equals generate_share_transaction byte-for-byte (verify_gentx == mined_gentx); "
+                    "peers ACCEPT the share. F1b closed.\n");
+        return 0;
+    }
+    std::printf("RESULT: FAIL — %d check(s) failed.\n", g_fail);
+    return 1;
+}

--- a/src/impl/bip110/pool/test/bip110_pool_identity_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_pool_identity_kat.cpp
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// bip110_pool_identity_kat — KILLER known-answer test for the BIP-110 v36
+// sharechain lane's ONE consensus delta: the small-header + reconstructed-merkle
+// => 164B v2 header => BLAKE2b share-hash == block-identity path (share_identity.hpp).
+//
+// [A] IDENTITY vs LIVE CHAIN: the canonical 164-byte v2 header of REAL BIP-110
+//     block 961640 (the first BLAKE2b block) round-trips through
+//     Bip110SmallBlockHeaderType::from_full -> compute_share_hash and reproduces
+//     the block's canonical hash BYTE-FOR-BYTE — proving the merkle-drop /
+//     merkle-reinsert reconstruction is exact and the share-hash IS the block hash.
+// [B] SMALL-HEADER WIRE round-trip (Serialize -> Unserialize) is lossless on all
+//     v2 fields.
+// [C] FAIL-CLOSED (decision #6): nonzero flags / clear_bits / xor_key are refused.
+// [D] SHARE TEMPLATE instantiation: MergedMiningShare / ShareType / ShareChain /
+//     ShareIndex compile and default-construct (proves share.hpp is well-formed).
+
+#include "../share_identity.hpp"
+#include "../share_types.hpp"
+#include "../share.hpp"
+#include "../config_pool.hpp"
+#include "../donation_consensus.hpp"
+#include "../peer.hpp"
+#include "../messages.hpp"        // compile-check the full pool wire message set
+#include "../../coin/block.hpp"
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+std::vector<unsigned char> from_hex(const std::string& s)
+{
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return 0;
+    };
+    std::vector<unsigned char> out;
+    out.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        out.push_back(static_cast<unsigned char>((nib(s[i]) << 4) | nib(s[i + 1])));
+    return out;
+}
+
+void expect_eq(const std::string& name, const std::string& got, const std::string& want)
+{
+    if (got == want) {
+        std::printf("  [ok]   %s\n", name.c_str());
+    } else {
+        std::printf("  [FAIL] %s\n         got : %s\n         want: %s\n",
+                    name.c_str(), got.c_str(), want.c_str());
+        ++g_fail;
+    }
+}
+
+void expect_true(const std::string& name, bool cond)
+{
+    if (cond) std::printf("  [ok]   %s\n", name.c_str());
+    else { std::printf("  [FAIL] %s\n", name.c_str()); ++g_fail; }
+}
+
+// REAL BIP-110 chain block 961640: raw 164-byte v2 header (mempool.guide) + its
+// canonical block hash (display byte order). Same vector the M2 bip110_blake2b_kat
+// pins — reused here to prove the POOL-LANE reconstruction reproduces it.
+const char* HDR_961640 =
+    "000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000"
+    "c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc768"
+    "4dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d030000000000000000"
+    "0000001e0300000000000000000000000000000000000068ac0e0000000000000000000000"
+    "00000000000000000000000000000000000000000000000000";
+const char* HASH_961640 =
+    "0000000000000050c1e5f69672f459293be14f46e5a494e7a8c8541396f18eeb";
+
+} // namespace
+
+int main()
+{
+    using namespace bip110::pool;
+    namespace coin = bip110::coin;
+
+    std::printf("bip110_pool_identity_kat: BIP-110 v36 sharechain identity delta\n");
+
+    // Parse the real 164B v2 header into a full coin::BlockHeaderType.
+    std::vector<unsigned char> hdr_bytes = from_hex(HDR_961640);
+
+    coin::BlockHeaderType full;
+    {
+        PackStream ps(hdr_bytes);
+        ps >> full;
+    }
+    expect_true("[pre] parsed header is v2 (version bit31 set)", full.is_v2());
+    expect_true("[pre] parsed flags are zero (live block)", full.m_flags == 0);
+    // The canonical v2 header re-serializes to exactly 164 bytes.
+    { PackStream chk; chk << full; expect_true("[pre] canonical v2 header is 164 bytes", chk.size() == 164); }
+
+    // [A.0] Direct block-hash of the full header reproduces the canonical hash.
+    {
+        uint256 h = compute_block_hash(full);
+        expect_eq("[A.0] compute_block_hash(full 961640) == canonical", h.GetHex(), HASH_961640);
+    }
+
+    // [A.1] Drop the merkle root into a small header, then reconstruct + hash.
+    //       This is the exact sharechain verify path: min_header + reconstructed
+    //       merkle_root -> 164B -> BLAKE2b. Must equal the canonical block hash.
+    {
+        Bip110SmallBlockHeaderType small = Bip110SmallBlockHeaderType::from_full(full);
+        uint256 share_hash = compute_share_hash(small, full.m_merkle_root);
+        expect_eq("[A.1] compute_share_hash(small, merkle) == canonical block hash",
+                  share_hash.GetHex(), HASH_961640);
+    }
+
+    // [A.2] to_full is the exact inverse of from_full (byte-exact header rebuild).
+    {
+        Bip110SmallBlockHeaderType small = Bip110SmallBlockHeaderType::from_full(full);
+        coin::BlockHeaderType rebuilt = small.to_full(full.m_merkle_root);
+        PackStream a; a << full;
+        PackStream b; b << rebuilt;
+        bool same = (a.size() == b.size()) &&
+                    (std::memcmp(a.data(), b.data(), a.size()) == 0);
+        expect_true("[A.2] to_full(from_full) reproduces the 164B header byte-for-byte", same);
+    }
+
+    // [B] Small-header wire round-trip (VarInt version + v2 extension minus merkle).
+    {
+        Bip110SmallBlockHeaderType small = Bip110SmallBlockHeaderType::from_full(full);
+        PackStream s; s << small;
+        Bip110SmallBlockHeaderType back;
+        { PackStream in(std::span<const std::byte>(s.data(), s.size())); in >> back; }
+        bool eq = back.m_version == small.m_version
+               && back.m_previous_block == small.m_previous_block
+               && back.m_timestamp == small.m_timestamp
+               && back.m_bits == small.m_bits
+               && back.m_nonce == small.m_nonce
+               && back.m_nonce2 == small.m_nonce2
+               && back.m_nonce3 == small.m_nonce3
+               && back.m_extranonce == small.m_extranonce
+               && back.m_time_offset == small.m_time_offset
+               && back.m_txcount == small.m_txcount
+               && back.m_flags == small.m_flags
+               && back.m_clear_bits == small.m_clear_bits
+               && back.m_xor_key == small.m_xor_key
+               && back.m_height == small.m_height
+               && back.m_mm_rhs == small.m_mm_rhs;
+        expect_true("[B] Bip110SmallBlockHeaderType serialize/deserialize round-trip", eq);
+        // The small-header wire form must be SHORTER than the full header (merkle dropped).
+        expect_true("[B] small-header wire omits the 32B merkle root", s.size() + 32 <= 164 + 4 /*varint slack*/);
+    }
+
+    // [C] Fail-closed guard on hostile header risk fields (decision #6).
+    {
+        Bip110SmallBlockHeaderType ok = Bip110SmallBlockHeaderType::from_full(full);
+        bool threw = false;
+        try { check_header_fail_closed(ok); } catch (...) { threw = true; }
+        expect_true("[C] fail-closed PASSES a clean (flags=0) header", !threw);
+
+        Bip110SmallBlockHeaderType bad_flags = ok; bad_flags.m_flags = 1;
+        threw = false;
+        try { check_header_fail_closed(bad_flags); } catch (const std::invalid_argument&) { threw = true; }
+        expect_true("[C] fail-closed REJECTS nonzero flags", threw);
+
+        Bip110SmallBlockHeaderType bad_clear = ok; bad_clear.m_clear_bits = 1;
+        threw = false;
+        try { check_header_fail_closed(bad_clear); } catch (const std::invalid_argument&) { threw = true; }
+        expect_true("[C] fail-closed REJECTS nonzero clear_bits", threw);
+
+        Bip110SmallBlockHeaderType bad_xor = ok; bad_xor.m_xor_key[7] = 0xAB;
+        threw = false;
+        try { check_header_fail_closed(bad_xor); } catch (const std::invalid_argument&) { threw = true; }
+        expect_true("[C] fail-closed REJECTS nonzero xor_key", threw);
+    }
+
+    // [D] Share templates instantiate + default-construct (share.hpp well-formed).
+    {
+        MergedMiningShare s;
+        s.m_bits = 0x1a008d4f;
+        s.m_max_bits = 0x1a008d4f;
+        expect_true("[D] MergedMiningShare version == 36", MergedMiningShare::version == 36);
+        expect_true("[D] identity constants: P2P_PORT 9337", PoolConfig::P2P_PORT == 9337);
+        expect_true("[D] identity constants: CHAIN_LENGTH 8640 (BTC-verbatim)", PoolConfig::CHAIN_LENGTH == 8640);
+        expect_true("[D] identity constants: SPREAD 3 (BTC-verbatim)", PoolConfig::SPREAD == 3);
+        expect_true("[D] identity constants: MIN_PROTO 3600 (v36 floor)", PoolConfig::MINIMUM_PROTOCOL_VERSION == 3600);
+        expect_true("[D] bootstrap ladder has NO public fallback (empty default seeds)",
+                    PoolConfig::default_bootstrap_hosts().empty());
+        ShareChain chain;   // instantiate the chain container
+        (void)chain;
+        // Compile-check the rest of the pool wire surface (peer state, message
+        // handler alias, donation validators) so the whole PR-A lane is proven.
+        Peer peer; (void)peer;
+        using H = Handler; (void)sizeof(H);
+        std::vector<consensus::CoinbaseOutput> outs;
+        auto dv = consensus::validate_coinbase_total(outs, 5000000000ULL);
+        expect_true("[D] donation validators compile + accept empty coinbase", dv.valid);
+    }
+
+    if (g_fail == 0) {
+        std::printf("RESULT: PASS — BIP-110 v36 sharechain identity delta reproduced (share-hash == block-hash @ 961640).\n");
+        return 0;
+    }
+    std::printf("RESULT: FAIL — %d check(s) failed.\n", g_fail);
+    return 1;
+}

--- a/src/impl/bip110/pool/test/bip110_pool_mint_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_pool_mint_kat.cpp
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// bip110_pool_mint_kat — END-TO-END known-answer test for the M3 v36 sharechain
+// MINT primitive (bip110::pool::create_local_share). The node_compile KAT only
+// takes the mint's ADDRESS (instantiation); the identity KAT reproduces a real
+// block hash on the verify side. This KAT is the missing piece cont2 flagged: it
+// RUNS the mint to completion, pulls the minted share back out of the tracker,
+// and asserts:
+//   [1] the mint succeeds (non-null hash) and the share lands in the tracker;
+//   [2] donation == 66 (the wire-genesis FREEZE value, 0.1%);
+//   [3] the abswork %2^64 wrap (PR-A-cont NIT-2) actually dropped the high 64
+//       bits (we feed an abswork with bit-64 set and prove only the low 64 survive);
+//   [4] segwit_data is populated with the none-sentinel wtxid root = 2^256-1
+//       (SegwitDataDefault) when no witness commitment is supplied;
+//   [5] the coinbase OP_RETURN round-trips: the last_txout_nonce embedded in the
+//       mined coinbase is the one stored on the share;
+//   [6] MINT/VERIFY HASH SYMMETRY: recomputing compute_share_hash over the minted
+//       share's small header + the reconstructed merkle root (the exact
+//       derivation the verify path at share_check.hpp:2592-2597 uses) reproduces
+//       the share's stored m_hash byte-for-byte — i.e. the minted hash IS the
+//       BLAKE2b block-identity hash a peer will recompute on verify.
+//
+// The share PoW must meet the share target or create_local_share early-returns
+// null (share_check.hpp:2607). override_bits/override_max_bits (applied on the
+// has_frozen path) set an artificially easy target (~2^255) and we GRIND the
+// header nonce until the BLAKE2b share hash falls under it — a handful of tries.
+
+#include "../share_tracker.hpp"     // ShareTracker -> share_check.hpp (create_local_share) + share_identity + share_types
+#include "../config_pool.hpp"
+#include "../../coin/block.hpp"     // coin::BlockHeaderType
+
+#include <core/uint256.hpp>
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void expect_true(const std::string& name, bool cond)
+{
+    if (cond) std::printf("  [ok]   %s\n", name.c_str());
+    else { std::printf("  [FAIL] %s\n", name.c_str()); ++g_fail; }
+}
+
+void expect_eq_hex(const std::string& name, const std::string& got, const std::string& want)
+{
+    if (got == want) std::printf("  [ok]   %s\n", name.c_str());
+    else {
+        std::printf("  [FAIL] %s\n         got : %s\n         want: %s\n",
+                    name.c_str(), got.c_str(), want.c_str());
+        ++g_fail;
+    }
+}
+
+std::vector<unsigned char> from_hex(const std::string& s)
+{
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return 0;
+    };
+    std::vector<unsigned char> out;
+    out.reserve(s.size() / 2);
+    for (size_t i = 0; i + 1 < s.size(); i += 2)
+        out.push_back(static_cast<unsigned char>((nib(s[i]) << 4) | nib(s[i + 1])));
+    return out;
+}
+
+// REAL BIP-110 block 961640 v2 header (flags=0/clear_bits=0/xor_key=0 — passes
+// check_header_fail_closed). Reused as a well-formed 164B v2 header carrier; we
+// grind its nonce for the KAT's easy share target.
+const char* HDR_961640 =
+    "000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000"
+    "c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc768"
+    "4dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d030000000000000000"
+    "0000001e0300000000000000000000000000000000000068ac0e0000000000000000000000"
+    "00000000000000000000000000000000000000000000000000";
+
+} // namespace
+
+int main()
+{
+    using namespace bip110::pool;
+    namespace coin = bip110::coin;
+
+    std::printf("bip110_pool_mint_kat: M3 v36 sharechain MINT end-to-end\n");
+
+    ShareTracker tracker;
+
+    // Parse the real 164B v2 header into a full coin::BlockHeaderType.
+    std::vector<unsigned char> hdr_bytes = from_hex(HDR_961640);
+    coin::BlockHeaderType full;
+    { PackStream ps(hdr_bytes); ps >> full; }
+    expect_true("[pre] carrier header is v2 (flags/clear_bits/xor_key zero)",
+                full.is_v2() && full.m_flags == 0);
+
+    // A 25-byte P2PKH payout script so the share gets a pubkey_hash/type identity.
+    std::vector<unsigned char> payout_script = {
+        0x76, 0xa9, 0x14,
+        0x11,0x22,0x33,0x44,0x55,0x66,0x77,0x88,0x99,0xaa,
+        0xbb,0xcc,0xdd,0xee,0xff,0x01,0x02,0x03,0x04,0x05,
+        0x88, 0xac };
+
+    // ~20-byte coinbase scriptSig (share.m_coinbase is bounded 2..100 bytes).
+    BaseScript coinbase_bs;
+    coinbase_bs.m_data = { 0x03, 0x28,0xab,0x0e, 0x00, 0x00, 0x2f, 0x62, 0x69,
+                           0x70, 0x31, 0x31, 0x30, 0x2f, 0x00, 0x00, 0x00, 0x00 };
+
+    // A KNOWN full coinbase (actual_coinbase_bytes): create_local_share hashes
+    // THESE bytes for the tx-merkle root and extracts ref_hash + last_txout_nonce
+    // from the last 44 bytes (share_check.hpp:2458,2569). We embed a sentinel
+    // last_txout_nonce (8 bytes at size-12) and assert it round-trips onto the
+    // share, and we recompute the merkle root from these same bytes for the
+    // mint/verify hash-symmetry check.
+    const uint64_t KAT_NONCE = 0x0102030405060708ULL;
+    std::vector<unsigned char> actual_coinbase(80, 0xAB);   // 80 > 44, arbitrary body
+    // ref_hash[32] || last_txout_nonce[8] || locktime[4] = final 44 bytes.
+    for (int i = 0; i < 32; ++i) actual_coinbase[actual_coinbase.size() - 44 + i] = (unsigned char)(0x40 + i);
+    std::memcpy(actual_coinbase.data() + actual_coinbase.size() - 12, &KAT_NONCE, 8);
+    actual_coinbase[actual_coinbase.size() - 4] = 0;  // locktime = 0
+    actual_coinbase[actual_coinbase.size() - 3] = 0;
+    actual_coinbase[actual_coinbase.size() - 2] = 0;
+    actual_coinbase[actual_coinbase.size() - 1] = 0;
+
+    // abswork with bit-64 SET so the %2^64 wrap is observable: GetLow64() == 777.
+    uint128 frozen_abswork; frozen_abswork.SetHex("10000000000000309");  // (1<<64) + 0x309
+    expect_true("[pre] test abswork has high bits (pre-wrap != low64)",
+                frozen_abswork != uint128(frozen_abswork.GetLow64()));
+
+    // Easy share target (~2^255) via override_bits (has_frozen path): grind the
+    // header nonce until the BLAKE2b share hash falls under it.
+    const uint32_t EASY_BITS = 0x207fffff;
+    const uint64_t subsidy = 312500000ULL;   // 3.125 BTC-era
+
+    uint256 minted;
+    uint32_t grind = 0;
+    for (; grind < 200000; ++grind) {
+        full.m_nonce = grind;
+        uint256 h;
+        try {
+            h = create_local_share(
+                tracker, full, coinbase_bs,
+                /* subsidy */               subsidy,
+                /* prev_share (genesis) */  uint256(),
+                /* merkle_branches */       std::vector<uint256>{},
+                payout_script,
+                /* donation */              66,
+                /* merged_addrs */          {},
+                /* stale_info */            StaleInfo::none,
+                /* segwit_active */         true,
+                /* witness_commitment */    std::string{},   // -> SegwitDataDefault sentinel
+                /* message_data */          {},
+                /* actual_coinbase_bytes */ actual_coinbase,
+                /* witness_root */          uint256(),
+                /* override_max_bits */     EASY_BITS,
+                /* override_bits */         EASY_BITS,
+                /* frozen_absheight */      1,
+                /* frozen_abswork */        frozen_abswork,
+                /* frozen_far_share_hash */ uint256(),
+                /* frozen_timestamp */      full.m_timestamp,
+                /* frozen_merged_payout */  uint256(),
+                /* has_frozen */            true,           // REQUIRED for override_bits to apply
+                /* frozen_merkle_branches*/ std::vector<uint256>{},
+                /* frozen_witness_root */   uint256(),
+                /* frozen_merged_cb_info */ std::vector<unsigned char>{},
+                /* share_version */         36,
+                /* desired_version */       36);
+        } catch (const std::exception& e) {
+            std::printf("  [FAIL] create_local_share threw: %s\n", e.what());
+            ++g_fail; break;
+        }
+        if (!h.IsNull()) { minted = h; break; }
+    }
+
+    expect_true("[1] mint succeeded (non-null share hash under easy target)", !minted.IsNull());
+    expect_true("[1] mint landed in the tracker", tracker.chain.contains(minted));
+    if (minted.IsNull() || !tracker.chain.contains(minted)) {
+        std::printf("RESULT: FAIL — mint did not produce a tracked share (grind=%u).\n", grind);
+        return 1;
+    }
+    std::printf("  [info] minted after %u nonce grind(s): %s\n", grind, minted.GetHex().c_str());
+
+    // Recompute the expected merkle root the SAME way the mint (share_check.hpp:
+    // 2581-2592) and the verify path (:704-718) do: Hash(actual_coinbase) folded
+    // through the (empty) merkle link.
+    uint256 gentx_hash = Hash(std::span<const unsigned char>(actual_coinbase.data(), actual_coinbase.size()));
+
+    tracker.chain.get(minted).share.invoke([&](auto* s) {
+        expect_true("[2] donation == 66 (wire-genesis FREEZE 0.1%)", s->m_donation == 66);
+
+        expect_true("[3] abswork %2^64 wrap dropped the high bits (== low64)",
+                    s->m_abswork == uint128(s->m_abswork.GetLow64()));
+        expect_true("[3] abswork wrap value == 0x309 (777) — high bit-64 discarded",
+                    s->m_abswork == uint128(0x309));
+
+        expect_true("[4] segwit_data populated (v36-genesis: always has_value)",
+                    s->m_segwit_data.has_value());
+        if (s->m_segwit_data.has_value())
+            expect_eq_hex("[4] wtxid root == none-sentinel 2^256-1 (SegwitDataDefault)",
+                          s->m_segwit_data->m_wtxid_merkle_root.GetHex(),
+                          SegwitDataDefault::get().m_wtxid_merkle_root.GetHex());
+
+        expect_true("[5] coinbase last_txout_nonce round-trips onto the share",
+                    s->m_last_txout_nonce == KAT_NONCE);
+
+        // [6] MINT/VERIFY hash symmetry.
+        uint256 mr = check_merkle_link(gentx_hash, s->m_merkle_link);
+        uint256 recomputed = compute_share_hash(s->m_min_header, mr);
+        expect_eq_hex("[6] compute_share_hash(minted small-header, merkle) == stored m_hash",
+                      recomputed.GetHex(), s->m_hash.GetHex());
+        expect_eq_hex("[6] stored m_hash == the value create_local_share returned",
+                      s->m_hash.GetHex(), minted.GetHex());
+        expect_true("[6] m_pow_hash set (self-validation passed) and == m_hash",
+                    s->m_pow_hash == s->m_hash);
+    });
+
+    if (g_fail == 0) {
+        std::printf("RESULT: PASS — MINT end-to-end: share minted, fields round-trip, "
+                    "abswork wrapped, segwit sentinel, mint==verify BLAKE2b hash.\n");
+        return 0;
+    }
+    std::printf("RESULT: FAIL — %d check(s) failed.\n", g_fail);
+    return 1;
+}

--- a/src/impl/bip110/pool/test/bip110_pool_mint_kat.cpp
+++ b/src/impl/bip110/pool/test/bip110_pool_mint_kat.cpp
@@ -10,8 +10,9 @@
 //   [2] donation == 66 (the wire-genesis FREEZE value, 0.1%);
 //   [3] the abswork %2^64 wrap (PR-A-cont NIT-2) actually dropped the high 64
 //       bits (we feed an abswork with bit-64 set and prove only the low 64 survive);
-//   [4] segwit_data is populated with the none-sentinel wtxid root = 2^256-1
-//       (SegwitDataDefault) when no witness commitment is supplied;
+//   [4] segwit_data is populated with the REAL coinbase-only witness merkle root
+//       ZERO (merkle([0]), python v36 data.py:1090) when no witness commitment is
+//       supplied — NOT the 0xff None-sentinel;
 //   [5] the coinbase OP_RETURN round-trips: the last_txout_nonce embedded in the
 //       mined coinbase is the one stored on the share;
 //   [6] MINT/VERIFY HASH SYMMETRY: recomputing compute_share_hash over the minted
@@ -157,7 +158,7 @@ int main()
                 /* merged_addrs */          {},
                 /* stale_info */            StaleInfo::none,
                 /* segwit_active */         true,
-                /* witness_commitment */    std::string{},   // -> SegwitDataDefault sentinel
+                /* witness_commitment */    std::string{},   // coinbase-only -> ZERO root
                 /* message_data */          {},
                 /* actual_coinbase_bytes */ actual_coinbase,
                 /* witness_root */          uint256(),
@@ -205,9 +206,10 @@ int main()
         expect_true("[4] segwit_data populated (v36-genesis: always has_value)",
                     s->m_segwit_data.has_value());
         if (s->m_segwit_data.has_value())
-            expect_eq_hex("[4] wtxid root == none-sentinel 2^256-1 (SegwitDataDefault)",
+            expect_eq_hex("[4] wtxid root == ZERO (coinbase-only real root, merkle([0]); "
+                          "python v36 data.py:1090 — NOT the 0xff None-sentinel)",
                           s->m_segwit_data->m_wtxid_merkle_root.GetHex(),
-                          SegwitDataDefault::get().m_wtxid_merkle_root.GetHex());
+                          uint256().GetHex());
 
         expect_true("[5] coinbase last_txout_nonce round-trips onto the share",
                     s->m_last_txout_nonce == KAT_NONCE);

--- a/src/impl/bip110/pool/test/bip110_pool_node_compile.cpp
+++ b/src/impl/bip110/pool/test/bip110_pool_node_compile.cpp
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// bip110_pool_node_compile — COMPILE + INSTANTIATION + LINK gate for the M3
+// PR-A-cont2 sharechain NODE layer + the MINT path.
+//
+// This target compiles node.cpp + protocol_actual.cpp (as sources) so the
+// namespace-copied sharechain node + the single-protocol v36-genesis bridge
+// (bip110::pool::Node) and the c2pool protocol handler (Actual::handle_message)
+// are fully built and linked. main() then:
+//   (1) ODR-uses create_local_share<ShareTracker> — the MINT template — forcing
+//       the whole mint body (Bip110SmallBlockHeaderType::from_full,
+//       check_header_fail_closed, the abswork %2^64 wrap, SegwitDataDefault
+//       populate, and the BLAKE2b compute_share_hash header-identity delta) to
+//       instantiate.
+//   (2) constructs the config-seam adapter (bip110::pool::Config), exercising the
+//       PoolConfigRuntime prefix-from-SSOT derivation and confirming the empty-seed
+//       bootstrap ladder (no PublicDefault arm).
+//   (3) ODR-uses Node::handle + Actual::handle_message so the single-protocol
+//       bridge + protocol bodies link.
+// If this binary links, the PR-A-cont2 node + mint lane compiles end to end.
+
+#include "../node.hpp"          // Node / Actual / NodeImpl / Config
+#include "../share_check.hpp"   // create_local_share (mint path)
+
+#include <boost/asio/io_context.hpp>
+#include <cstdio>
+
+using namespace bip110::pool;
+
+int main()
+{
+    // (1) MINT: instantiate create_local_share against the ShareTracker. Taking its
+    //     address instantiates the full template body — the from_full split, the
+    //     fail-closed guard, the abswork %2^64 wrap, the SegwitDataDefault populate,
+    //     and the compute_share_hash BLAKE2b block-identity delta.
+    volatile auto mint = &create_local_share<ShareTracker>;
+    (void)mint;
+
+    // (2) Config seam: construct the runtime adapter. PoolConfigRuntime() derives
+    //     m_prefix from the static PoolConfig SSOT (params.hpp SHARECHAIN_PREFIX_HEX)
+    //     and leaves m_bootstrap_addrs EMPTY — the cross-pollution guard (decision
+    //     #2: no PublicDefault arm, cannot dial 9333 / the live BTC sharechain).
+    Config cfg;
+    (void)&cfg;
+    if (cfg.pool()->m_prefix.empty()) {
+        std::fprintf(stderr, "bip110_pool_node_compile: FAIL — empty sharechain prefix\n");
+        return 1;
+    }
+    if (!cfg.pool()->m_bootstrap_addrs.empty()) {
+        std::fprintf(stderr, "bip110_pool_node_compile: FAIL — non-empty bootstrap seeds "
+                             "(the empty-seed ladder / decision #2 guard is broken)\n");
+        return 1;
+    }
+    (void)sharechain_net_name(cfg.m_regtest, cfg.m_testnet);
+
+    // (3) Node + protocol: ODR-use the single-protocol bridge handle() and the
+    //     c2pool protocol handler so their bodies compile and link.
+    volatile auto node_handle = &Node::handle;
+    (void)node_handle;
+    volatile auto actual_handle = &Actual::handle_message;
+    (void)actual_handle;
+
+    std::printf("bip110_pool_node_compile: node + single-protocol bridge + Actual "
+                "protocol + config adapter + create_local_share mint instantiated + "
+                "linked OK\n");
+    return 0;
+}

--- a/src/impl/bip110/pool/test/bip110_pool_sharechain_compile.cpp
+++ b/src/impl/bip110/pool/test/bip110_pool_sharechain_compile.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// bip110_pool_sharechain_compile — COMPILE + INSTANTIATION gate for the M3
+// PR-A-continuation sharechain lane. Including share_tracker.hpp transitively
+// pulls the whole verify surface (share_check.hpp -> share.hpp, share_types.hpp,
+// share_identity.hpp, share_messages.hpp, config_pool.hpp, donation_consensus.hpp),
+// which forces every inline ShareTracker method (the v36 decayed-PPLNS walk
+// get_v36_decayed_cumulative_weights, get_expected_payouts, the emergency-decay
+// retarget get_target) to be fully compiled. main() then ODR-uses the verify-path
+// FUNCTION TEMPLATES against the single v36 variant (MergedMiningShare), which
+// transitively instantiates share_init_verify (with the BLAKE2b header-hash delta
+// via compute_share_hash + check_header_fail_closed), generate_share_transaction,
+// share_check, and verify_merged_coinbase_commitment. If this binary links, the
+// PR-A-cont lane compiles end to end.
+
+#include "../share_tracker.hpp"       // -> share_check.hpp -> share.hpp/share_types/share_identity/share_messages/config_pool
+#include "../donation_consensus.hpp"  // tracker-coupled build_expected_payouts (File 5)
+
+#include <cstdio>
+
+using namespace bip110::pool;
+
+int main()
+{
+    // (1) Force instantiation of the verify-path function templates against the
+    //     ONLY variant on this v36-genesis wire. verify_share() internally calls
+    //     share_init_verify(), generate_share_transaction(), share_check() and
+    //     verify_merged_coinbase_commitment(), so taking its address instantiates
+    //     the entire verify chain — including the BLAKE2b header-hash consensus
+    //     delta in share_init_verify (compute_share_hash / check_header_fail_closed).
+    volatile auto vp = &verify_share<MergedMiningShare, ShareTracker>;
+    (void)vp;
+
+    // (2) Construct a ShareTracker: a non-template class, so merely defining it
+    //     (via the include) compiles the v36 decayed-PPLNS walk + emergency-decay
+    //     retarget + get_expected_payouts (all inline members) end to end.
+    ShareTracker tracker;
+    (void)&tracker;  // ODR-use to defeat unused-var elision
+
+    // (3) File 5: tracker-coupled donation build_expected_payouts (instantiate).
+    volatile auto bep = &consensus::build_expected_payouts<ShareTracker>;
+    (void)bep;
+    volatile auto vpt = &consensus::validate_payouts_against_tracker<ShareTracker>;
+    (void)vpt;
+
+    std::printf("bip110_pool_sharechain_compile: verify-path + decayed-PPLNS + "
+                "donation-consensus templates instantiated + linked OK\n");
+    return 0;
+}

--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -14,6 +14,7 @@
 #include <core/coin/utxo.hpp>             // Coin / Outpoint / money_range (GAP2/3/5)
 
 #include <core/target_utils.hpp>
+#include <core/address_utils.hpp>          // M3 mint: username -> payout_script
 #include <core/log.hpp>
 
 #include <algorithm>
@@ -704,11 +705,33 @@ nlohmann::json Bip110WorkSource::mining_submit(
         bool sunk = submit_block_fn_ ? submit_block_fn_(block, f.height) : false;
         if (!sunk)
             LOG_ERROR << "[BIP110-WS] won block reached NO network sink (height=" << f.height << ")";
+
+        // GAP B (M3): a WON block is also a share — mint it into the sharechain
+        // after the block is dispatched (never behind the tracker lock; block
+        // relay must not wait on the mint), mirroring btc write_solved_share on
+        // the won-block arm. Unset in M2 (default OFF) => byte-identical to today.
+        // Uses the NON-witness coinbase (the txid/hash-link basis), NOT the
+        // BIP144 witness coinbase_block reassembled above.
+        if (create_share_fn_) {
+            std::vector<unsigned char> mint_cb;
+            {
+                std::lock_guard<std::mutex> lk(freeze_mutex_);
+                auto it = freeze_map_.find(to_hex(f.h2));
+                if (it != freeze_map_.end()) mint_cb = it->second.coinbase;
+            }
+            std::vector<unsigned char> payout_script = core::address_to_script(username);
+            if (payout_script.empty()) payout_script = donation_script_;
+            create_share_fn_(mint_cb, hdr, *job, payout_script);
+        }
         return nlohmann::json(true);
     }
 
     // SHARE ARM (M3 seam): p2pool sharechain write. Unset in M2 -> validated +
-    // counted by the core, no mint.
+    // counted by the core, no mint. When set (main_bip110 --bip110-sharechain),
+    // the callback mints via bip110::pool::create_local_share. The payout_script
+    // is derived here from the authorized username (the miner's own address),
+    // falling back to the node-owner/donation script — the same identity the
+    // coinbase pays — so the minted share's PPLNS payout is consistent.
     if (create_share_fn_) {
         std::vector<unsigned char> coinbase;
         {
@@ -716,7 +739,9 @@ nlohmann::json Bip110WorkSource::mining_submit(
             auto it = freeze_map_.find(to_hex(f.h2));
             if (it != freeze_map_.end()) coinbase = it->second.coinbase;
         }
-        create_share_fn_(coinbase, hdr, *job);
+        std::vector<unsigned char> payout_script = core::address_to_script(username);
+        if (payout_script.empty()) payout_script = donation_script_;
+        create_share_fn_(coinbase, hdr, *job, payout_script);
     }
     return nlohmann::json(true);
 }

--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -89,7 +89,12 @@ Bip110WorkSource::~Bip110WorkSource() = default;
 
 std::function<uint256()> Bip110WorkSource::get_best_share_hash_fn() const
 {
-    return {};  // M2: no p2pool sharechain best-share (create_share_fn unset)
+    // M3 PR-C (flag-ON): return the wired best-share accessor so the generic
+    // stratum_server seam (stratum_server.cpp:1607) feeds the sharechain tip into
+    // JobSnapshot.prev_share_hash and into build_connection_coinbase's ref walk.
+    // M2 (default OFF): best_share_hash_fn_ is unset -> return {} exactly as before
+    // (no p2pool sharechain best-share; create_share_fn/ref_hash_fn also unset).
+    return best_share_hash_fn_;
 }
 
 Bip110WorkSource::NextWork Bip110WorkSource::next_work() const
@@ -143,7 +148,7 @@ std::string Bip110WorkSource::get_current_gbt_prevhash() const
 }
 
 CoinbaseResult Bip110WorkSource::build_connection_coinbase(
-    const uint256& /*prev_share_hash*/,
+    const uint256& prev_share_hash,
     const std::string& extranonce1_hex,
     const std::vector<unsigned char>& payout_script,
     const std::vector<std::pair<uint32_t, std::vector<unsigned char>>>& /*merged_addrs*/) const
@@ -366,8 +371,62 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
         }
     }
 
-    // OP_RETURN ref marker (M2: empty commitment; M3 carries the share ref).
-    std::vector<unsigned char> op_return = {0x6a, 0x00};
+    // OP_RETURN ref marker.
+    //   M2 (default OFF, ref_hash_fn_ unset): EMPTY commitment {0x6a,0x00} —
+    //     byte-identical to the M2 header-follower coinbase. This is the exact btc
+    //     degrade pattern (emit_op_return = ref_hash_fn && !ref_hash.IsNull()).
+    //   M3 PR-C (flag-ON, --bip110-sharechain, ref_hash_fn_ set): the real 42-byte
+    //     p2pool ref commitment {0x6a, 0x28, ref_hash[32], last_txout_nonce[8]}.
+    //     ref_hash_fn_ walks the share tracker off prev_share_hash and returns both
+    //     the ref_hash AND the frozen share fields create_local_share reproduces —
+    //     so the commitment the coinbase carries == the ref_hash a peer recomputes
+    //     off the minted share (mint==verify; peers accept the share). The 8-byte
+    //     last_txout_nonce is BAKED IN here (unlike btc, where extranonce fills it
+    //     between coinb1/coinb2): on BIP-110 the extranonce lives in the 164B Sia
+    //     header, not the coinbase, so the coinbase tail is fully frozen at build.
+    //     The mint (create_local_share, share_check.hpp:2458/2569) extracts
+    //     ref_hash + last_txout_nonce from the coinbase's last 44 bytes
+    //     (ref_hash[32] + nonce[8] + locktime[4]) — this layout produces exactly
+    //     that tail.
+    // F1b (companion gap, NOT this PR): the reward split above still pays a SINGLE
+    // miner (coinbase-only), not the PPLNS distribution. A peer's share_check
+    // (share_check.hpp:1840-1952) rebuilds the expected coinbase from PPLNS weights
+    // (generate_share_transaction) and THROWS on mismatch — so a share minted off
+    // THIS coinbase passes the ref/hash_link check (below) but is still declined on
+    // PPLNS grounds until build_connection_coinbase serves the PPLNS-distributed
+    // coinbase (btc's set_pplns_fn / get_expected_payouts pattern). F1 (this PR)
+    // closes the empty-commitment blocker; F1b is the remaining peer-acceptance step.
+    std::vector<unsigned char> op_return = {0x6a, 0x00};   // M2 empty commitment
+    core::stratum::RefHashResult rh_result;
+    const bool sharechain_ref = static_cast<bool>(ref_hash_fn_);
+    if (sharechain_ref) {
+        try {
+            rh_result = ref_hash_fn_(prev_share_hash, cb_script, payout_script,
+                                     w.subsidy, w.nbits, w.curtime);
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[BIP110-WS] ref_hash_fn threw: " << e.what()
+                        << " — refusing job (would emit an unverifiable coinbase)";
+            return CoinbaseResult{};
+        }
+        if (rh_result.ref_hash.IsNull()) {
+            LOG_WARNING << "[BIP110-WS] ref_hash_fn returned null ref_hash (height="
+                        << w.height << ") — refusing job (unverifiable coinbase)";
+            return CoinbaseResult{};
+        }
+        // 6a 28 (OP_RETURN PUSH_40) + ref_hash[32] + last_txout_nonce[8] = 42 bytes.
+        op_return.assign({0x6a, 0x28});
+        op_return.insert(op_return.end(), rh_result.ref_hash.data(),
+                         rh_result.ref_hash.data() + 32);
+        const uint64_t nn = rh_result.last_txout_nonce;
+        const auto* np = reinterpret_cast<const unsigned char*>(&nn);
+        op_return.insert(op_return.end(), np, np + 8);   // LE nonce slot (baked)
+        // Freeze the SAME share target the ref committed so the job's difficulty
+        // classification and the mint's override_bits agree (btc work_source:717).
+        if (rh_result.bits != 0) {
+            share_bits_.store(rh_result.bits, std::memory_order_relaxed);
+            share_max_bits_.store(rh_result.max_bits, std::memory_order_relaxed);
+        }
+    }
 
     auto cb = bip110::coin::assemble_gentx_coinbase(
         cb_script, segwit_commit, payouts, donation_amt, donation, op_return);
@@ -563,6 +622,30 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
     s.segwit_active   = true;
     s.merkle_branches = {};                                   // literally empty
     s.witness_root    = uint256::ZERO;
+
+    // ── M3 PR-C: freeze the share fields the ref committed into the snapshot ──
+    // The generic stratum_server seam copies these into the JobEntry (stratum_
+    // server.cpp:1823-1834) and rebuilds them into JobSnapshot.frozen_ref, which
+    // create_local_share consumes on the has_frozen=TRUE path (main_bip110) so the
+    // minted share reproduces the EXACT ref_hash this coinbase embedded. Only on
+    // the flag-ON path; M2 leaves frozen_ref default (byte-identical to today).
+    if (sharechain_ref) {
+        s.frozen_ref.ref_hash          = rh_result.ref_hash;
+        s.frozen_ref.last_txout_nonce  = rh_result.last_txout_nonce;
+        s.frozen_ref.absheight         = rh_result.absheight;
+        s.frozen_ref.abswork           = rh_result.abswork;
+        s.frozen_ref.far_share_hash    = rh_result.far_share_hash;
+        s.frozen_ref.bits              = rh_result.bits;
+        s.frozen_ref.max_bits          = rh_result.max_bits;
+        s.frozen_ref.timestamp         = rh_result.timestamp;
+        s.frozen_ref.merged_payout_hash = rh_result.merged_payout_hash;
+        s.frozen_ref.share_version     = 36;   // v36-genesis (no AutoRatchet)
+        s.frozen_ref.desired_version   = 36;
+        // Coinbase-only: no merged mining, segwit is the none-sentinel constant;
+        // frozen_merkle_branches / frozen_witness_root / frozen_merged_coinbase_info
+        // stay empty (create_local_share then uses the sentinel SegwitData, matching
+        // the ref_hash_fn's segwit serialization).
+    }
     return out;
 }
 

--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -5,6 +5,8 @@
 #include "../coin/header_chain.hpp"
 #include "../coin/template_builder.hpp"   // get_block_subsidy, compute_merkle_root, witness_merkle_root
 #include "../coin/gentx_coinbase.hpp"
+#include "../pool/share_check.hpp"        // F1b: compute_p2pool_witness_commitment (SSOT segwit commitment)
+#include "../pool/share_types.hpp"        // F1b: SegwitDataDefault none-sentinel wtxid root
 #include "../coin/mempool.hpp"            // M3 tx-serving
 #include "../coin/block_assembler.hpp"    // M3 ancestor-package tx selection
 #include "serve_xcheck.hpp"               // GAP5 independent fee re-derivation
@@ -308,7 +310,7 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
     // fee_total came ONLY from tier-1/2/3-priced entries with MoneyRange checks;
     // over-claiming here = INVALID block = lost reward, so the value guard below
     // and the independent pre-serve xcheck both re-derive this sum.
-    const uint64_t subsidy = w.subsidy + fee_total;   // == coinbasevalue
+    const uint64_t subsidy = w.subsidy + fee_total;   // == coinbasevalue (M2 path)
     const std::vector<unsigned char>& owner_script =
         !node_owner_script_.empty() ? node_owner_script_ : donation_script_;
 
@@ -316,8 +318,99 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
     uint64_t donation_amt = 0;
     std::vector<unsigned char> donation = donation_script_;
 
-    if (!payout_script.empty()) {
-        // NORMAL MINING: split the subsidy between miner, author donation, owner.
+    // ── M3 PR-C (F1b): PPLNS-DISTRIBUTED coinbase on the FLAG-ON path ─────────
+    // When --bip110-sharechain is ON, main_bip110 installs pplns_fn_ (alongside
+    // ref_hash_fn_). A peer verifying a share runs generate_share_transaction
+    // (share_check.hpp:1840-1952, the SSOT), which rebuilds the coinbase paying the
+    // ENTIRE decayed PPLNS window and THROWS on any byte mismatch. So the minted
+    // coinbase MUST equal that reconstruction. pplns_fn_ returns exactly the
+    // {script->amount} map generate_share_transaction computes (ShareTracker::
+    // get_expected_payouts, share_tracker.hpp:2016 — the SAME get_v36_decayed_
+    // cumulative_weights, the SAME (uint288(subsidy)*weight/total).GetLow64()
+    // truncation, the SAME >=1-sat donation guard). Here we reproduce generate_
+    // share_transaction's ordering EXACTLY: extract the donation entry, drop empty/
+    // zero outputs, sort asc(amount, script), keep-LAST 4000, donation output
+    // second-to-last (absorbs the residual, == subsidy - Σamounts), OP_RETURN ref
+    // last. Byte-for-byte == generate_share_transaction => peers ACCEPT the share.
+    //
+    // Subsidy source: the flag-ON path distributes w.subsidy (BLOCK subsidy, NO
+    // fees) because ref_hash_fn_ is called with w.subsidy so the minted share
+    // stores m_subsidy = w.subsidy and verify distributes share.m_subsidy. Fees are
+    // NOT representable in generate_share_transaction, so we HARD-GUARD a fee- or
+    // tx-bearing job off the sharechain path (coinbase-only) until fee-into-PPLNS
+    // is designed (PR-D). Off the flag (pplns_fn_ unset) the single-miner split
+    // below is untouched — byte-identical to M2.
+    std::map<std::vector<unsigned char>, double> pmap;
+    if (pplns_fn_) {
+        const uint256 block_target = chain::bits_to_target(w.nbits);   // v36 ignores; pass real
+        try {
+            pmap = pplns_fn_(prev_share_hash, block_target, w.subsidy, donation_script_);
+        } catch (const std::exception& e) {
+            LOG_WARNING << "[BIP110-WS] pplns_fn threw: " << e.what()
+                        << " — refusing job (unverifiable coinbase)";
+            return CoinbaseResult{};
+        }
+        if (pmap.empty()) {
+            // Tracker busy / not walkable this refresh. Genesis is NOT empty (the
+            // window has no miners but pplns_fn folds the full-subsidy donation in),
+            // so an empty map means we cannot build a peer-verifiable coinbase —
+            // refuse rather than emit a single-miner coinbase peers would reject.
+            LOG_WARNING << "[BIP110-WS] pplns_fn returned empty (tracker busy) — "
+                           "refusing sharechain job (height=" << w.height << ")";
+            return CoinbaseResult{};
+        }
+        // Fees/txs are not in generate_share_transaction — refuse a tx-bearing job.
+        if (fee_total != 0 || n_other != 0) {
+            LOG_WARNING << "[BIP110-WS] flag-ON PPLNS refuses tx-bearing job (fee_total="
+                        << fee_total << " n_other=" << n_other << ", height=" << w.height
+                        << ") — fee-into-PPLNS unimplemented; sharechain path is coinbase-only";
+            return CoinbaseResult{};
+        }
+    }
+
+    if (pplns_fn_) {
+        // FLAG-ON PPLNS path (reproduces generate_share_transaction exactly).
+        // donation_script_ == PoolConfig::get_donation_script(36) here (set in
+        // main_bip110:502) — the SAME key pplns_fn folded the residual into, and the
+        // donation output script the assembler must emit second-to-last.
+        donation = donation_script_;
+        donation_amt = 0;
+        if (auto it = pmap.find(donation_script_); it != pmap.end()) {
+            donation_amt = static_cast<uint64_t>(it->second);   // pre-cap residual (SSOT)
+            pmap.erase(it);                                      // never amount-sorted among payouts
+        }
+        for (auto& [s, a] : pmap) {
+            if (s.empty()) continue;                            // empty-script drop (matches verify)
+            uint64_t v = static_cast<uint64_t>(a);              // GetLow64 truncation already applied
+            if (v > 0) payouts.emplace_back(s, v);              // dust (<1 sat) drop
+        }
+        std::sort(payouts.begin(), payouts.end(),
+            [](const auto& a, const auto& b) {
+                if (a.second != b.second) return a.second < b.second;  // asc by amount
+                return a.first < b.first;                              // tie-break asc by script
+            });
+        if (payouts.size() > 4000)                              // keep-LAST 4000 (== verify's [-4000:])
+            payouts.erase(payouts.begin(), payouts.end() - 4000);
+        if (donation.empty()) donation = {0x6a};                // never (get_donation_script(36) non-empty)
+
+        // Rebuild the witness-commitment output as the P2POOL commitment the verify
+        // SSOT reconstructs (compute_p2pool_witness_commitment over the SegwitData
+        // none-sentinel wtxid root = 2^256-1) — NOT the M2 standard zero-nonce
+        // commitment. A coinbase-only flag-ON job mints a share whose m_segwit_data
+        // is the SegwitDataDefault sentinel, and generate_share_transaction emits
+        // {6a 24 aa 21 a9 ed} ++ compute_p2pool_witness_commitment(sentinel). We
+        // MUST emit that same 32-byte body or the reconstruction diverges.
+        {
+            const uint256 wc = bip110::pool::compute_p2pool_witness_commitment(
+                bip110::pool::SegwitDataDefault::get().m_wtxid_merkle_root);
+            std::vector<unsigned char> sc = {0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed};
+            const auto wcb = wc.GetChars();
+            sc.insert(sc.end(), wcb.begin(), wcb.end());
+            segwit_commit = std::move(sc);
+        }
+    } else if (!payout_script.empty()) {
+        // NORMAL MINING (M2, flag OFF): split the subsidy between miner, author
+        // donation, owner. UNTOUCHED — byte-identical to M2.
         uint64_t don   = (!donation_script_.empty() && give_author_ppm_ > 0)
                        ? (subsidy * give_author_ppm_ / 1000000ULL) : 0;   // floor
         uint64_t owner = (!owner_script.empty() && node_owner_fee_ppm_ > 0)
@@ -357,16 +450,20 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
     if (donation.empty()) donation = {0x6a};      // OP_RETURN placeholder (0-value)
 
     // Value-conservation guard: the sum of all non-commitment output values MUST
-    // equal subsidy + fees (M2: fees == 0). A mismatch means a construction bug
-    // would over-claim or burn value — refuse rather than emit an invalid/burning
-    // coinbase.
+    // equal the distributed subsidy — w.subsidy on the flag-ON PPLNS path (fees
+    // hard-guarded to 0), subsidy+fees on the M2 path. A mismatch means a
+    // construction bug would over-claim or burn value — refuse rather than emit an
+    // invalid/burning coinbase. (On flag-ON this also fails-closed if the 4000-cap
+    // ever drops outputs, which cannot happen on the tiny federation window.)
     {
+        const uint64_t expect = pplns_fn_ ? w.subsidy : subsidy;
         uint64_t total_out = donation_amt;
         for (const auto& [scr, amt] : payouts) { (void)scr; total_out += amt; }
-        if (total_out != subsidy) {
+        if (total_out != expect) {
             LOG_ERROR << "[BIP110-WS] REFUSING work: coinbase output value " << total_out
-                      << " != subsidy+fees " << subsidy << " (subsidy=" << w.subsidy
-                      << " fees=" << fee_total << " height=" << w.height << ")";
+                      << " != expected " << expect << " (subsidy=" << w.subsidy
+                      << " fees=" << fee_total << " pplns=" << (pplns_fn_ ? 1 : 0)
+                      << " height=" << w.height << ")";
             return CoinbaseResult{};
         }
     }
@@ -388,14 +485,12 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
     //     ref_hash + last_txout_nonce from the coinbase's last 44 bytes
     //     (ref_hash[32] + nonce[8] + locktime[4]) — this layout produces exactly
     //     that tail.
-    // F1b (companion gap, NOT this PR): the reward split above still pays a SINGLE
-    // miner (coinbase-only), not the PPLNS distribution. A peer's share_check
-    // (share_check.hpp:1840-1952) rebuilds the expected coinbase from PPLNS weights
-    // (generate_share_transaction) and THROWS on mismatch — so a share minted off
-    // THIS coinbase passes the ref/hash_link check (below) but is still declined on
-    // PPLNS grounds until build_connection_coinbase serves the PPLNS-distributed
-    // coinbase (btc's set_pplns_fn / get_expected_payouts pattern). F1 (this PR)
-    // closes the empty-commitment blocker; F1b is the remaining peer-acceptance step.
+    // F1b (CLOSED here): on the flag-ON path the reward split above is now the FULL
+    // PPLNS distribution (pplns_fn_ branch) — byte-for-byte == generate_share_
+    // transaction (share_check.hpp:1840-1952), so the peer's PPLNS reconstruction no
+    // longer THROWS and the share is ACCEPTED. F1 closed the empty-commitment
+    // blocker (ref/hash_link); F1b closes the PPLNS-payout blocker. Off the flag the
+    // split stays the single-miner M2 coinbase (byte-identical to M2).
     std::vector<unsigned char> op_return = {0x6a, 0x00};   // M2 empty commitment
     core::stratum::RefHashResult rh_result;
     const bool sharechain_ref = static_cast<bool>(ref_hash_fn_);

--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -394,15 +394,22 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
         if (donation.empty()) donation = {0x6a};                // never (get_donation_script(36) non-empty)
 
         // Rebuild the witness-commitment output as the P2POOL commitment the verify
-        // SSOT reconstructs (compute_p2pool_witness_commitment over the SegwitData
-        // none-sentinel wtxid root = 2^256-1) — NOT the M2 standard zero-nonce
-        // commitment. A coinbase-only flag-ON job mints a share whose m_segwit_data
-        // is the SegwitDataDefault sentinel, and generate_share_transaction emits
-        // {6a 24 aa 21 a9 ed} ++ compute_p2pool_witness_commitment(sentinel). We
-        // MUST emit that same 32-byte body or the reconstruction diverges.
+        // SSOT reconstructs: compute_p2pool_witness_commitment over the REAL witness
+        // merkle root. Flag-ON is hard coinbase-only (n_other==0 above), so the real
+        // root is witness_merkle_root({}) = merkle([0]) = ZERO — exactly the python
+        // v36 fork's segwit_data['wtxid_merkle_root'] for a coinbase-only mined share
+        // (data.py:1090, merkle_hash([0])==0). It is NOT the 0xff None-sentinel
+        // (2^256-1): that value is only the PossiblyNoneType WIRE ENCODING of "no
+        // segwit_data", never a real root. Committing over the sentinel made the
+        // found block consensus-INVALID (segwit recomputes the commitment over the
+        // real root ZERO, not 0xff => bad-witness-merkle-match) AND diverged from a
+        // python-fork peer. The block-body reserved value spliced by assemble_gentx_
+        // coinbase below is '[P2Pool]'*4, so segwit consensus' check
+        // commitment == SHA256d(ZERO || '[P2Pool]'*4) passes. create_local_share and
+        // the ref_hash_fn store the SAME real root, so mint==verify still holds.
         {
-            const uint256 wc = bip110::pool::compute_p2pool_witness_commitment(
-                bip110::pool::SegwitDataDefault::get().m_wtxid_merkle_root);
+            const uint256 real_wroot = bip110::coin::witness_merkle_root({});  // ZERO
+            const uint256 wc = bip110::pool::compute_p2pool_witness_commitment(real_wroot);
             std::vector<unsigned char> sc = {0x6a, 0x24, 0xaa, 0x21, 0xa9, 0xed};
             const auto wcb = wc.GetChars();
             sc.insert(sc.end(), wcb.begin(), wcb.end());
@@ -523,8 +530,20 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
         }
     }
 
+    // Flag-ON found blocks MUST carry the P2Pool witness reserved value
+    // ('[P2Pool]'*4) in the coinbase input's witness stack so segwit consensus'
+    // witness-commitment check (commitment == SHA256d(witness_root || reserved))
+    // matches the P2Pool commitment output built above. Gated on the SAME
+    // discriminator (pplns_fn_) that chose that commitment. OFF/M2 leaves it empty
+    // => 32-zero reserved value, byte-identical to M2 (whose commitment is computed
+    // over reserved 0*32).
+    std::vector<unsigned char> witness_reserved;
+    if (pplns_fn_)
+        witness_reserved.assign(std::begin(bip110::pool::P2POOL_WITNESS_NONCE),
+                                std::end(bip110::pool::P2POOL_WITNESS_NONCE));
     auto cb = bip110::coin::assemble_gentx_coinbase(
-        cb_script, segwit_commit, payouts, donation_amt, donation, op_return);
+        cb_script, segwit_commit, payouts, donation_amt, donation, op_return,
+        witness_reserved);
 
     // ── Header tx-set commitment: the txid-merkle root over [coinbase] ++ the
     // selected txs (block order), and the u16 txcount = 1 + N. On BIP-110 BOTH
@@ -736,10 +755,13 @@ CoinbaseResult Bip110WorkSource::build_connection_coinbase(
         s.frozen_ref.merged_payout_hash = rh_result.merged_payout_hash;
         s.frozen_ref.share_version     = 36;   // v36-genesis (no AutoRatchet)
         s.frozen_ref.desired_version   = 36;
-        // Coinbase-only: no merged mining, segwit is the none-sentinel constant;
-        // frozen_merkle_branches / frozen_witness_root / frozen_merged_coinbase_info
-        // stay empty (create_local_share then uses the sentinel SegwitData, matching
-        // the ref_hash_fn's segwit serialization).
+        // Coinbase-only: no merged mining. frozen_merkle_branches /
+        // frozen_witness_root / frozen_merged_coinbase_info stay empty — a
+        // coinbase-only share's real witness merkle root is ZERO (merkle([0]),
+        // python v36 data.py:1090), which is exactly what create_local_share's
+        // segwit-active coinbase-only branch stores (frozen_witness_root default
+        // uint256() IsNull => witness_root default uint256() == ZERO) and what the
+        // ref_hash_fn serializes. NOT the 0xff None-sentinel.
     }
     return out;
 }

--- a/src/impl/bip110/stratum/work_source.hpp
+++ b/src/impl/bip110/stratum/work_source.hpp
@@ -109,6 +109,23 @@ public:
         const std::vector<unsigned char>& payout_script,
         uint64_t subsidy, uint32_t block_bits, uint32_t timestamp)>;
 
+    // Sharechain PPLNS-payout producer (M3 PR-C F1b, flag-ON only). Given the job's
+    // prev_share_hash (the sharechain tip) + the BLOCK subsidy + the canonical
+    // donation script, returns the {scriptPubKey -> amount} map for the ENTIRE
+    // decayed PPLNS window — EXACTLY what the verify SSOT generate_share_transaction
+    // (share_check.hpp) reconstructs off the minted share (get_expected_payouts,
+    // share_tracker.hpp). main_bip110 wires this to a lambda that, under
+    // read_tracker(), calls ShareTracker::get_expected_payouts. build_connection_
+    // coinbase consumes the map on the flag-ON path: extracts the donation entry,
+    // sorts the miner outputs asc(amount, script), applies the 4000-output cap, and
+    // emits them (donation output second-to-last, OP_RETURN ref last) so the minted
+    // coinbase == generate_share_transaction byte-for-byte (peers ACCEPT the share).
+    // Left UNSET in M2 (default OFF) => build_connection_coinbase keeps the single-
+    // miner split (byte-identical to today). Mirrors main_btc.cpp set_pplns_fn.
+    using PplnsFn = std::function<std::map<std::vector<unsigned char>, double>(
+        const uint256& prev_share_hash, const uint256& block_target,
+        uint64_t subsidy, const std::vector<unsigned char>& donation_script)>;
+
     Bip110WorkSource(bip110::coin::HeaderChain& chain,
                      bool is_testnet,
                      SubmitBlockFn submit_fn,
@@ -186,6 +203,11 @@ public:
     // seam); ref_hash_fn_ produces the coinbase ref commitment + frozen fields.
     void set_best_share_hash_fn(std::function<uint256()> fn) { best_share_hash_fn_ = std::move(fn); }
     void set_ref_hash_fn(RefHashFn fn) { ref_hash_fn_ = std::move(fn); }
+    // M3 PR-C F1b: the PPLNS-distributed coinbase producer (flag-ON only). Set from
+    // main_bip110 INSIDE the --bip110-sharechain block alongside set_ref_hash_fn.
+    // When unset (M2 default OFF) build_connection_coinbase keeps the single-miner
+    // split — byte-identical to M2.
+    void set_pplns_fn(PplnsFn fn) { pplns_fn_ = std::move(fn); }
 
     // ── M3 daemonless mempool tx-serving ─────────────────────────────────
     // Wire the embedded mempool (P2P-ingested, daemonlessly priced) so templates
@@ -248,6 +270,7 @@ private:
     // M3 PR-C sharechain ref-commitment (flag-ON only; unset in M2). See setters.
     std::function<uint256()>     best_share_hash_fn_;   // sharechain tip -> job.prev_share_hash
     RefHashFn                    ref_hash_fn_;          // coinbase ref_hash + frozen fields
+    PplnsFn                      pplns_fn_;             // F1b: PPLNS-distributed coinbase payouts (flag-ON only)
 
     // M3 mempool tx-serving. Read-only pointer; owned by main_bip110.
     bip110::coin::Mempool*       mempool_{nullptr};

--- a/src/impl/bip110/stratum/work_source.hpp
+++ b/src/impl/bip110/stratum/work_source.hpp
@@ -39,6 +39,34 @@ namespace bip110::coin { class HeaderChain; class Mempool; }
 
 namespace bip110::stratum {
 
+// Extract the coinbase scriptSig from a serialized (non-witness) coinbase tx.
+// The share's m_coinbase field is the coinbase *scriptSig* (share_init_verify
+// bounds it to 2..100 bytes), NOT the whole coinbase transaction — so the M3
+// mint path (main_bip110.cpp create_share_fn) slices it here before calling
+// bip110::pool::create_local_share. Per-coin copy of the btc/dgb helper
+// (btc/stratum/work_source.hpp:75) per the coin-isolation invariant; fail-closed
+// (returns {} on any truncation/overrun -> the mint declines on size<2).
+inline std::vector<unsigned char>
+extract_coinbase_scriptsig(const std::vector<unsigned char>& coinbase_tx) {
+    constexpr size_t kScriptOffset = 4 + 1 + 32 + 4;  // version|marker?|prevout(null)|index = 41
+    if (coinbase_tx.size() < kScriptOffset + 1)
+        return {};
+    size_t off = kScriptOffset;
+    uint64_t len = coinbase_tx[off++];
+    if (len == 0xfd) {
+        if (off + 2 > coinbase_tx.size()) return {};
+        len = static_cast<uint64_t>(coinbase_tx[off])
+            | (static_cast<uint64_t>(coinbase_tx[off + 1]) << 8);
+        off += 2;
+    } else if (len >= 0xfe) {
+        return {};  // implausible for a consensus-capped (<=100B) coinbase scriptSig
+    }
+    if (off + len > coinbase_tx.size())
+        return {};
+    return std::vector<unsigned char>(coinbase_tx.begin() + off,
+                                      coinbase_tx.begin() + off + len);
+}
+
 class Bip110WorkSource : public core::stratum::IWorkSource
 {
 public:
@@ -51,10 +79,16 @@ public:
     // Sharechain WRITE seam (M3). Called when a share meets sharechain (not
     // block) target. Left unset in M2 => shares are validated + counted but not
     // minted into a p2pool sharechain. Returns the share hash or uint256::ZERO.
+    // PR-B (M3): the 4th arg is the miner payout_script derived in mining_submit
+    // from the authorized username (core::address_to_script, donation fallback).
+    // create_local_share REQUIRES it to build the share's PPLNS payout identity;
+    // BTC's CreateShareFn is likewise 4-arg (main_btc.cpp:2219). Left unset in
+    // M2 (default OFF) => shares are validated + counted but not minted.
     using CreateShareFn = std::function<uint256(
         const std::vector<unsigned char>& full_coinbase,
         const std::vector<unsigned char>& header_164b,
-        const core::stratum::JobSnapshot&  job)>;
+        const core::stratum::JobSnapshot&  job,
+        const std::vector<unsigned char>& payout_script)>;
 
     Bip110WorkSource(bip110::coin::HeaderChain& chain,
                      bool is_testnet,

--- a/src/impl/bip110/stratum/work_source.hpp
+++ b/src/impl/bip110/stratum/work_source.hpp
@@ -90,6 +90,25 @@ public:
         const core::stratum::JobSnapshot&  job,
         const std::vector<unsigned char>& payout_script)>;
 
+    // Sharechain REF-COMMITMENT producer (M3 PR-C, flag-ON only). Given the job's
+    // prev_share_hash (the sharechain tip fed by best_share_hash_fn_), the coinbase
+    // scriptSig, the miner payout script, the block subsidy/bits/timestamp, returns
+    // the p2pool ref_hash + the frozen share fields (absheight/abswork/far/bits/
+    // max_bits/timestamp/merged_payout) that create_local_share must reproduce so
+    // the OP_RETURN commitment the coinbase carries == the ref_hash a peer recomputes
+    // off the minted share (mint==verify). main_bip110.cpp wires this to a lambda
+    // that walks the share tracker (near-verbatim port of main_btc.cpp's ref_hash_fn,
+    // minus merged-mining — bip110 v36 is single-chain, segwit sentinel constant).
+    // Left UNSET in M2 (default OFF) => build_connection_coinbase emits the empty
+    // {0x6a,0x00} M2 OP_RETURN and populates no frozen_ref (byte-identical to today).
+    // Coinbase-only: no txid_merkle_branches / witness_root / merged blob args (the
+    // segwit_data is the SegwitDataDefault none-sentinel, folded in by the lambda).
+    using RefHashFn = std::function<core::stratum::RefHashResult(
+        const uint256& prev_share_hash,
+        const std::vector<unsigned char>& coinbase_scriptSig,
+        const std::vector<unsigned char>& payout_script,
+        uint64_t subsidy, uint32_t block_bits, uint32_t timestamp)>;
+
     Bip110WorkSource(bip110::coin::HeaderChain& chain,
                      bool is_testnet,
                      SubmitBlockFn submit_fn,
@@ -159,6 +178,15 @@ public:
     void set_node_owner_fee_ppm(uint64_t ppm) { node_owner_fee_ppm_ = ppm; }
     void set_create_share_fn(CreateShareFn fn) { create_share_fn_ = std::move(fn); }
 
+    // M3 PR-C sharechain wiring (flag-ON only). set from main_bip110 INSIDE the
+    // --bip110-sharechain block. When unset (M2 default OFF) the OP_RETURN stays
+    // the empty {0x6a,0x00} commitment and no frozen_ref is populated — byte-
+    // identical to M2. best_share_hash_fn_ feeds the sharechain tip into the job's
+    // prev_share_hash (via get_best_share_hash_fn -> the generic stratum_server
+    // seam); ref_hash_fn_ produces the coinbase ref commitment + frozen fields.
+    void set_best_share_hash_fn(std::function<uint256()> fn) { best_share_hash_fn_ = std::move(fn); }
+    void set_ref_hash_fn(RefHashFn fn) { ref_hash_fn_ = std::move(fn); }
+
     // ── M3 daemonless mempool tx-serving ─────────────────────────────────
     // Wire the embedded mempool (P2P-ingested, daemonlessly priced) so templates
     // include REAL network txs instead of coinbase-only EMPTY blocks. serve=false
@@ -206,14 +234,20 @@ private:
     core::stratum::StratumConfig config_;
 
     std::atomic<uint64_t>        work_generation_{1};
-    std::atomic<uint32_t>        share_bits_{0};
-    std::atomic<uint32_t>        share_max_bits_{0};
+    // mutable: build_connection_coinbase() is const but freezes the ref's share
+    // target into these on the flag-ON path (mirrors btc work_source.hpp:355-356).
+    mutable std::atomic<uint32_t> share_bits_{0};
+    mutable std::atomic<uint32_t> share_max_bits_{0};
 
     std::vector<unsigned char>   donation_script_;     // author/dev donation destination
     std::vector<unsigned char>   node_owner_script_;   // node-owner fee destination (empty => == donation)
     uint64_t                     give_author_ppm_{0};  // author donation, ppm of coinbasevalue (0.1% = 1000)
     uint64_t                     node_owner_fee_ppm_{0};// node-owner fee, ppm of coinbasevalue (1% = 10000)
     CreateShareFn                create_share_fn_;
+
+    // M3 PR-C sharechain ref-commitment (flag-ON only; unset in M2). See setters.
+    std::function<uint256()>     best_share_hash_fn_;   // sharechain tip -> job.prev_share_hash
+    RefHashFn                    ref_hash_fn_;          // coinbase ref_hash + frozen fields
 
     // M3 mempool tx-serving. Read-only pointer; owned by main_bip110.
     bip110::coin::Mempool*       mempool_{nullptr};


### PR DESCRIPTION
> **DRAFT — DO NOT MERGE.** Stacks on the M3 PR chain (`bip110-m3-pra-sharechain-lane`, PR #1449 family). This branch is off the lane head, so the diff vs `master` includes the lane commits; only the top commit (`bip110 M3: flag-ON found-block witness reconcile`) belongs to this PR. Fold onto the M3 stack; merge after the lane lands.

## The bug (block validity / money)

On the flag-ON (`--bip110-sharechain`, default **OFF**) path the minted coinbase carries a P2Pool witness-commitment output, but:

1. the coinbase **block-body witness reserved value** was spliced as 32 zeros (`gentx_coinbase.hpp`), and
2. the **commitment** was computed over the `0xff` None-sentinel wtxid root (`2^256-1`, `SegwitDataDefault`).

A flag-ON share that **also meets the coin block target** and is submitted as a **found block** is therefore consensus-invalid. Segwit recomputes the coinbase witness commitment as `SHA256d(witness_merkle_root || reserved)` over the **real** witness root — coinbase-only ⇒ `merkle([0]) == ZERO` — which matched *neither* the `0xff` root *nor* the 0-reserved value ⇒ `bad-witness-merkle-match`, block rejected, **a won block lost**. This is not a share-acceptance blocker (peers verify the non-witness txid/merkle), which is why it is a separate must-fix.

## Fix — reconcile both axes to the python v36 reference

`p2pool-merged-v36 data.py:1090/1092-1094`: a segwit-active **coinbase-only** mined share uses `wtxid_merkle_root = merkle_hash([0]) = 0` and `witness_reserved_value = '[P2Pool]'*4`. Both are needed; fixing only the reserved value leaves the block invalid (the commitment would still be over `0xff`).

| file | change |
|---|---|
| `coin/gentx_coinbase.hpp` | `assemble_gentx_coinbase` takes an optional `witness_reserved_value` (empty ⇒ 32 zeros, byte-identical); block-body witness stack splices it |
| `stratum/work_source.cpp` | flag-ON commitment over the **real** root `witness_merkle_root({}) == ZERO` (not the `0xff` sentinel); assemble call passes `'[P2Pool]'*4` iff `pplns_fn_` (same discriminator that chose the P2Pool commitment). OFF/M2 passes empty ⇒ 32-zero reserved |
| `pool/share_check.hpp` | `create_local_share` stores a segwit-active coinbase-only share's `wtxid_merkle_root` as the real root `ZERO` — so mint==verify **and** the on-chain commitment is consensus-valid. Sentinel retained only for segwit-inactive (never on this v36-genesis chain) |
| `c2pool/main_bip110.cpp` | `ref_hash_fn` serializes the same `ZERO` root so the ref a peer recomputes off the stored share matches the coinbase |

The reconciled `ZERO` root **is** the python v36 wire value for a mined coinbase-only share (a present `segwit_data` with root 0), so this **converges** with a python-fork peer rather than diverging; the `0xff` sentinel is only the `PossiblyNoneType` wire encoding of "no segwit_data", never a real root.

## Proof they now agree (KAT)

`bip110_multiminer_pplns_kat` extended with `[WR]` assertions on the assembled flag-ON coinbase:

- `[WR]` block-body witness reserved value `== '[P2Pool]'*4`
- `[WR]` `SHA256d(witness_root(ZERO) || reserved_from_block) == coinbase commitment` — **a found block passes segwit CheckWitnessMalleation**
- `[WR-OFF]` no-reserved-arg path stays 32-zero and `SHA256d(ZERO || 0*32) == M2 commitment` (OFF path valid & unchanged)

`pool_mint_kat` / `extend_mint_kat` updated to assert the `ZERO` coinbase-only root.

## Build / test

- `c2pool-bip110`: **green**
- all 9 bip110 tests: **green** (`pool_mint_kat`, `extend_mint_kat`, `multiminer_pplns_kat` incl. new `[WR]`/`[WR-OFF]`, `pool_node_compile`, `pool_identity_kat`, `sharechain_compile`, `blake2b_kat`, `m2_workshape_kat`, `m3_serving_kat`)
- multiminer `[X] generate_share_transaction == minted PPLNS coinbase` still passes (mint==verify preserved)

## Constraints honored

`--bip110-sharechain` default **OFF**; OFF/M2 path **byte-identical** (empty reserved ⇒ 32 zeros; M2 commitment untouched). No `params.hpp` change. Per-coin isolation: changes confined to `src/impl/bip110/*` + a 2-line `ref_hash_fn` segwit-root change in `main_bip110.cpp` (unavoidable — it bakes the same root into the ref commitment).
