### PR TITLE
bch: restart-reorg SupersedeHint stack + periodic think/clean tick (split of #1459)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -784,6 +784,7 @@ jobs:
                     bch_cashaddr_kat_test \
                     bch_share_tx_refs_kat_test \
                     bch_share_remove_owns_data_test \
+                    bch_restart_reorg_supersede_test \
                     bch_block_connector_test bch_block_ordering_test \
                     bch_utxo_connect_test bch_reorg_connect_test bch_reorg_rerequest_test \
                     bch_compact_block_connector_test \
@@ -941,6 +942,7 @@ jobs:
                     bch_cashaddr_kat_test \
                     bch_share_tx_refs_kat_test \
                     bch_share_remove_owns_data_test \
+                    bch_restart_reorg_supersede_test \
                     bch_block_connector_test bch_block_ordering_test \
                     bch_utxo_connect_test bch_reorg_connect_test bch_reorg_rerequest_test \
                     bch_compact_block_connector_test \

--- a/src/impl/bch/node.cpp
+++ b/src/impl/bch/node.cpp
@@ -1618,6 +1618,55 @@ void NodeImpl::disarm_think_watchdog()
     }
 }
 
+bch::SupersedeHint NodeImpl::gate_supersede_convergence(bch::SupersedeHint hint)
+{
+    // Compute-thread only; caller holds the exclusive tracker lock.
+    const auto now = std::chrono::steady_clock::now();
+    for (auto it = m_supersede_denylist.begin(); it != m_supersede_denylist.end(); )
+    {
+        if (now - it->second >= SUPERSEDE_DENYLIST_TTL)
+            it = m_supersede_denylist.erase(it);
+        else
+            ++it;
+    }
+    if (!hint.active)
+        return hint;
+    const uint256 seg = hint.target_segment_last;
+    if (m_supersede_denylist.count(seg))
+    {
+        static int dl_log = 0;
+        if (dl_log++ % 20 == 0)
+            LOG_INFO << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                     << " denylisted as unconvergeable (parent unobtainable) — hint suppressed";
+        return bch::SupersedeHint{};
+    }
+    int32_t acc = 0;
+    try { acc = m_tracker.verified.get_acc_height(hint.target_head); }
+    catch (...) { acc = 0; }
+    auto& prog = m_supersede_progress[seg];
+    if (acc > prog.last_acc_height)
+    {
+        prog.last_acc_height = acc;
+        prog.stall_cycles = 0;
+    }
+    else
+    {
+        ++prog.stall_cycles;
+    }
+    if (prog.stall_cycles >= SUPERSEDE_STALL_LIMIT)
+    {
+        LOG_WARNING << "[SUPERSEDE] challenger segment " << seg.GetHex().substr(0, 16)
+                    << " made no verified-height progress in " << prog.stall_cycles
+                    << " cycles (verified_acc_height stuck at " << acc
+                    << ") — denylisting for " << SUPERSEDE_DENYLIST_TTL.count()
+                    << "m to break the elevated-verify treadmill and re-enable GC";
+        m_supersede_denylist[seg] = now;
+        m_supersede_progress.erase(seg);
+        return bch::SupersedeHint{};
+    }
+    return hint;
+}
+
 void NodeImpl::run_think()
 {
     // Skip if a think() is already running on the compute thread.
@@ -1678,13 +1727,36 @@ void NodeImpl::run_think()
         // real work so no IO callbacks need the tracker lock.  Matches p2pool
         // where think() runs synchronously on the reactor during initial sync.
         bool bootstrap = m_tracker.verified.size() == 0;
+
+        // Restart-reorg: detect a genuine higher-work fork the warm-loaded node
+        // is stuck away from (see SupersedeHint). Skipped during bootstrap. No-op
+        // on a healthy node. gate_supersede_convergence clears the hint if the
+        // challenger never converges (parent unobtainable).
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;  // bounded elevated per-tick verify
+        bch::SupersedeHint supersede = bootstrap
+            ? bch::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        m_supersede_hint = supersede;
+        uint256 prev_best_for_flip = m_best_share_hash;
+        if (supersede.active) {
+            LOG_WARNING << "[SUPERSEDE] restart-reorg trigger: incumbent="
+                        << m_best_share_hash.GetHex().substr(0,16)
+                        << " challenger=" << supersede.target_head.GetHex().substr(0,16)
+                        << " challenger_verified_h="
+                        << m_tracker.verified.get_acc_height(supersede.target_head)
+                        << " — challenger received work STRICTLY > incumbent verified work;"
+                        << " granting bounded elevated verify budget + 2*CL+10 backfill";
+        }
+
         LOG_INFO << "[ASYNC-THINK] compute: chain=" << m_tracker.chain.size()
                  << " verified=" << m_tracker.verified.size()
                  << " heads=" << m_tracker.chain.get_heads().size()
                  << " v_heads=" << m_tracker.verified.get_heads().size()
-                 << (bootstrap ? " BOOTSTRAP" : "");
+                 << (bootstrap ? " BOOTSTRAP" : "")
+                 << (supersede.active ? " SUPERSEDE" : "");
         auto think_t0 = std::chrono::steady_clock::now();
-        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap, supersede);
         think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::steady_clock::now() - think_t0).count();
 
