### PR TITLE
dash: restart-reorg SupersedeHint stack (Class-A self-fork fix) [DRAFT]

### DIFF
--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -504,6 +504,71 @@ void NodeImpl::apply_min_protocol_ratchet()
     }
 }
 
+dash::SupersedeHint NodeImpl::gate_supersede_convergence(dash::SupersedeHint hint)
+{
+    // Compute-thread only; caller holds the exclusive tracker lock.
+    const auto now = std::chrono::steady_clock::now();
+
+    // Expire old denylist entries so a segment whose parent later becomes
+    // obtainable can be retried.
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL)
+            it = m_supersede_denylist.erase(it);
+        else
+            ++it;
+    }
+
+    if (!hint.active)
+        return hint;
+
+    const uint256 seg = hint.target_segment_last;
+
+    // Already proven unconvergeable and not yet expired — keep it suppressed so
+    // the elevated-verify treadmill stays off and GC can reclaim the segment.
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable (parent unobtainable) — hint"
+                        " suppressed; normal argmax + GC continue";
+        return dash::SupersedeHint{};
+    }
+
+    // Forward-progress metric: the challenger's verified accumulated height. On a
+    // genuinely converging fork this climbs every cycle as the elevated budget
+    // verifies deeper; on an unrooted/unobtainable-parent fork it stays pinned.
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); }
+    catch (...) { acc = 0; }
+
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height)
+    {
+        prog.last_acc_height = acc;
+        prog.stall_cycles = 0;
+    }
+    else
+    {
+        ++prog.stall_cycles;
+    }
+
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " made no verified-height progress in " << prog.stall_cycles
+                    << " cycles (verified_acc_height stuck at " << acc
+                    << "; missing parent unobtainable from all peers) — denylisting for "
+                    << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return dash::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // THREAD-CONFINEMENT (enforced, not assumed — register_template_txs
@@ -558,10 +623,34 @@ void NodeImpl::run_think()
             // Bootstrap: no verified chain yet → verify everything in one
             // pass (p2pool think() runs synchronously during initial sync).
             const bool bootstrap = m_tracker.verified.size() == 0;
+
+            // Restart-reorg: detect a genuine higher-work fork the warm-loaded
+            // node is stuck away from (see SupersedeHint). Skipped during
+            // bootstrap (empty start already downloads to 2*CL+10 under the
+            // unlimited budget). No-op on a healthy node whose persisted head
+            // already carries the most work. gate_supersede_convergence clears
+            // the hint if the challenger never converges (parent unobtainable).
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;  // bounded elevated per-tick verify
+            dash::SupersedeHint supersede = bootstrap
+                ? dash::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+            m_supersede_hint = supersede;
+            uint256 prev_best_for_flip = m_best_share_hash;
+            if (supersede.active) {
+                LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                            << m_best_share_hash.GetHex().substr(0,16)
+                            << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                            << " challenger_verified_h="
+                            << m_tracker.verified.get_acc_height(supersede.target_head)
+                            << " — challenger received work STRICTLY > incumbent verified work;"
+                            << " granting bounded elevated verify budget + 2*CL+10 backfill";
+            }
+
             auto t0 = std::chrono::steady_clock::now();
             result = m_tracker.think(block_rel_height,
                                      /*previous_block=*/uint256(),
-                                     /*bits=*/0, bootstrap);
+                                     /*bits=*/0, bootstrap, supersede);
             think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - t0).count();
 
@@ -570,6 +659,21 @@ void NodeImpl::run_think()
                 best_changed = (m_best_share_hash != result.best);
                 m_best_share_hash = result.best;
                 apply_min_protocol_ratchet();  // v36 accept-floor ratchet (dgb node.cpp:1526 parallel)
+            }
+            // Restart-reorg: log the actual head flip once it happens, so the
+            // warm-restart soak can be verified from logs. The flip is driven
+            // ENTIRELY by the existing Phase-3 TailScore argmax — this records it.
+            if (best_changed && supersede.active && !result.best.IsNull()) {
+                bool onto_challenger = false;
+                try {
+                    onto_challenger =
+                        (m_tracker.chain.get_last(result.best) == supersede.target_segment_last);
+                } catch (...) {}
+                if (onto_challenger)
+                    LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                                << prev_best_for_flip.GetHex().substr(0,16)
+                                << " new_best=" << result.best.GetHex().substr(0,16)
+                                << " — converged onto the network highest-work chain";
             }
             publish_snapshot();
 
