### PR TITLE
explorer: derive nav Explorer fallback as <origin>/explorer path (completes #1460 pair)

### DIFF
--- a/web-static/dashboard.html
+++ b/web-static/dashboard.html
@@ -3125,20 +3125,20 @@
                 // Use configured explorer_url from the YAML (preferred — explicit
                 // and survives deployment topology changes). Otherwise auto-derive
                 // from the current hostname:
-                //   - DNS hostname (e.g. voidbind.com)  → https://explorer.<hostname>
+                //   - DNS hostname (e.g. dash.voidbind.com) → <origin>/explorer
                 //   - IP literal (e.g. 192.168.86.20)  → http://<host>:9090
                 //   - localhost                         → http://localhost:9090
-                // The DNS-subdomain default matches our production layout
-                // (Caddy fronts explorer.<domain>) and works for any host
-                // following the same convention. The :9090 fallback covers
-                // LAN/dev deployments without a reverse proxy.
+                // The /explorer PATH default matches our production layout
+                // (Caddy handle_path /explorer on the pool's own domain) and
+                // works for any host following the same convention. The :9090
+                // fallback covers LAN/dev deployments without a reverse proxy.
                 var explorerHref = info.explorer_url || (function() {
                     var h = window.location.hostname;
                     var isIPv4 = /^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(h);
                     var isIPv6 = h.indexOf(':') !== -1;
                     if (isIPv4 || isIPv6 || h === 'localhost')
                         return 'http://' + h + ':9090';
-                    return window.location.protocol + '//explorer.' + h;
+                    return window.location.origin + '/explorer';
                 })();
                 var nav = document.querySelector('nav');
                 var _old = document.getElementById('nav-explorer'); if (_old) _old.remove();


### PR DESCRIPTION
## Explorer nav button: derive fallback as `<origin>/explorer` (path), not `explorer.<host>` (subdomain)

Completes a pair of coin-generic explorer serving fixes, both proven live on the contabo integrator-diag copies (dash.voidbind.com/explorer now shows blocks and the Explorer nav button now resolves).

### This PR (Bug 2) — `web-static/dashboard.html`
The dashboard Explorer nav button's auto-derive fallback (used only when the node does not supply `info.explorer_url`) built `https://explorer.<hostname>` — a non-existent subdomain — so the button 404'd on the canonical production layout.

Production Caddy fronts the explorer as a **path** (`handle_path /explorer`) on the pool's own domain (e.g. `dash.voidbind.com/explorer`), not a subdomain. This derives `window.location.origin + '/explorer'` instead.

Untouched:
- `info.explorer_url` preference (YAML-configured URL still wins)
- the IP / IPv6 / localhost `:9090` branch

`dashboard.html` is the only page with this auto-derive fallback — every other page (index/share/miner/miners/stratum/graphs) gates the Explorer link on `info.explorer_url` being supplied, so the fix is confined to one file.

### Bug 1 (getblockhash envelope) already landed via #1460
The companion fix — `C2PoolClient.call('getblockhash', ...)` accepting both the `{"result": hash}` (LTC) and bare-string (DASH daemonless) answer shapes — landed on master in `34f542327` inside PR #1460 (`explorer/explorer.py:462-467`). No edit here; this PR completes the pair.

### Scope
Read-only serving/frontend only; coin-generic. Zero consensus / reward / share / coinbase / wire changes. No test: no frontend/explorer test harness exists in CI (CI only copies these files into release packages).
