### PR TITLE
sharechain: port restart-reorg supersede (Class-A self-fork) + periodic think tick to dash/btc/dgb

### DIFF
--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -3203,6 +3203,30 @@ int main(int argc, char* argv[])
         LOG_INFO << "[BTC-POOL] dashboard disabled (no --http bind given).";
     }
 
+    // Restart-reorg / liveness safety-net: periodic clean_tracker() tick (5s).
+    // clean_tracker() runs think() inline (advancing verification + the restart-
+    // reorg supersede convergence) and prunes stale heads/tails. Without this tick
+    // think() fires ONLY on inbound share arrival, so a node with no live share
+    // flow (all peers silent/hostile, no local miners) never re-attempts a
+    // timed-out bootstrap download and never advances a warm-restart reorg — the
+    // consumer-side single-peer-wedge / stuck-tip liveness gap. Mirrors
+    // main_ltc.cpp:6682. Self-rescheduling on the run-loop ioc; stops when the
+    // timer is cancelled at shutdown (ec set).
+    auto think_timer = std::make_shared<boost::asio::steady_timer>(ioc);
+    std::function<void(boost::system::error_code)> think_tick;
+    if (p2p_node) {
+        think_tick = [&, think_timer](boost::system::error_code ec) {
+            if (ec) return;
+            think_timer->expires_after(std::chrono::seconds(5));
+            think_timer->async_wait(think_tick);
+            try { p2p_node->clean_tracker(); }
+            catch (const std::exception& e) { LOG_ERROR << "[CLEAN-TRACKER] error: " << e.what(); }
+            catch (...) { LOG_ERROR << "[CLEAN-TRACKER] unknown error"; }
+        };
+        think_timer->expires_after(std::chrono::seconds(5));
+        think_timer->async_wait(think_tick);
+    }
+
     LOG_INFO << "[BTC] io_context running. Ctrl-C to stop.";
 
     // Diagnostic [IOC-LAT]: when a single run_for slice takes far longer

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -2347,6 +2347,26 @@ int run_node(const core::CoinParams& params, bool testnet,
     }
 
     std::cout << "[DGB] run-loop up: " << network_summary(params) << "\n";
+    // Restart-reorg / liveness safety-net: periodic clean_tracker() tick (5s).
+    // clean_tracker() runs think() inline (advancing verification + the restart-
+    // reorg supersede convergence) and prunes stale heads/tails. Without this tick
+    // think() fires ONLY on inbound share arrival, so a node with no live share
+    // flow never re-attempts a timed-out bootstrap download and never advances a
+    // warm-restart reorg — the consumer-side single-peer-wedge / stuck-tip
+    // liveness gap. Mirrors main_ltc.cpp:6682.
+    auto think_timer = std::make_shared<boost::asio::steady_timer>(ioc);
+    std::function<void(boost::system::error_code)> think_tick;
+    think_tick = [&, think_timer](boost::system::error_code ec) {
+        if (ec) return;
+        think_timer->expires_after(std::chrono::seconds(5));
+        think_timer->async_wait(think_tick);
+        try { p2p_node.clean_tracker(); }
+        catch (const std::exception& e) { LOG_ERROR << "[CLEAN-TRACKER] error: " << e.what(); }
+        catch (...) { LOG_ERROR << "[CLEAN-TRACKER] unknown error"; }
+    };
+    think_timer->expires_after(std::chrono::seconds(5));
+    think_timer->async_wait(think_tick);
+
     std::cout << "[DGB] io_context running. Ctrl-C to stop." << std::endl;
 
     ioc.run();

--- a/src/impl/btc/node.cpp
+++ b/src/impl/btc/node.cpp
@@ -1875,6 +1875,49 @@ void NodeImpl::disarm_think_watchdog()
     }
 }
 
+btc::SupersedeHint NodeImpl::gate_supersede_convergence(btc::SupersedeHint hint)
+{
+    // Compute-thread only; caller holds the exclusive tracker lock.
+    const auto now = std::chrono::steady_clock::now();
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL)
+            it = m_supersede_denylist.erase(it);
+        else
+            ++it;
+    }
+    if (!hint.active)
+        return hint;
+    const uint256 seg = hint.target_segment_last;
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable (parent unobtainable) — hint"
+                        " suppressed; normal argmax + GC continue";
+        return btc::SupersedeHint{};
+    }
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); }
+    catch (...) { acc = 0; }
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height) { prog.last_acc_height = acc; prog.stall_cycles = 0; }
+    else { ++prog.stall_cycles; }
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " made no verified-height progress in " << prog.stall_cycles
+                    << " cycles (stuck at " << acc << ") — denylisting for "
+                    << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return btc::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // Skip if a think() is already running on the compute thread.
@@ -1935,13 +1978,35 @@ void NodeImpl::run_think()
         // real work so no IO callbacks need the tracker lock.  Matches p2pool
         // where think() runs synchronously on the reactor during initial sync.
         bool bootstrap = m_tracker.verified.size() == 0;
+
+        // Restart-reorg: detect a genuine higher-work fork the warm-loaded node
+        // is stuck away from (see SupersedeHint). Skipped during bootstrap; no-op
+        // on a healthy node. gate_supersede_convergence clears an unconvergeable
+        // challenger after SUPERSEDE_STALL_LIMIT stalled cycles.
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        btc::SupersedeHint supersede = bootstrap
+            ? btc::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        m_supersede_hint = supersede;
+        uint256 prev_best_for_flip = m_best_share_hash;
+        if (supersede.active) {
+            LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                        << m_best_share_hash.GetHex().substr(0,16)
+                        << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                        << " challenger_verified_h="
+                        << m_tracker.verified.get_acc_height(supersede.target_head)
+                        << " — challenger received work STRICTLY > incumbent verified work;"
+                        << " granting bounded elevated verify budget + 2*CL+10 backfill";
+        }
         LOG_INFO << "[ASYNC-THINK] compute: chain=" << m_tracker.chain.size()
                  << " verified=" << m_tracker.verified.size()
                  << " heads=" << m_tracker.chain.get_heads().size()
                  << " v_heads=" << m_tracker.verified.get_heads().size()
-                 << (bootstrap ? " BOOTSTRAP" : "");
+                 << (bootstrap ? " BOOTSTRAP" : "")
+                 << (supersede.active ? " SUPERSEDE" : "");
         auto think_t0 = std::chrono::steady_clock::now();
-        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap, supersede);
         think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - think_t0).count();
 
@@ -1954,6 +2019,18 @@ void NodeImpl::run_think()
 
         if (!result.best.IsNull()) {
             best_changed = (m_best_share_hash != result.best);
+            if (best_changed && supersede.active) {
+                bool onto_challenger = false;
+                try {
+                    onto_challenger =
+                        (m_tracker.chain.get_last(result.best) == supersede.target_segment_last);
+                } catch (...) {}
+                if (onto_challenger)
+                    LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                                << prev_best_for_flip.GetHex().substr(0,16)
+                                << " new_best=" << result.best.GetHex().substr(0,16)
+                                << " — converged onto the network highest-work chain";
+            }
             m_best_share_hash = result.best;
         }
 
