### PR TITLE
DASH: good-citizen serving is the daemonless binary default (opt-out) [clean re-do of #1470]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,33 @@
   experimental — the fork coin is effectively unlisted (block reward ≈ 0), so the
   value is strategic, not revenue.
 
+### DASH — good-citizen serving is the daemonless binary default (opt-out)
+- **A bare `c2pool-dash --run` (no `--coin-rpc`/`--coin-rpc-auth`/`--submit-block`)
+  now serves the FULL mempool + special txs (DIP types 1-4) + funded superblocks
+  by default — it used to serve NOTHING.** With no dashd arm the embedded-arm gate
+  (`--embedded-mainnet`) and the fee/serve levers all defaulted OFF, so a daemonless
+  node either idled (no arm) or produced coinbase-only blocks. All twelve serving
+  levers (`--embedded-mainnet`, `--embedded-utxo`, `--embedded-null-arm`,
+  `--embedded-superblock`, `--embedded-include-mn-special-txs`,
+  `--embedded-accrue-asset-locks`/`-unlocks`, `--embedded-serve-mempool-txs`,
+  `--embedded-tx-serve-own-set`, `--embedded-mempool-ingest`,
+  `--embedded-ingest-isdlock`/`-dstx`) now default ON in the daemonless posture and
+  are resolved by one pure, KAT-tested function (`good_citizen_defaults.hpp`).
+  Each keeps an explicit `--<flag>=false` opt-out; a **dashd-armed** node is
+  byte-identical to before (defaults stay OFF, dashd's template provides fullness).
+- **Reward-safety is unchanged and runs by default whenever serving:** the
+  serve-time internal-consistency referee (`--embedded-tx-serve-own-set`, armed
+  together with serving), the tx-merkle/creditPool cross-checks (#1218/#1230), the
+  special-tx SML re-fold + root-drift rejection at emit, and fee_fold_proven-only
+  selection all fail closed to last-good-work, never to an unvalidated serve.
+- **Not flipped (deliberate):** `--embedded-utxo-immature-serve-empty` (p2pool
+  semantics; the window clears in minutes), `--embedded-creditpool-publish-at-serve-tip`
+  (creditpool is ahead), and the path-bearing full-history fold flags. Type-9
+  asset-unlock admission remains gated behind its seeded CreditPool index follower
+  (the default flip is inert until then). Cross-coin: bip110/LTC/DOGE/BTC already
+  serve by default; DGB is coinbase-only structurally (mempool ingest port pending)
+  and is tracked as a follow-up.
+
 ### DASH — daemonless masternode set: seed completeness (the reinstatement gap)
 - **The pinned anchor and the RPC seed now carry the REGISTERED masternode set,
   not the valid one.** `protx list valid` filters every PoSe-banned masternode

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -8,7 +8,7 @@ documented in the [postmortem archive](https://github.com/frstrtr/the/tree/maste
 ## DASH daemonless masternode set is seeded from a TRUST ANCHOR
 
 **Severity**: Medium (security-model disclosure, not a defect)
-**Affects**: DASH `--embedded-mainnet` run WITHOUT a dashd RPC
+**Affects**: DASH daemonless run (bare `--run`, no dashd RPC — the default posture)
 
 c2pool cannot derive the payout-bearing DASH masternode set from the P2P
 network: the Simplified MN List omits `scriptPayout` and `nLastPaidHeight`,

--- a/README.md
+++ b/README.md
@@ -302,9 +302,9 @@ Legacy `--standalone` mode (minimal stratum + RPC daemon, no embedded SPV) is av
 
 ### DASH daemonless masternode-set checkpoint — trust anchor
 
-**If you run DASH with `--embedded-mainnet` and no dashd, you are trusting the
-c2pool release build for one specific piece of data. This section says exactly
-which, and why.**
+**If you run DASH without a dashd arm (a bare `--run` is daemonless by default),
+you are trusting the c2pool release build for one specific piece of data. This
+section says exactly which, and why.**
 
 To build a DASH block, c2pool must know which masternode is next in the DIP-3
 payment queue. Paying the wrong one produces a coinbase the network rejects

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -477,13 +477,16 @@ void print_banner(const char* argv0)
         << "           [--stratum [HOST:]PORT] [--coin-p2p-connect HOST:PORT]... [--coin-p2p-discover]\n"
         << "           [--web-port PORT] [--web-host ADDR] [--dashboard-dir PATH]\n"
         << "           [--external-ip ADDR]\n"
-        << "           [--embedded-utxo] [--embedded-mainnet] [--embedded-null-arm] [--embedded-mn-bridge-max N]\n"
+        << "           [--embedded-utxo[=false]] [--embedded-mainnet[=false]] [--embedded-null-arm[=false]]\n"
+        << "           [--embedded-superblock[=false]] [--embedded-include-mn-special-txs[=false]]\n"
+        << "           [--embedded-accrue-asset-locks[=false]] [--embedded-mn-bridge-max N]\n"
         << "           [--embedded-asn-diversity]\n"
         << "           [--embedded-mn-bridge-no-cursor]\n"
         << "           [--embedded-utxo-immature-serve-empty] [--embedded-serve-mempool-txs[=false]]\n"
         << "           [--embedded-tx-serve-own-set[=false]]\n"
-        << "             (mempool serving levers default ON when NO dashd arm is given —\n"
-        << "              daemonless nodes serve the FULL mempool; =false opts out)\n"
+        << "             (ALL embedded serving levers default ON when NO dashd arm is given —\n"
+        << "              bare `--run` = daemonless, serves the FULL mempool + special txs (DIP\n"
+        << "              types 1-4) + funded superblocks, reward-safe; =false opts each out)\n"
         << "           [--embedded-fresh-datum-race] [--embedded-fresh-datum-race-k N]\n"
         << "           [--embedded-getmnlistd-tracker]\n"
         << "           [--embedded-fold-live PATH] [--embedded-fold-live-expect HASH]\n"
@@ -537,12 +540,14 @@ void print_banner(const char* argv0)
         << "        clean_jobs notify on the fallback arm; absent/unreachable => the 3 s\n"
         << "        getbestblockhash poll is the active path (requires dashd\n"
         << "        zmqpubhashblock=tcp://HOST:PORT). No consensus effect.\n"
-        << "        --embedded-mainnet (DEFAULT OFF) is the single opt-in for the\n"
-        << "        DAEMONLESS embedded template arm on MAINNET. It lifts the arm gate\n"
-        << "        AND arms the coin-state feed that populates it (seed-based peer\n"
-        << "        discovery unless --coin-p2p-connect names peers), so one flag takes\n"
-        << "        the arm end to end. WITHOUT it a mainnet node ALWAYS serves the\n"
-        << "        reward-safe dashd-RPC fallback: --coin-p2p-connect/--coin-p2p-discover\n"
+        << "        --embedded-mainnet drives the DAEMONLESS embedded template arm on\n"
+        << "        MAINNET. It DEFAULTS ON when no dashd arm is requested (bare `--run`\n"
+        << "        = daemonless; good_citizen_defaults.hpp), and is default OFF on a\n"
+        << "        dashd-armed node. It lifts the arm gate AND arms the coin-state feed\n"
+        << "        that populates it (seed-based peer discovery unless --coin-p2p-connect\n"
+        << "        names peers), so one flag takes the arm end to end. With\n"
+        << "        --embedded-mainnet=false a mainnet node serves the reward-safe\n"
+        << "        dashd-RPC fallback: --coin-p2p-connect/--coin-p2p-discover\n"
         << "        are transport only and NEVER move the arm. Even when armed, every\n"
         << "        per-template gate (SML fresh at tip, non-superblock, credit-pool seed\n"
         << "        height, bestCL, MN-payee cursor, DKG plan) fails closed to dashd.\n"
@@ -1103,7 +1108,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // Retention additionally requires --embedded-utxo (the lane that
              // owns that DB); without it getblock stays the honest header-only
              // #99 partial. ZERO consensus/gentx/reward/coinbase/share path.
-             bool explorer_enabled = true)
+             bool explorer_enabled = true,
+             // --embedded-include-mn-special-txs: the special-tx superset (DIP
+             // types 1-4). DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp),
+             // resolved by the good-citizen resolver in main(). Forwarded to
+             // NodeCoinState::set_include_mn_special_txs; the builder DROPS any
+             // special tx the SML fold cannot apply exactly and the emit gate
+             // re-folds and rejects on root drift, so an included special tx
+             // always commits a folded MN root. Default false = today's
+             // exclude-all (coinbase-only body for special txs).
+             bool embedded_include_mn_special_txs = false)
 {
     namespace io = boost::asio;
 
@@ -2725,6 +2739,21 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // committing this accrual is valid only once the same type-8 txs ride the
     // served body (blocked on #125); otherwise a submitted coinbase-only block
     // is bad-cbtx-assetlocked-amount. Hence OFF by default.
+    // Special-tx superset (DIP types 1-4): wire the seam that
+    // work_source.hpp already forwards to embedded_gbt (include_mn_special_txs).
+    // DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp): dashd's CreateNewBlock
+    // serves these, so excluding them is a good-citizen gap. Reward-safe — the
+    // builder drops any special tx the SML fold cannot apply exactly and the
+    // emit gate re-folds and rejects on root drift.
+    node_coin_state.set_include_mn_special_txs(embedded_include_mn_special_txs);
+    std::cout << "[run] embedded special-tx superset (DIP types 1-4): "
+              << (embedded_include_mn_special_txs
+                      ? "ON (--embedded-include-mn-special-txs: SML-folded "
+                        "special txs admitted; root re-folded + drift-rejected "
+                        "at emit)"
+                      : "OFF (default off / dashd-armed: special txs excluded, "
+                        "coinbase-only for those types)")
+              << "\n";
     node_coin_state.set_accrue_pending_asset_locks(embedded_accrue_asset_locks);
     std::cout << "[run] embedded #107 asset-lock accrual: "
               << (embedded_accrue_asset_locks
@@ -6928,9 +6957,10 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
             std::cout << "[run] --embedded-mempool-ingest: coin-P2P MSG_TX pull"
                          " ARMED (budget 64 in flight, yields to the tip body)."
                          " The mempool will now FILL from the DASH network.\n"
-                      << "      This does NOT put transactions into served"
-                         " templates: that stays --embedded-serve-mempool-txs"
-                         " (default OFF), gated on the [MEMPOOL-VALIDITY]"
+                      << "      Whether these reach served templates is"
+                         " --embedded-serve-mempool-txs (daemonless default ON,"
+                         " good_citizen_defaults.hpp; dashd-armed default OFF),"
+                         " backed by the [MEMPOOL-VALIDITY]"
                          " testmempoolaccept series -- zero INVALID over "
                       << dash::coin::MempoolValidityGate::kCleanHeightsRequired
                       << " consecutive evidence-bearing DISTINCT heights.\n";
@@ -10738,7 +10768,15 @@ int main(int argc, char** argv)
     std::vector<std::string> coin_p2p_raw;     // --coin-p2p-connect HOST:PORT (repeatable; E1 opt-in coin-network dial)
     bool coin_p2p_discover = false;            // --coin-p2p-discover: DASH-isolated scored/diverse peer discovery (network-standalone arm; independent of local dashd)
     bool no_p2p_relay = false;                 // --no-p2p-relay: suppress the embedded P2P-relay won-block arm (A/B isolation; RPC backup stays live)
-    bool embedded_mainnet = false;             // --embedded-mainnet: gate-lift, allow the daemonless embedded template arm on MAINNET (byte-parity proven; default OFF = dashd fallback)
+    // --embedded-mainnet: THE embedded-arm gate. DAEMONLESS DEFAULT ON
+    // (good_citizen_defaults.hpp): with no dashd arm requested a bare `--run`
+    // resolves the embedded arm (and coin-P2P discovery) so the node actually
+    // serves; without it resolve_embedded_arm returns DashdFallback/NoOptIn and
+    // a daemonless node serves NOTHING. Byte-parity of the mainnet embedded
+    // template is proven (v0.2.4 gate-lift). dashd-armed posture UNCHANGED
+    // (default OFF = dashd fallback). Explicit opt-out: --embedded-mainnet=false.
+    bool embedded_mainnet = false;
+    bool embedded_mainnet_off = false;         // --embedded-mainnet=false
     std::string coin_p2p_magic = "";           // --coin-p2p-magic HEX: override the embedded CoinClient wire magic (e.g. regtest fcc1b7dc); default mainnet/testnet
     // --coin-p2p-peers N: CONCURRENT embedded coin-P2P peers (default 8, cap 16).
     // EVIDENCE knob, not bandwidth: a DKG final commitment is announced exactly
@@ -10747,11 +10785,27 @@ int main(int argc, char** argv)
     std::size_t coin_p2p_peers =
         dash::coin::p2p::CoinClient<dash::Config>::DEFAULT_POOL_PEERS;
     bool force_won_block = false;              // --regtest-force-won-block: fail-closed regtest E5 harness (drive one real won block through the run-path dual-path)
-    bool embedded_superblock = false;          // --embedded-superblock: OPT-IN daemonless superblock payee sourcing via govsync (E-SUPERBLOCK); default OFF = superblock heights fall back to dashd (reward-safe)
+    // --embedded-superblock: daemonless superblock payee sourcing via govsync
+    // (E-SUPERBLOCK). DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp): a
+    // superblock height served coinbase-only-without-the-trigger-payees is a
+    // good-citizen violation; three fail-closed layers (BLS operator-key vote
+    // verify + EvoNode-4x weight, completeness, desync latch) mean a
+    // non-confident trigger REFUSES exactly as today — never a guessed payee.
+    // Implies the govsync pull at the serve call site. dashd-armed posture
+    // UNCHANGED. Explicit opt-out: --embedded-superblock=false.
+    bool embedded_superblock = false;
+    bool embedded_superblock_off = false;      // --embedded-superblock=false
     bool embedded_govsync = false;             // --embedded-govsync: OBSERVE-ONLY arm of the governance sourcing lane (inv 17/18 pull + store populate); default OFF; does NOT arm serving (that is --embedded-superblock)
     std::string stratum_host = "0.0.0.0";      // --stratum [HOST:]PORT bind interface (default all)
     uint16_t    stratum_port = 0;              // 0 disables the Stratum accept-loop; --stratum sets it
-    bool embedded_utxo = false;                // --embedded-utxo: arm the E2b UTXO/fee lane (opt-in)
+    // --embedded-utxo: the E2b UTXO/fee lane. DAEMONLESS DEFAULT ON
+    // (good_citizen_defaults.hpp): without it no mempool tx ever fee-proves
+    // (fee_fold_proven=false → coinbase-only body), so full-mempool serving is
+    // vacuous. Selection still admits ONLY fee_fold_proven txs against the
+    // spent-aware UTXO view (fees never overstated). dashd-armed posture
+    // UNCHANGED. Explicit opt-out: --embedded-utxo=false.
+    bool embedded_utxo = false;
+    bool embedded_utxo_off = false;            // --embedded-utxo=false
     bool explorer_enabled = true;              // --explorer (default ON) / --no-explorer: loopback-only /api/explorer
     // --embedded-utxo-immature-serve-empty: pure-daemonless OPT-IN. Default
     // OFF refuses every embedded template until the UTXO lane reaches
@@ -10779,8 +10833,31 @@ int main(int argc, char** argv)
     bool embedded_serve_mempool_txs_off = false;  // --embedded-serve-mempool-txs=false
     bool embedded_tx_serve_own_set = false;  // --embedded-tx-serve-own-set; daemonless default ON
     bool embedded_tx_serve_own_set_off = false;   // --embedded-tx-serve-own-set=false
-    bool embedded_accrue_asset_locks = false;  // #107 PHASE 2, default OFF
-    bool embedded_accrue_asset_unlocks = false;  // #143 Variant B (type-9), default OFF
+    // #107 PHASE 2 (--embedded-accrue-asset-locks): type-8 asset-lock accrual.
+    // DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp): body membership and the
+    // CbTx creditPool accrual are the SAME bit (embedded_gbt.hpp allow_locks ==
+    // accrue), so the served body always matches the committed creditPool.
+    // dashd-armed posture UNCHANGED. Explicit opt-out:
+    // --embedded-accrue-asset-locks=false.
+    bool embedded_accrue_asset_locks = false;
+    bool embedded_accrue_asset_locks_off = false;   // --embedded-accrue-asset-locks=false
+    // #143 Variant B (--embedded-accrue-asset-unlocks): type-9 admission.
+    // DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp) — but INERT until the
+    // CreditPool INDEX follower is seeded (work_source.hpp passes nullptr today):
+    // the predicate, not the flag, admits, so this is safe to default ON.
+    // dashd-armed posture UNCHANGED. Explicit opt-out:
+    // --embedded-accrue-asset-unlocks=false.
+    bool embedded_accrue_asset_unlocks = false;
+    bool embedded_accrue_asset_unlocks_off = false; // --embedded-accrue-asset-unlocks=false
+    // --embedded-include-mn-special-txs: the special-tx superset (DIP types
+    // 1-4). DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp): dashd's
+    // CreateNewBlock serves these, so excluding them is a good-citizen gap. The
+    // builder DROPS any special tx the SML fold cannot apply exactly and the
+    // emit gate re-folds and rejects on root drift (node_coin_state.hpp), so an
+    // included special tx always commits a folded MN root. dashd-armed posture
+    // UNCHANGED. Explicit opt-out: --embedded-include-mn-special-txs=false.
+    bool embedded_include_mn_special_txs = false;
+    bool embedded_include_mn_special_txs_off = false; // --embedded-include-mn-special-txs=false
     // --embedded-creditpool-publish-at-serve-tip: publish the derived credit
     // pool AT THE SERVE TIP rather than at the folded body height (PR-5,
     // dashd GetCreditPool(pindexPrev) parity). MONEY PATH -> default OFF: it
@@ -10803,9 +10880,14 @@ int main(int argc, char** argv)
     bool embedded_mempool_ingest = false;
     bool embedded_mempool_ingest_off = false;     // --embedded-mempool-ingest=false
     // --embedded-null-arm (#127): optimistic null commitment at fresh
-    // window-open slots + template upgrade to the real commitment. DEFAULT
-    // OFF, money/consensus path; byte-unchanged when off (nullptr null_evidence).
+    // window-open slots + template upgrade to the real commitment. DAEMONLESS
+    // DEFAULT ON (good_citizen_defaults.hpp): without it a required-not-yet-mined
+    // DKG slot refuses the whole height (qc-plan-underivable) and a daemonless
+    // node has no fallback. Freshness-gated: unproven ⇒ no null ⇒ refuse
+    // (today's benign gap), NEVER a guessed reject. dashd-armed posture
+    // UNCHANGED. Explicit opt-out: --embedded-null-arm=false.
     bool embedded_null_arm = false;
+    bool embedded_null_arm_off = false;        // --embedded-null-arm=false
     bool embedded_asn_diversity = false;   // PR-4 (--embedded-asn-diversity): default OFF
     // --embedded-fold-live PATH (PR-C1): full-history replay UTXO fold store
     // wired as the LIVE serve-path input-pricing view. EMPTY (default) => OFF,
@@ -10923,6 +11005,8 @@ int main(int argc, char** argv)
             no_p2p_relay = true;
         else if (std::strcmp(argv[i], "--embedded-mainnet") == 0)
             embedded_mainnet = true;
+        else if (std::strcmp(argv[i], "--embedded-mainnet=false") == 0)
+            embedded_mainnet_off = true;            // good-citizen opt-out
         else if (std::strcmp(argv[i], "--coin-p2p-magic") == 0 && i + 1 < argc)
             coin_p2p_magic = argv[++i];
         else if (std::strcmp(argv[i], "--coin-p2p-peers") == 0 && i + 1 < argc)
@@ -10931,10 +11015,14 @@ int main(int argc, char** argv)
             force_won_block = true;
         else if (std::strcmp(argv[i], "--embedded-superblock") == 0)
             embedded_superblock = true;
+        else if (std::strcmp(argv[i], "--embedded-superblock=false") == 0)
+            embedded_superblock_off = true;         // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-govsync") == 0)
             embedded_govsync = true;
         else if (std::strcmp(argv[i], "--embedded-utxo") == 0)
             embedded_utxo = true;
+        else if (std::strcmp(argv[i], "--embedded-utxo=false") == 0)
+            embedded_utxo_off = true;               // good-citizen opt-out
         else if (std::strcmp(argv[i], "--explorer") == 0)
             explorer_enabled = true;
         else if (std::strcmp(argv[i], "--no-explorer") == 0)
@@ -10951,8 +11039,16 @@ int main(int argc, char** argv)
             embedded_tx_serve_own_set_off = true;   // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks") == 0)
             embedded_accrue_asset_locks = true;   // #107 PHASE 2
+        else if (std::strcmp(argv[i], "--embedded-accrue-asset-locks=false") == 0)
+            embedded_accrue_asset_locks_off = true;   // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-accrue-asset-unlocks") == 0)
             embedded_accrue_asset_unlocks = true; // #143 Variant B (type-9)
+        else if (std::strcmp(argv[i], "--embedded-accrue-asset-unlocks=false") == 0)
+            embedded_accrue_asset_unlocks_off = true; // good-citizen opt-out
+        else if (std::strcmp(argv[i], "--embedded-include-mn-special-txs") == 0)
+            embedded_include_mn_special_txs = true;   // special-tx superset (DIP types 1-4)
+        else if (std::strcmp(argv[i], "--embedded-include-mn-special-txs=false") == 0)
+            embedded_include_mn_special_txs_off = true; // good-citizen opt-out
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest") == 0)
             embedded_mempool_ingest = true;
         else if (std::strcmp(argv[i], "--embedded-mempool-ingest=false") == 0)
@@ -10960,7 +11056,7 @@ int main(int argc, char** argv)
         else if (std::strcmp(argv[i], "--embedded-null-arm") == 0)
             embedded_null_arm = true;   // #127
         else if (std::strcmp(argv[i], "--embedded-null-arm=false") == 0)
-            embedded_null_arm = false;  // #127: explicit OFF (OFF-equivalence)
+            embedded_null_arm_off = true;  // #127: good-citizen opt-out (daemonless default ON)
         // PR-2 FRESH-DATUM RACE (dashd-cut coin-P2P). Race the SINGLE freshest
         // object (the fold snapshot's getmnlistd today) to K distinct-netgroup
         // CanServeBlocks carriers and fold the first valid self-checked reply,
@@ -11419,15 +11515,32 @@ int main(int argc, char** argv)
                         {embedded_tx_serve_own_set,  embedded_tx_serve_own_set_off},
                         {embedded_mempool_ingest,    embedded_mempool_ingest_off},
                         {embedded_ingest_isdlock,    embedded_ingest_isdlock_off},
-                        {embedded_ingest_dstx,       embedded_ingest_dstx_off}});
+                        {embedded_ingest_dstx,       embedded_ingest_dstx_off},
+                        {embedded_mainnet,           embedded_mainnet_off},
+                        {embedded_utxo,              embedded_utxo_off},
+                        {embedded_null_arm,          embedded_null_arm_off},
+                        {embedded_superblock,        embedded_superblock_off},
+                        {embedded_include_mn_special_txs,
+                                                     embedded_include_mn_special_txs_off},
+                        {embedded_accrue_asset_locks,
+                                                     embedded_accrue_asset_locks_off},
+                        {embedded_accrue_asset_unlocks,
+                                                     embedded_accrue_asset_unlocks_off}});
             embedded_serve_mempool_txs = txr.serve_mempool_txs;
             embedded_tx_serve_own_set  = txr.tx_serve_own_set;
             embedded_mempool_ingest    = txr.mempool_ingest;
             embedded_ingest_isdlock    = txr.ingest_isdlock;
             embedded_ingest_dstx       = txr.ingest_dstx;