@@ -1698,6 +1770,19 @@ void NodeImpl::run_think()
         if (!result.best.IsNull()) {
             best_changed = (m_best_share_hash != result.best);
             m_best_share_hash = result.best;
+        }
+        // Restart-reorg: log the actual head flip once it happens.
+        if (best_changed && supersede.active && !result.best.IsNull()) {
+            bool onto_challenger = false;
+            try {
+                onto_challenger =
+                    (m_tracker.chain.get_last(result.best) == supersede.target_segment_last);
+            } catch (...) {}
+            if (onto_challenger)
+                LOG_WARNING << "[SUPERSEDE] head FLIPPED to challenger chain: prev_best="
+                            << prev_best_for_flip.GetHex().substr(0,16)
+                            << " new_best=" << result.best.GetHex().substr(0,16)
+                            << " — converged onto the network highest-work chain";
         }
 
         // Publish lock-free snapshot for all IO-thread consumers
@@ -2061,11 +2146,20 @@ void NodeImpl::clean_tracker()
             uint32_t bits = 0;
 
             bootstrap = m_tracker.verified.size() == 0;
+            // Restart-reorg hint (same detector as run_think). Recomputed here so
+            // the Step-2/Step-3 GC exemptions below act on a current view.
+            constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+            m_supersede_hint = bootstrap
+                ? bch::SupersedeHint{}
+                : gate_supersede_convergence(
+                      m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
             LOG_INFO << "[CLEAN] think+clean starting on compute thread: chain="
                      << m_tracker.chain.size() << " verified=" << m_tracker.verified.size()
-                     << (bootstrap ? " BOOTSTRAP" : "");
+                     << (bootstrap ? " BOOTSTRAP" : "")
+                     << (m_supersede_hint.active ? " SUPERSEDE" : "");
             auto think_t0 = std::chrono::steady_clock::now();
-            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+            auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                          m_supersede_hint);
             auto think_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - think_t0).count();
 
@@ -2103,6 +2197,17 @@ void NodeImpl::clean_tracker()
 
                 // Guard 1: keep top-5 scored heads (p2pool node.py:363)
                 if (top5_set.count(head_hash)) continue;