@@ -1003,9 +1107,17 @@ void NodeImpl::clean_tracker()
         // Step 1: run think() inline (already holds the lock).
         {
             bootstrap = m_tracker.verified.size() == 0;
+            // Restart-reorg hint (same detector as run_think). Recomputed here so
+            // the Step-2/Step-3 GC exemptions below act on a current view, and so
+            // Step-1 think() also advances the converging challenger.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? dash::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             auto result = m_tracker.think(block_rel_height,
                                           /*previous_block=*/uint256(),
-                                          /*bits=*/0, bootstrap);
+                                          /*bits=*/0, bootstrap, m_supersede_hint);
             m_last_top5_heads = std::move(result.top5_heads);
             if (!result.best.IsNull()) {
                 m_best_share_hash = result.best;
@@ -1032,6 +1144,19 @@ void NodeImpl::clean_tracker()
                 {
                     if (!m_tracker.chain.contains(head_hash)) continue;
                     if (top5_set.count(head_hash)) continue;             // guard 1
+                    // Guard 1b (restart-reorg): keep the converging challenger
+                    // segment. Its verified height is below CHAIN_LENGTH so it is
+                    // never in the top-5; without this exemption its partial
+                    // verification would be eaten every clean and restarted forever
+                    // — the stuck-on-persisted-head latch in a different guise.
+                    // Matched by segment id (the shared missing-parent).
+                    if (m_supersede_hint.active) {
+                        try {
+                            if (m_tracker.chain.contains(head_hash) &&
+                                m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                                continue;
+                        } catch (...) {}
+                    }
                     auto* idx = m_tracker.chain.get_index(head_hash);
                     if (!idx || idx->time_seen > now_sec - 300) continue; // guard 2
                     if (!m_tracker.verified.contains(head_hash))          // guard 3
@@ -1078,6 +1203,20 @@ void NodeImpl::clean_tracker()
                 auto tails_copy = m_tracker.chain.get_tails();
                 for (auto& [tail_hash, head_hashes] : tails_copy)
                 {
+                    // Restart-reorg: never drop the tail of the converging
+                    // challenger segment. An unrooted challenger needs its FULL
+                    // ~2*CL depth to reach CHAIN_LENGTH verified shares; trimming
+                    // its bottom mid-verification silently restarts convergence.
+                    // The exemption lifts once it verifies to CHAIN_LENGTH and the
+                    // hint deactivates. Matched by segment id.
+                    if (m_supersede_hint.active) {
+                        try {
+                            if (m_tracker.chain.contains(tail_hash) &&
+                                m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                                continue;
+                        } catch (...) {}
+                    }
+
                     int32_t min_height = 0;  // 0 → skip if no valid heads
                     for (auto& hh : head_hashes) {
                         if (!m_tracker.chain.contains(hh)) continue;
@@ -1122,9 +1261,16 @@ void NodeImpl::clean_tracker()
 
         // Step 4: re-score after pruning (inline, still holding the lock).
         {
+            // Restart-reorg: re-detect after pruning and pass the hint so the
+            // re-score also advances/flips onto the challenger.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? dash::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             auto result = m_tracker.think(block_rel_height,
                                           /*previous_block=*/uint256(),
-                                          /*bits=*/0, bootstrap);
+                                          /*bits=*/0, bootstrap, m_supersede_hint);
             m_last_top5_heads = std::move(result.top5_heads);
             if (!result.best.IsNull()) {
                 m_best_share_hash = result.best;

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -348,6 +348,37 @@ protected:
     // thread under m_tracker_mutex (mirrors btc::NodeImpl::m_best_share_hash).
     uint256 m_best_share_hash;
 
+    // ── Restart-reorg supersede hint (see share_tracker.hpp SupersedeHint) ──
+    // From the last think()/clean cycle. When active it names a genuine
+    // higher-work fork the node is converging onto after a warm restart; used
+    // by clean_tracker() to exempt the converging challenger segment from
+    // stale-head eating and tail-dropping so its verification is not thrown
+    // away and restarted every clean (which would re-create the original
+    // stuck-on-persisted-head latch). Inactive on a healthy node.
+    dash::SupersedeHint m_supersede_hint;
+
+    // ── Supersede-convergence liveness (tip-freeze livelock fix) ──────────
+    // The restart-reorg elevated verify budget assumes the challenger segment
+    // will eventually verify to CHAIN_LENGTH and the Phase-3 argmax will flip.
+    // That assumption fails when the challenger's missing parent is UNOBTAINABLE
+    // — no connected peer still retains it. Then the challenger's verified
+    // height never advances, compute_supersede_hint re-arms it every cycle, and
+    // think() draws the elevated verify budget on the same never-winning shares
+    // forever: a treadmill that holds the exclusive tracker lock. We detect zero
+    // forward progress over SUPERSEDE_STALL_LIMIT consecutive cycles and denylist
+    // the segment (keyed by its stable target_segment_last) for
+    // SUPERSEDE_DENYLIST_TTL, which deactivates the hint and re-enables GC of the
+    // zombie segment. A later-obtainable parent retries after TTL.
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    // Deactivate the hint if the challenger segment is proven unconvergeable
+    // (already denylisted, or freshly stalled this call). Compute-thread only,
+    // called under the exclusive tracker lock. Returns the (possibly cleared) hint.
+    dash::SupersedeHint gate_supersede_convergence(dash::SupersedeHint hint);
+
     // #889: block-winning mints forfeited because the BOUNDED wait on the
     // exclusive tracker lock expired. Written from the stratum IO thread only,
     // read from anywhere (dashboard/KAT) — atomic, relaxed; it is a diagnostic

--- a/src/impl/dash/share_tracker.hpp
+++ b/src/impl/dash/share_tracker.hpp
@@ -118,6 +118,45 @@ struct DecoratedData
     }
 };
 
+// ── Restart-reorg supersede hint ─────────────────────────────────────────
+// Computed by NodeImpl before each think() cycle (compute_supersede_hint()).
+// C++ analog of the LTC restart-reorg fix ported to DASH (live money on the
+// hotel sharechain).
+//
+// The defect: a node that loads its persisted, fully-verified sharechain then
+// peers with a higher-work network STICKS on the old head. TailScore compares
+// chain_len FIRST and score() short-circuits to {verified_height,0} for any
+// tail below CHAIN_LENGTH, so a warm-loaded full-CL verified tail beats any
+// challenger whose VERIFIED height is still below CHAIN_LENGTH — and the
+// challenger never verifies to CHAIN_LENGTH because think() only ever extends
+// an unrooted segment ~8 shares deep and never backfills it to the ~2*CL depth
+// a CHAIN_LENGTH-tall verified tail needs. A node with local hashrate then
+// keeps extending its own verified incumbent = self-sustained minority fork.
+//
+// This hint makes the EXISTING think() argmax able to actually see the
+// challenger, mirroring p2pool's re-pick-best-after-download, WITHOUT adding a
+// reorg code path or weakening verified-only selection: when a chain head's
+// RECEIVED cumulative work is STRICTLY greater than the incumbent best's
+// VERIFIED work AND that head is a genuine fork (not an extension of the
+// incumbent) AND its verified height is still below CHAIN_LENGTH, think()
+// (a) deepens Phase-2 backfill for that segment to 2*CL+10 and (b) spends a
+// BOUNDED elevated verification budget on it through the ordinary Phase-2
+// attempt_verify loop. Over successive ticks the challenger verifies to
+// CHAIN_LENGTH, the Phase-3 TailScore comparison flips on its own, and the head
+// moves. It NEVER bypasses attempt_verify, never scores unverified work, and is
+// a no-op when the incumbent already IS the best head (no strictly-higher-work
+// fork exists) — so a healthy node is unaffected.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;          // challenger chain head (highest received work)
+    uint256  target_segment_last;  // chain.get_last(target_head): its missing parent —
+                                   // the stable identity of the whole challenger segment
+    int      budget{0};            // bounded elevated per-tick verify budget for the segment
+    uint288  challenger_work;      // received cumulative work of the challenger (diagnostics)
+    uint288  incumbent_work;       // verified cumulative work of the incumbent best (diagnostics)
+};
+
 // --- Result types ---
 
 struct TrackerThinkResult
@@ -705,16 +744,101 @@ public:
         return {static_cast<int32_t>(SharechainConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    // Returns an ACTIVE hint iff a genuine competing fork exists whose RECEIVED
+    // cumulative work is STRICTLY greater than the incumbent best's VERIFIED
+    // work and whose verified height is still below CHAIN_LENGTH. Pure read over
+    // chain + verified (no mutation); safe to call under the exclusive lock just
+    // before think(). Guardrails baked in here:
+    //   * strictly-greater only (incumbent_work < challenger_work) — a tie or
+    //     lower-work fork can never trigger;
+    //   * genuine-fork only (is_child_of(incumbent, head) skips extensions of
+    //     our own chain, so freshly-mined-but-unverified local shares that merely
+    //     extend the best head never masquerade as a challenger);
+    //   * verified-height < CHAIN_LENGTH only — once the challenger is full-length
+    //     verified the ordinary Phase-3 argmax owns the decision and the hint
+    //     deactivates (no perpetual trigger, no oscillation).
+    // No-op (inactive) when the incumbent best already carries the most work —
+    // the healthy single-head case.
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;  // bootstrap / no incumbent — bootstrap budget path applies
+        const auto CL = static_cast<int32_t>(SharechainConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+
+        uint256 best_ch;
+        uint288 best_ch_work;
+        bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            // Extension of our own best chain (not a fork) — the ordinary
+            // budgeted Phase-2 verifies it; never treat it as a challenger.
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) { /* concurrent trim — treat as fork candidate */ }
+            // Already a full-length verified chain — Phase-3 scoring handles it.
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+
+        if (found && incumbent_work < best_ch_work)  // STRICTLY higher received work
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    // The challenger segment's VERIFIED frontier is short, so it sorts LOW in
+    // the work-descending Phase-2 head order. Left there, a shorter non-
+    // challenger verified head that outranks it by verified work can spend the
+    // whole normal per-tick verify budget first and trip the outer per-head
+    // budget gate, breaking the loop before the challenger's iteration is ever
+    // entered — so its bounded elevated pool is never drawn and the higher-work
+    // fork can never verify to CHAIN_LENGTH (the stuck-on-persisted-head bug).
+    // Moving the challenger-segment heads to the FRONT (stable_partition, so the
+    // work-descending order is preserved within each group) guarantees the
+    // challenger is reached every tick regardless of non-challenger contention.
+    // Inactive supersede => predicate is always false => stable_partition is a
+    // no-op and the healthy-node order is byte-identical.
+    // Returns the number of challenger heads moved to the front.
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active)
+            return 0;
+        auto is_challenger_head = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_challenger_head);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
     // stratum isn't serving work — no IO needs the tracker lock.
     // Matches p2pool where think() runs synchronously on the reactor and
     // blocks everything else until verification completes.
+    // supersede: restart-reorg hint (see SupersedeHint). Default-inactive, so
+    // every existing caller and the healthy-node path are byte-unchanged.
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& previous_block,
                              uint32_t bits,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
         // The timestamp is used to filter stale requests at return time.
@@ -928,6 +1052,24 @@ public:
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
         m_think_needs_continue = false;
 
+        // Wall-clock bound on a single think() cycle (tip-freeze livelock fix,
+        // ported with the restart-reorg stack). The exclusive tracker lock is
+        // held for the whole of think(); the elevated verify pool (SupersedeHint)
+        // could otherwise draw hundreds of X11 verifies in one cycle and pin the
+        // lock for seconds, degrading the IO serve path to EMPTY replies. Cap the
+        // per-cycle hold; m_think_needs_continue makes run_think() repost the
+        // remainder next tick (releasing+reacquiring the lock between chunks).
+        // Bootstrap is exempt: there is no verified chain to serve yet and stratum
+        // is not serving real work, so the initial full verify runs uncapped.
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
+
         // ── V36 livelock mirror: cooperative-yield budget for the scoring walk ──
         // The Phase 3/4 scoring step walks the decayed-cumulative-weight + PPLNS
         // window per scored head while holding m_tracker_mutex.  On a healthy
@@ -954,6 +1096,19 @@ public:
         // budget priority.  p2pool iterates in arbitrary order but has no
         // budget — with our budget, a low-scored side chain can starve the
         // best chain if it goes first.
+        // Restart-reorg elevated budget (SupersedeHint): a BOUNDED extra pool
+        // that ONLY the challenger segment may draw from, after the normal
+        // budget is spent. Bounds the per-tick lock hold while still letting a
+        // strictly-higher-work fork verify to CHAIN_LENGTH over ~CL/budget ticks.
+        // Inactive → identical to before.
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active) {
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " segment_last=" << supersede.target_segment_last.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget
+                     << " challenger_work>incumbent_work (strictly greater)";
+        }
         std::vector<std::pair<uint256, uint256>> sorted_vheads(
             verified.get_heads().begin(), verified.get_heads().end());
         std::sort(sorted_vheads.begin(), sorted_vheads.end(),
@@ -962,9 +1117,40 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;  // highest work first
             });
+        // Restart-reorg liveness: move challenger-segment heads to the FRONT of
+        // the work-descending order so a shorter non-challenger head that
+        // outranks the challenger by verified work can never spend the normal
+        // budget and trip the outer per-head gate before the challenger's
+        // iteration is entered. No-op when supersede is inactive (byte-identical).
+        prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) {
+            // Wall-clock bound (tip-freeze fix): stop the per-head sweep once this
+            // cycle has held the exclusive lock long enough; resume next tick.
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Matched by segment identity (the shared
+            // missing-parent), so it survives the frontier advancing tick to tick.
+            // Hoisted above the per-head budget gate so the gate can be
+            // elevated-budget-aware (below).
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+
+            // Per-head budget gate. The normal budget bounds work per tick; only
+            // a challenger head may additionally draw the bounded elevated pool.
+            // When supersede is inactive is_challenger is always false, so this
+            // reduces to the original `budget_remaining <= 0` break (healthy path
+            // byte-identical).
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
                 m_think_needs_continue = true;
                 break;
             }
@@ -989,7 +1175,15 @@ public:
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(SharechainConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            // For an UNROOTED challenger segment a CHAIN_LENGTH-tall VERIFIED tail
+            // needs ~2*CL depth (each of the top CL shares needs CHAIN_LENGTH
+            // ancestors to pass attempt_verify's acc_height>=CL+1 guard on an
+            // unrooted chain). Target the fresh-bootstrap load depth 2*CL+10 so
+            // the segment can actually reach CHAIN_LENGTH verified shares — the
+            // core of the stuck-on-persisted-head bug. Rooted / non-challenger
+            // tails keep the original CL target (byte-unchanged).
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -1021,9 +1215,25 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) {
+                    // Normal budget for everyone; the challenger segment may draw
+                    // from the bounded elevated pool AFTER the normal budget is
+                    // spent. A non-challenger head can never touch elevated_remaining.
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) {
                         m_think_needs_continue = true;
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
+                                 << " verifications, deferring remainder"
+                                 << (is_challenger ? " (challenger elevated pool spent)" : "");
+                        break;
+                    }
+                    // Wall-clock bound (tip-freeze fix): even with budget left, do
+                    // not hold the exclusive lock past THINK_MAX_WALL_MS — each X11
+                    // verify is non-trivial, so a large elevated pool could pin the
+                    // lock for seconds. Resume next tick. Checked every 8 verifies.
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] wall-clock cap hit after " << p2_verified_count
                                  << " verifications, deferring remainder";
                         break;
                     }
