### PR TITLE
codeql: drop two provably-constant comparisons (stratum hasher, DOGE subsidy)

### DIFF
--- a/src/core/stratum_server.hpp
+++ b/src/core/stratum_server.hpp
@@ -69,7 +69,9 @@ private:
 struct PubkeyHashHasher {
     size_t operator()(const std::array<uint8_t, 20>& a) const {
         size_t h = 0;
-        for (int i = 0; i < 8 && i < 20; ++i)
+        // 8 bytes is the widest prefix a 64-bit size_t can hold, and 8 <= a.size()
+        // (std::array<uint8_t, 20>), so no second bounds clause is needed.
+        for (int i = 0; i < 8; ++i)
             h |= size_t(a[i]) << (8 * i);
         return h;
     }

--- a/src/impl/doge/coin/chain_params.hpp
+++ b/src/impl/doge/coin/chain_params.hpp
@@ -237,7 +237,11 @@ inline uint64_t get_doge_block_subsidy(uint32_t height, const DOGEChainParams& p
     int halvings = static_cast<int>(height) / DOGEChainParams::SUBSIDY_HALVING_INTERVAL;
 
     if (params.simplified_rewards) {
-        if (height >= 600000) return 10000ULL * COIN;
+        // Exact upstream shape (dogecoin.cpp GetDogecoinBlockSubsidy): below the
+        // 6th halving interval (600000) the fixed 500000 schedule applies, at or
+        // above it the reward is flat 10000 forever. A duplicate `height >= 600000`
+        // early return used to precede this test, which made the test below — and
+        // therefore its else-path — statically unreachable (CodeQL #434).
         if (height < 6u * DOGEChainParams::SUBSIDY_HALVING_INTERVAL)
             return (500000ULL * COIN) >> halvings;
         return 10000ULL * COIN;

--- a/test/test_doge_chain.cpp
+++ b/test/test_doge_chain.cpp
@@ -142,6 +142,41 @@ TEST(DOGESubsidyTest, SimplifiedIgnoresPrevHash) {
     EXPECT_EQ(get_doge_block_subsidy(200000, p, h1), 125000ULL * 100000000ULL);
 }
 
+// Pins the prevHash overload across the 600000 (= 6 * SUBSIDY_HALVING_INTERVAL)
+// simplified-rewards boundary, which no other case covered. This is the byte-
+// identity guard for the removal of the duplicate `height >= 600000` early
+// return in get_doge_block_subsidy(): every height below the boundary must keep
+// the 500000 >> halvings schedule, every height at or above it the flat 10000.
+TEST(DOGESubsidyTest, SimplifiedPrevHashOverloadAcross600kBoundary) {
+    static constexpr uint64_t COIN = 100000000ULL;
+    auto p = DOGEChainParams::mainnet();
+    uint256 h;
+    h.SetHex("ae162af2b7efd37f8ca439eb4e8df06eee3e7ffab1a2ed098ad5d7d4005bc774");
+
+    // Below the boundary: fixed 500000 >> (height / 100000).
+    EXPECT_EQ(get_doge_block_subsidy(0, p, h),      500000ULL * COIN);  // halving 0
+    EXPECT_EQ(get_doge_block_subsidy(99999, p, h),  500000ULL * COIN);
+    EXPECT_EQ(get_doge_block_subsidy(100000, p, h), 250000ULL * COIN);  // halving 1
+    EXPECT_EQ(get_doge_block_subsidy(500000, p, h),  15625ULL * COIN);  // halving 5
+    EXPECT_EQ(get_doge_block_subsidy(599999, p, h),  15625ULL * COIN);  // last pre-flat
+
+    // At and above the boundary: flat 10000 forever.
+    EXPECT_EQ(get_doge_block_subsidy(600000, p, h),  10000ULL * COIN);
+    EXPECT_EQ(get_doge_block_subsidy(600001, p, h),  10000ULL * COIN);
+    EXPECT_EQ(get_doge_block_subsidy(1000000, p, h), 10000ULL * COIN);
+    EXPECT_EQ(get_doge_block_subsidy(5000000, p, h), 10000ULL * COIN);
+
+    // The boundary result must not depend on prevHash under simplified rewards.
+    uint256 h2;
+    h2.SetHex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    EXPECT_EQ(get_doge_block_subsidy(599999, p, h), get_doge_block_subsidy(599999, p, h2));
+    EXPECT_EQ(get_doge_block_subsidy(600000, p, h), get_doge_block_subsidy(600000, p, h2));
+
+    // Both overloads must agree on both sides of the boundary.
+    EXPECT_EQ(get_doge_block_subsidy(599999, p, h), get_doge_block_subsidy(599999, p));
+    EXPECT_EQ(get_doge_block_subsidy(600000, p, h), get_doge_block_subsidy(600000, p));
+}
+
 // ─── DigiShield v3 Tests ────────────────────────────────────────────────────
 
 TEST(DigiShieldTest, NoChangeAtTargetSpacing) {


### PR DESCRIPTION
## What

Closes two `cpp/constant-comparison` code-scanning alerts where the analyzer is
correct and the dead clause can be deleted with no behavior change. Both were
verified against the analysis commit `c7c4392a` before being touched.

### 1. `src/core/stratum_server.hpp:72` — alert #430

`PubkeyHashHasher` looped `for (int i = 0; i < 8 && i < 20; ++i)` over a
`std::array<uint8_t, 20>`. `8 <= 20` holds statically, so `i < 20` can never
fail. Dropped; the intent (8 bytes is the widest prefix a 64-bit `size_t` can
hold, and 8 is within the array bound) is now a comment.

Checked by running the old and new loop side by side over 200000 random
20-byte inputs: identical hash for every input.

### 2. `src/impl/doge/coin/chain_params.hpp:241` — alert #434

The prevHash overload of `get_doge_block_subsidy()` carried a duplicate
`height >= 600000` early return ahead of the upstream test:

```cpp
if (params.simplified_rewards) {
    if (height >= 600000) return 10000ULL * COIN;                            // duplicate
    if (height < 6u * DOGEChainParams::SUBSIDY_HALVING_INTERVAL)             // <- always true
        return (500000ULL * COIN) >> halvings;
    return 10000ULL * COIN;                                                  // <- unreachable
}
```

`SUBSIDY_HALVING_INTERVAL == 100000`, so `6u * SUBSIDY_HALVING_INTERVAL` is
exactly the same 600000 the early return already excluded. The duplicate made
the second test statically always-true and its else-path unreachable. Removing
it restores the exact upstream shape from `dogecoin.cpp`
`GetDogecoinBlockSubsidy()` and leaves one live decision.

## Byte-identity evidence

This is a subsidy function, so it is pinned before it is touched. Nothing in
`test/test_doge_chain.cpp` covered the prevHash overload across the 600000
boundary — the existing prevHash cases sit at height 200000 and on the
random-rewards (testnet4alpha) path, and the 600k boundary cases used the
max-subsidy overload only.

The new `DOGESubsidyTest.SimplifiedPrevHashOverloadAcross600kBoundary` pins:

* below the boundary: heights 0, 99999, 100000, 500000, 599999 on the
  `500000 >> halvings` schedule (500000 / 500000 / 250000 / 15625 / 15625 DOGE);
* at and above: 600000, 600001, 1000000, 5000000 on the flat 10000 DOGE reward;
* prevHash-independence at 599999 and 600000;
* agreement between the prevHash and max-subsidy overloads on both sides.

Every pin was run against the pre-change and post-change header and produced
identical values, including the three pre-existing cases the suite already had.

## Scope

Display/hashing and subsidy-shape only. No consensus rule, payout split, wire
format or serialization surface is touched.

## Related alerts, not changed here

`#433` and `#475` (`sent > 0` in `coin_broadcaster.hpp:368/:410`) were checked
as part of the same sweep and are **not** bugs: `sent` is incremented inside a
range-for over the runtime `m_peers` map, so the guard is live. They are being
dismissed as analyzer artifacts rather than fixed, consistent with the existing
same-file dismissal `#299`.
