### PR TITLE
DGB good-citizen S1: embedded UTXO fee-proof lane (default ON, re-anchor on restart)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -45,6 +45,7 @@
 #include <impl/dgb/coin/embedded_tx_select.hpp>   // make_mempool_tx_source (EmbeddedTxSource)
 #include <impl/dgb/coin/good_citizen_defaults.hpp> // resolve_tx_serve_posture (S1 fee-proof lane arm)
 #include <impl/dgb/coin/header_sample_build.hpp>   // make_header_sample (full_block anchoring SSOT)
+#include <impl/dgb/coin/utxo_accrual.hpp>          // classify_full_block_accrual (restart-liveness re-anchor)
 #include <core/coin/utxo.hpp>                      // core::coin::DGB_LIMITS / DGB_MIN_BLOCKS_TO_KEEP
 #include <core/coin/utxo_view_db.hpp>              // core::coin::UTXOViewDB (embedded UTXO persistence)
 #include <core/coin/utxo_view_cache.hpp>           // core::coin::UTXOViewCache (spent-aware fee view)
@@ -387,14 +388,17 @@ int run_node(const core::CoinParams& params, bool testnet,
     // the selected set into the actually-mined stratum job (merkle branches +
     // BIP141 witness commitment + fee-fold into the coinbase) is the S2
     // follow-on; until it lands a won block is coinbase-only + subsidy-only by
-    // construction regardless of this lane. Default OFF (dormant infra); the
-    // good-citizen default flips ON in the daemonless posture when S2 lands.
+    // construction regardless of this lane. S1 GOOD-CITIZEN DEFAULT: the
+    // fee-proof lane (embedded_utxo) defaults ON so the advisory template is
+    // fee-bearing by default; --embedded-serve-mempool-txs=false opts out. The
+    // S2 job-commit lever stays default OFF (inert until S2 wires the merkle).
     const dgb::coin::TxServePosture tx_serve_posture =
         dgb::coin::resolve_tx_serve_posture(
             dgb::coin::TxServeLevers{
                 /*embedded_utxo    =*/{serve_mempool_txs, serve_mempool_txs_off},
                 /*serve_mempool_txs=*/{serve_mempool_txs, serve_mempool_txs_off}},
-            /*good_citizen_default_on=*/false);
+            /*embedded_utxo_default_on=*/true,       // S1 good-citizen: serve fee-paying mempool
+            /*serve_mempool_txs_default_on=*/false); // S2 job-commit stays opt-out until wired
 
     std::unique_ptr<core::coin::UTXOViewDB>    dgb_utxo_db;
     std::unique_ptr<core::coin::UTXOViewCache> dgb_utxo_cache;
@@ -1030,8 +1034,38 @@ int run_node(const core::CoinParams& params, bool testnet,
 
                 const uint32_t height  = *tip_h;
                 const uint32_t best_h  = dgb_utxo_ptr->get_best_height();
-                if (best_h != 0 && height != best_h + 1)
-                    return;  // gap / reorg -> fail-closed (stop accruing).
+                // Classify the confirmed-tip block against the persisted view
+                // (pure SSOT, utxo_accrual.hpp). RESTART-LIVENESS: best_h is read
+                // back from the view's LevelDB, so after a restart the header
+                // tip is many blocks past best_h+1 -- the pre-fix handler
+                // returned on that forward gap forever and the fee-proof lane
+                // was silently DEAD for the rest of the process. Re-anchor
+                // instead so accrual resumes.
+                switch (dgb::coin::classify_full_block_accrual(best_h, height)) {
+                    case dgb::coin::FullBlockAccrualAction::Connect:
+                        break;  // first anchor or normal +1 extend -> connect.
+                    case dgb::coin::FullBlockAccrualAction::Drop:
+                        return; // reorg / height <= view -> fail-closed hold.
+                    case dgb::coin::FullBlockAccrualAction::ReAnchorThenConnect:
+                        // Forward tip-gap (e.g. restart): wipe the stale view
+                        // (coins from before the gap may have been spent
+                        // on-chain during it -- keeping them could fee-prove an
+                        // already-spent output) and resume accrual with THIS
+                        // block as a fresh anchor. Coverage regrows with uptime
+                        // (accrual-only #145 partial-UTXO model), never
+                        // overstated. Fail-closed if the wipe fails: hold the
+                        // old view, drop this block.
+                        if (!dgb_utxo_ptr->reanchor()) {
+                            LOG_WARNING << "[EMB-DGB] full_block re-anchor FAILED at h="
+                                        << height << " (tip gap, stale best_h=" << best_h
+                                        << ") -- view held, fee-proof lane fail-closed.";
+                            return;
+                        }
+                        LOG_INFO << "[EMB-DGB] full_block re-anchored fee-proof view: tip h="
+                                 << height << " ran past stale best_h=" << best_h
+                                 << " (>1 gap, e.g. restart) -- accrual resumes here.";
+                        break;  // best_height now 0; connect this block as anchor.
+                }
 
                 // DGB txid = sha256d over the non-witness serialization (block
                 // id and prevout keys both use sha256d(no-witness)).
@@ -2748,6 +2782,18 @@ int main(int argc, char** argv)
         if (rc.file_set("sharechain.no_p2p_relay") && rc.get_string("sharechain.no_p2p_relay").value_or("") == "true") no_p2p_relay = true;
         if (rc.file_set("money.redistribute"))       redistribute_spec  = rc.get_string("money.redistribute").value_or(redistribute_spec);
         if (rc.file_set("money.node_owner_address")) node_owner_address = rc.get_string("money.node_owner_address").value_or(node_owner_address);
+        // embedded.serve_mempool_txs (S1 fee-proof lane): a [dgb] settings-file
+        // key arms / opts out of the lane exactly like the --embedded-serve-
+        // mempool-txs CLI flag. CLI (L2) wins over the file (L1): consult the
+        // file only when neither CLI spelling was given.
+        if (!serve_mempool_txs && !serve_mempool_txs_off
+                && rc.file_set("embedded.serve_mempool_txs")) {
+            switch (rc.get_tri("embedded.serve_mempool_txs")) {
+                case cs::TriBool::True:  serve_mempool_txs     = true; break;
+                case cs::TriBool::False: serve_mempool_txs_off = true; break;
+                case cs::TriBool::Unset: break;
+            }
+        }
     }
 
     const core::CoinParams params = dgb::make_coin_params(/*testnet=*/false);

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -43,6 +43,11 @@
 #include <impl/dgb/coin/coin_node.hpp>
 #include <impl/dgb/coin/embedded_coin_node.hpp>
 #include <impl/dgb/coin/embedded_tx_select.hpp>   // make_mempool_tx_source (EmbeddedTxSource)
+#include <impl/dgb/coin/good_citizen_defaults.hpp> // resolve_tx_serve_posture (S1 fee-proof lane arm)
+#include <impl/dgb/coin/header_sample_build.hpp>   // make_header_sample (full_block anchoring SSOT)
+#include <core/coin/utxo.hpp>                      // core::coin::DGB_LIMITS / DGB_MIN_BLOCKS_TO_KEEP
+#include <core/coin/utxo_view_db.hpp>              // core::coin::UTXOViewDB (embedded UTXO persistence)
+#include <core/coin/utxo_view_cache.hpp>           // core::coin::UTXOViewCache (spent-aware fee view)
 #include <impl/dgb/coin/won_block_dispatch.hpp>
 #include <impl/dgb/coin/reconstruct_closure.hpp>  // make_reconstruct_closure_from_template (#280)
 #include <impl/dgb/coin/template_capture.hpp>      // TemplateCapture per-job retain (#300/#271)
@@ -150,7 +155,7 @@ void print_banner(const char* argv0, const core::CoinParams& p)
         << "       [--coin-daemon H:P] [--coin-magic HEX] [--regtest]\n"
         << "       [--regtest-force-won-share] [--no-p2p-relay]\n"
         << "       [--redistribute SPEC] [--node-owner-address ADDR]\n"
-        << "       [--sharechain-port P]\n"
+        << "       [--sharechain-port P] [--embedded-serve-mempool-txs[=true|false]]\n"
         << "       [--data-dir PATH] [--dev-relax-algo-softforks]\n"
         << "       [--coin-p2p-discover]\n\n"
         << "  --data-dir PATH  root all per-instance state here (default ~/.c2pool);\n"