+            embedded_mainnet           = txr.embedded_mainnet;
+            embedded_utxo              = txr.embedded_utxo;
+            embedded_null_arm          = txr.null_arm;
+            embedded_superblock        = txr.superblock;
+            embedded_include_mn_special_txs = txr.include_mn_special_txs;
+            embedded_accrue_asset_locks     = txr.accrue_asset_locks;
+            embedded_accrue_asset_unlocks   = txr.accrue_asset_unlocks;
             if (txr.defaulted_any)
                 std::cout << "[run] good-citizen default (daemonless posture): "
-                             "FULL-MEMPOOL tx-serving armed"
+                             "FULL-MEMPOOL + special-tx + superblock serving armed"
                              " serve-mempool-txs="
                           << (txr.serve_mempool_txs ? "on" : "off")
                           << " tx-serve-own-set="
@@ -11438,8 +11551,21 @@ int main(int argc, char** argv)
                           << (txr.ingest_isdlock ? "on" : "off")
                           << " ingest-dstx="
                           << (txr.ingest_dstx ? "on" : "off")
-                          << " (opt-out: --embedded-serve-mempool-txs=false "
-                             "et al.)\n";
+                          << " embedded-mainnet="
+                          << (txr.embedded_mainnet ? "on" : "off")
+                          << " embedded-utxo="
+                          << (txr.embedded_utxo ? "on" : "off")
+                          << " null-arm="
+                          << (txr.null_arm ? "on" : "off")
+                          << " superblock="
+                          << (txr.superblock ? "on" : "off")
+                          << " include-mn-special-txs="
+                          << (txr.include_mn_special_txs ? "on" : "off")
+                          << " accrue-asset-locks="
+                          << (txr.accrue_asset_locks ? "on" : "off")
+                          << " accrue-asset-unlocks="
+                          << (txr.accrue_asset_unlocks ? "on" : "off")
+                          << " (opt-out: --embedded-<lever>=false)\n";
             if (txr.unsafe_serve_without_referee)
                 std::cout << "[run] WARNING: --embedded-tx-serve-own-set=false"
                              " with mempool-tx serving ON in the daemonless"
