### PR TITLE
ci: proto-harness lane (load-bearing proto/ goldens) + widen NOT_BUILT drift guard

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -20,6 +20,11 @@ jobs:
   param-catalog-tripwire:
     uses: ./.github/workflows/param-catalog-tripwire.yml
     secrets: inherit
+  # proto/ Python harness corpus: exit + stamp + golden-drift gates. Cheap
+  # (seconds, stdlib-only) so it runs on every PR to master, unconditionally.
+  proto-harness:
+    uses: ./.github/workflows/proto-harness.yml
+    secrets: inherit
   coin-matrix:
     uses: ./.github/workflows/coin-matrix.yml
     secrets: inherit
@@ -44,7 +49,7 @@ jobs:
 
   aggregate:
     name: aggregate
-    needs: [param-catalog-tripwire, coin-matrix, dash-g1, dash-g3a, dgb-phase-b, bch-g3a, bch-g3b, btc-daemonless-smoke]
+    needs: [param-catalog-tripwire, proto-harness, coin-matrix, dash-g1, dash-g3a, dgb-phase-b, bch-g3a, bch-g3b, btc-daemonless-smoke]
     if: always()
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/proto-harness.yml
+++ b/.github/workflows/proto-harness.yml
@@ -1,0 +1,59 @@
+name: proto-harness
+
+# Truth-in-CI guard for the proto/ Python harness corpus (the six conformance
+# harnesses + decay golden from PR #1465). No workflow referenced proto/, so
+# the pinned goldens (rev3-falsifiers 3692d922, p3-testbed bc2b5c84,
+# p5-integration 328a292b, p4-messaging 61ea15ed/8839b966, p3-overlay
+# d0d49556, refimpl decay d659c801, payment-hardening real-block replay) were
+# INERT: a PR that broke a harness rendered green. This lane runs every entry
+# point via tools/ci/run_proto_harnesses.py and fails on a non-zero exit, a
+# stamp/digest mismatch against its pin or committed .sha256, or any change
+# to a committed golden after the run (git diff). Python twin of
+# libmrr-go.yml (issue #1076). Prototypes-only, stdlib-only, seconds to run:
+# zero load on any coin lane, so it runs unconditionally (no path filter)
+# when called from ci-required.yml.
+#
+# Not covered on purpose: proto/payment-hardening/hmin-dust-anchor-longitudinal.py
+# needs the ~94 MB uncommitted data/longitudinal/blocks.json.
+
+on:
+  push:
+    branches:
+      - master
+      - v37-dev
+      - 'ci-steward/**'
+    paths:
+      - 'proto/**'
+      - 'tools/ci/run_proto_harnesses.py'
+      - '.github/workflows/proto-harness.yml'
+  workflow_call:      # required-but-skip-tolerant job in ci-required.yml
+
+permissions:
+  contents: read
+
+env:
+  # Match the fleet fail-fast-on-stalled-fetch convention (see pplns-parse-seedpin.yml).
+  GIT_HTTP_LOW_SPEED_LIMIT: '1000'
+  GIT_HTTP_LOW_SPEED_TIME: '20'
+
+jobs:
+  proto-harness:
+    name: proto harness corpus
+    # Self-hosted for trusted events; fork PRs fall back to GitHub-hosted
+    # (never run untrusted fork code self-hosted) -- the libmrr-go.yml pattern.
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Run proto harness corpus (exit + stamp + golden-drift gates)
+        run: python3 tools/ci/run_proto_harnesses.py
+
+      # Steady-state disk hygiene on the self-hosted runners (same as the
+      # build.yml no-build guard jobs). Always runs; no-op on GitHub-hosted.
+      - name: Prune runner workspace
+        if: always()
+        uses: ./.github/actions/prune-runner-workspace

--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,9 @@ tools/dash/*
 # W0 loopback simnet harness (Track A2) — tracked source: launches the
 # c2pool-v37 >= 8-process mesh and asserts the W0 exit criteria.
 !tools/v37_simnet.sh
+# tools/ci/ is tracked CI source (the test-target drift guard and the
+# proto-harness driver), not build output.
+!tools/ci/
 
 # CMake out-of-source build trees (any name starting with `build-`).
 # Catches build-spv/, build-qt/, build-relwithdebinfo/, etc.

--- a/tools/ci/check_test_target_allowlist.py
+++ b/tools/ci/check_test_target_allowlist.py
@@ -9,10 +9,15 @@
 #
 # Scope: per-coin test trees (src/impl/<coin>/test/), the sharechain engine
 # trees (src/sharechain/**/test/ -- both src/sharechain/test/ and
