### PR TITLE
dash: complete vendored dashscript MSVC portability (Windows x86_64) [DRAFT/do-not-merge]

### DIFF
--- a/src/impl/dash/coin/vendor/dashscript/c2pool_dash_export.h
+++ b/src/impl/dash/coin/vendor/dashscript/c2pool_dash_export.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+// Shared export marker for the pure-C entry points of the HIDDEN-VISIBILITY
+// dash_scriptcheck shared object. Included by BOTH c2pool_scriptcheck.h (the
+// extern "C" DECLARATIONS) and c2pool_scriptcheck.cpp (the DEFINITIONS) so the
+// declaration and the definition carry IDENTICAL linkage. MSVC emits C2375
+// ("redefinition; different linkage") when a dllexport definition was declared
+// without the same dllexport; GCC/Clang tolerate an attribute on the def alone,
+// but decl+def agreement is required for MSVC and harmless everywhere.
+//
+// On GCC/Clang the marker is __attribute__((visibility("default"))): the
+// dash_scriptcheck library builds with -fvisibility=hidden so every
+// bitcoin-derived symbol is hidden (never ODR-collides with c2pool's own
+// btclibs at the final c2pool-dash link), and this attribute re-exports exactly
+// the c2pool_dash_* entry points. On MSVC the equivalent is __declspec(
+// dllexport) on those same entry points. Neither token is defined on Linux, so
+// this reduces to the visibility attribute there — byte-identical to before.
+#ifndef C2POOL_DASH_SCRIPT_EXPORT_H
+#define C2POOL_DASH_SCRIPT_EXPORT_H
+
+#if defined(_MSC_VER)
+#  define C2POOL_DASH_SCRIPT_EXPORT __declspec(dllexport)
+#else
+#  define C2POOL_DASH_SCRIPT_EXPORT __attribute__((visibility("default")))
+#endif
+
+#endif // C2POOL_DASH_SCRIPT_EXPORT_H

--- a/src/impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.cpp
+++ b/src/impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.cpp
@@ -35,11 +35,11 @@
 // and hides all DLL symbols by default, so the equivalent is __declspec(
 // dllexport) on exactly these entry points — WITHOUT it the c2pool_dash_*
 // symbols stay unexported and c2pool-dash fails to link.