@@ -2318,11 +2395,18 @@ void NodeImpl::clean_tracker()
             uint32_t bits = 0;
 
             bootstrap = m_tracker.verified.size() == 0;
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? btc::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
                      << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
-                     << (bootstrap ? " BOOTSTRAP" : "");
+                     << (bootstrap ? " BOOTSTRAP" : "")
+                     << (m_supersede_hint.active ? " SUPERSEDE" : "");
             auto think_t0 = std::chrono::steady_clock::now();
-            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                          m_supersede_hint);
             auto think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - think_t0).count();
 
@@ -2360,6 +2444,17 @@ void NodeImpl::clean_tracker()
 
                 // Guard 1: keep top-5 scored heads (p2pool node.py:363)
                 if (top5_set.count(head_hash)) continue;
+
+                // Guard 1b (restart-reorg): keep the converging challenger segment
+                // so its partial verification is not eaten every ~300s. Matched by
+                // segment id. No-op when the hint is inactive.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(head_hash) &&
+                            m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
 
                 // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
                 auto* idx = m_tracker.chain.get_index(head_hash);
@@ -2423,6 +2518,16 @@ void NodeImpl::clean_tracker()
             auto tails_copy = m_tracker.chain.get_tails();
             for (auto& [tail_hash, head_hashes] : tails_copy)
             {
+                // Restart-reorg: never drop the converging challenger segment's
+                // tail (it needs its full ~2*CL depth). Matched by segment id.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(tail_hash) &&
+                            m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
+
                 int32_t min_height = 0;  // default 0 → skip if no valid heads
                 for (auto& hh : head_hashes) {
                     if (!m_tracker.chain.contains(hh)) continue;
@@ -2496,7 +2601,13 @@ void NodeImpl::clean_tracker()
             : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
         uint256 prev_block;
         uint32_t bits = 0;
-        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        m_supersede_hint = bootstrap
+            ? btc::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                      m_supersede_hint);
         m_last_top5_heads = std::move(result.top5_heads);
         if (!result.best.IsNull()) {
             clean_best_changed = (m_best_share_hash != result.best);

--- a/src/impl/btc/node.hpp
+++ b/src/impl/btc/node.hpp
@@ -23,6 +23,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <mutex>
 #include <shared_mutex>
 #include <random>
@@ -209,6 +210,27 @@ protected:
     // Top-5 scored heads from last think() — used by clean_tracker()
     // to protect the best chains from head pruning (p2pool node.py:363).
     std::vector<uint256> m_last_top5_heads;
+
+    // Restart-reorg supersede hint from the last think()/clean cycle
+    // (ShareTracker::compute_supersede_hint). When active it names a genuine
+    // higher-work fork the node is converging onto after a warm restart; used by
+    // clean_tracker() to exempt the converging challenger segment from stale-head
+    // eating and tail-dropping. Inactive on a healthy node.
+    btc::SupersedeHint m_supersede_hint;
+
+    // ── Supersede-convergence liveness (tip-freeze livelock fix) ──────────
+    // When a challenger's missing parent is UNOBTAINABLE its verified height
+    // never advances, compute_supersede_hint re-arms every cycle, and think()
+    // draws the elevated verify budget forever (treadmill holding the exclusive
+    // lock). Detect zero progress over SUPERSEDE_STALL_LIMIT cycles and denylist
+    // the segment (keyed by target_segment_last) for SUPERSEDE_DENYLIST_TTL,
+    // deactivating the hint and re-enabling GC. A later-obtainable parent retries.
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    btc::SupersedeHint gate_supersede_convergence(btc::SupersedeHint hint);
 
     // Buffer of newly verified share hashes, flushed to LevelDB periodically
     std::vector<uint256> m_verified_flush_buf;

--- a/src/impl/btc/share_tracker.hpp
+++ b/src/impl/btc/share_tracker.hpp
@@ -113,6 +113,44 @@ struct DecoratedData
     }
 };
 
+// ── Restart-reorg supersede hint ─────────────────────────────────────────
+// Computed by NodeImpl before each think() cycle (compute_supersede_hint()).
+//
+// A warm-restarted node that loads its persisted, fully-verified sharechain
+// then peers with a higher-work network STICKS on the old head and never
+// reorgs onto the higher-work chain, even though it receives it in full. The
+// incumbent enjoys a structural, permanent privilege: TailScore compares
+// chain_len FIRST and score() short-circuits to {verified_height,0} for any
+// tail below CHAIN_LENGTH, so a warm-loaded full-CL verified tail beats any
+// challenger whose VERIFIED height is still below CHAIN_LENGTH — and the
+// challenger never verifies to CHAIN_LENGTH because think() only ever extends
+// an unrooted segment ~8 shares deep and never backfills it to the
+// ~2*CHAIN_LENGTH depth a CHAIN_LENGTH-tall verified tail needs.
+//
+// This hint makes the EXISTING think() argmax able to actually see the
+// challenger, mirroring p2pool's re-pick-best-after-download, WITHOUT adding a
+// reorg code path or weakening verified-only selection: when a chain head's
+// RECEIVED cumulative work is STRICTLY greater than the incumbent best's
+// VERIFIED work AND that head is a genuine fork (not an extension of the
+// incumbent) AND its verified height is still below CHAIN_LENGTH, think()
+// (a) deepens Phase-2 backfill for that segment to 2*CL+10 and (b) spends a
+// BOUNDED elevated verification budget on it through the ordinary Phase-2
+// attempt_verify loop. Over successive ticks the challenger verifies to
+// CHAIN_LENGTH, the Phase-3 TailScore comparison flips on its own, and the head
+// moves. It NEVER bypasses attempt_verify, never scores unverified work, and is
+// a no-op when the incumbent already IS the best head (no strictly-higher-work
+// fork exists) — so a healthy node is unaffected.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;          // challenger chain head (highest received work)
+    uint256  target_segment_last;  // chain.get_last(target_head): its missing parent —
+                                   // the stable identity of the whole challenger segment
+    int      budget{0};            // bounded elevated per-tick verify budget for the segment
+    uint288  challenger_work;      // received cumulative work of the challenger (diagnostics)
+    uint288  incumbent_work;       // verified cumulative work of the incumbent best (diagnostics)
+};
+
 // --- Result types ---
 
 struct TrackerThinkResult
@@ -685,16 +723,87 @@ public:
         return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    // Returns an ACTIVE hint iff a genuine competing fork exists whose RECEIVED
