### PR TITLE
ltc: port kr1z1s v36 minority-fork convergence hotfixes (F2 + #25B + #25C)

### DIFF
--- a/src/impl/ltc/head_retention.hpp
+++ b/src/impl/ltc/head_retention.hpp
@@ -82,16 +82,6 @@ inline constexpr int64_t kHeadFreshWindow = 300;
 //   else                                                     -> reap
 inline bool head_retained(const HeadGcInput& in)
 {
-    // ⛔ MASTER SEMANTICS (pre-fix) — this is the c2pool clean_tracker Step-2
-    // policy BEFORE the F2 (#23) + #25(B) convergence hotfixes. The
-    // head_retention_test.cpp KAT is RED against this body and GREEN once it is
-    // replaced by the ported fix. The two defects encoded here:
-    //   * Guard 3 is gated on `!head_verified` and a 120s window, so the instant
-    //     the incremental verifier verifies a still-downloading head it loses
-    //     protection and is purged mid-catch-up (the 505,935-share livelock).
-    //   * There is NO desired-parent guard, so a slow / black-hole peer stalling
-    //     the frontier triggers the purge + full re-download loop.
-
     // Guard 1 — top-5 scored heads (p2pool node.py:363).
     if (in.in_top5)
         return true;
@@ -104,10 +94,19 @@ inline bool head_retained(const HeadGcInput& in)
     if (in.head_time_seen > in.now - kHeadFreshWindow)
         return true;
 
-    // Guard 3 (master) — protect only UNVERIFIED heads with frontier activity in
-    // the last 120s.
-    if (!in.head_verified && in.frontier_present
-        && in.frontier_max_time_seen > in.now - 120)
+    // Guard 2b — #25(B): the node is ACTIVELY downloading this head's missing
+    // parent (tail in `desired`) and the peer set has not collectively given up
+    // on it. This is the PRIMARY protection: a slow / black-hole peer can no
+    // longer trigger the purge + full re-download loop. Bounded by
+    // parent_abandoned so a peer re-advertising an unservable fragment cannot
+    // pin memory.
+    if (in.tail_in_desired && !in.parent_abandoned)
+        return true;
+
+    // Guard 3 — F2: protect any head whose FRONTIER received a share in the last
+    // 300s, REGARDLESS of the head's verification state. On master this was gated
+    // on `!head_verified` and 120s; that gate is the kr1z1s livelock and is gone.
+    if (in.frontier_present && in.frontier_max_time_seen > in.now - kFrontierFreshWindow)
         return true;
 
     return false;

--- a/src/impl/ltc/head_retention.hpp
+++ b/src/impl/ltc/head_retention.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+// head_retention.hpp — pure, side-effect-free predicate for the clean_tracker()
+// "eat away at heads" garbage-collection step (node.cpp Step 2). Extracted into a
+// header so the retention policy can be exercised by a KAT without a live node.
+//
+// This is the c2pool port of two p2pool-merged-v36 kr1z1s convergence hotfixes
+// (see p2pool node.py Node.clean_tracker):
+//
+//   F2  (#23, 9953edd6)  — protect a head whose FRONTIER (the oldest-downloaded
+//                          shares, reverse[tail]) received a share recently,
+//                          REGARDLESS of the head's verification state, and widen
+//                          the freshness window 120s -> 300s. On master the
+//                          protection was gated on `!verified.contains(head)` and
+//                          120s, so the instant the incremental verifier verified
+//                          a still-downloading head it LOST protection and was
+//                          purged mid-catch-up — the 505,935-share re-download
+//                          livelock.
+//
+//   #25(B) (9a2a90e8)    — protect a head whose missing parent think() is still
+//                          requesting (its `desired` set) unless every connected
+//                          peer has failed to serve that parent (parent_abandoned).
+//                          A slow / black-hole peer can no longer trigger the
+//                          purge + full re-download loop; a peer re-advertising an
+//                          unservable fragment cannot pin the tracker because the
+//                          head becomes reapable once the parent is abandoned.
+//
+// NONE of this touches share format, Share::check(), or PPLNS — it is local GC
+// scheduling only, so the verify SET stays byte-identical and there is no
+// sharechain-fork risk.
+
+#include <cstdint>
+
+namespace ltc {
+
+// All inputs a single head needs for the retain/reap decision. Timestamps are
+// unix seconds; `now` is the current time in the same unit.
+struct HeadGcInput {
+    // Guard 1: this head is among the top-5 scored heads (decorated_heads[-5:]).
+    bool in_top5{false};
+    // Guard 1b (c2pool restart-reorg): this head is on the converging challenger
+    // segment (a c2pool-specific protection, not present in p2pool). Kept as-is.
+    bool in_supersede_segment{false};
+
+    // Guard 2: when this head itself was last seen.
+    int64_t head_time_seen{0};
+
+    // Guard 3 (F2): does reverse[tail] (the frontier) exist, and what is the
+    // newest time_seen across it? A fresh frontier means shares are still
+    // arriving for this chain (it is actively downloading toward a common
+    // ancestor). This is evaluated regardless of `head_verified` after the fix.
+    bool frontier_present{false};
+    int64_t frontier_max_time_seen{0};
+
+    // Whether this head is already in the verified tracker. On master this gated
+    // Guard 3 (protection only while UNVERIFIED); after the F2 fix it does not.
+    bool head_verified{false};
+
+    // #25(B): think() still wants this head's missing parent (tail is in the
+    // `desired` set) and the peer set has not collectively abandoned it.
+    bool tail_in_desired{false};
+    bool parent_abandoned{false};
+
+    int64_t now{0};
+};
+
+// The FRONTIER freshness window (seconds). p2pool node.py: 300 after the F2 fix
+// (was 120, gated on unverified).
+inline constexpr int64_t kFrontierFreshWindow = 300;
+// The head-freshness window (Guard 2). p2pool node.py:366 — 300.
+inline constexpr int64_t kHeadFreshWindow = 300;
+
+// True  => KEEP this head (do not reap it this cycle).
+// False => the head may be removed by the GC walk.
+//
+// Byte-faithful to p2pool node.py Node.clean_tracker after #23 + #25(B):
+//   1.  in top5                                             -> keep
+//   1b. on the converging challenger segment (c2pool)       -> keep
+//   2.  head seen < 300s ago                                -> keep
+//   2b. (#25B) tail still desired AND not abandoned         -> keep   [PRIMARY]
+//   3.  (F2) frontier seen < 300s ago, ANY verified state   -> keep
+//   else                                                     -> reap
+inline bool head_retained(const HeadGcInput& in)
+{
+    // ⛔ MASTER SEMANTICS (pre-fix) — this is the c2pool clean_tracker Step-2
+    // policy BEFORE the F2 (#23) + #25(B) convergence hotfixes. The
+    // head_retention_test.cpp KAT is RED against this body and GREEN once it is
+    // replaced by the ported fix. The two defects encoded here:
+    //   * Guard 3 is gated on `!head_verified` and a 120s window, so the instant
+    //     the incremental verifier verifies a still-downloading head it loses
+    //     protection and is purged mid-catch-up (the 505,935-share livelock).
+    //   * There is NO desired-parent guard, so a slow / black-hole peer stalling
+    //     the frontier triggers the purge + full re-download loop.
+
+    // Guard 1 — top-5 scored heads (p2pool node.py:363).
+    if (in.in_top5)
+        return true;
+
+    // Guard 1b — c2pool converging-challenger segment (restart-reorg).
+    if (in.in_supersede_segment)
+        return true;
+
+    // Guard 2 — head seen recently (p2pool node.py:366).
+    if (in.head_time_seen > in.now - kHeadFreshWindow)
+        return true;
+
+    // Guard 3 (master) — protect only UNVERIFIED heads with frontier activity in
+    // the last 120s.
+    if (!in.head_verified && in.frontier_present
+        && in.frontier_max_time_seen > in.now - 120)
+        return true;
+
+    return false;
+}
+
+} // namespace ltc

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -1261,12 +1261,14 @@ void NodeImpl::readvertise_best_share()
              << " head share(s) to " << m_peers.size() << " peer(s) (ROOT-2)";
 }
 
-void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_hash)
+void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
 {
     // download_shares(): C++ implementation of the p2pool share-download loop.
     //
-    // Key differences from old c2pool implementation:
-    // 1. RANDOM peer selection (not the reporting peer)
+    // v36-0.24 kr1z1s convergence hotfix #25(C) — parent-fetch failover:
+    // 1. FAIL OVER across peers: skip peers that failed THIS hash within the TTL,
+    //    prefer the peer that advertised it (the `advertiser` argument, which was
+    //    previously discarded), and back off only once every peer has failed it.
     // 2. RANDOM parent count 0-499 (not fixed 500)
     // 3. STOPS list: known heads + their 10th parents (not empty)
     // 4. Log format: "Requesting parent share XXXX from IP:PORT"
@@ -1274,18 +1276,6 @@ void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_h
     // Already downloading this hash — avoid duplicate requests
     if (m_downloading_shares.count(target_hash))
         return;
-
-    // Stop requesting hashes that have returned empty too many times —
-    // the share is pruned from the network. p2pool uses reactive desired_var
-    // + sleep(1) backoff; we use explicit failure counting.
-    if (m_download_fail_count[target_hash] >= MAX_EMPTY_RETRIES) {
-        static int fail_log = 0;
-        if (fail_log++ % 20 == 0)
-            LOG_INFO << "[Pool] Skipping permanently failed hash "
-                     << target_hash.ToString().substr(0,16)
-                     << " (failed " << m_download_fail_count[target_hash] << " times)";
-        return;
-    }
 
     m_downloading_shares.insert(target_hash);
 
@@ -1295,12 +1285,46 @@ void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_h
         return;
     }
 