-#if defined(_MSC_VER)
-#  define C2POOL_DASH_SCRIPT_EXPORT __declspec(dllexport)
-#else
-#  define C2POOL_DASH_SCRIPT_EXPORT __attribute__((visibility("default")))
-#endif
+//
+// C2POOL_DASH_SCRIPT_EXPORT is defined in c2pool_dash_export.h, included via
+// c2pool_scriptcheck.h above. Sharing it there ensures the DECLARATIONS in the
+// header and the DEFINITIONS below carry IDENTICAL linkage — MSVC emits C2375
+// otherwise (dllexport def whose decl lacked the same dllexport).
 
 namespace {
 

--- a/src/impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.h
+++ b/src/impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.h
@@ -19,6 +19,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// Export marker (dllexport on MSVC / visibility(default) on GCC-Clang). Shared
+// with c2pool_scriptcheck.cpp so the DECLARATIONS below and the DEFINITIONS
+// there carry IDENTICAL linkage — MSVC rejects a dllexport def whose decl was
+// not also dllexport (C2375). No-op on Linux (visibility default, as before).
+#include "c2pool_dash_export.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -39,6 +45,7 @@ enum {
 // script mismatch, out-of-range index, deserialization error, or a size
 // mismatch between the deserialized tx and `tx_to_len`. FAIL-CLOSED: the caller
 // treats 0 as "exclude this tx from the template".
+C2POOL_DASH_SCRIPT_EXPORT
 int c2pool_dash_verify_input(const unsigned char* script_pubkey, unsigned int script_pubkey_len,
                              const unsigned char* tx_to,         unsigned int tx_to_len,
                              unsigned int nIn, unsigned int flags);
@@ -49,12 +56,14 @@ int c2pool_dash_verify_input(const unsigned char* script_pubkey, unsigned int sc
 // deserialize/index error. Used ONLY by the C4 self-signing KAT to produce a
 // valid signature exercising the real interpreter path; not called on the serve
 // path.
+C2POOL_DASH_SCRIPT_EXPORT
 int c2pool_dash_legacy_sighash(const unsigned char* tx_to, unsigned int tx_to_len,
                                unsigned int nIn,
                                const unsigned char* script_code, unsigned int script_code_len,
                                int hash_type, unsigned char* out32);
 
 // KAT helper: Hash160 (RIPEMD160(SHA256(data))). Test-only.
+C2POOL_DASH_SCRIPT_EXPORT
 void c2pool_dash_hash160(const unsigned char* data, unsigned int len, unsigned char* out20);
 
 #ifdef __cplusplus

--- a/src/impl/dash/coin/vendor/dashscript/serialize.h
+++ b/src/impl/dash/coin/vendor/dashscript/serialize.h
@@ -889,7 +889,13 @@ template<typename Stream, typename T> void Unserialize(Stream& is, std::atomic<T
 /**
  * If none of the specialized versions above matched and T is a class, default to calling member function.
  */
-template <class T, class Stream, typename std::enable_if<std::is_class<T>::value>::type* = nullptr >
+// NB: the redundant `enable_if<is_class<T>>` head that used to sit here made
+// MSVC's two-phase lookup evaluate `enable_if<false>::type` at concept-
+// definition time (error C2794); GCC deferred it. Bitcoin Core's serialize.h
+// (MSVC-clean) carries the bare concept — the `requires { a.Serialize(s); }`
+// body already excludes every non-class scalar (int/enum have no .Serialize),
+// so the overload set is byte-identical; this is a pure portability fix.
+template <class T, class Stream>
 concept Serializable = requires(T a, Stream s) { a.Serialize(s); };
 template <typename Stream, typename T>
     requires Serializable<T, Stream>
@@ -898,7 +904,7 @@ void Serialize(Stream& os, const T& a)
     a.Serialize(os);
 }
 
-template <class T, class Stream, typename std::enable_if<std::is_class<std::remove_reference<T> >::value>::type* = nullptr>
+template <class T, class Stream>
 concept Unserializable = requires(T a, Stream s) { a.Unserialize(s); };
 template <typename Stream, typename T>
     requires Unserializable<T, Stream>

--- a/src/impl/dash/coin/vendor/dashscript/support/cleanse.cpp
+++ b/src/impl/dash/coin/vendor/dashscript/support/cleanse.cpp
@@ -7,13 +7,20 @@
 
 #include <cstring>
 
-#if defined(WIN32)
+// _MSC_VER (not bare WIN32) is the correct "this is MSVC" discriminator: MSVC
+// predefines _WIN32/_MSC_VER but NOT WIN32 (only the build system / windows.h
+// sets that token, and this vendored lib's CMake never does), so a WIN32 guard
+// fell through to the GCC inline-asm branch on MSVC (C2065 __asm__/C3861
+// __volatile__). Mirrors Bitcoin Core's _MSC_VER cleanse guard. MinGW-GCC
+// (which supports __asm__) correctly stays on the asm branch. Linux defines
+// neither token → still takes the #else memset+barrier, byte-identical.
+#if defined(_MSC_VER)
 #include <windows.h>
 #endif
 
 void memory_cleanse(void *ptr, size_t len)
 {
-#if defined(WIN32)
+#if defined(_MSC_VER)
     /* SecureZeroMemory is guaranteed not to be optimized out. */
     SecureZeroMemory(ptr, len);
 #else


### PR DESCRIPTION
## dash-Windows MSVC port — vendored dashscript portability (3 defects)

**DRAFT / DO-NOT-MERGE.** Windows-green verification is pending on the self-hosted MSVC runner (it frees after the in-flight bip110 matrix). This PR must stay draft until the integrator confirms the `dash package (Windows x86_64)` release cell compiles + links green. Linux is proven green here (see below).

### Why
The `dash package (Windows x86_64)` release cell has been red since #1341 (v0.2.5-alpha shipped it red). With the conan lock cleared, the real MSVC compile errors now surface. #1448 (the export-attribute macro) was necessary but insufficient. This closes the remaining three MSVC incompatibilities, all inside the vendored dashcore tree under `src/impl/dash/coin/vendor/dashscript/`.

Every change is either `#if defined(_MSC_VER)`-guarded or the byte-identical upstream-Bitcoin-Core form, so **GCC/Clang-Linux codegen is unchanged** (Linux defines neither `WIN32` nor `_MSC_VER`). No params/consensus/serialization-wire change — this is portability-only over consensus script-verification code.

### The three fixes (all in `src/impl/dash/coin/vendor/dashscript/`)

**1. C2375 redefinition; different linkage** (`c2pool_scriptcheck.cpp` 90/114/138)
The export macro (`__declspec(dllexport)` on MSVC) lived only in the `.cpp` and rode the three definitions, but the header declarations of the same `extern "C"` functions carried no macro. MSVC rejects a dllexport definition whose declaration was not also dllexport. Fix: new shared header `c2pool_dash_export.h` defines the marker once; both the header (on the three decls) and the `.cpp` (via the header include) now see the identical macro, so decl and def agree. On GCC the marker is `visibility("default")` on both — adding it to the decls is a no-op for codegen and does not change the `.so` export set.

**2. C2794 'type' is not a member** (`serialize.h` 892/901)
Two C++20 `concept` heads carried a redundant SFINAE `enable_if<is_class<T>>` fragment; MSVC's two-phase lookup evaluates `enable_if<false>::type` at concept-definition time (GCC defers it). Fix: drop the `enable_if` fragment, leaving the bare concept — exactly Bitcoin Core's MSVC-clean form. The `requires { a.Serialize(s); }` body already excludes every non-class scalar (int/enum have no `.Serialize`), so the overload set is byte-identical for every consensus type. No wire change.

**3. C2065 `__asm__` / C3861 `__volatile__`** (`support/cleanse.cpp` 33)
`memory_cleanse`'s barrier was guarded by `#if defined(WIN32)`, but MSVC predefines `_WIN32`/`_MSC_VER`, not bare `WIN32` (this vendored lib's CMake never defines it), so MSVC fell through to the GCC inline-asm branch. Fix: retarget both guard sites `WIN32` → `_MSC_VER` (mirrors Core's cleanse guard). MSVC now takes `SecureZeroMemory` (documented non-elidable secure zero); Linux still takes the `#else` `memset` + `__asm__ __volatile__` barrier, byte-identical; MinGW-GCC (supports `__asm__`) correctly stays on the asm branch. The wipe is not weakened on either toolchain.

### Linux verification (proves the MSVC guards did not perturb GCC)
- `dash_scriptcheck` shared lib (compiles all three changed files) — **built clean**.
- Exported symbols intact: `nm -D` shows exactly `c2pool_dash_verify_input` / `_legacy_sighash` / `_hash160` as `T`, and **zero** other `T` exports — hidden visibility unchanged.
- Consuming KATs + `c2pool-dash` binary — built + linked green (the C4 self-signing KAT exercises the exported entry points through the real interpreter).
- dash KAT suite green.

### Scope
Only `dashscript/*` + `c2pool_scriptcheck.h/.cpp` (+ the new `c2pool_dash_export.h`). No other coin, no bip110, no CMake/consensus/params change.