+    // cumulative work is STRICTLY greater than the incumbent best's VERIFIED
+    // work and whose verified height is still below CHAIN_LENGTH. Pure read over
+    // chain + verified (no mutation); safe to call under the exclusive lock just
+    // before think(). Guardrails baked in here:
+    //   * strictly-greater only (incumbent_work < challenger_work);
+    //   * genuine-fork only (is_child_of skips extensions of our own chain);
+    //   * verified-height < CHAIN_LENGTH only (deactivates once full-length).
+    // No-op (inactive) when the incumbent best already carries the most work.
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;  // bootstrap / no incumbent — bootstrap budget path applies
+        const auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+
+        uint256 best_ch;
+        uint288 best_ch_work;
+        bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            // Extension of our own best chain (not a fork) — never a challenger.
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) { /* concurrent trim — treat as fork candidate */ }
+            // Already a full-length verified chain — Phase-3 scoring handles it.
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+
+        if (found && incumbent_work < best_ch_work)  // STRICTLY higher received work
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    // Move challenger-segment heads to the FRONT of the work-descending Phase-2
+    // order (stable_partition, order preserved within each group) so a shorter
+    // non-challenger head that outranks the challenger by verified work can never
+    // spend the whole per-tick budget and trip the outer gate before the
+    // challenger's iteration is entered. Inactive supersede => no-op (byte-
+    // identical healthy-node order). Selection (Phase 3/4 argmax) is untouched.
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active)
+            return 0;
+        auto is_challenger_head = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_challenger_head);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
     // stratum isn't serving work — no IO needs the tracker lock.
     // Matches p2pool where think() runs synchronously on the reactor and
     // blocks everything else until verification completes.
+    // supersede: restart-reorg hint (see SupersedeHint). Default-inactive, so
+    // every other caller and the healthy-node path are byte-unchanged.
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& previous_block,
                              uint32_t bits,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
         // The timestamp is used to filter stale requests at return time.
@@ -906,7 +1015,32 @@ public:
         // now, so budgeting is a safety net for cold starts only.
         constexpr int THINK_VERIFY_BUDGET = 100;
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
+        // Restart-reorg elevated budget (SupersedeHint): a BOUNDED extra pool
+        // that ONLY the challenger segment may draw from, after the normal budget
+        // is spent. Inactive → identical to before.
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active) {
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " segment_last=" << supersede.target_segment_last.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget
+                     << " challenger_work>" << "incumbent_work (strictly greater)";
+        }
         m_think_needs_continue = false;
+
+        // Wall-clock bound on a single think() cycle (tip-freeze livelock fix).
+        // While the exclusive lock is held the IO serve path returns EMPTY, so a
+        // multi-second/minute hold degenerates a behind peer's bulk download and
+        // back-pressures inbound shares. Cap the per-cycle hold; needs_continue
+        // reposts the remainder next tick. Bootstrap is exempt.
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
 
         // Frontier diagnostic (C2): when the verified tip lags the raw chain by
         // a wide margin the mint path extends a stale private fork (money bug).
@@ -953,9 +1087,34 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;  // highest work first
             });
+        // Restart-reorg liveness: move challenger-segment heads to the FRONT so a
+        // shorter non-challenger head cannot spend the normal budget and trip the
+        // per-head gate before the challenger is reached. No-op when inactive.
+        prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) {
+            // Wall-clock bound (tip-freeze fix): stop the per-head sweep once this
+            // cycle has held the lock long enough; remainder resumes next tick.
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Matched by segment identity (the shared
+            // missing-parent). Hoisted above the gate so the gate is elevated-aware.
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+
+            // Per-head budget gate; only a challenger head may additionally draw
+            // the bounded elevated pool. Inactive supersede reduces this to the
+            // original `budget_remaining <= 0` break (byte-identical).
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
                 m_think_needs_continue = true;
                 break;
             }
@@ -980,7 +1139,11 @@ public:
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(PoolConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            // For an UNROOTED challenger segment a CHAIN_LENGTH-tall VERIFIED tail
+            // needs ~2*CL depth; target the fresh-bootstrap load depth 2*CL+10.
+            // Rooted / non-challenger tails keep the original CL target.
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -1012,9 +1175,21 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) {
+                    // Normal budget for everyone; the challenger segment may draw
+                    // from the bounded elevated pool AFTER the normal budget is spent.
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) {
                         m_think_needs_continue = true;
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
+                                 << " verifications, deferring remainder"
+                                 << (is_challenger ? " (challenger elevated pool spent)" : "");
+                        break;
+                    }
+                    // Wall-clock bound (tip-freeze fix): checked every 8 verifies.
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] wall-clock cap hit after " << p2_verified_count
                                  << " verifications, deferring remainder";
                         break;
                     }
@@ -1110,7 +1285,10 @@ public:
                     }
                     ++p2_verified_count;
                     if (!was_already_verified) {
-                        --budget_remaining;
+                        // Spend the normal budget first; only the challenger may
+                        // then draw from the bounded elevated pool.
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
                     }
                     // Throttled progress log: contabo freeze-diag (2026-05-24) caught
                     // this loop wedging the io_context for 2-7.5s at a time when emit
@@ -1127,8 +1305,16 @@ public:
                 }
             }
 
-            // Request more shares if verified chain is short
-            if (head_height < static_cast<int32_t>(PoolConfig::chain_length()) && !last_last_hash.IsNull())
+            // Request more shares if verified chain is short.
+            // Non-challenger: request until MAIN chain reaches CHAIN_LENGTH.
+            // Challenger (restart-reorg): keep requesting parents until the
+            // segment reaches 2*CL+10 depth (the unrooted verified-tail depth).
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(PoolConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 // Option A: check MAIN chain height (not verified height).
                 // If main chain is already in pruning zone, the unverified

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -504,6 +504,71 @@ void NodeImpl::apply_min_protocol_ratchet()
     }
 }
 
+dash::SupersedeHint NodeImpl::gate_supersede_convergence(dash::SupersedeHint hint)
+{
+    // Compute-thread only; caller holds the exclusive tracker lock.
+    const auto now = std::chrono::steady_clock::now();
+
+    // Expire old denylist entries so a segment whose parent later becomes
+    // obtainable can be retried.
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL)
+            it = m_supersede_denylist.erase(it);
+        else
+            ++it;
+    }
+
+    if (!hint.active)
+        return hint;
+
+    const uint256 seg = hint.target_segment_last;
+
+    // Already proven unconvergeable and not yet expired — keep it suppressed so
+    // the elevated-verify treadmill stays off and GC can reclaim the segment.
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable (parent unobtainable) — hint"
+                        " suppressed; normal argmax + GC continue";
+        return dash::SupersedeHint{};
+    }
+
+    // Forward-progress metric: the challenger's verified accumulated height. On a
+    // genuinely converging fork this climbs every cycle as the elevated budget
+    // verifies deeper; on an unrooted/unobtainable-parent fork it stays pinned.
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); }
+    catch (...) { acc = 0; }
+
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height)
+    {
+        prog.last_acc_height = acc;
+        prog.stall_cycles = 0;
+    }
+    else
+    {
+        ++prog.stall_cycles;
+    }
+
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " made no verified-height progress in " << prog.stall_cycles
+                    << " cycles (verified_acc_height stuck at " << acc
+                    << "; missing parent unobtainable from all peers) — denylisting for "
+                    << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return dash::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // THREAD-CONFINEMENT (enforced, not assumed — register_template_txs
@@ -558,16 +623,56 @@ void NodeImpl::run_think()
             // Bootstrap: no verified chain yet → verify everything in one
             // pass (p2pool think() runs synchronously during initial sync).
             const bool bootstrap = m_tracker.verified.size() == 0;