+
+                // Guard 1b (restart-reorg): keep the converging challenger segment
+                // (verified height below CHAIN_LENGTH so never in top-5; would else
+                // be eaten every clean). Matched by segment id.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(head_hash) &&
+                            m_tracker.chain.get_last(head_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
 
                 // Guard 2: keep heads seen < 300s ago (p2pool node.py:366)
                 auto* idx = m_tracker.chain.get_index(head_hash);
@@ -2166,6 +2271,16 @@ void NodeImpl::clean_tracker()
             auto tails_copy = m_tracker.chain.get_tails();
             for (auto& [tail_hash, head_hashes] : tails_copy)
             {
+                // Restart-reorg: never drop the tail of the converging challenger
+                // segment (needs its FULL ~2*CL depth). Matched by segment id.
+                if (m_supersede_hint.active) {
+                    try {
+                        if (m_tracker.chain.contains(tail_hash) &&
+                            m_tracker.chain.get_last(tail_hash) == m_supersede_hint.target_segment_last)
+                            continue;
+                    } catch (...) {}
+                }
+
                 int32_t min_height = 0;  // default 0 → skip if no valid heads
                 for (auto& hh : head_hashes) {
                     if (!m_tracker.chain.contains(hh)) continue;
@@ -2249,7 +2364,15 @@ void NodeImpl::clean_tracker()
             : std::function<int32_t(uint256)>([](uint256) -> int32_t { return 0; });
         uint256 prev_block;
         uint32_t bits = 0;
-        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap);
+        // Restart-reorg: re-detect after pruning and pass the hint so the
+        // re-score also advances/flips onto the challenger.
+        constexpr int SUPERSEDE_VERIFY_BUDGET = 400;
+        m_supersede_hint = bootstrap
+            ? bch::SupersedeHint{}
+            : gate_supersede_convergence(
+                  m_tracker.compute_supersede_hint(m_best_share_hash, SUPERSEDE_VERIFY_BUDGET));
+        auto result = m_tracker.think(block_rel_height, prev_block, bits, bootstrap,
+                                      m_supersede_hint);
         m_last_top5_heads = std::move(result.top5_heads);
         if (!result.best.IsNull()) {
             clean_best_changed = (m_best_share_hash != result.best);

--- a/src/impl/bch/node.hpp
+++ b/src/impl/bch/node.hpp
@@ -44,6 +44,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <map>
 #include <mutex>
 #include <shared_mutex>
 #include <random>
@@ -900,6 +901,20 @@ protected:
 
     // Cached best share hash from the most recent think() cycle
     uint256 m_best_share_hash;
+
+    // ── Restart-reorg supersede hint (see share_tracker.hpp SupersedeHint) ──
+    // From the last think()/clean cycle; used by clean_tracker() to exempt the
+    // converging challenger segment from GC. Inactive on a healthy node.
+    bch::SupersedeHint m_supersede_hint;
+    // Supersede-convergence liveness: detect zero forward progress over
+    // SUPERSEDE_STALL_LIMIT cycles and denylist an unconvergeable challenger
+    // segment for SUPERSEDE_DENYLIST_TTL (breaks the elevated-verify treadmill).
+    struct SupersedeProgress { int32_t last_acc_height{-1}; int stall_cycles{0}; };
+    std::map<uint256, SupersedeProgress> m_supersede_progress;
+    std::map<uint256, std::chrono::steady_clock::time_point> m_supersede_denylist;
+    static constexpr int SUPERSEDE_STALL_LIMIT = 20;
+    static constexpr std::chrono::minutes SUPERSEDE_DENYLIST_TTL{60};
+    bch::SupersedeHint gate_supersede_convergence(bch::SupersedeHint hint);
 
     // ROOT-2: fire exactly one delayed re-advert when the verified chain
     // first transitions from empty to non-empty (peers that handshook

--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -887,6 +887,31 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
         LOG_INFO << "[BCH-POOL] dashboard disabled (no --http bind given).";
     }
 
+    // Periodic think/clean tick (every 5s, safety net) — mirrors the LTC/dash
+    // tick. Without it, think() fired only on share arrival: no stale-head
+    // eating, unbounded raw-tracker growth past 2*CHAIN_LENGTH+10, and a timed-
+    // out bootstrap download was never retried if all peers went silent.
+    // clean_tracker() runs think() inline then prunes on the compute thread under
+    // the exclusive lock. `node` is a by-value local that outlives ioc.run(),
+    // captured by reference. On shutdown ioc.stop() cancels the timer → the
+    // handler is invoked with ec set and returns without re-arming.
+    auto bch_think_timer = std::make_shared<boost::asio::steady_timer>(ioc);
+    std::function<void(boost::system::error_code)> bch_think_tick;
+    bch_think_tick = [&node, bch_think_timer, &bch_think_tick](boost::system::error_code ec) {
+        if (ec) return;
+        bch_think_timer->expires_after(std::chrono::seconds(5));
+        bch_think_timer->async_wait(bch_think_tick);
+        try {
+            node.clean_tracker();
+        } catch (const std::exception& e) {
+            LOG_ERROR << "[CLEAN-TRACKER] error: " << e.what();
+        } catch (...) {
+            LOG_ERROR << "[CLEAN-TRACKER] unknown error";
+        }
+    };
+    bch_think_timer->expires_after(std::chrono::seconds(5));
+    bch_think_timer->async_wait(bch_think_tick);
+
     // Drive the shared io_context: pool node + embedded daemon + stratum run together.
     ioc.run();
 

--- a/src/impl/bch/share_tracker.hpp
+++ b/src/impl/bch/share_tracker.hpp
@@ -342,6 +342,40 @@ struct DecoratedData
 //   bad_peer_addresses  = peers that served unverifiable shares (ban targets)
 //   top5_heads          = best-scored heads protected from head-pruning
 // The s1 link-skeleton think() returns this EMPTY; s2 populates it.
+
+// ── Restart-reorg supersede hint ─────────────────────────────────────────
+// Computed by NodeImpl before each think() cycle (compute_supersede_hint()).
+// Closes the Class-A self-sustained-minority-fork defect: score() short-circuits
+// to {verified_height,0} for any tail below CHAIN_LENGTH and TailScore compares
+// chain_len FIRST, so a warm-loaded full-CL verified tail beats any challenger
+// whose VERIFIED height is still below CHAIN_LENGTH — and the challenger never
+// verifies to CHAIN_LENGTH because think() never backfills its unrooted segment
+// to the ~2*CL depth a CHAIN_LENGTH-tall verified tail needs. A node with local
+// hashrate then keeps extending its own verified incumbent = self-sustained
+// minority fork.
+//
+// This hint makes the EXISTING think() argmax able to see the challenger,
+// mirroring p2pool's re-pick-best-after-download, WITHOUT a reorg code path and
+// WITHOUT weakening verified-only selection: when a chain head's RECEIVED work is
+// STRICTLY greater than the incumbent best's VERIFIED work AND it is a genuine
+// fork (not an extension of the incumbent) AND its verified height is still below
+// CHAIN_LENGTH, think() (a) deepens Phase-2 backfill for that segment to 2*CL+10
+// and (b) spends a BOUNDED elevated verification budget on it through the ordinary
+// Phase-2 attempt_verify loop. Over successive ticks the challenger verifies to
+// CHAIN_LENGTH, the Phase-3 TailScore comparison flips on its own, and the head
+// moves. It NEVER bypasses attempt_verify, never scores unverified work, and is a
+// no-op when the incumbent already IS the best head — a healthy node is unaffected.
+struct SupersedeHint
+{
+    bool     active{false};
+    uint256  target_head;          // challenger chain head (highest received work)
+    uint256  target_segment_last;  // chain.get_last(target_head): its missing parent —
+                                   // the stable identity of the whole challenger segment
+    int      budget{0};            // bounded elevated per-tick verify budget for the segment
+    uint288  challenger_work;      // received cumulative work of the challenger (diagnostics)
+    uint288  incumbent_work;       // verified cumulative work of the incumbent best (diagnostics)
+};
+
 struct TrackerThinkResult
 {
     uint256 best;
@@ -651,16 +685,80 @@ public:
         return {static_cast<int32_t>(PoolConfig::chain_length()), score_res};
     }
 
+    // -- Restart-reorg supersede detector (see SupersedeHint) --
+    // Returns an ACTIVE hint iff a genuine competing fork exists whose RECEIVED
+    // cumulative work is STRICTLY greater than the incumbent best's VERIFIED
+    // work and whose verified height is still below CHAIN_LENGTH. Pure read over
+    // chain + verified. Guardrails: strictly-greater only, genuine-fork only
+    // (is_child_of skips extensions of our own chain), verified-height < CL only.
+    SupersedeHint compute_supersede_hint(const uint256& incumbent_best, int budget)
+    {
+        SupersedeHint hint;
+        if (incumbent_best.IsNull() || !verified.contains(incumbent_best))
+            return hint;  // bootstrap / no incumbent — bootstrap budget path applies
+        const auto CL = static_cast<int32_t>(PoolConfig::chain_length());
+        const uint288 incumbent_work = verified.get_work(incumbent_best);
+
+        uint256 best_ch;
+        uint288 best_ch_work;
+        bool found = false;
+        for (auto& [head, tail] : chain.get_heads())
+        {
+            if (head == incumbent_best) continue;
+            if (!chain.contains(head)) continue;
+            try { if (chain.is_child_of(incumbent_best, head)) continue; }
+            catch (...) { /* concurrent trim — treat as fork candidate */ }
+            if (verified.get_acc_height(head) >= CL) continue;
+            uint288 w;
+            try { w = chain.get_work(head); } catch (...) { continue; }
+            if (!found || w > best_ch_work) { best_ch_work = w; best_ch = head; found = true; }
+        }
+
+        if (found && incumbent_work < best_ch_work)  // STRICTLY higher received work
+        {
+            hint.active = true;
+            hint.target_head = best_ch;
+            try { hint.target_segment_last = chain.get_last(best_ch); } catch (...) {}
+            hint.budget = budget;
+            hint.challenger_work = best_ch_work;
+            hint.incumbent_work = incumbent_work;
+        }
+        return hint;
+    }
+
+    // -- Restart-reorg liveness: challenger-first Phase-2 scheduling --
+    // Move the challenger-segment heads to the FRONT of the work-descending
+    // Phase-2 head order so a shorter non-challenger verified head cannot spend
+    // the whole normal budget and trip the outer per-head gate before the
+    // challenger's iteration is entered. Inactive supersede => no-op and the
+    // healthy-node order is byte-identical. Returns the number moved.
+    size_t prioritize_challenger_heads(
+        std::vector<std::pair<uint256, uint256>>& heads,
+        const SupersedeHint& supersede)
+    {
+        if (!supersede.active)
+            return 0;
+        auto is_challenger_head = [&](const std::pair<uint256, uint256>& hv) -> bool {
+            try { return chain.get_last(hv.first) == supersede.target_segment_last; }
+            catch (...) { return false; }
+        };
+        auto mid = std::stable_partition(heads.begin(), heads.end(), is_challenger_head);
+        return static_cast<size_t>(std::distance(heads.begin(), mid));
+    }
+
     // -- Best-chain selection with verification + punishment (oracle think) --
     // bootstrap_mode: removes the per-call verification budget so the entire
     // chain is verified in one pass (initial sync, no IO needs the lock).
     // Oracle: p2pool/data.py:731-845 (Tracker.think); p2pool runs think()
     // synchronously on the reactor. The known_txs/feecache/block_abs_height
     // args fold into verify_share via share_check.hpp.
+    // supersede: restart-reorg hint (see SupersedeHint). Default-inactive, so
+    // every existing caller and the healthy-node path are byte-unchanged.
     TrackerThinkResult think(const std::function<int32_t(uint256)>& block_rel_height_func,
                              const uint256& /*previous_block*/,
                              uint32_t /*bits*/,
-                             bool bootstrap_mode = false)
+                             bool bootstrap_mode = false,
+                             const SupersedeHint& supersede = SupersedeHint{})
     {
         // oracle: desired is a set of (peer_addr, hash, max_timestamp, min_target).
         // The timestamp filters stale requests at return time.
@@ -796,6 +894,21 @@ public:
         int budget_remaining = bootstrap_mode ? INT_MAX : THINK_VERIFY_BUDGET;
         m_think_needs_continue = false;
 
+        // Wall-clock bound on a single think() cycle (ported with the restart-
+        // reorg stack). The elevated verify pool (SupersedeHint) could otherwise
+        // draw hundreds of verifies in one cycle and pin the exclusive lock for
+        // seconds, degrading the IO serve path to EMPTY replies. Cap the per-cycle
+        // hold; m_think_needs_continue reposts the remainder next tick. Bootstrap
+        // is exempt (initial full verify runs uncapped).
+        const auto think_wall_t0 = std::chrono::steady_clock::now();
+        constexpr int64_t THINK_MAX_WALL_MS = 2000;
+        auto think_wall_exceeded = [&]() -> bool {
+            return !bootstrap_mode &&
+                   std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - think_wall_t0).count()
+                       >= THINK_MAX_WALL_MS;
+        };
+
         // V36 livelock mirror: cooperative-yield budget for the scoring walk.
         // Sized FAR above a normal full-window pass so it NEVER trips on healthy
         // load (semantics unchanged); a pure starvation circuit breaker.
@@ -806,6 +919,17 @@ public:
         // Sort verified heads by work (descending) so the best chain gets budget
         // priority. p2pool iterates in arbitrary order but has no budget; with a
         // budget, a low-work side chain going first could starve the best chain.
+        // Restart-reorg elevated budget (SupersedeHint): a BOUNDED extra pool
+        // that ONLY the challenger segment may draw from, after the normal budget
+        // is spent. Inactive → identical to before.
+        int elevated_remaining = supersede.active ? supersede.budget : 0;
+        if (supersede.active) {
+            LOG_INFO << "[SUPERSEDE] elevated verify armed: target="
+                     << supersede.target_head.GetHex().substr(0,16)
+                     << " segment_last=" << supersede.target_segment_last.GetHex().substr(0,16)
+                     << " budget=" << supersede.budget
+                     << " challenger_work>incumbent_work (strictly greater)";
+        }
         std::vector<std::pair<uint256, uint256>> sorted_vheads(
             verified.get_heads().begin(), verified.get_heads().end());
         std::sort(sorted_vheads.begin(), sorted_vheads.end(),
@@ -814,10 +938,35 @@ public:
                 auto wb = verified.contains(b.first) ? verified.get_work(b.first) : uint288{};
                 return wa > wb;
             });