-# src/sharechain/<module>/test/), the shared core test tree (src/core/test/)
+# src/sharechain/<module>/test/), the c2pool consumer-side trees
+# (src/c2pool/**/test/ -- e.g. src/c2pool/v37/test/, where the v37 node
+# scaffold lands its unit test), the shared core test tree (src/core/test/)
 # and the top-level test/ tree. The sharechain + core trees were previously
 # unaudited, so a standalone add_executable there could land NOT_BUILT-silent
 # (the coverage gap that let PR #1467's src/sharechain/v37/test/ go unguarded).
+# The c2pool tree is the same surface: PR #1477 (W0 node scaffold) adds
+# src/c2pool/v37/test/v37_scaffold_test, which this glob now audits so a future
+# add_test there missing from build.yml fails closed instead of hollow-greening.
 #
 # Escape hatch: a target intentionally NOT built in CI (e.g. a compile-only TU
 # or a live-only harness) must be declared explicitly with a comment line:
@@ -32,6 +37,11 @@ COIN_GLOB = os.path.join(REPO, "src", "impl", "*", "test", "CMakeLists.txt")
 # code there. Recursive on sharechain so src/sharechain/test/ (no module
 # directory) and src/sharechain/<module>/test/ are both audited.
 SHARECHAIN_GLOB = os.path.join(REPO, "src", "sharechain", "**", "test", "CMakeLists.txt")
+# The c2pool consumer-side trees are the same NOT_BUILT surface: the v37 node
+# scaffold (PR #1477) lands its unit test under src/c2pool/v37/test/. Recursive
+# so src/c2pool/test/ (no module directory) and src/c2pool/<module>/test/ are
+# both audited.
+C2POOL_GLOB = os.path.join(REPO, "src", "c2pool", "**", "test", "CMakeLists.txt")
 CORE_TEST = os.path.join(REPO, "src", "core", "test", "CMakeLists.txt")
 # The top-level shared test tree is ALSO a NOT_BUILT surface: a standalone
 # add_executable here that is missing from build.yml is silently "Not Run"
