### PR TITLE
dash: enable /api/explorer + wire getblock bodies/mempool from the daemonless node

### DIFF
--- a/explorer/explorer.py
+++ b/explorer/explorer.py
@@ -66,6 +66,12 @@ from datetime import datetime, timezone
 from functools import lru_cache
 from html import escape
 
+# Reverse-proxy sub-path mount (set from --url-prefix in main()). Empty string
+# = served at root, and every generated page is byte-identical to before this
+# option existed. When set (e.g. "/explorer") it is prepended to generated
+# links and stripped from incoming request paths in ExplorerHandler.
+URL_PREFIX = ""
+
 # ============================================================================
 # COIN PROFILES — data-driven per-coin configuration.
 #
@@ -2010,13 +2016,28 @@ class ExplorerHandler(http.server.BaseHTTPRequestHandler):
         from urllib.parse import urlparse, parse_qs
         parsed = urlparse(self.path)
         params = parse_qs(parsed.query)
-        return parsed.path, {k: v[0] for k, v in params.items()}
+        path = parsed.path
+        # Strip the reverse-proxy mount prefix so the exact-match routing below
+        # is unchanged whether or not the proxy forwards the sub-path.
+        if URL_PREFIX and path.startswith(URL_PREFIX):
+            path = path[len(URL_PREFIX):] or "/"
+        return path, {k: v[0] for k, v in params.items()}
 
     def _respond(self, code, content, content_type="text/html"):
         self.send_response(code)
         self.send_header("Content-Type", content_type)
         self.send_header("Access-Control-Allow-Origin", "*")
         self.end_headers()
+        # Reverse-proxy mount: rewrite the site-absolute links in generated HTML
+        # so navigation stays inside the sub-path. Only HTML pages carry links;
+        # JSON/SSE responses are untouched. No-op (byte-identical) when unset.
+        if URL_PREFIX and content_type.startswith("text/html"):
+            if isinstance(content, bytes):
+                content = content.decode()
+            content = (content
+                       .replace('href="/', f'href="{URL_PREFIX}/')
+                       .replace('action="/', f'action="{URL_PREFIX}/')
+                       .replace('EventSource("/', f'EventSource("{URL_PREFIX}/'))
         if isinstance(content, str):
             content = content.encode()
         self.wfile.write(content)
@@ -2204,7 +2225,21 @@ def main():
     parser.add_argument("--doge-c2pool", default=None, help="[legacy] c2pool explorer API URL for DOGE")
 
     parser.add_argument("--web-port", type=int, default=8888, help="Explorer web port")
+    parser.add_argument("--url-prefix", default="",
+                        help="Serve under a sub-path (e.g. /explorer) behind a reverse "
+                             "proxy. Prepended to every generated link and stripped from "
+                             "incoming request paths. Default \"\" = root (byte-identical).")
     args = parser.parse_args()
+
+    # URL sub-path support (reverse-proxy mount). Normalised to leading-slash,
+    # no trailing slash; empty string leaves every generated page byte-identical.
+    global URL_PREFIX
+    up = (args.url_prefix or "").strip()
+    if up:
+        if not up.startswith("/"):
+            up = "/" + up
+        up = up.rstrip("/")
+    URL_PREFIX = up
 
     coins = OrderedDict()
     primary = None

--- a/explorer/explorer.py
+++ b/explorer/explorer.py
@@ -460,7 +460,11 @@ class C2PoolClient:
         if method == "getblockchaininfo":
             return self._get(f"/getblockchaininfo?chain={self.chain}", timeout)
         elif method == "getblockhash":
-            return self._get(f"/getblockhash?height={args[0]}&chain={self.chain}", timeout)["result"]
+            r = self._get(f"/getblockhash?height={args[0]}&chain={self.chain}", timeout)
+            # Two live node answer shapes: the explorer-callback path wraps the
+            # hash as {"result": hash} (LTC), the coin-owned chain-query path
+            # returns the bare hash string (DASH's daemonless header chain).
+            return r if isinstance(r, str) else r["result"]
         elif method == "getblock":
             return self._get(f"/getblock?hash={args[0]}&chain={self.chain}", timeout)
         elif method == "getmempoolinfo":

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -549,6 +549,27 @@ target_link_libraries(dash_tx_serve_self_validation_kat
 )
 add_test(NAME dash_tx_serve_self_validation_kat COMMAND dash_tx_serve_self_validation_kat)
 
+# dash_explorer_json_kat — KAT for the read-only /api/explorer getblock body
+# decode (dash::coin::block_to_explorer_json): DIP4 CbTx type/extraPayload +
+# masternode-payee X-address + txid. Decode-only, no node/network.
+add_executable(dash_explorer_json_kat dash_explorer_json_kat.cpp)
+target_link_libraries(dash_explorer_json_kat
+    core pool sharechain
+    c2pool_node_enhanced
+    dash
+    c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+    dash_x11
+    dash_rpc
+    dash_stratum
+    dash_block_replay
+    dash_bls_verify
+    btclibs
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    ${Boost_LIBRARIES}
+)
+add_test(NAME dash_explorer_json_kat COMMAND dash_explorer_json_kat)
+
 # ---- Control-plane M0: money-gate KAT (Qt-free sibling of test_reward_safe_launch)
 # The settings-file loader + param catalog are self-contained (stdlib only), so
 # this test compiles them directly rather than dragging the full core object lib