+
+            // Restart-reorg: detect a genuine higher-work fork the warm-loaded
+            // node is stuck away from (see SupersedeHint). Skipped during
+            // bootstrap (empty start already downloads to 2*CL+10 under the
+            // unlimited budget). No-op on a healthy node whose persisted head
+            // already carries the most work. gate_supersede_convergence() clears
+            // the hint after SUPERSEDE_STALL_LIMIT cycles of zero progress so an
+            // unconvergeable (missing-parent-unobtainable) challenger can never
+            // pin the elevated-verify treadmill.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;  // bounded elevated per-tick verify
+            dash::SupersedeHint supersede = bootstrap
+                ? dash::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+            m_supersede_hint = supersede;
+            uint256 prev_best_for_flip = m_best_share_hash;
+            if (supersede.active) {
+                LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                            << m_best_share_hash.GetHex().substr(0,16)
+                            << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                            << " challenger_chain_h="
+                            << (m_tracker.chain.contains(supersede.target_head)
+                                ? m_tracker.chain.get_height(supersede.target_head) : -1)
+                            << " challenger_verified_h="
+                            << m_tracker.verified.get_acc_height(supersede.target_head)
+                            << " — challenger received work STRICTLY > incumbent verified work;"
+                            << " granting bounded elevated verify budget + 2*CL+10 backfill";
+            }
             auto t0 = std::chrono::steady_clock::now();
             result = m_tracker.think(block_rel_height,
                                      /*previous_block=*/uint256(),
-                                     /*bits=*/0, bootstrap);
+                                     /*bits=*/0, bootstrap, supersede);
             think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - t0).count();
 
             m_last_top5_heads = std::move(result.top5_heads);
             if (!result.best.IsNull()) {
                 best_changed = (m_best_share_hash != result.best);
+                if (best_changed && supersede.active) {
+                    bool onto_challenger = false;
+                    try {
+                        onto_challenger =
+                            (m_tracker.chain.get_last(result.best) == supersede.target_segment_last);
+                    } catch (...) {}
+                    if (onto_challenger)
+                        LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                                    << prev_best_for_flip.GetHex().substr(0,16)
+                                    << " new_best=" << result.best.GetHex().substr(0,16)
+                                    << " — converged onto the network highest-work chain";
+                }
                 m_best_share_hash = result.best;
                 apply_min_protocol_ratchet();  // v36 accept-floor ratchet (dgb node.cpp:1526 parallel)
             }