@@ -119,9 +129,11 @@ def parse_coin_targets(path):
 
 def audited_roots():
     """Every test CMakeLists.txt the guard polices, deduplicated, in a stable
-    order: per-coin trees, sharechain engine trees, core, then top-level."""
+    order: per-coin trees, sharechain engine trees, c2pool consumer trees,
+    core, then top-level."""
     roots = sorted(glob.glob(COIN_GLOB))
     roots += sorted(glob.glob(SHARECHAIN_GLOB, recursive=True))
+    roots += sorted(glob.glob(C2POOL_GLOB, recursive=True))
     if os.path.exists(CORE_TEST):
         roots.append(CORE_TEST)
     if os.path.exists(TOP_LEVEL_TEST):

--- a/tools/ci/check_test_target_allowlist.py
+++ b/tools/ci/check_test_target_allowlist.py
@@ -7,10 +7,12 @@
 # master in the DGB #137 / test_dgb_subsidy regression. This guard fails closed
 # on that drift so it is caught at PR time, not after merge.
 #
-# Scope: per-coin (src/impl/*/test) and per-sharechain (src/sharechain/*/test)
-# test trees, plus the singleton shared trees test/ and src/core/test. Widened
-# from per-coin-only 2026-09-04 (#1467 post-mortem) -- a missing target under
-# any of these paths is the same silent NOT_BUILT trap.
+# Scope: per-coin test trees (src/impl/<coin>/test/), the sharechain engine
+# trees (src/sharechain/**/test/ -- both src/sharechain/test/ and
+# src/sharechain/<module>/test/), the shared core test tree (src/core/test/)
+# and the top-level test/ tree. The sharechain + core trees were previously
+# unaudited, so a standalone add_executable there could land NOT_BUILT-silent
+# (the coverage gap that let PR #1467's src/sharechain/v37/test/ go unguarded).
 #
 # Escape hatch: a target intentionally NOT built in CI (e.g. a compile-only TU
 # or a live-only harness) must be declared explicitly with a comment line:
@@ -24,19 +26,18 @@ import glob
 
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 BUILD_YML = os.path.join(REPO, ".github", "workflows", "build.yml")
-# Globbed per-parent test trees: <parent>/*/test/CMakeLists.txt.
 COIN_GLOB = os.path.join(REPO, "src", "impl", "*", "test", "CMakeLists.txt")
-SHARECHAIN_GLOB = os.path.join(REPO, "src", "sharechain", "*", "test", "CMakeLists.txt")
-GLOB_ROOTS = (COIN_GLOB, SHARECHAIN_GLOB)
-# Singleton shared test trees are ALSO a NOT_BUILT surface: a standalone
+# The sharechain engine trees and the shared core test tree are the same
+# NOT_BUILT surface as the coin trees, and the v37 engine work lands its test
+# code there. Recursive on sharechain so src/sharechain/test/ (no module
+# directory) and src/sharechain/<module>/test/ are both audited.
+SHARECHAIN_GLOB = os.path.join(REPO, "src", "sharechain", "**", "test", "CMakeLists.txt")
+CORE_TEST = os.path.join(REPO, "src", "core", "test", "CMakeLists.txt")
+# The top-level shared test tree is ALSO a NOT_BUILT surface: a standalone
 # add_executable here that is missing from build.yml is silently "Not Run"
 # too (this is why targets get hand-folded into allowlisted executables to
-# dodge the trap). Audit them with the same fail-closed rule. Widened
-# 2026-09-04 (#1467 post-mortem) to src/core/test alongside top-level test/.
-SINGLETON_TESTS = (
-    os.path.join(REPO, "test", "CMakeLists.txt"),
-    os.path.join(REPO, "src", "core", "test", "CMakeLists.txt"),
-)
+# dodge the trap). Audit it with the same fail-closed rule.
+TOP_LEVEL_TEST = os.path.join(REPO, "test", "CMakeLists.txt")
 
 
 def strip_comment(line):
@@ -116,17 +117,28 @@ def parse_coin_targets(path):
     return targets
 
 
+def audited_roots():
+    """Every test CMakeLists.txt the guard polices, deduplicated, in a stable
+    order: per-coin trees, sharechain engine trees, core, then top-level."""
+    roots = sorted(glob.glob(COIN_GLOB))
+    roots += sorted(glob.glob(SHARECHAIN_GLOB, recursive=True))
+    if os.path.exists(CORE_TEST):
+        roots.append(CORE_TEST)
+    if os.path.exists(TOP_LEVEL_TEST):
+        roots.append(TOP_LEVEL_TEST)
+    seen = set()
+    return [r for r in roots if not (r in seen or seen.add(r))]
+
+
 def main():
     allowlist = build_yml_targets(BUILD_YML)
     violations = []
     audited = 0
-    roots = []
-    for g in GLOB_ROOTS:
-        roots.extend(sorted(glob.glob(g)))
-    roots.extend(p for p in SINGLETON_TESTS if os.path.exists(p))
+    roots = audited_roots()
     for cml in roots:
-        # Label: coin name for a per-coin tree (src/impl/<coin>/test/...),
-        # "test/" for the shared top-level tree.
+        # Label: coin/module name for a src/ tree (src/impl/<coin>/test/,
+        # src/sharechain/<module>/test/, src/core/test/), "test/" for the
+        # shared top-level tree.
         rel = os.path.relpath(cml, REPO)
         coin = cml.split(os.sep)[-3] if rel.startswith("src" + os.sep) else "test/"
         with open(cml) as f:
@@ -138,14 +150,14 @@ def main():
             violations.append((coin, tgt, cml))
 
     if violations:
-        print("CI drift-guard FAILED: coin test target(s) missing from "
+        print("CI drift-guard FAILED: test target(s) missing from "
               ".github/workflows/build.yml --target allowlist (NOT_BUILT risk):\n")
         for coin, tgt, cml in violations:
             print("  [%s] %s  (declared in %s)"
                   % (coin, tgt, os.path.relpath(cml, REPO)))
         print("\nFix: add the target to the relevant build.yml --target list, "
               "or declare it '# ci-allowlist-exempt: <target>  -- <reason>' in "
-              "the coin test CMakeLists.txt.")
+              "that test CMakeLists.txt.")
         return 1
 
     print("CI drift-guard OK: %d test target(s) across %d test tree(s) "

--- a/tools/ci/run_proto_harnesses.py
+++ b/tools/ci/run_proto_harnesses.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Truth-in-CI driver for the proto/ harness corpus (the six conformance
+# harnesses + the decay golden that landed via PR #1465). Until this lane
+# existed no workflow referenced proto/, so the pinned goldens were inert: a
+# PR that broke a harness rendered green. This driver runs every harness entry
+# point and FAILS on
+#   (a) a non-zero exit from any harness,
+#   (b) a printed stamp / digest that differs from its pin or its committed
+#       .sha256 file,
+#   (c) a regenerated golden file whose sha256 differs from its pin, and
+#   (d) -- authoritatively -- any change to a committed file under proto/
+#       after the harnesses have run (`git diff --exit-code -- proto/`).
+# (d) matters because most harnesses REWRITE their golden/*.json on the green
+# path and two of them (p3-testbed, p3-overlay) do not fail their own exit
+# code on a golden change, so "trust the exit code" is insufficient.
+#
+# The A2 C++ bring-up diffs the engine against these goldens; an unguarded
+# oracle is no oracle. Python twin of libmrr-go.yml (issue #1076).
+#
+# stdlib-only; no pip deps. The harnesses are deterministic (fixed seeds, no
+# wall-clock). The proto/payment-hardening longitudinal script needs the
+# ~94 MB uncommitted data/longitudinal/blocks.json and is deliberately NOT
+# part of this lane (see proto/payment-hardening/README.md).
+#
+# Run locally:  python3 tools/ci/run_proto_harnesses.py
+
+import os
+import re
+import subprocess
+import sys
+import hashlib
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+PROTO = os.path.join(ROOT, "proto")
+
+HEX64 = r"([0-9a-f]{64})"
+
+# Each entry: (slice dir under proto/, argv relative to that dir, checks).
+# checks keys:
+#   stamp_re   -- regex with one HEX64 group; the LAST match in stdout is the stamp
+#   pin        -- expected stamp (full sha256 hex)
+#   digest_file-- committed <slice>/<file>; first field is the expected stamp
+#   file_sha256-- (relative path, expected sha256) of a golden the harness
+#                 regenerates; checked after the run
+HARNESSES = [
+    # rev3 AT-REPAIR/SPINE/BROADCAST acceptance harness: 75/75 checks.
+    ("rev3-falsifiers", ["harness/run_all.py"], {
+        "stamp_re": r"golden sha256 " + HEX64,
+        "pin": "3692d922af75b61bc3d40b431e0c048ee5ed0412b093c05911294b3ec5af4efe",
+    }),
+    # P3 multichain settlement testbed: 18 rows, main() does not fail its own
+    # exit on golden drift, so the pin + git diff carry the gate.
+    ("p3-testbed", ["harness/scenarios.py"], {
+        "stamp_re": r"suite stamp = " + HEX64,
+        "pin": "bc2b5c84390a6c07630f1a6aee1f9ee40d513caec133e746c7f2b8490d87d6db",
+    }),
+    # P5 port/adapter composition scaffold: 5 E2E rows.
+    ("p5-integration", ["harness/scenarios.py"], {
+        "stamp_re": r"P5 suite stamp: " + HEX64,
+        "pin": "328a292b0162b31b64dea4ffc5a8decfe7e56e2780d850611a7593348ff2098e",
+    }),
+    # refimpl MRR accumulator + K_fair settlement goldens: self-checking
+    # (P/D/F/G/V properties), rewrite golden/*.json; drift caught by git diff.
+    ("refimpl", ["gen_golden.py"], {}),
+    ("refimpl", ["gen_golden_settlement.py"], {}),
+    # refimpl canonical decay-table golden. F-1 / OI-7 is UNADJUDICATED (the
+    # decay-table construction contradiction between v37_fixed.hpp
+    # DecayTables::init and the exact-root golden): this entry is a
+    # SELF-CONSISTENCY drift gate only -- does the refimpl still reproduce its
+    # own committed table -- and is NOT a consensus-authority assertion that
+    # d659c801 is canonical. When the integrator rules OI-7, re-pin here and
+    # the committed file together.
+    ("refimpl", ["gen_golden_decaytable.py"], {
+        "file_sha256": ("golden/decay_table_canonical_golden_v1.json",
+                        "d659c801a2544672e383c2a6ae6c68047c574d0cb212d3140794ca1f3b5b1349"),
+    }),
+    # P4 perishable-receipt admission core (slice 1) and TTL-as-decayed-work
+    # (slice 2): print a digest, never rewrite the committed .sha256, and do
+    # not fail on digest drift while invariants pass -- so compare here.
+    ("p4-messaging", ["harness/run_p4.py"], {
+        "stamp_re": r"golden-digest sha256: " + HEX64,
+        "digest_file": "golden/p4-slice1.sha256",
+    }),
+    ("p4-messaging", ["harness/run_p4_slice2.py"], {
+        "stamp_re": r"golden-digest sha256: " + HEX64,
+        "digest_file": "golden/p4-slice2.sha256",
+    }),
+    # P3-F1 KEYED_CRDT overlay commutativity (P3-12): prints a stamp only, no
+    # committed golden file, so the pin is the whole gate.
+    ("p3-overlay", ["harness/p3f1_overlay_commutativity.py"], {
+        "stamp_re": r"GOLDEN VECTOR sha256: " + HEX64,
+        "pin": "d0d495569a4ddd11604d8cdd119b590e17e527d8499b26bfaf8b1176a0c32ac8",
+    }),
+    # Real-block 955609 h_min replay over committed data/coinbase.json:
+    # in-script assertions, exit code is the gate.
+    ("payment-hardening", ["realblock-955609-replay.py"], {}),
+]
+
+
+def run(slice_dir, argv):
+    cwd = os.path.join(PROTO, slice_dir)
+    p = subprocess.run([sys.executable] + argv, cwd=cwd,
+                       capture_output=True, text=True)
+    sys.stdout.write(p.stdout)
+    sys.stderr.write(p.stderr)
+    return p.returncode, p.stdout
+
+
+def last_match(pattern, out):
+    hits = re.findall(pattern, out)
+    return hits[-1] if hits else None
+
+
+def sha256_of(path):
+    with open(path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def main():
+    fails = []
+    ran = 0
+    for slice_dir, argv, checks in HARNESSES:
+        label = "proto/%s/%s" % (slice_dir, argv[0])
+        print("\n===== %s" % label, flush=True)
+        rc, out = run(slice_dir, argv)
+        ran += 1
+        if rc != 0:
+            fails.append("%s: non-zero exit %d" % (label, rc))
+            continue
+        if "stamp_re" in checks:
+            got = last_match(checks["stamp_re"], out)
+            if got is None:
+                fails.append("%s: no stamp line matched /%s/"
+                             % (label, checks["stamp_re"]))
+            elif "pin" in checks and got != checks["pin"]:
+                fails.append("%s: stamp %s != pinned %s" % (label, got, checks["pin"]))
+            elif "digest_file" in checks:
+                dpath = os.path.join(PROTO, slice_dir, checks["digest_file"])
+                with open(dpath) as f:
+                    want = f.read().split()[0]
+                if got != want:
+                    fails.append("%s: digest %s != committed %s (%s)"
+                                 % (label, got, want, checks["digest_file"]))
+        if "file_sha256" in checks:
+            rel, want = checks["file_sha256"]
+            got = sha256_of(os.path.join(PROTO, slice_dir, rel))
+            if got != want:
+                fails.append("%s: regenerated %s sha256 %s != pinned %s"
+                             % (label, rel, got, want))
+
+    # AUTHORITATIVE drift gate: the writers rewrote their golden/*.json in
+    # place; if any committed byte under proto/ moved, that is a regression or
+    # an unpinned golden change. Untracked files are reported too, so a
+    # harness that starts emitting a new artifact is caught.
+    diff = subprocess.run(["git", "diff", "--exit-code", "--stat", "--", "proto/"],
+                          cwd=ROOT, capture_output=True, text=True)
+    if diff.returncode != 0:
+        sys.stdout.write(diff.stdout)
+        fails.append("committed proto/ golden(s) changed after running the "
+                     "harnesses (regression or unpinned golden); see diff above")
+    untracked = subprocess.run(["git", "ls-files", "--others", "--exclude-standard", "--", "proto/"],
+                               cwd=ROOT, capture_output=True, text=True).stdout.split()
+    if untracked:
+        fails.append("harness run left untracked file(s) under proto/: %s"
+                     % ", ".join(untracked))
+
+    print()
+    if fails:
+        print("PROTO-HARNESS LANE FAILED (%d harness(es) ran):" % ran)
+        for f in fails:
+            print("  - " + f)
+        return 1
+    print("PROTO-HARNESS LANE OK: %d harness entry points green, all pinned "
+          "stamps matched, committed proto/ goldens unchanged." % ran)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**ci-steward lane change — DRAFT for ci-steward review; standing merge-tap applies, no self-merge.**

## What this gates

The proto/ conformance corpus landed via #1465 (the six proto/ harnesses + the decay golden) with **no workflow referencing `proto/`** — every pinned golden was inert, and a PR that broke a harness rendered green. These goldens are the differential oracles the A2 C++ bring-up diffs the engine against; an unguarded oracle is no oracle. Same class as #1076 (the libmrr truth-in-CI gap, closed by `libmrr-go.yml`); this is the Python-side twin.

New `tools/ci/run_proto_harnesses.py` runs every entry point and **fails** on:

- a non-zero exit from any harness;
- a printed stamp that differs from its pin, or from the first field of its committed `.sha256`;
- a regenerated golden file whose sha256 differs from its pin;
- **authoritatively:** any change to a committed file under `proto/` after the run (`git diff --exit-code -- proto/`), plus any untracked file left behind. This gate is required because most harnesses *rewrite* `golden/*.json` on the green path and `p3-testbed` / `p3-overlay` do not fail their own exit on golden drift — "trust the exit code" is insufficient.

## Stamps pinned (all verified live at master `98e11b57`, the #1467 merge)

| entry point | gate | stamp |
|---|---|---|
| `rev3-falsifiers/harness/run_all.py` (75/75 checks) | printed `golden sha256` vs pin | `3692d922…5af4efe` |
| `p3-testbed/harness/scenarios.py` (18 rows) | printed `suite stamp` vs pin | `bc2b5c84…d87d6db` |
| `p5-integration/harness/scenarios.py` (5 rows) | printed `P5 suite stamp` vs pin | `328a292b…8ff2098e` |
| `p4-messaging/harness/run_p4.py` (12/12) | printed digest vs `golden/p4-slice1.sha256` | `61ea15ed…fa64741f` |
| `p4-messaging/harness/run_p4_slice2.py` (9/9) | printed digest vs `golden/p4-slice2.sha256` | `8839b966…cb5ffb86` |
| `p3-overlay/harness/p3f1_overlay_commutativity.py` (P3-12) | printed `GOLDEN VECTOR` vs pin | `d0d49556…a0c32ac8` |
| `refimpl/gen_golden_decaytable.py` | sha256 of regenerated `golden/decay_table_canonical_golden_v1.json` | `d659c801…3b5b1349` |
| `refimpl/gen_golden.py`, `refimpl/gen_golden_settlement.py` | exit + git diff | — |
| `payment-hardening/realblock-955609-replay.py` (block 955609 h_min replay) | exit | — |

Local run on this branch: **10/10 entry points green, all pins matched, `proto/` diff clean.** Negative tests (mutating `p4-slice1.sha256`; perturbing the rev3 stamp payload) each fail the lane with the specific mismatch plus the git-diff trip.

**F-1 / OI-7 caveat (unadjudicated):** the refimpl decay entry is a *self-consistency* drift gate only — it does not assert `d659c801` is the canonical consensus decay base. When the integrator rules OI-7, re-pin the manifest entry and the committed file together.

## Environment

- `actions/setup-python@v5`, `python-version: '3.x'`; harnesses are stdlib-only (json/hashlib/random with fixed seeds, no wall-clock), **no pip install**. Runs in seconds.
- **No Go needed** — `prototypes/libmrr` (Go, go1.22) stays under `libmrr-go.yml`; `proto/**` is Python only. Disjoint lanes.
- Runner: self-hosted for trusted events, `ubuntu-24.04` fallback for fork PRs (the `libmrr-go.yml` ternary; never run untrusted fork code self-hosted). Prune step is a no-op on GitHub-hosted.
- **Deliberately excluded:** `proto/payment-hardening/hmin-dust-anchor-longitudinal.py` needs the ~94 MB uncommitted `data/longitudinal/blocks.json` (the known #1465 blocker) — documented in the workflow header and driver docstring.

## Wiring

- `.github/workflows/proto-harness.yml` — reusable workflow (`workflow_call`) + standalone `push` trigger on `master` / `v37-dev` / `ci-steward/**` path-scoped to `proto/**` and the lane files.
- `.github/workflows/ci-required.yml` — new `proto-harness` job via `uses:`, added to `aggregate.needs`, so it folds into the single required `CI Required / aggregate` context on **every** PR to master (unconditional, no path filter — cheap enough, and the strongest anti-hollow-green posture).

## Drift-guard fix (the #1467-class NOT_BUILT hole)

`tools/ci/check_test_target_allowlist.py` only globbed `src/impl/*/test/CMakeLists.txt` + `test/CMakeLists.txt`. It never audited `src/sharechain/**/test/` or `src/core/test/` — so #1467 (the W1 lane executor) could add test code under `src/sharechain/v37/test/` with no guard that a new `add_executable` there is actually built (the DGB #137 / `test_dgb_subsidy` silent-NOT_BUILT failure mode). Now audited recursively: `src/sharechain/test/`, `src/sharechain/v37/test/`, `src/core/test/`.

**Result today: zero new violations** — `v37_test`, `sharechain_test`, `core_test` (and their folded siblings) are already in the `build.yml` `--target` allowlist. Guard output moves from `246 targets / 6 trees` to **`250 targets / 9 trees OK`**. Pure prophylaxis for A2's upcoming W-step test additions.

Also: `.gitignore` exception `!tools/ci/` so CI source there is tracked by rule (the existing guard had been force-added past `tools/*`).

## Drift-guard: also cover `src/c2pool/**/test/` (W0 #1477 path)

Follow-up to the widening above. The verify on PR **#1477** (W0 node scaffold) showed the sharechain/core widening **still** did not reach `src/c2pool/v37/test/` — where W0's `v37_scaffold_test` lives — so the guard as-shipped would not have caught W0 registering that CTest while omitting it from `build.yml`'s `--target` list (the same NOT_BUILT hollow-green class this PR exists to close). Extended `check_test_target_allowlist.py` with `C2POOL_GLOB = src/c2pool/**/test/CMakeLists.txt` (recursive, identical treatment to the sharechain glob).

**On this branch the result is unchanged (`250 targets / 9 trees OK`, exit 0):** `src/c2pool/v37/` does not exist here — #1477 introduces it — so the new glob matches nothing and adds no violation. The extension is pure prophylaxis for the c2pool consumer tree. (Still no `build.yml` change in this PR; see "Not in scope".)

### Inter-PR ordering (with #1477)

- **#1477 (W0)** supplies BOTH `src/c2pool/v37/test/v37_scaffold_test` AND its matching `build.yml` `--target` entry (Linux x86_64 + ASan/UBSan legs) in a single, self-consistent commit.
- **This PR (#1476)** supplies only the guard's *coverage* of that path.

**The two are order-independent — neither PR alone, nor either merge order, produces a RED:**

- If **#1476 merges first**: master gains the `src/c2pool/**/test/` glob but the tree is still absent → guard matches nothing → green.
- If **#1477 merges first**: master gains the test dir *and its own* `build.yml` entry (self-consistent) → green even under the not-yet-extended guard.
- **Once both land on master the guard actively enforces the path.** Verified against the merged tree: `251 targets / 10 trees` green; deleting the `build.yml` entry flips it RED with `[v37] v37_scaffold_test  (declared in src/c2pool/v37/test/CMakeLists.txt)`, exit 1.

## Not in scope

- No C++ build touched; no `build.yml` change.
- #1068 posture reminder for ci-steward: if A2 uses an intermediate integration branch instead of PRing straight into master, that branch must be added to `build.yml` and `ci-required.yml` trigger lists in the same change.

