### PR TITLE
dgb: seed sharechain bootstrap addrs + --sharechain-addnode (contabo revival)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -156,7 +156,8 @@ void print_banner(const char* argv0, const core::CoinParams& p)
         << "       [--coin-daemon H:P] [--coin-magic HEX] [--regtest]\n"
         << "       [--regtest-force-won-share] [--no-p2p-relay]\n"
         << "       [--redistribute SPEC] [--node-owner-address ADDR]\n"
-        << "       [--sharechain-port P] [--embedded-serve-mempool-txs[=true|false]]\n"
+        << "       [--sharechain-port P] [--sharechain-addnode HOST:PORT ...]\n"
+        << "       [--embedded-serve-mempool-txs[=true|false]]\n"
         << "       [--data-dir PATH] [--dev-relax-algo-softforks]\n"
         << "       [--coin-p2p-discover]\n\n"
         << "  --data-dir PATH  root all per-instance state here (default ~/.c2pool);\n"
@@ -244,7 +245,12 @@ int run_node(const core::CoinParams& params, bool testnet,
              // explicit --embedded-serve-mempool-txs=false opt-out. Both false =
              // operator said nothing (resolver applies the posture default).
              bool serve_mempool_txs = false,
-             bool serve_mempool_txs_off = false)
+             bool serve_mempool_txs_off = false,
+             // --sharechain-addnode HOST:PORT (repeatable): explicit sharechain
+             // (pool P2P) peer(s) to pin. When non-empty, seeds ONLY these into
+             // m_bootstrap_addrs (public defaults suppressed); empty falls back to
+             // DEFAULT_BOOTSTRAP_HOSTS. Contabo DGB revival lever. Mirrors BCH.
+             const std::vector<std::pair<std::string, uint16_t>>& sharechain_addnodes = {})
 {
     io::io_context ioc;
 
@@ -270,14 +276,36 @@ int run_node(const core::CoinParams& params, bool testnet,
     // the YAML path never sets it here). OFF by default; the only flip is the
     // explicit --dev-relax-algo-softforks marker. Mainnet stays fail-closed.
     config.coin()->m_dev_relax_algo_softforks = dev_relax_algo_softforks;
-    // DEFAULT_BOOTSTRAP_HOSTS is empty until DGB p2pool nodes come online, so
-    // there are no outbound seeds to dial this slice — the node binds its
-    // listener and waits for inbound sharechain peers.
-    for (const auto& host : dgb::PoolConfig::DEFAULT_BOOTSTRAP_HOSTS) {
-        const std::string addr = host.find(':') == std::string::npos
-            ? host + ":" + std::to_string(dgb::PoolConfig::P2P_PORT)
-            : host;
-        config.pool()->m_bootstrap_addrs.emplace_back(addr);
+    // Sharechain bootstrap addr-store seed (contabo DGB revival FIX).
+    // run_node hand-builds Config WITHOUT PoolConfig::load() (the sole YAML
+    // populator of m_bootstrap_addrs), and on master DEFAULT_BOOTSTRAP_HOSTS was
+    // ALSO empty AND there was no --sharechain-addnode flag -> a public DGB node
+    // had 0 outbound sharechain seeds and never joined the kr1z1s DGB (scrypt)
+    // sharechain. Seed it here, BEFORE the NodeImpl ctor reads
+    // pool()->m_bootstrap_addrs into the addr store (below). --sharechain-addnode
+    // pins an explicit peer (e.g. 92.53.224.27:5024, the live kr1z1s DGB
+    // sharechain); with none given, the public DEFAULT_BOOTSTRAP_HOSTS are
+    // seeded at :5024. REWARD-SAFE: transport addresses only -- PREFIX/
+    // IDENTIFIER/port/proto/share/PPLNS/coinbase untouched; the node JOINS the
+    // existing chain via the standard handshake, it cannot fork it.
+    dgb::seed_sharechain_bootstrap(*config.pool(), sharechain_addnodes, regtest);
+    if (!sharechain_addnodes.empty()) {
+        // Explicit pin: reset any stale public addr book so saved public peers
+        // (scored by first_seen/last_seen) can't outrank the pinned target.
+        // AddrStore builds config_path()/<net_subdir>/addrs.json (DGB keeps a
+        // per-net dir, unlike BCH). Best-effort.
+        std::filesystem::path addrs_path =
+            core::filesystem::config_path() / net_subdir / "addrs.json";
+        std::error_code rm_ec;
+        std::filesystem::remove(addrs_path, rm_ec);  // best-effort
+    }
+    {
+        const char* mode_name = !sharechain_addnodes.empty()
+            ? "explicit --sharechain-addnode"
+            : (regtest ? "regtest-isolated" : "public-default");
+        std::cout << "[DGB] sharechain bootstrap: "
+                  << config.pool()->m_bootstrap_addrs.size()
+                  << " addr(s) (" << mode_name << ")\n";
     }
 
     // ── DGB coin-network peer discovery (--coin-p2p-discover) ────────────────
@@ -2612,6 +2640,11 @@ int main(int argc, char** argv)
     bool coin_p2p_discover = false;         // --coin-p2p-discover: DGB-isolated scored/diverse coin-network peer discovery (network-standalone arm; independent of local digibyted)
     bool serve_mempool_txs = false;         // --embedded-serve-mempool-txs: arm the embedded UTXO fee-proof lane (S1)
     bool serve_mempool_txs_off = false;     // --embedded-serve-mempool-txs=false: explicit opt-out
+    // --sharechain-addnode HOST:PORT (repeatable): explicit sharechain (pool
+    // P2P) peer(s) to pin. Seeds m_bootstrap_addrs before the Node ctor reads it
+    // (contabo DGB revival FIX). e.g. --sharechain-addnode 92.53.224.27:5024
+    // pins the live kr1z1s DGB sharechain. Mirrors main_bch.cpp.
+    std::vector<std::pair<std::string, uint16_t>> sharechain_addnodes;
     // ── DGB-as-DOGE-parent embedded merged-mining arm (--merged DOGE) [SLICE 2] ──
     // --merged SYMBOL:CHAIN_ID[:HOST:PORT:USER:PASS[:P2P_PORT]] stands up an
     // embedded DOGE aux backend DAEMONLESS (DOGE chain_id=98, P2P port 22556). The
@@ -2711,6 +2744,24 @@ int main(int argc, char** argv)
             // STAYS 5024 (PoolConfig::P2P_PORT) when omitted, preserving G1 oracle
             // byte-parity + share_test pins. DGB-fenced opt-in; no shared-base touch.
             sharechain_port = static_cast<uint16_t>(std::stoi(argv[++i]));
+        }
+        else if (std::strcmp(argv[i], "--sharechain-addnode") == 0 && i + 1 < argc) {
+            // --sharechain-addnode HOST:PORT -- repeatable; pin explicit
+            // sharechain (pool P2P) peer(s). HOST:PORT split via rfind(':')
+            // (IPv6-safe enough for the numeric-IP/hostname seeds we pin).
+            // Reject a bare HOST with no port (matches main_bch.cpp). Seeds
+            // m_bootstrap_addrs (public defaults suppressed) so a public DGB
+            // node joins the kr1z1s DGB sharechain -- e.g.
+            // --sharechain-addnode 92.53.224.27:5024.
+            std::string ep = argv[++i];
+            const auto c = ep.rfind(':');
+            if (c == std::string::npos) {
+                std::cerr << "--sharechain-addnode requires HOST:PORT\n";
+                return 1;
+            }
+            sharechain_addnodes.emplace_back(
+                ep.substr(0, c),
+                static_cast<uint16_t>(std::stoi(ep.substr(c + 1))));
         }
         else if (std::strcmp(argv[i], "--merged") == 0 && i + 1 < argc) {
             merged_chain_specs.emplace_back(argv[++i]);  // SYMBOL:CHAIN_ID[:HOST:PORT:USER:PASS[:P2P_PORT]]
@@ -2814,7 +2865,8 @@ int main(int argc, char** argv)
                         http_addr, http_port,
                         merged_chain_specs, doge_p2p_address, doge_p2p_port,
                         embedded_doge,
-                        serve_mempool_txs, serve_mempool_txs_off);
+                        serve_mempool_txs, serve_mempool_txs_off,
+                        sharechain_addnodes);
 
     // --selftest, or a bare invocation: drive the live score path so the
     // binary exercises real consensus code, then exit cleanly.

--- a/src/core/param_catalog.inc
+++ b/src/core/param_catalog.inc
@@ -157,11 +157,12 @@ C2P_PARAM("sharechain.listen", Sharechain, HOSTPORT, RESTART, C_ALL, FROM_POOL_C
   C2P_ALIAS("sharechain.listen", BIN_DGB, "--sharechain-port", VALUE)
   C2P_ALIAS("sharechain.listen", BIN_BCH, "--p2p-port", VALUE)
 
-C2P_PARAM("sharechain.addnodes", Sharechain, LIST_HOSTPORT, RESTART, C_DASH|C_BTC|C_BIP110|C_BCH, LIT, "", HOSTPORT_V, "persistent outbound sharechain peers")
+C2P_PARAM("sharechain.addnodes", Sharechain, LIST_HOSTPORT, RESTART, C_DASH|C_BTC|C_BIP110|C_BCH|C_DGB, LIT, "", HOSTPORT_V, "persistent outbound sharechain peers")
   C2P_ALIAS("sharechain.addnodes", BIN_DASH, "--addnode", VALUE)
   C2P_ALIAS("sharechain.addnodes", BIN_BTC, "--sharechain-addnode", VALUE)
   C2P_ALIAS("sharechain.addnodes", BIN_BIP110, "--sharechain-addnode", VALUE)
   C2P_ALIAS("sharechain.addnodes", BIN_BCH, "--sharechain-addnode", VALUE)
+  C2P_ALIAS("sharechain.addnodes", BIN_DGB, "--sharechain-addnode", VALUE)
 
 C2P_PARAM("sharechain.connects", Sharechain, LIST_HOSTPORT, RESTART, C_DASH, LIT, "", HOSTPORT_V, "connect-only sharechain peers")
   C2P_ALIAS("sharechain.connects", BIN_DASH, "--connect", VALUE)

--- a/src/impl/dgb/config_pool.hpp
+++ b/src/impl/dgb/config_pool.hpp
@@ -10,6 +10,7 @@
 #include <cstdint>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace dgb
@@ -138,9 +139,17 @@ public:
         "nversionbips", "csv", "segwit", "reservealgo", "odo", "taproot"
     };
 
-    // Bootstrap peers for the DGB Scrypt p2pool network
+    // Bootstrap peers for the DGB Scrypt p2pool network.
+    // 92.53.224.27 is the live kr1z1s DGB sharechain node (host p2p-spb.xyz,
+    // web :5025), the anchor of the public DGB (scrypt) sharechain this lane
+    // joins. Seeded at P2P_PORT (5024) by run_node / the bootstrap seam below
+    // unless a host literal already carries an explicit ":port". Was empty on
+    // master, so a public DGB node had 0 outbound sharechain seeds to dial and
+    // never joined the chain. REWARD-SAFE: a transport address only -- PREFIX/
+    // IDENTIFIER/P2P_PORT/proto/share/PPLNS/coinbase are untouched, so a node
+    // JOINS the existing chain through the standard handshake; it cannot fork it.
     static inline const std::vector<std::string> DEFAULT_BOOTSTRAP_HOSTS = {
-        // Will be populated as DGB p2pool nodes come online
+        "92.53.224.27",   // kr1z1s DGB scrypt sharechain (p2p-spb.xyz), :5024
     };
 
     // -----------------------------------------------------------------------
@@ -150,5 +159,86 @@ public:
     std::string m_worker;
     std::vector<NetService> m_bootstrap_addrs;
 };