+        // Restart-reorg liveness: move challenger-segment heads to the FRONT so a
+        // shorter non-challenger head cannot spend the normal budget and trip the
+        // outer per-head gate before the challenger's iteration is entered. No-op
+        // when supersede is inactive.
+        prioritize_challenger_heads(sorted_vheads, supersede);
 
         for (auto& [head_hash, tail_hash] : sorted_vheads)
         {
-            if (budget_remaining <= 0) { m_think_needs_continue = true; break; }
+            // Wall-clock bound: stop the per-head sweep once this cycle has held
+            // the exclusive lock long enough; resume next tick.
+            if (think_wall_exceeded()) {
+                m_think_needs_continue = true;
+                LOG_INFO << "[think-P2] wall-clock cap hit between heads, deferring remainder";
+                break;
+            }
+            // Restart-reorg: is this verified head the frontier of the challenger
+            // segment named by the hint? Hoisted above the per-head budget gate.
+            bool is_challenger = false;
+            if (supersede.active) {
+                try {
+                    is_challenger = (chain.get_last(head_hash) == supersede.target_segment_last);
+                } catch (...) { is_challenger = false; }
+            }
+            // Per-head budget gate. Only a challenger head may additionally draw
+            // the bounded elevated pool. Inactive supersede → original break.
+            if (budget_remaining <= 0 && !(is_challenger && elevated_remaining > 0)) {
+                m_think_needs_continue = true;
+                break;
+            }
             if (!chain.contains(head_hash)) continue;
 
             auto [head_height, last_hash] = verified.get_height_and_last(head_hash);
@@ -829,7 +978,12 @@ public:
             // short of CHAIN_LENGTH (want), capped by how many the rooted peer
             // can actually supply (can); to_get = min(want, can).
             auto CL = static_cast<int32_t>(PoolConfig::chain_length());
-            auto want = std::max(CL - head_height, 0);
+            // For an UNROOTED challenger segment a CHAIN_LENGTH-tall VERIFIED tail
+            // needs ~2*CL depth; target the fresh-bootstrap load depth 2*CL+10 so
+            // the segment can reach CHAIN_LENGTH verified shares. Rooted / non-
+            // challenger tails keep the original CL target (byte-unchanged).
+            auto want_depth = is_challenger ? (2 * CL + 10) : CL;
+            auto want = std::max(want_depth - head_height, 0);
             auto can = last_last_hash.IsNull()
                 ? last_height
                 : std::max(last_height - 1 - CL, 0);
@@ -851,7 +1005,16 @@ public:
                 int p2_verified_count = 0;
                 for (auto [hash, data] : chain_view)
                 {
-                    if (budget_remaining <= 0) { m_think_needs_continue = true; break; }
+                    // Normal budget for everyone; the challenger segment may draw
+                    // from the bounded elevated pool AFTER the normal budget is spent.
+                    bool can_spend = budget_remaining > 0
+                                     || (is_challenger && elevated_remaining > 0);
+                    if (!can_spend) { m_think_needs_continue = true; break; }
+                    // Wall-clock bound: do not hold the exclusive lock past
+                    // THINK_MAX_WALL_MS even with budget left. Checked every 8 verifies.
+                    if ((p2_verified_count & 7) == 0 && think_wall_exceeded()) {
+                        m_think_needs_continue = true; break;
+                    }
 
                     uint256 prev_hash;
                     int share_ver = 0;
@@ -892,14 +1055,27 @@ public:
                     bool was_already_verified = verified.contains(hash);
                     if (!attempt_verify(hash)) break;
                     ++p2_verified_count;
-                    if (!was_already_verified) --budget_remaining;
+                    if (!was_already_verified) {
+                        // Spend the normal budget first; only the challenger may
+                        // then draw from the bounded elevated pool.
+                        if (budget_remaining > 0) --budget_remaining;
+                        else if (is_challenger && elevated_remaining > 0) --elevated_remaining;
+                    }
                 }
             }
 
             // oracle data.py:781-788: request more shares if the verified chain
             // is still short. Skip if the MAIN chain is already in the pruning
             // zone (the unverified shares exist — they just need verification).
