### PR TITLE
dgb: restart-reorg SupersedeHint stack + periodic think/clean tick (split of #1459)

### DIFF
--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -2547,6 +2547,31 @@ int run_node(const core::CoinParams& params, bool testnet,
         std::cout << "[DGB] dashboard disabled (no --http flag)" << std::endl;
     }
 
+    // Periodic think/clean tick (every 5s, safety net) — mirrors the LTC/dash
+    // tick. Without it, think() fired only on share arrival: no stale-head
+    // eating, unbounded raw-tracker growth past 2*CHAIN_LENGTH+10, and a timed-
+    // out bootstrap download was never retried if all peers went silent (the
+    // first-ever drop-tails is also a memory WIN for the long-warm dgb node,
+    // task #165). clean_tracker() runs think() inline then prunes on the compute
+    // thread under the exclusive lock. p2p_node is a by-value local that outlives
+    // ioc.run(), captured by reference.
+    auto dgb_think_timer = std::make_shared<io::steady_timer>(ioc);
+    std::function<void(boost::system::error_code)> dgb_think_tick;
+    dgb_think_tick = [&, dgb_think_timer](boost::system::error_code ec) {
+        if (ec || shutdown_initiated) return;
+        dgb_think_timer->expires_after(std::chrono::seconds(5));
+        dgb_think_timer->async_wait(dgb_think_tick);
+        try {
+            p2p_node.clean_tracker();
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[CLEAN-TRACKER] error: " << e.what();
+        } catch (...) {
+            LOG_ERROR << "[CLEAN-TRACKER] unknown error";
+        }
+    };
+    dgb_think_timer->expires_after(std::chrono::seconds(5));
+    dgb_think_timer->async_wait(dgb_think_tick);
+
     std::cout << "[DGB] run-loop up: " << network_summary(params) << "\n";
     std::cout << "[DGB] io_context running. Ctrl-C to stop." << std::endl;
 

--- a/src/impl/dgb/node.cpp
+++ b/src/impl/dgb/node.cpp
@@ -1645,6 +1645,55 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
 
 // (old phases 5-7 removed — replaced by p2pool-style pruning above)
 
+dgb::SupersedeHint NodeImpl::gate_supersede_convergence(dgb::SupersedeHint hint)
+{
+    // Compute-thread only; caller holds the exclusive tracker lock.
+    const auto now = std::chrono::steady_clock::now();
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL)
+            it = m_supersede_denylist.erase(it);
+        else
+            ++it;
+    }
+    if (!hint.active)
+        return hint;
+    const uint256 seg = hint.target_segment_last;
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable (parent unobtainable) — hint suppressed";
+        return dgb::SupersedeHint{};
+    }
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); }
+    catch (...) { acc = 0; }
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height)
+    {
+        prog.last_acc_height = acc;
+        prog.stall_cycles = 0;
+    }
+    else
+    {
+        ++prog.stall_cycles;
+    }
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " made no verified-height progress in " << prog.stall_cycles
+                    << " cycles (verified_acc_height stuck at " << acc
+                    << ") — denylisting for " << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return dgb::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // Skip if a think() is already running on the compute thread.
@@ -1701,13 +1750,36 @@ void NodeImpl::run_think()
         // real work so no IO callbacks need the tracker lock.  Matches p2pool
         // where think() runs synchronously on the reactor during initial sync.
         bool bootstrap = m_tracker.verified.size() == 0;
+
+        // Restart-reorg: detect a genuine higher-work fork the warm-loaded node
+        // is stuck away from (see SupersedeHint). Skipped during bootstrap. No-op
+        // on a healthy node. gate_supersede_convergence clears the hint if the
+        // challenger never converges (parent unobtainable).
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;  // bounded elevated per-tick verify
+        dgb::SupersedeHint supersede = bootstrap
+            ? dgb::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        m_supersede_hint = supersede;
+        uint256 prev_best_for_flip = m_best_share_hash;
+        if (supersede.active) {
+            LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                        << m_best_share_hash.GetHex().substr(0,16)
+                        << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                        << " challenger_verified_h="
+                        << m_tracker.verified.get_acc_height(supersede.target_head)
+                        << " — challenger received work STRICTLY > incumbent verified work;"
+                        << " granting bounded elevated verify budget + 2*CL+10 backfill";
+        }
+
         LOG_INFO << "[ASYNC-THINK] compute: chain=" << m_tracker.chain.size()
                  << " verified=" << m_tracker.verified.size()
                  << " heads=" << m_tracker.chain.get_heads().size()
                  << " v_heads=" << m_tracker.verified.get_heads().size()
-                 << (bootstrap ? " BOOTSTRAP" : "");
+                 << (bootstrap ? " BOOTSTRAP" : "")
+                 << (supersede.active ? " SUPERSEDE" : "");
         auto think_t0 = std::chrono::steady_clock::now();
-        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap, supersede);
         think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - think_t0).count();
 