+
+// ---------------------------------------------------------------------------
+// Sharechain bootstrap-source selection (pure, testable seam)
+//
+// FIX (contabo DGB revival, 2026-09-05): run_node (main_dgb.cpp) hand-builds
+// dgb::Config WITHOUT the YAML load() that is the sole populator of
+// m_bootstrap_addrs. On master DEFAULT_BOOTSTRAP_HOSTS was ALSO empty AND there
+// was no --sharechain-addnode flag, so a public DGB node had 0 outbound
+// sharechain seeds and never joined the kr1z1s DGB (scrypt) sharechain. This
+// resolver + builder let run_node seed the addr store deterministically before
+// the Node ctor reads it, WITHOUT a YAML file. Mirrors the BCH seam
+// (src/impl/bch/config_pool.hpp select_sharechain_bootstrap_mode): DGB has no
+// --network-id federation CLI either, so there is no custom-net precedence tier.
+//
+// REWARD-SAFE: this touches ONLY which transport addresses are dialed. PREFIX
+// (1c0553f23ebfcffe), IDENTIFIER (4b62545b1a631afe), P2P_PORT (5024), protocol
+// versions, share format, PPLNS and coinbase are UNCHANGED -- the node joins the
+// existing kr1z1s DGB sharechain through the standard handshake; it cannot fork
+// it.
+// ---------------------------------------------------------------------------
+enum class SharechainBootstrapMode {
+    ExplicitPeers,    // --sharechain-addnode given: dial ONLY those peers
+    RegtestIsolated,  // --regtest: 0 seeds (never dial public mainnet 5024 seeds)
+    PublicDefault,    // public net, no explicit peers: DEFAULT_BOOTSTRAP_HOSTS
+};
+
+// Precedence: explicit peers > regtest > public default.
+inline SharechainBootstrapMode select_sharechain_bootstrap_mode(
+    bool has_explicit_peers, bool regtest)
+{
+    if (has_explicit_peers) return SharechainBootstrapMode::ExplicitPeers;
+    if (regtest)            return SharechainBootstrapMode::RegtestIsolated;
+    return SharechainBootstrapMode::PublicDefault;
+}
+
+// Pure builder: compute the sharechain bootstrap address list. No I/O, no
+// config mutation -- the whole logic lives here so it is unit-testable without
+// constructing a PoolConfig or touching the network.
+//   ExplicitPeers   -> exactly `addnodes`, at the ports given.
+//   RegtestIsolated -> empty (solo/local; a won share is never relayed to the
+//                      public net).
+//   PublicDefault   -> DEFAULT_BOOTSTRAP_HOSTS, each at P2P_PORT (5024) unless
+//                      the host literal already carries an explicit ":port".
+inline std::vector<NetService> build_sharechain_bootstrap(
+    SharechainBootstrapMode mode,
+    const std::vector<std::pair<std::string, uint16_t>>& addnodes)
+{
+    std::vector<NetService> out;
+    switch (mode)
+    {
+    case SharechainBootstrapMode::ExplicitPeers:
+        for (const auto& [host, port] : addnodes)
+            out.emplace_back(host, port);
+        break;
+    case SharechainBootstrapMode::RegtestIsolated:
+        break;  // empty by design
+    case SharechainBootstrapMode::PublicDefault:
+        for (const auto& host : PoolConfig::DEFAULT_BOOTSTRAP_HOSTS)
+        {
+            if (host.find(':') == std::string::npos)
+                out.emplace_back(host, PoolConfig::P2P_PORT);
+            else
+                out.emplace_back(host);  // literal already HOST:PORT
+        }
+        break;
+    }
+    return out;
+}
+
+// Populate pool.m_bootstrap_addrs from the resolved mode (thin plumbing over the
+// pure builder). Called by run_node BEFORE the Node ctor reads the vector.
+inline void seed_sharechain_bootstrap(
+    PoolConfig& pool,
+    const std::vector<std::pair<std::string, uint16_t>>& addnodes,
+    bool regtest)
+{
+    pool.m_bootstrap_addrs = build_sharechain_bootstrap(
+        select_sharechain_bootstrap_mode(/*has_explicit_peers=*/!addnodes.empty(),
+                                          /*regtest=*/regtest),
+        addnodes);
+}
 
 } // namespace dgb

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -7,7 +7,12 @@ if (BUILD_TESTING AND GTest_FOUND)
     # F1 retention + F2/F3 broadcast-gate KATs are actually compiled and run;
     # a fresh target would need a build.yml entry and would otherwise report
     # the silently-passing NOT_BUILT sentinel.
