### PR TITLE
bip110: make peer-discovery KAT deterministic + hermetic (fix warm-runner flake)

### DIFF
--- a/src/impl/bip110/coin/coin_peer_manager.hpp
+++ b/src/impl/bip110/coin/coin_peer_manager.hpp
@@ -240,6 +240,15 @@ struct BtcPeerManagerConfig
     int         max_peers_per_group{4};         // max peers from same /16 (IPv4) or /32 (IPv6)
     int         max_new_peers_per_group{3};     // stricter limit for unverified (new) peers
     int         anchor_count{2};                // number of anchor connections to persist
+
+    // Address-manager bucket key (SipHash k0/k1). Left (0,0) in production
+    // so CoinAddrMan seeds a per-node RANDOM key -> bucket placement is
+    // unpredictable (anti-Sybil). Tests set a fixed non-zero key to make
+    // bucketing deterministic: CoinAddrMan::add() drops a fresh addr that
+    // collides into an occupied new-slot, so 'N distinct groups -> N banked'
+    // holds only PROBABILISTICALLY under a random key. See coin_addrman.hpp.
+    uint64_t    addrman_key0{0};
+    uint64_t    addrman_key1{0};
 };
 
 // ─── BtcCoinPeerManager ──────────────────────────────────────────────────────
@@ -262,6 +271,7 @@ public:
         , m_fixed_seed_timer(ioc)
         , m_http_seed_timer(ioc)
         , m_emergency_timer(ioc)
+        , m_addrman(config.addrman_key0, config.addrman_key1)
     {
     }
 

--- a/src/impl/bip110/coin/test/bip110_peer_discovery_kat.cpp
+++ b/src/impl/bip110/coin/test/bip110_peer_discovery_kat.cpp
@@ -27,6 +27,8 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <cstdlib>       // ::mkdtemp
+#include <filesystem>    // std::filesystem::remove_all
 
 #include <boost/asio/io_context.hpp>
 
@@ -70,6 +72,45 @@ btc_addr_record_t make_rec(uint64_t services, uint32_t ts, const NetService& ep)
     r.m_endpoint  = ep;
     return r;
 }
+
+// Per-invocation unique data dir. Each BtcCoinPeerManager persists addrman +
+// working-set JSON into its data_dir on teardown (~mgr -> stop -> save_peers).
+// A fixed shared /tmp path let a warm runner reuse leftover files and, under
+// ctest -j, let concurrent runs write the same tree; mkdtemp isolates every
+// invocation and remove_all reclaims it on scope exit (RAII also covers the
+// CHECK-failure path). NOTE: path isolation is hygiene, NOT the flake fix --
+// see KAT_ADDRMAN_K* below.
+struct KatTempDir {
+    std::string path;
+    explicit KatTempDir(const char* stem)
+    {
+        auto tmpl = (std::filesystem::temp_directory_path() /
+                     (std::string(stem) + "_XXXXXX")).string();
+        std::vector<char> buf(tmpl.begin(), tmpl.end());
+        buf.push_back('\0');
+        const char* made = ::mkdtemp(buf.data());
+        if (!made) { std::cerr << "mkdtemp failed for " << tmpl << "\n"; std::abort(); }
+        path = made;
+    }
+    ~KatTempDir()
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(path, ec);
+    }
+    KatTempDir(const KatTempDir&) = delete;
+    KatTempDir& operator=(const KatTempDir&) = delete;
+};
+
+// THE FLAKE FIX. CoinAddrMan(0,0) seeds its SipHash bucket key from
+// std::random_device, so which new-table slot each address lands in varies
+// run to run. When two fresh distinct-group addrs happen to collide into one
+// occupied slot, add() drops the newcomer (coin_addrman.hpp: erase_new_entry
+// -> return false), so the banked count comes up one short. Measured ~1/300
+// even sequentially with a freshly cleaned dir -> the shared /tmp path is NOT
+// the cause. A fixed non-zero key makes bucketing deterministic; this value
+// is arbitrary but verified collision-free for every set the KAT banks.
+constexpr uint64_t KAT_ADDRMAN_K0 = 0x0123456789abcdefULL;
+constexpr uint64_t KAT_ADDRMAN_K1 = 0xfedcba9876543210ULL;
 
 int g_failures = 0;
 #define CHECK(cond) do { if (!(cond)) { \
@@ -170,7 +211,10 @@ void t3_ingest_bucket_tried_plan()
     boost::asio::io_context ioc;
     BtcPeerManagerConfig cfg;
     cfg.valid_ports = { 8333, 9333 };