@@ -1003,9 +1108,17 @@ void NodeImpl::clean_tracker()
         // Step 1: run think() inline (already holds the lock).
         {
             bootstrap = m_tracker.verified.size() == 0;
+            // Restart-reorg hint (same detector as run_think). Recomputed here so
+            // the Step-2/Step-3 GC exemptions below act on a current view, and so
+            // Step-1 think() also advances the converging challenger.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? dash::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             auto result = m_tracker.think(block_rel_height,
                                           /*previous_block=*/uint256(),
-                                          /*bits=*/0, bootstrap);
+                                          /*bits=*/0, bootstrap, m_supersede_hint);
             m_last_top5_heads = std::move(result.top5_heads);
             if (!result.best.IsNull()) {
                 m_best_share_hash = result.best;
@@ -1032,6 +1145,18 @@ void NodeImpl::clean_tracker()
                 {
                     if (!m_tracker.chain.contains(head_hash)) continue;
                     if (top5_set.count(head_hash)) continue;             // guard 1
+                    // Guard 1b (restart-reorg): keep the converging challenger
+                    // segment. Its verified height is below CHAIN_LENGTH so it is
+                    // never in the top-5; without this exemption its partial
+                    // verification would be eaten every ~300s and restarted forever
+                    // — the original stuck-on-persisted-head latch in a different
+                    // guise. Matched by segment id. No-op when the hint is inactive.
+                    if (m_supersede_hint.active) {
+                        try {
+                            if (m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                                continue;
+                        } catch (...) {}
+                    }
                     auto* idx = m_tracker.chain.get_index(head_hash);
                     if (!idx || idx->time_seen > now_sec - 300) continue; // guard 2
                     if (!m_tracker.verified.contains(head_hash))          // guard 3
@@ -1078,6 +1203,21 @@ void NodeImpl::clean_tracker()
                 auto tails_copy = m_tracker.chain.get_tails();
                 for (auto& [tail_hash, head_hashes] : tails_copy)
                 {
+                    // Restart-reorg: never drop the tail of the converging
+                    // challenger segment. An unrooted challenger needs its FULL
+                    // ~2*CL depth to reach CHAIN_LENGTH verified shares; trimming
+                    // its bottom mid-verification silently restarts convergence
+                    // (looks like the original stickiness). The exemption lifts
+                    // once it verifies to CHAIN_LENGTH and the hint deactivates.
+                    // Matched by segment id (the shared missing-parent).
+                    if (m_supersede_hint.active) {
+                        try {
+                            if (m_tracker.chain.contains(tail_hash) &&
+                                m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                                continue;
+                        } catch (...) {}
+                    }
+
                     int32_t min_height = 0;  // 0 → skip if no valid heads
                     for (auto& hh : head_hashes) {
                         if (!m_tracker.chain.contains(hh)) continue;
@@ -1122,9 +1262,16 @@ void NodeImpl::clean_tracker()
 
         // Step 4: re-score after pruning (inline, still holding the lock).
         {
+            // Restart-reorg: re-detect after pruning and pass the hint so the
+            // re-score also advances/flips onto the challenger.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? dash::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             auto result = m_tracker.think(block_rel_height,
                                           /*previous_block=*/uint256(),
-                                          /*bits=*/0, bootstrap);
+                                          /*bits=*/0, bootstrap, m_supersede_hint);
             m_last_top5_heads = std::move(result.top5_heads);
             if (!result.best.IsNull()) {
                 m_best_share_hash = result.best;

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -338,6 +338,37 @@ protected:
     // to protect the best chains from head pruning.
     std::vector<uint256> m_last_top5_heads;
 
+    // Restart-reorg supersede hint from the last think()/clean cycle
+    // (ShareTracker::compute_supersede_hint). When active it names a genuine
+    // higher-work fork the node is converging onto after a warm restart; used
+    // by clean_tracker() to exempt the converging challenger segment from
+    // stale-head eating and tail-dropping so its verification is not thrown
+    // away and restarted every ~300s (which would re-create the original
+    // stuck-on-persisted-head latch). Inactive on a healthy node.
+    dash::SupersedeHint m_supersede_hint;
+
+    // ── Supersede-convergence liveness (tip-freeze livelock fix) ──────────
+    // The restart-reorg elevated verify budget assumes the challenger segment
+    // will eventually verify to CHAIN_LENGTH and the Phase-3 argmax will flip.
+    // That assumption fails when the challenger's missing parent is UNOBTAINABLE
+    // — no connected peer still retains it. Then the challenger's verified height
+    // never advances, compute_supersede_hint re-arms it every cycle, and think()
+    // draws the elevated verify budget on the same never-winning shares forever:
+    // a treadmill that holds the exclusive tracker lock. We detect zero forward
+    // progress over SUPERSEDE_STALL_LIMIT consecutive cycles and denylist the
+    // segment (keyed by its stable target_segment_last) for SUPERSEDE_DENYLIST_TTL,
+    // which deactivates the hint — stopping the treadmill AND re-enabling GC of
+    // the zombie segment. A later-obtainable parent retries after TTL.
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    // Deactivate the hint if the challenger segment is proven unconvergeable
+    // (already denylisted, or freshly stalled this call). Compute-thread only,
+    // called under the exclusive tracker lock. Returns the (possibly cleared) hint.
+    dash::SupersedeHint gate_supersede_convergence(dash::SupersedeHint hint);
+
     // Buffer of newly verified share hashes, flushed to LevelDB periodically.
     std::vector<uint256> m_verified_flush_buf;
     // Buffer of pruned share hashes, batch-deleted from LevelDB after clean.

--- a/src/impl/dash/share_tracker.hpp
+++ b/src/impl/dash/share_tracker.hpp
@@ -118,6 +118,46 @@ struct DecoratedData
     }
 };
 
+// ── Restart-reorg supersede hint ─────────────────────────────────────────
+// Computed by NodeImpl before each think() cycle (compute_supersede_hint()).
+//
+// A warm-restarted node that loads its persisted, fully-verified sharechain
+// then peers with a higher-work network STICKS on the old head and never
+// reorgs onto the higher-work chain, even though it receives it in full. The
+// incumbent enjoys a structural, permanent privilege: TailScore compares
+// chain_len FIRST and score() short-circuits to {verified_height,0} for any
+// tail below CHAIN_LENGTH, so a warm-loaded full-CL verified tail beats any
+// challenger whose VERIFIED height is still below CHAIN_LENGTH — and the
+// challenger never verifies to CHAIN_LENGTH because think() only ever extends
+// an unrooted segment ~8 shares deep and never backfills it to the
+// ~2*CHAIN_LENGTH depth a CHAIN_LENGTH-tall verified tail needs. A fresh
+// re-seed only converges because an EMPTY start has no incumbent and downloads
+// to 2*CL+10 under the bootstrap budget.
+//
+// This hint makes the EXISTING think() argmax able to actually see the
+// challenger, mirroring p2pool's re-pick-best-after-download, WITHOUT adding a
+// reorg code path or weakening verified-only selection: when a chain head's
+// RECEIVED cumulative work is STRICTLY greater than the incumbent best's
+// VERIFIED work AND that head is a genuine fork (not an extension of the
+// incumbent) AND its verified height is still below CHAIN_LENGTH, think()
+// (a) deepens Phase-2 backfill for that segment to 2*CL+10 and (b) spends a
+// BOUNDED elevated verification budget on it through the ordinary Phase-2
+// attempt_verify loop. Over successive ticks the challenger verifies to
+// CHAIN_LENGTH, the Phase-3 TailScore comparison flips on its own, and the head
+// moves. It NEVER bypasses attempt_verify, never scores unverified work, and is
+// a no-op when the incumbent already IS the best head (no strictly-higher-work
+// fork exists) — so a healthy node is unaffected.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;          // challenger chain head (highest received work)
+    uint256  target_segment_last;  // chain.get_last(target_head): its missing parent —
+                                   // the stable identity of the whole challenger segment
+    int      budget{0};            // bounded elevated per-tick verify budget for the segment
+    uint288  challenger_work;      // received cumulative work of the challenger (diagnostics)
+    uint288  incumbent_work;       // verified cumulative work of the incumbent best (diagnostics)
+};
+
 // --- Result types ---
 
 struct TrackerThinkResult
@@ -705,16 +745,106 @@ public:
         return {static_cast<int32_t>(SharechainConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    // Returns an ACTIVE hint iff a genuine competing fork exists whose RECEIVED
+    // cumulative work is STRICTLY greater than the incumbent best's VERIFIED
+    // work and whose verified height is still below CHAIN_LENGTH. Pure read over
+    // chain + verified (no mutation); safe to call under the exclusive lock just
+    // before think(). Guardrails baked in here:
+    //   * strictly-greater only (incumbent_work < challenger_work) — a tie or
+    //     lower-work fork can never trigger;
+    //   * genuine-fork only (is_child_of(incumbent, head) skips extensions of
+    //     our own chain, so freshly-mined-but-unverified local shares that merely
+    //     extend the best head never masquerade as a challenger);
+    //   * verified-height < CHAIN_LENGTH only — once the challenger is full-length
+    //     verified the ordinary Phase-3 argmax owns the decision and the hint
+    //     deactivates (no perpetual trigger, no oscillation).
+    // No-op (inactive) when the incumbent best already carries the most work —
+    // the healthy single-head case.
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;  // bootstrap / no incumbent — bootstrap budget path applies
+        const auto CL = static_cast<int32_t>(SharechainConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+
+        uint256 best_ch;
+        uint288 best_ch_work;
+        bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            // Extension of our own best chain (not a fork) — the ordinary
+            // budgeted Phase-2 verifies it; never treat it as a challenger.
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) { /* concurrent trim — treat as fork candidate */ }
+            // Already a full-length verified chain — Phase-3 scoring handles it.
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+
+        if (found && incumbent_work < best_ch_work)  // STRICTLY higher received work
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    // The challenger segment's VERIFIED frontier is short, so it sorts LOW in
+    // the work-descending Phase-2 head order. Left there, a shorter non-
+    // challenger verified head that outranks it by verified work can spend the
+    // whole normal per-tick verify budget first and trip the outer per-head
+    // budget gate, breaking the loop before the challenger's iteration is ever
+    // entered — so its bounded elevated pool is never drawn and the higher-work
+    // fork can never verify to CHAIN_LENGTH (the stuck-on-persisted-head bug).
+    // Moving the challenger-segment heads to the FRONT (stable_partition, so the
+    // work-descending order is preserved within each group) guarantees the
+    // challenger is reached every tick regardless of non-challenger contention.
+    // Challenger identity is the segment-last (shared missing parent), matched
+    // by chain.get_last so it survives the frontier advancing tick to tick —
+    // exactly the Phase-2 is_challenger test. Pure read over chain (get_last);
+    // no mutation, no PoW. Inactive supersede => predicate is always false =>
+    // stable_partition is a no-op and the healthy-node order is byte-identical.
+    // Returns the number of challenger heads moved to the front (priority prefix
+    // length). Selection (Phase 3/4 argmax) is untouched — this only orders the
+    // Phase-2 verify sweep so the challenger's elevated budget is actually drawn.
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active)
+            return 0;
+        auto is_challenger_head = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_challenger_head);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
     // stratum isn't serving work — no IO needs the tracker lock.
     // Matches p2pool where think() runs synchronously on the reactor and
     // blocks everything else until verification completes.
+    // supersede: restart-reorg hint (see SupersedeHint). Default-inactive, so
+    // every other caller and the healthy-node path are byte-unchanged.
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& previous_block,
                              uint32_t bits,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
         // The timestamp is used to filter stale requests at return time.
@@ -926,7 +1056,37 @@ public:
         // now, so budgeting is a safety net for cold starts only.
         constexpr int THINK_VERIFY_BUDGET = 100;
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
+        // Restart-reorg elevated budget (SupersedeHint): a BOUNDED extra pool
+        // that ONLY the challenger segment may draw from, after the normal
+        // budget is spent. Bounds the per-tick lock hold while still letting a
+        // strictly-higher-work fork verify to CHAIN_LENGTH over ~CL/budget ticks.
+        // Inactive → identical to before.
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active) {
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " segment_last=" << supersede.target_segment_last.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget
+                     << " challenger_work>" << "incumbent_work (strictly greater)";
+        }
         m_think_needs_continue = false;
+
+        // Wall-clock bound on a single think() cycle (tip-freeze livelock fix).
+        // The exclusive tracker lock is held for the whole of think(); while it
+        // is held the IO serve path uses try_to_lock and returns EMPTY, so a
+        // multi-second — in the livelock, multi-MINUTE — hold degenerates a
+        // behind peer's bulk download to empty replies and back-pressures inbound
+        // shares. Cap the per-cycle hold; m_think_needs_continue makes run_think()
+        // repost the remainder next tick. Bootstrap is exempt (no verified chain
+        // to serve yet; initial full verify runs uncapped, matching p2pool).
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
 
         // ── V36 livelock mirror: cooperative-yield budget for the scoring walk ──
         // The Phase 3/4 scoring step walks the decayed-cumulative-weight + PPLNS
@@ -962,9 +1122,46 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;  // highest work first
             });