--- a/src/c2pool/dash_explorer_json_kat.cpp
+++ b/src/c2pool/dash_explorer_json_kat.cpp
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// dash_explorer_json_kat — known-answer test for dash::coin::block_to_explorer_json.
+//
+// Guards the read-only /api/explorer getblock body decode wired into
+// main_dash.cpp (the coin-chain-query getblock hook). Asserts that a synthetic
+// Dash block carrying a v3/type-5 DIP4 CbTx coinbase + a masternode-payee
+// P2PKH output decodes to the JSON shape explorer.py's dash profile consumes:
+//   - per-tx "type" (5 for the special CbTx, 0 for a plain tx),
+//   - "extraPayload" hex present iff version==3 && type!=0, byte-exact,
+//   - "txid" = sha256d(canonical tx),
+//   - masternode-payee vout classified as a Dash X-address (p2pkh 0x4c),
+//   - header fields (hash/height/bits/nTx) present.
+//
+// Pure decode test — no node, no network, no consensus/reward path.
+
+#include <impl/dash/coin/block_json.hpp>
+#include <impl/dash/coin/block.hpp>
+#include <impl/dash/coin/transaction.hpp>
+
+#include <core/uint256.hpp>
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace dash::coin;
+
+static int g_fail = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { std::printf("FAIL: %s\n", msg); ++g_fail; } \
+    else         { std::printf("ok:   %s\n", msg); } \
+} while (0)
+
+// P2PKH scriptPubKey: OP_DUP OP_HASH160 <20> OP_EQUALVERIFY OP_CHECKSIG
+static std::vector<unsigned char> p2pkh_spk(const std::vector<unsigned char>& h160)
+{
+    std::vector<unsigned char> s;
+    s.push_back(0x76); s.push_back(0xa9); s.push_back(0x14);
+    s.insert(s.end(), h160.begin(), h160.end());
+    s.push_back(0x88); s.push_back(0xac);
+    return s;
+}
+
+static std::string hexstr(const std::vector<unsigned char>& v)
+{
+    static const char H[] = "0123456789abcdef";
+    std::string o;
+    for (unsigned char b : v) { o += H[b >> 4]; o += H[b & 0x0f]; }
+    return o;
+}
+
+int main()
+{
+    // ── Synthetic v3/type-5 CbTx coinbase ─────────────────────────────────
+    MutableTransaction cb;
+    cb.version = 3;
+    cb.type    = 5;   // TRANSACTION_COINBASE (DIP4 CbTx)
+    // A stand-in DIP4 CbTx extra payload (opaque here: explorer.py decodes it
+    // client-side). The KAT only proves the node emits the hex byte-exact.
+    cb.extra_payload = {0x02, 0x00,                         // nVersion=2
+                        0x40, 0x42, 0x0f, 0x00,             // height=1000000
+                        0xde, 0xad, 0xbe, 0xef};            // (truncated) roots
+    // Coinbase input (prevout null, BIP34 height + /c2pool/ tag optional).
+    {
+        TxIn in;
+        in.prevout.hash.SetNull();
+        in.prevout.index = 0xffffffff;
+        in.scriptSig.m_data = {0x03, 0x40, 0x42, 0x0f};   // push BIP34 height
+        in.sequence = 0xffffffff;
+        cb.vin.push_back(in);
+    }
+    // vout[0] = masternode payee (P2PKH), vout[1] = miner (P2PKH).
+    std::vector<unsigned char> mn_h160(20, 0x11);
+    std::vector<unsigned char> miner_h160(20, 0x22);
+    {
+        TxOut o; o.value = 82980000; o.scriptPubKey.m_data = p2pkh_spk(mn_h160);
+        cb.vout.push_back(o);
+    }
+    {
+        TxOut o; o.value = 44260000; o.scriptPubKey.m_data = p2pkh_spk(miner_h160);
+        cb.vout.push_back(o);
+    }
+
+    // ── A plain (type-0) tx to prove extraPayload is ABSENT there ──────────
+    MutableTransaction plain;
+    plain.version = 2;
+    plain.type    = 0;
+    {
+        TxIn in;
+        in.prevout.hash.SetNull();
+        in.prevout.index = 0;
+        in.sequence = 0xffffffff;
+        plain.vin.push_back(in);
+    }
+    {
+        TxOut o; o.value = 10000000; o.scriptPubKey.m_data = p2pkh_spk(miner_h160);
+        plain.vout.push_back(o);
+    }
+
+    BlockType block;
+    block.m_version       = 0x20000000;
+    block.m_previous_block.SetHex("0000000000000000000000000000000000000000000000000000000000000abc");
+    block.m_merkle_root.SetHex("0000000000000000000000000000000000000000000000000000000000000def");
+    block.m_timestamp = 1700000000;
+    block.m_bits      = 0x1b104be1;   // a plausible Dash-range compact target
+    block.m_nonce     = 12345;
+    block.m_txs.push_back(cb);
+    block.m_txs.push_back(plain);
+
+    uint256 block_hash;
+    block_hash.SetHex("00000000000000001111111111111111222222222222222233333333cafebabe");
+
+    ExplorerChainParams p;
+    p.bech32_hrp = "";      // Dash: no bech32
+    p.p2pkh_ver  = 0x4c;    // mainnet X...
+    p.p2sh_ver   = 0x10;    // mainnet 7...
+    p.chain_name = "main";
+
+    nlohmann::json j = block_to_explorer_json(block, 1000000, block_hash, p);
+
+    std::printf("---- block_to_explorer_json output ----\n%s\n---------------------------------------\n",
+                j.dump(2).c_str());
+
+    // Header fields
+    CHECK(j["hash"] == block_hash.GetHex(), "block hash echoed");
+    CHECK(j["height"] == 1000000, "height echoed");
+    CHECK(j["bits"] == "1b104be1", "bits hex");
+    CHECK(j["nTx"] == 2, "nTx == 2");
+    CHECK(j.contains("difficulty"), "difficulty present");
+    CHECK(j["tx"].is_array() && j["tx"].size() == 2, "tx array size 2");
+
+    // Coinbase CbTx (tx[0])
+    const auto& t0 = j["tx"][0];
+    CHECK(t0["type"] == 5, "coinbase type == 5");
+    CHECK(t0["version"] == 3, "coinbase version == 3");
+    CHECK(t0.contains("extraPayload"), "coinbase extraPayload present");
+    CHECK(t0.value("extraPayload", std::string()) == hexstr(cb.extra_payload),
+          "coinbase extraPayload byte-exact");
+    CHECK(t0["txid"].is_string() && t0["txid"].get<std::string>().size() == 64,
+          "coinbase txid is 64-hex");
+    CHECK(t0["vin"][0].contains("coinbase"), "vin[0] is coinbase");
+
+    // Masternode-payee vout → Dash X-address
+    const auto& vout0 = t0["vout"][0];
+    CHECK(vout0["value_sat"] == 82980000, "mn payee value_sat");
+    CHECK(vout0["scriptPubKey"]["type"] == "pubkeyhash", "mn payee is pubkeyhash");
+    std::string mn_addr = vout0["scriptPubKey"].value("address", std::string());
+    CHECK(!mn_addr.empty() && mn_addr[0] == 'X', "mn payee is a Dash X-address");
+    std::printf("      mn payee address = %s\n", mn_addr.c_str());
+
+    // Plain tx (tx[1]) — extraPayload MUST be absent, type 0
+    const auto& t1 = j["tx"][1];
+    CHECK(t1["type"] == 0, "plain tx type == 0");
+    CHECK(!t1.contains("extraPayload"), "plain tx has NO extraPayload");
+
+    if (g_fail == 0) { std::printf("\nALL DASH EXPLORER-JSON KAT CHECKS PASSED\n"); return 0; }
+    std::printf("\n%d CHECK(S) FAILED\n", g_fail);
+    return 1;
+}

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -90,6 +90,7 @@
 #include <impl/dash/coin/header_chain.hpp>       // dash::coin::HeaderChain — SPV header/tip authority (E2a)
 #include <impl/dash/coin/block_confirm.hpp>      // dash::coin::block_confirm — post-broadcast confirm/orphan verdict
 #include <impl/dash/coin/chain_rpc.hpp>          // dash::coin::chain_rpc — daemonless getbestblockhash/getblockhash/getblockchaininfo