@@ -1098,7 +1308,10 @@ public:
                         break;
                     ++p2_verified_count;
                     if (!was_already_verified) {
-                        --budget_remaining;
+                        // Spend the normal budget first; only the challenger may
+                        // then draw from the bounded elevated pool.
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
                     }
                     // Throttled progress log: contabo freeze-diag (2026-05-24) caught
                     // this loop wedging the io_context for 2-7.5s at a time when emit
@@ -1115,8 +1328,18 @@ public:
                 }
             }
 
-            // Request more shares if verified chain is short
-            if (head_height < static_cast<int32_t>(SharechainConfig::chain_length()) && !last_last_hash.IsNull())
+            // Request more shares if verified chain is short.
+            // Non-challenger: request until the MAIN chain reaches CHAIN_LENGTH
+            // (original behaviour). Challenger (restart-reorg): keep requesting
+            // parents until the segment reaches 2*CL+10 depth — the depth needed
+            // for a CHAIN_LENGTH-tall verified tail on an unrooted chain — so it
+            // is no longer pinned at ~CL+8 (the stuck state).
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(SharechainConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 // Option A: check MAIN chain height (not verified height).
                 // If main chain is already in pruning zone, the unverified

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1467,7 +1467,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # --target allowlist AND already compiles coin/replay_bulk_fetch.hpp, so its
     # link set resolves BulkBlockScheduler/bulkpolicy with no new deps; a
     # standalone executable was a NOT_BUILT/"Not Run" CTest sentinel.
-    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp test_dash_replay_bulk_fetch.cpp test_dash_spork.cpp test_dash_bulk_local_primary_kat.cpp)
+    add_executable(test_dash_p2p_node test_dash_p2p_node.cpp test_dash_coin_p2p_client.cpp test_dash_coin_peer_manager.cpp test_dash_coin_p2p_pool.cpp test_dash_qrinfo_wire.cpp test_dash_coin_peer_rearm.cpp test_dash_replay_bulk_fetch.cpp test_dash_spork.cpp test_dash_bulk_local_primary_kat.cpp test_dash_restart_reorg_supersede_kat.cpp)
     target_compile_definitions(test_dash_p2p_node PRIVATE
         DASH_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures")
     target_link_libraries(test_dash_p2p_node PRIVATE

--- a/test/test_dash_restart_reorg_supersede_kat.cpp
+++ b/test/test_dash_restart_reorg_supersede_kat.cpp
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Restart-reorg supersede detector -- KAT, exercised through DASH's REAL
+// ShareTracker API (dash::ShareTracker::compute_supersede_hint /
+// prioritize_challenger_heads). C++ analog of the LTC restart-reorg fix ported
+// to DASH (live money on the hotel sharechain).
+//
+// THE DEFECT this pins: a node that loads its persisted, fully-verified
+// sharechain then peers with a higher-work network STICKS on the old head.
+// TailScore compares chain_len FIRST and score() short-circuits to
+// {verified_height,0} below CHAIN_LENGTH, so a warm-loaded full-CL verified tail
+// beats any challenger whose VERIFIED height is still short -- and the challenger
+// never verifies to CHAIN_LENGTH because think() never backfills the unrooted
+// segment to the ~2*CL depth a CHAIN_LENGTH-tall verified tail needs. A node with
+// local hashrate then keeps extending its own verified incumbent = self-sustained
+// minority fork.
+//
+// compute_supersede_hint is the visibility fix: it fires an ACTIVE hint iff a
+// GENUINE competing fork exists whose RECEIVED cumulative work is STRICTLY
+// greater than the incumbent best's VERIFIED work and whose verified height is
+// still below CHAIN_LENGTH. think() then deepens that segment's backfill to
+// 2*CL+10 and spends a bounded elevated verification budget on it, so it verifies
+// to CHAIN_LENGTH and the EXISTING Phase-3 TailScore argmax flips on its own.
+// This KAT drives the DECISION through the real chain/verified work accounting
+// (get_work over ShareIndex.work) -- the exact mechanism -- without needing real
+// PoW verification: the detector is a pure read over chain + verified.
+//
+// GUARDRAILS asserted here (mirror of the LTC KAT):
+//   * strictly-higher-work only  -> a lower-work or equal-work fork never fires;
+//   * genuine-fork only          -> an extension of the incumbent's own chain
+//                                   (freshly-mined-but-unverified local shares)
+//                                   never masquerades as a challenger;
+//   * no-op when incumbent is best (healthy single-head node) -> inactive;
+//   * no incumbent (bootstrap)   -> inactive;
+//   * challenger-first scheduling -> the shorter higher-verified-work
+//                                    non-challenger head does not starve it.
+//
+// Folded into the EXISTING allowlisted `test_dash_p2p_node` gtest target (the
+// #154 test_dash_bulk_local_primary_kat.cpp precedent), never a standalone
+// add_executable -- the #769 NOT_BUILT trap.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <core/uint256.hpp>
+#include <impl/dash/share.hpp>
+#include <impl/dash/share_tracker.hpp>
+
+namespace {
+
+// Short hex tail -> uint256 (zero-padded).
+uint256 hx(const std::string& tail) {
+    uint256 v;
+    v.SetHex(std::string(64 - tail.size(), '0') + tail);
+    return v;
+}
+
+constexpr uint32_t kBits = 0x1e0fffff;  // uniform per-share work
+
+// Build a linear run of `count` uniform DASH shares into `tracker.chain`.
+//   root_prev : m_prev_hash of the DEEPEST share (share 0). Null -> rooted
+//               chain end (get_last == null); non-null-and-absent -> UNROOTED
+//               segment (get_last == root_prev), the challenger shape.
+//   salt      : disjoint hash space so independent runs never collide.
+// Returns the tip hash. Every share carries equal work, so total received work
+// is monotone in `count`.
+uint256 build_run(dash::ShareTracker& tracker, int32_t count,
+                  const uint256& root_prev, size_t salt) {
+    uint256 prev = root_prev;
+    uint256 tip;
+    tip.SetNull();
+    for (int32_t i = 0; i < count; ++i) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%zx",
+                      static_cast<size_t>((salt << 20) + 0x5b70 + i));
+        uint256 h = hx(buf);
+        auto* sh = new dash::DashShare();
+        sh->m_hash = h;
+        sh->m_prev_hash = prev;   // share 0 uses root_prev
+        sh->m_desired_version = 16;
+        sh->m_bits = kBits;
+        sh->m_max_bits = kBits;
+        dash::ShareType st;
+        st = sh;
+        tracker.add(st);
+        prev = h;
+        tip = h;
+    }
+    return tip;
+}
+
+// Mark a whole in-chain run [share 0 .. tip] as verified, as
+// load_persisted_shares() does (ascending so parent-before-child holds).
+void mark_verified(dash::ShareTracker& tracker, const uint256& tip) {
+    std::vector<uint256> chainward;
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    for (auto it = chainward.rbegin(); it != chainward.rend(); ++it) {
+        if (tracker.chain.contains(*it) && !tracker.verified.contains(*it)) {
+            auto& sv = tracker.chain.get_share(*it);
+            tracker.verified.add(sv);
+        }
+    }
+}
+
+// Verify only the DEEPEST `n` shares of an in-chain run (root .. root+n-1),
+// ascending -- the partial "verified frontier" a challenger segment has
+// mid-catch-up. Returns the frontier verified head (shallowest verified share).
+uint256 verify_deep_prefix(dash::ShareTracker& tracker, const uint256& tip, int n) {
+    std::vector<uint256> chainward;  // tip -> root
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    const int sz = static_cast<int>(chainward.size());
+    if (n > sz) n = sz;
+    uint256 frontier;
+    for (int i = 0; i < n; ++i) {
+        const uint256& h = chainward[sz - 1 - i];  // root first (ascending)
+        if (tracker.chain.contains(h) && !tracker.verified.contains(h)) {
+            auto& sv = tracker.chain.get_share(h);
+            tracker.verified.add(sv);
+        }
+        frontier = h;
+    }
+    return frontier;
+}
+
+// Faithful in-test model of think()'s Phase-2 OUTER per-head budget gate.
+// `elevated_aware` selects the gate: false = the pre-fix `budget<=0` break;
+// true = the fix's `budget<=0 && !(is_challenger && elevated>0)` break.
+bool challenger_iteration_entered(
+        const std::vector<uint256>& order, const uint256& challenger_head,
+        const std::function<bool(const uint256&)>& is_challenger,
+        int normal_budget, int elevated_budget, bool elevated_aware) {
+    int budget = normal_budget, elevated = elevated_budget;
+    for (const auto& h : order) {
+        const bool ch = is_challenger(h);
+        const bool brk = elevated_aware
+                             ? (budget <= 0 && !(ch && elevated > 0))
+                             : (budget <= 0);
+        if (brk) break;
+        if (h == challenger_head) return true;
+        if (!ch) budget = 0;  // worst-case normal-budget spend
+    }
+    return false;
+}
+
+constexpr int kBudget = 400;
+constexpr int kNormalBudget = 100;  // THINK_VERIFY_BUDGET in think()
+
+}  // namespace
+
+// --- Higher-work genuine fork -> ACTIVE, targeted at the challenger ----------
+TEST(DashRestartReorgSupersede, HigherWorkForkActivates) {
+    dash::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+    const uint256 missing_parent = hx("dead0001");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+
+    ASSERT_TRUE(t.verified.contains(inc_tip));
+    ASSERT_FALSE(t.verified.contains(ch_tip));
+    EXPECT_TRUE(t.verified.get_work(inc_tip) < t.chain.get_work(ch_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_TRUE(hint.active);
+    EXPECT_EQ(hint.target_head, ch_tip);
+    EXPECT_EQ(hint.target_segment_last, missing_parent);
+    EXPECT_EQ(hint.budget, kBudget);
+    EXPECT_TRUE(hint.incumbent_work < hint.challenger_work);
+}
+
+// --- Lower-work fork -> INACTIVE (strictly-greater guard) --------------------
+TEST(DashRestartReorgSupersede, LowerWorkForkStaysInactive) {
+    dash::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 ch_tip = build_run(t, 10, hx("dead0002"), 2);
+
+    EXPECT_TRUE(t.chain.get_work(ch_tip) < t.verified.get_work(inc_tip));
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Equal-work fork -> INACTIVE (tie can never displace the head) ----------
+TEST(DashRestartReorgSupersede, EqualWorkForkStaysInactive) {
+    dash::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 ch_tip = build_run(t, 30, hx("dead0003"), 2);
+
+    EXPECT_TRUE(t.chain.get_work(ch_tip) == t.verified.get_work(inc_tip));
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Healthy single head -> INACTIVE (no-op when incumbent IS the best) ------
+TEST(DashRestartReorgSupersede, HealthySingleHeadIsNoOp) {
+    dash::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 40, uint256(), 1);
+    mark_verified(t, inc_tip);
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Own-chain extension (unverified) -> INACTIVE (genuine-fork guard) -------
+TEST(DashRestartReorgSupersede, OwnChainExtensionIsNotAChallenger) {
+    dash::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 ext_tip = build_run(t, 25, inc_tip /*extends incumbent*/, 2);
+
+    EXPECT_TRUE(t.verified.get_work(inc_tip) < t.chain.get_work(ext_tip));
+    EXPECT_TRUE(t.chain.is_child_of(inc_tip, ext_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);  // is_child_of guard excludes it
+}
+
+// --- No incumbent (bootstrap / empty verified) -> INACTIVE ------------------
+TEST(DashRestartReorgSupersede, NoIncumbentIsInactive) {
+    dash::ShareTracker t;
+    const uint256 ch_tip = build_run(t, 50, hx("dead0004"), 2);
+    (void)ch_tip;
+    auto hint = t.compute_supersede_hint(uint256() /*null incumbent*/, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Backfill-depth target is the fresh-bootstrap load depth 2*CL+10 --------
+TEST(DashRestartReorgSupersede, BackfillTargetIsTwiceChainLengthPlusTen) {
+    const int32_t CL = static_cast<int32_t>(dash::SharechainConfig::chain_length());
+    EXPECT_GT(CL, 0);
+    const int32_t challenger_target = 2 * CL + 10;
+    EXPECT_GT(challenger_target, CL);
+    EXPECT_EQ(challenger_target, 2 * CL + 10);
+}
+
+// --- STARVATION: a shorter, higher-verified-work non-challenger head must NOT
+//     starve the challenger's elevated budget within a think() tick -----------
+TEST(DashRestartReorgSupersede, ChallengerNotStarvedByShorterHigherWorkHead) {
+    dash::ShareTracker t;
+
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+
+    // Non-challenger SIDE fork: rooted, fully verified, but SHORT (12 shares).
+    const uint256 nc_tip = build_run(t, 12, uint256() /*rooted, own root*/, 3);
+    mark_verified(t, nc_tip);
+
+    // Challenger: UNROOTED segment of 50 received shares (highest RECEIVED work),
+    // only a SHORT verified frontier (deepest 3) -> sorts LOW by verified work.
+    const uint256 missing_parent = hx("dead0005");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+    const uint256 ch_frontier = verify_deep_prefix(t, ch_tip, 3);
+
+    ASSERT_TRUE(t.verified.contains(inc_tip));
+    ASSERT_TRUE(t.verified.contains(nc_tip));
+    ASSERT_TRUE(t.verified.contains(ch_frontier));
+    EXPECT_TRUE(t.verified.get_work(ch_frontier) < t.verified.get_work(nc_tip));
+    EXPECT_TRUE(t.verified.get_work(nc_tip)      < t.verified.get_work(inc_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    ASSERT_TRUE(hint.active);
+    EXPECT_EQ(hint.target_head, ch_tip);
+    EXPECT_EQ(hint.target_segment_last, missing_parent);
+    EXPECT_EQ(t.chain.get_last(ch_frontier), missing_parent);
+
+    auto build_sorted = [&]() {
+        std::vector<std::pair<uint256, uint256>> v(
+            t.verified.get_heads().begin(), t.verified.get_heads().end());
+        std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+            auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+            auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+            return wa > wb;
+        });
+        return v;
+    };
+    auto index_of = [](const std::vector<std::pair<uint256, uint256>>& v,
+                       const uint256& h) -> int {
+        for (int i = 0; i < static_cast<int>(v.size()); ++i)
+            if (v[i].first == h) return i;
+        return -1;
+    };
+    auto is_ch = [&](const uint256& h) -> bool {
+        return t.chain.get_last(h) == hint.target_segment_last;
+    };
+
+    // PRE-fix order: the challenger frontier sorts AFTER the shorter
+    // non-challenger head, and the pre-fix gate never enters its iteration.
+    auto pre = build_sorted();
+    ASSERT_GE(index_of(pre, ch_frontier), 0);
+    ASSERT_GE(index_of(pre, nc_tip), 0);
+    EXPECT_GT(index_of(pre, ch_frontier), index_of(pre, nc_tip));
+    std::vector<uint256> pre_order;
+    for (auto& hv : pre) pre_order.push_back(hv.first);
+    EXPECT_FALSE(challenger_iteration_entered(
+        pre_order, ch_frontier, is_ch, kNormalBudget, kBudget,
+        /*elevated_aware=*/false));
+
+    // FIX: prioritize the challenger segment to the front.
+    auto post = build_sorted();
+    const size_t n_challengers = t.prioritize_challenger_heads(post, hint);
+    EXPECT_EQ(n_challengers, 1u);
+    EXPECT_EQ(index_of(post, ch_frontier), 0);
+    EXPECT_LT(index_of(post, ch_frontier), index_of(post, nc_tip));
+
+    std::vector<uint256> post_order;
+    for (auto& hv : post) post_order.push_back(hv.first);
+    EXPECT_TRUE(challenger_iteration_entered(
+        post_order, ch_frontier, is_ch, kNormalBudget, kBudget,
+        /*elevated_aware=*/true));
+
+    EXPECT_LE(kNormalBudget + kBudget, 500);
+}
+
+// --- Healthy node: prioritize is a NO-OP (order byte-identical) --------------
+TEST(DashRestartReorgSupersede, PrioritizeIsNoOpWhenInactive) {
+    dash::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 side_tip = build_run(t, 12, uint256(), 3);
+    mark_verified(t, side_tip);
+
+    dash::SupersedeHint inactive;  // active == false
+    ASSERT_FALSE(inactive.active);
+
+    std::vector<std::pair<uint256, uint256>> v(
+        t.verified.get_heads().begin(), t.verified.get_heads().end());
+    std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+        auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+        auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+        return wa > wb;
+    });
+    const auto before = v;
+    const size_t moved = t.prioritize_challenger_heads(v, inactive);
+    EXPECT_EQ(moved, 0u);
+    ASSERT_EQ(v.size(), before.size());
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v[i].first, before[i].first);
+        EXPECT_EQ(v[i].second, before[i].second);
+    }
+}


### PR DESCRIPTION
## What

Ports the complete, LTC-proven restart-reorg **SupersedeHint** stack (#1357 + #1405) to the **DASH** share tracker. This is the C++ analog of the kr1z1s Python self-sustained-minority-fork desync, confirmed live on DASH by the cross-lane audit.

**DASH is first / separate** so it can be reviewed and merged independently of the btc/dgb/bch lane (live money on the hotel sharechain). DASH already runs a 15s think/clean tick, so **no periodic-tick change is needed here** — this PR is the SupersedeHint stack only.

## The defect (Class-A, live on DASH)

`score()` short-circuits to `{verified_height, 0}` for any head below `CHAIN_LENGTH` (`share_tracker.hpp` score cliff) and `TailScore` compares `chain_len` FIRST. So a warm-loaded, full-CL, fully-verified incumbent structurally beats **any** higher-work challenger fork whose verified height is still `< CL` — and the challenger can never verify up to CL because Phase-2 never backfilled its unrooted segment to the ~`2*CL` depth a CL-tall verified tail needs. A node with local hashrate then keeps extending its own verified incumbent = **self-sustained minority fork + own-share orphans**.

## The fix (mirror of the LTC design; no reorg path, no weakening of verified-only selection)

- **`share_tracker.hpp`**
  - `SupersedeHint` struct
  - `compute_supersede_hint()` — fires iff a **genuine fork** (`is_child_of` guard) has **strictly-greater received work** than the incumbent's verified work AND verified height `< CL`. Pure read over chain/verified.
  - `prioritize_challenger_heads()` — challenger-first Phase-2 scheduling (`stable_partition`; no-op when inactive)
  - `think()` — 5th **defaulted** `SupersedeHint` param (every existing caller byte-identical), bounded **elevated verify pool**, challenger `2*CL+10` backfill (`want_depth` + `want_more_parents`), and the `THINK_MAX_WALL_MS=2000` wall bound (required with the elevated pool; sets the existing `m_think_needs_continue` continuation)
- **`node.hpp` / `node.cpp`**
  - `m_supersede_hint` + stall-denylist (`SUPERSEDE_STALL_LIMIT=20`, TTL 60m) + `gate_supersede_convergence()` anti-thrash gate (breaks the elevated-verify treadmill when the challenger's missing parent is unobtainable)
  - `run_think()` and `clean_tracker()` (Step-1 / Guard-1b / Step-3 tail-drop / Step-4) compute+pass the hint and **exempt the converging challenger segment from GC**

## Invariant guaranteed

A node ALWAYS converges to the best reachable valid sharechain: a strictly-higher-work genuine-fork challenger can now verify up to CHAIN_LENGTH and supersede a warm incumbent, so a node with local hashrate can never self-sustain a minority fork. The anti-thrash stall denylist + the sub-CL / genuine-fork Sybil guardrails are preserved exactly as in the LTC design (a partial low-depth segment cannot win).

## Safety (live money)

- **Default-inactive**: on a healthy single-head node the hint is never active and the path is byte-identical (`prioritize` returns early; `elevated_remaining==0`).
- **Chain-selection only** — zero interplay with gentx / mint / serve / special-tx paths.
- A supersede flip triggers `apply_min_protocol_ratchet()` on best-change — correct (it is a real tip change), flagged here for the reviewer.
- The `THINK_MAX_WALL_MS` bound now applies to every non-bootstrap think cycle (matches the LTC shipped design); normal DASH cycles are well under 2s so it only bites under the elevated pool.

## Test

`test/test_dash_restart_reorg_supersede_kat.cpp`, folded into the allowlisted `test_dash_p2p_node` gtest target (the #154 bulk-KAT precedent — avoids the #769 NOT_BUILT trap). Drives the REAL `dash::ShareTracker` accounting: warm full-CL incumbent vs higher-work sub-CL challenger → hint activates + names the challenger segment; lower/equal-work, own-chain-extension, healthy-single-head, and no-incumbent stay inactive; challenger-first scheduling proven to prevent starvation by a shorter higher-verified non-challenger head; prioritize is a no-op when inactive.

## Verification status

Local build was **not** run (build host at 98% disk); relying on CI (fleet runners) for the authoritative build + KAT green. **Draft pending CI + operator review** (live money — DASH especially). Soak-verify grep keys unchanged: `[SUPERSEDE]` armed / trigger / FLIPPED.