+        // Restart-reorg liveness: move challenger-segment heads to the FRONT of
+        // the work-descending order so a shorter non-challenger head that
+        // outranks the challenger by verified work can never spend the normal
+        // budget and trip the outer per-head gate before the challenger's
+        // iteration is entered (which would leave its elevated pool undrawn this
+        // tick — the starvation the fix closes). No-op when supersede is
+        // inactive: the healthy-node order is byte-identical.
+        prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) {
+            // Wall-clock bound (tip-freeze fix): stop the per-head sweep once this
+            // cycle has held the exclusive lock long enough; the remainder resumes
+            // next tick. No-op under bootstrap.
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Matched by segment identity (the shared
+            // missing-parent), so it survives the frontier advancing tick to tick.
+            // Hoisted above the per-head budget gate so the gate can be
+            // elevated-budget-aware (below).
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+
+            // Per-head budget gate. The normal budget bounds work per tick; only
+            // a challenger head may additionally draw the bounded elevated pool.
+            // Do NOT break while THIS head is a challenger that can still draw
+            // elevated budget — challengers are ordered first, so once a budget-
+            // spent non-challenger head is reached, no challenger remains behind
+            // it and stopping is correct. When supersede is inactive is_challenger
+            // is always false, so this reduces to the original `budget_remaining
+            // <= 0` break (healthy-node path byte-identical).
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
                 m_think_needs_continue = true;
                 break;
             }
@@ -989,7 +1186,15 @@ public:
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(SharechainConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            // For an UNROOTED challenger segment a CHAIN_LENGTH-tall VERIFIED tail
+            // needs ~2*CL depth (each of the top CL shares needs CHAIN_LENGTH
+            // ancestors to pass attempt_verify's acc_height>=CL+1 guard on an
+            // unrooted chain). Target the fresh-bootstrap load depth 2*CL+10 so
+            // the segment can actually reach CHAIN_LENGTH verified shares — the
+            // core of the stuck-on-persisted-head bug. Rooted / non-challenger
+            // tails keep the original CL target (byte-unchanged).
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -1021,9 +1226,26 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) {
+                    // Normal budget for everyone; the challenger segment may draw
+                    // from the bounded elevated pool AFTER the normal budget is
+                    // spent. A non-challenger head can never touch elevated_remaining.
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) {
                         m_think_needs_continue = true;
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
+                                 << " verifications, deferring remainder"
+                                 << (is_challenger ? " (challenger elevated pool spent)" : "");
+                        break;
+                    }
+                    // Wall-clock bound (tip-freeze fix): even with budget left, do
+                    // not hold the exclusive lock past THINK_MAX_WALL_MS — each PoW
+                    // verify is costly, so a large elevated pool could pin the lock
+                    // for many seconds. Resume next tick. Checked every 8 verifies
+                    // to keep the steady_clock reads cheap.
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] wall-clock cap hit after " << p2_verified_count
                                  << " verifications, deferring remainder";
                         break;
                     }
@@ -1098,7 +1320,10 @@ public:
                         break;
                     ++p2_verified_count;
                     if (!was_already_verified) {
-                        --budget_remaining;
+                        // Spend the normal budget first; only the challenger may
+                        // then draw from the bounded elevated pool.
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
                     }
                     // Throttled progress log: contabo freeze-diag (2026-05-24) caught
                     // this loop wedging the io_context for 2-7.5s at a time when emit
@@ -1115,8 +1340,18 @@ public:
                 }
             }
 
-            // Request more shares if verified chain is short
-            if (head_height < static_cast<int32_t>(SharechainConfig::chain_length()) && !last_last_hash.IsNull())
+            // Request more shares if verified chain is short.
+            // Non-challenger: request until the MAIN chain reaches CHAIN_LENGTH
+            // (original behaviour). Challenger (restart-reorg): keep requesting
+            // parents until the segment reaches 2*CL+10 depth — the depth needed
+            // for a CHAIN_LENGTH-tall verified tail on an unrooted chain — so it
+            // is no longer pinned at ~CL+8 (the observed stuck state).
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(SharechainConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 // Option A: check MAIN chain height (not verified height).
                 // If main chain is already in pruning zone, the unverified

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -1645,6 +1645,42 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
 
 // (old phases 5-7 removed — replaced by p2pool-style pruning above)
 
+dgb::SupersedeHint NodeImpl::gate_supersede_convergence(dgb::SupersedeHint hint)
+{
+    const auto now = std::chrono::steady_clock::now();
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL) it = m_supersede_denylist.erase(it);
+        else ++it;
+    }
+    if (!hint.active) return hint;
+    const uint256 seg = hint.target_segment_last;
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable — hint suppressed; GC continues";
+        return dgb::SupersedeHint{};
+    }
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); } catch (...) { acc = 0; }
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height) { prog.last_acc_height = acc; prog.stall_cycles = 0; }
+    else { ++prog.stall_cycles; }
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " no progress in " << prog.stall_cycles << " cycles (stuck at " << acc
+                    << ") — denylisting for " << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return dgb::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // Skip if a think() is already running on the compute thread.
@@ -1701,13 +1737,29 @@ void NodeImpl::run_think()
         // real work so no IO callbacks need the tracker lock.  Matches p2pool
         // where think() runs synchronously on the reactor during initial sync.
         bool bootstrap = m_tracker.verified.size() == 0;