@@ -232,7 +237,13 @@ int run_node(const core::CoinParams& params, bool testnet,
              const std::vector<std::string>& merged_chain_specs = {},
              const std::string& doge_p2p_address = "",
              int doge_p2p_port = 0,
-             bool embedded_doge = false)
+             bool embedded_doge = false,
+             // Embedded UTXO fee-proof lane (S1). serve_mempool_txs = the
+             // positive --embedded-serve-mempool-txs; serve_mempool_txs_off = the
+             // explicit --embedded-serve-mempool-txs=false opt-out. Both false =
+             // operator said nothing (resolver applies the posture default).
+             bool serve_mempool_txs = false,
+             bool serve_mempool_txs_off = false)
 {
     io::io_context ioc;
 
@@ -353,7 +364,61 @@ int run_node(const core::CoinParams& params, bool testnet,
     // embedded port; header_chain is likewise still unfed), so nothing calls
     // add_tx and the pool stays empty until that node lands. The selection
     // below is therefore byte-identical to the subsidy-only #237 baseline today.
-    dgb::coin::Mempool       mempool;
+    //
+    // Constructed with core::coin::DGB_LIMITS (21B*1e8 MoneyRange, 100-block
+    // coinbase maturity) rather than the prior LTC_LIMITS default so the
+    // embedded fee-proof lane below prices DGB txs against DGB's own money
+    // range (LTC's 8.4e15 bound would falsely reject a >84M-DGB output).
+    dgb::coin::Mempool       mempool(core::coin::DGB_LIMITS);
+
+    // ── Embedded UTXO fee-proof lane (S1, --embedded-serve-mempool-txs) ───────
+    // GOOD-CITIZEN: a daemonless DGB node's served template is built ONLY by the
+    // embedded builder (the DGB RPC arm supplies just previousblockhash+bits, no
+    // transactions[]). Without a UTXO view every relayed tx stays fee_known=false
+    // (mempool.hpp compute_fee_locked returns false with no view), so
+    // make_mempool_tx_source selects nothing and the template is coinbase-only.
+    // This lane opens a spent-aware UTXO view and fee-proves each relayed tx
+    // against it (mirror BTC main_btc.cpp / LTC main_ltc.cpp), so the embedded
+    // template becomes FEE-BEARING. Selection admits ONLY fee_known txs (never
+    // overstated). REWARD SAFETY: this lane only makes fees COMPUTABLE for the
+    // advisory GBT template — it does NOT touch the connection coinbase
+    // (subsidy-only) or the won-block merkle (coinbase-only, fail-closed via
+    // won_block_serialize when the job carries no merkle branches). Committing
+    // the selected set into the actually-mined stratum job (merkle branches +
+    // BIP141 witness commitment + fee-fold into the coinbase) is the S2
+    // follow-on; until it lands a won block is coinbase-only + subsidy-only by
+    // construction regardless of this lane. Default OFF (dormant infra); the
+    // good-citizen default flips ON in the daemonless posture when S2 lands.
+    const dgb::coin::TxServePosture tx_serve_posture =
+        dgb::coin::resolve_tx_serve_posture(
+            dgb::coin::TxServeLevers{
+                /*embedded_utxo    =*/{serve_mempool_txs, serve_mempool_txs_off},
+                /*serve_mempool_txs=*/{serve_mempool_txs, serve_mempool_txs_off}},
+            /*good_citizen_default_on=*/false);
+
+    std::unique_ptr<core::coin::UTXOViewDB>    dgb_utxo_db;
+    std::unique_ptr<core::coin::UTXOViewCache> dgb_utxo_cache;
+    if (tx_serve_posture.arm_embedded_utxo) {
+        const std::string utxo_db_path = (net_dir / "utxo_view_db").string();
+        dgb_utxo_db = std::make_unique<core::coin::UTXOViewDB>(utxo_db_path);
+        if (!dgb_utxo_db->open()) {
+            std::cout << "[DGB] WARNING: UTXOViewDB open failed at " << utxo_db_path
+                      << " — embedded fee-proof lane DISABLED (coinbase-only "
+                         "templates), running without UTXO persistence" << std::endl;
+            dgb_utxo_db.reset();
+        } else {
+            dgb_utxo_cache = std::make_unique<core::coin::UTXOViewCache>(dgb_utxo_db.get());
+            mempool.set_utxo(dgb_utxo_cache.get());
+            std::cout << "[DGB] embedded UTXO fee-proof lane ARMED "
+                         "(--embedded-serve-mempool-txs): db=" << utxo_db_path
+                      << " best_height=" << dgb_utxo_cache->get_best_height()
+                      << std::endl;
+        }
+    }
+    // Non-owning view pointer shared by the tx-ingest connector and the
+    // full_block connect pipeline below; nullptr when the lane is disarmed
+    // (byte-identical to the pre-lane coinbase-only baseline).
+    core::coin::UTXOViewCache* const dgb_utxo_ptr = dgb_utxo_cache.get();
 
 #ifdef AUX_DOGE
     // ══════════════════════════════════════════════════════════════════════
@@ -923,9 +988,83 @@ int run_node(const core::CoinParams& params, bool testnet,
     // directed (2026-06-20).
     dgb::interfaces::Node coin_iface;
     auto header_ingest_sub  = c2pool::dgb::wire_header_ingest(coin_iface, header_chain);
-    auto mempool_ingest_sub = c2pool::dgb::wire_mempool_ingest(coin_iface, mempool);
+    // Pass the fee-proof UTXO view (nullptr when the lane is disarmed) so a
+    // relayed tx is fee-proved at ingest against the SAME view selection uses.
+    auto mempool_ingest_sub = c2pool::dgb::wire_mempool_ingest(coin_iface, mempool, dgb_utxo_ptr);
     std::cout << "[DGB] embedded coin-daemon ingest surface up — header+tx "
                  "feeds wired (NodeP2P producer standup next)" << std::endl;
+
+    // ── full_block -> UTXO connect + mempool maintenance (S1 fee-proof lane) ──
+    // Armed only when the UTXO lane is (dgb_utxo_ptr != nullptr). NodeP2P already
+    // auto-requests MSG_WITNESS_BLOCK on short header announcements, so witness
+    // data arrives intact for connect_block. DGB's HeaderChain is a rolling
+    // window with NO hash->height map and NO tip-changed/reorg hook, so we cannot
+    // look a block's height up the way BTC/LTC do. Instead we FAIL-CLOSED ACCRUE:
+    // connect a block ONLY when it is the confirmed header-chain tip (its
+    // sha256d id == header_chain.tip_hash(), giving a REAL absolute DGB height)
+    // AND it extends our own view by exactly one (height == best_height+1). Any
+    // block that does not — a gap, a reorg, or the first block before the header
+    // tip is identified — is DROPPED: the view simply stops accruing and every
+    // unproven tx stays fee_known=false (coinbase-only), never a wrong fee. This
+    // is the #145 partial-UTXO ceiling (coverage grows with uptime, never
+    // overstated). Full last-288 / genesis bootstrap of the UTXO set is a
+    // follow-on; accrual-only is the safe v1.
+    std::shared_ptr<EventDisposable> full_block_ingest_sub;
+    if (dgb_utxo_ptr) {
+        full_block_ingest_sub = coin_iface.full_block.subscribe(
+            [&header_chain, &mempool, &dgb_utxo_db, dgb_utxo_ptr]
+            (const dgb::coin::BlockType& block)
+            {
+                auto tip_h  = header_chain.tip_height();
+                auto tip_id = header_chain.tip_hash();
+                if (!tip_h || !tip_id)
+                    return;  // header tip not identified yet -> cannot anchor.
+
+                // Identify this block by its header id via the ingest SSOT
+                // (make_header_sample: block_hash = sha256d(80-byte header), the
+                // SAME u256 tip_hash() carries), so no manual hash conversion.
+                const c2pool::dgb::HeaderSample s = c2pool::dgb::make_header_sample(
+                    static_cast<const dgb::coin::BlockHeaderType&>(block));
+                if (!(s.block_hash == *tip_id))
+                    return;  // not the confirmed header tip -> fail-closed drop.
+
+                const uint32_t height  = *tip_h;
+                const uint32_t best_h  = dgb_utxo_ptr->get_best_height();
+                if (best_h != 0 && height != best_h + 1)
+                    return;  // gap / reorg -> fail-closed (stop accruing).
+
+                // DGB txid = sha256d over the non-witness serialization (block
+                // id and prevout keys both use sha256d(no-witness)).
+                auto dgb_txid = [](const dgb::coin::MutableTransaction& tx) {
+                    auto packed = pack(dgb::coin::TX_NO_WITNESS(tx));
+                    return Hash(packed.get_span());
+                };
+
+                try {
+                    auto undo = dgb_utxo_ptr->connect_block(block, height, dgb_txid);
+                    dgb_utxo_db->put_block_undo(height, undo);
+                    // flush anchors best_block/best_height to this block's id.
+                    auto packed_hdr = pack(
+                        static_cast<const dgb::coin::BlockHeaderType&>(block));
+                    dgb_utxo_ptr->flush(Hash(packed_hdr.get_span()), height);
+                    dgb_utxo_ptr->prune_undo(height, core::coin::DGB_MIN_BLOCKS_TO_KEEP);
+
+                    // Post-tip mempool maintenance (mirror BTC/LTC): drop mined
+                    // txs, then price newly-provable txs and evict inputs the
+                    // block spent out from under us.
+                    mempool.set_tip_height(height);
+                    mempool.remove_for_block(block);
+                    mempool.recompute_unknown_fees(dgb_utxo_ptr);
+                    mempool.revalidate_inputs(dgb_utxo_ptr);
+                } catch (const std::exception& e) {
+                    LOG_WARNING << "[EMB-DGB] full_block UTXO connect failed h="
+                                << height << ": " << e.what()
+                                << " — view held, fee-proof lane fail-closed.";
+                }
+            });
+        std::cout << "[DGB] embedded full_block UTXO connect pipeline ARMED "
+                     "(fee-proof accrual)" << std::endl;
+    }
 
     // ── Embedded coin-daemon P2P PRODUCER standup (Phase B) ───────────────
     //
@@ -2437,6 +2576,8 @@ int main(int argc, char** argv)
     // taproot (a real consensus floor; operator-gated, not relaxed here).
     bool dev_relax_algo_softforks = false;  // --dev-relax-algo-softforks (dev boot aid)
     bool coin_p2p_discover = false;         // --coin-p2p-discover: DGB-isolated scored/diverse coin-network peer discovery (network-standalone arm; independent of local digibyted)
+    bool serve_mempool_txs = false;         // --embedded-serve-mempool-txs: arm the embedded UTXO fee-proof lane (S1)
+    bool serve_mempool_txs_off = false;     // --embedded-serve-mempool-txs=false: explicit opt-out
     // ── DGB-as-DOGE-parent embedded merged-mining arm (--merged DOGE) [SLICE 2] ──
     // --merged SYMBOL:CHAIN_ID[:HOST:PORT:USER:PASS[:P2P_PORT]] stands up an
     // embedded DOGE aux backend DAEMONLESS (DOGE chain_id=98, P2P port 22556). The
@@ -2547,6 +2688,15 @@ int main(int argc, char** argv)
             doge_p2p_port = std::stoi(argv[++i]);
         }
         else if (std::strcmp(argv[i], "--embedded-doge") == 0) embedded_doge = true;
+        // --embedded-serve-mempool-txs[=true|false]: arm / opt out of the
+        // embedded UTXO fee-proof lane (S1). Bare flag or =true arms it; =false
+        // is the explicit opt-out. Mirrors the DASH parse pattern.
+        else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs") == 0)
+            serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs=true") == 0)
+            serve_mempool_txs = true;
+        else if (std::strcmp(argv[i], "--embedded-serve-mempool-txs=false") == 0)
+            serve_mempool_txs_off = true;
         else {
             std::cerr << "unknown argument: " << argv[i] << "\n";
             return 1;
@@ -2617,7 +2767,8 @@ int main(int argc, char** argv)
                         coin_p2p_discover,
                         http_addr, http_port,
                         merged_chain_specs, doge_p2p_address, doge_p2p_port,
-                        embedded_doge);
+                        embedded_doge,
+                        serve_mempool_txs, serve_mempool_txs_off);
 
     // --selftest, or a bare invocation: drive the live score path so the
     // binary exercises real consensus code, then exit cleanly.

--- a/src/core/coin/utxo.hpp
+++ b/src/core/coin/utxo.hpp
@@ -43,12 +43,31 @@ static constexpr ChainLimits LTC_LIMITS  = {8'400'000'000'000'000LL, 100, 6};
 /// Reference: dogecoin/src/chainparams.cpp digishieldConsensus.nCoinbaseMaturity
 static constexpr ChainLimits DOGE_LIMITS = {1'000'000'000'000'000'000LL, 240, 0};
 
+/// DGB: 21B DGB max supply * 1e8 sat = 2.1e18 sat, 100-block coinbase maturity
+///      at the current chain tip, no pegout (no MWEB).
+/// Reference: digibyte/src/consensus/consensus.h defines COINBASE_MATURITY = 8
+///   (legacy, early chain) AND COINBASE_MATURITY_2 = 100, selected by height
+///   (DigiByte-Core PR #157). c2pool-dgb only ever validates at the current
+///   tip, which is deep past the transition, so 100 is the operative value.
+///   100 is also the conservative choice for the embedded fee lane: if a coin's
+///   real maturity were lower, using 100 only OVER-rejects a young-coinbase
+///   spend (that tx is excluded from selection, never falsely admitted) — the
+///   same "never overstated" ceiling LTC/BTC/DASH accept. max_money 2.1e18 is
+///   above LTC's 8.4e15 so a legitimately large DGB output is not falsely
+///   rejected by a too-small bound (which LTC_LIMITS, the prior Mempool()
+///   default for DGB, would have done above 84M DGB in one output).
+static constexpr ChainLimits DGB_LIMITS = {2'100'000'000'000'000'000LL, 100, 0};
+
 /// Minimum blocks of undo data to keep for reorg safety + pruning.
 /// Matches the MIN_BLOCKS_TO_KEEP constant in each daemon's validation.h.
 /// Reference: litecoin/src/validation.h  MIN_BLOCKS_TO_KEEP = 288
 /// Reference: dogecoin/src/validation.h  MIN_BLOCKS_TO_KEEP = 1440
 static constexpr uint32_t LTC_MIN_BLOCKS_TO_KEEP  = 288;
 static constexpr uint32_t DOGE_MIN_BLOCKS_TO_KEEP = 1440;
+/// DGB: MIN_BLOCKS_TO_KEEP = 288 (matches digibyte/src/validation.h, same as
+/// Bitcoin Core). DGB's ~15 s block time makes 288 blocks ~72 min of undo
+/// data — ample for the shallow reorgs DGB sees.
+static constexpr uint32_t DGB_MIN_BLOCKS_TO_KEEP  = 288;
 
 /// Minimum UTXO depth before mining can start: coinbase_maturity + reorg_buffer.
 /// LTC: 100 (COINBASE_MATURITY) + 6 (PEGOUT_MATURITY reorg depth) = 106
@@ -56,6 +75,8 @@ static constexpr uint32_t DOGE_MIN_BLOCKS_TO_KEEP = 1440;
 /// Reference: litecoin/src/consensus/consensus.h, dogecoin/src/chainparams.cpp
 static constexpr uint32_t LTC_MINING_GATE_DEPTH  = LTC_LIMITS.coinbase_maturity + LTC_LIMITS.pegout_maturity; // 106
 static constexpr uint32_t DOGE_MINING_GATE_DEPTH = DOGE_LIMITS.coinbase_maturity + 10; // 250
+/// DGB: 100 (COINBASE_MATURITY_2) + 10-block reorg safety buffer = 110.
+static constexpr uint32_t DGB_MINING_GATE_DEPTH  = DGB_LIMITS.coinbase_maturity + 10; // 110
 
 /// Tip age threshold for considering chain synced (seconds).
 /// Both LTC and DOGE use 24 hours (86400s) as DEFAULT_MAX_TIP_AGE.

--- a/src/core/coin/utxo_view_cache.hpp
+++ b/src/core/coin/utxo_view_cache.hpp
@@ -271,6 +271,27 @@ public:
         return true;
     }
 
+    /// Re-anchor the view: drop all in-memory pending changes AND wipe the
+    /// backing DB, resetting the accrual anchor to zero so the next
+    /// connect_block() starts a fresh partial view from the current tip. Used
+    /// by the full_block accrual handler on a forward tip-gap (e.g. after a
+    /// restart) — see impl/dgb/coin/utxo_accrual.hpp and UTXOViewDB::reset().
+    ///
+    /// Fail-closed: if the backing wipe fails the cache is left UNTOUCHED and
+    /// false is returned; the caller must then NOT connect the current block.
+    /// With no backing DB (an in-memory-only view) there is nothing on disk to
+    /// wipe — the in-memory cache and counters are still reset and true is
+    /// returned.
+    bool reanchor() {
+        std::unique_lock<std::shared_mutex> lock(m_mu);
+        if (m_base && !m_base->reset())
+            return false;  // DB wipe failed -> fail-closed, cache held.
+        m_cache.clear();
+        m_blocks_connected = 0;
+        m_oldest_undo_height = 0;
+        return true;
+    }
+
     /// Number of entries in the cache (for diagnostics).
     size_t cache_size() const {
         std::shared_lock<std::shared_mutex> lock(m_mu);

--- a/src/core/coin/utxo_view_db.hpp
+++ b/src/core/coin/utxo_view_db.hpp
@@ -187,6 +187,48 @@ public:
         return pruned;
     }
 
+    // ── Re-anchor (wipe) ────────────────────────────────────────────────
+
+    /// Wipe the entire persisted accrual view — every coin ('C'), undo record
+    /// ('U') and retained raw block ('F') — and reset best-block state to zero,
+    /// so accrual restarts fresh from the next connected block. Used when the
+    /// confirmed header tip has advanced past the persisted view by more than
+    /// one block (e.g. after a restart): the stale view cannot legally extend
+    /// by one, so it is dropped and re-anchored rather than latching dead.
+    ///
+    /// Fail-closed: on a scan or commit failure the on-disk view and the cached
+    /// best_* fields are left UNCHANGED and false is returned; the caller must
+    /// then NOT connect the current block (hold the old view).
+    bool reset() {
+        // Snapshot every key under the three data prefixes first (not removing
+        // mid-iteration) so the scan reads a stable view, then batch-remove
+        // them + zero the best-state marker in one atomic commit.
+        std::vector<std::string> keys;
+        auto collect = [&keys](const std::string& key,
+                               const std::vector<uint8_t>&) {
+            keys.push_back(key);
+            return true;
+        };
+        for (char prefix : {'C', 'U', 'F'}) {
+            if (!m_store.for_each_prefix(std::string(1, prefix), collect))
+                return false;  // scan failure -> fail-closed, view untouched.
+        }
+        auto batch = m_store.create_batch();
+        for (const auto& k : keys)
+            batch.remove(k);
+        // Reset best-block state to genesis-of-accrual (null hash, height 0).
+        {
+            std::vector<uint8_t> state_data(36, 0);
+            batch.put(make_state_key(), state_data);
+        }
+        if (!batch.commit())
+            return false;  // commit failure -> fail-closed, cached fields intact.
+        m_best_block = uint256();
+        m_best_height = 0;
+        m_oldest_block_height = 0;
+        return true;
+    }
+
 private:
     LevelDBStore m_store;
     uint256  m_best_block;

--- a/src/core/param_catalog.inc
+++ b/src/core/param_catalog.inc
@@ -479,8 +479,9 @@ C2P_PARAM("embedded.superblock", Embedded, BOOL, RESTART, C_DASH, LIT, "false", 
 C2P_PARAM("embedded.govsync", Embedded, BOOL, RESTART, C_DASH, LIT, "false", NONE, "observe-only governance store")
   C2P_ALIAS("embedded.govsync", BIN_DASH, "--embedded-govsync", FLAG)
 
-C2P_PARAM("embedded.serve_mempool_txs", Embedded, TRISTATE_BOOL, RESTART, C_DASH|C_BIP110, NONE, "", NONE, "fee-carrying templates (daemonless default ON)")
+C2P_PARAM("embedded.serve_mempool_txs", Embedded, TRISTATE_BOOL, RESTART, C_DASH|C_BIP110|C_DGB, NONE, "", NONE, "fee-carrying templates (daemonless default ON)")
   C2P_ALIAS("embedded.serve_mempool_txs", BIN_DASH, "--embedded-serve-mempool-txs", FLAG_OPT_EQFALSE)
+  C2P_ALIAS("embedded.serve_mempool_txs", BIN_DGB, "--embedded-serve-mempool-txs", FLAG_OPT_EQFALSE)
   C2P_ALIAS("embedded.serve_mempool_txs", BIN_BIP110, "--serve-mempool-txs", FLAG)
   C2P_ALIAS("embedded.serve_mempool_txs", BIN_BIP110, "--no-serve-mempool-txs", FLAG_NO_PREFIX)
 

--- a/src/impl/dgb/coin/good_citizen_defaults.hpp
+++ b/src/impl/dgb/coin/good_citizen_defaults.hpp
@@ -30,13 +30,17 @@
 ///                        here. It is carried in the struct so the resolver's
 ///                        contract does not change shape when S2 wires it.
 ///
-/// == DEFAULT (this PR) ======================================================
-/// embedded_utxo defaults OFF. It is dormant infrastructure: its only consumer
-/// that changes SERVED bytes — the S2 job-commit — is not wired yet, and it
-/// imposes a UTXO view build. When S2 lands, the good-citizen default for the
-/// daemonless posture flips ON (serve the full mempool unless the operator opts
-/// out), matching the DASH good_citizen_defaults rationale. An explicit
-/// --embedded-serve-mempool-txs / =false is always honoured in both directions.
+/// == DEFAULT (S1) ===========================================================
+/// embedded_utxo defaults ON (good-citizen): a DGB node opens the UTXO view and
+/// fee-proves the relayed mempool by default, so its advisory GBT template is
+/// fee-bearing rather than coinbase-only — matching digibyted's CreateNewBlock.
+/// An explicit --embedded-serve-mempool-txs=false opts out. serve_mempool_txs
+/// (the S2 job-commit lever) stays default OFF: until S2 wires the merkle/
+/// witness/fee-fold into the mined block it is inert (won_block_serialize
+/// fail-closes on a merkle-less job), so defaulting it on would change nothing
+/// and is deferred. REWARD SAFETY (below) is unchanged: arming embedded_utxo
+/// only makes fees COMPUTABLE for the advisory template; the connection
+/// coinbase stays subsidy-only and the won-block merkle stays coinbase-only.
 ///
 /// == REWARD SAFETY ==========================================================
 /// Arming embedded_utxo only makes fees COMPUTABLE for the advisory GBT
@@ -71,24 +75,38 @@ struct TxServePosture {
 
 /// Pure resolver.
 ///
-/// `good_citizen_default_on` is the default the daemonless posture would apply
-/// when the operator said nothing. This PR passes it false (dormant S1 infra);
-/// the S2 follow-on flips it true for the daemonless arm. An explicit ON always
-/// wins; an explicit OFF always wins. serve_mempool_txs can never be armed
-/// without embedded_utxo (a fee-bearing commit requires fee-proved txs), so the
-/// resolver clamps it.
+/// The two levers carry SEPARATE good-citizen defaults:
+///   `embedded_utxo_default_on`     — the default for the S1 fee-proof lane.
+///                                    S1 (this lane) passes it TRUE: a
+///                                    daemonless DGB node serves the fee-paying
+///                                    mempool by default, matching digibyted's
+///                                    CreateNewBlock (good citizen). An explicit
+///                                    --embedded-serve-mempool-txs=false opts out.
+///   `serve_mempool_txs_default_on` — the default for the S2 job-commit lever.
+///                                    It defaults FALSE and stays opt-out until
+///                                    S2 wires the merkle/witness/fee-fold into
+///                                    the actually-mined block; arming it before
+///                                    then would be inert anyway (won_block_
+///                                    serialize fail-closes on a job with no
+///                                    merkle branches). Callers keep the default
+///                                    (omit the argument) until S2.
+///
+/// An explicit ON always wins; an explicit OFF always wins. serve_mempool_txs
+/// can never be armed without embedded_utxo (a fee-bearing commit requires
+/// fee-proved txs behind it), so the resolver clamps it.
 inline TxServePosture resolve_tx_serve_posture(const TxServeLevers& levers,
-                                               bool good_citizen_default_on)
+                                               bool embedded_utxo_default_on,
+                                               bool serve_mempool_txs_default_on = false)
 {
-    auto resolve = [&](const TxServeLever& l) -> bool {
+    auto resolve = [](const TxServeLever& l, bool default_on) -> bool {
         if (l.explicit_off) return false;   // explicit opt-out wins
         if (l.on)           return true;    // explicit opt-in wins
-        return good_citizen_default_on;     // silence -> the posture default
+        return default_on;                  // silence -> the posture default
     };
 
     TxServePosture out;
-    out.arm_embedded_utxo     = resolve(levers.embedded_utxo);
-    out.arm_serve_mempool_txs = resolve(levers.serve_mempool_txs);
+    out.arm_embedded_utxo     = resolve(levers.embedded_utxo, embedded_utxo_default_on);
+    out.arm_serve_mempool_txs = resolve(levers.serve_mempool_txs, serve_mempool_txs_default_on);
     // Clamp: no fee-bearing commit without the fee-proof lane behind it.
     if (!out.arm_embedded_utxo)
         out.arm_serve_mempool_txs = false;

--- a/src/impl/dgb/coin/good_citizen_defaults.hpp
+++ b/src/impl/dgb/coin/good_citizen_defaults.hpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// GOOD-CITIZEN mempool-serving posture resolver for DGB — a PURE function so
+/// the truth table is KAT-testable (test in dgb_mempool_ingest_test).
+///
+/// == WHY THIS EXISTS ========================================================
+/// A daemonless DGB node (--coin-p2p-discover, no digibyted) builds every
+/// served template from the embedded builder alone: unlike DASH, the DGB RPC
+/// arm supplies only previousblockhash+bits, so there is no gbt cross-check /
+/// fallback that could inject a daemon's full transactions[]. The embedded
+/// builder is the SOLE transactions[] source in EVERY posture. The baseline a
+/// good network citizen serves is what digibyted's own CreateNewBlock does:
+/// include the valid, fee-paying mempool set, filling the block.
+///
+/// == THE TWO LEVERS =========================================================
+///   embedded_utxo      — arms the embedded UTXO fee-proof lane (this PR, S1):
+///                        open the UTXO view, fee-prove each relayed tx against
+///                        it, so make_mempool_tx_source can select fee_known txs
+///                        into a FEE-BEARING GBT template. Without it no tx ever
+///                        fee-proves (fee_known=false) and the template stays
+///                        coinbase-only — the exact behaviour before this lane.
+///   serve_mempool_txs  — RESERVED for the reward-critical S2 follow-on: commit
+///                        the selected set into the actually-mined stratum job
+///                        (merkle branches + BIP141 witness commitment + fold
+///                        fees into the connection coinbase). Until S2 lands the
+///                        won block is coinbase-only + subsidy-only by
+///                        construction (won_block_serialize fail-closes when the
+///                        job carries no merkle branches), so this lever is inert
+///                        here. It is carried in the struct so the resolver's
+///                        contract does not change shape when S2 wires it.
+///
+/// == DEFAULT (this PR) ======================================================
+/// embedded_utxo defaults OFF. It is dormant infrastructure: its only consumer
+/// that changes SERVED bytes — the S2 job-commit — is not wired yet, and it
+/// imposes a UTXO view build. When S2 lands, the good-citizen default for the
+/// daemonless posture flips ON (serve the full mempool unless the operator opts
+/// out), matching the DASH good_citizen_defaults rationale. An explicit
+/// --embedded-serve-mempool-txs / =false is always honoured in both directions.
+///
+/// == REWARD SAFETY ==========================================================
+/// Arming embedded_utxo only makes fees COMPUTABLE for the advisory GBT
+/// template. It does NOT touch the connection coinbase (subsidy-only) or the
+/// won-block merkle (coinbase-only, fail-closed) — those are S2. Selection
+/// admits only fee_known txs against the spent-aware view (never overstated),
+/// so the worst case of a stale view is an advisory template with a wrong fee
+/// number, never an invalid block.
+
+namespace dgb {
+namespace coin {
+
+/// One serving lever as requested on the command line. `on` is the positive
+/// flag; `explicit_off` records the --<flag>=false spelling. Both false =
+/// "operator said nothing" = eligible for the good-citizen default.
+struct TxServeLever {
+    bool on{false};
+    bool explicit_off{false};
+};
+
+/// The levers the resolver governs (see header comment).
+struct TxServeLevers {
+    TxServeLever embedded_utxo;      // S1: fee-proof lane (this PR)
+    TxServeLever serve_mempool_txs;  // S2: commit into the mined block (reserved)
+};
+
+/// The resolved posture.
+struct TxServePosture {
+    bool arm_embedded_utxo{false};   // open UTXO view + fee-prove relayed txs
+    bool arm_serve_mempool_txs{false};
+};
+
+/// Pure resolver.
+///
+/// `good_citizen_default_on` is the default the daemonless posture would apply
+/// when the operator said nothing. This PR passes it false (dormant S1 infra);
+/// the S2 follow-on flips it true for the daemonless arm. An explicit ON always
+/// wins; an explicit OFF always wins. serve_mempool_txs can never be armed
+/// without embedded_utxo (a fee-bearing commit requires fee-proved txs), so the
+/// resolver clamps it.
+inline TxServePosture resolve_tx_serve_posture(const TxServeLevers& levers,
+                                               bool good_citizen_default_on)
+{
+    auto resolve = [&](const TxServeLever& l) -> bool {
+        if (l.explicit_off) return false;   // explicit opt-out wins
+        if (l.on)           return true;    // explicit opt-in wins
+        return good_citizen_default_on;     // silence -> the posture default
+    };
+
+    TxServePosture out;
+    out.arm_embedded_utxo     = resolve(levers.embedded_utxo);
+    out.arm_serve_mempool_txs = resolve(levers.serve_mempool_txs);
+    // Clamp: no fee-bearing commit without the fee-proof lane behind it.
+    if (!out.arm_embedded_utxo)
+        out.arm_serve_mempool_txs = false;
+    return out;
+}
+
+} // namespace coin
+} // namespace dgb

--- a/src/impl/dgb/coin/mempool_ingest.hpp
+++ b/src/impl/dgb/coin/mempool_ingest.hpp
@@ -21,12 +21,18 @@
 // connector adds NO policy of its own -- it is the tx analog of
 // wire_header_ingest (coin/header_ingest.hpp) for the new_headers feed.
 //
-// FEE POSTURE: add_tx is called WITHOUT a UTXOViewCache here, so fees stay
-// fee_known=false until a UTXO view feeds them. That is deliberate and matches
-// the embedded shaper's conservative default (make_mempool_tx_source emits
-// fee=null and excludes unknown-fee value from the coinbasevalue fold), so a
-// P2P-fed mempool cannot desync coinbasevalue versus a daemon's GBT. Wiring a
-// real UTXO view is a later slice; this one only opens the feed.
+// FEE POSTURE: add_tx accepts an OPTIONAL UTXOViewCache. When the caller
+// passes nullptr (the default, and every pre-existing call site), fees stay
+// fee_known=false — byte-identical to the feed-only slice: make_mempool_tx_source
+// emits fee=null and EXCLUDES unknown-fee value from the coinbasevalue fold, so
+// a P2P-fed pool with no view cannot desync coinbasevalue versus a daemon's GBT.
+// When the caller passes a live UTXOViewCache (the embedded fee-proof lane wired
+// in main_dgb behind --embedded-serve-mempool-txs), add_tx computes the fee
+// against that spent-aware view (Mempool::compute_fee_locked): a tx whose inputs
+// all resolve, pass MoneyRange, and clear coinbase maturity becomes fee_known and
+// is eligible for the fee-bearing template; a tx that does not remains excluded
+// (never overstated). This is the tx analog of BTC main_btc.cpp new_tx ->
+// add_tx(mtx, &utxo_cache).
 //
 // LIFETIME: the handler captures `pool` by reference, so `pool` MUST outlive
 // `node`. The returned EventDisposable lets a caller tear the subscription down
@@ -48,17 +54,25 @@ namespace c2pool::dgb
 // caller controls teardown; the subscription persists for the node's life if
 // the handle is dropped (EventDisposable does not auto-dispose on destruction).
 //
+// `utxo` is an OPTIONAL spent-aware UTXO view. nullptr (the default) preserves
+// the feed-only behaviour exactly (fee_known=false). A non-null view is fee-
+// proved per tx by Mempool::add_tx. The pointer is captured by value; it MUST
+// outlive `node` (in main_dgb the UTXOViewCache, Mempool and coin_iface share a
+// scope). Passing the SAME view here and to Mempool::set_utxo keeps ingest-time
+// and selection-time fee views identical.
+//
 // NOTE: pulls mempool.hpp -> transaction.hpp (the tx serialization codec), so
 // include this header ONLY from a TU that already links the full dgb_coin
 // codec (main_dgb.cpp + the codec conformance test), never a guard-weight TU
 // -- the #143 btclibs SCC trap, identical to embedded_tx_select.hpp.
 inline std::shared_ptr<EventDisposable>
-wire_mempool_ingest(::dgb::interfaces::Node& node, ::dgb::coin::Mempool& pool)
+wire_mempool_ingest(::dgb::interfaces::Node& node, ::dgb::coin::Mempool& pool,
+                    core::coin::UTXOViewCache* utxo = nullptr)
 {
     return node.new_tx.subscribe(
-        [&pool](const ::dgb::coin::Transaction& tx)
+        [&pool, utxo](const ::dgb::coin::Transaction& tx)
         {
-            pool.add_tx(::dgb::coin::MutableTransaction(tx));
+            pool.add_tx(::dgb::coin::MutableTransaction(tx), utxo);
         });
 }
 

--- a/src/impl/dgb/coin/utxo_accrual.hpp
+++ b/src/impl/dgb/coin/utxo_accrual.hpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+#include <cstdint>
+
+/// Pure decision for the embedded UTXO fee-proof lane's full_block accrual
+/// (main_dgb.cpp full_block handler) — extracted so the RESTART-LIVENESS
+/// contract is KAT-testable (dgb_mempool_ingest_test) rather than buried in a
+/// lambda.
+///
+/// == THE LIVENESS BUG THIS ENCODES THE FIX FOR ==============================
+/// The accrual view is a rolling partial UTXO set (#145): it connects a block
+/// only when that block is the confirmed header-chain tip AND extends the view
+/// by exactly one (height == best_height + 1). best_height is PERSISTED in the
+/// view's LevelDB, so it survives a restart. After a restart the header tip has
+/// moved far ahead of the persisted best_height, so the FIRST full_block seen
+/// is at a height MANY blocks past best_height + 1. The pre-fix handler simply
+/// returned on that mismatch — and since the view could then never again
+/// observe best_height + 1, it returned on EVERY subsequent block too: the
+/// fee-proof lane was silently DEAD for the rest of the process, every tx
+/// stuck fee_known=false, templates coinbase-only forever.
+///
+/// The fix: distinguish a FORWARD gap (tip ran ahead — the restart case) from a
+/// BACKWARD/equal height (reorg or duplicate). On a forward gap, RE-ANCHOR:
+/// wipe the stale view and resume accrual with this block as a fresh anchor
+/// (UTXOViewCache::reanchor()). On a backward/equal height, keep the
+/// fail-closed DROP — an accrual-only view cannot safely fold a reorg, and
+/// dropping never overstates a fee. A fresh view (best_height == 0) always
+/// connects as the first anchor.
+///
+/// This mirrors the DASH Window-2 re-anchor posture (main_dash.cpp): a view
+/// that has fallen behind the tip re-syncs rather than latching dead.
+
+namespace dgb {
+namespace coin {
+
+/// What the full_block handler should do with a confirmed-tip block, given the
+/// view's persisted best_height and the block's absolute height.
+enum class FullBlockAccrualAction {
+    Connect,             ///< extend the view by one (or first-ever anchor)
+    ReAnchorThenConnect, ///< forward gap (e.g. restart): wipe + accrue afresh
+    Drop,                ///< reorg / lower-or-equal height: fail-closed, hold view
+};
+
+/// Pure classifier. `best_height` is UTXOViewCache::get_best_height() (0 when
+/// the view has never connected a block); `incoming_height` is the absolute
+/// height of the confirmed-tip block being connected.
+inline FullBlockAccrualAction classify_full_block_accrual(uint32_t best_height,
+                                                          uint32_t incoming_height)
+{
+    if (best_height == 0)
+        return FullBlockAccrualAction::Connect;              // first anchor
+    if (incoming_height == best_height + 1)
+        return FullBlockAccrualAction::Connect;              // normal extend
+    if (incoming_height > best_height + 1)
+        return FullBlockAccrualAction::ReAnchorThenConnect;  // forward gap (restart)
+    return FullBlockAccrualAction::Drop;                     // reorg / <= best
+}
+
+} // namespace coin
+} // namespace dgb

--- a/src/impl/dgb/test/mempool_ingest_test.cpp
+++ b/src/impl/dgb/test/mempool_ingest_test.cpp
@@ -27,6 +27,7 @@
 #include <impl/dgb/coin/transaction.hpp>
 #include <impl/dgb/coin/embedded_tx_select.hpp>     // make_mempool_tx_source (fee-proof selection)
 #include <impl/dgb/coin/good_citizen_defaults.hpp>  // resolve_tx_serve_posture (S1 truth table)
+#include <impl/dgb/coin/utxo_accrual.hpp>            // classify_full_block_accrual (restart-liveness)
 #include <core/coin/utxo.hpp>                        // core::coin::Coin/Outpoint/DGB_LIMITS
 #include <core/coin/utxo_view_cache.hpp>            // core::coin::UTXOViewCache (fee view)
 
@@ -285,4 +286,94 @@ TEST(GoodCitizenDefaults, ServeClampedWithoutUtxoLane)
     auto p = resolve_tx_serve_posture(lv, /*default_on=*/false);
     EXPECT_FALSE(p.arm_embedded_utxo);
     EXPECT_FALSE(p.arm_serve_mempool_txs);  // clamped
+}
+// ===========================================================================
+// full_block accrual RESTART-LIVENESS re-anchor (utxo_accrual.hpp + reanchor).
+//
+// The pre-remediation full_block handler dropped every block whose height did
+// not equal best_height + 1 and — because best_height is PERSISTED across a
+// restart — that made the fee-proof lane silently DEAD after the first restart
+// (the header tip is far past best_height + 1, so every block is dropped and
+// the view never extends again). These pin the fix: a FORWARD tip-gap must
+// re-anchor rather than drop, and reanchor() must actually clear the view.
+// ===========================================================================
+
+using dgb::coin::FullBlockAccrualAction;
+using dgb::coin::classify_full_block_accrual;
+
+// 10a. Fresh view (best_height == 0): the first confirmed-tip block anchors.
+TEST(FullBlockAccrual, FreshViewConnectsFirstAnchor)
+{
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/0, /*incoming=*/1),
+              FullBlockAccrualAction::Connect);
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/0, /*incoming=*/900'000),
+              FullBlockAccrualAction::Connect);  // cold start at a live tip
+}
+
+// 10b. Normal +1 extend connects.
+TEST(FullBlockAccrual, ExactNextHeightConnects)
+{
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/100, /*incoming=*/101),
+              FullBlockAccrualAction::Connect);
+}
+
+// 10c. THE BUG: a forward tip-gap (height > best+1, e.g. the tip after a
+//      restart) must RE-ANCHOR, not drop. This is the liveness fix.
+TEST(FullBlockAccrual, ForwardGapReAnchors)
+{
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/100, /*incoming=*/102),
+              FullBlockAccrualAction::ReAnchorThenConnect);   // one-block gap
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/100, /*incoming=*/900'000),
+              FullBlockAccrualAction::ReAnchorThenConnect);   // restart jump
+}
+
+// 10d. A reorg / duplicate (height <= best) stays fail-closed DROP: an
+//      accrual-only view cannot safely fold a reorg, and dropping never
+//      overstates a fee.
+TEST(FullBlockAccrual, ReorgOrEqualDrops)
+{
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/100, /*incoming=*/100),
+              FullBlockAccrualAction::Drop);   // duplicate / same tip
+    EXPECT_EQ(classify_full_block_accrual(/*best=*/100, /*incoming=*/99),
+              FullBlockAccrualAction::Drop);   // reorg to a lower height
+}
+
+// 10e. reanchor() WIPES the view: seeded coins vanish and the pending cache is
+//      emptied, so accrual restarts from a clean slate (in-memory view, no
+//      LevelDB base — the wipe still clears the cache and returns true).
+TEST(FullBlockAccrual, ReAnchorClearsView)
+{
+    using core::coin::UTXOViewCache;
+    using core::coin::Outpoint;
+
+    UTXOViewCache utxo(nullptr);
+    seed_coin(utxo, /*index=*/0, /*value=*/60'000);
+    seed_coin(utxo, /*index=*/1, /*value=*/55'000);
+
+    uint256 null_hash; null_hash.SetNull();
+    Outpoint op0(null_hash, 0);
+    Outpoint op1(null_hash, 1);
+    EXPECT_TRUE(utxo.have_coin(op0));
+    EXPECT_TRUE(utxo.have_coin(op1));
+    EXPECT_EQ(utxo.cache_size(), 2u);
+
+    EXPECT_TRUE(utxo.reanchor());
+
+    EXPECT_FALSE(utxo.have_coin(op0));   // stale coins dropped
+    EXPECT_FALSE(utxo.have_coin(op1));
+    EXPECT_EQ(utxo.cache_size(), 0u);
+    EXPECT_EQ(utxo.blocks_connected(), 0u);
+}
+
+// 10f. S1 DEFAULT (blocker 3): with the operator silent, the S1 good-citizen
+//      default arms the fee-proof lane (embedded_utxo) but leaves the S2
+//      job-commit lever (serve_mempool_txs) OFF — it stays opt-out until S2.
+TEST(GoodCitizenDefaults, S1DefaultArmsUtxoButNotServe)
+{
+    auto p = resolve_tx_serve_posture(
+        TxServeLevers{},
+        /*embedded_utxo_default_on=*/true,
+        /*serve_mempool_txs_default_on=*/false);
+    EXPECT_TRUE(p.arm_embedded_utxo);        // fee-proof lane serves by default
+    EXPECT_FALSE(p.arm_serve_mempool_txs);   // S2 job-commit stays opt-out
 }

--- a/src/impl/dgb/test/mempool_ingest_test.cpp
+++ b/src/impl/dgb/test/mempool_ingest_test.cpp
@@ -25,6 +25,10 @@
 #include <impl/dgb/coin/node_interface.hpp>
 #include <impl/dgb/coin/mempool.hpp>
 #include <impl/dgb/coin/transaction.hpp>
+#include <impl/dgb/coin/embedded_tx_select.hpp>     // make_mempool_tx_source (fee-proof selection)
+#include <impl/dgb/coin/good_citizen_defaults.hpp>  // resolve_tx_serve_posture (S1 truth table)
+#include <core/coin/utxo.hpp>                        // core::coin::Coin/Outpoint/DGB_LIMITS
+#include <core/coin/utxo_view_cache.hpp>            // core::coin::UTXOViewCache (fee view)
 
 using c2pool::dgb::wire_mempool_ingest;
 using dgb::coin::Mempool;
@@ -123,4 +127,162 @@ TEST(MempoolIngest, UnwiredNodeIngestsNothing)
     node.new_tx.happened(Transaction(tagged_tx(0)));
 
     EXPECT_EQ(pool.size(), 0u);
+}
+
+// ===========================================================================
+// S1 fee-proof lane KATs (--embedded-serve-mempool-txs). These pin the ACTUAL
+// ingest port the good-citizen gap needs: a relayed tx priced against an
+// embedded UTXO view so make_mempool_tx_source builds a FEE-BEARING template.
+// ===========================================================================
+
+using dgb::coin::make_mempool_tx_source;
+
+namespace {
+
+// A tx that SPENDS a seeded outpoint (null-hash, `index`) for `out_value`; the
+// coin seeded below carries `out_value + fee`, so the fee is exactly `fee`.
+MutableTransaction spending_tx(uint32_t index, int64_t out_value)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash.SetNull();
+    in.prevout.index = index;
+    in.sequence = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = out_value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+// Seed the outpoint (null-hash, `index`) with a non-coinbase coin worth `value`.
+void seed_coin(core::coin::UTXOViewCache& utxo, uint32_t index, int64_t value)
+{
+    uint256 null_hash;
+    null_hash.SetNull();
+    core::coin::Outpoint op(null_hash, index);
+    utxo.add_coin(op, core::coin::Coin(value, OPScript{},
+                                       /*height=*/1, /*coinbase=*/false));
+}
+
+} // namespace
+
+// 6. REGRESSION WITNESS (coinbase-only "before"): a tx fed through the SAME
+//    connector with NO UTXO view stays fee_known=false, so the fee-sorted
+//    selection is EMPTY and the served template carries zero txs — today's
+//    exact behaviour, and the baseline the S1 lane lifts.
+TEST(MempoolIngest, NoUtxoViewLeavesSelectionEmpty)
+{
+    Mempool pool(core::coin::DGB_LIMITS);
+    dgb::interfaces::Node node;
+    auto sub = c2pool::dgb::wire_mempool_ingest(node, pool, /*utxo=*/nullptr);
+
+    node.new_tx.happened(Transaction(spending_tx(/*index=*/0, /*out_value=*/50'000)));
+    ASSERT_EQ(pool.size(), 1u);  // the tx IS in the pool (feed works)...
+
+    auto sel = make_mempool_tx_source(pool, /*max_weight=*/4'000'000)();
+    EXPECT_EQ(sel.total_fees, 0u);           // ...but its fee is UNKNOWN,
+    EXPECT_TRUE(sel.transactions.empty());   // so it is EXCLUDED (coinbase-only).
+}
+
+// 7. FEE-PROVED "after": the SAME tx fed through the connector WITH a UTXO view
+//    holding its input becomes fee_known, so the fee-sorted selection carries
+//    it and total_fees is exact — the fee-bearing template the good-citizen
+//    default serves.
+TEST(MempoolIngest, UtxoViewFeeProvesTxIntoSelection)
+{
+    Mempool pool(core::coin::DGB_LIMITS);
+    core::coin::UTXOViewCache utxo(nullptr);   // in-memory view (no LevelDB base)
+    seed_coin(utxo, /*index=*/0, /*value=*/60'000);  // input worth 60k
+    pool.set_utxo(&utxo);                       // selection-time view
+
+    dgb::interfaces::Node node;
+    auto sub = c2pool::dgb::wire_mempool_ingest(node, pool, &utxo);  // ingest-time view
+
+    node.new_tx.happened(Transaction(spending_tx(/*index=*/0, /*out_value=*/50'000)));
+    ASSERT_EQ(pool.size(), 1u);
+
+    auto sel = make_mempool_tx_source(pool, /*max_weight=*/4'000'000)();
+    EXPECT_EQ(sel.total_fees, 10'000u);        // 60k in - 50k out = 10k fee
+    ASSERT_TRUE(sel.transactions.is_array());
+    ASSERT_EQ(sel.transactions.size(), 1u);    // the tx is SELECTED (fee-bearing)
+    EXPECT_EQ(sel.transactions[0]["fee"].get<int64_t>(), 10'000);
+    EXPECT_EQ(sel.transactions[0]["txid"], compute_txid(spending_tx(0, 50'000)).GetHex());
+}
+
+// 8. Multiple fee-proved txs accumulate and their fees sum into total_fees —
+//    the fee total that folds into coinbasevalue.
+TEST(MempoolIngest, MultipleFeeProvedTxsSumFees)
+{
+    Mempool pool(core::coin::DGB_LIMITS);
+    core::coin::UTXOViewCache utxo(nullptr);
+    seed_coin(utxo, 0, 60'000);   // -> 10k fee
+    seed_coin(utxo, 1, 55'000);   // -> 5k  fee
+    pool.set_utxo(&utxo);
+
+    dgb::interfaces::Node node;
+    auto sub = c2pool::dgb::wire_mempool_ingest(node, pool, &utxo);
+
+    node.new_tx.happened(Transaction(spending_tx(0, 50'000)));
+    node.new_tx.happened(Transaction(spending_tx(1, 50'000)));
+    ASSERT_EQ(pool.size(), 2u);
+
+    auto sel = make_mempool_tx_source(pool, /*max_weight=*/4'000'000)();
+    EXPECT_EQ(sel.total_fees, 15'000u);
+    EXPECT_EQ(sel.transactions.size(), 2u);
+}
+
+// ===========================================================================
+// good_citizen_defaults resolver truth table (pure function).
+// ===========================================================================
+
+using dgb::coin::TxServeLever;
+using dgb::coin::TxServeLevers;
+using dgb::coin::resolve_tx_serve_posture;
+
+// 9a. Operator silent + default OFF (this PR's dormant posture): nothing armed.
+TEST(GoodCitizenDefaults, SilentDefaultOffArmsNothing)
+{
+    auto p = resolve_tx_serve_posture(TxServeLevers{}, /*default_on=*/false);
+    EXPECT_FALSE(p.arm_embedded_utxo);
+    EXPECT_FALSE(p.arm_serve_mempool_txs);
+}
+
+// 9b. Explicit opt-in arms the fee-proof lane even when the default is OFF.
+TEST(GoodCitizenDefaults, ExplicitOnArmsUtxoLane)
+{
+    TxServeLevers lv;
+    lv.embedded_utxo.on = true;
+    auto p = resolve_tx_serve_posture(lv, /*default_on=*/false);
+    EXPECT_TRUE(p.arm_embedded_utxo);
+}
+
+// 9c. Operator silent + good-citizen default ON (the S2 posture) arms the lane.
+TEST(GoodCitizenDefaults, SilentDefaultOnArmsUtxoLane)
+{
+    auto p = resolve_tx_serve_posture(TxServeLevers{}, /*default_on=*/true);
+    EXPECT_TRUE(p.arm_embedded_utxo);
+}
+
+// 9d. Explicit opt-out wins over a good-citizen default ON.
+TEST(GoodCitizenDefaults, ExplicitOffWinsOverDefaultOn)
+{
+    TxServeLevers lv;
+    lv.embedded_utxo.explicit_off = true;
+    auto p = resolve_tx_serve_posture(lv, /*default_on=*/true);
+    EXPECT_FALSE(p.arm_embedded_utxo);
+}
+
+// 9e. serve_mempool_txs (S2) is CLAMPED off whenever the fee-proof lane is off:
+//     a fee-bearing commit cannot be armed without fee-proved txs behind it.
+TEST(GoodCitizenDefaults, ServeClampedWithoutUtxoLane)
+{
+    TxServeLevers lv;
+    lv.serve_mempool_txs.on = true;      // ask to serve...
+    lv.embedded_utxo.explicit_off = true; // ...but the fee lane is off.
+    auto p = resolve_tx_serve_posture(lv, /*default_on=*/false);
+    EXPECT_FALSE(p.arm_embedded_utxo);
+    EXPECT_FALSE(p.arm_serve_mempool_txs);  // clamped
 }


### PR DESCRIPTION
## ⚠️ Remediation update (S1, commit ed7b874e6) — supersedes "default OFF" below

review NO-SHIP addressed. Three blockers fixed on this branch (normal push):

1. **CI param-catalog tripwire (was RED).** `main_dgb.cpp` accepts
   `--embedded-serve-mempool-txs` but the catalog had no `BIN_DGB` row. Added
   `C_DGB` to the `embedded.serve_mempool_txs` coin mask + a `BIN_DGB`
   `FLAG_OPT_EQFALSE` alias, and wired the `[dgb]` settings-file key into the
   lane locals (CLI L2 > file L1). **Tripwire now PASSES** (308 flags /
   296 aliases, forward+reverse consistent).

2. **Restart-liveness (lane went dead after the first restart).** The
   `full_block` accrual handler dropped every block with `height != best+1`;
   `best_height` is **persisted**, so after a restart the tip is far past
   `best+1` and it dropped **forever** — the fee-proof lane was silently dead
   for the rest of the process. Now `classify_full_block_accrual`
   (`impl/dgb/coin/utxo_accrual.hpp`, pure SSOT) **re-anchors** on a forward
   gap (`UTXOViewCache::reanchor` / `UTXOViewDB::reset` wipe the stale view +
   reset `best_height`, accrual resumes from this block) and keeps the
   fail-closed **drop** on a reorg / lower height. Mirrors the DASH Window-2
   re-anchor.

3. **Good-citizen default flipped ON.** The S1 fee-proof lane (`embedded_utxo`)
   now **defaults ON** — a daemonless DGB node serves the fee-paying mempool by
   default (matches digibyted `CreateNewBlock`); `--embedded-serve-mempool-txs=false`
   opts out. The **S2** job-commit lever (`serve_mempool_txs`) stays default
   **OFF** (opt-out until S2 wires the merkle/witness/fee-fold); the resolver
   now takes a **separate per-lever default**.

**Reward-safe:** subsidy / scrypt / `won_block_serialize` untouched — the lane
only makes fees *computable* for the advisory GBT template; the connection
coinbase stays subsidy-only and the won-block merkle coinbase-only (fail-closed)
until S2. **Tests:** +6 KATs (classify truth table incl. forward-gap re-anchor,
`reanchor()` clears the view, S1 default arms utxo but not serve). **19/19
green**, tripwire green, `c2pool-dgb` builds.

Out of scope (separate tickets): S2 job-commit; the daemonless-nBits P0 (`1d00ffff`).

---

## DGB good-citizen tx-serving — S1: embedded UTXO fee-proof lane

Ports the LTC/BTC embedded **UTXO fee lane** into the DGB node so relayed
mempool txs **fee-prove** and the embedded work template can become
**fee-bearing** — the good-citizen serving baseline — instead of coinbase-only
by construction. Gated behind `--embedded-serve-mempool-txs` (**default OFF**,
dormant), mirroring the DASH `#1230` dormant-then-arm pattern.

### The gap (corrected)
The DGB embedded mempool **feed already exists** (`wire_mempool_ingest`). The
real gap is **fee-proof**: with no UTXO view, `Mempool::compute_fee_locked`
returns `fee_known=false`, so `make_mempool_tx_source` selects nothing and the
template carries subsidy only. The full selection → fee-bearing-template path
(`dgb_embedded_tx_select_test`, `dgb_coinbase_value_parity_test`) is already
implemented and tested; the one missing piece for a *live* fee-bearing template
is an embedded UTXO view. This PR adds it.

### What changed
- **`core/coin/utxo.hpp`** — `DGB_LIMITS` (2.1e18 MoneyRange, 100-block coinbase
  maturity = DigiByte `COINBASE_MATURITY_2`), `DGB_MIN_BLOCKS_TO_KEEP=288`,
  `DGB_MINING_GATE_DEPTH=110`.
- **`mempool_ingest.hpp`** — `wire_mempool_ingest` takes an optional
  `UTXOViewCache*` (default `nullptr` = byte-identical to every existing call
  site); a fed tx is fee-proved against it.
- **`main_dgb.cpp`** — `Mempool(DGB_LIMITS)`; behind the flag, open a
  `UTXOViewDB`/`UTXOViewCache`, `set_utxo`, pass the view to the ingest
  connector, and wire a `full_block → connect_block + tip-maintenance`
  pipeline. DGB's `HeaderChain` has **no hash→height map and no reorg hook**, so
  the pipeline **fail-closed accrues**: it connects only a block that is the
  confirmed header tip **and** extends the view by exactly one; any gap/reorg is
  dropped and unproven txs stay `fee_known=false`. Coverage grows with uptime,
  never overstated (the partial-UTXO ceiling LTC/BTC/DASH accept).
- **`good_citizen_defaults.hpp`** — pure resolver for the serving posture
  (KAT-able truth table).

### Reward safety
Default OFF. This is the **fee-proof lane only**: it makes fees *computable* for
the advisory GBT template and **never touches the connection coinbase
(subsidy-only) or the won-block merkle (coinbase-only, fail-closed)**.
`serialize_won_block` already drops body txs when the job carries no merkle
branches, so a won block stays coinbase-only + subsidy-only **by construction**
regardless of this lane. Worst case of a stale view is an advisory template with
a wrong fee number, never an invalid block. Subsidy SSOT (`resolve_coinbase_value`)
and scrypt PoW are untouched.

### Tests — `dgb_mempool_ingest_test` (already in both `build.yml` allowlists)
- `NoUtxoViewLeavesSelectionEmpty` — **regression witness**: fed tx, no view →
  `fee_known=false` → selection empty (today's coinbase-only "before").
- `UtxoViewFeeProvesTxIntoSelection` — fed tx **with** view holding its input →
  `fee_known`, selection carries it, `total_fees` exact ("after").
- `MultipleFeeProvedTxsSumFees` — fees sum into `total_fees`.
- `GoodCitizenDefaults.*` — resolver truth table (5 cases: silent/default,
  explicit on/off, serve-clamp).

Local: 13/13 pass; `c2pool-dgb` builds; `--embedded-serve-mempool-txs[=true|false]`
parses and appears in `--help`.

### Staged follow-on (NOT in this PR)
- **S2 (reward-critical)** — commit the selected set into the **actually-mined
  stratum job**: `stratum_merkle_siblings` branches, BIP141 witness commitment
  using `P2POOL_WITNESS_NONCE`, fold fees into the connection coinbase,
  `template_capture` at mint. Only when S2 lands does a *won* block carry the
  txs; the good-citizen default flips ON then.
- Two **pre-existing** adjacent holes to fix before default-ON serving:
  (a) daemonless DGB emits no `bits` → stratum fabricates `1d00ffff` → invalid
  nBits regardless of txs (MultiShield-V4 next-target = v37);
  (b) the P2P-relay reconstruct arm injects a second, zero-nonce BIP141
  commitment that changes the coinbase txid.