+#include <impl/dash/coin/block_json.hpp>         // dash::coin::block_to_explorer_json — /api/explorer getblock body decode
 #include <impl/dash/coin/bestblock_diag.hpp>     // #1046 bestblock out=0 diagnostic classifier (RpcNotString/BadHexLen/Ok)
 #include <impl/dash/coin/coin_state_maintainer.hpp>  // dash::coin::CoinStateMaintainer — populate ordering gate (E2a)
 #include <impl/dash/coin/sml_quorum_db.hpp>      // dash::coin::SMLDb / QuorumDb — SML+quorum persistence (incremental restart)
@@ -1090,9 +1091,27 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // The #1218 gbt-xcheck-txmerkle guard is UNTOUCHED and stays
              // the referee on any divergence.
              const std::string& embedded_utxo_fold_fees_db = std::string(),
-             const std::string& embedded_utxo_fold_expect = std::string())
+             const std::string& embedded_utxo_fold_expect = std::string(),
+             // --explorer / --no-explorer: the loopback-only /api/explorer
+             // surface consumed by explorer.py --coin dash --c2pool. Default ON
+             // (read-only + loopback-guarded, so exposing it is safe). Enabling
+             // it (a) opens the http_session gate (set_explorer_enabled), (b)
+             // wires the three mempool explorer callbacks, (c) extends the
+             // coin-chain-query getblock hook to serve decoded block BODIES from
+             // retained raw blocks, and (d) arms flag-gated raw-block retention
+             // (depth DASH_EXPLORER_DEPTH) into the node's own UTXO LevelDB.
+             // Retention additionally requires --embedded-utxo (the lane that
+             // owns that DB); without it getblock stays the honest header-only
+             // #99 partial. ZERO consensus/gentx/reward/coinbase/share path.
+             bool explorer_enabled = true)
 {
     namespace io = boost::asio;
+
+    // Explorer raw-block retention window: heights whose full block bodies are
+    // kept in the UTXO LevelDB for /api/explorer getblock decode. 288 ≈ 2 days
+    // at Dash's 2.5-min block target (the LTC/bip110 explorer default). Storage
+    // only, flag-gated on explorer_enabled; NEVER a consensus/reward path.
+    constexpr uint32_t DASH_EXPLORER_DEPTH = 288;
 
     dash::coin::RpcConf conf;
     std::string conf_path = rpc_conf_path;
@@ -2945,8 +2964,25 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                     ? dash::coin::UtxoImmaturePolicy::ServeEmptyTxSet
                     : dash::coin::UtxoImmaturePolicy::Refuse);
             utxo_block_sub = coin_state.block_connected.subscribe(
-                [&utxo_lane](const dash::interfaces::BlockConnected& bc) {
+                [&utxo_lane, explorer_enabled, DASH_EXPLORER_DEPTH]
+                (const dash::interfaces::BlockConnected& bc) {
                     utxo_lane.on_block_connected(bc.block, bc.height);
+                    // Explorer raw-block retention (flag-gated, pruned to depth).
+                    // The embedded arm already downloaded this full block for the
+                    // UTXO fold; keep the last DASH_EXPLORER_DEPTH bodies in the
+                    // lane's own LevelDB so /api/explorer getblock can decode them.
+                    // STORAGE ONLY — no consensus/reward/coinbase path is touched;
+                    // below the window getblock stays the honest #99 partial.
+                    if (explorer_enabled && utxo_lane.db()) {
+                        PackStream ps;
+                        ps << bc.block;
+                        auto span = ps.get_span();
+                        std::vector<uint8_t> raw(
+                            reinterpret_cast<const uint8_t*>(span.data()),
+                            reinterpret_cast<const uint8_t*>(span.data()) + span.size());
+                        utxo_lane.db()->put_raw_block(bc.height, raw);
+                        utxo_lane.db()->prune_raw_blocks(bc.height, DASH_EXPLORER_DEPTH);
+                    }
                 });
             std::cout << "[run] embedded UTXO/fee lane ARMED: db=" << utxo_path
                       << " best_height=" << utxo_lane.cache()->get_best_height()
@@ -4457,18 +4493,243 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // named condition with its measured value and threshold, never a zero.
         if (web_server) {
             web_server->get_mining_interface()->set_coin_chain_query_fn(
-                [hc = header_chain.get()](const std::string& method,
-                                          const nlohmann::json& params,
-                                          const std::string& chain) -> nlohmann::json {
+                [hc = header_chain.get(), &utxo_lane, explorer_enabled,
+                 DASH_EXPLORER_DEPTH, testnet]
+                (const std::string& method,
+                 const nlohmann::json& params,
+                 const std::string& chain) -> nlohmann::json {
                     if (chain != "dash")
                         return nlohmann::json{
                             {"error", "chain '" + chain + "' is not served by this "
                                       "node (owned chain: dash)"}};
+
+                    // ── Explorer getblock BODY serve (read-only) ──────────────
+                    // http_session routes getblock to THIS coin-chain-query hook
+                    // (it precedes the explorer_getblock_fn family for coin-owned
+                    // methods). chain_rpc::getblock can only answer a header-only
+                    // #99 PARTIAL — it holds no block bodies. When the explorer is
+                    // enabled AND the embedded UTXO lane retained this block's
+                    // body (depth DASH_EXPLORER_DEPTH), decode it into a full
+                    // verbosity-2 JSON (tx list, DIP4 extraPayload, MN-payee
+                    // vouts). GOOD-CITIZEN: this only ADDS bodies; anything not
+                    // retained (below the window, body absent, verbosity 0 raw
+                    // hex) falls through to chain_rpc's existing named refusals —
+                    // nothing currently servable is removed.
+                    if (explorer_enabled && method == "getblock"
+                        && params.is_array() && !params.empty()
+                        && params[0].is_string() && utxo_lane.db()) {
+                        bool want_decode = true;   // no verbosity == full decode
+                        if (params.size() > 1) {
+                            if (params[1].is_number())
+                                want_decode = params[1].get<int>() >= 1;
+                            else if (params[1].is_boolean())
+                                want_decode = params[1].get<bool>();
+                        }
+                        if (want_decode) {
+                            uint256 blk_hash;
+                            blk_hash.SetHex(params[0].get<std::string>());
+                            auto entry = hc->get_header(blk_hash);
+                            if (entry) {
+                                uint32_t height = entry->height;
+                                uint32_t tip = hc->height();
+                                const bool in_window =
+                                    !(tip > DASH_EXPLORER_DEPTH
+                                      && height < tip - DASH_EXPLORER_DEPTH);
+                                if (in_window) {
+                                    auto raw = utxo_lane.db()->get_raw_block(height);
+                                    if (raw) {
+                                        try {
+                                            PackStream ps(*raw);
+                                            dash::coin::BlockType block;
+                                            ps >> block;
+                                            dash::coin::ExplorerChainParams ep;
+                                            ep.bech32_hrp = "";            // Dash: no bech32
+                                            ep.p2pkh_ver  = testnet ? 0x8c : 0x4c;
+                                            ep.p2sh_ver   = testnet ? 0x13 : 0x10;
+                                            ep.chain_name = testnet ? "test" : "main";
+                                            return dash::coin::block_to_explorer_json(
+                                                block, height, blk_hash, ep);
+                                        } catch (...) {
+                                            // Fall through to the header-chain
+                                            // partial; never fake a body.
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     return dash::coin::chain_rpc::chain_query(*hc, method, params);
                 });
             std::cout << "[run] daemonless chain queries ARMED "
                          "(getbestblockhash/getblockhash/getblockchaininfo "
-                         "answered from the header chain)\n";
+                         "answered from the header chain"
+                      << (explorer_enabled
+                              ? "; getblock bodies from retained raw blocks)"
+                              : ")")
+                      << "\n";
+
+            // ── Explorer API surface (loopback-only, read-only) ───────────────
+            // Open the http_session /api/explorer gate + wire the mempool
+            // callbacks explorer.py --coin dash --c2pool consumes. This is the
+            // ONLY caller of set_explorer_enabled on the DASH lane (main_ltc.cpp
+            // is the reference); without it the gate answers
+            // {"error":"Explorer not enabled"}.
+            //
+            // Only THREE callbacks are wired here — getmempoolinfo / getrawmempool
+            // / getmempoolentry. The chain-info / blockhash / getblock methods are
+            // coin-OWNED (served by the coin-chain-query hook above), so their
+            // explorer_*_fn siblings would be dead code and are deliberately NOT
+            // installed. All feeds are display-only reads over the mempool
+            // snapshot — no gentx/selection/reward/coinbase/share path is touched.
+            if (explorer_enabled) {
+                auto* mi = web_server->get_mining_interface();
+                mi->set_explorer_enabled(true);
+                auto* mp = &node_coin_state.mempool();
+                auto chain_ok = [](const std::string& c) {
+                    return c.empty() || c == "dash";
+                };
+
+                // getmempoolinfo — summary stats + feerate histogram.
+                mi->set_explorer_mempoolinfo_fn(
+                    [mp, chain_ok](const std::string& chain) -> nlohmann::json {
+                        if (!chain_ok(chain))
+                            return nlohmann::json{{"error", "Mempool not available for chain"}};
+                        auto snap = mp->get_summary();
+                        time_t now = std::time(nullptr);
+                        struct Bucket { double lo, hi; size_t count{0}; size_t bytes{0}; };
+                        std::vector<Bucket> buckets = {{0,1},{1,5},{5,20},{20,100},{100,1e9}};
+                        for (const auto& e : snap.entries) {
+                            double fr = e.feerate;
+                            for (auto& b : buckets) {
+                                if (fr >= b.lo && fr < b.hi) { ++b.count; b.bytes += e.base_size; break; }
+                            }
+                        }
+                        nlohmann::json hist = nlohmann::json::array();
+                        for (const auto& b : buckets) {
+                            hist.push_back({
+                                {"min_feerate", b.lo},
+                                {"max_feerate", b.hi >= 1e9 ? nlohmann::json("inf") : nlohmann::json(b.hi)},
+                                {"count", b.count}, {"bytes", b.bytes}});
+                        }
+                        return nlohmann::json{
+                            {"size", snap.tx_count},
+                            {"bytes", snap.total_bytes},
+                            {"total_fees", snap.total_fees},
+                            {"fee_known_count", snap.fee_known_count},
+                            {"fee_unknown_count", snap.tx_count - snap.fee_known_count},
+                            {"min_feerate", snap.min_feerate},
+                            {"max_feerate", snap.max_feerate},
+                            {"median_feerate", snap.median_feerate},
+                            {"avg_feerate", snap.avg_feerate},
+                            {"oldest_age_sec", (snap.oldest_time > 0 && now > snap.oldest_time)
+                                                  ? (now - snap.oldest_time) : 0},
+                            {"fee_histogram", hist},
+                            {"chain", "dash"}};
+                    });
+
+                // getrawmempool — txid list or verbose entries.
+                mi->set_explorer_rawmempool_fn(
+                    [mp, chain_ok](const std::string& chain, bool verbose, uint32_t limit) -> nlohmann::json {
+                        if (!chain_ok(chain))
+                            return nlohmann::json{{"error", "Mempool not available for chain"}};
+                        if (!verbose) {
+                            auto txids = mp->all_txids();
+                            nlohmann::json arr = nlohmann::json::array();
+                            for (const auto& id : txids) arr.push_back(id.GetHex());
+                            return arr;
+                        }
+                        auto snap = mp->get_summary();
+                        time_t now = std::time(nullptr);
+                        nlohmann::json arr = nlohmann::json::array();
+                        uint32_t count = 0;
+                        for (const auto& e : snap.entries) {
+                            if (count >= limit) break;
+                            arr.push_back({
+                                {"txid", e.txid.GetHex()},
+                                {"size", e.base_size},
+                                {"fee", e.fee},
+                                {"fee_known", e.fee_known},
+                                {"feerate", e.feerate},
+                                {"time_added", e.time_added},
+                                {"age_sec", (e.time_added > 0 && now > e.time_added) ? (now - e.time_added) : 0},
+                                {"n_vin", e.n_vin},
+                                {"n_vout", e.n_vout}});
+                            ++count;
+                        }
+                        return arr;
+                    });
+
+                // getmempoolentry — single tx full detail with vin/vout.
+                mi->set_explorer_mempoolentry_fn(
+                    [mp, chain_ok, testnet](const std::string& txid_hex, const std::string& chain) -> nlohmann::json {
+                        if (!chain_ok(chain))
+                            return nlohmann::json{{"error", "Mempool not available for chain"}};
+                        uint256 txid;
+                        txid.SetHex(txid_hex);
+                        auto opt = mp->get_entry(txid);
+                        if (!opt) return nlohmann::json{{"error", "Transaction not in mempool"}};
+                        const auto& e = *opt;
+                        time_t now = std::time(nullptr);
+                        const uint8_t p2pkh = testnet ? 0x8c : 0x4c;
+                        const uint8_t p2sh  = testnet ? 0x13 : 0x10;
+                        nlohmann::json vin_arr = nlohmann::json::array();
+                        for (const auto& inp : e.tx.vin) {
+                            vin_arr.push_back({
+                                {"prevout_hash", inp.prevout.hash.GetHex()},
+                                {"prevout_n", inp.prevout.index},
+                                {"sequence", inp.sequence}});
+                        }
+                        nlohmann::json vout_arr = nlohmann::json::array();
+                        for (size_t i = 0; i < e.tx.vout.size(); ++i) {
+                            const auto& out = e.tx.vout[i];
+                            std::vector<unsigned char> script(out.scriptPubKey.m_data.begin(),
+                                                              out.scriptPubKey.m_data.end());
+                            auto cls = core::classify_script(script, "", p2pkh, p2sh);
+                            nlohmann::json vout_obj = {
+                                {"n", i},
+                                {"value_sat", out.value},
+                                {"scriptPubKey_hex", cls.hex},
+                                {"type", cls.type}};
+                            if (!cls.addresses.empty()) vout_obj["address"] = cls.addresses[0];
+                            if (cls.addresses.size() > 1) vout_obj["addresses"] = cls.addresses;
+                            vout_arr.push_back(std::move(vout_obj));
+                        }
+                        nlohmann::json r = {
+                            {"txid", e.txid.GetHex()},
+                            {"size", e.base_size},
+                            {"fee", e.fee},
+                            {"fee_known", e.fee_known},
+                            {"feerate", e.feerate_satvb()},
+                            {"type", static_cast<int>(e.tx.type)},
+                            {"version", e.tx.version},
+                            {"time_added", e.time_added},
+                            {"age_sec", (e.time_added > 0 && now > e.time_added) ? (now - e.time_added) : 0},
+                            {"vin", vin_arr},
+                            {"vout", vout_arr},
+                            {"chain", "dash"}};
+                        // DIP2/DIP3/DIP4 special-tx payload (explorer.py decodes
+                        // client-side). Present iff version==3 && type!=0.
+                        if (e.tx.version == 3 && e.tx.type != 0 && !e.tx.extra_payload.empty()) {
+                            static const char H[] = "0123456789abcdef";
+                            std::string ep;
+                            ep.reserve(e.tx.extra_payload.size() * 2);
+                            for (unsigned char b : e.tx.extra_payload) {
+                                ep += H[b >> 4]; ep += H[b & 0x0f];
+                            }
+                            r["extraPayload"] = ep;
+                        }
+                        return r;
+                    });
+
+                std::cout << "[run] explorer /api/explorer ARMED (loopback-only): "
+                             "getblock bodies + mempool info/raw/entry, retention depth="
+                          << DASH_EXPLORER_DEPTH
+                          << (embedded_utxo ? "" : " (NOTE: --embedded-utxo absent -> "
+                                                  "no raw-block retention; getblock stays "
+                                                  "header-only #99 partial)")
+                          << "\n";
+            }
 
             // ── DEFECT-3 operator surface: WHY the embedded arm is not serving ──
             // web-static/dashboard.html has read a per-coin `no_work_reason` since
@@ -10491,6 +10752,7 @@ int main(int argc, char** argv)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
     bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
+    bool explorer_enabled = true;              // --explorer (default ON) / --no-explorer: loopback-only /api/explorer
     // --embedded-utxo-immature-serve-empty: pure-daemonless OPT-IN. Default
     // OFF refuses every embedded template until the UTXO lane reaches
     // blocks_connected >= 106 (p2pool semantics: an unsynced node does not
@@ -10673,6 +10935,10 @@ int main(int argc, char** argv)
             embedded_govsync = true;
         else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
             embedded_utxo = true;
+        else if (std::strcmp(argv[i], "--explorer") == 0)
+            explorer_enabled = true;
+        else if (std::strcmp(argv[i], "--no-explorer") == 0)
+            explorer_enabled = false;
         else if (std::strcmp(argv[i], "--embedded-utxo-immature-serve-empty") == 0)
             embedded_utxo_immature_serve_empty = true;
         else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
@@ -11217,7 +11483,8 @@ int main(int argc, char** argv)
                         embedded_fold_live_expect,     // PR-C1 store-verify hash
                         embedded_fold_checkscripts,   // PR-C4 input-script check
                         embedded_utxo_fold_fees_db,    // W5-A fold fee source
-                        embedded_utxo_fold_expect);    // W5-A anchor restatement
+                        embedded_utxo_fold_expect,     // W5-A anchor restatement
+                        explorer_enabled);             // /api/explorer surface (default ON)
     }
     return run_selftest();
 }

--- a/src/core/param_catalog.inc
+++ b/src/core/param_catalog.inc
@@ -318,6 +318,10 @@ C2P_PARAM("web.dashboard_dir", WebOps, PATH, RESTART, C_DASH|C_LTC, LIT, "web-st
   C2P_ALIAS("web.dashboard_dir", BIN_DASH, "--dashboard-dir", VALUE)
   C2P_ALIAS("web.dashboard_dir", BIN_LTC, "--dashboard-dir", VALUE)
 
+C2P_PARAM("web.explorer", WebOps, TRISTATE_BOOL, RESTART, C_DASH, NONE, "", NONE, "loopback-only /api/explorer surface (default on)")
+  C2P_ALIAS("web.explorer", BIN_DASH, "--explorer", FLAG)
+  C2P_ALIAS("web.explorer", BIN_DASH, "--no-explorer", FLAG_NO_PREFIX)
+
 C2P_PARAM("web.cors_origin", WebOps, STRING, LIVE, C_LTC, LIT, "", NONE, "CORS origin")
   C2P_ALIAS("web.cors_origin", BIN_LTC, "--cors-origin", VALUE)
 

--- a/src/impl/dash/coin/block_json.hpp
+++ b/src/impl/dash/coin/block_json.hpp
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// block_to_explorer_json(): Convert a Dash BlockType into dashd-compatible
+/// getblock verbosity=2 JSON for the lite block explorer API (explorer.py's
+/// --coin dash --c2pool mode).
+///
+/// Transliterated from src/impl/ltc/coin/block_json.hpp, adjusted for Dash:
+///   - NO witness / MWEB (Dash is non-segwit); txid = sha256d(canonical tx).
+///   - per-tx `type` field (Dash version|type<<16 special-tx nType).
+///   - per-tx `extraPayload` hex emitted for DIP2/DIP3/DIP4 special txs
+///     (version==3 && type!=0) — explorer.py's dash profile decodes the DIP4
+///     CbTx (height, MN-list/quorum roots, bestCLSignature) CLIENT-SIDE from
+///     this hex (decode_dip4_cbtx / coinbase_tx["extraPayload"]).
+///   - X-shaped addresses via core::classify_script (empty hrp, p2pkh 0x4c /
+///     p2sh 0x10 mainnet, 0x8c / 0x13 testnet) — no bech32.
+///   - THE commitment (/c2pool/ tag) decode is coin-generic, kept verbatim so
+///     the DASH found-block highlight + PPLNS state-root/metadata render.
+///
+/// Read-only display serving: nothing here builds a template, prices a fee, or
+/// touches consensus/gentx/reward/coinbase/share validity.
+
+#include "block.hpp"
+#include "transaction.hpp"
+
+#include <core/address_utils.hpp>
+#include <core/coinbase_builder.hpp>   // c2pool::TheMetadata
+#include <core/target_utils.hpp>       // chain::bits_to_target / target_to_difficulty
+#include <core/pack.hpp>
+#include <core/hash.hpp>
+#include <core/uint256.hpp>
+
+#include <nlohmann/json.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// Chain parameters needed for address encoding.
+struct ExplorerChainParams {
+    std::string bech32_hrp;   // Dash has no bech32 — always empty ("")
+    uint8_t p2pkh_ver;        // 0x4c (mainnet X...), 0x8c (testnet y...)
+    uint8_t p2sh_ver;         // 0x10 (mainnet 7...), 0x13 (testnet)
+    std::string chain_name;   // "main", "test", etc.
+};
+
+namespace detail {
+
+inline std::string to_hex(const unsigned char* data, size_t len) {
+    static const char H[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(len * 2);
+    for (size_t i = 0; i < len; ++i) {
+        out += H[data[i] >> 4];
+        out += H[data[i] & 0x0f];
+    }
+    return out;
+}
+
+inline std::string bits_to_hex_str(uint32_t bits) {
+    char buf[9];
+    snprintf(buf, sizeof(buf), "%08x", bits);
+    return buf;
+}
+
+inline nlohmann::json classify_to_json(const core::ScriptClassification& sc) {
+    nlohmann::json spk;
+    spk["type"] = sc.type;
+    spk["hex"] = sc.hex;
+
+    if (!sc.addresses.empty()) {
+        spk["addresses"] = sc.addresses;
+        if (sc.addresses.size() == 1)
+            spk["address"] = sc.addresses[0];
+    }
+
+    if (sc.type == "pubkey" && !sc.pubkey.empty())
+        spk["pubkey"] = sc.pubkey;
+
+    if (sc.type == "multisig") {
+        nlohmann::json ms;
+        ms["required"] = sc.multisig_required;
+        ms["total"] = sc.multisig_total;
+        nlohmann::json pks = nlohmann::json::array();
+        for (size_t i = 0; i < sc.multisig_pubkeys.size(); ++i) {
+            nlohmann::json pk;
+            pk["hex"] = sc.multisig_pubkeys[i];
+            if (i < sc.multisig_addresses.size())
+                pk["address"] = sc.multisig_addresses[i];
+            pks.push_back(std::move(pk));
+        }
+        ms["pubkeys"] = std::move(pks);
+        spk["multisig"] = std::move(ms);
+    }
+
+    if (sc.type == "nulldata" && !sc.op_return_hex.empty())
+        spk["data"] = sc.op_return_hex;
+
+    return spk;
+}
+
+/// Parse c2pool THE commitment from coinbase scriptSig. Coin-generic; identical
+/// to the LTC sibling (the /c2pool/ tag layout is shared across every lane).
+/// Layout: [BIP34 height push][...]["/c2pool/" tag][state_root 32B][TheMetadata]
+inline nlohmann::json parse_the_commitment(const std::vector<unsigned char>& scriptSig) {
+    const uint8_t tag[] = {'/', 'c', '2', 'p', 'o', 'o', 'l', '/'};
+    const size_t tag_len = 8;
+    const auto* data = scriptSig.data();
+    const size_t len = scriptSig.size();
+
+    size_t tag_pos = std::string::npos;
+    for (size_t i = 0; i + tag_len <= len; ++i) {
+        if (std::memcmp(data + i, tag, tag_len) == 0) {
+            tag_pos = i;
+            break;
+        }
+    }
+    if (tag_pos == std::string::npos)
+        return nullptr;
+
+    nlohmann::json the;
+    the["pool_tag"] = "/c2pool/";
+
+    size_t after_tag = tag_pos + tag_len;
+
+    if (after_tag + 32 <= len) {
+        the["state_root"] = to_hex(data + after_tag, 32);
+        size_t meta_start = after_tag + 32;
+
+        if (meta_start < len) {
+            auto meta = c2pool::TheMetadata::unpack(data + meta_start, len - meta_start);
+            nlohmann::json md;
+            md["version"] = meta.version;
+            md["sharechain_height"] = meta.sharechain_height;
+            md["miner_count"] = meta.miner_count;
+            md["hashrate_class"] = meta.hashrate_class;
+            double hr = c2pool::TheMetadata::decode_hashrate(meta.hashrate_class);
+            const char* suffix = "H/s";
+            if (hr >= 1e12)      { hr /= 1e12; suffix = "TH/s"; }
+            else if (hr >= 1e9)  { hr /= 1e9;  suffix = "GH/s"; }
+            else if (hr >= 1e6)  { hr /= 1e6;  suffix = "MH/s"; }
+            else if (hr >= 1e3)  { hr /= 1e3;  suffix = "KH/s"; }
+            char buf[64];
+            snprintf(buf, sizeof(buf), "%.2f %s", hr, suffix);
+            md["hashrate_human"] = buf;
+
+            char fp[17];
+            snprintf(fp, sizeof(fp), "%016lx",
+                     static_cast<unsigned long>(meta.chain_fingerprint));
+            md["chain_fingerprint"] = fp;
+            md["share_period"] = meta.share_period;
+            md["verified_length"] = meta.verified_length;
+            the["metadata"] = std::move(md);
+        }
+    } else {
+        the["state_root"] = nullptr;
+    }
+
+    return the;
+}
+
+/// txid = sha256d(canonical non-witness tx bytes) — identical to dash_txid()
+/// (utxo_adapter.hpp); recomputed inline here so this header stays free of the
+/// UTXO machinery.
+inline uint256 dash_explorer_txid(const MutableTransaction& mtx) {
+    auto packed = ::pack(mtx);
+    return ::Hash(packed.get_span());
+}
+
+} // namespace detail
+
+/// Convert a Dash BlockType + metadata into dashd-compatible getblock JSON.
+inline nlohmann::json block_to_explorer_json(
+    const BlockType& block,
+    uint32_t height,
+    const uint256& block_hash,
+    const ExplorerChainParams& params)
+{
+    using namespace detail;
+
+    nlohmann::json j;
+
+    // Block header fields
+    j["hash"] = block_hash.GetHex();
+    j["height"] = height;
+    j["version"] = static_cast<int64_t>(block.m_version);
+    j["previousblockhash"] = block.m_previous_block.GetHex();
+    j["merkleroot"] = block.m_merkle_root.GetHex();
+    j["time"] = block.m_timestamp;
+    j["bits"] = bits_to_hex_str(block.m_bits);
+    j["nonce"] = block.m_nonce;
+
+    // Difficulty from bits (Dash uses the standard nBits compact format).
+    auto target = chain::bits_to_target(block.m_bits);
+    j["difficulty"] = chain::target_to_difficulty(target);
+
+    // Serialized size
+    {
+        PackStream ps;
+        ps << block;
+        j["size"] = ps.get_span().size();
+    }
+
+    // Transactions
+    nlohmann::json txs = nlohmann::json::array();
+    bool first_tx = true;
+    for (const auto& mtx : block.m_txs) {
+        nlohmann::json tx;
+
+        uint256 txid = dash_explorer_txid(mtx);
+        tx["txid"] = txid.GetHex();
+
+        // Dash special-tx type (nType). Always present; 0 == standard.
+        tx["type"] = static_cast<int>(mtx.type);
+        tx["version"] = mtx.version;
+
+        // DIP2/DIP3/DIP4 extra payload (present on the wire iff version==3 &&
+        // type!=0). explorer.py's dash profile reads this hex to decode the
+        // DIP4 CbTx (height, MN-list/quorum merkle roots, bestCLSignature) and
+        // the other special-tx payloads CLIENT-SIDE.
+        if (mtx.version == 3 && mtx.type != 0 && !mtx.extra_payload.empty()) {
+            tx["extraPayload"] = to_hex(mtx.extra_payload.data(),
+                                        mtx.extra_payload.size());
+        }
+
+        // vin
+        nlohmann::json vins = nlohmann::json::array();
+        if (first_tx && !mtx.vin.empty()) {
+            nlohmann::json vin;
+            auto& scriptSig = mtx.vin[0].scriptSig;
+            std::vector<unsigned char> sig_vec(scriptSig.m_data.begin(), scriptSig.m_data.end());
+            vin["coinbase"] = to_hex(sig_vec.data(), sig_vec.size());
+            vin["sequence"] = mtx.vin[0].sequence;
+            vins.push_back(std::move(vin));
+        } else {
+            for (const auto& in : mtx.vin) {
+                nlohmann::json vin;
+                vin["txid"] = in.prevout.hash.GetHex();
+                vin["vout"] = in.prevout.index;
+                vin["sequence"] = in.sequence;
+                vins.push_back(std::move(vin));
+            }
+        }
+        tx["vin"] = std::move(vins);
+
+        // vout
+        nlohmann::json vouts = nlohmann::json::array();
+        for (size_t i = 0; i < mtx.vout.size(); ++i) {
+            nlohmann::json vout;
+            vout["value"] = static_cast<double>(mtx.vout[i].value) / 1e8;
+            vout["value_sat"] = static_cast<int64_t>(mtx.vout[i].value);
+            vout["n"] = i;
+
+            std::vector<unsigned char> script_vec(
+                mtx.vout[i].scriptPubKey.m_data.begin(),
+                mtx.vout[i].scriptPubKey.m_data.end());
+            auto sc = core::classify_script(script_vec,
+                params.bech32_hrp, params.p2pkh_ver, params.p2sh_ver);
+            vout["scriptPubKey"] = classify_to_json(sc);
+
+            vouts.push_back(std::move(vout));
+        }
+        tx["vout"] = std::move(vouts);
+
+        txs.push_back(std::move(tx));
+        first_tx = false;
+    }
+    j["tx"] = std::move(txs);
+    j["nTx"] = block.m_txs.size();
+
+    // THE commitment (c2pool-found blocks) — coinbase scriptSig.
+    if (!block.m_txs.empty() && !block.m_txs[0].vin.empty()) {
+        auto& scriptSig = block.m_txs[0].vin[0].scriptSig;
+        std::vector<unsigned char> sig_vec(scriptSig.m_data.begin(), scriptSig.m_data.end());
+        auto the = parse_the_commitment(sig_vec);
+        if (!the.is_null())
+            j["_the"] = std::move(the);
+    }
+
+    return j;
+}
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -64,6 +64,7 @@
 #include <core/log.hpp>
 #include <core/coin/utxo_view_cache.hpp>
 
+#include <algorithm>             // get_summary(): feerate percentile sort (display-only)
 #include <atomic>
 #include <cmath>                 // block_min_fee_for_size: dashd CFeeRate::GetFee std::ceil
 #include <functional>
@@ -979,6 +980,78 @@ public:
         out.reserve(m_pool.size());
         for (auto& [txid, _] : m_pool) out.push_back(txid);
         return out;
+    }
+
+    /// Read-only display snapshot for the lite explorer API
+    /// (/api/explorer/getmempoolinfo, getrawmempool). DISPLAY-ONLY: taken under
+    /// m_mutex like every other accessor, it touches NO selection/gentx/fee
+    /// path — it copies the same fields the dashboard already reads elsewhere
+    /// into one atomic snapshot so the three explorer callbacks need a single
+    /// lock acquisition. Feerate percentiles are computed over fee_known
+    /// entries (feerate_satvb == 0 for unpriced txs, consistent with the DASH
+    /// exclusion-discipline selector).
+    struct MempoolSummary {
+        struct Entry {
+            uint256  txid;
+            uint32_t base_size{0};
+            uint64_t fee{0};
+            bool     fee_known{false};
+            double   feerate{0.0};   // sat/vB (== MempoolEntry::feerate_satvb())
+            size_t   n_vin{0};
+            size_t   n_vout{0};
+            time_t   time_added{0};
+        };
+        size_t   tx_count{0};
+        uint64_t total_bytes{0};
+        uint64_t total_fees{0};       // sum of KNOWN fees (satoshi)
+        size_t   fee_known_count{0};
+        double   min_feerate{0.0};
+        double   max_feerate{0.0};
+        double   median_feerate{0.0};
+        double   avg_feerate{0.0};
+        time_t   oldest_time{0};
+        std::vector<Entry> entries;
+    };
+
+    MempoolSummary get_summary() const
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        MempoolSummary s;
+        s.tx_count    = m_pool.size();
+        s.total_bytes = m_total_bytes;
+        s.entries.reserve(m_pool.size());
+        std::vector<double> frs;
+        frs.reserve(m_pool.size());
+        for (const auto& [txid, e] : m_pool) {
+            MempoolSummary::Entry se;
+            se.txid       = txid;
+            se.base_size  = e.base_size;
+            se.fee        = e.fee;
+            se.fee_known  = e.fee_known;
+            se.feerate    = e.feerate_satvb();
+            se.n_vin      = e.tx.vin.size();
+            se.n_vout     = e.tx.vout.size();
+            se.time_added = e.time_added;
+            if (e.fee_known) {
+                s.total_fees += e.fee;
+                ++s.fee_known_count;
+                frs.push_back(se.feerate);
+            }
+            if (e.time_added > 0 &&
+                (s.oldest_time == 0 || e.time_added < s.oldest_time))
+                s.oldest_time = e.time_added;
+            s.entries.push_back(std::move(se));
+        }
+        if (!frs.empty()) {
+            std::sort(frs.begin(), frs.end());
+            s.min_feerate    = frs.front();
+            s.max_feerate    = frs.back();
+            s.median_feerate = frs[frs.size() / 2];
+            double sum = 0.0;
+            for (double f : frs) sum += f;
+            s.avg_feerate = sum / static_cast<double>(frs.size());
+        }
+        return s;
     }
 
     /// #107 PHASE 2: the pending type-8 (TRANSACTION_ASSET_LOCK) txs currently

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -336,6 +336,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_dependencies(test_dash_serve_gate_journal dash_proactive_rotation_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_asn_diversity_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
     add_dependencies(test_dash_serve_gate_journal dash_getmnlistd_tracker_kat)  # coin-P2P KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
+    add_dependencies(test_dash_serve_gate_journal dash_explorer_json_kat)  # explorer block->JSON KAT: not in build.yml --target allowlist; piggyback on allowlisted anchor so CI builds it (avoids NOT_BUILT/Not-Run)
 
     # DASH serve-gate LEDGER cross-restart never-a-reject accounting KAT: the
     # CUMULATIVE, persisted companion to ServeGateJournal (the journal wipes on


### PR DESCRIPTION
## What

Wire the DASH block explorer so a daemonless DASH c2pool node (dash.voidbind.com) serves a real DASH explorer FROM its own validated state. explorer.py already has a full DASH profile (X11, X-addresses, DIP4 CbTx decode, masternode-payee, PPLNS/donation/ref_hash payout trace); the node just needed to serve raw blocks + mempool over `/api/explorer`.

DASH analog of the bip110 explorer enablement (`3f748296d`), adjusted for the DASH lane's coin-chain-query hook that shadows the coin-owned methods.

## Changes (all behind `--explorer`, default ON; loopback-only + read-only)

- **main_dash.cpp** — `set_explorer_enabled(true)`; extend the coin-chain-query `getblock` hook to decode retained raw block **bodies** into verbosity-2 JSON (fall through to the existing #99 header-only partial when un-retained); wire the three mempool callbacks (`getmempoolinfo`/`getrawmempool`/`getmempoolentry`); flag-gated raw-block retention (depth 288) into the embedded UTXO lane's LevelDB. chaininfo/blockhash are already coin-owned so their explorer_*_fn siblings are deliberately not wired.
- **src/impl/dash/coin/block_json.hpp** (new) — `block_to_explorer_json`, dashd-compatible getblock v2 JSON, minus witness/MWEB, plus per-tx `type` + `extraPayload` hex (v3/type!=0) for client-side DIP4 decode; X-addresses (p2pkh 0x4c / p2sh 0x10).
- **src/impl/dash/coin/mempool.hpp** — read-only `MempoolSummary` + `get_summary()` under `m_mutex` (display-only).
- **explorer/explorer.py** — `--url-prefix` for reverse-proxy sub-path serving (`/explorer`); default `""` keeps every page byte-identical (bip110/ltc/btc unregressed).
- **dash_explorer_json_kat.cpp** (new, registered) — KAT: v3/type-5 CbTx + MN-payee decodes to type:5, byte-exact extraPayload, X-address, txid, nTx.

## Safety

READ-ONLY serving. ZERO change to consensus / gentx / reward / coinbase / DIP4-CCbTx build / share validity / wire. The only new write is flag-gated raw-block storage pruned to depth. `git diff` deletions are purely the surgical signature/lambda-capture/cout edits; mempool.hpp is additive-only.

## Validation

- Full `c2pool-dash` binary builds clean with the wiring.
- `dash_explorer_json_kat` green via ctest (test #686): DIP4 type/extraPayload + MN-payee `X...` address + txid + nTx.
- explorer.py py_compiles; `--url-prefix` additive.
- Live HTTP validation of the enabled endpoints requires deploying this binary to the contabo canary (operator tap on the live-value coin) — the currently-deployed binary is the old explorer-off build.

## DO NOT auto-merge

DASH is the live-value production coin. Operator reviews + taps deploy.