### PR TITLE
pool: contain persisted whitelist path on the save/rename sink too (CodeQL cpp/path-injection)

### DIFF
--- a/src/pool/sharechain_node.hpp
+++ b/src/pool/sharechain_node.hpp
@@ -204,6 +204,16 @@ protected:
     void save_whitelist_to_disk() const
     {
         if (m_whitelist_path.empty()) return;
+        // Same containment guard as the load path: refuse to write a whitelist
+        // that resolves outside its configured base directory. Covers both
+        // sinks below — the ".new" temporary is a sibling of m_whitelist_path
+        // (same parent), so containing m_whitelist_path contains the rename
+        // target and the temporary it is renamed from.
+        if (!path_within_base(m_whitelist_path, m_whitelist_dir)) {
+            LOG_WARNING << "[Pool] Refusing to save whitelist outside config dir: "
+                        << m_whitelist_path;
+            return;
+        }
         try {
             nlohmann::json j;
             j["version"] = 1;


### PR DESCRIPTION
## What

Adds the `path_within_base(m_whitelist_path, m_whitelist_dir)` containment guard to `save_whitelist_to_disk()` in `src/pool/sharechain_node.hpp`, mirroring the one already on the load path.

## Why — the load/save asymmetry

PR #1195 (the whitelist load-path containment, commit `829e9412`) added a `weakly_canonical()` containment guard to `load_whitelist_from_disk()`. Its commit message closed with:

> Guard covers the :150 load site; the :193 save/rename sink follows.

This PR is that promised follow-up. The save side was left reaching the filesystem unguarded on **both** of its sinks:

- the `ofstream` write to `m_whitelist_path + ".new"`, and
- the `std::filesystem::rename()` onto `m_whitelist_path`.

The asymmetry was an omission rather than a decision: `set_whitelist_path()` and the `m_whitelist_dir` member both already document the base as constraining *"load/save"*, and the two sides share the same `m_whitelist_path` / `m_whitelist_dir` pair.

## One check, both sinks

The guard is a single early return at the top of the function. That is sufficient for both sinks because the `".new"` temporary is a sibling of `m_whitelist_path` in the same parent directory — containing `m_whitelist_path` therefore contains both the temporary that gets written and the rename target it is renamed onto.

## Risk

Unchanged from the load side: the path is **not** attacker-controlled today (node config dir joined with a fixed filename), so this is defense-in-depth against a future caller supplying a `..` traversal or an absolute override. Behaviour on every in-base path is identical to before; only an escaping path is refused, with a `LOG_WARNING` matching the load guard's wording.

## Verification

The guard's semantics were exercised in isolation (containment helper unchanged, so this pins the behaviour the save site now inherits):

| case | contained? |
|---|---|
| `<base>/../escape.json` | no — refused |
| `<base>/whitelist.json` | yes — allowed |
| `/etc/passwd` (absolute override) | no — refused |
| `<base>/whitelist.json.new` (tmp sibling) | yes — allowed |

The last row confirms the single-guard-covers-both-sinks reasoning above.

+10 LOC, one file, no behavioural change to any valid configuration.