@@ -1722,6 +1794,19 @@ void NodeImpl::run_think()
             best_changed = (m_best_share_hash != result.best);
             m_best_share_hash = result.best;
             apply_min_protocol_ratchet();  // oracle main.py:216 (per best-share advance)
+        }
+        // Restart-reorg: log the actual head flip once it happens.
+        if (best_changed && supersede.active && !result.best.IsNull()) {
+            bool onto_challenger = false;
+            try {
+                onto_challenger =
+                    (m_tracker.chain.get_last(result.best) == supersede.target_segment_last);
+            } catch (...) {}
+            if (onto_challenger)
+                LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                            << prev_best_for_flip.GetHex().substr(0,16)
+                            << " new_best=" << result.best.GetHex().substr(0,16)
+                            << " — converged onto the network highest-work chain";
         }
 
         // Phase 1c: drive the whale-departure detector with the fresh best
@@ -2089,11 +2174,20 @@ void NodeImpl::clean_tracker()
             uint32_t bits = 0;
 
             bootstrap = m_tracker.verified.size() == 0;
+            // Restart-reorg hint (same detector as run_think). Recomputed here so
+            // the Step-2/Step-3 GC exemptions below act on a current view.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? dgb::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
                      << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
-                     << (bootstrap ? " BOOTSTRAP" : "");
+                     << (bootstrap ? " BOOTSTRAP" : "")
+                     << (m_supersede_hint.active ? " SUPERSEDE" : "");
             auto think_t0 = std::chrono::steady_clock::now();
-            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                          m_supersede_hint);
             auto think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - think_t0).count();
 
@@ -2132,6 +2226,17 @@ void NodeImpl::clean_tracker()
 
                 // Guard 1: keep top-5 scored heads (p2pool node.py:363)
                 if (top5_set.count(head_hash)) continue;
+
+                // Guard 1b (restart-reorg): keep the converging challenger segment
+                // (verified height below CHAIN_LENGTH so never in top-5; would else
+                // be eaten every clean). Matched by segment id.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(head_hash) &&
+                            m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
 
                 // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
                 auto* idx = m_tracker.chain.get_index(head_hash);
@@ -2195,6 +2300,16 @@ void NodeImpl::clean_tracker()
             auto tails_copy = m_tracker.chain.get_tails();
             for (auto& [tail_hash, head_hashes] : tails_copy)
             {
+                // Restart-reorg: never drop the tail of the converging challenger
+                // segment (needs its FULL ~2*CL depth). Matched by segment id.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(tail_hash) &&
+                            m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
+
                 int32_t min_height = 0;  // default 0 → skip if no valid heads
                 for (auto& hh : head_hashes) {
                     if (!m_tracker.chain.contains(hh)) continue;
@@ -2268,7 +2383,15 @@ void NodeImpl::clean_tracker()
             : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
         uint256 prev_block;
         uint32_t bits = 0;
-        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        // Restart-reorg: re-detect after pruning and pass the hint so the
+        // re-score also advances/flips onto the challenger.
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        m_supersede_hint = bootstrap
+            ? dgb::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                      m_supersede_hint);
         m_last_top5_heads = std::move(result.top5_heads);
         if (!result.best.IsNull()) {
             clean_best_changed = (m_best_share_hash != result.best);

--- a/src/impl/dgb/node.hpp
+++ b/src/impl/dgb/node.hpp
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <mutex>
 #include <shared_mutex>
 #include <random>
@@ -695,6 +696,20 @@ protected:
 
     // Cached best share hash from the most recent think() cycle
     uint256 m_best_share_hash;
+
+    // ── Restart-reorg supersede hint (see share_tracker.hpp SupersedeHint) ──
+    // From the last think()/clean cycle; used by clean_tracker() to exempt the
+    // converging challenger segment from GC. Inactive on a healthy node.
+    dgb::SupersedeHint m_supersede_hint;
+    // Supersede-convergence liveness: detect zero forward progress over
+    // SUPERSEDE_STALL_LIMIT cycles and denylist an unconvergeable challenger
+    // segment for SUPERSEDE_DENYLIST_TTL (breaks the elevated-verify treadmill).
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    dgb::SupersedeHint gate_supersede_convergence(dgb::SupersedeHint hint);
 
     // ROOT-2: fire exactly one delayed re-advert when the verified chain first
     // transitions from empty to non-empty (peers that handshook during the

--- a/src/impl/dgb/share_tracker.hpp
+++ b/src/impl/dgb/share_tracker.hpp
@@ -123,6 +123,39 @@ struct DecoratedData
     }
 };
 