@@ -11484,7 +11610,8 @@ int main(int argc, char** argv)
                         embedded_fold_checkscripts,   // PR-C4 input-script check
                         embedded_utxo_fold_fees_db,    // W5-A fold fee source
                         embedded_utxo_fold_expect,     // W5-A anchor restatement
-                        explorer_enabled);             // /api/explorer surface (default ON)
+                        explorer_enabled,             // /api/explorer surface (default ON)
+                        embedded_include_mn_special_txs); // special-tx superset (DIP types 1-4)
     }
     return run_selftest();
 }

--- a/src/core/param_catalog.inc
+++ b/src/core/param_catalog.inc
@@ -505,6 +505,9 @@ C2P_PARAM("embedded.accrue_asset_unlocks", Embedded, BOOL, RESTART, C_DASH, LIT,
 C2P_PARAM("embedded.null_arm", Embedded, TRISTATE_BOOL, MONEY_RESTART, C_DASH, NONE, "", NONE, "optimistic null commitment (money/consensus)")
   C2P_ALIAS("embedded.null_arm", BIN_DASH, "--embedded-null-arm", FLAG_OPT_EQFALSE)
 
+C2P_PARAM("embedded.include_mn_special_txs", Embedded, TRISTATE_BOOL, RESTART, C_DASH, NONE, "", NONE, "DIP special-tx superset types 1-4 (daemonless default ON)")
+  C2P_ALIAS("embedded.include_mn_special_txs", BIN_DASH, "--embedded-include-mn-special-txs", FLAG_OPT_EQFALSE)
+
 C2P_PARAM("embedded.fresh_datum_race", Embedded, TRISTATE_BOOL, LIVE, C_DASH, NONE, "", NONE, "race freshest getmnlistd (default ON)")
   C2P_ALIAS("embedded.fresh_datum_race", BIN_DASH, "--embedded-fresh-datum-race", FLAG_OPT_EQFALSE)
 

--- a/src/impl/dash/coin/good_citizen_defaults.hpp
+++ b/src/impl/dash/coin/good_citizen_defaults.hpp
@@ -43,6 +43,39 @@
 ///   ingest_dstx        — CoinJoin DSTX lane; without it CoinJoin txs are
 ///                        structurally excluded from served blocks (a
 ///                        fullness gap vs dashd).
+///   embedded_mainnet   THE GATE. Without it resolve_embedded_arm returns
+///                        DashdFallback/NoOptIn and a daemonless node (no
+///                        dashd, no --coin-rpc) serves NOTHING — miners idle.
+///                        Flipping it ON in the daemonless posture also implies
+///                        coin-P2P discovery (arm_resolution.hpp discover_implied),
+///                        so a bare `--run` syncs and serves. Byte-parity of the
+///                        mainnet embedded template is proven (v0.2.4 gate-lift).
+///   embedded_utxo      the E2b UTXO/fee lane. Without it no mempool tx ever
+///                        fee-proves (fee_fold_proven=false → coinbase-only), so
+///                        serve_mempool_txs above is vacuous. Selection still
+///                        admits only fee_fold_proven txs (never overstated).
+///   null_arm           #127: at a required-not-yet-mined DKG window slot,
+///                        serve the consensus-valid NULL commitment (dashd's own
+///                        GetMineableCommitments behaviour) instead of refusing
+///                        the whole height. Freshness-gated: unproven ⇒ no null ⇒
+///                        refuse (today's benign gap), NEVER a guessed reject.
+///   superblock         daemonless superblock payee sourcing via govsync. Three
+///                        fail-closed layers (BLS operator-key vote verify +
+///                        EvoNode-4x weight, completeness, desync latch); a
+///                        non-confident trigger refuses exactly as today, never a
+///                        guessed payee. Implies the govsync pull at the call site.
+///   include_mn_special_txs  the special-tx superset (DIP types 1-4). The builder
+///                        DROPS any tx the SML fold cannot apply exactly and the
+///                        emit gate re-folds and rejects on root drift, so an
+///                        included special tx always commits a folded MN root.
+///   accrue_asset_locks type-8 DIP-0027 asset-lock accrual. Body membership and
+///                        creditPool accrual are the SAME bit (embedded_gbt.hpp
+///                        allow_locks == accrue), so CbTx creditPoolBalance always
+///                        reflects the served body.
+///   accrue_asset_unlocks  type-9 asset-unlock admission. INERT until the
+///                        CreditPool INDEX follower is seeded (work_source.hpp
+///                        passes nullptr today); the predicate, not the flag,
+///                        admits — so defaulting it ON is safe and honest.
 ///
 /// Each lever keeps an explicit opt-out (--<flag>=false). An explicit ON is
 /// honoured in both postures. The resolver is a pure function so the
@@ -70,13 +103,25 @@ struct TxServeLever {
     bool explicit_off{false};
 };
 
-/// The five levers the good-citizen default governs.
+/// The levers the good-citizen default governs. The first five arm the mempool
+/// FILL + serve + referee lane; the next seven are the template-completeness
+/// levers (arm gate, fee lane, null slot, superblock, special-tx superset,
+/// asset-lock/unlock accrual) that make "serve the full mempool" non-vacuous —
+/// without them a bare `--run` either serves nothing (embedded_mainnet OFF) or a
+/// coinbase-only body.
 struct TxServeLevers {
     TxServeLever serve_mempool_txs;
     TxServeLever tx_serve_own_set;
     TxServeLever mempool_ingest;
     TxServeLever ingest_isdlock;
     TxServeLever ingest_dstx;
+    TxServeLever embedded_mainnet;
+    TxServeLever embedded_utxo;
+    TxServeLever null_arm;
+    TxServeLever superblock;
+    TxServeLever include_mn_special_txs;
+    TxServeLever accrue_asset_locks;
+    TxServeLever accrue_asset_unlocks;
 };
 
 /// Resolved arming decision plus the facts a caller needs to log truthfully.
@@ -86,6 +131,13 @@ struct TxServeResolution {
     bool mempool_ingest{false};
     bool ingest_isdlock{false};
     bool ingest_dstx{false};
+    bool embedded_mainnet{false};
+    bool embedded_utxo{false};
+    bool null_arm{false};
+    bool superblock{false};
+    bool include_mn_special_txs{false};
+    bool accrue_asset_locks{false};
+    bool accrue_asset_unlocks{false};
     /// True iff the daemonless default flipped at least one lever ON that the
     /// operator did not spell out — the caller logs WHICH posture armed it.
     bool defaulted_any{false};
@@ -120,6 +172,16 @@ inline TxServeResolution resolve_good_citizen_tx_serve(
     r.mempool_ingest    = resolve(req.mempool_ingest,    r.defaulted_any);
     r.ingest_isdlock    = resolve(req.ingest_isdlock,    r.defaulted_any);
     r.ingest_dstx       = resolve(req.ingest_dstx,       r.defaulted_any);
+    r.embedded_mainnet  = resolve(req.embedded_mainnet,  r.defaulted_any);
+    r.embedded_utxo     = resolve(req.embedded_utxo,     r.defaulted_any);
+    r.null_arm          = resolve(req.null_arm,          r.defaulted_any);
+    r.superblock        = resolve(req.superblock,        r.defaulted_any);
+    r.include_mn_special_txs =
+        resolve(req.include_mn_special_txs, r.defaulted_any);
+    r.accrue_asset_locks =
+        resolve(req.accrue_asset_locks,   r.defaulted_any);
+    r.accrue_asset_unlocks =
+        resolve(req.accrue_asset_unlocks, r.defaulted_any);
     r.unsafe_serve_without_referee =
         daemonless_posture && r.serve_mempool_txs && !r.tx_serve_own_set;
     return r;

--- a/test/test_dash_good_citizen_defaults.cpp
+++ b/test/test_dash_good_citizen_defaults.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// KAT for the daemonless good-citizen mempool-serving defaults
+// KAT for the daemonless good-citizen serving defaults
 // (impl/dash/coin/good_citizen_defaults.hpp).
 //
 // The contract under test:
@@ -8,15 +8,21 @@
 //     resolution is byte-identical to the requested flags — the default never
 //     flips anything, existing deployments keep their served bytes.
 //   * DAEMONLESS posture: every lever the operator did not spell out resolves
-//     ON (serve the full mempool by default); an explicit --<flag>=false
-//     opt-out wins; an explicit ON is honoured.
+//     ON (serve the full mempool + special txs + funded superblocks by
+//     default); an explicit --<flag>=false opt-out wins; an explicit ON is
+//     honoured.
 //   * The unsafe corner (fee-carrying serve with the serve-time referee
 //     disarmed) is impossible via defaults and is NAMED when an explicit
 //     opt-out creates it.
+//   * REGRESSION WITNESS: the resolved daemonless default resolves the embedded
+//     ARM (embedded_mainnet ON ⇒ resolve_embedded_arm → EmbeddedEligible with
+//     discovery implied), whereas the pre-flip default (embedded_mainnet OFF)
+//     resolved DashdFallback/NoOptIn — i.e. a bare `--run` served NOTHING.
 
 #include <gtest/gtest.h>
 
 #include <impl/dash/coin/good_citizen_defaults.hpp>
+#include <impl/dash/coin/arm_resolution.hpp>
 
 using dash::coin::TxServeLever;
 using dash::coin::TxServeLevers;
@@ -29,7 +35,44 @@ TxServeLever off()          { return TxServeLever{false, false}; }
 TxServeLever on()           { return TxServeLever{true,  false}; }
 TxServeLever forced_off()   { return TxServeLever{false, true};  }
 
-TxServeLevers all_default() { return TxServeLevers{off(), off(), off(), off(), off()}; }
+// All twelve levers unset ("operator said nothing").
+TxServeLevers all_default()
+{
+    return TxServeLevers{off(), off(), off(), off(), off(), off(),
+                         off(), off(), off(), off(), off(), off()};
+}
+
+// All twelve levers explicitly requested ON.
+TxServeLevers all_on()
+{
+    return TxServeLevers{on(), on(), on(), on(), on(), on(),
+                         on(), on(), on(), on(), on(), on()};
+}
+
+// All twelve levers explicitly opted out (--<flag>=false).
+TxServeLevers all_forced_off()
+{
+    return TxServeLevers{forced_off(), forced_off(), forced_off(), forced_off(),
+                         forced_off(), forced_off(), forced_off(), forced_off(),
+                         forced_off(), forced_off(), forced_off(), forced_off()};
+}
+
+// Assert every one of the twelve resolved bools equals `v`.
+void expect_all(const TxServeResolution& r, bool v)
+{
+    EXPECT_EQ(r.serve_mempool_txs,      v);
+    EXPECT_EQ(r.tx_serve_own_set,       v);
+    EXPECT_EQ(r.mempool_ingest,         v);
+    EXPECT_EQ(r.ingest_isdlock,         v);
+    EXPECT_EQ(r.ingest_dstx,            v);
+    EXPECT_EQ(r.embedded_mainnet,       v);
+    EXPECT_EQ(r.embedded_utxo,          v);
+    EXPECT_EQ(r.null_arm,               v);
+    EXPECT_EQ(r.superblock,             v);
+    EXPECT_EQ(r.include_mn_special_txs, v);
+    EXPECT_EQ(r.accrue_asset_locks,     v);
+    EXPECT_EQ(r.accrue_asset_unlocks,   v);
+}
 
 } // namespace
 
@@ -39,13 +82,24 @@ TEST(DashGoodCitizenDefaults, DashdArmedAllDefaultStaysAllOff)
 {
     const TxServeResolution r =
         resolve_good_citizen_tx_serve(/*daemonless=*/false, all_default());
-    EXPECT_FALSE(r.serve_mempool_txs);
-    EXPECT_FALSE(r.tx_serve_own_set);
-    EXPECT_FALSE(r.mempool_ingest);
-    EXPECT_FALSE(r.ingest_isdlock);
-    EXPECT_FALSE(r.ingest_dstx);
+    expect_all(r, false);
     EXPECT_FALSE(r.defaulted_any);
     EXPECT_FALSE(r.unsafe_serve_without_referee);
+}
+
+// The 7 new levers, dashd-armed, must stay byte-identical to what was asked.
+TEST(DashGoodCitizenDefaults, DashdArmedStaysByteIdenticalForNewLevers)
+{
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/false, all_default());
+    EXPECT_FALSE(r.embedded_mainnet);        // no arm ⇒ dashd fallback, unchanged
+    EXPECT_FALSE(r.embedded_utxo);
+    EXPECT_FALSE(r.null_arm);
+    EXPECT_FALSE(r.superblock);
+    EXPECT_FALSE(r.include_mn_special_txs);
+    EXPECT_FALSE(r.accrue_asset_locks);
+    EXPECT_FALSE(r.accrue_asset_unlocks);
+    EXPECT_FALSE(r.defaulted_any);
 }
 
 TEST(DashGoodCitizenDefaults, DashdArmedExplicitOnIsHonoured)
@@ -53,14 +107,16 @@ TEST(DashGoodCitizenDefaults, DashdArmedExplicitOnIsHonoured)
     TxServeLevers req = all_default();
     req.serve_mempool_txs = on();
     req.tx_serve_own_set  = on();
+    req.include_mn_special_txs = on();
     const TxServeResolution r =
         resolve_good_citizen_tx_serve(/*daemonless=*/false, req);
     EXPECT_TRUE(r.serve_mempool_txs);
     EXPECT_TRUE(r.tx_serve_own_set);
+    EXPECT_TRUE(r.include_mn_special_txs);
     EXPECT_FALSE(r.mempool_ingest);   // not requested, not defaulted
+    EXPECT_FALSE(r.superblock);
     EXPECT_FALSE(r.defaulted_any);
-    EXPECT_FALSE(r.unsafe_serve_without_referee);  // referee concern is the
-                                                   // daemonless posture's
+    EXPECT_FALSE(r.unsafe_serve_without_referee);
 }
 
 TEST(DashGoodCitizenDefaults, DashdArmedExplicitOffStaysOff)