-    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp share_remove_owns_data_test.cpp)
+    # sharechain_bootstrap_test: contabo revival KAT for seed_sharechain_bootstrap
+    # (resolver+builder) -- empty-before regression witness + explicit-pin/
+    # public-default/regtest-isolated modes + reward-safe identity constants.
+    # Pure over config_pool.hpp; folded here (not a fresh target) to ride the
+    # allowlist and dodge the NOT_BUILT sentinel.
+    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp share_remove_owns_data_test.cpp sharechain_bootstrap_test.cpp)
     target_link_libraries(dgb_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core dgb

--- a/src/impl/dgb/test/sharechain_bootstrap_test.cpp
+++ b/src/impl/dgb/test/sharechain_bootstrap_test.cpp
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// dgb::seed_sharechain_bootstrap KAT -- pins the pure sharechain bootstrap-addr
+// resolver + builder added for the contabo DGB revival (2026-09-05).
+//
+// THE INCIDENT: run_node (main_dgb.cpp) hand-builds dgb::Config WITHOUT
+// PoolConfig::load() -- the YAML load() was the ONLY populator of
+// m_bootstrap_addrs. On master DEFAULT_BOOTSTRAP_HOSTS was ALSO empty AND there
+// was no --sharechain-addnode flag, so a public DGB node had 0 outbound
+// sharechain seeds and never joined the kr1z1s DGB (scrypt) sharechain. Section 1
+// pins the fix's empty -> populated directly: the exact no-explicit-peers/
+// mainnet inputs run_node now feeds must yield a NON-empty bootstrap set (the
+// broken baseline was 0).
+//
+// The resolver/builder are PURE (no I/O, no network), so this KAT is header-only
+// over config_pool.hpp + <core/netaddress.hpp>. Folded into the allowlisted
+// dgb_share_test executable (per the DGB test CMakeLists convention) so it is
+// actually built and run -- no NOT_BUILT sentinel.
+//
+// REWARD-SAFETY: this seam decides ONLY which transport addresses are dialed.
+// PREFIX/IDENTIFIER, P2P_PORT, protocol versions, share format, PPLNS and
+// coinbase are untouched -- section 6 asserts the compiled-in identity
+// constants are the live p2pool-dgb-scrypt oracle values, so a bootstrap edit
+// can never silently fork the net.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <core/netaddress.hpp>
+#include "../config_pool.hpp"
+
+namespace {
+using dgb::PoolConfig;
+using dgb::SharechainBootstrapMode;
+using dgb::select_sharechain_bootstrap_mode;
+using dgb::build_sharechain_bootstrap;
+
+using AddNodes = std::vector<std::pair<std::string, uint16_t>>;
+} // namespace
+
+// ---- 1) REGRESSION WITNESS: empty BEFORE seed -> populated AFTER -----------
+// The pre-fix live state: run_node never populated m_bootstrap_addrs (empty
+// DEFAULT_BOOTSTRAP_HOSTS, no --sharechain-addnode), so it stayed default-empty
+// (0 sharechain peers). The fix, fed the exact inputs run_node now uses (no
+// explicit peers, mainnet), must produce a NON-empty set -- a proven
+// empty(0) -> populated. Deleting the 92.53.224.27 seed (or the seam) flips
+// this red.
+TEST(DgbSharechainBootstrap, EmptyBeforeSeedPopulatedAfter)
+{
+    auto after = build_sharechain_bootstrap(
+        select_sharechain_bootstrap_mode(/*has_explicit_peers=*/false, /*regtest=*/false),
+        AddNodes{});
+    EXPECT_FALSE(after.empty());                         // populated AFTER the fix
+    EXPECT_GT(after.size(), 0u);
+}
+
+// ---- 2) mode selection precedence: explicit > regtest > public ------------
+TEST(DgbSharechainBootstrap, ModeSelectionPrecedence)
+{
+    EXPECT_EQ(select_sharechain_bootstrap_mode(/*explicit=*/true,  /*regtest=*/false),
+              SharechainBootstrapMode::ExplicitPeers);
+    EXPECT_EQ(select_sharechain_bootstrap_mode(/*explicit=*/true,  /*regtest=*/true),
+              SharechainBootstrapMode::ExplicitPeers);   // explicit wins over regtest
+    EXPECT_EQ(select_sharechain_bootstrap_mode(/*explicit=*/false, /*regtest=*/true),
+              SharechainBootstrapMode::RegtestIsolated);
+    EXPECT_EQ(select_sharechain_bootstrap_mode(/*explicit=*/false, /*regtest=*/false),
+              SharechainBootstrapMode::PublicDefault);
+}
+
+// ---- 3) PublicDefault seeds ALL default hosts on :5024 --------------------
+// The kr1z1s DGB sharechain node 92.53.224.27 must be present, dialed at
+// P2P_PORT (5024).
+TEST(DgbSharechainBootstrap, PublicDefaultSeedsAllHostsOnP2pPort)
+{
+    auto addrs = build_sharechain_bootstrap(
+        SharechainBootstrapMode::PublicDefault, AddNodes{});
+    EXPECT_EQ(addrs.size(), PoolConfig::DEFAULT_BOOTSTRAP_HOSTS.size());
+    EXPECT_FALSE(addrs.empty());
+    bool saw_kr1z1s = false;
+    for (const auto& a : addrs) {
+        EXPECT_EQ(a.port(), PoolConfig::P2P_PORT);       // every entry on 5024
+        if (a.to_string() == "92.53.224.27:5024") saw_kr1z1s = true;
+    }
+    EXPECT_TRUE(saw_kr1z1s);                              // anchor seed present
+}
+
+// ---- 4) ExplicitAddnode pins EXACTLY the given peer(s) --------------------
+// The load-bearing contabo revival lever: --sharechain-addnode 92.53.224.27:5024
+// (the live kr1z1s DGB sharechain) must be the ONLY dialed peer when pinned.
+TEST(DgbSharechainBootstrap, ExplicitAddnodePinsExactly)
+{
+    AddNodes pin = { {"92.53.224.27", 5024} };
+    auto addrs = build_sharechain_bootstrap(
+        select_sharechain_bootstrap_mode(/*explicit=*/true, /*regtest=*/false), pin);
+    ASSERT_EQ(addrs.size(), 1u);
+    EXPECT_EQ(addrs.at(0).to_string(), "92.53.224.27:5024");
+}
+
+TEST(DgbSharechainBootstrap, ExplicitAddnodeRepeatableOrderPreserved)
+{
+    // Repeatable: two pins accumulate, both preserved, order kept, per-pin port.
+    AddNodes pins = { {"92.53.224.27", 5024}, {"5.8.79.155", 5030} };
+    auto addrs = build_sharechain_bootstrap(
+        SharechainBootstrapMode::ExplicitPeers, pins);
+    ASSERT_EQ(addrs.size(), 2u);
+    EXPECT_EQ(addrs.at(0).to_string(), "92.53.224.27:5024");
+    EXPECT_EQ(addrs.at(1).to_string(), "5.8.79.155:5030");   // per-pin port honored
+}
+
+// ---- 5) RegtestIsolated is EMPTY (never dial public 5024 seeds) -----------
+TEST(DgbSharechainBootstrap, RegtestIsolatedIsEmpty)
+{
+    auto addrs = build_sharechain_bootstrap(
+        SharechainBootstrapMode::RegtestIsolated, AddNodes{});
+    EXPECT_TRUE(addrs.empty());
+    // Explicit peer STILL wins over regtest (a tuned isolated peer is OK).
+    AddNodes pin = { {"127.0.0.1", 15024} };
+    auto ex = build_sharechain_bootstrap(
+        select_sharechain_bootstrap_mode(/*explicit=*/true, /*regtest=*/true), pin);
+    ASSERT_EQ(ex.size(), 1u);
+    EXPECT_EQ(ex.at(0).to_string(), "127.0.0.1:15024");
+}
+
+// ---- 6) REWARD-SAFETY: sharechain identity constants UNCHANGED -------------
+// A bootstrap edit must not touch the values that decide which chain we join.
+// These pin the live p2pool-dgb-scrypt oracle DGB sharechain identity: any
+// change here would be the fork vector -- this seam leaves them alone.
+TEST(DgbSharechainBootstrap, RewardSafeIdentityConstants)
+{
+    EXPECT_EQ(PoolConfig::P2P_PORT, 5024);
+    EXPECT_EQ(PoolConfig::DEFAULT_PREFIX_HEX, "1c0553f23ebfcffe");
+    EXPECT_EQ(PoolConfig::IDENTIFIER_HEX,     "4b62545b1a631afe");
+    EXPECT_EQ(PoolConfig::MINIMUM_PROTOCOL_VERSION,    1400u);
+    EXPECT_EQ(PoolConfig::ADVERTISED_PROTOCOL_VERSION, 3501u);
+}


### PR DESCRIPTION
## Problem

The contabo DGB (scrypt) node had **0 sharechain peers** and never joined the kr1z1s DGB (scrypt) sharechain, even though its sharechain identity already matched (IDENTIFIER `4b62545b1a631afe` / PREFIX `1c0553f23ebfcffe`, P2P_PORT `5024`).

`run_node` (main_dgb.cpp) hand-builds `dgb::Config` **without** `PoolConfig::load()` — the YAML `load()` is the sole populator of `m_bootstrap_addrs`. On master `DEFAULT_BOOTSTRAP_HOSTS` was **also empty** *and* there was no `--sharechain-addnode` flag, so a public DGB node had no outbound sharechain seeds to dial. Mirrors the BCH contabo revival (#1480).

## Fix

- **`config_pool.hpp`**: seed `DEFAULT_BOOTSTRAP_HOSTS` with the live kr1z1s DGB node `92.53.224.27` (host p2p-spb.xyz, dialed `:5024`), and add the pure, testable seam `select_sharechain_bootstrap_mode` + `build_sharechain_bootstrap` + `seed_sharechain_bootstrap` (header-only, no I/O). Modes: `ExplicitPeers` / `RegtestIsolated` / `PublicDefault` — the BCH seam minus a custom-net arm (DGB has no `--network-id` CLI).
- **`main_dgb.cpp`**: repeatable `--sharechain-addnode HOST:PORT`; `run_node` seeds `m_bootstrap_addrs` via the seam **before** the `NodeImpl` ctor reads the vector into the addr store. An explicit pin resets a stale `addrs.json` and suppresses the public defaults. Banner + parse mirror `main_bch.cpp`.
- **`param_catalog.inc`**: register `sharechain.addnodes` for `C_DGB` + the `BIN_DGB` `--sharechain-addnode` alias (catalog-completeness tripwire).
- **KAT `dgb_sharechain_bootstrap`** (folded into the already-allowlisted `dgb_share_test` executable — no NOT_BUILT risk): empty(0) → populated regression witness + explicit-pin / public-default / regtest-isolated modes + reward-safe identity-constant pins. **7/7 pass.**

## Reward safety

**Transport addresses only.** PREFIX, IDENTIFIER, P2P_PORT, protocol versions, share format, PPLNS and coinbase are **unchanged** — the node JOINS the existing kr1z1s DGB sharechain through the standard handshake; it cannot fork it. The KAT's reward-safety section pins the identity constants so a bootstrap edit can never silently change which chain we join.

## Validation

- `python3 ci/check_param_catalog.py` → PASS (310 spellings / 298 aliases, forward+reverse consistent)
- `python3 tools/ci/check_test_target_allowlist.py` → PASS (253 targets across 10 trees)
- Build `-DCOIN_DGB=ON`: `c2pool-dgb` + `dgb_share_test` compile clean
- `dgb_share_test --gtest_filter='DgbSharechainBootstrap.*'` → 7/7 pass
- `c2pool-dgb --help` shows the flag; bare-host `--sharechain-addnode nohost` correctly rejected with "requires HOST:PORT"