+// ── Restart-reorg supersede hint ─────────────────────────────────────────
+// Computed by NodeImpl before each think() cycle (compute_supersede_hint()).
+// Closes the Class-A self-sustained-minority-fork defect: score() short-circuits
+// to {verified_height,0} for any tail below CHAIN_LENGTH and TailScore compares
+// chain_len FIRST, so a warm-loaded full-CL verified tail beats any challenger
+// whose VERIFIED height is still below CHAIN_LENGTH — and the challenger never
+// verifies to CHAIN_LENGTH because think() never backfills its unrooted segment
+// to the ~2*CL depth a CHAIN_LENGTH-tall verified tail needs. A node with local
+// hashrate then keeps extending its own verified incumbent = self-sustained
+// minority fork.
+//
+// This hint makes the EXISTING think() argmax able to see the challenger,
+// mirroring p2pool's re-pick-best-after-download, WITHOUT a reorg code path and
+// WITHOUT weakening verified-only selection: when a chain head's RECEIVED work is
+// STRICTLY greater than the incumbent best's VERIFIED work AND it is a genuine
+// fork (not an extension of the incumbent) AND its verified height is still below
+// CHAIN_LENGTH, think() (a) deepens Phase-2 backfill for that segment to 2*CL+10
+// and (b) spends a BOUNDED elevated verification budget on it through the ordinary
+// Phase-2 attempt_verify loop. Over successive ticks the challenger verifies to
+// CHAIN_LENGTH, the Phase-3 TailScore comparison flips on its own, and the head
+// moves. It NEVER bypasses attempt_verify, never scores unverified work, and is a
+// no-op when the incumbent already IS the best head — a healthy node is unaffected.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;          // challenger chain head (highest received work)
+    uint256  target_segment_last;  // chain.get_last(target_head): its missing parent —
+                                   // the stable identity of the whole challenger segment
+    int      budget{0};            // bounded elevated per-tick verify budget for the segment
+    uint288  challenger_work;      // received cumulative work of the challenger (diagnostics)
+    uint288  incumbent_work;       // verified cumulative work of the incumbent best (diagnostics)
+};
+
 // --- Result types ---
 
 struct TrackerThinkResult
@@ -690,16 +723,81 @@ public:
         return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    // Returns an ACTIVE hint iff a genuine competing fork exists whose RECEIVED
+    // cumulative work is STRICTLY greater than the incumbent best's VERIFIED
+    // work and whose verified height is still below CHAIN_LENGTH. Pure read over
+    // chain + verified (no mutation). Guardrails: strictly-greater only, genuine-
+    // fork only (is_child_of skips extensions of our own chain), verified-height
+    // < CL only.
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;  // bootstrap / no incumbent — bootstrap budget path applies
+        const auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+
+        uint256 best_ch;
+        uint288 best_ch_work;
+        bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) { /* concurrent trim — treat as fork candidate */ }
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+
+        if (found && incumbent_work < best_ch_work)  // STRICTLY higher received work
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    // Move the challenger-segment heads to the FRONT of the work-descending
+    // Phase-2 head order so a shorter non-challenger verified head cannot spend
+    // the whole normal budget and trip the outer per-head gate before the
+    // challenger's iteration is entered. Inactive supersede => no-op and the
+    // healthy-node order is byte-identical. Returns the number moved.
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active)
+            return 0;
+        auto is_challenger_head = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_challenger_head);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification and punishment --
     // bootstrap_mode: when true, removes verification budget limit so the
     // entire chain is verified in one call.  Used during initial sync when
     // stratum isn't serving work — no IO needs the tracker lock.
     // Matches p2pool where think() runs synchronously on the reactor and
     // blocks everything else until verification completes.
+    // supersede: restart-reorg hint (see SupersedeHint). Default-inactive, so
+    // every existing caller and the healthy-node path are byte-unchanged.
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& previous_block,
                              uint32_t bits,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // p2pool: desired is a set of (peer_addr, hash, max_timestamp, min_target)
         // The timestamp is used to filter stale requests at return time.
@@ -914,6 +1012,22 @@ public:
         constexpr int THINK_VERIFY_BUDGET = 100;
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
         m_think_needs_continue = false;
+
+        // Wall-clock bound on a single think() cycle (ported with the restart-
+        // reorg stack). The elevated verify pool (SupersedeHint) could otherwise
+        // draw hundreds of scrypt verifies in one cycle and pin the exclusive
+        // lock for seconds (scrypt is the slow verify class on dgb), degrading
+        // the IO serve path to EMPTY replies. Cap the per-cycle hold;
+        // m_think_needs_continue makes run_think() repost the remainder next tick.
+        // Bootstrap is exempt (initial full verify runs uncapped).
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
         {
             static int p2_skip_log = 0;
             if (p2_skip_log++ % 20 == 0)
@@ -924,6 +1038,17 @@ public:
         // budget priority.  p2pool iterates in arbitrary order but has no
         // budget — with our budget, a low-scored side chain can starve the
         // best chain if it goes first.
+        // Restart-reorg elevated budget (SupersedeHint): a BOUNDED extra pool
+        // that ONLY the challenger segment may draw from, after the normal budget
+        // is spent. Inactive → identical to before.
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active) {
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " segment_last=" << supersede.target_segment_last.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget
+                     << " challenger_work>incumbent_work (strictly greater)";
+        }
         std::vector<std::pair<uint256, uint256>> sorted_vheads(
             verified.get_heads().begin(), verified.get_heads().end());
         std::sort(sorted_vheads.begin(), sorted_vheads.end(),
@@ -932,9 +1057,33 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;  // highest work first
             });