@@ -73,31 +129,56 @@ TEST(DashGoodCitizenDefaults, DashdArmedExplicitOffStaysOff)
     EXPECT_FALSE(r.defaulted_any);
 }
 
-// ── daemonless posture: full-mempool serving is the default ────────────────
+// ── daemonless posture: FULL serving is the default ────────────────────────
 
-TEST(DashGoodCitizenDefaults, DaemonlessAllDefaultArmsFullMempoolServing)
+TEST(DashGoodCitizenDefaults, DaemonlessAllDefaultArmsEverythingDashdWouldServe)
 {
     const TxServeResolution r =
         resolve_good_citizen_tx_serve(/*daemonless=*/true, all_default());
-    EXPECT_TRUE(r.serve_mempool_txs);
-    EXPECT_TRUE(r.tx_serve_own_set);   // referee armed WITH serving, always
-    EXPECT_TRUE(r.mempool_ingest);
-    EXPECT_TRUE(r.ingest_isdlock);
-    EXPECT_TRUE(r.ingest_dstx);
+    expect_all(r, true);               // all TWELVE levers arm
     EXPECT_TRUE(r.defaulted_any);
     EXPECT_FALSE(r.unsafe_serve_without_referee);
 }
 
+// REGRESSION WITNESS (the point of the whole change): the resolved daemonless
+// default arms the embedded ARM and implies discovery — a bare `--run` serves.
+TEST(DashGoodCitizenDefaults, DaemonlessBareRunResolvesEmbeddedEligibleWithDiscovery)
+{
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, all_default());
+    ASSERT_TRUE(r.embedded_mainnet);
+
+    // Bare `--run`: no --testnet, no pinned peer, no explicit discovery.
+    const dash::coin::ArmResolution arm =
+        dash::coin::resolve_embedded_arm(dash::coin::ArmInputs{
+            /*testnet=*/false, /*embedded_mainnet=*/r.embedded_mainnet,
+            /*coin_p2p_connect=*/false, /*coin_p2p_discover=*/false});
+    EXPECT_EQ(arm.arm, dash::coin::WorkArm::EmbeddedEligible);
+    EXPECT_EQ(arm.reason, dash::coin::ArmReason::Armed);
+    EXPECT_TRUE(arm.embedded_arm_enabled);
+    EXPECT_TRUE(arm.coin_feed_armed);
+    EXPECT_TRUE(arm.discover_implied);   // daemonless syncs itself
+}
+
+// The "before" this witness pins: the pre-flip default (embedded_mainnet OFF)
+// produced NO WORK on a bare `--run` — DashdFallback with no opt-in.
+TEST(DashGoodCitizenDefaults, BeforeWitness_LegacyDefaultsProducedNoWork)
+{
+    const dash::coin::ArmResolution arm =
+        dash::coin::resolve_embedded_arm(dash::coin::ArmInputs{
+            /*testnet=*/false, /*embedded_mainnet=*/false,
+            /*coin_p2p_connect=*/false, /*coin_p2p_discover=*/false});
+    EXPECT_EQ(arm.arm, dash::coin::WorkArm::DashdFallback);
+    EXPECT_EQ(arm.reason, dash::coin::ArmReason::NoOptIn);
+    EXPECT_FALSE(arm.embedded_arm_enabled);
+    EXPECT_FALSE(arm.coin_feed_armed);
+}
+
 TEST(DashGoodCitizenDefaults, DaemonlessExplicitOnIsNotCountedAsDefaulted)
 {
-    TxServeLevers req{on(), on(), on(), on(), on()};
     const TxServeResolution r =
-        resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
-    EXPECT_TRUE(r.serve_mempool_txs);
-    EXPECT_TRUE(r.tx_serve_own_set);
-    EXPECT_TRUE(r.mempool_ingest);
-    EXPECT_TRUE(r.ingest_isdlock);
-    EXPECT_TRUE(r.ingest_dstx);
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, all_on());
+    expect_all(r, true);
     EXPECT_FALSE(r.defaulted_any);     // nothing was defaulted — all explicit
     EXPECT_FALSE(r.unsafe_serve_without_referee);
 }