+
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        dgb::SupersedeHint supersede = bootstrap
+            ? dgb::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        m_supersede_hint = supersede;
+        uint256 prev_best_for_flip = m_best_share_hash;
+        if (supersede.active)
+            LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                        << m_best_share_hash.GetHex().substr(0,16)
+                        << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                        << " challenger_verified_h="
+                        << m_tracker.verified.get_acc_height(supersede.target_head)
+                        << " — granting bounded elevated verify budget + 2*CL+10 backfill";
         LOG_INFO << "[ASYNC-THINK] compute: chain=" << m_tracker.chain.size()
                  << " verified=" << m_tracker.verified.size()
                  << " heads=" << m_tracker.chain.get_heads().size()
                  << " v_heads=" << m_tracker.verified.get_heads().size()
-                 << (bootstrap ? " BOOTSTRAP" : "");
+                 << (bootstrap ? " BOOTSTRAP" : "")
+                 << (supersede.active ? " SUPERSEDE" : "");
         auto think_t0 = std::chrono::steady_clock::now();
-        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap, supersede);
         think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - think_t0).count();
 
@@ -1720,6 +1772,16 @@ void NodeImpl::run_think()
 
         if (!result.best.IsNull()) {
             best_changed = (m_best_share_hash != result.best);
+            if (best_changed && supersede.active) {
+                bool onto_challenger = false;
+                try { onto_challenger = (m_tracker.chain.get_last(result.best) == supersede.target_segment_last); }
+                catch (...) {}
+                if (onto_challenger)
+                    LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                                << prev_best_for_flip.GetHex().substr(0,16)
+                                << " new_best=" << result.best.GetHex().substr(0,16)
+                                << " — converged onto the network highest-work chain";
+            }
             m_best_share_hash = result.best;
             apply_min_protocol_ratchet();  // oracle main.py:216 (per best-share advance)
         }
@@ -2089,11 +2151,18 @@ void NodeImpl::clean_tracker()
             uint32_t bits = 0;
 
             bootstrap = m_tracker.verified.size() == 0;
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? dgb::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
                      << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
-                     << (bootstrap ? " BOOTSTRAP" : "");
+                     << (bootstrap ? " BOOTSTRAP" : "")
+                     << (m_supersede_hint.active ? " SUPERSEDE" : "");
             auto think_t0 = std::chrono::steady_clock::now();
-            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                          m_supersede_hint);
             auto think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - think_t0).count();
 
@@ -2132,6 +2201,15 @@ void NodeImpl::clean_tracker()
 
                 // Guard 1: keep top-5 scored heads (p2pool node.py:363)
                 if (top5_set.count(head_hash)) continue;
+
+                // Guard 1b (restart-reorg): keep the converging challenger segment.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(head_hash) &&
+                            m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
 
                 // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
                 auto* idx = m_tracker.chain.get_index(head_hash);
@@ -2195,6 +2273,15 @@ void NodeImpl::clean_tracker()
             auto tails_copy = m_tracker.chain.get_tails();
             for (auto& [tail_hash, head_hashes] : tails_copy)
             {
+                // Restart-reorg: never drop the converging challenger segment's tail.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(tail_hash) &&
+                            m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
+
                 int32_t min_height = 0;  // default 0 → skip if no valid heads
                 for (auto& hh : head_hashes) {
                     if (!m_tracker.chain.contains(hh)) continue;
@@ -2268,7 +2355,13 @@ void NodeImpl::clean_tracker()
             : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
         uint256 prev_block;
         uint32_t bits = 0;
-        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        m_supersede_hint = bootstrap
+            ? dgb::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                      m_supersede_hint);
         m_last_top5_heads = std::move(result.top5_heads);
         if (!result.best.IsNull()) {
             clean_best_changed = (m_best_share_hash != result.best);

--- a/src/impl/dgb/node.hpp
+++ b/src/impl/dgb/node.hpp
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <mutex>
 #include <shared_mutex>
 #include <random>
@@ -183,6 +184,20 @@ protected:
     // Top-5 scored heads from last think() — used by clean_tracker()
     // to protect the best chains from head pruning (p2pool node.py:363).
     std::vector<uint256> m_last_top5_heads;
+
+    // Restart-reorg supersede hint (see share_tracker SupersedeHint). Names a
+    // genuine higher-work fork a warm-restarted node is converging onto; used by
+    // clean_tracker() to exempt the challenger segment from GC. Inactive when healthy.
+    dgb::SupersedeHint m_supersede_hint;
+    // Supersede-convergence liveness: denylist an unconvergeable challenger after
+    // SUPERSEDE_STALL_LIMIT stalled cycles (TTL-bounded) to stop the elevated-verify
+    // treadmill and re-enable GC.
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    dgb::SupersedeHint gate_supersede_convergence(dgb::SupersedeHint hint);
 
     // Buffer of newly verified share hashes, flushed to LevelDB periodically
     std::vector<uint256> m_verified_flush_buf;

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -123,6 +123,27 @@ struct DecoratedData
     }
 };
 
+// ── Restart-reorg supersede hint (see LTC #1357) ─────────────────────────
+// A warm-restarted node that loads its persisted, fully-verified sharechain
+// then peers with a higher-work network STICKS on the old head: TailScore
+// compares chain_len FIRST and score() short-circuits below CHAIN_LENGTH, so a
+// warm-loaded full-CL verified tail beats any challenger whose VERIFIED height
+// is still below CHAIN_LENGTH — and the challenger never verifies to CHAIN_LENGTH
+// because think() only extends an unrooted segment ~8 deep. This hint lets the
+// EXISTING think() argmax see the challenger (deeper backfill + a bounded
+// elevated verify budget through the ordinary attempt_verify loop); it never
+// bypasses verification, never scores unverified work, and is a no-op on a
+// healthy node whose head already carries the most work.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;
+    uint256  target_segment_last;
+    int      budget{0};
+    uint288  challenger_work;
+    uint288  incumbent_work;
+};
+
 // --- Result types ---
 
 struct TrackerThinkResult
@@ -690,16 +711,64 @@ public:
         return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;
+        const auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+        uint256 best_ch; uint288 best_ch_work; bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) {}
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+        if (found && incumbent_work < best_ch_work)
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active) return 0;
+        auto is_ch = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_ch);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
     // stratum isn't serving work — no IO needs the tracker lock.
     // Matches p2pool where think() runs synchronously on the reactor and
     // blocks everything else until verification completes.