+        // Restart-reorg liveness: move challenger-segment heads to the FRONT so a
+        // shorter non-challenger head cannot spend the normal budget and trip the
+        // outer per-head gate before the challenger's iteration is entered. No-op
+        // when supersede is inactive.
+        prioritize_challenger_heads(sorted_vheads, supersede);
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) {
+            // Wall-clock bound: stop the per-head sweep once this cycle has held
+            // the exclusive lock long enough; resume next tick.
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Hoisted above the per-head budget gate.
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+
+            // Per-head budget gate. Only a challenger head may additionally draw
+            // the bounded elevated pool. Inactive supersede → original break.
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
                 m_think_needs_continue = true;
                 break;
             }
@@ -959,7 +1108,12 @@ public:
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(PoolConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            // For an UNROOTED challenger segment a CHAIN_LENGTH-tall VERIFIED tail
+            // needs ~2*CL depth; target the fresh-bootstrap load depth 2*CL+10 so
+            // the segment can reach CHAIN_LENGTH verified shares. Rooted / non-
+            // challenger tails keep the original CL target (byte-unchanged).
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -991,9 +1145,22 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) {
+                    // Normal budget for everyone; the challenger segment may draw
+                    // from the bounded elevated pool AFTER the normal budget is spent.
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) {
                         m_think_needs_continue = true;
                         LOG_INFO << "[think-P2] budget exhausted after " << p2_verified_count
+                                 << " verifications, deferring remainder"
+                                 << (is_challenger ? " (challenger elevated pool spent)" : "");
+                        break;
+                    }
+                    // Wall-clock bound: do not hold the exclusive lock past
+                    // THINK_MAX_WALL_MS even with budget left. Checked every 8 verifies.
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true;
+                        LOG_INFO << "[think-P2] wall-clock cap hit after " << p2_verified_count
                                  << " verifications, deferring remainder";
                         break;
                     }
@@ -1068,7 +1235,10 @@ public:
                         break;
                     ++p2_verified_count;
                     if (!was_already_verified) {
-                        --budget_remaining;
+                        // Spend the normal budget first; only the challenger may
+                        // then draw from the bounded elevated pool.
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
                     }
                     // Throttled progress log: contabo freeze-diag (2026-05-24) caught
                     // this loop wedging the io_context for 2-7.5s at a time when emit
@@ -1085,8 +1255,16 @@ public:
                 }
             }
 