-            if (head_height < static_cast<int32_t>(PoolConfig::chain_length()) && !last_last_hash.IsNull())
+            // Non-challenger: request until the MAIN chain reaches CHAIN_LENGTH.
+            // Challenger (restart-reorg): keep requesting parents until the segment
+            // reaches 2*CL+10 depth so it is no longer pinned at ~CL+8.
+            auto main_ht_req = chain.get_height(head_hash);
+            auto CL_req = static_cast<int32_t>(PoolConfig::chain_length());
+            bool want_more_parents = is_challenger
+                ? (main_ht_req < 2 * CL_req + 10)
+                : (head_height < CL_req);
+            if (want_more_parents && !last_last_hash.IsNull())
             {
                 auto main_ht = chain.get_height(head_hash);
                 auto CL_prune = static_cast<int32_t>(PoolConfig::chain_length());

--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -57,6 +57,23 @@ if(BUILD_TESTING)
         BCH_SHARE_TRACKER_SRC="${CMAKE_CURRENT_SOURCE_DIR}/../share_tracker.hpp")
     add_test(NAME bch_share_remove_owns_data_test COMMAND bch_share_remove_owns_data_test)
 
+    # Restart-reorg SupersedeHint behavioral KAT (BCH-lane mirror of the
+    # dash/btc/dgb/ltc KATs): drives the REAL bch::ShareTracker accounting —
+    # warm full-CL incumbent vs higher-work sub-CL challenger -> the hint
+    # activates and names the challenger; lower/equal-work + own-chain-extension
+    # + healthy-single-head stay inactive; challenger-first scheduling prevents
+    # starvation. Plain main()+CHECK (BCH tree has no GTest); links the ABLA set
+    # since bch::ShareTracker/MergedMiningShare are header-only over coin/*.hpp.
+    # Standalone add_executable + add_test (the #1131 precedent). Also listed in
+    # build.yml's bch --target set so CI compiles+runs it (unregistered = fake green).
+    add_executable(bch_restart_reorg_supersede_test restart_reorg_supersede_test.cpp)
+    target_include_directories(bch_restart_reorg_supersede_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(bch_restart_reorg_supersede_test PRIVATE
+        core pool sharechain
+        c2pool_payout c2pool_merged_mining c2pool_hashrate c2pool_storage c2pool_difficulty
+        btclibs)
+    add_test(NAME bch_restart_reorg_supersede_test COMMAND bch_restart_reorg_supersede_test)
+
     # block_connector_test exercises the full-block -> mempool reconciliation
     # path, so it constructs MutableTransaction objects whose ctors are out-of-line
     # in coin/transaction.cpp. Add that single TU to this test only; the link set

--- a/src/impl/bch/test/restart_reorg_supersede_test.cpp
+++ b/src/impl/bch/test/restart_reorg_supersede_test.cpp
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Restart-reorg supersede detector -- KAT, exercised through BCH's REAL
+// ShareTracker API (bch::ShareTracker::compute_supersede_hint /
+// prioritize_challenger_heads). C++ analog of the LTC restart-reorg fix ported
+// to BCH.
+//
+// THE DEFECT this pins: a node that loads its persisted, fully-verified
+// sharechain then peers with a higher-work network STICKS on the old head.
+// TailScore compares chain_len FIRST and score() short-circuits to
+// {verified_height,0} below CHAIN_LENGTH, so a warm-loaded full-CL verified tail
+// beats any challenger whose VERIFIED height is still short -- and the challenger
+// never verifies to CHAIN_LENGTH because think() never backfills the unrooted
+// segment to the ~2*CL depth a CHAIN_LENGTH-tall verified tail needs. A node with
+// local hashrate then keeps extending its own verified incumbent = self-sustained
+// minority fork.
+//
+// compute_supersede_hint is the visibility fix: it fires an ACTIVE hint iff a
+// GENUINE competing fork exists whose RECEIVED cumulative work is STRICTLY
+// greater than the incumbent best's VERIFIED work and whose verified height is
+// still below CHAIN_LENGTH. think() then deepens that segment's backfill to
+// 2*CL+10 and spends a bounded elevated verification budget on it, so it verifies
+// to CHAIN_LENGTH and the EXISTING Phase-3 TailScore argmax flips on its own.
+// This KAT drives the DECISION through the real chain/verified work accounting
+// (get_work over ShareIndex.work) -- the exact mechanism -- without needing real
+// PoW verification: the detector is a pure read over chain + verified.
+//
+// Harness: plain int main() + CHECK (the BCH test tree has no GTest dependency;
+// it links no coin lib, but bch::ShareTracker / bch::MergedMiningShare are
+// header-only over coin/*.hpp, exactly like the ABLA seam tests). Registered as a
+// standalone add_executable + add_test (the #1131 bch_share_remove_owns_data_test
+// precedent). CTest treats exit 0 as PASS.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <core/uint256.hpp>
+#include <impl/bch/share.hpp>
+#include <impl/bch/share_tracker.hpp>
+
+namespace {
+
+int g_failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::cerr << "CHECK FAILED: " #cond " @ " << __FILE__ << ":" << __LINE__ << "\n"; \
+    ++g_failures; } } while (0)
+
+uint256 hx(const std::string& tail) {
+    uint256 v;
+    v.SetHex(std::string(64 - tail.size(), '0') + tail);
+    return v;
+}
+
+constexpr uint32_t kBits = 0x1e0fffff;  // uniform per-share work
+constexpr int kBudget = 400;
+constexpr int kNormalBudget = 100;  // THINK_VERIFY_BUDGET in think()
+
+uint256 build_run(bch::ShareTracker& tracker, int32_t count,
+                  const uint256& root_prev, size_t salt) {
+    uint256 prev = root_prev;
+    uint256 tip;
+    tip.SetNull();
+    for (int32_t i = 0; i < count; ++i) {
+        char buf[32];
+        std::snprintf(buf, sizeof(buf), "%zx",
+                      static_cast<size_t>((salt << 20) + 0x5b70 + i));
+        uint256 h = hx(buf);
+        auto* sh = new bch::MergedMiningShare();
+        sh->m_hash = h;
+        sh->m_prev_hash = prev;
+        sh->m_desired_version = 36;
+        sh->m_bits = kBits;
+        sh->m_max_bits = kBits;
+        bch::ShareType st;
+        st = sh;
+        tracker.add(st);
+        prev = h;
+        tip = h;
+    }
+    return tip;
+}
+
+void mark_verified(bch::ShareTracker& tracker, const uint256& tip) {
+    std::vector<uint256> chainward;
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    for (auto it = chainward.rbegin(); it != chainward.rend(); ++it) {
+        if (tracker.chain.contains(*it) && !tracker.verified.contains(*it)) {
+            auto& sv = tracker.chain.get_share(*it);
+            tracker.verified.add(sv);
+        }
+    }
+}
+
+uint256 verify_deep_prefix(bch::ShareTracker& tracker, const uint256& tip, int n) {
+    std::vector<uint256> chainward;
+    uint256 cur = tip;
+    while (!cur.IsNull() && tracker.chain.contains(cur)) {
+        chainward.push_back(cur);
+        auto* idx = tracker.chain.get_index(cur);
+        cur = idx ? idx->tail : uint256();
+    }
+    const int sz = static_cast<int>(chainward.size());
+    if (n > sz) n = sz;
+    uint256 frontier;
+    for (int i = 0; i < n; ++i) {
+        const uint256& h = chainward[sz - 1 - i];
+        if (tracker.chain.contains(h) && !tracker.verified.contains(h)) {
+            auto& sv = tracker.chain.get_share(h);
+            tracker.verified.add(sv);
+        }
+        frontier = h;
+    }
+    return frontier;
+}
+
+bool challenger_iteration_entered(
+        const std::vector<uint256>& order, const uint256& challenger_head,
+        const std::function<bool(const uint256&)>& is_challenger,
+        int normal_budget, int elevated_budget, bool elevated_aware) {
+    int budget = normal_budget, elevated = elevated_budget;
+    for (const auto& h : order) {
+        const bool ch = is_challenger(h);
+        const bool brk = elevated_aware
+                             ? (budget <= 0 && !(ch && elevated > 0))
+                             : (budget <= 0);
+        if (brk) break;
+        if (h == challenger_head) return true;
+        if (!ch) budget = 0;
+    }
+    return false;
+}
+
+// --- Higher-work genuine fork -> ACTIVE, targeted at the challenger ----------
+void HigherWorkForkActivates() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+    const uint256 missing_parent = hx("dead0001");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+
+    CHECK(t.verified.contains(inc_tip));
+    CHECK(!t.verified.contains(ch_tip));
+    CHECK(t.verified.get_work(inc_tip) < t.chain.get_work(ch_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    CHECK(hint.active);
+    CHECK(hint.target_head == ch_tip);
+    CHECK(hint.target_segment_last == missing_parent);
+    CHECK(hint.budget == kBudget);
+    CHECK(hint.incumbent_work < hint.challenger_work);
+}
+
+// --- Lower-work fork -> INACTIVE ---------------------------------------------
+void LowerWorkForkStaysInactive() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 ch_tip = build_run(t, 10, hx("dead0002"), 2);
+    CHECK(t.chain.get_work(ch_tip) < t.verified.get_work(inc_tip));
+    CHECK(!t.compute_supersede_hint(inc_tip, kBudget).active);
+}
+
+// --- Equal-work fork -> INACTIVE (tie never displaces) -----------------------
+void EqualWorkForkStaysInactive() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 ch_tip = build_run(t, 30, hx("dead0003"), 2);
+    CHECK(t.chain.get_work(ch_tip) == t.verified.get_work(inc_tip));
+    CHECK(!t.compute_supersede_hint(inc_tip, kBudget).active);
+}
+
+// --- Healthy single head -> INACTIVE -----------------------------------------
+void HealthySingleHeadIsNoOp() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 40, uint256(), 1);
+    mark_verified(t, inc_tip);
+    CHECK(!t.compute_supersede_hint(inc_tip, kBudget).active);
+}
+
+// --- Own-chain extension (unverified) -> INACTIVE (genuine-fork guard) --------
+void OwnChainExtensionIsNotAChallenger() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 ext_tip = build_run(t, 25, inc_tip /*extends incumbent*/, 2);
+    CHECK(t.verified.get_work(inc_tip) < t.chain.get_work(ext_tip));
+    CHECK(t.chain.is_child_of(inc_tip, ext_tip));
+    CHECK(!t.compute_supersede_hint(inc_tip, kBudget).active);
+}
+
+// --- No incumbent (bootstrap) -> INACTIVE ------------------------------------
+void NoIncumbentIsInactive() {
+    bch::ShareTracker t;
+    (void)build_run(t, 50, hx("dead0004"), 2);
+    CHECK(!t.compute_supersede_hint(uint256() /*null incumbent*/, kBudget).active);
+}
+
+// --- Backfill-depth target is 2*CL+10 ----------------------------------------
+void BackfillTargetIsTwiceChainLengthPlusTen() {
+    const int32_t CL = static_cast<int32_t>(bch::PoolConfig::chain_length());
+    CHECK(CL > 0);
+    CHECK(2 * CL + 10 > CL);
+}
+
+// --- STARVATION: shorter higher-verified-work non-challenger must NOT starve --
+void ChallengerNotStarvedByShorterHigherWorkHead() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256() /*rooted*/, 1);
+    mark_verified(t, inc_tip);
+    const uint256 nc_tip = build_run(t, 12, uint256() /*rooted, own root*/, 3);
+    mark_verified(t, nc_tip);
+    const uint256 missing_parent = hx("dead0005");
+    const uint256 ch_tip = build_run(t, 50, missing_parent, 2);
+    const uint256 ch_frontier = verify_deep_prefix(t, ch_tip, 3);
+
+    CHECK(t.verified.contains(inc_tip));
+    CHECK(t.verified.contains(nc_tip));
+    CHECK(t.verified.contains(ch_frontier));
+    CHECK(t.verified.get_work(ch_frontier) < t.verified.get_work(nc_tip));
+    CHECK(t.verified.get_work(nc_tip)      < t.verified.get_work(inc_tip));
+
+    auto hint = t.compute_supersede_hint(inc_tip, kBudget);
+    CHECK(hint.active);
+    CHECK(hint.target_head == ch_tip);
+    CHECK(hint.target_segment_last == missing_parent);
+    CHECK(t.chain.get_last(ch_frontier) == missing_parent);
+
+    auto build_sorted = [&]() {
+        std::vector<std::pair<uint256, uint256>> v(
+            t.verified.get_heads().begin(), t.verified.get_heads().end());
+        std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+            auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+            auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+            return wa > wb;
+        });
+        return v;
+    };
+    auto index_of = [](const std::vector<std::pair<uint256, uint256>>& v,
+                       const uint256& h) -> int {
+        for (int i = 0; i < static_cast<int>(v.size()); ++i)
+            if (v[i].first == h) return i;
+        return -1;
+    };
+    auto is_ch = [&](const uint256& h) -> bool {
+        return t.chain.get_last(h) == hint.target_segment_last;
+    };
+
+    auto pre = build_sorted();
+    CHECK(index_of(pre, ch_frontier) >= 0);
+    CHECK(index_of(pre, nc_tip) >= 0);
+    CHECK(index_of(pre, ch_frontier) > index_of(pre, nc_tip));
+    std::vector<uint256> pre_order;
+    for (auto& hv : pre) pre_order.push_back(hv.first);
+    CHECK(!challenger_iteration_entered(
+        pre_order, ch_frontier, is_ch, kNormalBudget, kBudget, /*elevated_aware=*/false));
+
+    auto post = build_sorted();
+    const size_t n_challengers = t.prioritize_challenger_heads(post, hint);
+    CHECK(n_challengers == 1u);
+    CHECK(index_of(post, ch_frontier) == 0);
+    CHECK(index_of(post, ch_frontier) < index_of(post, nc_tip));
+
+    std::vector<uint256> post_order;
+    for (auto& hv : post) post_order.push_back(hv.first);
+    CHECK(challenger_iteration_entered(
+        post_order, ch_frontier, is_ch, kNormalBudget, kBudget, /*elevated_aware=*/true));
+
+    CHECK(kNormalBudget + kBudget <= 500);
+}
+
+// --- Healthy node: prioritize is a NO-OP -------------------------------------
+void PrioritizeIsNoOpWhenInactive() {
+    bch::ShareTracker t;
+    const uint256 inc_tip = build_run(t, 30, uint256(), 1);
+    mark_verified(t, inc_tip);
+    const uint256 side_tip = build_run(t, 12, uint256(), 3);
+    mark_verified(t, side_tip);
+
+    bch::SupersedeHint inactive;
+    CHECK(!inactive.active);
+
+    std::vector<std::pair<uint256, uint256>> v(
+        t.verified.get_heads().begin(), t.verified.get_heads().end());
+    std::sort(v.begin(), v.end(), [&](const auto& a, const auto& b) {
+        auto wa = t.verified.contains(a.first) ? t.verified.get_work(a.first) : uint288{};
+        auto wb = t.verified.contains(b.first) ? t.verified.get_work(b.first) : uint288{};
+        return wa > wb;
+    });
+    const auto before = v;
+    const size_t moved = t.prioritize_challenger_heads(v, inactive);
+    CHECK(moved == 0u);
+    CHECK(v.size() == before.size());
+    for (size_t i = 0; i < v.size(); ++i) {
+        CHECK(v[i].first == before[i].first);
+        CHECK(v[i].second == before[i].second);
+    }
+}
+
+}  // namespace
+
+int main() {
+    HigherWorkForkActivates();
+    LowerWorkForkStaysInactive();
+    EqualWorkForkStaysInactive();
+    HealthySingleHeadIsNoOp();
+    OwnChainExtensionIsNotAChallenger();
+    NoIncumbentIsInactive();
+    BackfillTargetIsTwiceChainLengthPlusTen();
+    ChallengerNotStarvedByShorterHigherWorkHead();
+    PrioritizeIsNoOpWhenInactive();
+    if (g_failures == 0) {
+        std::cout << "bch_restart_reorg_supersede_test: ALL CHECKS PASSED\n";
+        return 0;
+    }
+    std::cerr << "bch_restart_reorg_supersede_test: " << g_failures << " CHECK(s) FAILED\n";
+    return 1;
+}


### PR DESCRIPTION
Per-coin split of the **bch** portion of #1459 (a btc/dgb/bch cross-coin bundle that cannot land — per-coin isolation is a hard stop). btc portion is #1488; this is the bch half; dgb half is its sibling PR.

Change: rewires think() call sites to carry SupersedeHint on restart-driven reorg (semantic-preserving 4->5-arg reshape), and adds the 5s periodic think/clean tick wired via pool_entrypoint.hpp (the embedded bch layout has no standalone main_bch). Adds bch_restart_reorg_supersede KAT and registers it in the CI --target allowlist (build.yml, both matrix legs).

HOLD: do-not-merge until the shared SupersedeHint reshape clears the .45 deep-engine SHIP verdict (card sem-4cc135475a, host currently down) that gates the whole family incl #1488. Routing to bch-embedded-steward for coin ownership review.