-    // p2pool: peer = random.choice(self.peers.values())
-    auto peer_it = m_peers.begin();
-    if (m_peers.size() > 1) {
-        std::advance(peer_it, core::random::random_uint256().GetLow64() % m_peers.size());
+    // Build the connected-peer key set and a key->peer lookup (IO thread owns
+    // m_peers). The advertiser is the peer that told us about this hash.
+    std::vector<NetService> peer_keys;
+    peer_keys.reserve(m_peers.size());
+    std::map<NetService, peer_ptr> by_key;
+    for (auto& [nonce, p] : m_peers) {
+        if (!p) continue;
+        auto k = p->addr();
+        peer_keys.push_back(k);
+        by_key.emplace(k, p);
     }
-    auto& peer = peer_it->second;
+    std::optional<NetService> advertiser_key;
+    if (advertiser) advertiser_key = advertiser->addr();
+
+    // #25(C): pick a peer that has NOT recently failed this exact hash, preferring
+    // the advertiser. nullopt => every peer has failed it within the TTL: back off
+    // this cycle (the failures age out and a different desired parent is tried).
+    const double fnow = static_cast<double>(std::time(nullptr));
+    std::optional<NetService> chosen_key;
+    {
+        std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
+        m_fetch_failures.prune(fnow);
+        m_peer_keys_snapshot = peer_keys;  // keep fresh for clean_tracker's parent_abandoned
+        chosen_key = m_fetch_failures.choose(
+            target_hash, advertiser_key, peer_keys, fnow,
+            [](std::size_t n) -> std::size_t {
+                return static_cast<std::size_t>(core::random::random_uint256().GetLow64() % n);
+            });
+    }
+    if (!chosen_key.has_value()) {
+        m_downloading_shares.erase(target_hash);
+        return;
+    }
+    auto pk_it = by_key.find(*chosen_key);
+    if (pk_it == by_key.end()) {
+        m_downloading_shares.erase(target_hash);
+        return;
+    }
+    auto& peer = pk_it->second;
+    const NetService chosen_key_val = *chosen_key;
 
     // p2pool: parents=random.randrange(500)
     uint64_t parents = core::random::random_uint256().GetLow64() % 500;
@@ -1352,26 +1376,34 @@ void NodeImpl::download_shares(peer_ptr /*unused_peer*/, const uint256& target_h
     auto peer_addr_for_log = peer->addr();
 
     request_shares(req_id, peer, hashes, parents, stops,
-        [this, weak_peer, target_hash, peer_addr_for_log, req_id](ltc::ShareReplyData reply)
+        [this, weak_peer, target_hash, peer_addr_for_log, req_id, chosen_key_val](ltc::ShareReplyData reply)
         {
             m_downloading_shares.erase(target_hash);
             m_pending_share_reqs.erase(req_id);
 
             if (reply.m_items.empty())
             {
-                // Empty reply = timeout or peer had no matching shares.
-                // Track failures — stop requesting after MAX_EMPTY_RETRIES.
-                auto& fail_cnt = m_download_fail_count[target_hash];
-                ++fail_cnt;
+                // Empty reply = timeout or this peer had no matching shares.
+                // #25(C): remember the (hash, peer) failure so we fail over to a
+                // DIFFERENT peer next cycle, and only abandon the head once the
+                // whole peer set has failed it (see FetchFailureMemory::abandoned).
+                {
+                    std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
+                    m_fetch_failures.record(target_hash, chosen_key_val,
+                                            static_cast<double>(std::time(nullptr)));
+                }
                 LOG_INFO << "[Pool] Share request empty for "
                          << target_hash.ToString().substr(0,16)
                          << " from " << peer_addr_for_log.to_string()
-                         << " (fail " << fail_cnt << "/" << MAX_EMPTY_RETRIES << ")";
+                         << " (failing over to another peer)";
                 return;
             }
 
-            // Success — clear failure count for this hash
-            m_download_fail_count.erase(target_hash);
+            // Success — this parent is fetchable again; clear its failure memory.
+            {
+                std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
+                m_fetch_failures.clear_hash(target_hash);
+            }
 
             LOG_INFO << "[Pool] Received " << reply.m_items.size() << " shares for download request";
 
@@ -2040,20 +2072,29 @@ void NodeImpl::run_think()
             // Clear stale download set (p2pool node.py:108-141)
             m_downloading_shares.clear();
 
-            // Reset fail counts each think() cycle — matches p2pool which
-            // re-adds desired hashes from scratch every cycle with sleep(1)
-            // backoff.  Permanent blacklisting caused bootstrap stalls:
-            // the tail parent hash would get 3 empty replies and never be
-            // requested again, leaving the chain stuck at <CHAIN_LENGTH.
-            m_download_fail_count.clear();
+            // v36-0.24 #25(C): no per-think() fail-count reset. The old peer-blind
+            // counter had to be cleared every cycle (else a tail parent that got 3
+            // empty replies was blacklisted forever and the chain stuck below
+            // CHAIN_LENGTH). The per-(hash,peer) failover memory ages out on its
+            // 90s TTL instead, so a transiently-failed peer is retried on schedule
+            // while a persistent black-hole stays skipped for that hash.
+            {
+                std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
+                m_fetch_failures.prune(static_cast<double>(std::time(nullptr)));
+            }
+            // Keep the peer-key snapshot fresh for clean_tracker's parent_abandoned.
+            refresh_peer_keys_snapshot();
 
-            // Request desired shares from random peers
+            // Request desired shares. #25(C): pass the ADVERTISER (the peer whose
+            // desired entry named the hash) so download_shares prefers it and fails
+            // over to other peers instead of picking a fully random one.
             if (!result.desired.empty() && !m_peers.empty()) {
                 for (auto& [peer_addr, hash] : result.desired) {
-                    auto peer_it = m_peers.begin();
-                    if (m_peers.size() > 1)
-                        std::advance(peer_it, core::random::random_uint256().GetLow64() % m_peers.size());
-                    download_shares(peer_it->second, hash);
+                    peer_ptr advertiser;
+                    for (auto& [nonce, p] : m_peers) {
+                        if (p && p->addr() == peer_addr) { advertiser = p; break; }
+                    }
+                    download_shares(advertiser, hash);
                 }
             }
 
@@ -2328,6 +2369,10 @@ void NodeImpl::clean_tracker()
 
       bool clean_best_changed = false;
       bool bootstrap = false;
+      // v36-0.24 #25(B): the missing parents think() still wants (its `desired`
+      // set), captured from Step-1's think() result and consulted by Step-2's head
+      // GC so a head we are ACTIVELY downloading toward is not purged mid-catch-up.
+      std::set<uint256> desired_parents;
       try {
         std::unique_lock lock(m_tracker_mutex);  // exclusive
 
@@ -2361,6 +2406,10 @@ void NodeImpl::clean_tracker()
 
             m_last_top5_heads = std::move(result.top5_heads);
 
+            // #25(B): snapshot the parents think() still wants for Step-2's GC.
+            for (const auto& [peer, hash] : result.desired)
+                desired_parents.insert(hash);
+
             if (!result.best.IsNull()) {
                 m_best_share_hash = result.best;
             }
@@ -2391,33 +2440,49 @@ void NodeImpl::clean_tracker()
             {
                 if (!m_tracker.chain.contains(head_hash)) continue;
 
-                // Guard 1: keep top-5 scored heads (p2pool node.py:363)
-                if (top5_set.count(head_hash)) continue;
+                // Assemble the retain/reap inputs for this head and delegate the
+                // policy to ltc::head_retained() (p2pool node.py Node.clean_tracker
+                // after the F2 (#23) + #25(B) convergence hotfixes). Extracting the
+                // predicate into a pure header makes it KAT-testable; the guards
+                // themselves are unchanged apart from the two ported fixes.
+                ltc::HeadGcInput gc;
+                gc.now = now_sec;
 
-                // Guard 1b (restart-reorg): keep the converging challenger segment.
+                // Guard 1: top-5 scored heads (p2pool node.py:363).
+                gc.in_top5 = top5_set.count(head_hash) != 0;
+
+                // Guard 1b (c2pool restart-reorg): converging challenger segment.
                 // Its verified height is below CHAIN_LENGTH so it is never in the
                 // top-5; without this exemption its partial verification would be
-                // eaten every ~300s and restarted forever — the original stuck-on-
-                // persisted-head latch in a different guise. Matched by segment id.
+                // eaten every ~300s and restarted forever. Matched by segment id.
+                gc.in_supersede_segment = false;
                 if (m_supersede_hint.active) {
                     try {
-                        if (m_tracker.chain.contains(head_hash) &&
-                            m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
-                            continue;
+                        if (m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                            gc.in_supersede_segment = true;
                     } catch (...) {}
                 }
 
-                // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
+                // Guard 2: head seen recently (p2pool node.py:366).
                 auto* idx = m_tracker.chain.get_index(head_hash);
-                if (!idx || idx->time_seen > now_sec - 300) continue;
+                gc.head_time_seen = idx ? idx->time_seen : 0;
+                if (!idx) {
+                    // No index => cannot evaluate freshness; keep (matches the old
+                    // `!idx || ... continue` short-circuit) and move on.
+                    continue;
+                }
 
-                // Guard 3: keep unverified heads with recent tail activity (p2pool node.py:369)
-                if (!m_tracker.verified.contains(head_hash))
+                gc.head_verified = m_tracker.verified.contains(head_hash);
+
+                // Guard 3 (F2): frontier freshness — newest time_seen across
+                // reverse[tail] (the oldest-downloaded shares). Evaluated
+                // regardless of verification state after the fix.
                 {
                     auto& rev = m_tracker.chain.get_reverse();
                     auto rev_it = rev.find(tail_hash);
                     if (rev_it != rev.end() && !rev_it->second.empty())
                     {
+                        gc.frontier_present = true;
                         int64_t max_child_ts = 0;
                         for (const auto& child : rev_it->second)
                         {
@@ -2425,9 +2490,19 @@ void NodeImpl::clean_tracker()
                             if (cidx && cidx->time_seen > max_child_ts)
                                 max_child_ts = cidx->time_seen;
                         }
-                        if (max_child_ts > now_sec - 120) continue;
+                        gc.frontier_max_time_seen = max_child_ts;
                     }
                 }
+
+                // Guard 2b (#25B): the node still wants this head's missing parent
+                // (tail in `desired`) and the peer set has not collectively given
+                // up on it (parent_fetch_abandoned takes m_fetch_failover_mtx).
+                gc.tail_in_desired = desired_parents.count(tail_hash) != 0;
+                gc.parent_abandoned = gc.tail_in_desired
+                                      ? parent_fetch_abandoned(tail_hash)
+                                      : false;
+
+                if (ltc::head_retained(gc)) continue;
 
                 to_remove.push_back(head_hash);
             }

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -7,6 +7,8 @@
 #include "share_tracker.hpp"
 #include "peer.hpp"
 #include "messages.hpp"
+#include "head_retention.hpp"        // v36-0.24 convergence: clean_tracker Guard predicate (F2 + #25B)
+#include "share_fetch_failover.hpp"  // v36-0.24 convergence: parent-fetch failover memory (#25C)
 
 #include <core/coin_params.hpp>
 #include <core/tx_advertiser.hpp>
@@ -713,12 +715,44 @@ protected:
     std::atomic<uint64_t> m_broadcast_reached_send{0};
     std::set<uint256> m_downloading_shares;   // hashes currently being fetched
 
-    // Track share hashes that peers couldn't provide (empty reply).
-    // After MAX_EMPTY_RETRIES failures, stop requesting — the share is
-    // pruned from the network. p2pool avoids this via reactive desired_var
-    // + sleep(1) backoff. We use explicit failure counting.
-    static constexpr int MAX_EMPTY_RETRIES = 3;
-    std::unordered_map<uint256, int, ShareHasher> m_download_fail_count;
+    // v36-0.24 kr1z1s convergence hotfix #25(C): per-(hash,peer) parent-fetch
+    // failure memory. Replaces the old peer-BLIND per-hash counter
+    // (m_download_fail_count / MAX_EMPTY_RETRIES) which let a single black-hole
+    // peer that answered "empty" starve every other peer that actually had the
+    // parent. Now a peer is skipped only for the hash IT failed, we fail over to
+    // other peers, prefer the advertiser, and back off only once EVERY peer has
+    // failed (failures age out on a 90s TTL, so no per-think() reset is needed).
+    //
+    // Written on the IO thread (download_shares + the run_think dispatch loop);
+    // read on the compute thread (clean_tracker Guard 2b, parent_abandoned).
+    // m_fetch_failover_mtx guards BOTH the memory and the peer-key snapshot it is
+    // queried against so the compute-thread read never races the IO-thread peer
+    // map. Contention is negligible (a handful of hashes per cycle).
+    std::mutex m_fetch_failover_mtx;
+    ltc::FetchFailureMemory<uint256, NetService> m_fetch_failures;  // guarded by m_fetch_failover_mtx
+    std::vector<NetService> m_peer_keys_snapshot;                   // guarded by m_fetch_failover_mtx
+
+    // Refresh the peer-key snapshot from the live IO-owned m_peers map. MUST be
+    // called on the IO thread. Takes m_fetch_failover_mtx.
+    void refresh_peer_keys_snapshot()
+    {
+        std::vector<NetService> keys;
+        keys.reserve(m_peers.size());
+        for (const auto& [nonce, p] : m_peers)
+            if (p) keys.push_back(p->addr());
+        std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
+        m_peer_keys_snapshot = std::move(keys);
+    }
+
+    // True iff every currently-connected peer has recently failed to serve
+    // `parent_hash` (clean_tracker Guard 2b input). Thread-safe; safe to call
+    // from the compute thread. No peers / any peer not-yet-failed -> false.
+    bool parent_fetch_abandoned(const uint256& parent_hash)
+    {
+        std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
+        return m_fetch_failures.abandoned(parent_hash, m_peer_keys_snapshot,
+                                          static_cast<double>(std::time(nullptr)));
+    }
 
     // Track req_id → peer addr for selective cancellation on disconnect.
     // p2pool has per-peer get_shares (GenericDeferrer), so connectionLost calls

--- a/src/impl/ltc/share_fetch_failover.hpp
+++ b/src/impl/ltc/share_fetch_failover.hpp
@@ -103,23 +103,27 @@ public:
                                    double now,
                                    PickIndexFn&& pick_index) const
     {
-        // ⛔ MASTER SEMANTICS (pre-fix) — this is the c2pool download-path policy
-        // BEFORE the #25(C) failover hotfix: a peer-BLIND per-hash counter. Any
-        // failure recorded for the hash within the TTL skips it for the WHOLE peer
-        // set (the m_download_fail_count / MAX_EMPTY_RETRIES model), so one
-        // black-hole peer that answers "empty" starves every other peer that has
-        // the parent. share_fetch_failover_test.cpp is RED against this body and
-        // GREEN once it is replaced by the per-peer failover.
         if (peers.empty())
             return std::nullopt;
-        if (!failed_keys(hash, now).empty())
-            return std::nullopt;                 // peer-blind: any failure blocks all
+        const std::set<PeerKeyT> failed = failed_keys(hash, now);
+
+        std::vector<PeerKeyT> eligible;
+        eligible.reserve(peers.size());
+        for (const auto& p : peers)
+            if (!failed.count(p))
+                eligible.push_back(p);
+
+        if (eligible.empty())
+            return std::nullopt;
+
+        // Prefer the advertiser when it is still eligible.
         if (advertiser.has_value())
-            for (const auto& p : peers)
+            for (const auto& p : eligible)
                 if (p == *advertiser)
                     return p;
-        const std::size_t idx = pick_index(peers.size());
-        return peers[idx % peers.size()];
+
+        const std::size_t idx = pick_index(eligible.size());
+        return eligible[idx % eligible.size()];
     }
 
     // True iff there ARE connected peers and EVERY one has recently failed

--- a/src/impl/ltc/share_fetch_failover.hpp
+++ b/src/impl/ltc/share_fetch_failover.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+// share_fetch_failover.hpp — pure, per-(hash,peer) failure memory for the parent
+// share-download path (node.cpp download_shares). Extracted into a header so the
+// failover policy can be exercised by a KAT without a live node.
+//
+// c2pool port of p2pool-merged-v36 kr1z1s convergence hotfix #25(C) (9a2a90e8,
+// P2PNode.download_shares): remember which peer recently failed to serve a given
+// share hash, skip those peers for THAT hash, prefer the peer that advertised it,
+// and back off only once EVERY connected peer has failed it. Guarantees no single
+// slow / black-hole / malicious peer can wedge a parent fetch or desync the node
+// (the measured kr1z1s wall-parent loop: one hash re-requested 247x in 40 min,
+// 12,929 requests for 4,459 hashes in 4h).
+//
+// On master c2pool used a peer-BLIND per-hash counter (m_download_fail_count,
+// MAX_EMPTY_RETRIES=3, reset every think()): after 3 empty replies the hash was
+// skipped for the WHOLE peer set, so one black-hole peer that answers "empty"
+// starved every other peer that actually had the parent. This replaces that with
+// per-peer memory that ages out on a TTL.
+//
+// Pure / templated: no c2pool types, no consensus surface. HashT and PeerKeyT are
+// any ordered, copyable key types (production: uint256 hash, NetService peer key).
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <vector>
+#include <optional>
+
+namespace ltc {
+
+template <typename HashT, typename PeerKeyT>
+class FetchFailureMemory {
+public:
+    // p2pool node.py: _fetch_failure_ttl = 90.0 (~6*SHARE_PERIOD). Long enough to
+    // route around a black-hole peer across several attempts; short enough that a
+    // transiently-busy honest peer is retried and a parent that becomes available
+    // again is re-fetched.
+    static constexpr double kDefaultTtl = 90.0;
+
+    explicit FetchFailureMemory(double ttl = kDefaultTtl) : m_ttl(ttl) {}
+
+    double ttl() const { return m_ttl; }
+
+    // Record that `peer` failed to serve `hash` at time `now` (empty reply,
+    // timeout, connection loss, or handler exception).
+    void record(const HashT& hash, const PeerKeyT& peer, double now)
+    {
+        m_failures[hash][peer] = now;
+    }
+
+    // The parent became fetchable again — forget its whole failure record.
+    void clear_hash(const HashT& hash)
+    {
+        m_failures.erase(hash);
+    }
+
+    // Drop failure entries older than the TTL (and empty hash buckets). Bounds
+    // memory; called once per download cycle.
+    void prune(double now)
+    {
+        for (auto it = m_failures.begin(); it != m_failures.end();) {
+            auto& per_peer = it->second;
+            for (auto pit = per_peer.begin(); pit != per_peer.end();) {
+                if (now - pit->second > m_ttl)
+                    pit = per_peer.erase(pit);
+                else
+                    ++pit;
+            }
+            if (per_peer.empty())
+                it = m_failures.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    // Peer keys that failed `hash` within the TTL (i.e. currently ineligible).
+    std::set<PeerKeyT> failed_keys(const HashT& hash, double now) const
+    {
+        std::set<PeerKeyT> out;
+        auto it = m_failures.find(hash);
+        if (it == m_failures.end())
+            return out;
+        for (const auto& [peer, ts] : it->second)
+            if (now - ts <= m_ttl)
+                out.insert(peer);
+        return out;
+    }
+
+    // Pick a peer to request `hash` from, EXCLUDING peers that failed this exact
+    // hash within the TTL. Prefer `advertiser` if it is still eligible. Returns
+    // nullopt iff every connected peer has recently failed this hash (caller backs
+    // off and lets the failures age out). `pick_index(n)` chooses a uniform index
+    // in [0, n) — injected so the KAT is deterministic; production passes the RNG.
+    //
+    // This is the attack-vector fix: a single black-hole / slow / malicious peer
+    // can never wedge a parent fetch, because the node always fails over to
+    // another peer that may have the parent.
+    template <typename PickIndexFn>
+    std::optional<PeerKeyT> choose(const HashT& hash,
+                                   const std::optional<PeerKeyT>& advertiser,
+                                   const std::vector<PeerKeyT>& peers,
+                                   double now,
+                                   PickIndexFn&& pick_index) const
+    {
+        // ⛔ MASTER SEMANTICS (pre-fix) — this is the c2pool download-path policy
+        // BEFORE the #25(C) failover hotfix: a peer-BLIND per-hash counter. Any
+        // failure recorded for the hash within the TTL skips it for the WHOLE peer
+        // set (the m_download_fail_count / MAX_EMPTY_RETRIES model), so one
+        // black-hole peer that answers "empty" starves every other peer that has
+        // the parent. share_fetch_failover_test.cpp is RED against this body and
+        // GREEN once it is replaced by the per-peer failover.
+        if (peers.empty())
+            return std::nullopt;
+        if (!failed_keys(hash, now).empty())
+            return std::nullopt;                 // peer-blind: any failure blocks all
+        if (advertiser.has_value())
+            for (const auto& p : peers)
+                if (p == *advertiser)
+                    return p;
+        const std::size_t idx = pick_index(peers.size());
+        return peers[idx % peers.size()];
+    }
+
+    // True iff there ARE connected peers and EVERY one has recently failed
+    // `hash` — the parent is unfetchable from the whole peer set, so a head
+    // waiting on it may be reaped (clean_tracker Guard 2b). No peers, or any peer
+    // not-yet-failed -> false: the download is still viable, keep protecting.
+    bool abandoned(const HashT& hash,
+                   const std::vector<PeerKeyT>& peers,
+                   double now) const
+    {
+        if (peers.empty())
+            return false;
+        const std::set<PeerKeyT> failed = failed_keys(hash, now);
+        for (const auto& p : peers)
+            if (!failed.count(p))
+                return false;
+        return true;
+    }
+
+    std::size_t tracked_hashes() const { return m_failures.size(); }
+
+private:
+    double m_ttl;
+    // hash -> { peer_key -> last_failure_timestamp }
+    std::map<HashT, std::map<PeerKeyT, double>> m_failures;
+};
+
+} // namespace ltc

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -18,7 +18,16 @@ if (BUILD_TESTING AND GTest_FOUND)
     # measurement that justifies it, and that an all-pass window logs no blocked
     # line and actually activates. Same folding rule: into the existing
     # allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp)
+    #
+    # head_retention_test.cpp + share_fetch_failover_test.cpp: the two
+    # p2pool-merged-v36 kr1z1s convergence hotfixes ported into c2pool LTC — the
+    # clean_tracker head-retention predicate (F2 (#23) + #25(B)) and the
+    # parent-fetch failover memory (#25(C)). Both drive the REAL pure headers
+    # (head_retention.hpp / share_fetch_failover.hpp) that node.cpp wires in.
+    # RED on master semantics, GREEN after the fix. Same folding rule: into the
+    # existing allowlisted target (a standalone add_executable would be absent
+    # from build.yml's --target list and silently Not-Run — the #769 trap).
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/head_retention_test.cpp
+++ b/src/impl/ltc/test/head_retention_test.cpp
@@ -1,0 +1,128 @@
+// head_retention_test.cpp — KAT for the clean_tracker() head-retention predicate
+// (p2pool-merged-v36 kr1z1s convergence hotfixes F2 (#23) + #25(B)).
+//
+// RED on master semantics (Guard 3 gated on `!verified` + 120s, no desired-parent
+// guard), GREEN after the fix (Guard 3 ungated + 300s, Guard 2b desired&&!abandoned).
+//
+// Mirrors p2pool test_convergence.py:313-387 and test_minority_fork_livelock.py:331-366.
+
+#include <gtest/gtest.h>
+#include "../head_retention.hpp"
+
+using ltc::HeadGcInput;
+using ltc::head_retained;
+
+namespace {
+
+// A head that is NOT trivially protected: not top-5, not on a supersede segment,
+// itself seen long ago (so Guard 1/1b/2 never fire and the test isolates
+// Guard 2b / Guard 3).
+HeadGcInput base_old_head(int64_t now)
+{
+    HeadGcInput in;
+    in.now = now;
+    in.in_top5 = false;
+    in.in_supersede_segment = false;
+    in.head_time_seen = now - 10000;   // ancient: Guard 2 cannot fire
+    in.head_verified = false;
+    in.frontier_present = false;
+    in.frontier_max_time_seen = 0;
+    in.tail_in_desired = false;
+    in.parent_abandoned = false;
+    return in;
+}
+
+} // namespace
+
+// Regression guard (GREEN on both master and fix): a still-downloading UNVERIFIED
+// head with a fresh frontier is protected. Master already did this.
+TEST(HeadRetention, downloading_head_retained_when_unverified)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.head_verified = false;
+    in.frontier_present = true;
+    in.frontier_max_time_seen = now - 60;   // 60s: fresh under both 120s and 300s
+    EXPECT_TRUE(head_retained(in));
+}
+
+// RED on master: once F1's incremental verifier VERIFIES a still-downloading head,
+// master's Guard 3 (`!verified`) stops protecting it and it is purged mid-catch-up.
+// The fix drops the verified gate: a fresh frontier protects it regardless.
+TEST(HeadRetention, downloading_head_retained_after_it_becomes_verified)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.head_verified = true;                // <- master loses protection here
+    in.frontier_present = true;
+    in.frontier_max_time_seen = now - 200;  // 200s: fresh under the fixed 300s window
+    EXPECT_TRUE(head_retained(in));
+}
+
+// GREEN on both: a genuinely dead fork (frontier >300s stale, not desired, not
+// top-5) is still reaped. The 300s window self-lapses after download activity stops.
+TEST(HeadRetention, dead_head_still_reaped)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.head_verified = false;
+    in.frontier_present = true;
+    in.frontier_max_time_seen = now - 301;  // just past the window
+    in.tail_in_desired = false;
+    EXPECT_FALSE(head_retained(in));
+}
+
+// RED on master: the node is still requesting this head's missing parent
+// (tail in `desired`) but a peer STALLED so no fresh frontier shares arrived
+// (frontier >300s stale). Master has no desired-parent guard, so it reaps the
+// partial chain and re-downloads from scratch — the 12,929-request relapse loop.
+// The fix protects it via Guard 2b.
+TEST(HeadRetention, head_with_outstanding_request_survives_peer_stall)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.frontier_present = true;
+    in.frontier_max_time_seen = now - 400;  // peer stalled: frontier gone stale
+    in.tail_in_desired = true;              // but we still WANT the parent
+    in.parent_abandoned = false;            // and not every peer has failed it
+    EXPECT_TRUE(head_retained(in));
+}
+
+// GREEN on both (invariant): once EVERY connected peer has failed to serve the
+// missing parent, the head is abandoned and becomes reapable — memory stays
+// bounded, an unservable re-advertised fragment cannot pin the tracker.
+TEST(HeadRetention, head_reaped_when_all_peers_failed_the_parent)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.frontier_present = true;
+    in.frontier_max_time_seen = now - 400;  // stale frontier
+    in.tail_in_desired = true;
+    in.parent_abandoned = true;             // <- whole peer set gave up
+    EXPECT_FALSE(head_retained(in));
+}
+
+// GREEN on both: top-5 and supersede-segment protections are unconditional.
+TEST(HeadRetention, top5_and_supersede_always_kept)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.frontier_present = false;
+    in.tail_in_desired = false;
+
+    auto t5 = in; t5.in_top5 = true;
+    EXPECT_TRUE(head_retained(t5));
+
+    auto ss = in; ss.in_supersede_segment = true;
+    EXPECT_TRUE(head_retained(ss));
+}
+
+// GREEN on both: a recently-seen head is kept by Guard 2 regardless of everything
+// downstream.
+TEST(HeadRetention, recently_seen_head_kept)
+{
+    const int64_t now = 1'000'000;
+    auto in = base_old_head(now);
+    in.head_time_seen = now - 100;   // < 300s
+    EXPECT_TRUE(head_retained(in));
+}

--- a/src/impl/ltc/test/share_fetch_failover_test.cpp
+++ b/src/impl/ltc/test/share_fetch_failover_test.cpp
@@ -1,0 +1,138 @@
+// share_fetch_failover_test.cpp — KAT for the parent-fetch failover memory
+// (p2pool-merged-v36 kr1z1s convergence hotfix #25(C)).
+//
+// RED on master semantics (peer-BLIND per-hash counter: any failure on a hash
+// skips it for the whole peer set), GREEN after the per-peer failover fix.
+//
+// Mirrors p2pool test_minority_fork_livelock.py:459-505.
+
+#include <gtest/gtest.h>
+#include <string>
+#include "../share_fetch_failover.hpp"
+
+using Mem = ltc::FetchFailureMemory<std::string, std::string>;
+
+namespace {
+// Deterministic index picker for the KAT (production injects the RNG).
+auto first = [](std::size_t) -> std::size_t { return 0; };
+}
+
+// RED on master: peerA failed hash H, peerB has not. choose() must return peerB.
+// Master's peer-blind counter skips H for everyone once it has failed -> nullopt.
+TEST(FetchFailover, choose_skips_recently_failed_peer)
+{
+    Mem m;
+    m.record("H", "A", /*now=*/100.0);
+    auto pick = m.choose("H", /*advertiser=*/std::nullopt,
+                         /*peers=*/{"A", "B"}, /*now=*/110.0, first);
+    ASSERT_TRUE(pick.has_value());
+    EXPECT_EQ(*pick, "B");
+}
+
+// GREEN on both: with no failures the advertiser is preferred.
+TEST(FetchFailover, choose_prefers_the_advertiser)
+{
+    Mem m;
+    auto pick = m.choose("H", /*advertiser=*/std::optional<std::string>{"B"},
+                         /*peers=*/{"A", "B", "C"}, /*now=*/100.0, first);
+    ASSERT_TRUE(pick.has_value());
+    EXPECT_EQ(*pick, "B");
+}
+
+// GREEN on both: the advertiser is skipped if IT is the one that failed the hash.
+TEST(FetchFailover, choose_skips_advertiser_when_it_failed)
+{
+    Mem m;
+    m.record("H", "B", 100.0);
+    auto pick = m.choose("H", /*advertiser=*/std::optional<std::string>{"B"},
+                         /*peers=*/{"A", "B"}, /*now=*/110.0, first);
+    ASSERT_TRUE(pick.has_value());
+    EXPECT_EQ(*pick, "A");
+}
+
+// GREEN on both: once EVERY peer has failed the hash, back off (nullopt).
+TEST(FetchFailover, choose_returns_none_when_all_peers_failed)
+{
+    Mem m;
+    m.record("H", "A", 100.0);
+    m.record("H", "B", 100.0);
+    auto pick = m.choose("H", std::nullopt, {"A", "B"}, 110.0, first);
+    EXPECT_FALSE(pick.has_value());
+}
+
+// RED on master: a single black-hole peer (answers "empty" forever) must never
+// wedge a two-peer fetch. Record its failure repeatedly; choose() must keep
+// returning the good peer. Master skips the hash for everyone -> nullopt (wedge).
+TEST(FetchFailover, single_blackhole_never_wedges_multi_peer_fetch)
+{
+    Mem m;
+    const std::vector<std::string> peers{"blackhole", "good"};
+    // The black-hole advertised the hash and was tried once — it failed (empty).
+    m.record("H", "blackhole", /*now=*/100.0);
+    // From here on, even with the black-hole re-advertising, every fetch must fail
+    // over to the good peer. Master's peer-blind counter would skip H entirely.
+    for (double t = 101.0; t < 130.0; t += 1.0) {
+        auto pick = m.choose("H", /*advertiser=*/std::optional<std::string>{"blackhole"},
+                             peers, t, first);
+        ASSERT_TRUE(pick.has_value()) << "wedged at t=" << t;
+        EXPECT_EQ(*pick, "good");
+        // the black-hole fails again on every attempt, refreshing its failure ts
+        m.record("H", "blackhole", t);
+    }
+}
+
+// GREEN on both: a per-peer failure ages out after the TTL, and that peer becomes
+// eligible again.
+TEST(FetchFailover, failure_memory_expires_after_ttl)
+{
+    Mem m(/*ttl=*/90.0);
+    m.record("H", "A", /*now=*/0.0);
+    // Within the TTL: A is ineligible.
+    EXPECT_EQ(m.failed_keys("H", 10.0).count("A"), 1u);
+    // Past the TTL: A is eligible again.
+    EXPECT_EQ(m.failed_keys("H", 100.0).count("A"), 0u);
+    auto pick = m.choose("H", std::nullopt, {"A"}, 100.0, first);
+    ASSERT_TRUE(pick.has_value());
+    EXPECT_EQ(*pick, "A");
+}
+
+// GREEN on both: prune() drops aged entries and empties the bucket.
+TEST(FetchFailover, prune_bounds_memory)
+{
+    Mem m(/*ttl=*/90.0);
+    m.record("H", "A", 0.0);
+    EXPECT_EQ(m.tracked_hashes(), 1u);
+    m.prune(/*now=*/200.0);
+    EXPECT_EQ(m.tracked_hashes(), 0u);
+}
+
+// GREEN on both (invariant): a head's parent is abandoned only once EVERY peer
+// has failed it. Mirrors clean_tracker Guard 2b's `parent_abandoned` input.
+TEST(FetchFailover, parent_abandoned_requires_every_peer_to_have_failed)
+{
+    Mem m;
+    const std::vector<std::string> peers{"A", "B"};
+    m.record("H", "A", 100.0);
+    EXPECT_FALSE(m.abandoned("H", peers, 110.0));   // B has not failed
+    m.record("H", "B", 100.0);
+    EXPECT_TRUE(m.abandoned("H", peers, 110.0));     // both failed
+}
+
+// GREEN on both: with no connected peers a parent is NOT abandoned (the download
+// is merely waiting for a peer, not unfetchable).
+TEST(FetchFailover, no_peers_is_not_abandoned)
+{
+    Mem m;
+    m.record("H", "A", 100.0);
+    EXPECT_FALSE(m.abandoned("H", /*peers=*/{}, 110.0));
+}
+
+// GREEN on both: a success clears the whole failure record for that hash.
+TEST(FetchFailover, success_clears_failure_memory)
+{
+    Mem m;
+    m.record("H", "A", 100.0);
+    m.clear_hash("H");
+    EXPECT_TRUE(m.failed_keys("H", 110.0).empty());
+    EXPECT_FALSE(m.abandoned("H", {"A"}, 110.0));
+}


### PR DESCRIPTION
## Port p2pool-merged-v36 kr1z1s convergence hotfixes → c2pool LTC

ltc.voidbind was showing a controversial hashrate graph; the node lagged the
Python fork's minority-fork convergence fixes. This ports the missing convergence
hotfixes into c2pool LTC, byte-faithful for consensus (the verify SET stays
identical — **no sharechain fork**), each behind a red-on-master / green-after KAT.

### What was ported (mapped present-vs-missing)

| Fix | p2pool commit | c2pool status before | This PR |
|-----|---------------|----------------------|---------|
| **F1** think() verify budget | 9953edd6 (#23) | already PRESENT (stronger than py) | untouched |
| **F2** frontier retention regardless of verified state | 9953edd6 (#23) | **MISSING** (Guard 3 gated on `!verified`, 120s) | **PORTED** |
| **#25(B)** desired-parent protection | 9a2a90e8 (#25) | **MISSING** | **PORTED** |
| **#25(C)** parent-fetch failover | 9a2a90e8 (#25) | **MISSING** (peer-blind per-hash counter) | **PORTED** |
| **F4** majority-escape denominator | d21279ce (#24) | **N/A** — c2pool never had the v0.20 stale-tip serve-hold; #25(A) confirms c2pool's serve-always design is the correct one | nothing to port |

### The fix

**F2 + #25(B) — `clean_tracker()` head retention** (`head_retention.hpp`, `node.cpp` Step 2)
- Guard 3 now protects a head whose **frontier** (`reverse[tail]`) received a share in the last 300s **regardless of verification state** (was: only while unverified, 120s). Removes the livelock where the incremental verifier verified a still-downloading head and `clean_tracker` then purged it mid-catch-up (kr1z1s: 505,935 shares re-downloaded in 76 min without adopting).
- New Guard 2b: protect a head whose missing parent think() still wants (tail in the `desired` set) unless every connected peer has failed to serve it (`parent_fetch_abandoned`). A slow / black-hole peer can no longer trigger the purge + re-download loop; memory stays bounded.

**#25(C) — parent-fetch failover** (`share_fetch_failover.hpp`, `node.cpp` `download_shares` + desired-dispatch)
- Replaces the peer-blind per-hash counter (`m_download_fail_count` / `MAX_EMPTY_RETRIES`, reset every think()) with per-`(hash, peer)` failure memory on a 90s TTL. `download_shares` now uses the **advertiser** argument (previously discarded), skips peers that recently failed *this* hash, prefers the advertiser, and backs off only once every peer has failed it. One black-hole / slow / malicious peer can no longer wedge a parent fetch (the measured wall-parent loop: one hash re-requested 247× in 40 min).
- The failure memory + a peer-key snapshot are guarded by `m_fetch_failover_mtx` so `clean_tracker`'s compute-thread `parent_abandoned` read never races the IO-thread peer map.

### Consensus surface
None. Neither fix touches share format, `Share::check()`, or PPLNS — the verify SET stays byte-identical network-wide. The CHAIN_LENGTH score cliff is unchanged: convergence is achieved by making the full window reliably deliverable so the existing selection adopts the real chain, not by letting a partial fragment win best.

### Tests (per-fix KAT, red-on-master / green-after)
Both KATs are folded into the existing allowlisted `share_test` target (a standalone `add_executable` would be Not-Run — the #769 trap). The predicates are extracted into pure headers so the policy is exercised without a live node.

- Commit 1 encodes the **master** semantics in the two headers → the KATs are **RED** (5 failures: 2 head-retention, 3 failover), verified in the real `share_test` binary.
- Commit 2 flips both headers to the fixed policy and wires them into the node → **GREEN**.

Local `share_test`: **114/114 pass** at HEAD (17 new cases across `HeadRetention.*` + `FetchFailover.*`). Full build of the `ltc` library + `share_test` target from a clean conan tree.

### Follow-ups (out of scope here)
- **Graph-estimate / display correction** (the visible `ltc.voidbind` symptom): the graph controversy at the observed moment is a **display** artifact (the pool-rate/stale-prop feed anchors on the tallest *raw* head, which flips between forks), not convergence — tracked separately so this PR stays a clean, consensus-adjacent convergence port.
- p2pool's negative verify cache (7242073f) and serve-side easing clamp — neither is in the .23/.24 set and neither applies to c2pool's serve-always design.

Refs p2pool-merged-v36 `9953edd6` (#23), `d21279ce` (#24), `9a2a90e8` (#25).