+    // supersede: restart-reorg hint (default-inactive; healthy path byte-unchanged).
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& previous_block,
                              uint32_t bits,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
         // The timestamp is used to filter stale requests at return time.
@@ -913,7 +982,21 @@ public:
         // now, so budgeting is a safety net for cold starts only.
         constexpr int THINK_VERIFY_BUDGET = 100;
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active)
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget;
         m_think_needs_continue = false;
+
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
         {
             static int p2_skip_log = 0;
             if (p2_skip_log++ % 20 == 0)
@@ -932,9 +1015,22 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;  // highest work first
             });
+        prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) {
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+
+            bool is_challenger = false;
+            if (supersede.active) {
+                try { is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last); }
+                catch (...) { is_challenger = false; }
+            }
+
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
                 m_think_needs_continue = true;
                 break;
             }
@@ -959,7 +1055,8 @@ public:
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(PoolConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -991,9 +1088,18 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) {
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) {
                         m_think_needs_continue = true;
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
+                                 << " verifications, deferring remainder"
+                                 << (is_challenger ? " (challenger elevated pool spent)" : "");
+                        break;
+                    }
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] wall-clock cap hit after " << p2_verified_count
                                  << " verifications, deferring remainder";
                         break;
                     }
@@ -1068,7 +1174,8 @@ public:
                         break;
                     ++p2_verified_count;
                     if (!was_already_verified) {
-                        --budget_remaining;
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
                     }
                     // Throttled progress log: contabo freeze-diag (2026-05-24) caught
                     // this loop wedging the io_context for 2-7.5s at a time when emit
@@ -1085,8 +1192,13 @@ public:
                 }
             }
 
-            // Request more shares if verified chain is short
-            if (head_height < static_cast<int32_t>(PoolConfig::chain_length()) && !last_last_hash.IsNull())
+            // Request more shares if verified chain is short (challenger: to 2*CL+10).
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(PoolConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 // Option A: check MAIN chain height (not verified height).
                 // If main chain is already in pruning zone, the unverified


### PR DESCRIPTION
## Summary

An audit of the shared C++ sharechain engine (all coin lanes) for the two
kr1z1s-class convergence defects found the LTC-only restart-reorg supersede fix
(#1357 + #1405) **unported and live** on the btc/dgb/bch/dash lanes:

- **Class A — self-fork / incumbent structural privilege (HIGH).** A warm-restarted
  node that loads its persisted, fully-verified sharechain then peers with a
  higher-work network STICKS on the old head and self-sustains its own minority
  fork. `TailScore` compares `chain_len` FIRST and `score()` short-circuits to
  `{verified_height,0}` below `CHAIN_LENGTH`, so a warm-loaded full-CL verified
  tail beats any higher-*received*-work challenger whose verified height is still
  short — and `think()` never backfills the unrooted challenger to the ~2*CL depth
  a CHAIN_LENGTH-tall verified tail needs. This is the C++ analog of the python
  fork's majority-escape (different mechanism, same outcome: own-share orphans).
- **Class B — single-peer wedge (liveness, btc/dgb/bch only).** `think()`/`clean_tracker()`
  fire ONLY on inbound share arrival because these three mains have no periodic
  think tick, so a node with no live share flow (all peers silent/hostile, no
  local miners) never re-attempts a timed-out bootstrap download. (The consumer
  request path already fails over across random peers with a 15s timeout and
  per-cycle reset — it is otherwise immune to a single hostile peer.)

This PR ports the complete, proven LTC stack per-lane (per-coin isolation
invariant — each lane's `share_tracker.hpp`/`node.{hpp,cpp}` edited separately):

- `compute_supersede_hint()` — fires only for a **genuine** fork (`is_child_of`
  guard) whose **RECEIVED** work is **strictly greater** than the incumbent
  best's **VERIFIED** work and whose verified height is still `< CHAIN_LENGTH`.
- `think()` — deepens that segment's backfill to `2*CL+10`, spends a **bounded**
  elevated verify budget (400/tick) through the ordinary `attempt_verify` loop
  (never bypasses verification, never scores unverified work), and bounds the
  per-cycle exclusive-lock hold with `THINK_MAX_WALL_MS` (2s).
- `prioritize_challenger_heads()` — gives the challenger Phase-2 budget priority
  (stable_partition; no-op when inactive → healthy-node order byte-identical).
- `gate_supersede_convergence()` — denylists an unconvergeable segment (missing
  parent unobtainable) after `SUPERSEDE_STALL_LIMIT`=20 stalled cycles, TTL 60m,
  to break the elevated-verify treadmill and re-enable GC.
- `clean_tracker()` — exempts the converging challenger from stale-head eating /
  tail-dropping while the hint is active.
- **FIX-2** (btc/dgb): 5s `clean_tracker()` safety-net tick in the main loop
  (mirrors `main_ltc.cpp`), closing Class-B and making `clean_tracker()`
  (previously never called on these lanes) actually run. DASH already has its tick.

Guarantee: a node **always converges to the best reachable valid sharechain**
(strictly-higher-work-only, verified-only selection preserved, deactivates once
full-length verified — no oscillation) and can no longer self-sustain a minority
fork or be wedged by a silent-peer bootstrap stall.

## Lane status

| lane | Class-A (FIX-1) | FIX-2 tick | notes |
|------|-----------------|------------|-------|
| ltc  | already fixed (#1357/#1405) | already has 5s tick | reference |
| dash | **this PR** | already has 15s tick | live money on the shared hotel sharechain |
| btc  | **this PR** | **this PR** | btc.voidbind live |
| dgb  | **this PR** | **this PR** | dgb.voidbind live |
| bch  | **NOT in this PR** | **NOT in this PR** | tracker is structurally divergent (see below) |
| bip110 | n/a | n/a | no sharechain node yet (M3); port the btc-cloned tracker as part of M3 |

## Not yet done (follow-up, called out honestly)

- **bch lane** — bch's `share_tracker.hpp` is structurally divergent from the
  ltc/btc/dgb template (no matching Phase-2 head-sort anchor; different struct
  layout). It needs the same port but adapted by hand, not mechanically. Deferred
  to avoid shipping unverified divergent consensus code.
- **Per-lane KATs** — the shared algorithm (`compute_supersede_hint` /
  `prioritize_challenger_heads`) is already covered by
  `src/impl/ltc/test/restart_reorg_supersede_test.cpp`; the per-lane clones (which
  need each lane's share-construction harness) are the immediate next step, to be
  authored once CI confirms the ports compile so they can be iterated.
- **Local build** — deliberately NOT run: this host is disk-constrained (96%) and
  shared with live infra. CI is the authoritative multi-lane build/test gate for
  this PR. Static verification done locally: symbol-coherence greps across all
  three lanes, brace balance, attribution scrub, structural review of the
  hand-edited DASH lane.

DRAFT pending CI (compile proof) + adversarial review.