-            // Request more shares if verified chain is short
-            if (head_height < static_cast<int32_t>(PoolConfig::chain_length()) && !last_last_hash.IsNull())
+            // Request more shares if verified chain is short.
+            // Non-challenger: request until the MAIN chain reaches CHAIN_LENGTH.
+            // Challenger (restart-reorg): keep requesting parents until the segment
+            // reaches 2*CL+10 depth so it is no longer pinned at ~CL+8.
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(PoolConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 // Option A: check MAIN chain height (not verified height).
                 // If main chain is already in pruning zone, the unverified

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # public-default/regtest-isolated modes + reward-safe identity constants.
     # Pure over config_pool.hpp; folded here (not a fresh target) to ride the
     # allowlist and dodge the NOT_BUILT sentinel.
-    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp share_remove_owns_data_test.cpp sharechain_bootstrap_test.cpp)
+    add_executable(dgb_share_test share_test.cpp known_txs_retention_test.cpp broadcast_gate_test.cpp race913_lock_guard_test.cpp share_remove_owns_data_test.cpp sharechain_bootstrap_test.cpp restart_reorg_supersede_test.cpp)
     target_link_libraries(dgb_share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core dgb

--- a/src/impl/dgb/test/restart_reorg_supersede_test.cpp
+++ b/src/impl/dgb/test/restart_reorg_supersede_test.cpp
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Restart-reorg supersede detector -- KAT, exercised through DGB's REAL
+// ShareTracker API (dgb::ShareTracker::compute_supersede_hint).
+//
+// LIVE EVIDENCE this pins (contabo DGB, warm restart on the shared v36
+// sharechain): a node that loads its persisted, fully-verified sharechain then
+// peers with a higher-work v36 network STICKS on the old head --
+// [FORK-DIAG] heads=2 verified=12279 chain=20920 gap=8648 with the best VERIFIED
+// head frozen while the node RECEIVES the higher-work chain to height 20920. The
+// incumbent enjoys a structural, permanent privilege: TailScore compares
+// chain_len FIRST and score() short-circuits to {verified_height,0} below
+// CHAIN_LENGTH, so a warm-loaded full-CL verified tail beats any challenger whose
+// VERIFIED height is still short -- and the challenger never verifies to
+// CHAIN_LENGTH because think() never backfills the unrooted segment to the ~2*CL
+// depth a CHAIN_LENGTH-tall verified tail needs. A fresh re-seed only converges
+// because an EMPTY start has no incumbent.
+//
+// compute_supersede_hint is the visibility fix: it fires an ACTIVE hint iff a
+// GENUINE competing fork exists whose RECEIVED cumulative work is STRICTLY
+// greater than the incumbent best's VERIFIED work and whose verified height is
+// still below CHAIN_LENGTH. think() then deepens that segment's backfill to
+// 2*CL+10 and spends a bounded elevated verification budget on it, so it verifies
+// to CHAIN_LENGTH and the EXISTING Phase-3 TailScore argmax flips on its own.
+// This KAT drives the DECISION through the real chain/verified work accounting
+// (get_work over ShareIndex.work) -- the exact mechanism -- without needing real
+// PoW verification: the detector is a pure read over chain + verified.
+//
+// GUARDRAILS asserted here:
+//   * strictly-higher-work only  -> a lower-work or equal-work fork never fires;
+//   * genuine-fork only          -> an extension of the incumbent's own chain
+//                                   (freshly-mined-but-unverified local shares)
+//                                   never masquerades as a challenger;
+//   * no-op when incumbent is best (healthy single-head node) -> inactive;
+//   * no incumbent (bootstrap)   -> inactive.
+//
+// Folded into the EXISTING allowlisted `dgb_share_test` target (never a standalone
+// add_executable -- the #769 NOT_BUILT trap), so CI actually builds and runs it.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <core/uint256.hpp>
+#include <impl/dgb/share.hpp>
+#include <impl/dgb/share_tracker.hpp>
+
+namespace {
+
+// Short hex tail -> uint256 (zero-padded), matching the btc share_test hx()
+// convention used by the sibling chain_walk_window / desired_version tests.
+uint256 hx(const std::string& tail) {
+    uint256 v;
+    v.SetHex(std::string(64 - tail.size(), '0') + tail);
+    return v;
+}
+
+constexpr uint64_t kDv = 36;
+constexpr uint32_t kBits = 0x1e0fffff;  // uniform per-share work
+
+// Build a linear run of `count` uniform V36 shares into `tracker.chain`.
+//   root_prev : m_prev_hash of the DEEPEST share (share 0). Null -> rooted
+//               chain end (get_last == null); non-null-and-absent -> UNROOTED
+//               segment (get_last == root_prev), the challenger shape.
+//   salt      : disjoint hash space so independent runs never collide.
+// Returns the tip hash. Every share carries equal work, so total received work
+// is monotone in `count`.
+uint256 build_run(dgb::ShareTracker& tracker, int32_t count,
+                  const uint256& root_prev, size_t salt) {
+    uint256 prev = root_prev;
+    uint256 tip;
+    tip.SetNull();
+    for (int32_t i = 0; i < count; ++i) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%zx",
+                      static_cast<size_t>((salt << 20) + 0x5b70 + i));
+        uint256 h = hx(buf);
+        auto* sh = new dgb::MergedMiningShare();
+        sh->m_hash = h;
+        sh->m_prev_hash = prev;   // share 0 uses root_prev
+        sh->m_desired_version = kDv;
+        sh->m_bits = kBits;
+        sh->m_max_bits = kBits;
+        dgb::ShareType st;
+        st = sh;
+        tracker.add(st);
+        prev = h;
+        tip = h;
+    }
+    return tip;
+}
+
+// Mark a whole in-chain run [share 0 .. tip] as verified, as
+// load_persisted_shares() does (verified.add of the chain-owned share, ascending
+// so parent-before-child holds). Walks tip -> root via prev_hash.
+void mark_verified(dgb::ShareTracker& tracker, const uint256& tip) {
+    // Collect hashes tip->root, then add root->tip.
+    std::vector<uint256> chainward;
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    for (auto it = chainward.rbegin(); it != chainward.rend(); ++it) {
+        if (tracker.chain.contains(*it) && !tracker.verified.contains(*it)) {
+            auto& sv = tracker.chain.get_share(*it);
+            tracker.verified.add(sv);
+        }
+    }
+}
+
+// Verify only the DEEPEST `n` shares of an in-chain run (root .. root+n-1),
+// ascending so parent-before-child holds — the partial "verified frontier" a
+// challenger segment has mid-catch-up. Returns the frontier verified head (the
+// shallowest verified share of the prefix), which is what verified.get_heads()
+// reports for the segment. n<=0 or n>=len verifies nothing extra beyond len.
+uint256 verify_deep_prefix(dgb::ShareTracker& tracker, const uint256& tip, int n) {
+    std::vector<uint256> chainward;  // tip -> root
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    const int sz = static_cast<int>(chainward.size());
+    if (n > sz) n = sz;
+    uint256 frontier;
+    for (int i = 0; i < n; ++i) {
+        const uint256& h = chainward[sz - 1 - i];  // root first (ascending)
+        if (tracker.chain.contains(h) && !tracker.verified.contains(h)) {
+            auto& sv = tracker.chain.get_share(h);
+            tracker.verified.add(sv);
+        }
+        frontier = h;  // last added = shallowest of the prefix = frontier head
+    }
+    return frontier;
+}
+
+// Faithful in-test model of think()'s Phase-2 OUTER per-head budget gate,
+// stepping an ordered head list. Worst case (the starvation driver): a
+// non-challenger head can spend the whole normal budget on its first turn.
+// `elevated_aware` selects the gate: false = the pre-fix `budget<=0` break;
+// true = the fix's `budget<=0 && !(is_challenger && elevated>0)` break.
+// Returns whether the challenger head's iteration is ENTERED (its elevated
+// budget becomes drawable this tick).
+bool challenger_iteration_entered(
+        const std::vector<uint256>& order, const uint256& challenger_head,
+        const std::function<bool(const uint256&)>& is_challenger,
+        int normal_budget, int elevated_budget, bool elevated_aware) {
+    int budget = normal_budget, elevated = elevated_budget;
+    for (const auto& h : order) {
+        const bool ch = is_challenger(h);
+        const bool brk = elevated_aware
+                             ? (budget <= 0 && !(ch && elevated > 0))
+                             : (budget <= 0);
+        if (brk) break;                       // outer loop terminates here
+        if (h == challenger_head) return true;  // challenger reached
+        if (!ch) budget = 0;                  // worst-case normal-budget spend
+    }
+    return false;
+}
+
+constexpr int kBudget = 400;
+constexpr int kNormalBudget = 100;  // THINK_VERIFY_BUDGET in think()
+
+}  // namespace
+
+// --- Higher-work genuine fork -> ACTIVE, targeted at the challenger ----------
+TEST(DgbRestartReorgSupersede, HigherWorkForkActivates) {
+    dgb::ShareTracker t;
+    // Incumbent: rooted, fully verified, 30 shares.
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+    // Challenger: UNROOTED segment of 50 shares (more work than the incumbent),
+    // received but NOT verified. Its deepest share references an absent parent.
+    const uint256 missing_parent = hx("dead0001");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+
+    ASSERT_TRUE(t.verified.contains(inc_tip));
+    ASSERT_FALSE(t.verified.contains(ch_tip));
+    // Sanity: challenger received work strictly exceeds incumbent verified work.
+    EXPECT_TRUE(t.verified.get_work(inc_tip) < t.chain.get_work(ch_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_TRUE(hint.active);
+    EXPECT_EQ(hint.target_head, ch_tip);
+    EXPECT_EQ(hint.target_segment_last, missing_parent);  // segment identity
+    EXPECT_EQ(hint.budget, kBudget);
+    // Strictly-greater guard actually holds on the recorded works.
+    EXPECT_TRUE(hint.incumbent_work < hint.challenger_work);
+}
+
+// --- Lower-work fork -> INACTIVE (strictly-greater guard) --------------------
+TEST(DgbRestartReorgSupersede, LowerWorkForkStaysInactive) {
+    dgb::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    // Shorter unrooted fork: less received work than the incumbent's verified work.
+    const uint256 ch_tip = build_run(t, 10, hx("dead0002"), 2);
+
+    EXPECT_TRUE(t.chain.get_work(ch_tip) < t.verified.get_work(inc_tip));
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Equal-work fork -> INACTIVE (tie can never displace the head) ----------
+TEST(DgbRestartReorgSupersede, EqualWorkForkStaysInactive) {
+    dgb::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    // Same length -> identical total work (uniform per-share work).
+    const uint256 ch_tip = build_run(t, 30, hx("dead0003"), 2);
+
+    EXPECT_TRUE(t.chain.get_work(ch_tip) == t.verified.get_work(inc_tip));
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);  // requires STRICTLY greater
+}
+
+// --- Healthy single head -> INACTIVE (no-op when incumbent IS the best) ------
+TEST(DgbRestartReorgSupersede, HealthySingleHeadIsNoOp) {
+    dgb::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 40, uint256(), 1);
+    mark_verified(t, inc_tip);
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Own-chain extension (unverified) -> INACTIVE (genuine-fork guard) -------
+// Freshly-received-but-unverified shares that EXTEND the incumbent (higher
+// received work, same root) must NOT be treated as a challenger — they are the
+// node's own tip advancing, and the ordinary budgeted Phase-2 verifies them.
+TEST(DgbRestartReorgSupersede, OwnChainExtensionIsNotAChallenger) {
+    dgb::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    // 25 more shares built ON TOP of inc_tip, in-chain but unverified.
+    const uint256 ext_tip = build_run(t, 25, inc_tip /*extends incumbent*/, 2);
+
+    // Received work of the extension strictly exceeds the incumbent's verified
+    // work (it is 25 shares longer) — yet it is an extension, not a fork.
+    EXPECT_TRUE(t.verified.get_work(inc_tip) < t.chain.get_work(ext_tip));
+    EXPECT_TRUE(t.chain.is_child_of(inc_tip, ext_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    EXPECT_FALSE(hint.active);  // is_child_of guard excludes it
+}
+
+// --- No incumbent (bootstrap / empty verified) -> INACTIVE ------------------
+TEST(DgbRestartReorgSupersede, NoIncumbentIsInactive) {
+    dgb::ShareTracker t;
+    // Only an unrooted segment exists; nothing verified, no incumbent best.
+    const uint256 ch_tip = build_run(t, 50, hx("dead0004"), 2);
+    (void)ch_tip;
+    auto hint = t.compute_supersede_hint(uint256() /*null incumbent*/, kBudget);
+    EXPECT_FALSE(hint.active);
+}
+
+// --- Backfill-depth target is the fresh-bootstrap load depth 2*CL+10 --------
+// The stuck state pinned the challenger segment at ~CL+8; the fix targets
+// 2*CL+10 so a CHAIN_LENGTH-tall verified tail is reachable on an unrooted chain.
+// This documents the invariant the think() Phase-2 want_depth uses.
+TEST(DgbRestartReorgSupersede, BackfillTargetIsTwiceChainLengthPlusTen) {
+    const int32_t CL = static_cast<int32_t>(dgb::PoolConfig::chain_length());
+    EXPECT_GT(CL, 0);
+    const int32_t challenger_target = 2 * CL + 10;
+    // Strictly deeper than the incumbent CL target — the whole point.
+    EXPECT_GT(challenger_target, CL);
+    // Matches the persisted-load depth (node.cpp keep_per_head = 2*CL + 10).
+    EXPECT_EQ(challenger_target, 2 * CL + 10);
+}
+
+// --- STARVATION: a shorter, higher-verified-work non-challenger head must NOT
+//     starve the challenger's elevated budget within a think() tick -----------
+//
+// The liveness gap this pins: think() Phase-2 sorts VERIFIED heads by verified
+// work DESCENDING, then breaks the loop when the normal per-tick budget is
+// spent. The challenger's verified frontier is SHORT, so it sorts LOW; a shorter
+// non-challenger verified head that still outranks that short frontier can spend
+// the whole normal budget first and trip the outer break BEFORE the challenger's
+// iteration is ever entered — so the bounded elevated pool is never drawn that
+// tick, and m_think_needs_continue merely restarts the same starving sort order.
+// Property (a) "reorgs to the higher-work verified head after sync" then fails
+// under fork contention. The fix gives the challenger head budget PRIORITY:
+// prioritize_challenger_heads() moves the challenger-segment head(s) to the FRONT
+// (used verbatim by think()), and the outer gate is elevated-budget-aware. This
+// KAT drives the REAL chain/verified accounting and the REAL scheduling helper.
+TEST(DgbRestartReorgSupersede, ChallengerNotStarvedByShorterHigherWorkHead) {
+    dgb::ShareTracker t;
+
+    // Incumbent: rooted, fully verified, 30 shares (the warm-loaded head).
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+
+    // Non-challenger SIDE fork: rooted, fully verified, but SHORT (12 shares).
+    // Its verified work outranks the challenger's short frontier — the exact
+    // head that spends the normal budget first and would trip the break.
+    const uint256 nc_tip = build_run(t, 12, uint256() /*rooted, own root*/, 3);
+    mark_verified(t, nc_tip);
+
+    // Challenger: UNROOTED segment of 50 received shares (highest RECEIVED work),
+    // but only a SHORT verified frontier (deepest 3) — so it sorts LOW by
+    // verified work. Its segment identity is the shared missing parent.
+    const uint256 missing_parent = hx("dead0005");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+    const uint256 ch_frontier = verify_deep_prefix(t, ch_tip, 3);
+
+    // Sanity on the setup: all three are verified heads with the intended
+    // work ordering, and the challenger frontier carries the LEAST verified work.
+    ASSERT_TRUE(t.verified.contains(inc_tip));
+    ASSERT_TRUE(t.verified.contains(nc_tip));
+    ASSERT_TRUE(t.verified.contains(ch_frontier));
+    EXPECT_TRUE(t.verified.get_work(ch_frontier) < t.verified.get_work(nc_tip));
+    EXPECT_TRUE(t.verified.get_work(nc_tip)      < t.verified.get_work(inc_tip));
+
+    // The hint fires and names the challenger SEGMENT (by its missing parent),
+    // so the frontier head — deeper in the same segment — is is_challenger.
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    ASSERT_TRUE(hint.active);
+    EXPECT_EQ(hint.target_head, ch_tip);
+    EXPECT_EQ(hint.target_segment_last, missing_parent);
+    EXPECT_EQ(t.chain.get_last(ch_frontier), missing_parent);  // segment identity
+
+    // Build the Phase-2 head order EXACTLY as think() does: verified heads,
+    // sorted by verified work descending.
+    auto build_sorted = [&]() {
+        std::vector<std::pair<uint256, uint256>> v(
+            t.verified.get_heads().begin(), t.verified.get_heads().end());
+        std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+            auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+            auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+            return wa > wb;
+        });
+        return v;
+    };
+    auto index_of = [](const std::vector<std::pair<uint256, uint256>>& v,
+                       const uint256& h) -> int {
+        for (int i = 0; i < static_cast<int>(v.size()); ++i)
+            if (v[i].first == h) return i;
+        return -1;
+    };
+    auto is_ch = [&](const uint256& h) -> bool {
+        return t.chain.get_last(h) == hint.target_segment_last;
+    };
+
+    // PRE-fix order: the challenger frontier sorts AFTER the shorter
+    // non-challenger head — the starvation shape.
+    auto pre = build_sorted();
+    ASSERT_GE(index_of(pre, ch_frontier), 0);
+    ASSERT_GE(index_of(pre, nc_tip), 0);
+    EXPECT_GT(index_of(pre, ch_frontier), index_of(pre, nc_tip));
+    // And with the pre-fix `budget<=0` gate the challenger iteration is NEVER
+    // entered: a higher-work non-challenger spends the normal budget first.
+    std::vector<uint256> pre_order;
+    for (auto& hv : pre) pre_order.push_back(hv.first);
+    EXPECT_FALSE(challenger_iteration_entered(
+        pre_order, ch_frontier, is_ch, kNormalBudget, kBudget,
+        /*elevated_aware=*/false));
+
+    // FIX: prioritize the challenger segment to the front. Exactly one challenger
+    // head, and it lands ahead of the shorter non-challenger head.
+    auto post = build_sorted();
+    const size_t n_challengers = t.prioritize_challenger_heads(post, hint);
+    EXPECT_EQ(n_challengers, 1u);
+    EXPECT_EQ(index_of(post, ch_frontier), 0);
+    EXPECT_LT(index_of(post, ch_frontier), index_of(post, nc_tip));
+
+    // Post-fix order + elevated-aware gate: the challenger iteration IS entered,
+    // so its bounded elevated budget is drawn this tick — the head can advance
+    // toward CHAIN_LENGTH over successive ticks and Phase-3 flips on its own.
+    std::vector<uint256> post_order;
+    for (auto& hv : post) post_order.push_back(hv.first);
+    EXPECT_TRUE(challenger_iteration_entered(
+        post_order, ch_frontier, is_ch, kNormalBudget, kBudget,
+        /*elevated_aware=*/true));
+
+    // Per-tick bound is unchanged: normal budget + bounded elevated pool.
+    EXPECT_LE(kNormalBudget + kBudget, 500);
+}
+
+// --- Healthy node: prioritize is a NO-OP (order byte-identical) --------------
+// With no active supersede hint, prioritize_challenger_heads must not move a
+// single head — the healthy-node Phase-2 order stays exactly the sorted order.
+TEST(DgbRestartReorgSupersede, PrioritizeIsNoOpWhenInactive) {
+    dgb::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 side_tip = build_run(t, 12, uint256(), 3);
+    mark_verified(t, side_tip);
+
+    dgb::SupersedeHint inactive;  // active == false
+    ASSERT_FALSE(inactive.active);
+
+    std::vector<std::pair<uint256, uint256>> v(
+        t.verified.get_heads().begin(), t.verified.get_heads().end());
+    std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+        auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+        auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+        return wa > wb;
+    });
+    const auto before = v;
+    const size_t moved = t.prioritize_challenger_heads(v, inactive);
+    EXPECT_EQ(moved, 0u);
+    ASSERT_EQ(v.size(), before.size());
+    for (size_t i = 0; i < v.size(); ++i) {
+        EXPECT_EQ(v[i].first, before[i].first);
+        EXPECT_EQ(v[i].second, before[i].second);
+    }
+}


### PR DESCRIPTION
Per-coin split of the **dgb** portion of #1459 (a btc/dgb/bch cross-coin bundle that cannot land — per-coin isolation is a hard stop). btc portion is #1488; this is the dgb half; bch half is its sibling PR.

Change: rewires think() call sites to carry SupersedeHint on restart-driven reorg (semantic-preserving 4->5-arg reshape), and adds a 5s periodic think/clean timer in main_dgb.cpp so stale-head eating, raw-tracker pruning past 2*CHAIN_LENGTH+10, and timed-out bootstrap retry no longer depend on share arrival. Adds dgb_restart_reorg_supersede KAT (rides dgb_share_test AUTO; CMakeLists merge keeps both this and sharechain_bootstrap_test).

HOLD: do-not-merge until the shared SupersedeHint reshape clears the .45 deep-engine SHIP verdict (card sem-4cc135475a, host currently down) that gates the whole family incl #1488. Routing to dgb-scrypt-steward for coin ownership review.