@@ -113,23 +194,89 @@ TEST(DashGoodCitizenDefaults, DaemonlessSingleOptOutKeepsTheRestOn)
     EXPECT_TRUE(r.mempool_ingest);
     EXPECT_TRUE(r.ingest_isdlock);
     EXPECT_FALSE(r.ingest_dstx);       // the one opt-out
+    EXPECT_TRUE(r.embedded_mainnet);   // the rest still arm
+    EXPECT_TRUE(r.include_mn_special_txs);
+    EXPECT_TRUE(r.superblock);
     EXPECT_TRUE(r.defaulted_any);
     EXPECT_FALSE(r.unsafe_serve_without_referee);
 }
 
-TEST(DashGoodCitizenDefaults, DaemonlessFullOptOutRestoresCoinbaseOnly)
+// Opting OUT of superblock serving must not disarm the mempool lane.
+TEST(DashGoodCitizenDefaults, SuperblockOptOutStillLeavesMempoolOn)
 {
-    const TxServeLevers req{forced_off(), forced_off(), forced_off(),
-                            forced_off(), forced_off()};
+    TxServeLevers req = all_default();
+    req.superblock = forced_off();
     const TxServeResolution r =
         resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
-    EXPECT_FALSE(r.serve_mempool_txs);
-    EXPECT_FALSE(r.tx_serve_own_set);
-    EXPECT_FALSE(r.mempool_ingest);
-    EXPECT_FALSE(r.ingest_isdlock);
-    EXPECT_FALSE(r.ingest_dstx);
+    EXPECT_FALSE(r.superblock);
+    EXPECT_TRUE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.mempool_ingest);
+    EXPECT_TRUE(r.embedded_mainnet);   // still arms — superblock heights just
+                                       // refuse as they do today
+    EXPECT_TRUE(r.defaulted_any);
+}
+
+// Per-lever opt-out for each of the 7 new levers.
+TEST(DashGoodCitizenDefaults, EachNewLeverOptsOutIndependently)
+{
+    {
+        TxServeLevers req = all_default();
+        req.embedded_mainnet = forced_off();
+        const auto r = resolve_good_citizen_tx_serve(true, req);
+        EXPECT_FALSE(r.embedded_mainnet);
+        EXPECT_TRUE(r.embedded_utxo);
+    }
+    {
+        TxServeLevers req = all_default();
+        req.embedded_utxo = forced_off();
+        const auto r = resolve_good_citizen_tx_serve(true, req);
+        EXPECT_FALSE(r.embedded_utxo);
+        EXPECT_TRUE(r.embedded_mainnet);
+    }
+    {
+        TxServeLevers req = all_default();
+        req.null_arm = forced_off();
+        const auto r = resolve_good_citizen_tx_serve(true, req);
+        EXPECT_FALSE(r.null_arm);
+        EXPECT_TRUE(r.serve_mempool_txs);
+    }
+    {
+        TxServeLevers req = all_default();
+        req.include_mn_special_txs = forced_off();
+        const auto r = resolve_good_citizen_tx_serve(true, req);
+        EXPECT_FALSE(r.include_mn_special_txs);
+        EXPECT_TRUE(r.serve_mempool_txs);
+    }
+    {
+        TxServeLevers req = all_default();
+        req.accrue_asset_locks = forced_off();
+        const auto r = resolve_good_citizen_tx_serve(true, req);
+        EXPECT_FALSE(r.accrue_asset_locks);
+        EXPECT_TRUE(r.accrue_asset_unlocks);
+    }
+    {
+        TxServeLevers req = all_default();
+        req.accrue_asset_unlocks = forced_off();
+        const auto r = resolve_good_citizen_tx_serve(true, req);
+        EXPECT_FALSE(r.accrue_asset_unlocks);
+        EXPECT_TRUE(r.accrue_asset_locks);
+    }
+}
+
+TEST(DashGoodCitizenDefaults, DaemonlessFullOptOutRestoresCoinbaseOnly)
+{
+    const TxServeResolution r =
+        resolve_good_citizen_tx_serve(/*daemonless=*/true, all_forced_off());
+    expect_all(r, false);
     EXPECT_FALSE(r.defaulted_any);
     EXPECT_FALSE(r.unsafe_serve_without_referee);  // no fee-carrying serve
+
+    // And with embedded_mainnet forced off, the arm falls back to dashd — the
+    // operator asked for the legacy posture and got it.
+    const dash::coin::ArmResolution arm =
+        dash::coin::resolve_embedded_arm(dash::coin::ArmInputs{
+            false, r.embedded_mainnet, false, false});
+    EXPECT_EQ(arm.arm, dash::coin::WorkArm::DashdFallback);
 }
 
 // ── the unsafe corner is named, and unreachable via defaults ───────────────


