### PR TITLE
tools/bip110: GPU (CUDA/CuPy) + CPU Stratum-v1 test miners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,14 @@ tools/dash/*
 # W1 replay-fold KAT fixture generator — tracked source: the fixture .inc
 # headers under test/data/ name it as their reproduction path.
 !tools/dash/gen_replay_kat.py
+# BIP-110 Stratum-v1 test miners — tracked source: GPU (CUDA/CuPy) + CPU
+# reference miners that drive real pool-diff shares into a BIP-110 node to
+# exercise the M3 sharechain / PPLNS / multi-miner convergence.
+!tools/bip110/
+tools/bip110/*
+!tools/bip110/bip110_gpu_miner.py
+!tools/bip110/bip110_miner.py
+!tools/bip110/README.md
 
 # CMake out-of-source build trees (any name starting with `build-`).
 # Catches build-spv/, build-qt/, build-relwithdebinfo/, etc.

--- a/tools/bip110/README.md
+++ b/tools/bip110/README.md
@@ -1,0 +1,115 @@
+# BIP-110 test miners
+
+Standalone Stratum-v1 test miners for the BIP-110 (BLAKE2b, Sia-family PoW)
+Bitcoin fork. They exist to drive **real pool-diff shares** into a c2pool
+BIP-110 node so the M3 sharechain, PPLNS split, multi-miner convergence and the
+majority-escape scenario can be tested with genuine work.
+
+GPUs (and CPUs) **cannot win a block** against BLAKE2b ASICs at network
+difficulty — that is expected and fine. They produce **shares** at pool
+difficulty, which is exactly what these tools are for.
+
+Neither tool touches the pool or c2pool source. Each mirrors the pool's PoW
+fold in Python and **self-tests against live fork block 961640 before it ever
+connects** — a wrong fold fails the self-test and aborts, so an accepted share
+proves the miner did genuine, byte-correct BLAKE2b work.
+
+## Files
+
+| file | PoW backend | use |
+|------|-------------|-----|
+| `bip110_gpu_miner.py` | NVIDIA CUDA BLAKE2b (CuPy `RawModule`, JIT via the driver's nvrtc) | real GPUs — enough hashrate to cross share-diff |
+| `bip110_miner.py`     | CPU (`hashlib.blake2b`), multi-process | reference / low-rate; the byte-correct Stratum plumbing the GPU miner reuses |
+
+## The BIP-110 Stratum-v1 work format
+
+Verified against the pool source (`src/impl/bip110/stratum/work_source.cpp`,
+`pseudoheader.hpp`, `src/core/stratum_server.cpp`):
+
+- **subscribe reply**: `[[[mining.set_difficulty,sid],[mining.notify,sid]], extranonce1(8 hex = 4 bytes), extranonce2_size=4]`. The miner sends extranonce2 as exactly 8 hex.
+- **mining.notify** `[job_id, prevhash, coinb1, coinb2, merkle_branch, version, nbits, ntime, clean_jobs]`:
+  - `prevhash` = RAW wire hex of `prevblock_hidden` — **no** word-swab, **no** reversal. Used as-is.
+  - `coinb1` = 44 bytes = `u32(0) || h2(32) || 8*0x00`; `h2` sits at `coinb1[4..36]`.
+  - `coinb2` = `""` (empty). `merkle_branch` = `[]` — there is **no** SHA256d merkle fold.
+  - `version` = `a0000000` (0xA0000000); version-rolling is **disabled** (do not negotiate).
+  - `nbits` = block bits; the share target comes from `mining.set_difficulty` only.
+  - `ntime` = 8 hex big-endian; **must be echoed unchanged** (ntime is committed into h1; rolling it desyncs h1→h2→root → reject).
+- **mining.submit** `[user, job_id, extranonce2(8 hex), ntime(8 hex), nonce(8 hex)]`.
+
+### The hash pipeline
+
+Per-job, host-side (SHA256 fold — not on the GPU):
+1. `pbh` (prevblock_hidden) arrives verbatim as the notify `prevhash` (32 B).
+2. `root = BLAKE2b-256( coinb1(44) || extranonce1(4) || extranonce2(4) )` — 52-byte preimage; `coinb1` already carries `h2` at `[4..36]`. No merkle branch.
+
+Per-nonce, the **only** on-device op:
+3. `b2 = BLAKE2b-256( pbh(32) || nonce_LE(4) || 0*12 || root(32) )` — one single-block 80-byte BLAKE2b (t0=80, f0=all-ones, param word `IV[0] ^ 0x01010020`, 12 rounds). The 12 zero bytes are `nonce2 || time_offset || nonce3`, all zero for the served Sv1 shape. Display/block hash = `hex(b2)`; a share is found when big-endian `b2 <= target`.
+
+## KAT (correctness gate)
+
+Both miners pin live fork block **961640** and assert their fold reproduces its
+canonical display hash before mining:
+
+```
+80B buf  = pbh || nonce || nonce2 || time_offset || nonce3 || root
+BLAKE2b-256(80B) = 0000000000000050c1e5f69672f459293be14f46e5a494e7a8c8541396f18eeb
+```
+
+The GPU miner additionally runs the 80-byte KAT buffer **through the actual
+`__device__` BLAKE2b core** and a mining-kernel round-trip (own-hash-as-target
+must flag the nonce) at startup, and **aborts on any mismatch**.
+
+```
+python3 bip110_gpu_miner.py --selftest-only      # GPU core == canonical == CPU ref, then exit
+python3 bip110_miner.py     --selftest-only      # CPU ref == canonical (+ fastpath equivalence)
+```
+
+## GPU setup (NVIDIA driver only — no CUDA toolkit needed)
+
+CuPy JIT-compiles the kernel through the driver-provided nvrtc, so only the
+NVIDIA driver is required on the host:
+
+```
+python3 -m venv gpuvenv
+gpuvenv/bin/pip install cupy-cuda12x     # cupy-cuda11x for CUDA 11 drivers
+```
+
+## Run
+
+Single GPU:
+
+```
+gpuvenv/bin/python bip110_gpu_miner.py \
+  --host bip110.voidbind.com --port 9336 \
+  --address <BIP110-ADDR> --worker rig-0 \
+  --diff 2 --minutes 4320 --log /tmp/bip110_gpu_0.log
+```
+
+Multi-GPU = **one process per GPU** with a distinct payout `--address` each (so
+PPLNS split + the concentration monitor have distinct payees to attribute). Use
+`--device N` (or `CUDA_VISIBLE_DEVICES=N`). For a 3-GPU rig, e.g. the 3x3060 at
+192.168.86.123:
+
+```
+for i in 0 1 2; do
+  nohup gpuvenv/bin/python bip110_gpu_miner.py \
+    --device $i \
+    --host bip110.voidbind.com --port 9336 \
+    --address <ADDR_$i> --worker rig3060-$i \
+    --diff 2 --minutes 4320 --log /tmp/bip110_gpu_$i.log & 
+done
+```
+
+### Notes
+
+- `--diff` is the pool's real acceptance floor (a pinned `+N` suffix on the
+  worker name). The live `set_difficulty` vardiff can be looser; the miner mines
+  at `max(--diff, live)` so a share passes both the core "low difficulty" gate
+  and the work-source gate.
+- `--margin` submits shares this many × above the required difficulty (guards a
+  vardiff up-creep between `set_difficulty` messages from borderline-rejecting an
+  in-flight share).
+- The 3060 is LHR, but LHR only throttles Ethash (memory-hard). BLAKE2b is
+  compute-bound, so LHR does not apply.
+- Generate **real** payout addresses before PPLNS-split economics matter — do
+  not reuse the BIP-173 test-vector address for shares you care about.

--- a/tools/bip110/bip110_gpu_miner.py
+++ b/tools/bip110/bip110_gpu_miner.py
@@ -1,0 +1,663 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# bip110_gpu_miner.py — GPU (CuPy RawKernel BLAKE2b) BIP-110 Stratum-v1 test miner.
+#
+# Host-side Sv1 plumbing is reused VERBATIM from the proven CPU miner
+# (bip110_miner.py, gate wcbszi5xo). ONLY the nonce loop is swapped for a
+# CUDA BLAKE2b kernel JIT-compiled by CuPy through the driver-provided nvrtc.
+#
+# The kernel's BLAKE2b core is self-tested against live fork block 961640's
+# canonical display hash BEFORE mining (feeds the block's REAL 80-byte
+# profile-0 buffer through the SAME __device__ blake2b core the mining kernel
+# uses, and asserts byte-for-byte == canonical == the Python reference fold).
+# A wrong core fails the self-test and aborts, so an accepted share proves
+# genuine GPU BLAKE2b work.
+#
+# Usage:
+#   python3 bip110_gpu_miner.py --selftest-only
+#   python3 bip110_gpu_miner.py --host bip110.voidbind.com --port 9336 \
+#       --address bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4 --worker legion64gpu \
+#       --diff 1 --minutes 600 --log /tmp/legion64_gpu_miner.log
+
+import argparse
+import hashlib
+import json
+import os
+import socket
+import struct
+import sys
+import time
+
+# ─────────────────────────── PoW primitives (CPU reference) ─────────────
+
+def sha256(b):
+    return hashlib.sha256(b).digest()
+
+def tagged_hash(tag, msg):
+    th = sha256(tag.encode())
+    return sha256(th + th + msg)
+
+def blake2b256(b):
+    return hashlib.blake2b(b, digest_size=32).digest()
+
+# ─────────────────────────── KAT self-test vector ──────────────────────
+
+KAT_HEADER_HEX = "000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc7684dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d0300000000000000000000001e0300000000000000000000000000000000000068ac0e000000000000000000000000000000000000000000000000000000000000000000"
+KAT_CANONICAL = "0000000000000050c1e5f69672f459293be14f46e5a494e7a8c8541396f18eeb"
+
+
+def parse_header_v2(h):
+    assert len(h) == 164, "v2 header must be 164 bytes, got %d" % len(h)
+    o = {}
+    p = 0
+    def take(n):
+        nonlocal p
+        s = h[p:p+n]; p += n; return s
+    o['version']     = take(4)
+    o['prev']        = take(32)
+    o['merkle']      = take(32)
+    o['time']        = take(4)
+    o['nbits']       = take(4)
+    o['nonce']       = take(4)
+    o['nonce2']      = take(4)
+    o['nonce3']      = take(4)
+    o['extranonce']  = take(16)
+    o['time_offset'] = take(4)
+    o['txcount']     = take(2)
+    o['flags']       = take(1)
+    o['clear_bits']  = take(1)
+    o['xor_key']     = take(16)
+    o['height']      = take(4)
+    o['mm_rhs']      = take(32)
+    assert p == 164
+    return o
+
+
+def compute_h1_h2_pbh(f):
+    assert f['flags'] == b"\x00", "flags must be 0 (profile 0)"
+    assert f['clear_bits'] == b"\x00", "clear_bits must be 0"
+    assert f['xor_key'] == b"\x00" * 16, "xor_key must be null"
+    rev_prev = f['prev'][::-1]
+    xkh = tagged_hash("Bitcoin block hash PoW XOR key", f['xor_key'])
+    txcount = f['txcount'][0] | (f['txcount'][1] << 8)
+    msg1 = b""
+    msg1 += f['version']
+    msg1 += rev_prev
+    msg1 += f['height']
+    msg1 += f['merkle']
+    msg1 += f['time']
+    msg1 += b"\x00"
+    msg1 += f['nbits']
+    msg1 += bytes([txcount & 0xff, (txcount >> 8) & 0xff, 0x00, 0x00])
+    msg1 += f['flags']
+    msg1 += f['clear_bits']
+    msg1 += xkh
+    assert len(msg1) == 119, len(msg1)
+    h1 = tagged_hash("Bitcoin block header 1", msg1)
+    msg2 = h1 + b"\x00" * 32 + f['mm_rhs']
+    assert len(msg2) == 96
+    h2 = tagged_hash("Merge-mining hook", msg2)
+    pbh = bytearray(tagged_hash("Bitcoin prevblock header, hashed", rev_prev))
+    for i in range(6):
+        pbh[i] = 0
+    return h1, h2, bytes(pbh)
+
+
+def compute_root(h2, extranonce16):
+    msg3 = b"\x00" * 4 + h2 + extranonce16
+    assert len(msg3) == 52
+    return blake2b256(msg3)
+
+
+def b2_from(pbh, nonce4, nonce2_4, time_offset4, nonce3_4, root):
+    buf = pbh + nonce4 + nonce2_4 + time_offset4 + nonce3_4 + root
+    assert len(buf) == 80
+    return blake2b256(buf)
+
+# ─────────────────────────── target / diff ─────────────────────────────
+
+DIFF1 = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+
+def share_target_from_diff(diff):
+    if diff <= 0:
+        return DIFF1
+    return int(DIFF1 // diff)
+
+# ─────────────────────────── CUDA BLAKE2b kernel ────────────────────────
+
+CUDA_SRC = r'''
+typedef unsigned long long u64;
+typedef unsigned int       u32;
+typedef unsigned char      u8;
+
+__device__ __forceinline__ u64 rotr64(u64 x, int n){ return (x >> n) | (x << (64 - n)); }
+
+__device__ __forceinline__ u64 bswap64(u64 x){
+    x = ((x & 0x00000000FFFFFFFFULL) << 32) | ((x & 0xFFFFFFFF00000000ULL) >> 32);
+    x = ((x & 0x0000FFFF0000FFFFULL) << 16) | ((x & 0xFFFF0000FFFF0000ULL) >> 16);
+    x = ((x & 0x00FF00FF00FF00FFULL) <<  8) | ((x & 0xFF00FF00FF00FF00ULL) >>  8);
+    return x;
+}
+
+__constant__ u64 IV[8] = {
+    0x6a09e667f3bcc908ULL, 0xbb67ae8584caa73bULL, 0x3c6ef372fe94f82bULL, 0xa54ff53a5f1d36f1ULL,
+    0x510e527fade682d1ULL, 0x9b05688c2b3e6c1fULL, 0x1f83d9abfb41bd6bULL, 0x5be0cd19137e2179ULL
+};
+
+__constant__ u8 SIGMA[12][16] = {
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15},
+    {14,10, 4, 8, 9,15,13, 6, 1,12, 0, 2,11, 7, 5, 3},
+    {11, 8,12, 0, 5, 2,15,13,10,14, 3, 6, 7, 1, 9, 4},
+    { 7, 9, 3, 1,13,12,11,14, 2, 6, 5,10, 4, 0,15, 8},
+    { 9, 0, 5, 7, 2, 4,10,15,14, 1,11,12, 6, 8, 3,13},
+    { 2,12, 6,10, 0,11, 8, 3, 4,13, 7, 5,15,14, 1, 9},
+    {12, 5, 1,15,14,13, 4,10, 0, 7, 6, 3, 9, 2, 8,11},
+    {13,11, 7,14,12, 1, 3, 9, 5, 0,15, 4, 8, 6, 2,10},
+    { 6,15,14, 9,11, 3, 0, 8,12, 2,13, 7, 1, 4,10, 5},
+    {10, 2, 8, 4, 7, 6, 1, 5,15,11, 9,14, 3,12,13, 0},
+    { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15},
+    {14,10, 4, 8, 9,15,13, 6, 1,12, 0, 2,11, 7, 5, 3}
+};
+
+#define G(a,b,c,d,x,y) \
+    v[a] = v[a] + v[b] + (x); v[d] = rotr64(v[d] ^ v[a], 32); \
+    v[c] = v[c] + v[d];       v[b] = rotr64(v[b] ^ v[c], 24); \
+    v[a] = v[a] + v[b] + (y); v[d] = rotr64(v[d] ^ v[a], 16); \
+    v[c] = v[c] + v[d];       v[b] = rotr64(v[b] ^ v[c], 63);
+
+// BLAKE2b-256, single 128-byte compression block, message length = 80 bytes,
+// no key.  m[0..15] are the 16 little-endian 64-bit words of the 128-byte
+// zero-padded block. Writes the first 4 output words (32-byte digest) to h4.
+__device__ void blake2b80_core(const u64 m[16], u64 h4[4]){
+    u64 h[8];
+    h[0] = IV[0] ^ 0x0000000001010020ULL;  // param: digest_length=32, fanout=1, depth=1
+    #pragma unroll
+    for (int i = 1; i < 8; i++) h[i] = IV[i];
+
+    u64 v[16];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) { v[i] = h[i]; v[i+8] = IV[i]; }
+    v[12] ^= 80ULL;                 // t0 = bytes processed = 80
+    // v[13] ^= 0  (t1)
+    v[14] ^= 0xFFFFFFFFFFFFFFFFULL; // f0 = last block
+    // v[15] ^= 0  (f1)
+
+    #pragma unroll
+    for (int r = 0; r < 12; r++){
+        const u8* s = SIGMA[r];
+        G(0,4, 8,12, m[s[ 0]], m[s[ 1]]);
+        G(1,5, 9,13, m[s[ 2]], m[s[ 3]]);
+        G(2,6,10,14, m[s[ 4]], m[s[ 5]]);
+        G(3,7,11,15, m[s[ 6]], m[s[ 7]]);
+        G(0,5,10,15, m[s[ 8]], m[s[ 9]]);
+        G(1,6,11,12, m[s[10]], m[s[11]]);
+        G(2,7, 8,13, m[s[12]], m[s[13]]);
+        G(3,4, 9,14, m[s[14]], m[s[15]]);
+    }
+    #pragma unroll
+    for (int i = 0; i < 4; i++) h4[i] = h[i] ^ v[i] ^ v[i+8];
+}
+
+// ---- Self-test kernel: hash one arbitrary 80-byte buffer through the core ----
+extern "C" __global__ void hash_one(const u8* buf, u8* out){
+    u64 m[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++){
+        u64 w = 0;
+        #pragma unroll
+        for (int j = 0; j < 8; j++){
+            int bi = i*8 + j;
+            u8 c = (bi < 80) ? buf[bi] : 0;
+            w |= ((u64)c) << (8*j);
+        }
+        m[i] = w;
+    }
+    u64 h4[4];
+    blake2b80_core(m, h4);
+    #pragma unroll
+    for (int i = 0; i < 4; i++)
+        #pragma unroll
+        for (int j = 0; j < 8; j++)
+            out[i*8 + j] = (u8)((h4[i] >> (8*j)) & 0xff);
+}
+
+// ---- Mining kernel ----
+// pbh_w[0..3] = little-endian 64-bit words of the 32-byte prevblock_hidden.
+// root_w[0..3]= little-endian 64-bit words of the 32-byte BLAKE2b root.
+// Buffer per nonce = pbh(32) || nonce_le(4) || 0*12 || root(32).  nonce2 =
+// time_offset = nonce3 = 0 (the served Sv1 shape). Big-endian digest <= target
+// (t0 = most-significant 64 bits) emits the nonce.
+extern "C" __global__ void mine(
+        const u64* pbh_w, const u64* root_w,
+        u32 nonce_base, u32 count,
+        u64 t0, u64 t1, u64 t2, u64 t3,
+        u32* out_nonces, u32* out_count, u32 out_cap){
+    u32 idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= count) return;
+    u32 nonce = nonce_base + idx;
+
+    u64 m[16];
+    m[0] = pbh_w[0]; m[1] = pbh_w[1]; m[2] = pbh_w[2]; m[3] = pbh_w[3];
+    m[4] = (u64)nonce;   // bytes 32..35 = nonce LE, bytes 36..39 = 0
+    m[5] = 0ULL;         // bytes 40..47 = time_offset(0) || nonce3(0)
+    m[6] = root_w[0]; m[7] = root_w[1]; m[8] = root_w[2]; m[9] = root_w[3];
+    m[10]=0ULL; m[11]=0ULL; m[12]=0ULL; m[13]=0ULL; m[14]=0ULL; m[15]=0ULL;
+
+    u64 h4[4];
+    blake2b80_core(m, h4);
+
+    u64 be0 = bswap64(h4[0]);
+    u64 be1 = bswap64(h4[1]);
+    u64 be2 = bswap64(h4[2]);
+    u64 be3 = bswap64(h4[3]);
+
+    bool le;
+    if      (be0 != t0) le = be0 < t0;
+    else if (be1 != t1) le = be1 < t1;
+    else if (be2 != t2) le = be2 < t2;
+    else                le = be3 <= t3;
+
+    if (le){
+        u32 p = atomicAdd(out_count, 1u);
+        if (p < out_cap) out_nonces[p] = nonce;
+    }
+}
+'''
+
+# ─────────────────────────── GPU engine ────────────────────────────────
+
+class GpuEngine:
+    def __init__(self, threads_per_block=256, blocks=4096, device=0):
+        import cupy as cp
+        self.cp = cp
+        # Bind this engine (and therefore this whole process) to one GPU. With
+        # one process per GPU this gives clean multi-GPU: --device 0/1/2, each
+        # process owning a distinct board. (CUDA_VISIBLE_DEVICES also works and
+        # composes — device is then an index into the visible subset.)
+        self.device = int(device)
+        cp.cuda.Device(self.device).use()
+        self.module = cp.RawModule(code=CUDA_SRC, options=('--std=c++14',))
+        self.k_mine = self.module.get_function('mine')
+        self.k_hash = self.module.get_function('hash_one')
+        self.tpb = threads_per_block
+        self.blocks = blocks
+        self.batch = threads_per_block * blocks
+        # persistent output buffers
+        self.d_out_nonces = cp.zeros(4096, dtype=cp.uint32)
+        self.d_out_count = cp.zeros(1, dtype=cp.uint32)
+        self.out_cap = 4096
+
+    def gpu_hash_one(self, buf80):
+        cp = self.cp
+        assert len(buf80) == 80
+        d_buf = cp.frombuffer(bytes(buf80), dtype=cp.uint8)
+        d_out = cp.zeros(32, dtype=cp.uint8)
+        self.k_hash((1,), (1,), (d_buf, d_out))
+        cp.cuda.Stream.null.synchronize()
+        return bytes(d_out.get())
+
+    @staticmethod
+    def _words_le(b32):
+        # 32 bytes -> 4 little-endian uint64 words
+        return struct.unpack('<4Q', b32)
+
+    def mine_batch(self, pbh, root, target, nonce_base, count=None):
+        cp = self.cp
+        d_pbh = cp.array(self._words_le(pbh), dtype=cp.uint64)
+        d_root = cp.array(self._words_le(root), dtype=cp.uint64)
+        tb = target.to_bytes(32, 'big')
+        t0, t1, t2, t3 = struct.unpack('>4Q', tb)
+        self.d_out_count.fill(0)
+        if count is None:
+            count = self.batch
+        grid = (count + self.tpb - 1) // self.tpb
+        self.k_mine(
+            (grid,), (self.tpb,),
+            (d_pbh, d_root,
+             cp.uint32(nonce_base & 0xffffffff), cp.uint32(count),
+             cp.uint64(t0), cp.uint64(t1), cp.uint64(t2), cp.uint64(t3),
+             self.d_out_nonces, self.d_out_count, cp.uint32(self.out_cap)))
+        cp.cuda.Stream.null.synchronize()
+        n_found = int(self.d_out_count.get()[0])
+        if n_found == 0:
+            return []
+        n_found = min(n_found, self.out_cap)
+        return [int(x) for x in self.d_out_nonces[:n_found].get()]
+
+# ─────────────────────────── self-test ─────────────────────────────────
+
+def run_selftest_cpu(verbose=True):
+    H = bytes.fromhex(KAT_HEADER_HEX)
+    f = parse_header_v2(H)
+    _h1, h2, pbh = compute_h1_h2_pbh(f)
+    wire_coinb1 = b"\x00" * 4 + h2 + b"\x00" * 8
+    assert wire_coinb1[4:36] == h2
+    root = compute_root(h2, f['extranonce'])
+    b2 = b2_from(pbh, f['nonce'], f['nonce2'], f['time_offset'], f['nonce3'], root)
+    got = b2.hex()
+    ok = (got == KAT_CANONICAL)
+    if verbose:
+        print("  [CPU ref] h2               = %s" % h2.hex())
+        print("  [CPU ref] root(extranonce) = %s" % root.hex())
+        print("  [CPU ref] display          = %s" % got)
+        print("  [CPU ref] canonical (KAT)  = %s" % KAT_CANONICAL)
+        print("  [CPU ref] SELFTEST %s" % ("PASS" if ok else "FAIL"))
+    return ok, f, h2, pbh, root
+
+
+def run_selftest_gpu(engine, verbose=True):
+    ok_cpu, f, h2, pbh, root = run_selftest_cpu(verbose=verbose)
+    # Build the EXACT 80-byte profile-0 buffer of block 961640 (real rolled
+    # fields) and hash it through the GPU core.
+    buf = pbh + f['nonce'] + f['nonce2'] + f['time_offset'] + f['nonce3'] + root
+    assert len(buf) == 80
+    gpu_hash = engine.gpu_hash_one(buf)
+    cpu_hash = blake2b256(buf)
+    gpu_hex = gpu_hash.hex()
+    ok_gpu_vs_canon = (gpu_hex == KAT_CANONICAL)
+    ok_gpu_vs_cpu = (gpu_hash == cpu_hash)
+    if verbose:
+        print("  [GPU]     display          = %s" % gpu_hex)
+        print("  [GPU]     == canonical(KAT) : %s" % ok_gpu_vs_canon)
+        print("  [GPU]     == CPU ref fold   : %s" % ok_gpu_vs_cpu)
+    # Also exercise the MINING kernel path (nonce2=nonce3=time_offset=0) against
+    # a CPU cross-check on a random target so we know the mine-kernel buffer
+    # construction + big-endian compare agrees with hashlib.
+    import random
+    en1 = os.urandom(4); en2 = os.urandom(4)
+    coinb1 = b"\x00" * 4 + h2 + b"\x00" * 8
+    root2 = blake2b256(coinb1 + en1 + en2)
+    test_nonce = random.randint(0, 0xffffffff)
+    cpu_b2 = blake2b256(pbh + struct.pack('<I', test_nonce) + b"\x00" * 12 + root2)
+    # target = cpu_b2 exactly -> the mine kernel MUST flag test_nonce as <= target
+    tgt = int.from_bytes(cpu_b2, 'big')
+    base = test_nonce
+    # 1-thread launch: only test_nonce is evaluated, so the digest==target check
+    # (buffer construction + big-endian compare in the MINE kernel) is exercised
+    # deterministically with no output-cap overflow.
+    found = engine.mine_batch(pbh, root2, tgt, base, count=1)
+    ok_mine = (found == [test_nonce])
+    if verbose:
+        print("  [GPU mine] nonce=%08x root=%s" % (test_nonce, root2.hex()))
+        print("  [GPU mine] cpu_b2          = %s" % cpu_b2.hex())
+        print("  [GPU mine] kernel flagged nonce at its own hash-target: %s" % ok_mine)
+    return ok_cpu and ok_gpu_vs_canon and ok_gpu_vs_cpu and ok_mine
+
+# ─────────────────────────── Stratum client (reused) ───────────────────
+
+class GpuMiner:
+    def __init__(self, args, engine):
+        self.args = args
+        self.engine = engine
+        self.sock = None
+        self.buf = b""
+        self.msg_id = 1
+        self.extranonce1 = None
+        self.en2_size = None
+        self.job = None
+        self.difficulty = args.diff
+        self.log_path = args.log
+        self.logf = None
+        self.job_epoch = 0   # bump on every notify to drop in-flight work
+
+    def log(self, s):
+        line = "[%s] %s" % (time.strftime("%Y-%m-%d %H:%M:%S"), s)
+        print(line, flush=True)
+        if self.logf:
+            self.logf.write(line + "\n"); self.logf.flush()
+
+    def log_raw(self, direction, obj):
+        line = "[%s] %s %s" % (time.strftime("%Y-%m-%d %H:%M:%S"), direction, json.dumps(obj))
+        if self.logf:
+            self.logf.write(line + "\n"); self.logf.flush()
+        print(line, flush=True)
+
+    def connect(self):
+        self.log("connecting to %s:%d" % (self.args.host, self.args.port))
+        self.sock = socket.create_connection((self.args.host, self.args.port), timeout=30)
+        # Non-blocking: the GPU mining loop polls the socket without stalling.
+        # (A 0.2s timeout here throttled the loop to ~5 batches/s = ~10 MH/s.)
+        self.sock.setblocking(False)
+
+    def send(self, method, params, mid=None):
+        if mid is None:
+            mid = self.msg_id; self.msg_id += 1
+        obj = {"id": mid, "method": method, "params": params}
+        data = (json.dumps(obj) + "\n").encode()
+        self.sock.sendall(data)
+        self.log_raw("SEND", obj)
+        return mid
+
+    def recv_lines(self):
+        try:
+            chunk = self.sock.recv(65536)
+        except (socket.timeout, BlockingIOError):
+            return []
+        if not chunk:
+            raise ConnectionError("pool closed connection")
+        self.buf += chunk
+        lines = []
+        while b"\n" in self.buf:
+            line, self.buf = self.buf.split(b"\n", 1)
+            line = line.strip()
+            if line:
+                try:
+                    lines.append(json.loads(line))
+                except Exception as e:
+                    self.log("bad json: %r (%s)" % (line, e))
+        return lines
+
+    def handle_notify(self, params):
+        job_id = params[0]
+        prevhash_hex = params[1]
+        coinb1_hex = params[2]
+        merkle_branch = params[4]
+        ntime = params[7]
+        clean = params[8] if len(params) > 8 else True
+        pbh = bytes.fromhex(prevhash_hex)
+        coinb1 = bytes.fromhex(coinb1_hex)
+        self.job = {
+            "job_id": job_id,
+            "pbh": pbh,
+            "coinb1": coinb1,
+            "ntime": ntime,
+            "difficulty": self.difficulty,
+        }
+        self.job_epoch += 1
+        self.log("notify job=%s clean=%s coinb1=%dB pbh=%dB ntime=%s branches=%d diff=%s"
+                 % (job_id, clean, len(coinb1), len(pbh), ntime, len(merkle_branch), self.difficulty))
+
+    @staticmethod
+    def fmt_diff(d):
+        if d == int(d):
+            return str(int(d))
+        return ("%g" % d)
+
+    def build_extranonce16(self, en2_int):
+        en1 = bytes.fromhex(self.extranonce1)
+        assert len(en1) == 4, "extranonce1 must be 4 bytes, got %d" % len(en1)
+        en2 = struct.pack("<I", en2_int & 0xffffffff)
+        return en1, en2
+
+    def subscribe_authorize(self):
+        self.send("mining.subscribe", ["bip110-gpuminer/0.1"])
+        got_sub = False
+        deadline = time.time() + 30
+        while time.time() < deadline and not got_sub:
+            for m in self.recv_lines():
+                if m.get("id") == 1 and "result" in m and m["result"]:
+                    res = m["result"]
+                    self.extranonce1 = res[1]
+                    self.en2_size = res[2]
+                    self.log("subscribed extranonce1=%s en2_size=%s" % (self.extranonce1, self.en2_size))
+                    got_sub = True
+                elif m.get("method") == "mining.notify":
+                    self.handle_notify(m["params"])
+                elif m.get("method") == "mining.set_difficulty":
+                    self.difficulty = float(m["params"][0])
+                    self.log("set_difficulty=%s" % self.difficulty)
+            if not got_sub:
+                time.sleep(0.01)
+        if not got_sub:
+            raise RuntimeError("no subscribe reply")
+        user = "%s.%s+%s" % (self.args.address, self.args.worker, self.fmt_diff(self.args.diff))
+        self.authorize_user = user
+        self.send("mining.authorize", [user, "x"])
+
+    def drain_socket(self, pending):
+        for m in self.recv_lines():
+            if m.get("method") == "mining.notify":
+                self.handle_notify(m["params"])
+            elif m.get("method") == "mining.set_difficulty":
+                self.difficulty = float(m["params"][0])
+                self.log("set_difficulty=%s" % self.difficulty)
+            elif "id" in m and ("result" in m or "error" in m):
+                mid = m.get("id")
+                if mid in pending:
+                    jid, nonce, en2hex = pending.pop(mid)
+                    res = m.get("result")
+                    err = m.get("error")
+                    self.log_raw("SUBMIT_RESULT", m)
+                    if res is True:
+                        self.accepted += 1
+                        self.log("SHARE ACCEPTED result=true job=%s nonce=%s en2=%s (accepted=%d)"
+                                 % (jid, nonce, en2hex, self.accepted))
+                    else:
+                        self.rejected += 1
+                        self.log("SHARE REJECTED result=%r error=%r job=%s nonce=%s"
+                                 % (res, err, jid, nonce))
+                elif mid == 2:
+                    self.log_raw("AUTHORIZE_RESULT", m)
+
+    def run(self):
+        if self.log_path:
+            self.logf = open(self.log_path, "a")
+        self.connect()
+        self.subscribe_authorize()
+
+        end = time.time() + self.args.minutes * 60
+        en2_int = (os.getpid() * 2654435761) & 0xffffffff
+        self.accepted = 0
+        self.rejected = 0
+        submitted = 0
+        pending = {}
+        hashes = 0
+        last_report = time.time()
+        hr_hashes = 0
+        hr_t0 = time.time()
+
+        cur_epoch = -1
+        nonce_base = 0
+        en1 = en2 = root = None
+        en2hex = None
+
+        while time.time() < end:
+            self.drain_socket(pending)
+            if not self.job:
+                time.sleep(0.05)
+                continue
+
+            job = self.job
+            # New job -> drop in-flight work (avoid DOA), reset nonce sweep + root.
+            if self.job_epoch != cur_epoch:
+                cur_epoch = self.job_epoch
+                nonce_base = 0
+                en1, en2 = self.build_extranonce16(en2_int)
+                root = blake2b256(job["coinb1"] + en1 + en2)
+                en2hex = en2.hex()
+
+            # The pinned +N fixed diff (args.diff) is the pool's REAL acceptance
+            # floor; its set_difficulty (observed 0.0005) is a loose vardiff that
+            # is BELOW the real gate. Never mine easier than args.diff, or the
+            # pool rejects with "Low difficulty share". Honor a HIGHER live diff.
+            eff_diff = max(self.args.diff, self.difficulty)
+            target = share_target_from_diff(eff_diff * self.args.margin)
+
+            found = self.engine.mine_batch(job["pbh"], root, target, nonce_base)
+            batch = self.engine.batch
+            hashes += batch
+            hr_hashes += batch
+
+            # If a new job arrived DURING the kernel launch, drop these results.
+            if self.job_epoch != cur_epoch:
+                continue
+
+            for n in found:
+                nonce_hex = "%08x" % n
+                ntime = job["ntime"]
+                mid = self.send("mining.submit",
+                                [self.authorize_user, job["job_id"], en2hex, ntime, nonce_hex])
+                pending[mid] = (job["job_id"], nonce_hex, en2hex)
+                submitted += 1
+                self.log("SUBMIT job=%s en2=%s ntime=%s nonce=%s (batch found %d)"
+                         % (job["job_id"], en2hex, ntime, nonce_hex, len(found)))
+
+            # advance nonce sweep; roll en2 (new root) when 32-bit space exhausted
+            nonce_base = (nonce_base + batch) & 0xffffffff
+            if nonce_base < batch:  # wrapped -> exhausted the 2^32 nonce space
+                en2_int = (en2_int + 1) & 0xffffffff
+                en1, en2 = self.build_extranonce16(en2_int)
+                root = blake2b256(job["coinb1"] + en1 + en2)
+                en2hex = en2.hex()
+
+            now = time.time()
+            if now - last_report > 30:
+                dt = now - hr_t0
+                hr = hr_hashes / dt if dt > 0 else 0
+                self.log("progress: submitted=%d accepted=%d rejected=%d hashes~%d hashrate=%.3f MH/s"
+                         % (submitted, self.accepted, self.rejected, hashes, hr / 1e6))
+                last_report = now
+                hr_hashes = 0
+                hr_t0 = now
+
+        self.log("DONE submitted=%d accepted=%d rejected=%d" % (submitted, self.accepted, self.rejected))
+        return self.accepted
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="bip110.voidbind.com")
+    ap.add_argument("--port", type=int, default=9336)
+    ap.add_argument("--address", default="")
+    ap.add_argument("--worker", default="legion64gpu")
+    ap.add_argument("--diff", type=float, default=1.0)
+    ap.add_argument("--minutes", type=float, default=600)
+    ap.add_argument("--log", default="")
+    ap.add_argument("--margin", type=float, default=1.0,
+                    help="submit shares this many x above the required difficulty")
+    ap.add_argument("--tpb", type=int, default=256)
+    ap.add_argument("--blocks", type=int, default=8192)
+    ap.add_argument("--device", type=int, default=0,
+                    help="CUDA device ordinal to bind this process to (multi-GPU: "
+                         "run one process per GPU with --device 0/1/2 and a "
+                         "distinct --address each)")
+    ap.add_argument("--selftest-only", action="store_true")
+    args = ap.parse_args()
+
+    print("=== bip110_gpu_miner self-test (KAT block 961640, GPU BLAKE2b) ===")
+    engine = GpuEngine(threads_per_block=args.tpb, blocks=args.blocks, device=args.device)
+    print("bound to CUDA device %d" % engine.device)
+    ok = run_selftest_gpu(engine, verbose=True)
+    if not ok:
+        print("ABORT: GPU PoW self-test FAILED — kernel is not byte-correct.")
+        sys.exit(1)
+    print("=== GPU self-test PASSED — kernel BLAKE2b == canonical == CPU ref ===")
+
+    if args.selftest_only:
+        sys.exit(0)
+
+    if not args.address:
+        print("ABORT: --address required to mine")
+        sys.exit(2)
+
+    m = GpuMiner(args, engine)
+    try:
+        m.run()
+    except Exception as e:
+        m.log("FATAL: %r" % e)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bip110/bip110_miner.py
+++ b/tools/bip110/bip110_miner.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# bip110_miner.py — standalone BIP-110 Stratum-v1 test miner.
+#
+# NEW standalone tool. Does NOT touch the pool or c2pool source. Its PoW is a
+# byte-for-byte Python mirror of src/impl/bip110/pow.hpp + pseudoheader.hpp,
+# self-tested against live fork block 961640 (the SAME KAT vector the pool pins)
+# BEFORE it ever connects. A wrong fold fails the self-test and aborts, so an
+# accepted share genuinely exercises the pool's real verification fold.
+#
+# Usage:
+#   python3 bip110_miner.py --selftest-only
+#   python3 bip110_miner.py --host bip110.voidbind.com --port 9336 \
+#       --address <BIP110-ADDR> --worker legion64test --diff 0.01 \
+#       --procs 8 --minutes 45 --log /path/miner.log
+
+import argparse
+import hashlib
+import json
+import os
+import socket
+import struct
+import sys
+import time
+import multiprocessing as mp
+
+# ─────────────────────────── PoW primitives ────────────────────────────
+
+def sha256(b):
+    return hashlib.sha256(b).digest()
+
+def tagged_hash(tag, msg):
+    # BIP340-style: SHA256( SHA256(tag) || SHA256(tag) || msg )
+    th = sha256(tag.encode())
+    return sha256(th + th + msg)
+
+def blake2b256(b):
+    return hashlib.blake2b(b, digest_size=32).digest()
+
+# ─────────────────────────── KAT self-test ─────────────────────────────
+
+KAT_HEADER_HEX = "000000a0657e02138733654183a2c7320d85ca9d743fe139c4bb01000000000000000000c137a8515a0f6b3aaf6049cc7611787c022ad523d51094be0a0363d0dc0bc7684dca936a4f8d001a5671798c84daeb494dca936a00000000b1ccf00d0300000000000000000000001e0300000000000000000000000000000000000068ac0e000000000000000000000000000000000000000000000000000000000000000000"
+KAT_CANONICAL = "0000000000000050c1e5f69672f459293be14f46e5a494e7a8c8541396f18eeb"
+
+
+def parse_header_v2(h):
+    # returns dict of field byte-slices, offsets per pow.hpp parse_header_v2
+    assert len(h) == 164, "v2 header must be 164 bytes, got %d" % len(h)
+    o = {}
+    p = 0
+    def take(n):
+        nonlocal p
+        s = h[p:p+n]; p += n; return s
+    o['version']     = take(4)
+    o['prev']        = take(32)
+    o['merkle']      = take(32)
+    o['time']        = take(4)
+    o['nbits']       = take(4)
+    o['nonce']       = take(4)
+    o['nonce2']      = take(4)
+    o['nonce3']      = take(4)
+    o['extranonce']  = take(16)
+    o['time_offset'] = take(4)
+    o['txcount']     = take(2)
+    o['flags']       = take(1)
+    o['clear_bits']  = take(1)
+    o['xor_key']     = take(16)
+    o['height']      = take(4)
+    o['mm_rhs']      = take(32)
+    assert p == 164
+    return o
+
+
+def compute_h1_h2_pbh(f):
+    # f: parsed header dict. Mirrors pseudoheader.hpp compute_h1_h2 exactly.
+    assert f['flags'] == b"\x00", "flags must be 0 (profile 0)"
+    assert f['clear_bits'] == b"\x00", "clear_bits must be 0"
+    assert f['xor_key'] == b"\x00" * 16, "xor_key must be null"
+
+    rev_prev = f['prev'][::-1]
+    xkh = tagged_hash("Bitcoin block hash PoW XOR key", f['xor_key'])
+
+    txcount = f['txcount'][0] | (f['txcount'][1] << 8)
+    msg1 = b""
+    msg1 += f['version']                       # 4
+    msg1 += rev_prev                           # 32
+    msg1 += f['height']                        # 4  (raw wire LE bytes)
+    msg1 += f['merkle']                        # 32
+    msg1 += f['time']                          # 4
+    msg1 += b"\x00"                            # 1
+    msg1 += f['nbits']                         # 4
+    msg1 += bytes([txcount & 0xff, (txcount >> 8) & 0xff, 0x00, 0x00])  # 4
+    msg1 += f['flags']                         # 1
+    msg1 += f['clear_bits']                    # 1
+    msg1 += xkh                                # 32
+    assert len(msg1) == 119, len(msg1)
+    h1 = tagged_hash("Bitcoin block header 1", msg1)
+
+    msg2 = h1 + b"\x00" * 32 + f['mm_rhs']
+    assert len(msg2) == 96
+    h2 = tagged_hash("Merge-mining hook", msg2)
+
+    pbh = bytearray(tagged_hash("Bitcoin prevblock header, hashed", rev_prev))
+    for i in range(6):
+        pbh[i] = 0
+    return h1, h2, bytes(pbh)
+
+
+def compute_root(h2, extranonce16):
+    msg3 = b"\x00" * 4 + h2 + extranonce16
+    assert len(msg3) == 52
+    return blake2b256(msg3)
+
+
+def b2_from(pbh, nonce4, nonce2_4, time_offset4, nonce3_4, root):
+    # 80-byte profile-0 buffer, flags=0.
+    buf = pbh + nonce4 + nonce2_4 + time_offset4 + nonce3_4 + root
+    assert len(buf) == 80
+    return blake2b256(buf)
+
+
+def run_selftest(verbose=True):
+    H = bytes.fromhex(KAT_HEADER_HEX)
+    if len(H) != 164:
+        print("SELFTEST FAIL: header hex is %d bytes not 164" % len(H))
+        return False
+    f = parse_header_v2(H)
+    h1, h2, pbh = compute_h1_h2_pbh(f)
+
+    # (b) coinb1 round-trip: 00000000 || h2 || 0000000000000000  (44 bytes)
+    wire_coinb1 = b"\x00" * 4 + h2 + b"\x00" * 8
+    assert len(wire_coinb1) == 44
+    assert wire_coinb1[4:36] == h2, "h2 does not round-trip through coinb1"
+
+    # (c) root using the block's REAL 16-byte extranonce
+    root = compute_root(h2, f['extranonce'])
+
+    # (d) b2 using the block's real rolled fields -> canonical
+    b2 = b2_from(pbh, f['nonce'], f['nonce2'], f['time_offset'], f['nonce3'], root)
+    got = b2.hex()
+    ok = (got == KAT_CANONICAL)
+    if verbose:
+        print("  h2                = %s" % h2.hex())
+        print("  root(b1)          = %s" % root.hex())
+        print("  computed display  = %s" % got)
+        print("  canonical (KAT)   = %s" % KAT_CANONICAL)
+        print("  SELFTEST %s" % ("PASS" if ok else "FAIL"))
+    return ok
+
+
+def selftest_fastpath_equiv():
+    # Prove the miner's Sv1 loop fast path is byte-identical to the reference
+    # field-parse fold FOR THE POOL'S SERVED SHAPE (extranonce16 = 8*0x00||en1||en2,
+    # nonce2 = nonce3 = time_offset = 0 — the constraint the Sv1->BLAKE2b mapping
+    # imposes). The KAT block itself was mined with nonzero nonce2/nonce3 and a
+    # populated extranonce top (general chain freedom), so it is NOT a witness for
+    # this identity; the field-path selftest above is the binding vs-canonical
+    # proof. Here we exercise the exact expressions the mining loop uses.
+    H = bytes.fromhex(KAT_HEADER_HEX)
+    f = parse_header_v2(H)
+    _, h2, pbh = compute_h1_h2_pbh(f)
+
+    coinb1 = b"\x00" * 4 + h2 + b"\x00" * 8      # 44-byte wire coinb1 for this h2
+    for (en1, en2, n) in [
+        (bytes.fromhex("deadbeef"), bytes.fromhex("00000000"), 0),
+        (bytes.fromhex("01020304"), bytes.fromhex("aabbccdd"), 123456),
+        (bytes.fromhex("ffffffff"), bytes.fromhex("12345678"), 0xfffffffe),
+    ]:
+        ex16 = b"\x00" * 8 + en1 + en2                       # Sv1 make_extranonce16
+        root_fast = blake2b256(coinb1 + en1 + en2)           # loop root
+        root_ref = compute_root(h2, ex16)                    # reference root
+        if root_fast != root_ref:
+            print("  FASTPATH root mismatch (en1=%s en2=%s)" % (en1.hex(), en2.hex()))
+            return False
+        b2_fast = blake2b256(pbh + struct.pack("<I", n) + b"\x00" * 12 + root_fast)
+        b2_ref = b2_from(pbh, struct.pack("<I", n), b"\x00" * 4, b"\x00" * 4, b"\x00" * 4, root_ref)
+        if b2_fast != b2_ref:
+            print("  FASTPATH b2 mismatch (en1=%s en2=%s n=%d)" % (en1.hex(), en2.hex(), n))
+            return False
+    print("  FASTPATH loop-math == reference fold (3 vectors, served Sv1 shape) PASS")
+    return True
+
+# ─────────────────────────── target / diff ─────────────────────────────
+
+DIFF1 = 0x00000000FFFF0000000000000000000000000000000000000000000000000000
+
+def share_target_from_diff(diff):
+    if diff <= 0:
+        return DIFF1
+    return int(DIFF1 // diff)
+
+# ─────────────────────────── Stratum client ────────────────────────────
+
+class Miner:
+    def __init__(self, args):
+        self.args = args
+        self.sock = None
+        self.buf = b""
+        self.msg_id = 1
+        self.extranonce1 = None
+        self.en2_size = None
+        self.job = None            # dict: job_id, coinb1(bytes), pbh(bytes), ntime(str)
+        self.difficulty = args.diff
+        self.log_path = args.log
+        self.logf = None
+
+    def log(self, s):
+        line = "[%s] %s" % (time.strftime("%Y-%m-%d %H:%M:%S"), s)
+        print(line, flush=True)
+        if self.logf:
+            self.logf.write(line + "\n"); self.logf.flush()
+
+    def log_raw(self, direction, obj):
+        line = "[%s] %s %s" % (time.strftime("%Y-%m-%d %H:%M:%S"), direction, json.dumps(obj))
+        if self.logf:
+            self.logf.write(line + "\n"); self.logf.flush()
+        print(line, flush=True)
+
+    def connect(self):
+        self.log("connecting to %s:%d" % (self.args.host, self.args.port))
+        self.sock = socket.create_connection((self.args.host, self.args.port), timeout=30)
+        self.sock.settimeout(1.0)
+
+    def send(self, method, params, mid=None):
+        if mid is None:
+            mid = self.msg_id; self.msg_id += 1
+        obj = {"id": mid, "method": method, "params": params}
+        data = (json.dumps(obj) + "\n").encode()
+        self.sock.sendall(data)
+        self.log_raw("SEND", obj)
+        return mid
+
+    def recv_lines(self):
+        try:
+            chunk = self.sock.recv(65536)
+        except socket.timeout:
+            return []
+        if not chunk:
+            raise ConnectionError("pool closed connection")
+        self.buf += chunk
+        lines = []
+        while b"\n" in self.buf:
+            line, self.buf = self.buf.split(b"\n", 1)
+            line = line.strip()
+            if line:
+                try:
+                    lines.append(json.loads(line))
+                except Exception as e:
+                    self.log("bad json: %r (%s)" % (line, e))
+        return lines
+
+    def handle_notify(self, params):
+        # [job_id, prevhash, coinb1, coinb2, merkle_branch, version, nbits, ntime, clean_jobs]
+        job_id = params[0]
+        prevhash_hex = params[1]
+        coinb1_hex = params[2]
+        merkle_branch = params[4]
+        ntime = params[7]
+        clean = params[8] if len(params) > 8 else True
+        pbh = bytes.fromhex(prevhash_hex)          # use AS-IS (raw wire prevblock_hidden)
+        coinb1 = bytes.fromhex(coinb1_hex)
+        self.job = {
+            "job_id": job_id,
+            "pbh": pbh,
+            "coinb1": coinb1,
+            "ntime": ntime,
+            "difficulty": self.difficulty,   # diff in force when job arrived
+        }
+        self.log("notify job=%s clean=%s coinb1=%dB pbh=%dB ntime=%s branches=%d diff=%s"
+                 % (job_id, clean, len(coinb1), len(pbh), ntime, len(merkle_branch), self.difficulty))
+
+    def subscribe_authorize(self):
+        self.send("mining.subscribe", ["bip110-testminer/0.1"])
+        # wait for subscribe reply
+        got_sub = False
+        deadline = time.time() + 30
+        while time.time() < deadline and not got_sub:
+            for m in self.recv_lines():
+                if m.get("id") == 1 and "result" in m and m["result"]:
+                    res = m["result"]
+                    self.extranonce1 = res[1]
+                    self.en2_size = res[2]
+                    self.log("subscribed extranonce1=%s en2_size=%s" % (self.extranonce1, self.en2_size))
+                    got_sub = True
+                elif m.get("method") == "mining.notify":
+                    self.handle_notify(m["params"])
+                elif m.get("method") == "mining.set_difficulty":
+                    self.difficulty = float(m["params"][0])
+                    self.log("set_difficulty=%s" % self.difficulty)
+        if not got_sub:
+            raise RuntimeError("no subscribe reply")
+        if self.en2_size != 4:
+            self.log("WARNING: en2_size=%s (expected 4) — GAP for standard miners" % self.en2_size)
+        user = "%s.%s+%s" % (self.args.address, self.args.worker, self.fmt_diff(self.args.diff))
+        self.authorize_user = user
+        self.send("mining.authorize", [user, "x"])
+
+    @staticmethod
+    def fmt_diff(d):
+        # pin suffix; keep it compact
+        if d == int(d):
+            return str(int(d))
+        return ("%g" % d)
+
+    def build_extranonce16(self, en2_int):
+        en1 = bytes.fromhex(self.extranonce1)
+        assert len(en1) == 4, "extranonce1 must be 4 bytes, got %d" % len(en1)
+        en2 = struct.pack("<I", en2_int & 0xffffffff)   # 4 bytes, any encoding (opaque)
+        return en1, en2
+
+    def run(self):
+        if self.log_path:
+            self.logf = open(self.log_path, "a")
+        self.connect()
+        self.subscribe_authorize()
+
+        end = time.time() + self.args.minutes * 60
+        # single-process inline miner (procs handled by outer launcher for simplicity)
+        en2_int = (os.getpid() * 2654435761) & 0xffffffff
+        accepted = 0
+        submitted = 0
+        pending = {}   # id -> (job_id, nonce, en2hex)
+        hashes = 0
+        last_report = time.time()
+
+        while time.time() < end:
+            for m in self.recv_lines():
+                if m.get("method") == "mining.notify":
+                    self.handle_notify(m["params"])
+                elif m.get("method") == "mining.set_difficulty":
+                    self.difficulty = float(m["params"][0])
+                    self.log("set_difficulty=%s" % self.difficulty)
+                elif "id" in m and ("result" in m or "error" in m):
+                    mid = m.get("id")
+                    if mid in pending:
+                        jid, nonce, en2hex = pending.pop(mid)
+                        res = m.get("result")
+                        err = m.get("error")
+                        self.log_raw("SUBMIT_RESULT", m)
+                        if res is True:
+                            accepted += 1
+                            self.log("SHARE ACCEPTED result=true job=%s nonce=%s en2=%s (accepted=%d)"
+                                     % (jid, nonce, en2hex, accepted))
+                        else:
+                            self.log("SHARE REJECTED result=%r error=%r job=%s nonce=%s"
+                                     % (res, err, jid, nonce))
+                    elif mid == 2:
+                        self.log_raw("AUTHORIZE_RESULT", m)
+
+            if not self.job:
+                continue
+
+            job = self.job
+            # Judge against the STRICTER (harder = smaller target) of the diff issued
+            # with the job and the current live vardiff, so a share passes BOTH the
+            # core stratum "Low difficulty share" gate (live) AND the work-source
+            # gate (min(live, issued)). With a pinned +N fixed diff these coincide.
+            eff_diff = max(job["difficulty"], self.difficulty)
+            # SUBMIT_MARGIN: only submit shares comfortably (margin x) above the
+            # gate, so a vardiff up-creep between set_difficulty messages cannot
+            # borderline-reject an in-flight share. Costs margin x time/share.
+            target = share_target_from_diff(eff_diff * self.args.margin)
+            en1, en2 = self.build_extranonce16(en2_int)
+            root = blake2b256(job["coinb1"] + en1 + en2)
+            en2hex = en2.hex()
+            # grind a batch of nonces
+            base = (hashes) & 0xffffffff
+            found = None
+            for i in range(200000):
+                n = (base + i) & 0xffffffff
+                b2 = blake2b256(job["pbh"] + struct.pack("<I", n) + b"\x00" * 12 + root)
+                if int.from_bytes(b2, "big") <= target:
+                    found = (n, b2)
+                    break
+            hashes += 200000
+            if found:
+                n, b2 = found
+                nonce_hex = "%08x" % n
+                ntime = job["ntime"]
+                mid = self.send("mining.submit",
+                                [self.authorize_user, job["job_id"], en2hex, ntime, nonce_hex])
+                pending[mid] = (job["job_id"], nonce_hex, en2hex)
+                submitted += 1
+                self.log("SUBMIT job=%s en2=%s ntime=%s nonce=%s hash=%s target=%064x"
+                         % (job["job_id"], en2hex, ntime, nonce_hex, b2.hex(), target))
+                en2_int = (en2_int + 1) & 0xffffffff   # roll extranonce2 after a hit
+            else:
+                # exhausted this en2 stripe region; roll en2 to continue
+                en2_int = (en2_int + 1) & 0xffffffff
+
+            if time.time() - last_report > 30:
+                self.log("progress: submitted=%d accepted=%d hashes~%d" % (submitted, accepted, hashes))
+                last_report = time.time()
+
+        self.log("DONE submitted=%d accepted=%d" % (submitted, accepted))
+        return accepted
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="bip110.voidbind.com")
+    ap.add_argument("--port", type=int, default=9336)
+    ap.add_argument("--address", default="")
+    ap.add_argument("--worker", default="legion64test")
+    ap.add_argument("--diff", type=float, default=0.01)
+    ap.add_argument("--minutes", type=float, default=45)
+    ap.add_argument("--log", default="")
+    ap.add_argument("--procs", type=int, default=1)
+    ap.add_argument("--margin", type=float, default=2.0,
+                    help="submit shares this many x above the required difficulty")
+    ap.add_argument("--selftest-only", action="store_true")
+    ap.add_argument("--worker-index", type=int, default=-1,
+                    help="internal: single child index (set by the launcher)")
+    args = ap.parse_args()
+
+    print("=== bip110_miner self-test (KAT block 961640) ===")
+    ok = run_selftest(verbose=True)
+    ok2 = selftest_fastpath_equiv()
+    if not (ok and ok2):
+        print("ABORT: PoW self-test FAILED — pipeline is not byte-correct.")
+        sys.exit(1)
+    print("=== self-test PASSED — pipeline is byte-correct vs the pool's KAT ===")
+
+    if args.selftest_only:
+        sys.exit(0)
+
+    if not args.address:
+        print("ABORT: --address required to mine")
+        sys.exit(2)
+
+    if args.procs > 1 and args.worker_index < 0:
+        # Launcher: fork N independent miner processes, each with its own socket
+        # connection but the SAME worker name (the pool aggregates by worker id).
+        procs = []
+        for idx in range(args.procs):
+            p = mp.Process(target=_child_entry, args=(args, idx))
+            p.start()
+            procs.append(p)
+            time.sleep(0.3)   # stagger connects
+        for p in procs:
+            p.join()
+        return
+
+    m = Miner(args)
+    try:
+        m.run()
+    except Exception as e:
+        m.log("FATAL: %r" % e)
+        raise
+
+
+def _child_entry(args, idx):
+    # Give each child its own log file so raw JSON proof is per-connection.
+    if args.log:
+        base = args.log
+        if base.endswith(".log"):
+            args.log = base[:-4] + (".p%d.log" % idx)
+        else:
+            args.log = base + (".p%d" % idx)
+    args.worker_index = idx
+    m = Miner(args)
+    try:
+        m.run()
+    except Exception as e:
+        m.log("FATAL: %r" % e)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds standalone BIP-110 (BLAKE2b, Sia-family PoW) Stratum-v1 test miners under `tools/bip110/` so **real pool-diff shares** can be driven into a BIP-110 node — enough hashrate to cross share-diff and mint real M3 sharechain shares, which the CPU legion64 miner alone cannot do. This exercises PPLNS split, multi-miner convergence and the majority-escape scenario with genuine work.

GPUs cannot *win* a block against BLAKE2b ASICs at network difficulty (expected); they produce *shares* at pool difficulty, which is exactly the test goal.

## Files

- **`bip110_gpu_miner.py`** — NVIDIA CUDA BLAKE2b via CuPy `RawModule` (JIT through the driver's nvrtc; no CUDA toolkit needed). `pbh` + `root` precomputed host-side, only the nonce word varies on-device, `atomicAdd` output queue. `--device N` selects the GPU (multi-GPU = one process per GPU, distinct `--address` each for the PPLNS split).
- **`bip110_miner.py`** — CPU (`hashlib`) reference / low-rate miner; the byte-correct Stratum plumbing the GPU miner reuses.
- **`README.md`** — the exact Stratum-v1 work format, hash pipeline, KAT, and single/multi-GPU run commands.

## Correctness gate

Both mirror the pool PoW fold (`src/impl/bip110/pow.hpp` + `pseudoheader.hpp`) and **self-test against live fork block 961640 before connecting** — a wrong fold aborts. The GPU miner runs the KAT through the actual `__device__` BLAKE2b core AND a mine-kernel round-trip, so an accepted share proves genuine byte-correct GPU work. Neither touches the pool or c2pool source.

## Verified

- **CPU KAT: PASS** host-side (`--selftest-only`), both files; GPU-file CPU reference + mine-kernel buffer layout independently cross-checked.
- **Live Stratum path**: subscribe → extranonce1 → authorize(true) → notify → submit → **ACCEPTED** against `bip110.voidbind.com:9336` (CPU miner, byte-identical stratum plumbing).
- **GPU device run**: proven on a single RTX 3060 Laptop during investigation (1128 MH/s, 0 rejects, real sharechain shares minted). A **3-GPU concurrent, 3-distinct-address** run is **pending a real NVIDIA host** (the 3x3060 at 192.168.86.123 once freed).

## Run (3x3060)

```
python3 -m venv gpuvenv && gpuvenv/bin/pip install cupy-cuda12x
for i in 0 1 2; do
  nohup gpuvenv/bin/python tools/bip110/bip110_gpu_miner.py --device $i \
    --host bip110.voidbind.com --port 9336 \
    --address <ADDR_$i> --worker rig3060-$i \
    --diff 2 --minutes 4320 --log /tmp/bip110_gpu_$i.log &
done
```

Draft: awaiting review + a real 3-GPU host run.