-    BtcCoinPeerManager mgr(ioc, "BIP110", "/tmp/bip110_peerdisc_kat", cfg);
+    cfg.addrman_key0 = KAT_ADDRMAN_K0;
+    cfg.addrman_key1 = KAT_ADDRMAN_K1;
+    KatTempDir tmp("bip110_peerdisc_kat");
+    BtcCoinPeerManager mgr(ioc, "BIP110", tmp.path, cfg);
 
     // A single fork peer gossiped by the oracle enters the bucketed addrman.
     const NetService peer("8.8.8.8", 8333);
@@ -208,7 +252,10 @@ void t4_oracle_bootstraps_many()
     BtcPeerManagerConfig cfg;
     cfg.valid_ports = { 8333, 9333 };
     cfg.max_peers = 64;
-    BtcCoinPeerManager mgr(ioc, "BIP110", "/tmp/bip110_peerdisc_kat_e2e", cfg);
+    cfg.addrman_key0 = KAT_ADDRMAN_K0;
+    cfg.addrman_key1 = KAT_ADDRMAN_K1;
+    KatTempDir tmp("bip110_peerdisc_kat_e2e");
+    BtcCoinPeerManager mgr(ioc, "BIP110", tmp.path, cfg);
 
     const int64_t now = static_cast<int64_t>(core::timestamp());
 
@@ -270,7 +317,10 @@ void t5_self_auth_directory_and_count()
     BtcPeerManagerConfig cfg;
     cfg.valid_ports = { 8333, 9333 };
     cfg.max_peers = 64;
-    BtcCoinPeerManager mgr(ioc, "BIP110", "/tmp/bip110_peerdisc_kat_t5", cfg);
+    cfg.addrman_key0 = KAT_ADDRMAN_K0;
+    cfg.addrman_key1 = KAT_ADDRMAN_K1;
+    KatTempDir tmp("bip110_peerdisc_kat_t5");
+    BtcCoinPeerManager mgr(ioc, "BIP110", tmp.path, cfg);
 
     // (a) Self-authenticated add: on a completed NODE_BLAKE2B handshake, NodeP2P
     // calls m_addr_callback({target}, target). main wires that to


### PR DESCRIPTION
## What

Makes `bip110_peer_discovery_kat` deterministic and hermetic. It flaked on
warm CI runners and blocked #1467 at merge (rerun cleared it).

## Root cause (verified empirically — not the /tmp path)

The symptom pointed at the KAT's three fixed `/tmp/bip110_peerdisc_kat*`
paths. That is **not** the cause:

- The KAT never calls `BtcCoinPeerManager::start()`, so it never loads any
  persisted state — a warm runner's leftover files are never read.
- Real cause: `CoinAddrMan(0, 0)` — the default the KAT's manager builds —
  seeds its SipHash bucket key from `std::random_device`
  (`src/core/coin_addrman.hpp:217-227`), so each address's new-table slot
  changes every run. When two fresh, distinct `/16`-group addresses hash
  into the same occupied slot, `add()` drops the newcomer
  (`erase_new_entry -> return false`). T4's `addrman().size() == 10u` then
  intermittently reads 9.
- **Measured: 1 failure / 300 runs run strictly sequentially, each with a
  freshly cleaned dir** (zero possible cross-run contamination). That rules
  the shared path out. It shows up more on warm runners only because
  `ctest -j` runs more instances, not because of leftover files.

## Fix

- Add optional `addrman_key0 / addrman_key1` to `BtcPeerManagerConfig`,
  default `(0,0)` so **production keeps its per-node random key unchanged**
  (anti-Sybil), and seed `m_addrman` from them. The KAT sets a fixed
  non-zero key so bucket placement is deterministic and the banked-count
  assertions are reproducible. *(The `add()`-drop path for fresh distinct
  addrs is a pure function of the key — no `m_rng` involved — so a fixed
  key fully determinizes it.)*
- Replace the three fixed `/tmp` paths with a per-invocation `mkdtemp` dir
  torn down via `remove_all` on scope exit (RAII, covering the
  `CHECK`-failure path). This is hygiene the reporter asked for and matches
  the `::getpid()` pattern every other bip110 KAT already uses — but it is
  not what fixes the flake.

Diff is confined to the `src/impl/bip110/coin` tree; `bip110_peer_discovery_kat`
is an existing allowlisted target (no new `add_executable`).

## Verification

- **Before:** 1 fail / 300 sequential clean runs; fails under parallel load.
- **After:** 0 fail / 500 sequential warm (no clean between runs) + 160
  parallel (`8×20`, no clean).
- Reporter's acceptance — `ctest -R bip110_peer_discovery_kat` twice
  back-to-back in the same tree, no clean: both green; no `/tmp` residue
  left behind.
- `c2pool-bip110` production target builds clean with the config change.