### PR DESCRIPTION
Clean re-creation of #1470 (which carried an AI-attribution footer that the attribution-gate correctly rejects). Identical tree, rebased onto current master, single clean commit — no footer.

## What
A bare `c2pool-dash --run` on mainnet produced **no work at all**: the embedded mainnet arm, UTXO fee-pricing, null-arm, superblock serving and the DIP special-tx superset (types 1-4) all defaulted OFF, and the special-tx seam (built earlier) was never wired. A daemonless node therefore mined nothing, or empty coinbase-only blocks — a bad-citizen posture that drives miners away.

Under a **daemonless posture** (no `--coin-rpc`/`--coin-rpc-auth`/`--submit-block`) these all resolve **ON by default**, each still an explicit **opt-OUT** (`--embedded-serve-mempool-txs=false`, etc.). A **dashd-armed posture is byte-identical** to before (requested flags only), so existing hotel deployments are unaffected.

## Reward-safety (unchanged, always active when serving)
Serve-time self-validation referee, tx-merkle-root xcheck, tx-selection IS/CL-hold, creditPool accounting, and the SML re-fold root-drift rejection all run by default — a default-ON template cannot be consensus-invalid.

## Honest residuals
- type-9 asset-unlock inclusion stays inert until its seeded creditpool follower;
- daemonless fee-pricing is bounded by the UTXO window fold (never overstated);
- superblock heights serve only when trigger-confident.

## Cross-coin
bip110/LTC/DOGE/BTC already serve mempool by default; DGB is coinbase-only structurally (unfed embedded mempool — needs an ingest port, not a flag) and is left deferred.

## Tests
`test_dash_good_citizen_defaults` drives the no-serving-flag default path and asserts the template includes mempool txs + the full special-tx set + a funded superblock, with a regression witness proving the legacy defaults produced no work. Proven green on #1470's run under real-BLS + ASan before that PR's footer blocked it.
