### PR TITLE
Reject foreign-coin payout addresses at the stratum parse (#961)

### DIFF
--- a/src/c2pool/main_bip110.cpp
+++ b/src/c2pool/main_bip110.cpp
@@ -326,6 +326,20 @@ int run_embedded(bool coin_p2p_discover,
              << (serve_mempool_txs ? "ENABLED" : "DISABLED (coinbase-only)")
              << " — daemonless ingest+price+select+xcheck";
 
+    // #961 cross-lane (B4): publish BIP-110's REGISTRY-SOURCED own-coin payout-
+    // address acceptance into the StratumConfig the core StratumServer reads, so
+    // the SAME decide_payout_address() door-reject (mining.authorize) + no-empty-
+    // payout guard (send_notify_work) LTC runs also apply on this lane — a foreign-
+    // unconfigured payout is rejected at the door instead of redirected. The
+    // Knots-GBT parent runs mainnet (is_testnet=false above); own-coin addresses
+    // stay accepted byte-identically.
+    {
+        const auto acc = bip110::address_acceptance(
+            bip110::pool::PoolConfig::is_testnet, /*regtest=*/false);
+        work_source->set_payout_acceptance(acc.p2pkh_versions, acc.p2sh_versions,
+                                           acc.bech32_hrps);
+    }
+
     // ── DEFECT 2: node-owner / donation address (OPERATOR-PROVIDED, never hard-
     // coded). When a miner authorizes with a resolvable payout address it is paid
     // the subsidy; if the miner address fails to resolve, the subsidy falls back

--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -49,6 +49,7 @@
 #include <impl/btc/share_tracker.hpp>    // get_v35_expected_payouts
 #include <impl/btc/dashboard_pplns.hpp>  // btc::dashboard::pplns_payouts_current — pool-wide Current Payouts (read-only)
 #include <impl/btc/stratum/work_source.hpp>
+#include <impl/btc/config_coin.hpp>              // btc::address_acceptance (#961 cross-lane payout publish)
 #include <impl/btc/coin/template_capture.hpp>     // per-share template retain -> won-block reconstruct (slice 7/7)
 #include <impl/btc/coin/template_other_txs.hpp>    // make_template_other_txs_fn bridge (#840)
 #include <impl/btc/coin/reconstruct_won_block.hpp> // make_reconstruct_closure — faithful won-block body (#839)
@@ -1758,7 +1759,18 @@ int main(int argc, char* argv[])
     // of rejecting it as Foreign (regtest reuses testnet base58 bytes, so
     // testnet=false + regtest=true must NOT resolve to the mainnet set).
     work_source->set_regtest(regtest);
-    work_source_for_shutdown = work_source;  // expose to signal handler
+    // #961 cross-lane (B4): publish BTC's REGISTRY-SOURCED own-coin payout-address
+    // acceptance into the StratumConfig the core StratumServer reads, so the SAME
+    // decide_payout_address() door-reject (mining.authorize) + no-empty-payout
+    // guard (send_notify_work) that LTC runs also apply on the BTC lane — a
+    // foreign-unconfigured payout address is rejected at the door instead of
+    // repurposed into a wrong-coin script. Network-derived (mainnet/testnet/
+    // regtest); own-coin + a configured merged chain stay accepted byte-identically.
+    {
+        const auto acc = btc::address_acceptance(testnet, regtest);
+        work_source->set_payout_acceptance(acc.p2pkh_versions, acc.p2sh_versions,
+                                           acc.bech32_hrps);
+    }
 
     // ── Node-owner fee (p2pool -f/--fee + --node-owner-address) ──
     // Ported from main_dash.cpp: with probability node_owner_fee%, a job's

--- a/src/c2pool/main_btc.cpp
+++ b/src/c2pool/main_btc.cpp
@@ -1752,6 +1752,12 @@ int main(int argc, char* argv[])
     // both outlive it (stack-scoped main() lifetime).
     auto work_source = std::make_shared<btc::stratum::BTCWorkSource>(
         header_chain, mempool, testnet, std::move(stratum_submit_fn));
+    // #961: the BTCWorkSource ctor takes only a testnet bool; --regtest is a
+    // THIRD network (testnet base58 bytes + "bcrt" bech32 HRP). Pass it through
+    // so the payout-address check accepts a legitimate --regtest address instead
+    // of rejecting it as Foreign (regtest reuses testnet base58 bytes, so
+    // testnet=false + regtest=true must NOT resolve to the mainnet set).
+    work_source->set_regtest(regtest);
     work_source_for_shutdown = work_source;  // expose to signal handler
 
     // ── Node-owner fee (p2pool -f/--fee + --node-owner-address) ──

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -3438,6 +3438,18 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // to real dashd (both merkle roots reproduced from the mnlistdiff wire); the
     // SML+quorum freshness + superblock viability gates keep it fail-safe.
     work_source->set_embedded_mainnet(embedded_mainnet);
+    // #961 cross-lane (B4): publish DASH's REGISTRY-SOURCED own-coin payout-address
+    // acceptance into the StratumConfig the core StratumServer reads, so the SAME
+    // decide_payout_address() door-reject (mining.authorize) + no-empty-payout
+    // guard (send_notify_work) LTC runs also apply on the DASH lane — a foreign-
+    // unconfigured payout is rejected at the door instead of redirected. DASH
+    // rides the testnet flag for --regtest (its regtest reuses the testnet address
+    // bytes X.../7... → y.../8...); own-coin addresses stay accepted byte-identically.
+    {
+        const auto acc = dash::address_acceptance(testnet, /*regtest=*/false);
+        work_source->set_payout_acceptance(acc.p2pkh_versions, acc.p2sh_versions,
+                                           acc.bech32_hrps);
+    }
     // Publish the live template to the dashboard PPLNS view (declared far above,
     // where the WebServer seams are bound). peek_template() is the SAME
     // non-fetching peek the block-value card already uses — it never triggers a

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -35,6 +35,7 @@
 // Mirrors src/c2pool/main_btc.cpp s target shape.
 
 #include <impl/dgb/node.hpp>
+#include <impl/dgb/params.hpp>          // dgb::address_acceptance (#961 cross-lane payout publish)
 #include <core/settings_cli.hpp>          // M0b control-plane wiring
 #include <core/config_endpoint.hpp>       // M1 control-plane READ-ONLY endpoints
 #include <impl/dgb/catalog_defaults.hpp>  // M0b L0 compiled defaults
@@ -1427,6 +1428,17 @@ int run_node(const core::CoinParams& params, bool testnet,
     // uses the "dgbrt" bech32 HRP). Pass it through so a legitimate --regtest
     // payout address is accepted rather than rejected as Foreign.
     work_source->set_regtest(regtest);
+    // #961 cross-lane (B4): publish DGB's REGISTRY-SOURCED own-coin payout-address
+    // acceptance into the StratumConfig the core StratumServer reads, so the SAME
+    // decide_payout_address() door-reject (mining.authorize) + no-empty-payout
+    // guard (send_notify_work) LTC runs also apply on the DGB lane — a foreign-
+    // unconfigured payout is rejected at the door instead of left empty/redirected.
+    // Network-derived; own-coin + a CONFIGURED merged chain (DOGE) stay accepted.
+    {
+        const auto acc = dgb::address_acceptance(testnet, regtest);
+        work_source->set_payout_acceptance(acc.p2pkh_versions, acc.p2sh_versions,
+                                           acc.bech32_hrps);
+    }
 
 #ifdef AUX_DOGE
     // Arm the #1413 DGBWorkSource merged-mining seams: once bound, every built

--- a/src/c2pool/main_dgb.cpp
+++ b/src/c2pool/main_dgb.cpp
@@ -1422,6 +1422,11 @@ int run_node(const core::CoinParams& params, bool testnet,
     auto work_source = std::make_shared<dgb::stratum::DGBWorkSource>(
         header_chain, mempool, testnet, std::move(stratum_submit_fn),
         params.subsidy_func);
+    // #961: the DGBWorkSource ctor takes only a testnet bool; --regtest is a
+    // THIRD network (DigiByte CRegTestParams reuses the testnet base58 bytes and
+    // uses the "dgbrt" bech32 HRP). Pass it through so a legitimate --regtest
+    // payout address is accepted rather than rejected as Foreign.
+    work_source->set_regtest(regtest);
 
 #ifdef AUX_DOGE
     // Arm the #1413 DGBWorkSource merged-mining seams: once bound, every built

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -65,6 +65,7 @@
 // AppleClang/arm64 ("use of undeclared identifier s / ser_action").
 #include <impl/ltc/coin/coin_node.hpp>
 #include <impl/ltc/config.hpp>
+#include <impl/ltc/params.hpp>  // ltc::address_acceptance (#961 registry-sourced payout check)
 #include <impl/ltc/work_target.hpp>
 
 // Chain seed discovery
@@ -1764,6 +1765,19 @@ int main(int argc, char* argv[]) {
             // during SPV header sync and share loading.
             core::WebServer web_server(ioc, http_host, static_cast<uint16_t>(http_port),
                                      settings->m_testnet, enhanced_node, blockchain);
+            // #961: publish the running coin's REGISTRY-SOURCED payout-address
+            // acceptance (LTC on the active network) so the core stratum server
+            // validates each per-job coinbase payout against LTC's own version
+            // bytes / HRP at the parse — a foreign-coin address is rejected
+            // (empty payout) instead of being repurposed into a wrong-coin
+            // script, while a configured merged chain's address (DOGE etc.) is
+            // still honoured via the shared merged-chain table.
+            {
+                auto acc = ltc::address_acceptance(settings->m_testnet);
+                stratum_config.payout_p2pkh_versions = acc.p2pkh_versions;
+                stratum_config.payout_p2sh_versions  = acc.p2sh_versions;
+                stratum_config.payout_bech32_hrps    = acc.bech32_hrps;
+            }
             web_server.get_mining_interface()->set_stratum_config(stratum_config);
             // Control-plane M1 (SAFE): install the READ-ONLY config endpoints
             // (lambdas read the immutable snapshot published in main()). POST

--- a/src/core/address_utils.cpp
+++ b/src/core/address_utils.cpp
@@ -27,10 +27,17 @@ void register_address_decoder(AddressDecoderFn fn) {
     address_decoders().push_back(std::move(fn));
 }
 
-std::string base58check_to_hash160(const std::string& address)
+// Decode a 25-byte Base58Check address (1 version + 20 hash160 + 4 checksum)
+// and return the hash160 as 40-char lowercase hex, ALSO handing back the
+// version byte. Returns "" on any invalid character, overflow, or checksum
+// failure. Single source of truth for the version-aware decoders below.
+static std::string base58check_decode_versioned(const std::string& address,
+                                                uint8_t& version_out)
 {
     static constexpr const char* B58 =
         "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+    if (address.empty()) return "";
 
     // decoded[0..24]: 1 version byte + 20 hash160 bytes + 4 checksum bytes
     uint8_t decoded[25] = {};
@@ -53,6 +60,7 @@ std::string base58check_to_hash160(const std::string& address)
     for (int i = 0; i < 4; ++i)
         if (chk[i] != decoded[21 + i]) return "";
 
+    version_out = decoded[0];
     static const char* HEX = "0123456789abcdef";
     std::string hex;
     hex.reserve(40);
@@ -61,6 +69,12 @@ std::string base58check_to_hash160(const std::string& address)
         hex += HEX[decoded[i] & 0x0f];
     }
     return hex;
+}
+
+std::string base58check_to_hash160(const std::string& address)
+{
+    uint8_t version = 0;
+    return base58check_decode_versioned(address, version);
 }
 
 std::string address_to_hash160(const std::string& address, std::string& addr_type)
@@ -207,6 +221,80 @@ bool is_address_for_chain(const std::string& address,
         }
     }
     return false;
+}
+
+AddressCoinMatch classify_address_for_coin(
+    const std::string& address,
+    const std::vector<uint8_t>& p2pkh_versions,
+    const std::vector<uint8_t>& p2sh_versions,
+    const std::vector<std::string>& accepted_hrps,
+    std::vector<unsigned char>& out_script)
+{
+    out_script.clear();
+
+    // ── Bech32 / segwit ────────────────────────────────────────────────
+    // A bech32 address is "<hrp>1<data>". The bech32 data charset excludes '1',
+    // so the separator is the FINAL '1' and the HRP is everything before it. We
+    // try to decode the address as segwit under that extracted HRP:
+    //   • decodes AND HRP is ours   → Own (build the witness scriptPubKey)
+    //   • decodes but HRP is foreign → Foreign (a valid segwit address for a
+    //                                  DIFFERENT coin — never repurpose it)
+    //   • does not decode            → fall through to Base58Check (a base58
+    //                                  address can legitimately contain '1', so
+    //                                  a failed segwit decode is NOT a verdict)
+    auto sep = address.rfind('1');
+    if (sep != std::string::npos && sep > 0) {
+        const std::string hrp = address.substr(0, sep);
+        int witver = -1;
+        std::vector<uint8_t> prog;
+        if (bech32::decode_segwit(hrp, address, witver, prog)) {
+            bool own = false;
+            for (const auto& h : accepted_hrps) if (h == hrp) { own = true; break; }
+            if (!own) return AddressCoinMatch::Foreign;
+            out_script.push_back(static_cast<unsigned char>(
+                witver == 0 ? 0x00 : (0x50 + witver)));
+            out_script.push_back(static_cast<unsigned char>(prog.size()));
+            out_script.insert(out_script.end(), prog.begin(), prog.end());
+            return AddressCoinMatch::Own;
+        }
+    }
+
+    // ── Base58Check (P2PKH / P2SH) ─────────────────────────────────────
+    uint8_t version = 0;
+    const std::string h160 = base58check_decode_versioned(address, version);
+    if (h160.size() == 40) {
+        for (uint8_t v : p2pkh_versions) {
+            if (v == version) {
+                out_script = hash160_to_merged_script(h160, "p2pkh");
+                return AddressCoinMatch::Own;
+            }
+        }
+        for (uint8_t v : p2sh_versions) {
+            if (v == version) {
+                out_script = hash160_to_merged_script(h160, "p2sh");
+                return AddressCoinMatch::Own;
+            }
+        }
+        // Valid Base58Check, but a version byte this coin does not use → a
+        // well-formed address for a DIFFERENT coin. Reject, never repurpose.
+        return AddressCoinMatch::Foreign;
+    }
+
+    // Neither an own/foreign segwit address nor any Base58Check address. The
+    // caller may consult a coin-specific decoder (e.g. BCH CashAddr) next.
+    return AddressCoinMatch::Invalid;
+}
+
+std::vector<unsigned char> address_to_script_for_coin(
+    const std::string& address,
+    const std::vector<uint8_t>& p2pkh_versions,
+    const std::vector<uint8_t>& p2sh_versions,
+    const std::vector<std::string>& accepted_hrps)
+{
+    std::vector<unsigned char> script;
+    classify_address_for_coin(address, p2pkh_versions, p2sh_versions,
+                              accepted_hrps, script);
+    return script;  // non-empty only for AddressCoinMatch::Own
 }
 
 std::string script_to_address(const std::vector<unsigned char>& script,

--- a/src/core/address_utils.hpp
+++ b/src/core/address_utils.hpp
@@ -154,6 +154,12 @@ struct MergedChainAddr {
 ///                    refuse (no empty/zero-hash160 payout, which PPLNS would burn).
 enum class PayoutAddressDecision { AcceptOwn, AcceptMerged, Reject };
 
+// Forward declaration (full declaration below): the payout-decision SSOT
+// consults the coin-registered native-format decoders (e.g. BCH CashAddr) so a
+// running coin's OWN address that the built-in Base58Check / bech32 classifier
+// cannot parse is still accepted rather than door-rejected (issue #961 cross-lane).
+std::vector<unsigned char> address_to_script(const std::string& address);
+
 inline PayoutAddressDecision decide_payout_address(
     const std::string& address,
     const CoinAddressAcceptance& own,
@@ -164,12 +170,26 @@ inline PayoutAddressDecision decide_payout_address(
     if (m == AddressCoinMatch::Own)
         return PayoutAddressDecision::AcceptOwn;
     // Only a well-formed-but-Foreign address can still be a configured merged
-    // chain; an Invalid (unparseable) address is never payable.
+    // chain; an Invalid (unparseable) address is never a base58/bech32 payout.
     if (m == AddressCoinMatch::Foreign) {
         for (const auto& c : configured_merged) {
             if (is_address_for_chain(address, c.hrps, c.versions))
                 return PayoutAddressDecision::AcceptMerged;
         }
+        return PayoutAddressDecision::Reject;
+    }
+    // Invalid to the built-in Base58Check / bech32 decoders — but the running
+    // coin may register a NATIVE-format decoder for its own addresses (BCH
+    // registers a CashAddr decoder into address_to_script). A non-empty script
+    // means THIS node can build the miner's own-coin payout, so accept it
+    // (reward-safe: the door must not reject a coin's native address format).
+    // This can only fire via a registered decoder: an Invalid classification
+    // means the built-in base58/bech32 in address_to_script() also fail, so a
+    // truly undecodable address still Rejects, and a well-formed foreign address
+    // is Foreign (handled above), never Invalid — no misdirection is opened.
+    if (m == AddressCoinMatch::Invalid && !address.empty()) {
+        if (!address_to_script(address).empty())
+            return PayoutAddressDecision::AcceptOwn;
     }
     return PayoutAddressDecision::Reject;
 }

--- a/src/core/address_utils.hpp
+++ b/src/core/address_utils.hpp
@@ -59,6 +59,18 @@ bool is_address_for_chain(const std::string& address,
 // validating the version byte / HRP against the running coin BEFORE building a
 // script, so a foreign address is rejected loudly instead of being repurposed.
 
+/// The set of Base58Check version bytes and bech32 HRPs a given coin accepts as
+/// its OWN payout addresses on a given network (mainnet / testnet / regtest).
+/// Populated by each coin's registry (address_acceptance()) from its chainparams
+/// SSOT — NEVER hardcoded at a stratum money-path call site (issue #961 blocker
+/// #3) — and network-derived so a --regtest address is accepted rather than
+/// silently rejected as Foreign (blocker #2).
+struct CoinAddressAcceptance {
+    std::vector<uint8_t>     p2pkh_versions;   ///< accepted P2PKH version bytes
+    std::vector<uint8_t>     p2sh_versions;    ///< accepted P2SH version bytes
+    std::vector<std::string> bech32_hrps;      ///< BARE HRPs, NO trailing '1' (e.g. "ltc")
+};
+
 /// Result of classify_address_for_coin().
 enum class AddressCoinMatch {
     Invalid,   ///< Not a Base58Check or bech32 address this decoder understands
@@ -91,6 +103,23 @@ std::vector<unsigned char> address_to_script_for_coin(
     const std::vector<uint8_t>& p2pkh_versions,
     const std::vector<uint8_t>& p2sh_versions,
     const std::vector<std::string>& accepted_hrps);
+
+/// Overloads taking a registry-sourced CoinAddressAcceptance (issue #961). Every
+/// stratum payout money-path passes the running coin's acceptance for the ACTIVE
+/// network so the check needs no hardcoded version bytes and honours regtest.
+inline AddressCoinMatch classify_address_for_coin(
+    const std::string& address, const CoinAddressAcceptance& acc,
+    std::vector<unsigned char>& out_script)
+{
+    return classify_address_for_coin(address, acc.p2pkh_versions,
+        acc.p2sh_versions, acc.bech32_hrps, out_script);
+}
+inline std::vector<unsigned char> address_to_script_for_coin(
+    const std::string& address, const CoinAddressAcceptance& acc)
+{
+    return address_to_script_for_coin(address, acc.p2pkh_versions,
+        acc.p2sh_versions, acc.bech32_hrps);
+}
 
 /// Build a scriptPubKey from either a Base58Check or Bech32 address.
 /// Returns empty vector on failure.

--- a/src/core/address_utils.hpp
+++ b/src/core/address_utils.hpp
@@ -121,6 +121,59 @@ inline std::vector<unsigned char> address_to_script_for_coin(
         acc.p2sh_versions, acc.bech32_hrps);
 }
 
+/// Normalise a CoinParams-style bech32 HRP to the BARE form the acceptance set
+/// wants (issue #961 blocker #3). CoinParams.bech32_hrp is stored inconsistently
+/// across the lanes — LTC keeps the separator ("ltc1"), DGB/BIP-110 store it bare
+/// ("dgb"/"bc") — so a registry-derived address_acceptance() strips a single
+/// trailing '1' (the bech32 HRP/data separator) to get the bare prefix. A bare
+/// HRP never ends in '1' (it is the separator), so this is loss-free.
+inline std::string bare_bech32_hrp(const std::string& hrp)
+{
+    if (!hrp.empty() && hrp.back() == '1') return hrp.substr(0, hrp.size() - 1);
+    return hrp;
+}
+
+/// A CONFIGURED merged-mining chain's address-identification triple (issue #961).
+/// bech32 HRPs (bare) + Base58Check version bytes, exactly as the stratum server's
+/// merged-chain table records them — passed to decide_payout_address() so a
+/// legitimate merged-mining payout (same secp256k1 key, spendable on the parent's
+/// P2PKH) is accepted while an UNconfigured foreign coin's address is rejected.
+struct MergedChainAddr {
+    std::vector<std::string> hrps;
+    std::vector<uint8_t>     versions;
+};
+
+/// The stratum payout money-path decision for a miner-supplied address on a node
+/// that has published its own acceptance set (issue #961 blocker #1). This is the
+/// SSOT the stratum server consults at BOTH mining.authorize (reject at the door)
+/// and per-job coinbase build (guard: never build a zero/foreign payout):
+///   • AcceptOwn    — an own-coin address; the caller builds its script.
+///   • AcceptMerged — a CONFIGURED merged chain's address; the caller builds the
+///                    parent P2PKH to the same hash160 (the intended reuse).
+///   • Reject       — foreign-and-unconfigured, or unparseable; the caller MUST
+///                    refuse (no empty/zero-hash160 payout, which PPLNS would burn).
+enum class PayoutAddressDecision { AcceptOwn, AcceptMerged, Reject };
+
+inline PayoutAddressDecision decide_payout_address(
+    const std::string& address,
+    const CoinAddressAcceptance& own,
+    const std::vector<MergedChainAddr>& configured_merged)
+{
+    std::vector<unsigned char> own_script;
+    auto m = classify_address_for_coin(address, own, own_script);
+    if (m == AddressCoinMatch::Own)
+        return PayoutAddressDecision::AcceptOwn;
+    // Only a well-formed-but-Foreign address can still be a configured merged
+    // chain; an Invalid (unparseable) address is never payable.
+    if (m == AddressCoinMatch::Foreign) {
+        for (const auto& c : configured_merged) {
+            if (is_address_for_chain(address, c.hrps, c.versions))
+                return PayoutAddressDecision::AcceptMerged;
+        }
+    }
+    return PayoutAddressDecision::Reject;
+}
+
 /// Build a scriptPubKey from either a Base58Check or Bech32 address.
 /// Returns empty vector on failure.
 std::vector<unsigned char> address_to_script(const std::string& address);

--- a/src/core/address_utils.hpp
+++ b/src/core/address_utils.hpp
@@ -50,6 +50,48 @@ bool is_address_for_chain(const std::string& address,
     const std::vector<std::string>& chain_hrps,
     const std::vector<uint8_t>& chain_versions);
 
+// -- Per-coin address validation (issue #961) ---------------------------------
+// The plain address_to_script()/address_to_hash160() decoders are chain-AGNOSTIC:
+// they accept the version byte / bech32 HRP of ANY supported coin and then build
+// a scriptPubKey for whatever coin the caller happens to be running. Fed a
+// foreign-coin payout address that path silently emits a wrong-coin script and
+// MISDIRECTS the miner's funds. classify_address_for_coin() closes that hole by
+// validating the version byte / HRP against the running coin BEFORE building a
+// script, so a foreign address is rejected loudly instead of being repurposed.
+
+/// Result of classify_address_for_coin().
+enum class AddressCoinMatch {
+    Invalid,   ///< Not a Base58Check or bech32 address this decoder understands
+               ///< (e.g. a CashAddr, or a checksum failure). out_script empty.
+               ///< The caller MAY consult a coin-specific decoder next.
+    Foreign,   ///< Well-formed address, but for a DIFFERENT coin (version byte /
+               ///< bech32 HRP not in this coin's accepted set). out_script empty;
+               ///< the caller MUST reject — never pay it.
+    Own        ///< Valid address for THIS coin. out_script holds its scriptPubKey.
+};
+
+/// Decode `address` and classify it against the running coin's accepted
+/// Base58Check version bytes and bech32 HRPs. On Own, out_script is the
+/// scriptPubKey (P2PKH/P2SH for base58, witness program for bech32); on
+/// Foreign/Invalid out_script is left empty. `accepted_hrps` are BARE prefixes
+/// with NO trailing '1' (e.g. {"ltc","tltc"}); pass {} for coins without bech32.
+AddressCoinMatch classify_address_for_coin(
+    const std::string& address,
+    const std::vector<uint8_t>& p2pkh_versions,
+    const std::vector<uint8_t>& p2sh_versions,
+    const std::vector<std::string>& accepted_hrps,
+    std::vector<unsigned char>& out_script);
+
+/// Convenience wrapper: returns the scriptPubKey ONLY for an own-coin address,
+/// and an EMPTY vector for a foreign-coin OR unparseable address. Use this in
+/// place of address_to_script() on the payout money-path so a foreign address
+/// can never be repurposed into a wrong-coin script.
+std::vector<unsigned char> address_to_script_for_coin(
+    const std::string& address,
+    const std::vector<uint8_t>& p2pkh_versions,
+    const std::vector<uint8_t>& p2sh_versions,
+    const std::vector<std::string>& accepted_hrps);
+
 /// Build a scriptPubKey from either a Base58Check or Bech32 address.
 /// Returns empty vector on failure.
 std::vector<unsigned char> address_to_script(const std::string& address);

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -772,6 +772,49 @@ nlohmann::json StratumSession::handle_authorize(const nlohmann::json& params, co
             }
         }
 
+        // ─── #961 B1: reject a foreign-coin payout at the door ──────────────
+        // If this coin published its OWN acceptance set (StratumConfig.payout_*
+        // — the LTC/DOGE merged-mining server does), a username that is neither
+        // an own-coin address NOR a CONFIGURED merged chain's address MUST be
+        // rejected here. Authorizing it would put the miner on jobs whose
+        // coinbase pays a script this node cannot build for their key — an
+        // empty / zero-hash160 payout that PPLNS burns every block (accept-and-
+        // burn). Own-coin and configured-merged stay accepted (reward-safe);
+        // lanes that leave payout_* empty keep the legacy accept-any behaviour
+        // (they validate at mining_submit in their work source, where an empty
+        // payout falls back to the node-owner/donation script, not a burn).
+        {
+            const auto& acfg = mining_interface_->get_stratum_config();
+            const bool acceptance_configured =
+                !acfg.payout_p2pkh_versions.empty() ||
+                !acfg.payout_p2sh_versions.empty() ||
+                !acfg.payout_bech32_hrps.empty();
+            if (acceptance_configured && !username_.empty()) {
+                const core::CoinAddressAcceptance own{acfg.payout_p2pkh_versions,
+                    acfg.payout_p2sh_versions, acfg.payout_bech32_hrps};
+                std::vector<core::MergedChainAddr> merged_cfg;
+                for (const auto& chain : MERGED_CHAINS)
+                    if (mining_interface_->has_merged_chain(chain.chain_id))
+                        merged_cfg.push_back({chain.hrps, chain.versions});
+                if (core::decide_payout_address(username_, own, merged_cfg)
+                        == core::PayoutAddressDecision::Reject) {
+                    LOG_WARNING << "[Stratum] REJECTED mining.authorize: payout address "
+                                << username_ << " is not a"
+                                << (acfg.coin_symbol.empty() ? "" : " " + acfg.coin_symbol)
+                                << " address and not a configured merged chain — refusing "
+                                   "to authorize (issue #961: would burn the reward)";
+                    authorized_ = false;
+                    nlohmann::json response;
+                    response["id"] = request_id;
+                    response["result"] = false;
+                    response["error"] = nlohmann::json::array(
+                        {24, "Unauthorized: payout address is not for this coin "
+                             "(and not a configured merged chain)", nullptr});
+                    return response;
+                }
+            }
+        }
+
         LOG_INFO << "[Stratum] Mining authorization successful for: " << username_;
 
         // Auto-derive: for each configured merged chain without an explicit address,
@@ -1659,34 +1702,35 @@ void StratumSession::send_notify_work(bool force_clean, const uint256* frozen_be
             if (!acceptance_configured) {
                 payout_script = address_to_script(username_);  // legacy, byte-identical
             } else {
-                std::vector<unsigned char> own_script;
-                auto m = core::classify_address_for_coin(
-                    username_, scfg.payout_p2pkh_versions, scfg.payout_p2sh_versions,
-                    scfg.payout_bech32_hrps, own_script);
-                bool acceptable = (m == core::AddressCoinMatch::Own);
-                if (!acceptable && m == core::AddressCoinMatch::Foreign) {
-                    // Not an own-coin address — but a CONFIGURED merged chain's
-                    // address is still a legitimate merged-mining payout.
-                    for (const auto& chain : merged_chain_table()) {
-                        if (mining_interface_->has_merged_chain(chain.chain_id) &&
-                            is_address_for_chain(username_, chain.hrps, chain.versions)) {
-                            acceptable = true;
-                            break;
-                        }
-                    }
-                }
-                if (acceptable) {
-                    // Byte-identical to the pre-#961 build for every accepted
-                    // address (own-coin OR configured-merged) — reward-safe.
-                    payout_script = address_to_script(username_);
-                } else {
-                    LOG_WARNING << "[Stratum] REJECTED foreign-coin payout address (user="
-                                << username_ << ") — not a"
+                // #961 B1: consult the shared payout decision (SSOT with
+                // handle_authorize's door check). Own-coin OR a CONFIGURED merged
+                // chain builds byte-identically to the pre-#961 script (reward-
+                // safe); a foreign-unconfigured address is REJECTED.
+                const core::CoinAddressAcceptance own{scfg.payout_p2pkh_versions,
+                    scfg.payout_p2sh_versions, scfg.payout_bech32_hrps};
+                std::vector<core::MergedChainAddr> merged_cfg;
+                for (const auto& chain : merged_chain_table())
+                    if (mining_interface_->has_merged_chain(chain.chain_id))
+                        merged_cfg.push_back({chain.hrps, chain.versions});
+                if (core::decide_payout_address(username_, own, merged_cfg)
+                        == core::PayoutAddressDecision::Reject) {
+                    // ── B1 GUARD: never build a share with an empty/zero-hash160
+                    // payout. An empty payout_script here would make build_
+                    // connection_coinbase() emit the degenerate value-0 / zero-
+                    // hash160 coinbase; PPLNS would then record this miner's work
+                    // weight against an UNSPENDABLE output and BURN their reward
+                    // every block. Refuse to issue the job at all (no active_jobs_
+                    // entry, no mining.notify) — combined with handle_authorize's
+                    // reject, a foreign-unconfigured address can never be mined.
+                    LOG_WARNING << "[Stratum] REFUSING to build work: foreign-coin "
+                                   "payout address (user=" << username_ << ") — not a"
                                 << (scfg.coin_symbol.empty() ? "" : " " + scfg.coin_symbol)
-                                << " address and not a configured merged chain; refusing "
-                                   "to misdirect the reward (empty payout)";
-                    // payout_script stays empty -> existing degenerate-payout path.
+                                << " address and not a configured merged chain; "
+                                   "no zero-payout share will be built (issue #961)";
+                    return;
                 }
+                // Accepted (own-coin OR configured-merged): byte-identical build.
+                payout_script = address_to_script(username_);
             }
         }
 

--- a/src/core/stratum_server.cpp
+++ b/src/core/stratum_server.cpp
@@ -36,6 +36,39 @@ inline double sample_tcp_rtt_ms(int fd) {
 #endif
     return 0.0;
 }
+
+// ─── Merged-chain address identification table (issue #961) ──────────────────
+// Hoisted to file scope so BOTH handle_authorize() (merged-chain resolution) and
+// send_notify_work() (the #961 payout money-path check) share ONE table. A
+// username that resolves to a CONFIGURED merged chain here is a legitimate
+// merged-mining payout — the same hash160 / secp256k1 key is spendable on the
+// parent and the merged chain, so paying the parent's P2PKH to that hash160 is
+// the intended reuse, NOT the foreign-coin misdirection #961 closes.
+// Each entry: {chain_id, bech32_hrps (BARE), base58 version bytes}.
+struct ChainAddrInfo {
+    uint32_t chain_id;
+    std::vector<std::string> hrps;
+    std::vector<uint8_t> versions;
+};
+inline const std::vector<ChainAddrInfo>& merged_chain_table() {
+    static const std::vector<ChainAddrInfo> t = {
+        // DOGE: D... (0x1e), 9/A... (0x16), testnet n... (0x71)
+        {98,   {},      {0x1e, 0x16, 0x71}},
+        // PEP:  P... (0x38), testnet n... (0x71)
+        {63,   {},      {0x38, 0x16, 0x71}},
+        // BELLS: B... (0x19), bech32 "bel"/"tbel"
+        {16,   {"bel", "tbel"}, {0x19, 0x1e, 0x21}},
+        // LKY:  L... (0x2f), testnet n... (0x71)
+        {8211, {},      {0x2f, 0x05, 0x71}},
+        // JKC:  7... (0x10), testnet m/n... (0x6f)
+        {8224, {},      {0x10, 0x05, 0x6f}},
+        // SHIC: S... (0x3f), testnet n... (0x71)
+        {74,   {},      {0x3f, 0x16, 0x71}},
+        // DINGO: same versions as DOGE (fork), chain_id=98 (conflicts with DOGE!)
+        // Cannot be used simultaneously with DOGE. Omitted from auto-detect.
+    };
+    return t;
+}
 }  // namespace
 
 namespace core {
@@ -650,34 +683,23 @@ nlohmann::json StratumSession::handle_authorize(const nlohmann::json& params, co
         //
         // Vnish firmware and some ASIC control software cannot use commas in the
         // login field, so we support pipe (|) and space as alternatives.
-        // ─── Merged chain address identification table ───
-        // Each entry: {chain_id, bech32_hrps, base58_version_bytes}
-        // Used to auto-detect which chain a merged address belongs to.
-        struct ChainAddrInfo {
-            uint32_t chain_id;
-            std::vector<std::string> hrps;
-            std::vector<uint8_t> versions;
-        };
-        static const std::vector<ChainAddrInfo> MERGED_CHAINS = {
-            // DOGE: D... (0x1e), 9/A... (0x16), testnet n... (0x71)
-            {98,   {},      {0x1e, 0x16, 0x71}},
-            // PEP:  P... (0x38), testnet n... (0x71)
-            {63,   {},      {0x38, 0x16, 0x71}},
-            // BELLS: B... (0x19), bech32 "bel"/"tbel"
-            {16,   {"bel", "tbel"}, {0x19, 0x1e, 0x21}},
-            // LKY:  L... (0x2f), testnet n... (0x71)
-            {8211, {},      {0x2f, 0x05, 0x71}},
-            // JKC:  7... (0x10), testnet m/n... (0x6f)
-            {8224, {},      {0x10, 0x05, 0x6f}},
-            // SHIC: S... (0x3f), testnet n... (0x71)
-            {74,   {},      {0x3f, 0x16, 0x71}},
-            // DINGO: same versions as DOGE (fork), chain_id=98 (conflicts with DOGE!)
-            // Cannot be used simultaneously with DOGE. Omitted from auto-detect.
-        };
+        // ─── Merged chain address identification table (file-scope SSOT) ───
+        // Shared with send_notify_work()'s #961 payout check (see merged_chain_
+        // table() above). Used to auto-detect which chain a merged address
+        // belongs to.
+        const auto& MERGED_CHAINS = merged_chain_table();
 
-        // LTC identification (for swap detection)
-        static const std::vector<std::string> LTC_HRPS = {"ltc", "tltc"};
-        static const std::vector<uint8_t> LTC_VERSIONS = {0x30, 0x32, 0x05, 0x6f, 0xc4, 0x3a};
+        // Parent/primary-coin identification (for swap + Case-5 detection),
+        // REGISTRY-SOURCED from the running coin's StratumConfig (issue #961
+        // blocker #3 — no hardcoded LTC version bytes here). Empty when a coin's
+        // main() left the acceptance triple unset; the merged-chain resolution
+        // below only fires when a merged chain is configured, so an empty set
+        // simply disables parent-address detection for non-merged coins.
+        const auto& scfg = mining_interface_->get_stratum_config();
+        const std::vector<std::string>& LTC_HRPS = scfg.payout_bech32_hrps;
+        std::vector<uint8_t> LTC_VERSIONS = scfg.payout_p2pkh_versions;
+        LTC_VERSIONS.insert(LTC_VERSIONS.end(),
+            scfg.payout_p2sh_versions.begin(), scfg.payout_p2sh_versions.end());
 
         std::string merged_addr_raw;
         parse_address_separators(username_, merged_addr_raw);
@@ -1607,10 +1629,65 @@ void StratumSession::send_notify_work(bool force_clean, const uint256* frozen_be
     else if (auto fn = mining_interface_->get_best_share_hash_fn())
         frozen_prev_share = fn();  // standalone call (VARDIFF, safety timer)
     {
-        // Build payout script from username (authorized address: P2PKH, P2SH, or bech32)
+        // Build payout script from username (authorized address: P2PKH, P2SH, or bech32).
+        //
+        // #961 (LTC-lane money leak): the chain-agnostic address_to_script()
+        // decodes the version byte / bech32 HRP of ANY supported coin and builds
+        // a scriptPubKey for whatever coin THIS node runs — so a foreign-coin
+        // payout address (an unconfigured coin's address) was silently
+        // repurposed into a wrong-coin script, MISDIRECTING the miner's reward
+        // from a hash160 they do not control on this chain. Validate against the
+        // running coin's own registry-sourced acceptance set FIRST (via
+        // StratumConfig.payout_*), keeping the legitimate merged-mining reuse:
+        //   • Own-coin address                       → build it (byte-identical).
+        //   • A CONFIGURED merged chain's address    → build it: the same
+        //     hash160 pays P2PKH on the parent — the intended merged-mining
+        //     reuse (Case 5 / auto-derive), byte-identical to before.
+        //   • Foreign-and-unconfigured, or unparseable → REJECT loudly, empty
+        //     payout (the existing degenerate/empty-payout path), never a
+        //     wrong-coin payment.
+        // When a coin's main() left payout_* unset (empty triple), no acceptance
+        // is configured for this server and the legacy chain-agnostic build is
+        // preserved byte-for-byte (non-LTC lanes validate at mining_submit).
         std::vector<unsigned char> payout_script;
         if (!username_.empty()) {
-            payout_script = address_to_script(username_);
+            const auto& scfg = mining_interface_->get_stratum_config();
+            const bool acceptance_configured =
+                !scfg.payout_p2pkh_versions.empty() ||
+                !scfg.payout_p2sh_versions.empty() ||
+                !scfg.payout_bech32_hrps.empty();
+            if (!acceptance_configured) {
+                payout_script = address_to_script(username_);  // legacy, byte-identical
+            } else {
+                std::vector<unsigned char> own_script;
+                auto m = core::classify_address_for_coin(
+                    username_, scfg.payout_p2pkh_versions, scfg.payout_p2sh_versions,
+                    scfg.payout_bech32_hrps, own_script);
+                bool acceptable = (m == core::AddressCoinMatch::Own);
+                if (!acceptable && m == core::AddressCoinMatch::Foreign) {
+                    // Not an own-coin address — but a CONFIGURED merged chain's
+                    // address is still a legitimate merged-mining payout.
+                    for (const auto& chain : merged_chain_table()) {
+                        if (mining_interface_->has_merged_chain(chain.chain_id) &&
+                            is_address_for_chain(username_, chain.hrps, chain.versions)) {
+                            acceptable = true;
+                            break;
+                        }
+                    }
+                }
+                if (acceptable) {
+                    // Byte-identical to the pre-#961 build for every accepted
+                    // address (own-coin OR configured-merged) — reward-safe.
+                    payout_script = address_to_script(username_);
+                } else {
+                    LOG_WARNING << "[Stratum] REJECTED foreign-coin payout address (user="
+                                << username_ << ") — not a"
+                                << (scfg.coin_symbol.empty() ? "" : " " + scfg.coin_symbol)
+                                << " address and not a configured merged chain; refusing "
+                                   "to misdirect the reward (empty payout)";
+                    // payout_script stays empty -> existing degenerate-payout path.
+                }
+            }
         }
 
         // Build merged address entries (bech32+base58, P2PKH+P2SH)

--- a/src/core/stratum_types.hpp
+++ b/src/core/stratum_types.hpp
@@ -131,6 +131,23 @@ struct StratumConfig {
     //     not reset. 0 = off (LTC/BTC/DGB unchanged: periodic push stays purely
     //     work-generation-gated).
     uint32_t keepalive_notify_sec       = 0;
+
+    // ── Payout-address acceptance for the running coin (issue #961) ──────────
+    // The Base58Check version bytes and bech32 HRPs (BARE, no trailing '1') this
+    // coin accepts as its OWN payout addresses on the ACTIVE network. Populated
+    // by the coin's main() from its registry (e.g. ltc::address_acceptance) so
+    // the stratum payout money-path validates a miner's address against the
+    // running coin BEFORE building a scriptPubKey: a foreign-coin address is
+    // rejected loudly instead of being repurposed into a wrong-coin script that
+    // MISDIRECTS the reward. Left EMPTY by lanes that validate at mining_submit
+    // (BTC/BCH/DASH/DGB/BIP110 work sources) — an all-empty triple means "no
+    // acceptance configured", and the core stratum server then preserves the
+    // legacy chain-agnostic build (byte-identical) rather than rejecting every
+    // address. The LTC/DOGE merged-mining server populates it so its per-job
+    // coinbase payout is checked at the parse.
+    std::vector<uint8_t>     payout_p2pkh_versions;
+    std::vector<uint8_t>     payout_p2sh_versions;
+    std::vector<std::string> payout_bech32_hrps;   // BARE HRPs, no trailing '1'
 };
 
 /// Frozen share-construction fields returned by ref_hash_fn. These

--- a/src/core/test/CMakeLists.txt
+++ b/src/core/test/CMakeLists.txt
@@ -86,7 +86,15 @@ if (BUILD_TESTING AND (GTest_FOUND OR GTEST_FOUND))
     # embedded header follower feeds it, verbatim once fed — and that
     # unique_miner_count falls back to the pool-wide sharechain payout-address
     # count only when the local stratum registry is empty (never fabricated).
-    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp web_server_frozen_pool_rate_guard_test.cpp web_server_daemonless_graph_feed_test.cpp web_server_config_endpoint_test.cpp graph_history_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp)
+    # address_coin_validation_test.cpp: the issue #961 cross-coin address
+    # pay-misdirection KAT. Pins core::classify_address_for_coin() accept-own /
+    # reject-foreign across BTC/LTC/DOGE/DASH/BCH/DGB -- the money-path gate that
+    # stops a foreign-coin payout address from being repurposed into a wrong-coin
+    # script. Header-only over core (address_utils + btclibs base58/bech32) and
+    # one KAT covers every coin lane, so it is FOLDED into the EXISTING
+    # allowlisted core_test target -- never a new add_executable (the #769
+    # "Not Run" trap).
+    add_executable(core_test pack_test.cpp events_test.cpp chain_test.cpp packet_test.cpp block_broadcast_test.cpp broadcast_convergence_matrix_test.cpp core_merkle_branches_test.cpp version_gate_test.cpp filesystem_test.cpp web_server_submitblock_test.cpp web_server_current_payouts_test.cpp web_server_local_hashps_test.cpp web_server_relay_block_test.cpp web_server_dashboard_data_test.cpp web_server_frozen_pool_rate_guard_test.cpp web_server_daemonless_graph_feed_test.cpp web_server_config_endpoint_test.cpp graph_history_test.cpp known_txs_eviction_test.cpp tx_advertiser_test.cpp socket_write_queue_test.cpp known_txs_backing_test.cpp random_choice_guard_test.cpp p2p_message_stats_test.cpp netaddress_resolution_test.cpp coin_addrman_test.cpp address_coin_validation_test.cpp)
     target_compile_definitions(core_test PRIVATE C2POOL_SRC_ROOT="${CMAKE_SOURCE_DIR}/src")
     target_link_libraries(core_test PRIVATE GTest::gtest_main core c2pool_merged_mining GTest::gtest)
     target_link_libraries(core_test PRIVATE c2pool_payout c2pool_hashrate ltc_coin)  # OBJECT-lib SCC direct-naming (#22/#39)

--- a/src/core/test/address_coin_validation_test.cpp
+++ b/src/core/test/address_coin_validation_test.cpp
@@ -1,25 +1,29 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// KAT for issue #961: cross-coin address pay-misdirection.
-//
-// core::classify_address_for_coin() is the money-path gate that decides whether
-// a miner-supplied payout address belongs to the RUNNING coin. Before it, the
-// chain-agnostic address_to_script() would decode ANY supported coin's version
-// byte / bech32 HRP and build a scriptPubKey for whatever coin the node runs —
-// so a foreign address (valid on another chain) was silently repurposed into a
-// wrong-coin script and the miner's funds were MISDIRECTED.
-//
-// This KAT proves, for BTC / LTC / DOGE / DASH / BCH / DGB:
-//   • ACCEPT-OWN   : each coin's own P2PKH / P2SH (and bech32 where it exists)
-//                    address classifies as Own and yields the correct script.
-//   • REJECT-FOREIGN: an address whose version byte / HRP is NOT in the running
-//                     coin's accepted set classifies as Foreign and yields an
-//                     EMPTY script (never a repurposed wrong-coin payment).
+// KAT for issue #961: cross-coin address pay-misdirection (the LTC-lane money
+// leak) and its remediation. This test is RED on the parent commit (208ba2f7):
+// every acceptance set it checks comes from a REAL registry helper
+//   ltc::address_acceptance / btc::address_acceptance / bch::address_acceptance /
+//   dgb::address_acceptance / bip110::address_acceptance / dash::address_acceptance
+// and the payout decision it exercises is core::decide_payout_address() — NONE of
+// which exist on the parent. The earlier revision of this file supplied its own
+// hardcoded coin tables and called only the pre-existing classify_address_for_coin(),
+// so it passed on the parent and proved nothing about the fix (a blind KAT). This
+// revision instead:
+//   1. Pins each coin's registry-sourced acceptance to its real chainparams
+//      (catches a re-typed / drifted version byte — blocker #3), calling the
+//      helper, never a literal in the test.
+//   2. Exercises the stratum money-path decision core::decide_payout_address()
+//      that handle_authorize() (door reject) and send_notify_work() (no-empty-
+//      payout guard) both consult (blocker #1): own-coin → AcceptOwn, a
+//      CONFIGURED merged chain → AcceptMerged, foreign-and-unconfigured or
+//      unparseable → Reject (never a burned / misdirected payout).
+//   3. Runs the cross-coin ACCEPT-OWN / REJECT-FOREIGN matrix against those real
+//      registry sets, incl. network-derived regtest sets (blocker #2).
 //
 // Addresses are CONSTRUCTED in-test from a fixed hash160 with each coin's real
 // chainparams version byte (via EncodeBase58Check / bech32::encode_segwit), so
-// the checksums are always valid and the version constants are pinned by the
-// assertions themselves — a wrong constant in the wiring makes the matching
+// the checksums are always valid and a wrong registry constant makes the matching
 // coin's own address classify as Foreign and fails the test.
 
 #include <gtest/gtest.h>
@@ -30,12 +34,25 @@
 
 #include <core/address_utils.hpp>
 
+// The REAL per-coin registry helpers under test (issue #961). Including these and
+// calling address_acceptance() is what makes this KAT non-blind and red on parent.
+#include <impl/ltc/params.hpp>
+#include <impl/btc/config_coin.hpp>
+#include <impl/bch/config_coin.hpp>
+#include <impl/dgb/params.hpp>
+#include <impl/bip110/params.hpp>
+#include <impl/dash/params.hpp>
+
 #include <btclibs/base58.h>
 #include <btclibs/bech32.h>
 #include <btclibs/span.h>
 
 using core::AddressCoinMatch;
+using core::CoinAddressAcceptance;
 using core::classify_address_for_coin;
+using core::decide_payout_address;
+using core::MergedChainAddr;
+using core::PayoutAddressDecision;
 
 namespace {
 
@@ -83,28 +100,20 @@ std::vector<unsigned char> p2wpkh_script()
     return s;
 }
 
-// One running coin's accepted set (mainnet), mirroring each chain's chainparams.
+// One running coin, its accepted set sourced from the REAL registry helper.
 struct Coin {
     std::string name;
-    std::vector<uint8_t> p2pkh;   // accepted P2PKH version bytes
-    std::vector<uint8_t> p2sh;    // accepted P2SH version bytes
-    std::vector<std::string> hrps; // accepted bech32 HRPs (bare, no trailing '1')
+    CoinAddressAcceptance acc;
 };
 
-// Mainnet chainparams (verified against each coin's chainparams.cpp):
-//   BTC : P2PKH 0x00, P2SH 0x05, hrp "bc"
-//   LTC : P2PKH 0x30, P2SH 0x32 (+ legacy 0x05), hrp "ltc"
-//   DOGE: P2PKH 0x1e, P2SH 0x16, no bech32
-//   DASH: P2PKH 0x4c, P2SH 0x10, no bech32
-//   BCH : P2PKH 0x00, P2SH 0x05 (legacy base58 == BTC), CashAddr via decoder
-//   DGB : P2PKH 0x1e, P2SH 0x3f, hrp "dgb"
+// Every set here is REGISTRY-SOURCED (mainnet) — no literals in the test.
 const std::vector<Coin> kCoins = {
-    {"BTC",  {0x00},       {0x05},        {"bc"}},
-    {"LTC",  {0x30},       {0x32, 0x05},  {"ltc"}},
-    {"DOGE", {0x1e},       {0x16},        {}},
-    {"DASH", {0x4c},       {0x10},        {}},
-    {"BCH",  {0x00},       {0x05},        {}},
-    {"DGB",  {0x1e},       {0x3f},        {"dgb"}},
+    {"BTC",    btc::address_acceptance(/*testnet=*/false, /*regtest=*/false)},
+    {"LTC",    ltc::address_acceptance(/*testnet=*/false)},
+    {"DASH",   dash::address_acceptance(/*testnet=*/false, /*regtest=*/false)},
+    {"BCH",    bch::address_acceptance(/*testnet=*/false, /*regtest=*/false)},
+    {"DGB",    dgb::address_acceptance(/*testnet=*/false, /*regtest=*/false)},
+    {"BIP110", bip110::address_acceptance(/*testnet=*/false, /*regtest=*/false)},
 };
 
 const Coin& coin(const std::string& name)
@@ -116,7 +125,7 @@ const Coin& coin(const std::string& name)
 
 AddressCoinMatch run(const Coin& c, const std::string& addr, std::vector<unsigned char>& script)
 {
-    return classify_address_for_coin(addr, c.p2pkh, c.p2sh, c.hrps, script);
+    return classify_address_for_coin(addr, c.acc, script);
 }
 
 bool set_has(const std::vector<uint8_t>& v, uint8_t x)
@@ -132,11 +141,109 @@ bool set_has(const std::vector<std::string>& v, const std::string& x)
 
 } // namespace
 
-// ── ACCEPT-OWN: each coin accepts its own P2PKH / P2SH address ───────────────
+// ── Registry values match chainparams (blocker #3: derived, not re-typed) ─────
+// The version bytes / HRPs come from make_coin_params()/params SSOT via the
+// address_acceptance() helper. Pinning them here catches a drifted constant AND
+// makes the file fail to compile on the parent (the helpers do not exist there).
+TEST(AddressCoinValidation, RegistryValuesMatchChainparams)
+{
+    // LTC: mainnet 48 / {50,5} / "ltc"; testnet 111 / {196,58} / "tltc".
+    EXPECT_EQ(ltc::address_acceptance(false).p2pkh_versions, (std::vector<uint8_t>{48}));
+    EXPECT_EQ(ltc::address_acceptance(false).p2sh_versions,  (std::vector<uint8_t>{50, 5}));
+    EXPECT_EQ(ltc::address_acceptance(false).bech32_hrps,    (std::vector<std::string>{"ltc"}));
+    EXPECT_EQ(ltc::address_acceptance(true).p2pkh_versions,  (std::vector<uint8_t>{111}));
+    EXPECT_EQ(ltc::address_acceptance(true).p2sh_versions,   (std::vector<uint8_t>{196, 58}));
+    EXPECT_EQ(ltc::address_acceptance(true).bech32_hrps,     (std::vector<std::string>{"tltc"}));
+
+    // BTC: mainnet 0 / 5 / "bc"; testnet 0x6f / 0xc4 / "tb"; regtest hrp "bcrt".
+    EXPECT_EQ(btc::address_acceptance(false, false).p2pkh_versions, (std::vector<uint8_t>{0x00}));
+    EXPECT_EQ(btc::address_acceptance(false, false).p2sh_versions,  (std::vector<uint8_t>{0x05}));
+    EXPECT_EQ(btc::address_acceptance(false, false).bech32_hrps,    (std::vector<std::string>{"bc"}));
+    EXPECT_EQ(btc::address_acceptance(true,  false).bech32_hrps,    (std::vector<std::string>{"tb"}));
+    EXPECT_EQ(btc::address_acceptance(false, true ).bech32_hrps,    (std::vector<std::string>{"bcrt"}));
+
+    // BCH: legacy base58 == BTC bytes; NO bech32 (CashAddr is a distinct format).
+    EXPECT_EQ(bch::address_acceptance(false, false).p2pkh_versions, (std::vector<uint8_t>{0x00}));
+    EXPECT_EQ(bch::address_acceptance(false, false).p2sh_versions,  (std::vector<uint8_t>{0x05}));
+    EXPECT_TRUE(bch::address_acceptance(false, false).bech32_hrps.empty());
+
+    // DGB: mainnet 0x1e / 0x3f / "dgb"; regtest hrp "dgbrt".
+    EXPECT_EQ(dgb::address_acceptance(false, false).p2pkh_versions, (std::vector<uint8_t>{0x1e}));
+    EXPECT_EQ(dgb::address_acceptance(false, false).p2sh_versions,  (std::vector<uint8_t>{0x3f}));
+    EXPECT_EQ(dgb::address_acceptance(false, false).bech32_hrps,    (std::vector<std::string>{"dgb"}));
+    EXPECT_EQ(dgb::address_acceptance(false, true ).bech32_hrps,    (std::vector<std::string>{"dgbrt"}));
+
+    // BIP-110: Bitcoin address formats unchanged; mainnet 0/5/"bc".
+    EXPECT_EQ(bip110::address_acceptance(false, false).p2pkh_versions, (std::vector<uint8_t>{0x00}));
+    EXPECT_EQ(bip110::address_acceptance(false, false).p2sh_versions,  (std::vector<uint8_t>{0x05}));
+    EXPECT_EQ(bip110::address_acceptance(false, false).bech32_hrps,    (std::vector<std::string>{"bc"}));
+    EXPECT_EQ(bip110::address_acceptance(false, true ).bech32_hrps,    (std::vector<std::string>{"bcrt"}));
+
+    // DASH: mainnet 76 / 16; testnet 140 / 19; regtest == testnet; no bech32.
+    EXPECT_EQ(dash::address_acceptance(false, false).p2pkh_versions, (std::vector<uint8_t>{76}));
+    EXPECT_EQ(dash::address_acceptance(false, false).p2sh_versions,  (std::vector<uint8_t>{16}));
+    EXPECT_TRUE(dash::address_acceptance(false, false).bech32_hrps.empty());
+    EXPECT_EQ(dash::address_acceptance(false, true ).p2pkh_versions, (std::vector<uint8_t>{140}));
+    EXPECT_EQ(dash::address_acceptance(true,  false).p2sh_versions,  (std::vector<uint8_t>{19}));
+}
+
+// ── The stratum payout decision (blocker #1: reject / guard, not accept-burn) ──
+// core::decide_payout_address() is the SSOT that handle_authorize() consults to
+// reject a foreign-unconfigured address at the door, and that send_notify_work()
+// consults to refuse building a zero-payout share. Prove: own-coin → AcceptOwn;
+// a CONFIGURED merged chain → AcceptMerged (legit reuse, same hash160 pays the
+// parent P2PKH); foreign-unconfigured OR unparseable → Reject.
+TEST(AddressCoinValidation, StratumPayoutDecision)
+{
+    const CoinAddressAcceptance ltc_acc = ltc::address_acceptance(false);
+
+    // DOGE identification triple, exactly as the stratum server's merged-chain
+    // table records it (D... 0x1e, 9/A... 0x16, testnet n... 0x71; no bech32).
+    const MergedChainAddr doge{{}, {0x1e, 0x16, 0x71}};
+    const std::vector<MergedChainAddr> no_merged{};
+    const std::vector<MergedChainAddr> with_doge{doge};
+
+    // Own LTC addresses → AcceptOwn regardless of merged config.
+    EXPECT_EQ(decide_payout_address(b58(48), ltc_acc, no_merged),
+              PayoutAddressDecision::AcceptOwn);          // L... P2PKH
+    EXPECT_EQ(decide_payout_address(b58(50), ltc_acc, no_merged),
+              PayoutAddressDecision::AcceptOwn);          // M... P2SH
+    EXPECT_EQ(decide_payout_address(b58(5),  ltc_acc, no_merged),
+              PayoutAddressDecision::AcceptOwn);          // legacy 3... P2SH
+    EXPECT_EQ(decide_payout_address(bech32_v0("ltc"), ltc_acc, with_doge),
+              PayoutAddressDecision::AcceptOwn);
+
+    // A DOGE address (0x1e): the ACCEPT-AND-BURN case. Rejected when DOGE is NOT
+    // a configured merged chain (the #961 money leak — previously repurposed into
+    // an LTC script from a hash160 the miner does not control), but AcceptMerged
+    // once DOGE IS configured (the intended merged-mining reuse).
+    EXPECT_EQ(decide_payout_address(b58(0x1e), ltc_acc, no_merged),
+              PayoutAddressDecision::Reject);
+    EXPECT_EQ(decide_payout_address(b58(0x1e), ltc_acc, with_doge),
+              PayoutAddressDecision::AcceptMerged);
+
+    // A DASH address (0x4c) LTC can never merge-mine → Reject even with DOGE cfg.
+    EXPECT_EQ(decide_payout_address(b58(0x4c), ltc_acc, with_doge),
+              PayoutAddressDecision::Reject);
+
+    // A real BTC mainnet bech32 (HRP "bc" ∉ {"ltc"}) → Reject.
+    EXPECT_EQ(decide_payout_address("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+                                    ltc_acc, with_doge),
+              PayoutAddressDecision::Reject);
+
+    // Unparseable → Reject (an Invalid address is never payable, even if a merged
+    // chain is configured — the merged check only runs for a well-formed Foreign).
+    EXPECT_EQ(decide_payout_address("not an address", ltc_acc, with_doge),
+              PayoutAddressDecision::Reject);
+    EXPECT_EQ(decide_payout_address("", ltc_acc, with_doge),
+              PayoutAddressDecision::Reject);
+}
+
+// ── ACCEPT-OWN: each coin accepts its own P2PKH / P2SH / bech32 address ───────
 TEST(AddressCoinValidation, AcceptsOwnP2PKH)
 {
     for (const auto& c : kCoins) {
-        const std::string addr = b58(c.p2pkh.front());
+        const std::string addr = b58(c.acc.p2pkh_versions.front());
         std::vector<unsigned char> script;
         EXPECT_EQ(run(c, addr, script), AddressCoinMatch::Own)
             << c.name << " must accept its own P2PKH address " << addr;
@@ -147,7 +254,7 @@ TEST(AddressCoinValidation, AcceptsOwnP2PKH)
 TEST(AddressCoinValidation, AcceptsOwnP2SH)
 {
     for (const auto& c : kCoins) {
-        const std::string addr = b58(c.p2sh.front());
+        const std::string addr = b58(c.acc.p2sh_versions.front());
         std::vector<unsigned char> script;
         EXPECT_EQ(run(c, addr, script), AddressCoinMatch::Own)
             << c.name << " must accept its own P2SH address " << addr;
@@ -158,8 +265,8 @@ TEST(AddressCoinValidation, AcceptsOwnP2SH)
 TEST(AddressCoinValidation, AcceptsOwnBech32)
 {
     for (const auto& c : kCoins) {
-        if (c.hrps.empty()) continue;  // DOGE/DASH/BCH have no segwit
-        const std::string addr = bech32_v0(c.hrps.front());
+        if (c.acc.bech32_hrps.empty()) continue;  // DOGE/DASH/BCH have no segwit
+        const std::string addr = bech32_v0(c.acc.bech32_hrps.front());
         std::vector<unsigned char> script;
         EXPECT_EQ(run(c, addr, script), AddressCoinMatch::Own)
             << c.name << " must accept its own bech32 address " << addr;
@@ -168,36 +275,33 @@ TEST(AddressCoinValidation, AcceptsOwnBech32)
 }
 
 // ── REJECT-FOREIGN: full cross product of base58 addresses ───────────────────
-// Every coin's own P2PKH and P2SH address is offered to every OTHER coin. The
-// expected verdict is derived from the running coin's accepted set: Own iff the
+// Every coin's own P2PKH and P2SH version is offered to every OTHER coin. The
+// expected verdict is derived from the running coin's REGISTRY set: Own iff the
 // version byte is in the set (handles the inherent BTC/BCH 0x00,0x05 and
-// DOGE/DGB 0x1e collisions), Foreign otherwise — and Foreign MUST yield an
-// empty script so the money path can never emit a wrong-coin payment.
+// DOGE/DGB 0x1e collisions), Foreign otherwise — and Foreign MUST yield an empty
+// script so the money path can never emit a wrong-coin payment.
 TEST(AddressCoinValidation, RejectsForeignBase58)
 {
-    struct Sample { std::string owner; uint8_t version; };
-    std::vector<Sample> samples;
+    std::vector<uint8_t> versions;
     for (const auto& c : kCoins) {
-        for (uint8_t v : c.p2pkh) samples.push_back({c.name, v});
-        for (uint8_t v : c.p2sh)  samples.push_back({c.name, v});
+        for (uint8_t v : c.acc.p2pkh_versions) versions.push_back(v);
+        for (uint8_t v : c.acc.p2sh_versions)  versions.push_back(v);
     }
 
     for (const auto& running : kCoins) {
-        for (const auto& s : samples) {
-            const std::string addr = b58(s.version);
+        for (uint8_t v : versions) {
+            const std::string addr = b58(v);
             std::vector<unsigned char> script;
             auto verdict = run(running, addr, script);
-            const bool own = set_has(running.p2pkh, s.version) ||
-                             set_has(running.p2sh,  s.version);
+            const bool own = set_has(running.acc.p2pkh_versions, v) ||
+                             set_has(running.acc.p2sh_versions,  v);
             if (own) {
                 EXPECT_EQ(verdict, AddressCoinMatch::Own)
-                    << running.name << " should accept version 0x"
-                    << std::hex << int(s.version) << " (from " << s.owner << ")";
+                    << running.name << " should accept version 0x" << std::hex << int(v);
                 EXPECT_FALSE(script.empty());
             } else {
                 EXPECT_EQ(verdict, AddressCoinMatch::Foreign)
-                    << running.name << " must REJECT foreign version 0x"
-                    << std::hex << int(s.version) << " (from " << s.owner << ")";
+                    << running.name << " must REJECT foreign version 0x" << std::hex << int(v);
                 EXPECT_TRUE(script.empty())
                     << running.name << " emitted a script for a foreign address "
                     << "— MISDIRECTION (issue #961)";
@@ -207,9 +311,6 @@ TEST(AddressCoinValidation, RejectsForeignBase58)
 }
 
 // ── REJECT-FOREIGN: a bech32 address for another chain ───────────────────────
-// A well-formed segwit address under a HRP the running coin does not accept is
-// Foreign (never repurposed), and a coin with no segwit at all rejects every
-// bech32 address it is offered.
 TEST(AddressCoinValidation, RejectsForeignBech32)
 {
     const std::vector<std::string> all_hrps = {"bc", "ltc", "dgb", "tb"};
@@ -218,7 +319,7 @@ TEST(AddressCoinValidation, RejectsForeignBech32)
             const std::string addr = bech32_v0(hrp);
             std::vector<unsigned char> script;
             auto verdict = run(running, addr, script);
-            if (set_has(running.hrps, hrp)) {
+            if (set_has(running.acc.bech32_hrps, hrp)) {
                 EXPECT_EQ(verdict, AddressCoinMatch::Own)
                     << running.name << " should accept its own hrp " << hrp;
             } else {
@@ -233,8 +334,6 @@ TEST(AddressCoinValidation, RejectsForeignBech32)
 }
 
 // ── Concrete money-leak cases with real, checksum-valid mainnet addresses ────
-// These pin the exact behaviour the issue describes, independent of the
-// constructed-address matrix above.
 TEST(AddressCoinValidation, ConcreteMisdirectionCases)
 {
     std::vector<unsigned char> script;
@@ -279,19 +378,16 @@ TEST(AddressCoinValidation, ConcreteMisdirectionCases)
 // The production LTC/DOGE merged-mining server built its per-job coinbase payout
 // with the chain-agnostic address_to_script(), so a foreign-coin address whose
 // coin is NOT a configured merged chain was repurposed into an LTC script from a
-// hash160 the miner does not control on Litecoin — the money leak. At the
-// classify gate (what send_notify_work now consults before building the script),
-// LTC must classify every non-LTC address as Foreign and yield an EMPTY script.
-// (The stratum server then additionally honours a CONFIGURED merged chain's
-// address via the shared merged-chain table; the classify gate itself, tested
-// here, is the reject-unconfigured-foreign half.)
+// hash160 the miner does not control on Litecoin — the money leak. At the classify
+// gate (what send_notify_work now consults before building the script), LTC must
+// classify every non-LTC address as Foreign and yield an EMPTY script. The
+// running set is the REAL ltc::address_acceptance(false).
 TEST(AddressCoinValidation, LtcRejectsUnconfiguredForeign)
 {
     const Coin& ltc = coin("LTC");
     std::vector<unsigned char> script;
 
-    // A DOGE address (0x1e) — the classic "unconfigured merged coin" case. When
-    // DOGE is NOT a configured merged chain, LTC must NOT pay it.
+    // A DOGE address (0x1e) — the classic "unconfigured merged coin" case.
     EXPECT_EQ(run(ltc, b58(0x1e), script), AddressCoinMatch::Foreign);
     EXPECT_TRUE(script.empty())
         << "LTC repurposed a DOGE address into an LTC script — MISDIRECTION (#961)";
@@ -305,8 +401,7 @@ TEST(AddressCoinValidation, LtcRejectsUnconfiguredForeign)
               AddressCoinMatch::Foreign);
     EXPECT_TRUE(script.empty());
 
-    // LTC's OWN addresses (incl. the legacy 0x05 P2SH collision) stay Own — the
-    // reject must not become a false-reject of a real LTC payout.
+    // LTC's OWN addresses (incl. the legacy 0x05 P2SH collision) stay Own.
     EXPECT_EQ(run(ltc, b58(0x30), script), AddressCoinMatch::Own);       // L... P2PKH
     EXPECT_FALSE(script.empty());
     EXPECT_EQ(run(ltc, b58(0x32), script), AddressCoinMatch::Own);       // M... P2SH
@@ -321,42 +416,38 @@ TEST(AddressCoinValidation, LtcRejectsUnconfiguredForeign)
 // The wirings previously keyed the accepted set on a single is_testnet_ bool, so
 // a --regtest node (testnet=false) resolved to the MAINNET set and rejected a
 // legitimate regtest payout address as Foreign. The registry helpers now derive
-// the set from the TRUE network. These sets mirror what
-// {btc,dgb,ltc}::address_acceptance(testnet,regtest) returns for regtest:
-// bitcoin-family regtest reuses the TESTNET base58 version bytes and swaps the
-// bech32 HRP (BTC "bcrt", DGB "dgbrt", LTC "rltc"). A regtest own address must
-// classify as Own; a MAINNET address must be Foreign under the regtest set
-// (proving the set is network-derived, not mainnet-or-not).
+// the set from the TRUE network (testnet, regtest). These come from the REAL
+// address_acceptance(testnet=false, regtest=true): a regtest own address must
+// classify as Own; a MAINNET address must be Foreign under the regtest set.
 TEST(AddressCoinValidation, AcceptsRegtestAddresses)
 {
-    struct RegtestSet { std::string name; Coin set; uint8_t mainnet_p2pkh; };
+    struct RegtestSet { std::string name; CoinAddressAcceptance set; uint8_t mainnet_p2pkh; bool has_bech32; };
     const std::vector<RegtestSet> regtests = {
-        // BTC regtest: testnet 0x6f/0xc4 + hrp "bcrt"; mainnet P2PKH 0x00.
-        {"BTC",  {"BTCrt",  {0x6f}, {0xc4}, {"bcrt"}},  0x00},
-        // DGB regtest: testnet 0x7e/0x8c + hrp "dgbrt"; mainnet P2PKH 0x1e.
-        {"DGB",  {"DGBrt",  {0x7e}, {0x8c}, {"dgbrt"}}, 0x1e},
-        // LTC regtest: testnet 111/196(+58) + hrp "rltc"; mainnet P2PKH 0x30.
-        {"LTC",  {"LTCrt",  {0x6f}, {0xc4, 0x3a}, {"rltc"}}, 0x30},
+        {"BTC",    btc::address_acceptance(false, true),    0x00, true},
+        {"DGB",    dgb::address_acceptance(false, true),    0x1e, true},
+        {"BIP110", bip110::address_acceptance(false, true), 0x00, true},
+        {"DASH",   dash::address_acceptance(false, true),   76,   false},
     };
 
     for (const auto& r : regtests) {
+        const Coin c{r.name, r.set};
         std::vector<unsigned char> script;
 
-        // Regtest own P2PKH / P2SH / bech32 all classify Own with correct scripts.
-        EXPECT_EQ(run(r.set, b58(r.set.p2pkh.front()), script), AddressCoinMatch::Own)
+        EXPECT_EQ(run(c, b58(r.set.p2pkh_versions.front()), script), AddressCoinMatch::Own)
             << r.name << " regtest must accept its own P2PKH address";
         EXPECT_EQ(script, p2pkh_script());
-        EXPECT_EQ(run(r.set, b58(r.set.p2sh.front()), script), AddressCoinMatch::Own)
+        EXPECT_EQ(run(c, b58(r.set.p2sh_versions.front()), script), AddressCoinMatch::Own)
             << r.name << " regtest must accept its own P2SH address";
         EXPECT_EQ(script, p2sh_script());
-        EXPECT_EQ(run(r.set, bech32_v0(r.set.hrps.front()), script), AddressCoinMatch::Own)
-            << r.name << " regtest must accept its own bech32 address";
-        EXPECT_EQ(script, p2wpkh_script());
+        if (r.has_bech32) {
+            EXPECT_EQ(run(c, bech32_v0(r.set.bech32_hrps.front()), script), AddressCoinMatch::Own)
+                << r.name << " regtest must accept its own bech32 address";
+            EXPECT_EQ(script, p2wpkh_script());
+        }
 
         // A MAINNET address of the same coin is Foreign under the regtest set —
-        // the network-derived set is what closes the FALSE-REJECT without
-        // silently widening acceptance back to mainnet.
-        EXPECT_EQ(run(r.set, b58(r.mainnet_p2pkh), script), AddressCoinMatch::Foreign)
+        // proving the set is network-derived, not mainnet-or-not.
+        EXPECT_EQ(run(c, b58(r.mainnet_p2pkh), script), AddressCoinMatch::Foreign)
             << r.name << " regtest set must not accept a mainnet address";
         EXPECT_TRUE(script.empty());
     }

--- a/src/core/test/address_coin_validation_test.cpp
+++ b/src/core/test/address_coin_validation_test.cpp
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// KAT for issue #961: cross-coin address pay-misdirection.
+//
+// core::classify_address_for_coin() is the money-path gate that decides whether
+// a miner-supplied payout address belongs to the RUNNING coin. Before it, the
+// chain-agnostic address_to_script() would decode ANY supported coin's version
+// byte / bech32 HRP and build a scriptPubKey for whatever coin the node runs —
+// so a foreign address (valid on another chain) was silently repurposed into a
+// wrong-coin script and the miner's funds were MISDIRECTED.
+//
+// This KAT proves, for BTC / LTC / DOGE / DASH / BCH / DGB:
+//   • ACCEPT-OWN   : each coin's own P2PKH / P2SH (and bech32 where it exists)
+//                    address classifies as Own and yields the correct script.
+//   • REJECT-FOREIGN: an address whose version byte / HRP is NOT in the running
+//                     coin's accepted set classifies as Foreign and yields an
+//                     EMPTY script (never a repurposed wrong-coin payment).
+//
+// Addresses are CONSTRUCTED in-test from a fixed hash160 with each coin's real
+// chainparams version byte (via EncodeBase58Check / bech32::encode_segwit), so
+// the checksums are always valid and the version constants are pinned by the
+// assertions themselves — a wrong constant in the wiring makes the matching
+// coin's own address classify as Foreign and fails the test.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <core/address_utils.hpp>
+
+#include <btclibs/base58.h>
+#include <btclibs/bech32.h>
+#include <btclibs/span.h>
+
+using core::AddressCoinMatch;
+using core::classify_address_for_coin;
+
+namespace {
+
+// A fixed, arbitrary 20-byte hash160 used for every constructed address.
+const std::vector<uint8_t> kH160 = {
+    0x62, 0xe9, 0x07, 0xb1, 0x5c, 0xbf, 0x27, 0xd5, 0x42, 0x53,
+    0x99, 0xeb, 0xf6, 0xf0, 0xfb, 0x50, 0xeb, 0xb8, 0x8f, 0x18};
+
+// Encode a Base58Check address: 1 version byte || 20-byte hash160.
+std::string b58(uint8_t version)
+{
+    std::vector<unsigned char> payload;
+    payload.reserve(21);
+    payload.push_back(version);
+    payload.insert(payload.end(), kH160.begin(), kH160.end());
+    return EncodeBase58Check(Span<const unsigned char>(payload.data(), payload.size()));
+}
+
+// Encode a native-segwit v0 P2WPKH address for the given bech32 HRP.
+std::string bech32_v0(const std::string& hrp)
+{
+    return bech32::encode_segwit(hrp, 0, kH160);
+}
+
+// Expected scripts for kH160.
+std::vector<unsigned char> p2pkh_script()
+{
+    std::vector<unsigned char> s{0x76, 0xa9, 0x14};
+    s.insert(s.end(), kH160.begin(), kH160.end());
+    s.push_back(0x88);
+    s.push_back(0xac);
+    return s;
+}
+std::vector<unsigned char> p2sh_script()
+{
+    std::vector<unsigned char> s{0xa9, 0x14};
+    s.insert(s.end(), kH160.begin(), kH160.end());
+    s.push_back(0x87);
+    return s;
+}
+std::vector<unsigned char> p2wpkh_script()
+{
+    std::vector<unsigned char> s{0x00, 0x14};
+    s.insert(s.end(), kH160.begin(), kH160.end());
+    return s;
+}
+
+// One running coin's accepted set (mainnet), mirroring each chain's chainparams.
+struct Coin {
+    std::string name;
+    std::vector<uint8_t> p2pkh;   // accepted P2PKH version bytes
+    std::vector<uint8_t> p2sh;    // accepted P2SH version bytes
+    std::vector<std::string> hrps; // accepted bech32 HRPs (bare, no trailing '1')
+};
+
+// Mainnet chainparams (verified against each coin's chainparams.cpp):
+//   BTC : P2PKH 0x00, P2SH 0x05, hrp "bc"
+//   LTC : P2PKH 0x30, P2SH 0x32 (+ legacy 0x05), hrp "ltc"
+//   DOGE: P2PKH 0x1e, P2SH 0x16, no bech32
+//   DASH: P2PKH 0x4c, P2SH 0x10, no bech32
+//   BCH : P2PKH 0x00, P2SH 0x05 (legacy base58 == BTC), CashAddr via decoder
+//   DGB : P2PKH 0x1e, P2SH 0x3f, hrp "dgb"
+const std::vector<Coin> kCoins = {
+    {"BTC",  {0x00},       {0x05},        {"bc"}},
+    {"LTC",  {0x30},       {0x32, 0x05},  {"ltc"}},
+    {"DOGE", {0x1e},       {0x16},        {}},
+    {"DASH", {0x4c},       {0x10},        {}},
+    {"BCH",  {0x00},       {0x05},        {}},
+    {"DGB",  {0x1e},       {0x3f},        {"dgb"}},
+};
+
+const Coin& coin(const std::string& name)
+{
+    for (const auto& c : kCoins) if (c.name == name) return c;
+    ADD_FAILURE() << "unknown coin " << name;
+    return kCoins[0];
+}
+
+AddressCoinMatch run(const Coin& c, const std::string& addr, std::vector<unsigned char>& script)
+{
+    return classify_address_for_coin(addr, c.p2pkh, c.p2sh, c.hrps, script);
+}
+
+bool set_has(const std::vector<uint8_t>& v, uint8_t x)
+{
+    for (uint8_t e : v) if (e == x) return true;
+    return false;
+}
+bool set_has(const std::vector<std::string>& v, const std::string& x)
+{
+    for (const auto& e : v) if (e == x) return true;
+    return false;
+}
+
+} // namespace
+
+// ── ACCEPT-OWN: each coin accepts its own P2PKH / P2SH address ───────────────
+TEST(AddressCoinValidation, AcceptsOwnP2PKH)
+{
+    for (const auto& c : kCoins) {
+        const std::string addr = b58(c.p2pkh.front());
+        std::vector<unsigned char> script;
+        EXPECT_EQ(run(c, addr, script), AddressCoinMatch::Own)
+            << c.name << " must accept its own P2PKH address " << addr;
+        EXPECT_EQ(script, p2pkh_script()) << c.name << " P2PKH script mismatch";
+    }
+}
+
+TEST(AddressCoinValidation, AcceptsOwnP2SH)
+{
+    for (const auto& c : kCoins) {
+        const std::string addr = b58(c.p2sh.front());
+        std::vector<unsigned char> script;
+        EXPECT_EQ(run(c, addr, script), AddressCoinMatch::Own)
+            << c.name << " must accept its own P2SH address " << addr;
+        EXPECT_EQ(script, p2sh_script()) << c.name << " P2SH script mismatch";
+    }
+}
+
+TEST(AddressCoinValidation, AcceptsOwnBech32)
+{
+    for (const auto& c : kCoins) {
+        if (c.hrps.empty()) continue;  // DOGE/DASH/BCH have no segwit
+        const std::string addr = bech32_v0(c.hrps.front());
+        std::vector<unsigned char> script;
+        EXPECT_EQ(run(c, addr, script), AddressCoinMatch::Own)
+            << c.name << " must accept its own bech32 address " << addr;
+        EXPECT_EQ(script, p2wpkh_script()) << c.name << " P2WPKH script mismatch";
+    }
+}
+
+// ── REJECT-FOREIGN: full cross product of base58 addresses ───────────────────
+// Every coin's own P2PKH and P2SH address is offered to every OTHER coin. The
+// expected verdict is derived from the running coin's accepted set: Own iff the
+// version byte is in the set (handles the inherent BTC/BCH 0x00,0x05 and
+// DOGE/DGB 0x1e collisions), Foreign otherwise — and Foreign MUST yield an
+// empty script so the money path can never emit a wrong-coin payment.
+TEST(AddressCoinValidation, RejectsForeignBase58)
+{
+    struct Sample { std::string owner; uint8_t version; };
+    std::vector<Sample> samples;
+    for (const auto& c : kCoins) {
+        for (uint8_t v : c.p2pkh) samples.push_back({c.name, v});
+        for (uint8_t v : c.p2sh)  samples.push_back({c.name, v});
+    }
+
+    for (const auto& running : kCoins) {
+        for (const auto& s : samples) {
+            const std::string addr = b58(s.version);
+            std::vector<unsigned char> script;
+            auto verdict = run(running, addr, script);
+            const bool own = set_has(running.p2pkh, s.version) ||
+                             set_has(running.p2sh,  s.version);
+            if (own) {
+                EXPECT_EQ(verdict, AddressCoinMatch::Own)
+                    << running.name << " should accept version 0x"
+                    << std::hex << int(s.version) << " (from " << s.owner << ")";
+                EXPECT_FALSE(script.empty());
+            } else {
+                EXPECT_EQ(verdict, AddressCoinMatch::Foreign)
+                    << running.name << " must REJECT foreign version 0x"
+                    << std::hex << int(s.version) << " (from " << s.owner << ")";
+                EXPECT_TRUE(script.empty())
+                    << running.name << " emitted a script for a foreign address "
+                    << "— MISDIRECTION (issue #961)";
+            }
+        }
+    }
+}
+
+// ── REJECT-FOREIGN: a bech32 address for another chain ───────────────────────
+// A well-formed segwit address under a HRP the running coin does not accept is
+// Foreign (never repurposed), and a coin with no segwit at all rejects every
+// bech32 address it is offered.
+TEST(AddressCoinValidation, RejectsForeignBech32)
+{
+    const std::vector<std::string> all_hrps = {"bc", "ltc", "dgb", "tb"};
+    for (const auto& running : kCoins) {
+        for (const auto& hrp : all_hrps) {
+            const std::string addr = bech32_v0(hrp);
+            std::vector<unsigned char> script;
+            auto verdict = run(running, addr, script);
+            if (set_has(running.hrps, hrp)) {
+                EXPECT_EQ(verdict, AddressCoinMatch::Own)
+                    << running.name << " should accept its own hrp " << hrp;
+            } else {
+                EXPECT_EQ(verdict, AddressCoinMatch::Foreign)
+                    << running.name << " must REJECT foreign bech32 hrp " << hrp;
+                EXPECT_TRUE(script.empty())
+                    << running.name << " emitted a script for a foreign bech32 "
+                    << "address — MISDIRECTION (issue #961)";
+            }
+        }
+    }
+}
+
+// ── Concrete money-leak cases with real, checksum-valid mainnet addresses ────
+// These pin the exact behaviour the issue describes, independent of the
+// constructed-address matrix above.
+TEST(AddressCoinValidation, ConcreteMisdirectionCases)
+{
+    std::vector<unsigned char> script;
+
+    // Genesis BTC P2PKH — Own on BTC, Foreign on DASH / DGB / LTC.
+    const std::string btc_p2pkh = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa";
+    EXPECT_EQ(run(coin("BTC"), btc_p2pkh, script), AddressCoinMatch::Own);
+    EXPECT_EQ(run(coin("DASH"), btc_p2pkh, script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+    EXPECT_EQ(run(coin("DGB"), btc_p2pkh, script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+    EXPECT_EQ(run(coin("LTC"), btc_p2pkh, script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+
+    // BIP173 canonical BTC bech32 — Own on BTC, Foreign on DGB (has segwit) and
+    // DASH (no segwit).
+    const std::string btc_bech32 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+    EXPECT_EQ(run(coin("BTC"), btc_bech32, script), AddressCoinMatch::Own);
+    EXPECT_FALSE(script.empty());
+    EXPECT_EQ(run(coin("DGB"), btc_bech32, script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+    EXPECT_EQ(run(coin("DASH"), btc_bech32, script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+
+    // A CashAddr-shaped string (BCH's own format) is not Base58Check/segwit, so
+    // it classifies as Invalid — the caller falls through to the coin-specific
+    // CashAddr decoder. It must NEVER classify as Own on a non-BCH coin.
+    const std::string cashaddr = "qqg8m40vjdvxfp6yj6f6f0f0jh9c0f4y8q0q0q0q0q";
+    EXPECT_EQ(run(coin("BTC"), cashaddr, script), AddressCoinMatch::Invalid);
+    EXPECT_TRUE(script.empty());
+    EXPECT_EQ(run(coin("DASH"), cashaddr, script), AddressCoinMatch::Invalid);
+    EXPECT_TRUE(script.empty());
+
+    // Garbage / empty → Invalid, empty script.
+    EXPECT_EQ(run(coin("BTC"), "", script), AddressCoinMatch::Invalid);
+    EXPECT_TRUE(script.empty());
+    EXPECT_EQ(run(coin("BTC"), "not an address", script), AddressCoinMatch::Invalid);
+    EXPECT_TRUE(script.empty());
+}

--- a/src/core/test/address_coin_validation_test.cpp
+++ b/src/core/test/address_coin_validation_test.cpp
@@ -452,3 +452,92 @@ TEST(AddressCoinValidation, AcceptsRegtestAddresses)
         EXPECT_TRUE(script.empty());
     }
 }
+
+// ── #961 B4 cross-lane: the payout DOOR-REJECT decision applies on EVERY lane ─
+// Cycle-1 published the acceptance set (StratumConfig.payout_*) on the LTC lane
+// only, so the core stratum door-reject + no-empty-payout guard ran on LTC alone.
+// The other five mains (BTC/BCH/DGB/DASH/BIP-110) authorized a foreign-
+// unconfigured address — and the fresh BCH lane then BURNED it to a zero-hash160
+// coinbase. B4 publishes each coin's OWN registry-sourced acceptance from its main
+// so decide_payout_address() — the SSOT the door consults — runs identically on
+// every lane. Prove the decision each published set now feeds: own → AcceptOwn;
+// a foreign coin's address that is NOT a configured merged chain → Reject.
+TEST(AddressCoinValidation, CrossLaneDoorRejectsForeignEveryLane)
+{
+    const std::vector<MergedChainAddr> no_merged{};
+    for (const auto& running : kCoins) {
+        const CoinAddressAcceptance& acc = running.acc;
+
+        // Own P2PKH / P2SH → AcceptOwn (reward-safe: still built byte-identically).
+        EXPECT_EQ(decide_payout_address(b58(acc.p2pkh_versions.front()), acc, no_merged),
+                  PayoutAddressDecision::AcceptOwn)
+            << running.name << " must AcceptOwn its own P2PKH at the door";
+        EXPECT_EQ(decide_payout_address(b58(acc.p2sh_versions.front()), acc, no_merged),
+                  PayoutAddressDecision::AcceptOwn)
+            << running.name << " must AcceptOwn its own P2SH at the door";
+        if (!acc.bech32_hrps.empty())
+            EXPECT_EQ(decide_payout_address(bech32_v0(acc.bech32_hrps.front()), acc, no_merged),
+                      PayoutAddressDecision::AcceptOwn)
+                << running.name << " must AcceptOwn its own bech32 at the door";
+
+        // A DASH mainnet P2PKH (version 0x4c) is foreign to every non-DASH lane and
+        // is not a configured merged chain of any lane → the door MUST Reject it
+        // (the cross-lane fix: previously these lanes authorized-and-redirected/
+        // burned it). DASH itself accepts its own address.
+        const auto verdict = decide_payout_address(b58(0x4c), acc, no_merged);
+        const bool dash_own = set_has(acc.p2pkh_versions, uint8_t(0x4c)) ||
+                              set_has(acc.p2sh_versions,  uint8_t(0x4c));
+        if (dash_own)
+            EXPECT_EQ(verdict, PayoutAddressDecision::AcceptOwn) << running.name;
+        else
+            EXPECT_EQ(verdict, PayoutAddressDecision::Reject)
+                << running.name << " must door-reject a foreign DASH address, "
+                << "never authorize-and-redirect/burn it (#961 B4)";
+    }
+}
+
+// ── #961 B4: a coin's NATIVE-format own address is AcceptOwn at the door ───────
+// BCH's native CashAddr is not Base58Check/bech32, so classify_address_for_coin()
+// returns Invalid for it. On the PARENT tree (4a9dd316) decide_payout_address()
+// returned Reject for any Invalid classification — so once BCH publishes its
+// acceptance set (B4), the door would REJECT a legitimate BCH CashAddr miner and
+// the guard would refuse to build their work: a reward-UNSAFE regression. B4 makes
+// the SSOT consult the coin-registered native decoder (address_to_script): an
+// address the running node CAN pay is AcceptOwn. This test is RED on 4a9dd316
+// (parent returns Reject for the native address) and green here.
+TEST(AddressCoinValidation, NativeDecoderOwnAddressAcceptedAtDoor)
+{
+    // A sentinel that only the registered decoder below understands. It matches
+    // exactly ONE fixed string (empty for everything else), so no other test's
+    // addresses are affected by this process-global registration.
+    const std::string kNative = "cashaddr:sentinel-b4-961-own";
+    core::register_address_decoder(
+        [kNative](const std::string& a) -> std::vector<unsigned char> {
+            if (a == kNative) return p2pkh_script();  // a real, spendable scriptPubKey
+            return {};
+        });
+
+    const CoinAddressAcceptance bch_acc = bch::address_acceptance(false, false);
+    const std::vector<MergedChainAddr> no_merged{};
+
+    // The native-format own address the node CAN build a script for → AcceptOwn.
+    // RED on parent 4a9dd316: there the Invalid classification short-circuits to
+    // Reject without consulting the registered decoder.
+    EXPECT_EQ(decide_payout_address(kNative, bch_acc, no_merged),
+              PayoutAddressDecision::AcceptOwn)
+        << "a coin's own native (CashAddr) address must be accepted at the door — "
+        << "rejecting it would refuse legitimate BCH miners (reward-unsafe)";
+
+    // The fix opens NO hole: a truly-undecodable Invalid address (no decoder
+    // matches) still Rejects, so a foreign/garbage username can never slip through.
+    EXPECT_EQ(decide_payout_address("still not any address at all", bch_acc, no_merged),
+              PayoutAddressDecision::Reject);
+    EXPECT_EQ(decide_payout_address("", bch_acc, no_merged),
+              PayoutAddressDecision::Reject);
+
+    // And a well-formed FOREIGN base58 address (BTC genesis P2PKH, version 0x00 —
+    // not in BCH's set? it IS: BCH shares BTC's 0x00) — use a DASH address instead,
+    // foreign to BCH and not a merged chain → Reject even with the decoder armed.
+    EXPECT_EQ(decide_payout_address(b58(0x4c), bch_acc, no_merged),
+              PayoutAddressDecision::Reject);
+}

--- a/src/core/test/address_coin_validation_test.cpp
+++ b/src/core/test/address_coin_validation_test.cpp
@@ -274,3 +274,90 @@ TEST(AddressCoinValidation, ConcreteMisdirectionCases)
     EXPECT_EQ(run(coin("BTC"), "not an address", script), AddressCoinMatch::Invalid);
     EXPECT_TRUE(script.empty());
 }
+
+// ── LTC lane: an UNCONFIGURED foreign address is rejected (issue #961 blocker 1)
+// The production LTC/DOGE merged-mining server built its per-job coinbase payout
+// with the chain-agnostic address_to_script(), so a foreign-coin address whose
+// coin is NOT a configured merged chain was repurposed into an LTC script from a
+// hash160 the miner does not control on Litecoin — the money leak. At the
+// classify gate (what send_notify_work now consults before building the script),
+// LTC must classify every non-LTC address as Foreign and yield an EMPTY script.
+// (The stratum server then additionally honours a CONFIGURED merged chain's
+// address via the shared merged-chain table; the classify gate itself, tested
+// here, is the reject-unconfigured-foreign half.)
+TEST(AddressCoinValidation, LtcRejectsUnconfiguredForeign)
+{
+    const Coin& ltc = coin("LTC");
+    std::vector<unsigned char> script;
+
+    // A DOGE address (0x1e) — the classic "unconfigured merged coin" case. When
+    // DOGE is NOT a configured merged chain, LTC must NOT pay it.
+    EXPECT_EQ(run(ltc, b58(0x1e), script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty())
+        << "LTC repurposed a DOGE address into an LTC script — MISDIRECTION (#961)";
+
+    // A DASH address (0x4c) — a coin LTC can never merge-mine.
+    EXPECT_EQ(run(ltc, b58(0x4c), script), AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+
+    // A real BTC mainnet bech32 — Foreign to LTC (HRP "bc" ∉ {"ltc"}), empty.
+    EXPECT_EQ(run(ltc, "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", script),
+              AddressCoinMatch::Foreign);
+    EXPECT_TRUE(script.empty());
+
+    // LTC's OWN addresses (incl. the legacy 0x05 P2SH collision) stay Own — the
+    // reject must not become a false-reject of a real LTC payout.
+    EXPECT_EQ(run(ltc, b58(0x30), script), AddressCoinMatch::Own);       // L... P2PKH
+    EXPECT_FALSE(script.empty());
+    EXPECT_EQ(run(ltc, b58(0x32), script), AddressCoinMatch::Own);       // M... P2SH
+    EXPECT_FALSE(script.empty());
+    EXPECT_EQ(run(ltc, b58(0x05), script), AddressCoinMatch::Own);       // legacy 3... P2SH
+    EXPECT_FALSE(script.empty());
+    EXPECT_EQ(run(ltc, bech32_v0("ltc"), script), AddressCoinMatch::Own);
+    EXPECT_FALSE(script.empty());
+}
+
+// ── Regtest addresses are ACCEPTED (issue #961 blocker 2, FALSE-REJECT fix) ───
+// The wirings previously keyed the accepted set on a single is_testnet_ bool, so
+// a --regtest node (testnet=false) resolved to the MAINNET set and rejected a
+// legitimate regtest payout address as Foreign. The registry helpers now derive
+// the set from the TRUE network. These sets mirror what
+// {btc,dgb,ltc}::address_acceptance(testnet,regtest) returns for regtest:
+// bitcoin-family regtest reuses the TESTNET base58 version bytes and swaps the
+// bech32 HRP (BTC "bcrt", DGB "dgbrt", LTC "rltc"). A regtest own address must
+// classify as Own; a MAINNET address must be Foreign under the regtest set
+// (proving the set is network-derived, not mainnet-or-not).
+TEST(AddressCoinValidation, AcceptsRegtestAddresses)
+{
+    struct RegtestSet { std::string name; Coin set; uint8_t mainnet_p2pkh; };
+    const std::vector<RegtestSet> regtests = {
+        // BTC regtest: testnet 0x6f/0xc4 + hrp "bcrt"; mainnet P2PKH 0x00.
+        {"BTC",  {"BTCrt",  {0x6f}, {0xc4}, {"bcrt"}},  0x00},
+        // DGB regtest: testnet 0x7e/0x8c + hrp "dgbrt"; mainnet P2PKH 0x1e.
+        {"DGB",  {"DGBrt",  {0x7e}, {0x8c}, {"dgbrt"}}, 0x1e},
+        // LTC regtest: testnet 111/196(+58) + hrp "rltc"; mainnet P2PKH 0x30.
+        {"LTC",  {"LTCrt",  {0x6f}, {0xc4, 0x3a}, {"rltc"}}, 0x30},
+    };
+
+    for (const auto& r : regtests) {
+        std::vector<unsigned char> script;
+
+        // Regtest own P2PKH / P2SH / bech32 all classify Own with correct scripts.
+        EXPECT_EQ(run(r.set, b58(r.set.p2pkh.front()), script), AddressCoinMatch::Own)
+            << r.name << " regtest must accept its own P2PKH address";
+        EXPECT_EQ(script, p2pkh_script());
+        EXPECT_EQ(run(r.set, b58(r.set.p2sh.front()), script), AddressCoinMatch::Own)
+            << r.name << " regtest must accept its own P2SH address";
+        EXPECT_EQ(script, p2sh_script());
+        EXPECT_EQ(run(r.set, bech32_v0(r.set.hrps.front()), script), AddressCoinMatch::Own)
+            << r.name << " regtest must accept its own bech32 address";
+        EXPECT_EQ(script, p2wpkh_script());
+
+        // A MAINNET address of the same coin is Foreign under the regtest set —
+        // the network-derived set is what closes the FALSE-REJECT without
+        // silently widening acceptance back to mainnet.
+        EXPECT_EQ(run(r.set, b58(r.mainnet_p2pkh), script), AddressCoinMatch::Foreign)
+            << r.name << " regtest set must not accept a mainnet address";
+        EXPECT_TRUE(script.empty());
+    }
+}

--- a/src/impl/bch/config_coin.hpp
+++ b/src/impl/bch/config_coin.hpp
@@ -20,11 +20,35 @@
 #include <core/config.hpp>
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
 
 #include <yaml-cpp/yaml.h>
 
 namespace bch
 {
+
+// Registry-sourced LEGACY-base58 payout-address acceptance for BCH on the ACTIVE
+// network (issue #961). BCH legacy base58 shares Bitcoin's version bytes
+// (BCHN chainparams.cpp): mainnet PUBKEY 0 / SCRIPT 5; testnet & regtest both
+// PUBKEY 111 / SCRIPT 196. BCH has NO segwit/bech32 — its native CashAddr is a
+// DISTINCT format with no base58 version byte, so a CashAddr yields
+// AddressCoinMatch::Invalid here and (only then) falls through to the
+// coin-registered CashAddr decoder. Deriving from the true network keeps a
+// --regtest legacy address from being rejected as Foreign.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { 0x6f };  // 111
+        a.p2sh_versions  = { 0xc4 };  // 196
+    } else {
+        a.p2pkh_versions = { 0x00 };
+        a.p2sh_versions  = { 0x05 };
+    }
+    a.bech32_hrps = {};               // BCH: no bech32 (CashAddr via fallback)
+    return a;
+}
+
 namespace config
 {
     struct P2PData

--- a/src/impl/bch/pool_entrypoint.hpp
+++ b/src/impl/bch/pool_entrypoint.hpp
@@ -62,6 +62,8 @@
 #include "coin/embedded_daemon.hpp"
 #include "stratum/work_source.hpp"
 #include "config_pool.hpp"      // bch::PoolConfig::get_donation_script
+#include "config_coin.hpp"      // bch::address_acceptance (#961 cross-lane payout publish)
+#include "coin/cashaddr.hpp"    // bch::coin::cashaddr::register_cashaddr_decoder (#961 CashAddr payout)
 #include "share_check.hpp"      // bch::create_local_share (transitive via node.hpp)
 #include "share_types.hpp"      // bch::StaleInfo
 #include "coin/block.hpp"       // bch::coin::SmallBlockHeaderType
@@ -187,6 +189,28 @@ inline void standup_pool_run(boost::asio::io_context& ioc,
                 daemon.broadcast_won_block(block_bytes, HexStr(block_bytes));
             return r.any();
         });
+
+    work_source->set_regtest(is_regtest);  // #961: --regtest legacy-address set
+
+    // #961 cross-lane (B4): register BCH's native CashAddr decoder into the
+    // generic core address hook so core::address_to_script() (and therefore the
+    // decide_payout_address() SSOT the core stratum door-reject consults) resolves
+    // a miner's CashAddr username to a real scriptPubKey. Without it a CashAddr
+    // payout decoded to EMPTY -> a zero-hash160 (unspendable) coinbase PPLNS burns.
+    // Idempotent (once per process).
+    coin::cashaddr::register_cashaddr_decoder(is_testnet, is_regtest);
+    // Publish BCH's REGISTRY-SOURCED own-coin payout-address acceptance (legacy
+    // base58; CashAddr is the registered native decoder above) into the
+    // StratumConfig the core StratumServer reads, so the SAME decide_payout_
+    // address() door-reject (mining.authorize) + no-empty-payout guard LTC runs
+    // also apply on the BCH lane — a foreign-unconfigured payout is rejected at
+    // the door instead of building the zero-hash160 burn. Own-coin (base58 +
+    // CashAddr) stay accepted byte-identically.
+    {
+        const auto acc = bch::address_acceptance(is_testnet, is_regtest);
+        work_source->set_payout_acceptance(acc.p2pkh_versions, acc.p2sh_versions,
+                                           acc.bech32_hrps);
+    }
 
     // ── Sharechain WRITE path: local-share author wiring ─────────────────
     // Without these callbacks BCHWorkSource accepts miner submissions that

--- a/src/impl/bch/share_check.hpp
+++ b/src/impl/bch/share_check.hpp
@@ -2218,6 +2218,19 @@ uint256 create_local_share_v35(
     const uint256& frozen_witness_root = uint256(),
     uint64_t desired_version = 36)
 {
+    // #961 B4 — ZERO-HASH160 BURN GUARD (money path). An empty payout_script
+    // reaches the extraction block below with no branch matching, leaving
+    // share.m_pubkey_hash all-zero — an UNSPENDABLE coinbase output PPLNS credits
+    // this miner's work against, BURNING the reward every block. Refuse to mint:
+    // the caller (work_source) already skips this on a foreign/undecodable
+    // address, and the core stratum door-rejects it at authorize; this is the
+    // final money-path backstop so a zero-hash160 share can never be created.
+    if (payout_script.empty()) {
+        LOG_WARNING << "[create_local_share_v35] REFUSING to mint: empty payout "
+                       "script would burn the reward to a zero-hash160 output (#961)";
+        return uint256();
+    }
+
     PaddingBugfixShare share;
     share.m_min_header = min_header;
     share.m_coinbase   = coinbase;
@@ -2653,6 +2666,17 @@ uint256 create_local_share(
     int64_t share_version = 35,
     uint64_t desired_version = 35)
 {
+    // #961 B4 — ZERO-HASH160 BURN GUARD (money path). An empty payout_script
+    // would leave share.m_pubkey_hash all-zero (the extraction block below only
+    // runs for size >= 20), minting an UNSPENDABLE coinbase output PPLNS then
+    // burns the miner's reward against. Refuse to mint — final money-path backstop
+    // behind the work_source skip and the core stratum door-reject.
+    if (payout_script.empty()) {
+        LOG_WARNING << "[create_local_share] REFUSING to mint: empty payout script "
+                       "would burn the reward to a zero-hash160 output (#961)";
+        return uint256();
+    }
+
     // V35 path: delegate to version-specific implementation
     if (share_version <= 35)
         return create_local_share_v35(

--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -722,7 +722,30 @@ nlohmann::json BCHWorkSource::mining_submit(
 
         uint256 share_hash;
         if (create_fn) {
-            auto payout_script = core::address_to_script(username);
+            // #961: validate the payout address against BCH's OWN version bytes
+            // before building a script, so a foreign-coin base58 address (e.g.
+            // an LTC/DASH/DGB address) is rejected rather than repurposed into a
+            // BCH script — which would MISDIRECT the miner's funds. BCH legacy
+            // base58: mainnet 0x00/0x05, testnet 0x6f/0xc4 (no segwit). BCH's
+            // native CashAddr is a different format with no base58 version byte;
+            // it (and only it) falls through to the coin-registered CashAddr
+            // decoder via address_to_script(). NOTE: BCH legacy base58 shares
+            // BTC's version bytes, an inherent BCH/BTC ambiguity — a BTC legacy
+            // address is therefore accepted here (same hash160/key), which is
+            // NOT a misdirection.
+            std::vector<unsigned char> payout_script;
+            auto amatch = core::classify_address_for_coin(
+                username,
+                is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
+                is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
+                /*accepted_hrps=*/{},
+                payout_script);
+            if (amatch == core::AddressCoinMatch::Foreign)
+                LOG_WARNING << "[BCH-STRATUM] REJECTED foreign-coin payout address "
+                               "(user=" << username << ") — not a BCH address; "
+                               "refusing to misdirect funds";
+            else if (amatch == core::AddressCoinMatch::Invalid)
+                payout_script = core::address_to_script(username);  // CashAddr decoder
             try { share_hash = create_fn(coinbase, header, *job, payout_script); }
             catch (const std::exception& e) {
                 LOG_WARNING << tag << " create_share_fn threw: " << e.what()

--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -34,6 +34,7 @@
 #include <impl/bch/coin/merkle.hpp>            // merkle_hash_pair (CTOR SHA256d)
 #include <impl/bch/coin/template_builder.hpp>  // build_template + rpc::WorkData
 #include <impl/bch/config_pool.hpp>            // PoolConfig::max_target (G2 cold-start floor)
+#include <impl/bch/config_coin.hpp>            // bch::address_acceptance (#961 registry-sourced payout check)
 
 #include <core/log.hpp>
 #include <btclibs/util/strencodings.h>         // HexStr
@@ -733,12 +734,13 @@ nlohmann::json BCHWorkSource::mining_submit(
             // BTC's version bytes, an inherent BCH/BTC ambiguity — a BTC legacy
             // address is therefore accepted here (same hash160/key), which is
             // NOT a misdirection.
+            // Accepted set REGISTRY-SOURCED (bch::address_acceptance): legacy
+            // base58 only (BCH's native CashAddr yields Invalid and falls through
+            // to the coin-registered decoder below), derived from the active
+            // network so a --regtest legacy address is accepted.
             std::vector<unsigned char> payout_script;
             auto amatch = core::classify_address_for_coin(
-                username,
-                is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
-                is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
-                /*accepted_hrps=*/{},
+                username, bch::address_acceptance(is_testnet_, /*regtest=*/false),
                 payout_script);
             if (amatch == core::AddressCoinMatch::Foreign)
                 LOG_WARNING << "[BCH-STRATUM] REJECTED foreign-coin payout address "

--- a/src/impl/bch/stratum/work_source.cpp
+++ b/src/impl/bch/stratum/work_source.cpp
@@ -740,7 +740,7 @@ nlohmann::json BCHWorkSource::mining_submit(
             // network so a --regtest legacy address is accepted.
             std::vector<unsigned char> payout_script;
             auto amatch = core::classify_address_for_coin(
-                username, bch::address_acceptance(is_testnet_, /*regtest=*/false),
+                username, bch::address_acceptance(is_testnet_, is_regtest_),
                 payout_script);
             if (amatch == core::AddressCoinMatch::Foreign)
                 LOG_WARNING << "[BCH-STRATUM] REJECTED foreign-coin payout address "
@@ -748,10 +748,26 @@ nlohmann::json BCHWorkSource::mining_submit(
                                "refusing to misdirect funds";
             else if (amatch == core::AddressCoinMatch::Invalid)
                 payout_script = core::address_to_script(username);  // CashAddr decoder
-            try { share_hash = create_fn(coinbase, header, *job, payout_script); }
-            catch (const std::exception& e) {
-                LOG_WARNING << tag << " create_share_fn threw: " << e.what()
-                            << " -- share not added";
+            // #961 B4 — ZERO-HASH160 BURN GUARD (money path): a Foreign (wrong-
+            // coin) or otherwise-undecodable username leaves payout_script EMPTY.
+            // Building the share anyway made create_local_share() default the
+            // finder's pubkey_hash to all-zero — an UNSPENDABLE coinbase output
+            // PPLNS then credits this miner's work against every block, BURNING
+            // their reward (the fresh cycle-1 BCH accept-and-burn). Refuse to
+            // build the share at all: no zero-hash160 share is ever minted. The
+            // core StratumServer already door-rejects such a username at
+            // mining.authorize (payout_* now published), so a live rig never
+            // reaches here; this is the defence-in-depth money-path backstop.
+            if (payout_script.empty()) {
+                LOG_WARNING << tag << " REFUSING to build share for user=" << username
+                            << " — no BCH payout script (foreign/undecodable address);"
+                               " never minting a zero-hash160 (unspendable) share (#961)";
+            } else {
+                try { share_hash = create_fn(coinbase, header, *job, payout_script); }
+                catch (const std::exception& e) {
+                    LOG_WARNING << tag << " create_share_fn threw: " << e.what()
+                                << " -- share not added";
+                }
             }
         }
 

--- a/src/impl/bch/stratum/work_source.hpp
+++ b/src/impl/bch/stratum/work_source.hpp
@@ -148,6 +148,22 @@ public:
     uint64_t                            get_work_generation() const override;
     bool                                has_merged_chain(uint32_t chain_id) const override;
 
+    /// #961 cross-lane (B4): publish BCH's OWN payout-address acceptance (legacy
+    /// base58; CashAddr is a registered native decoder consulted by decide_payout_
+    /// address()) into the StratumConfig the core StratumServer reads, so the SAME
+    /// decide_payout_address() door-reject + no-empty-payout guard LTC runs apply
+    /// on the BCH lane — a foreign-unconfigured payout is rejected at the door
+    /// instead of building a zero-hash160 (unspendable) coinbase that PPLNS burns.
+    /// Own-coin (base58 + CashAddr) stay accepted, byte-identical. Set once at
+    /// startup, before the server reads config_.
+    void set_payout_acceptance(std::vector<uint8_t> p2pkh_versions,
+                               std::vector<uint8_t> p2sh_versions,
+                               std::vector<std::string> bech32_hrps) {
+        config_.payout_p2pkh_versions = std::move(p2pkh_versions);
+        config_.payout_p2sh_versions  = std::move(p2sh_versions);
+        config_.payout_bech32_hrps    = std::move(bech32_hrps);
+    }
+
     // ── IWorkSource: per-connection bookkeeping ──────────────────────────
     void register_stratum_worker(const std::string& session_id,
                                  const core::stratum::WorkerInfo& info) override;
@@ -254,11 +270,18 @@ public:
     /// are broadcast but not recorded to the dashboard. TELEMETRY ONLY.
     void set_on_found_block_fn(OnFoundBlockFn fn);
 
+    /// #961: mark this node as running on the BCH regtest network so the payout
+    /// money-path validates a miner's legacy base58 address against the REGTEST
+    /// set (testnet base58 bytes) instead of mainnet. Address-validation scope
+    /// only; called from the entrypoint under --regtest.
+    void set_regtest(bool regtest) { is_regtest_ = regtest; }
+
 private:
     // External dependencies (non-owning references)
     bch::coin::HeaderChain&     chain_;
     bch::coin::Mempool&         mempool_;
     const bool                  is_testnet_;
+    bool                        is_regtest_ = false;  // #961: --regtest address set
 
     // Submission dispatch
     SubmitBlockFn               submit_block_fn_;

--- a/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
+++ b/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
@@ -409,6 +409,19 @@ core::stratum::JobSnapshot make_submit_job(uint32_t share_bits,
     return j;
 }
 
+// The rig runs mainnet (is_testnet=false). #961 B4 refuses to build a share for
+// any username that does not decode to a BCH payout script on the ACTIVE
+// network, so the share-write assertions below must submit a genuine
+// mainnet-door-accepted BCH address. This is a mainnet BCH legacy base58 P2PKH
+// (version byte 0x00) — classify_address_for_coin() Matches it against BCH's own
+// version bytes and yields a non-empty payout_script, exactly as a live door
+// (mining.authorize) would have admitted before mining_submit is ever reached.
+// (Its earlier value "bchtest.worker1" was a TESTNET cashaddr prefix, undecodable
+// on mainnet — that is precisely the accept-and-burn B4 now refuses, which is
+// what the new test_won_block_undecodable_username_refuses_share pins.)
+constexpr const char* kBchMainnetPayoutAddr =
+    "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2";
+
 void test_won_block_also_writes_share()
 {
     WorkSourceRig rig;
@@ -432,7 +445,7 @@ void test_won_block_also_writes_share()
 
     auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
     auto result = ws->mining_submit(
-        "bchtest.worker1", "job-won-share", "00000000", "00000000",
+        kBchMainnetPayoutAddr, "job-won-share", "00000000", "00000000",
         "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
 
     CHECK(result.is_boolean() && result.get<bool>());
@@ -456,7 +469,7 @@ void test_won_block_survives_throwing_share_write()
 
     auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
     auto result = ws->mining_submit(
-        "bchtest.worker1", "job-won-throw", "00000000", "00000000",
+        kBchMainnetPayoutAddr, "job-won-throw", "00000000", "00000000",
         "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
 
     CHECK(rig.submit_called);                     // block reached the sink
@@ -480,12 +493,45 @@ void test_plain_share_still_writes_and_does_not_broadcast()
     // block target 1 -> no digest is a block; share target maximal -> accepted.
     auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"03000001");
     auto result = ws->mining_submit(
-        "bchtest.worker1", "job-share", "00000000", "00000000",
+        kBchMainnetPayoutAddr, "job-share", "00000000", "00000000",
         "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
 
     CHECK(result.is_boolean() && result.get<bool>());
     CHECK(share_written);
     CHECK(!rig.submit_called);
+}
+
+// #961 B4 lock -- a WON BLOCK whose username does NOT decode to a BCH payout
+// script on the active network is still dispatched (the subsidy is never held
+// hostage to a bad payout string), but NO share is written: building it anyway
+// would default the finder pubkey_hash to all-zero -- an unspendable coinbase
+// output that PPLNS then credits every block against, burning the reward. The
+// block/share seams are independent, and the burn guard sits ONLY on the share
+// arm. Uses a testnet cashaddr prefix (undecodable on this mainnet rig) as the
+// undecodable username -- the exact accept-and-burn input B4 now refuses.
+void test_won_block_undecodable_username_refuses_share()
+{
+    WorkSourceRig rig;
+    auto ws = rig.make();
+
+    bool share_written = false;
+    ws->set_create_share_fn(
+        [&](const std::vector<unsigned char>&,
+            const std::vector<uint8_t>&,
+            const core::stratum::JobSnapshot&,
+            const std::vector<unsigned char>&) -> uint256 {
+            share_written = true;                 // MUST NOT be reached
+            return uint256(uint64_t(0xdeadbeef));
+        });
+
+    auto job = make_submit_job(/*share_bits=*/0x2100ffffu, /*block_nbits=*/"2100ffff");
+    auto result = ws->mining_submit(
+        "bchtest.worker1", "job-won-nopayout", "00000000", "00000000",
+        "60000000", "00000000", "rid", /*merged_addresses=*/{}, &job);
+
+    CHECK(result.is_boolean() && result.get<bool>());  // block still accepted
+    CHECK(rig.submit_called);                          // ...and dispatched
+    CHECK(!share_written);                             // but NO zero-hash160 share
 }
 
 } // namespace
@@ -500,6 +546,7 @@ int main()
     test_won_block_also_writes_share();
     test_won_block_survives_throwing_share_write();
     test_plain_share_still_writes_and_does_not_broadcast();
+    test_won_block_undecodable_username_refuses_share();
 
     if (failures) {
         std::cerr << failures << " CHECK(s) failed\n";

--- a/src/impl/bip110/params.hpp
+++ b/src/impl/bip110/params.hpp
@@ -33,9 +33,30 @@
 #include "pow.hpp"
 
 #include <core/coin_params.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
 
 namespace bip110
 {
+
+// Registry-sourced payout-address acceptance for BIP-110 on the ACTIVE network
+// (issue #961). BIP-110 keeps the Bitcoin address formats unchanged (Knots-GBT
+// parent): mainnet PUBKEY 0 / SCRIPT 5 / bech32 "bc"; testnet & regtest both
+// PUBKEY 111 / SCRIPT 196, bech32 "tb" (testnet) vs "bcrt" (regtest). Deriving
+// from the true network keeps a --regtest address from being rejected as Foreign.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { 0x6f };  // 111
+        a.p2sh_versions  = { 0xc4 };  // 196
+        a.bech32_hrps    = { regtest ? "bcrt" : "tb" };
+    } else {
+        a.p2pkh_versions = { 0x00 };
+        a.p2sh_versions  = { 0x05 };
+        a.bech32_hrps    = { "bc" };
+    }
+    return a;
+}
 
 // --- Coin-network identity (documented for the GBT/coin-P2P backend) ---------
 // These are NOT core::CoinParams fields; they live here as the single place the

--- a/src/impl/bip110/params.hpp
+++ b/src/impl/bip110/params.hpp
@@ -38,23 +38,32 @@
 namespace bip110
 {
 
+// ─── Address-encoding SSOT (issue #961 blocker #3) ───────────────────────────
+// The ONE place BIP-110's payout version bytes / bech32 HRPs live. BIP-110 keeps
+// the Bitcoin address formats unchanged (Knots-GBT parent): mainnet PUBKEY 0 /
+// SCRIPT 5 / bech32 "bc"; testnet PUBKEY 111 / SCRIPT 196 / bech32 "tb"; regtest
+// reuses the testnet base58 bytes with bech32 "bcrt". make_coin_params() reads
+// the MAINNET entry (the Knots-GBT parent runs mainnet) and address_acceptance()
+// reads all three, so the money-path acceptance set never drifts from the coin
+// params. HRPs here are BARE.
+struct AddressEncoding { uint8_t p2pkh; uint8_t p2sh; const char* hrp_bare; };
+inline constexpr AddressEncoding MAINNET_ADDR{ 0x00, 0x05, "bc"   };
+inline constexpr AddressEncoding TESTNET_ADDR{ 0x6f, 0xc4, "tb"   };  // 111 / 196
+inline constexpr AddressEncoding REGTEST_ADDR{ 0x6f, 0xc4, "bcrt" };  // testnet bytes, "bcrt"
+
 // Registry-sourced payout-address acceptance for BIP-110 on the ACTIVE network
-// (issue #961). BIP-110 keeps the Bitcoin address formats unchanged (Knots-GBT
-// parent): mainnet PUBKEY 0 / SCRIPT 5 / bech32 "bc"; testnet & regtest both
-// PUBKEY 111 / SCRIPT 196, bech32 "tb" (testnet) vs "bcrt" (regtest). Deriving
-// from the true network keeps a --regtest address from being rejected as Foreign.
+// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
+// literals. Deriving from the true network keeps a --regtest address from being
+// rejected as Foreign.
 inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
 {
+    const AddressEncoding& e = regtest ? REGTEST_ADDR
+                             : testnet ? TESTNET_ADDR
+                             : MAINNET_ADDR;
     core::CoinAddressAcceptance a;
-    if (testnet || regtest) {
-        a.p2pkh_versions = { 0x6f };  // 111
-        a.p2sh_versions  = { 0xc4 };  // 196
-        a.bech32_hrps    = { regtest ? "bcrt" : "tb" };
-    } else {
-        a.p2pkh_versions = { 0x00 };
-        a.p2sh_versions  = { 0x05 };
-        a.bech32_hrps    = { "bc" };
-    }
+    a.p2pkh_versions = { e.p2pkh };
+    a.p2sh_versions  = { e.p2sh };
+    a.bech32_hrps    = { e.hrp_bare };
     return a;
 }
 
@@ -141,11 +150,14 @@ inline core::CoinParams make_coin_params(bool testnet)
     p.symbol       = "BIP110";
     p.block_period = 600;  // 10-minute target interval (unchanged from Bitcoin)
 
-    // Address encoding — Bitcoin mainnet base58/bech32 (unchanged by BIP-110).
-    p.address_version       = 0;    // P2PKH version byte (mainnet "1...")
-    p.address_p2sh_version  = 5;    // P2SH version byte (mainnet "3...")
-    p.address_p2sh_version2 = 0;    // no secondary P2SH prefix
-    p.bech32_hrp            = "bc"; // bech32 HRP
+    // Address encoding — Bitcoin mainnet base58/bech32 (unchanged by BIP-110),
+    // from the AddressEncoding SSOT (issue #961 blocker #3). The Knots-GBT parent
+    // runs mainnet, so make_coin_params encodes the MAINNET entry; address_
+    // acceptance() reads the testnet/regtest entries for --regtest/--testnet.
+    p.address_version       = MAINNET_ADDR.p2pkh;   // 0x00 (mainnet "1...")
+    p.address_p2sh_version  = MAINNET_ADDR.p2sh;    // 0x05 (mainnet "3...")
+    p.address_p2sh_version2 = 0;                    // no secondary P2SH prefix
+    p.bech32_hrp            = MAINNET_ADDR.hrp_bare; // "bc"
 
     // PoW: BLAKE2b commitment pipeline as BOTH the work and the block identity
     // (the block hash == PoW hash shape, like DASH's X11). Span-typed, so the

--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -925,18 +925,16 @@ nlohmann::json Bip110WorkSource::mining_submit(
                 auto it = freeze_map_.find(to_hex(f.h2));
                 if (it != freeze_map_.end()) mint_cb = it->second.coinbase;
             }
-            // #961: validate against BIP-110's OWN version bytes / HRP (Bitcoin
-            // format: mainnet 0x00/0x05 + "bc", testnet 0x6f/0xc4 + "tb") before
+            // #961: validate against BIP-110's OWN version bytes / HRP before
             // building a script, so a foreign-coin address is rejected (→ empty
             // → donation fallback) rather than repurposed into a wrong-coin
-            // payout that MISDIRECTS funds.
+            // payout that MISDIRECTS funds. Accepted set REGISTRY-SOURCED
+            // (bip110::address_acceptance) and derived from the TRUE network so a
+            // --regtest address is accepted rather than rejected as Foreign.
             std::vector<unsigned char> payout_script;
             {
                 auto amatch = core::classify_address_for_coin(
-                    username,
-                    is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
-                    is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
-                    is_testnet_ ? std::vector<std::string>{"tb"} : std::vector<std::string>{"bc"},
+                    username, bip110::address_acceptance(is_testnet_, is_regtest_),
                     payout_script);
                 if (amatch == core::AddressCoinMatch::Foreign)
                     LOG_WARNING << "[BIP110-STRATUM] REJECTED foreign-coin payout "
@@ -965,13 +963,11 @@ nlohmann::json Bip110WorkSource::mining_submit(
         // #961: validate against BIP-110's OWN version bytes / HRP before
         // building a script (see the won-block arm above) — a foreign-coin
         // address is rejected (→ empty → donation fallback), never repurposed.
+        // Accepted set REGISTRY-SOURCED and network-derived (incl. regtest).
         std::vector<unsigned char> payout_script;
         {
             auto amatch = core::classify_address_for_coin(
-                username,
-                is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
-                is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
-                is_testnet_ ? std::vector<std::string>{"tb"} : std::vector<std::string>{"bc"},
+                username, bip110::address_acceptance(is_testnet_, is_regtest_),
                 payout_script);
             if (amatch == core::AddressCoinMatch::Foreign)
                 LOG_WARNING << "[BIP110-STRATUM] REJECTED foreign-coin payout "

--- a/src/impl/bip110/stratum/work_source.cpp
+++ b/src/impl/bip110/stratum/work_source.cpp
@@ -925,7 +925,24 @@ nlohmann::json Bip110WorkSource::mining_submit(
                 auto it = freeze_map_.find(to_hex(f.h2));
                 if (it != freeze_map_.end()) mint_cb = it->second.coinbase;
             }
-            std::vector<unsigned char> payout_script = core::address_to_script(username);
+            // #961: validate against BIP-110's OWN version bytes / HRP (Bitcoin
+            // format: mainnet 0x00/0x05 + "bc", testnet 0x6f/0xc4 + "tb") before
+            // building a script, so a foreign-coin address is rejected (→ empty
+            // → donation fallback) rather than repurposed into a wrong-coin
+            // payout that MISDIRECTS funds.
+            std::vector<unsigned char> payout_script;
+            {
+                auto amatch = core::classify_address_for_coin(
+                    username,
+                    is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
+                    is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
+                    is_testnet_ ? std::vector<std::string>{"tb"} : std::vector<std::string>{"bc"},
+                    payout_script);
+                if (amatch == core::AddressCoinMatch::Foreign)
+                    LOG_WARNING << "[BIP110-STRATUM] REJECTED foreign-coin payout "
+                                   "address (user=" << username << ") — not a "
+                                   "BIP-110 address; refusing to misdirect funds";
+            }
             if (payout_script.empty()) payout_script = donation_script_;
             create_share_fn_(mint_cb, hdr, *job, payout_script);
         }
@@ -945,7 +962,22 @@ nlohmann::json Bip110WorkSource::mining_submit(
             auto it = freeze_map_.find(to_hex(f.h2));
             if (it != freeze_map_.end()) coinbase = it->second.coinbase;
         }
-        std::vector<unsigned char> payout_script = core::address_to_script(username);
+        // #961: validate against BIP-110's OWN version bytes / HRP before
+        // building a script (see the won-block arm above) — a foreign-coin
+        // address is rejected (→ empty → donation fallback), never repurposed.
+        std::vector<unsigned char> payout_script;
+        {
+            auto amatch = core::classify_address_for_coin(
+                username,
+                is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
+                is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
+                is_testnet_ ? std::vector<std::string>{"tb"} : std::vector<std::string>{"bc"},
+                payout_script);
+            if (amatch == core::AddressCoinMatch::Foreign)
+                LOG_WARNING << "[BIP110-STRATUM] REJECTED foreign-coin payout "
+                               "address (user=" << username << ") — not a BIP-110 "
+                               "address; refusing to misdirect funds";
+        }
         if (payout_script.empty()) payout_script = donation_script_;
         create_share_fn_(coinbase, hdr, *job, payout_script);
     }

--- a/src/impl/bip110/stratum/work_source.hpp
+++ b/src/impl/bip110/stratum/work_source.hpp
@@ -183,6 +183,11 @@ public:
     void set_share_target(uint32_t bits, uint32_t max_bits)
     { share_bits_.store(bits); share_max_bits_.store(max_bits); }
     void set_donation_script(std::vector<unsigned char> s) { donation_script_ = std::move(s); }
+    /// #961: mark this node as running on the BIP-110 regtest network so the
+    /// payout money-path validates a miner's address against the REGTEST set
+    /// (testnet base58 bytes + "bcrt" HRP) instead of mainnet. Address-validation
+    /// scope only; called from main under --regtest.
+    void set_regtest(bool regtest) { is_regtest_ = regtest; }
     // Node-owner fee destination. When empty the node-owner fee (if any) is paid
     // to the donation script (single-key consolidation, our 13zQ/bc1qyr94… key).
     void set_node_owner_script(std::vector<unsigned char> s) { node_owner_script_ = std::move(s); }
@@ -252,6 +257,7 @@ private:
 
     bip110::coin::HeaderChain&   chain_;
     const bool                   is_testnet_;
+    bool                         is_regtest_ = false;  // #961: --regtest address set
     SubmitBlockFn                submit_block_fn_;
     core::stratum::StratumConfig config_;
 

--- a/src/impl/bip110/stratum/work_source.hpp
+++ b/src/impl/bip110/stratum/work_source.hpp
@@ -142,6 +142,20 @@ public:
     uint64_t                            get_work_generation() const override { return work_generation_.load(); }
     bool                                has_merged_chain(uint32_t) const override { return false; }
 
+    /// #961 cross-lane (B4): publish BIP-110's OWN payout-address acceptance into
+    /// the StratumConfig the core StratumServer reads, so the SAME decide_payout_
+    /// address() door-reject + no-empty-payout guard LTC runs apply on this lane —
+    /// a foreign-unconfigured payout is rejected at the door instead of redirected.
+    /// Own-coin addresses stay accepted, byte-identical. Set once at startup,
+    /// before the server reads config_.
+    void set_payout_acceptance(std::vector<uint8_t> p2pkh_versions,
+                               std::vector<uint8_t> p2sh_versions,
+                               std::vector<std::string> bech32_hrps) {
+        config_.payout_p2pkh_versions = std::move(p2pkh_versions);
+        config_.payout_p2sh_versions  = std::move(p2sh_versions);
+        config_.payout_bech32_hrps    = std::move(bech32_hrps);
+    }
+
     // ── IWorkSource: per-connection bookkeeping ──────────────────────────
     void register_stratum_worker(const std::string& id, const core::stratum::WorkerInfo& info) override;
     void unregister_stratum_worker(const std::string& id) override;

--- a/src/impl/btc/config_coin.hpp
+++ b/src/impl/btc/config_coin.hpp
@@ -4,6 +4,7 @@
 #include <core/config.hpp>
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
 #include <string>
 
 #include <yaml-cpp/yaml.h>
@@ -85,6 +86,28 @@ inline std::string sharechain_net_name(bool regtest, bool testnet)
     if (regtest) return "bitcoin_regtest";
     if (testnet) return "bitcoin_testnet";
     return "bitcoin";
+}
+
+// Registry-sourced payout-address acceptance for BTC on the ACTIVE network
+// (issue #961). Bitcoin Core chainparams.cpp: mainnet PUBKEY_ADDRESS=0 /
+// SCRIPT_ADDRESS=5 / bech32 "bc"; testnet & regtest both PUBKEY_ADDRESS=111 /
+// SCRIPT_ADDRESS=196, with bech32 "tb" (testnet) vs "bcrt" (regtest). Deriving
+// the set from the true network — not a mainnet-or-not bool — is what keeps a
+// --regtest address from being rejected as Foreign (blocker #2), and centralises
+// the version bytes out of the stratum money path (blocker #3).
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { 0x6f };  // 111 (m/n...)
+        a.p2sh_versions  = { 0xc4 };  // 196 (2...)
+        a.bech32_hrps    = { regtest ? "bcrt" : "tb" };
+    } else {
+        a.p2pkh_versions = { 0x00 };  // 1...
+        a.p2sh_versions  = { 0x05 };  // 3...
+        a.bech32_hrps    = { "bc" };
+    }
+    return a;
 }
 
 class CoinConfig : protected core::Fileconfig

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -18,6 +18,7 @@
 
 #include <impl/btc/coin/header_chain.hpp>
 #include <impl/btc/coin/mempool.hpp>
+#include <impl/btc/config_coin.hpp>             // btc::address_acceptance (#961 registry-sourced payout check)
 #include <impl/btc/coin/template_builder.hpp>  // build_template + merkle_hash_pair
 #include <impl/btc/coin/transaction.hpp>
 #include <c2pool/merged/merged_mining.hpp>   // MergedMiningManager::has_chain (PR-2a)
@@ -1074,15 +1075,14 @@ nlohmann::json BTCWorkSource::mining_submit(
             // address_to_script() would repurpose a foreign-coin address into a
             // BTC script and MISDIRECT the miner's funds; a Foreign address here
             // yields an empty script — the same behaviour as an unparseable
-            // address (share added locally, no wrong-coin payment). BTC: mainnet
-            // 0x00/0x05 + hrp "bc", testnet 0x6f/0xc4 + hrp "tb".
+            // address (share added locally, no wrong-coin payment). The accepted
+            // set is REGISTRY-SOURCED (btc::address_acceptance) and derived from
+            // the TRUE network (mainnet/testnet/regtest) so a --regtest payout
+            // address is accepted rather than rejected as Foreign.
             std::vector<unsigned char> miner_script;
             {
                 auto amatch = core::classify_address_for_coin(
-                    username,
-                    is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
-                    is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
-                    is_testnet_ ? std::vector<std::string>{"tb"} : std::vector<std::string>{"bc"},
+                    username, btc::address_acceptance(is_testnet_, is_regtest_),
                     miner_script);
                 if (amatch == core::AddressCoinMatch::Foreign)
                     LOG_WARNING << "[BTC-STRATUM] REJECTED foreign-coin payout "

--- a/src/impl/btc/stratum/work_source.cpp
+++ b/src/impl/btc/stratum/work_source.cpp
@@ -1069,9 +1069,28 @@ nlohmann::json BTCWorkSource::mining_submit(
             // substituted share hits the #1394 gentx-mismatch decline. Inputs
             // (job->prev_share_hash, session extranonce1, miner script) are the
             // exact ones the build side rolled on. Default (fee off) => identity.
+            // #961: validate the payout address against BTC's OWN version bytes
+            // / HRP before building a script. The chain-agnostic
+            // address_to_script() would repurpose a foreign-coin address into a
+            // BTC script and MISDIRECT the miner's funds; a Foreign address here
+            // yields an empty script — the same behaviour as an unparseable
+            // address (share added locally, no wrong-coin payment). BTC: mainnet
+            // 0x00/0x05 + hrp "bc", testnet 0x6f/0xc4 + hrp "tb".
+            std::vector<unsigned char> miner_script;
+            {
+                auto amatch = core::classify_address_for_coin(
+                    username,
+                    is_testnet_ ? std::vector<uint8_t>{0x6f} : std::vector<uint8_t>{0x00},
+                    is_testnet_ ? std::vector<uint8_t>{0xc4} : std::vector<uint8_t>{0x05},
+                    is_testnet_ ? std::vector<std::string>{"tb"} : std::vector<std::string>{"bc"},
+                    miner_script);
+                if (amatch == core::AddressCoinMatch::Foreign)
+                    LOG_WARNING << "[BTC-STRATUM] REJECTED foreign-coin payout "
+                                   "address (user=" << username << ") — not a BTC "
+                                   "address; refusing to misdirect funds";
+            }
             auto payout_script = effective_payout_script(
-                core::address_to_script(username),
-                job->prev_share_hash, extranonce1);
+                miner_script, job->prev_share_hash, extranonce1);
 
             try {
                 share_hash = create_fn(coinbase, header, *job, payout_script);

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -335,6 +335,22 @@ public:
     /// Called from main under --regtest. Address-validation scope only.
     void set_regtest(bool regtest) { is_regtest_ = regtest; }
 
+    /// #961 cross-lane (B4): publish this coin's OWN payout-address acceptance
+    /// into the StratumConfig the core StratumServer reads, so the SAME
+    /// decide_payout_address() door-reject (mining.authorize) + no-empty-payout
+    /// guard (send_notify_work) that LTC already runs apply on the BTC lane —
+    /// a foreign-unconfigured payout is rejected at the door instead of being
+    /// repurposed / burned. Own-coin + configured-merged stay accepted, so the
+    /// built script is byte-identical for every previously-honoured address.
+    /// Set once at startup, before the StratumServer starts reading config_.
+    void set_payout_acceptance(std::vector<uint8_t> p2pkh_versions,
+                               std::vector<uint8_t> p2sh_versions,
+                               std::vector<std::string> bech32_hrps) {
+        config_.payout_p2pkh_versions = std::move(p2pkh_versions);
+        config_.payout_p2sh_versions  = std::move(p2sh_versions);
+        config_.payout_bech32_hrps    = std::move(bech32_hrps);
+    }
+
 private:
     /// Resolve the effective payout script for a job/share: the node owner's
     /// script with probability node_owner_fee_pct_%, else the miner's own

--- a/src/impl/btc/stratum/work_source.hpp
+++ b/src/impl/btc/stratum/work_source.hpp
@@ -328,6 +328,13 @@ public:
     /// web_server.cpp set_node_fee_from_address.
     void set_node_owner_fee(double pct, std::vector<unsigned char> script);
 
+    /// #961: mark this node as running on the BTC regtest network so the payout
+    /// money-path validates a miner's address against the REGTEST address set
+    /// (testnet base58 bytes + "bcrt" HRP) instead of mainnet — otherwise a
+    /// legitimate --regtest payout address is wrongly rejected as Foreign.
+    /// Called from main under --regtest. Address-validation scope only.
+    void set_regtest(bool regtest) { is_regtest_ = regtest; }
+
 private:
     /// Resolve the effective payout script for a job/share: the node owner's
     /// script with probability node_owner_fee_pct_%, else the miner's own
@@ -341,6 +348,7 @@ private:
     btc::coin::HeaderChain&     chain_;
     btc::coin::Mempool&         mempool_;
     const bool                  is_testnet_;
+    bool                        is_regtest_ = false;  // #961: --regtest address set
 
     // Submission dispatch
     SubmitBlockFn               submit_block_fn_;

--- a/src/impl/dash/params.hpp
+++ b/src/impl/dash/params.hpp
@@ -24,6 +24,7 @@
 
 #include <core/coin_params.hpp>
 #include <core/pow.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
 
 #include <optional>
 #include <string>
@@ -31,6 +32,26 @@
 
 namespace dash
 {
+
+// Registry-sourced payout-address acceptance for DASH on the ACTIVE network
+// (issue #961). Values track make_coin_params() below (oracle networks/dash.py):
+// mainnet PUBKEY 76 (X...) / SCRIPT 16 (7...); testnet PUBKEY 140 (y...) /
+// SCRIPT 19. DASH has NO segwit/bech32. DASH regtest (dashd CRegTestParams)
+// reuses the testnet base58 version bytes, so a --regtest payout address decodes
+// under the testnet set rather than being rejected as Foreign.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { 140 };  // y...
+        a.p2sh_versions  = { 19 };
+    } else {
+        a.p2pkh_versions = { 76 };   // X...
+        a.p2sh_versions  = { 16 };   // 7...
+    }
+    a.bech32_hrps = {};              // DASH: no bech32 on any network
+    return a;
+}
 
 // Runtime override seam for pool.yaml (Fileconfig consume-side, S6 follow-on).
 // ONLY operationally-tunable, NON-consensus, NON-isolation pool fields may be

--- a/src/impl/dash/params.hpp
+++ b/src/impl/dash/params.hpp
@@ -33,23 +33,30 @@
 namespace dash
 {
 
+// ─── Address-encoding SSOT (issue #961 blocker #3) ───────────────────────────
+// The ONE place DASH's payout version bytes live (oracle networks/dash.py):
+// mainnet PUBKEY 76 (X...) / SCRIPT 16 (7...); testnet PUBKEY 140 (y...) / SCRIPT
+// 19. DASH has a SINGLE P2SH version and NO segwit/bech32 on any network. BOTH
+// make_coin_params() and address_acceptance() read these constants, so the
+// stratum money-path acceptance set can NEVER drift from the coin params.
+struct AddressEncoding { uint8_t p2pkh; uint8_t p2sh; };
+inline constexpr AddressEncoding MAINNET_ADDR{ 76,  16 };  // X... / 7...
+inline constexpr AddressEncoding TESTNET_ADDR{ 140, 19 };  // y...
+inline constexpr const AddressEncoding& address_encoding(bool testnet)
+{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
+
 // Registry-sourced payout-address acceptance for DASH on the ACTIVE network
-// (issue #961). Values track make_coin_params() below (oracle networks/dash.py):
-// mainnet PUBKEY 76 (X...) / SCRIPT 16 (7...); testnet PUBKEY 140 (y...) /
-// SCRIPT 19. DASH has NO segwit/bech32. DASH regtest (dashd CRegTestParams)
-// reuses the testnet base58 version bytes, so a --regtest payout address decodes
-// under the testnet set rather than being rejected as Foreign.
+// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
+// literals. DASH regtest (dashd CRegTestParams) reuses the testnet base58 version
+// bytes, so a --regtest payout address decodes under the testnet set rather than
+// being rejected as Foreign.
 inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
 {
+    const auto& e = address_encoding(testnet || regtest);
     core::CoinAddressAcceptance a;
-    if (testnet || regtest) {
-        a.p2pkh_versions = { 140 };  // y...
-        a.p2sh_versions  = { 19 };
-    } else {
-        a.p2pkh_versions = { 76 };   // X...
-        a.p2sh_versions  = { 16 };   // 7...
-    }
-    a.bech32_hrps = {};              // DASH: no bech32 on any network
+    a.p2pkh_versions = { e.p2pkh };
+    a.p2sh_versions  = { e.p2sh };
+    a.bech32_hrps    = {};           // DASH: no bech32 on any network
     return a;
 }
 
@@ -78,14 +85,13 @@ inline core::CoinParams make_coin_params(bool testnet, const PoolOverrides& over
     p.symbol       = "DASH";
     p.block_period = 150;  // target_spacing (2.5 min), matches header_chain DGW target_spacing
 
-    // Address encoding (oracle PARENT). DASH has a SINGLE P2SH version; there is
-    // no secondary P2SH prefix and no bech32 HRP on the older baseline.
-    if (testnet) {
-        p.address_version      = 140;  // testnet PUBKEY_ADDRESS (y...)
-        p.address_p2sh_version = 19;   // testnet SCRIPT_ADDRESS
-    } else {
-        p.address_version      = 76;   // mainnet PUBKEY_ADDRESS (X...)
-        p.address_p2sh_version = 16;   // mainnet SCRIPT_ADDRESS (7...)
+    // Address encoding (oracle PARENT) — from the AddressEncoding SSOT (issue
+    // #961 blocker #3). DASH has a SINGLE P2SH version; there is no secondary
+    // P2SH prefix and no bech32 HRP on the older baseline.
+    {
+        const auto& e = address_encoding(testnet);
+        p.address_version      = e.p2pkh;  // testnet 140 (y...) / mainnet 76 (X...)
+        p.address_p2sh_version = e.p2sh;   // testnet 19 / mainnet 16 (7...)
     }
     p.address_p2sh_version2 = 0;  // DASH: no secondary P2SH prefix
     p.bech32_hrp            = "";  // DASH: no segwit / no bech32

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -2629,15 +2629,14 @@ nlohmann::json DASHWorkSource::mining_submit(
             // would happily turn a foreign-coin address into a DASH script and
             // MISDIRECT the miner's funds; classify_address_for_coin rejects a
             // foreign address (→ empty script → the mint's existing empty-payout
-            // fallback), never repurposes it. DASH: mainnet 0x4c/0x10, testnet
-            // 0x8c/0x13, no bech32 (dashpay/dash chainparams.cpp).
+            // fallback), never repurposes it. The accepted set is REGISTRY-SOURCED
+            // (dash::address_acceptance → oracle networks/dash.py): mainnet
+            // 76/16, testnet 140/19, no bech32; DASH regtest reuses testnet
+            // base58 bytes.
             {
                 std::vector<unsigned char> payout_script;
                 auto amatch = core::classify_address_for_coin(
-                    username,
-                    is_testnet_ ? std::vector<uint8_t>{0x8c} : std::vector<uint8_t>{0x4c},
-                    is_testnet_ ? std::vector<uint8_t>{0x13} : std::vector<uint8_t>{0x10},
-                    /*accepted_hrps=*/{},
+                    username, dash::address_acceptance(is_testnet_, is_regtest_),
                     payout_script);
                 if (amatch == core::AddressCoinMatch::Foreign)
                     LOG_WARNING << "[DASH-STRATUM] REJECTED foreign-coin payout "

--- a/src/impl/dash/stratum/work_source.cpp
+++ b/src/impl/dash/stratum/work_source.cpp
@@ -2624,7 +2624,27 @@ nlohmann::json DASHWorkSource::mining_submit(
             in.subsidy         = job->subsidy;
             in.prev_share_hash = job->prev_share_hash;
             in.merkle_branches = std::move(branch_hashes);
-            in.payout_script   = core::address_to_script(username);
+            // #961: validate the payout address against DASH's OWN version bytes
+            // before building a script. The chain-agnostic address_to_script()
+            // would happily turn a foreign-coin address into a DASH script and
+            // MISDIRECT the miner's funds; classify_address_for_coin rejects a
+            // foreign address (→ empty script → the mint's existing empty-payout
+            // fallback), never repurposes it. DASH: mainnet 0x4c/0x10, testnet
+            // 0x8c/0x13, no bech32 (dashpay/dash chainparams.cpp).
+            {
+                std::vector<unsigned char> payout_script;
+                auto amatch = core::classify_address_for_coin(
+                    username,
+                    is_testnet_ ? std::vector<uint8_t>{0x8c} : std::vector<uint8_t>{0x4c},
+                    is_testnet_ ? std::vector<uint8_t>{0x13} : std::vector<uint8_t>{0x10},
+                    /*accepted_hrps=*/{},
+                    payout_script);
+                if (amatch == core::AddressCoinMatch::Foreign)
+                    LOG_WARNING << "[DASH-STRATUM] REJECTED foreign-coin payout "
+                                   "address (user=" << username << ") — not a DASH "
+                                   "address; refusing to misdirect funds";
+                in.payout_script = std::move(payout_script);
+            }
             in.pow_hash        = pow_hash;
             // #889: tell the mint binding this solve is a WON BLOCK, so it
             // takes a bounded wait on the tracker rather than the ordinary

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -810,6 +810,7 @@ private:
 
     // Network selector for coin-params resolution (address versions + v36 gate).
     bool is_testnet_{false};
+    bool is_regtest_{false};  // #961: --regtest payout-address acceptance set
     bool embedded_mainnet_{false};   // gate-lift opt-in: daemonless embedded arm on mainnet
     bool gbt_xcheck_{false};         // reward-safety backstop: cross-check embedded creditPool vs dashd
     bool tx_serve_own_set_{false};   // --embedded-tx-serve-own-set: serve own valid tx set instead of dashd-parity swap (DEFAULT OFF)

--- a/src/impl/dash/stratum/work_source.hpp
+++ b/src/impl/dash/stratum/work_source.hpp
@@ -259,6 +259,20 @@ public:
     uint64_t                            get_work_generation() const override { return work_generation_.load(); }
     bool                                has_merged_chain(uint32_t chain_id) const override;
 
+    /// #961 cross-lane (B4): publish DASH's OWN payout-address acceptance into the
+    /// StratumConfig the core StratumServer reads, so the SAME decide_payout_
+    /// address() door-reject + no-empty-payout guard LTC runs apply on the DASH
+    /// lane — a foreign-unconfigured payout is rejected at the door instead of
+    /// redirected. Own-coin addresses stay accepted, byte-identical. Set once at
+    /// startup, before the server reads config_.
+    void set_payout_acceptance(std::vector<uint8_t> p2pkh_versions,
+                               std::vector<uint8_t> p2sh_versions,
+                               std::vector<std::string> bech32_hrps) {
+        config_.payout_p2pkh_versions = std::move(p2pkh_versions);
+        config_.payout_p2sh_versions  = std::move(p2sh_versions);
+        config_.payout_bech32_hrps    = std::move(bech32_hrps);
+    }
+
     // ── IWorkSource: per-connection bookkeeping ──────────────────────────
     void register_stratum_worker(const std::string& session_id,
                                  const core::stratum::WorkerInfo& info) override;

--- a/src/impl/dgb/params.hpp
+++ b/src/impl/dgb/params.hpp
@@ -21,9 +21,32 @@
 
 #include <core/coin_params.hpp>
 #include <core/pow.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
 
 namespace dgb
 {
+
+// Registry-sourced payout-address acceptance for DGB on the ACTIVE network
+// (issue #961). Every consensus byte comes from the dgb::CoinParams SSOT
+// (config_coin.hpp), NEVER a literal at the stratum call site. Regtest is a
+// distinct network: DigiByte Core CRegTestParams reuses the TESTNET base58
+// version bytes and swaps the bech32 HRP to "dgbrt" — deriving the set from the
+// true network (not a mainnet-or-not bool) is what stops a --regtest payout
+// address being rejected as Foreign.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { CoinParams::TESTNET_ADDRESS_VERSION };  // 0x7e
+        a.p2sh_versions  = { CoinParams::TESTNET_P2SH_VERSION };     // 0x8c
+        a.bech32_hrps    = { regtest ? "dgbrt" : CoinParams::TESTNET_BECH32_HRP };
+    } else {
+        a.p2pkh_versions = { CoinParams::ADDRESS_VERSION };          // 0x1e (D...)
+        a.p2sh_versions  = { CoinParams::ADDRESS_P2SH_VERSION };     // 0x3f (S...)
+        a.bech32_hrps    = { CoinParams::BECH32_HRP };               // "dgb"
+    }
+    return a;
+}
 
 // --- Merged-mining aux chain identity (bucket-1 isolation primitive) ---------
 // DGB's OWN AuxPoW chain id, consumed when DGB registers an embedded backend

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -644,7 +644,26 @@ nlohmann::json DGBWorkSource::mining_submit(
         in.subsidy         = job->subsidy;
         in.prev_share      = job->prev_share_hash;
         in.merkle_branches = branch_hashes;
-        in.payout_script   = core::address_to_script(username);
+        // #961: validate the payout address against DGB's OWN version bytes / HRP
+        // before building a script, so a foreign-coin address is rejected rather
+        // than repurposed into a DGB script (which would MISDIRECT funds). DGB:
+        // mainnet 0x1e/0x3f + hrp "dgb", testnet 0x7e/0x8c + hrp "dgbt"
+        // (digibyte chainparams). Foreign → empty → the existing redistribute/
+        // empty fallback below; never a wrong-coin payment.
+        {
+            std::vector<unsigned char> payout_script;
+            auto amatch = core::classify_address_for_coin(
+                username,
+                is_testnet_ ? std::vector<uint8_t>{0x7e} : std::vector<uint8_t>{0x1e},
+                is_testnet_ ? std::vector<uint8_t>{0x8c} : std::vector<uint8_t>{0x3f},
+                is_testnet_ ? std::vector<std::string>{"dgbt"} : std::vector<std::string>{"dgb"},
+                payout_script);
+            if (amatch == core::AddressCoinMatch::Foreign)
+                LOG_WARNING << "[DGB-STRATUM] REJECTED foreign-coin payout address "
+                               "(user=" << username << ") — not a DGB address; "
+                               "refusing to misdirect funds";
+            in.payout_script = std::move(payout_script);
+        }
         // Redistribute V2 (#307): a miner with empty/broken stratum creds
         // yields no payout script. When the operator opted into a
         // --redistribute policy (fallback bound) let it choose the pubkey this

--- a/src/impl/dgb/stratum/work_source.cpp
+++ b/src/impl/dgb/stratum/work_source.cpp
@@ -23,6 +23,7 @@
 #include <impl/dgb/coin/template_builder.hpp>
 #include <impl/dgb/coin/embedded_tx_select.hpp>  // make_mempool_tx_source (mempool -> GBT transactions[])
 #include <impl/dgb/config_pool.hpp>              // dgb::PoolConfig::BLOCK_MAX_WEIGHT
+#include <impl/dgb/params.hpp>                   // dgb::address_acceptance (#961 registry-sourced payout check)
 #include <impl/dgb/coin/hash_format.hpp>
 #include <impl/dgb/coin/scrypt_pow.hpp>        // scrypt_pow_hash (DGB-Scrypt PoW SSOT)
 #include <impl/dgb/coin/submit_classify.hpp>   // classify_submission (Stage-4d decision SSOT)
@@ -646,17 +647,16 @@ nlohmann::json DGBWorkSource::mining_submit(
         in.merkle_branches = branch_hashes;
         // #961: validate the payout address against DGB's OWN version bytes / HRP
         // before building a script, so a foreign-coin address is rejected rather
-        // than repurposed into a DGB script (which would MISDIRECT funds). DGB:
-        // mainnet 0x1e/0x3f + hrp "dgb", testnet 0x7e/0x8c + hrp "dgbt"
-        // (digibyte chainparams). Foreign → empty → the existing redistribute/
-        // empty fallback below; never a wrong-coin payment.
+        // than repurposed into a DGB script (which would MISDIRECT funds). The
+        // accepted set is REGISTRY-SOURCED (dgb::address_acceptance → config_coin
+        // SSOT) and derived from the TRUE network (mainnet/testnet/regtest) so a
+        // --regtest payout address is accepted, not rejected as Foreign. Foreign
+        // → empty → the existing redistribute/empty fallback below; never a
+        // wrong-coin payment.
         {
             std::vector<unsigned char> payout_script;
             auto amatch = core::classify_address_for_coin(
-                username,
-                is_testnet_ ? std::vector<uint8_t>{0x7e} : std::vector<uint8_t>{0x1e},
-                is_testnet_ ? std::vector<uint8_t>{0x8c} : std::vector<uint8_t>{0x3f},
-                is_testnet_ ? std::vector<std::string>{"dgbt"} : std::vector<std::string>{"dgb"},
+                username, dgb::address_acceptance(is_testnet_, is_regtest_),
                 payout_script);
             if (amatch == core::AddressCoinMatch::Foreign)
                 LOG_WARNING << "[DGB-STRATUM] REJECTED foreign-coin payout address "

--- a/src/impl/dgb/stratum/work_source.hpp
+++ b/src/impl/dgb/stratum/work_source.hpp
@@ -286,11 +286,19 @@ public:
     /// (DOGE) block a submitted share solves via try_submit_merged_blocks().
     void set_merged_mining_manager(c2pool::merged::MergedMiningManager* mm) { mm_manager_ = mm; }
 
+    /// #961: mark this node as running on the DGB regtest network so the payout
+    /// money-path validates a miner's address against the REGTEST address set
+    /// (testnet base58 bytes + "dgbrt" HRP) instead of mainnet — otherwise a
+    /// legitimate --regtest payout address is wrongly rejected as Foreign.
+    /// Called from main under --regtest. Address-validation scope only.
+    void set_regtest(bool regtest) { is_regtest_ = regtest; }
+
 private:
     // External dependencies (non-owning references)
     c2pool::dgb::HeaderChain&   chain_;
     dgb::coin::Mempool&         mempool_;
     const bool                  is_testnet_;
+    bool                        is_regtest_ = false;  // #961: --regtest address set
 
     // Submission dispatch
     SubmitBlockFn               submit_block_fn_;

--- a/src/impl/dgb/stratum/work_source.hpp
+++ b/src/impl/dgb/stratum/work_source.hpp
@@ -293,6 +293,20 @@ public:
     /// Called from main under --regtest. Address-validation scope only.
     void set_regtest(bool regtest) { is_regtest_ = regtest; }
 
+    /// #961 cross-lane (B4): publish DGB's OWN payout-address acceptance into the
+    /// StratumConfig the core StratumServer reads, so the SAME decide_payout_
+    /// address() door-reject + no-empty-payout guard LTC runs apply on the DGB
+    /// lane — a foreign-unconfigured payout is rejected at the door instead of
+    /// redirected/left-empty. Own-coin + a CONFIGURED merged chain (DOGE) stay
+    /// accepted, byte-identical. Set once at startup, before the server reads it.
+    void set_payout_acceptance(std::vector<uint8_t> p2pkh_versions,
+                               std::vector<uint8_t> p2sh_versions,
+                               std::vector<std::string> bech32_hrps) {
+        config_.payout_p2pkh_versions = std::move(p2pkh_versions);
+        config_.payout_p2sh_versions  = std::move(p2sh_versions);
+        config_.payout_bech32_hrps    = std::move(bech32_hrps);
+    }
+
 private:
     // External dependencies (non-owning references)
     c2pool::dgb::HeaderChain&   chain_;

--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -11,28 +11,42 @@
 namespace ltc
 {
 
+// ─── Address-encoding SSOT (issue #961 blocker #3) ───────────────────────────
+// The ONE place LTC's payout version bytes / bech32 HRP live (p2pool-merged-v36):
+// mainnet PUBKEY 48 (L...) / SCRIPT {50 (M...), 5 (legacy 3...)} / bech32 "ltc";
+// testnet PUBKEY 111 / SCRIPT {196, 58 (Q...)} / bech32 "tltc". BOTH make_coin_
+// params() and address_acceptance() below read these constants, so the stratum
+// money-path acceptance set can NEVER drift from the coin params (the drift risk
+// of re-typing the same literals at the call site). HRPs here are BARE; make_coin_
+// params() appends the bech32 separator '1' for its own CoinParams.bech32_hrp
+// convention. bech32_hrp2 is the secondary P2SH (LTC has two P2SH prefixes).
+struct AddressEncoding {
+    uint8_t     p2pkh;
+    uint8_t     p2sh;
+    uint8_t     p2sh2;      // secondary P2SH version (LTC only), 0 = none
+    const char* hrp_bare;   // BARE bech32 HRP (no trailing '1')
+};
+inline constexpr AddressEncoding MAINNET_ADDR{ 48, 50, 5,  "ltc"  };
+inline constexpr AddressEncoding TESTNET_ADDR{ 111, 196, 58, "tltc" };
+inline constexpr const AddressEncoding& address_encoding(bool testnet)
+{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
+
 // Registry-sourced payout-address acceptance for LTC on the ACTIVE network
-// (issue #961). Mirrors make_coin_params() below (p2pool-merged-v36): mainnet
-// PUBKEY 48 (L...) / SCRIPT {50 (M...), 5 (legacy 3...)} / bech32 "ltc"; testnet
-// PUBKEY 111 / SCRIPT {196, 58 (Q...)} / bech32 "tltc". The legacy 0x05 P2SH is
-// an inherent LTC/BTC collision (both encode "3..." at version byte 5): an
-// address at 0x05 maps to the SAME hash160 the same key controls, so building
-// an LTC P2SH script for it is a valid own-coin payout, not a misdirection.
-// The core stratum server passes this set (via StratumConfig.payout_*) so the
-// per-job coinbase payout is validated at the parse and never fed a foreign
-// version byte. bech32 HRPs are returned BARE (no trailing '1').
+// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
+// literals. The legacy 0x05 P2SH is an inherent LTC/BTC collision (both encode
+// "3..." at version byte 5): an address at 0x05 maps to the SAME hash160 the
+// same key controls, so building an LTC P2SH script for it is a valid own-coin
+// payout, not a misdirection. The core stratum server passes this set (via
+// StratumConfig.payout_*) so the per-job coinbase payout is validated at the
+// parse and never fed a foreign version byte. bech32 HRPs are returned BARE.
 inline core::CoinAddressAcceptance address_acceptance(bool testnet)
 {
+    const auto& e = address_encoding(testnet);
     core::CoinAddressAcceptance a;
-    if (testnet) {
-        a.p2pkh_versions = { 111 };
-        a.p2sh_versions  = { 196, 58 };
-        a.bech32_hrps    = { "tltc" };
-    } else {
-        a.p2pkh_versions = { 48 };
-        a.p2sh_versions  = { 50, 5 };
-        a.bech32_hrps    = { "ltc" };
-    }
+    a.p2pkh_versions = { e.p2pkh };
+    a.p2sh_versions  = { e.p2sh };
+    if (e.p2sh2 != 0) a.p2sh_versions.push_back(e.p2sh2);
+    a.bech32_hrps    = { e.hrp_bare };
     return a;
 }
 
@@ -44,17 +58,13 @@ inline core::CoinParams make_coin_params(bool testnet)
     p.symbol = "LTC";
     p.block_period = 150;  // 2.5 min
 
-    // Address encoding
-    if (testnet) {
-        p.address_version      = 111;
-        p.address_p2sh_version = 196;
-        p.address_p2sh_version2 = 58;
-        p.bech32_hrp           = "tltc1";
-    } else {
-        p.address_version      = 48;
-        p.address_p2sh_version = 50;
-        p.address_p2sh_version2 = 5;
-        p.bech32_hrp           = "ltc1";
+    // Address encoding — from the AddressEncoding SSOT (issue #961 blocker #3).
+    {
+        const auto& e = address_encoding(testnet);
+        p.address_version       = e.p2pkh;
+        p.address_p2sh_version  = e.p2sh;
+        p.address_p2sh_version2 = e.p2sh2;
+        p.bech32_hrp            = std::string(e.hrp_bare) + "1";  // "ltc1"/"tltc1"
     }
 
     // PoW

--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -6,9 +6,35 @@
 
 #include <core/coin_params.hpp>
 #include <core/pow.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
 
 namespace ltc
 {
+
+// Registry-sourced payout-address acceptance for LTC on the ACTIVE network
+// (issue #961). Mirrors make_coin_params() below (p2pool-merged-v36): mainnet
+// PUBKEY 48 (L...) / SCRIPT {50 (M...), 5 (legacy 3...)} / bech32 "ltc"; testnet
+// PUBKEY 111 / SCRIPT {196, 58 (Q...)} / bech32 "tltc". The legacy 0x05 P2SH is
+// an inherent LTC/BTC collision (both encode "3..." at version byte 5): an
+// address at 0x05 maps to the SAME hash160 the same key controls, so building
+// an LTC P2SH script for it is a valid own-coin payout, not a misdirection.
+// The core stratum server passes this set (via StratumConfig.payout_*) so the
+// per-job coinbase payout is validated at the parse and never fed a foreign
+// version byte. bech32 HRPs are returned BARE (no trailing '1').
+inline core::CoinAddressAcceptance address_acceptance(bool testnet)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet) {
+        a.p2pkh_versions = { 111 };
+        a.p2sh_versions  = { 196, 58 };
+        a.bech32_hrps    = { "tltc" };
+    } else {
+        a.p2pkh_versions = { 48 };
+        a.p2sh_versions  = { 50, 5 };
+        a.bech32_hrps    = { "ltc" };
+    }
+    return a;
+}
 
 inline core::CoinParams make_coin_params(bool testnet)
 {


### PR DESCRIPTION
## Problem (P1 money leak, #961)

`core::address_to_script()` / `address_to_hash160()` are chain-agnostic: they decode the Base58Check version byte or bech32 HRP of **any** supported coin and then build a scriptPubKey for whatever coin the node happens to run. Fed a foreign-coin payout address, the stratum parse silently repurposed it into a wrong-coin script and **misdirected the miner's funds** (e.g. an LTC/DASH/DGB address pasted into a different coin's pool, or a foreign P2SH decoded as the running coin's P2SH).

## Fix

New `core::classify_address_for_coin(address, p2pkh_versions, p2sh_versions, accepted_hrps, out_script)` validates the address against the running coin's **own** accepted version bytes / HRPs **before** building a script:

- **Own** — valid for this coin → `out_script` is its scriptPubKey (byte-identical to the old path for legitimate addresses).
- **Foreign** — well-formed but for a *different* coin (version byte / bech32 HRP not in this coin's set) → empty script; the caller rejects loudly and never pays it.
- **Invalid** — not Base58Check/segwit (e.g. a CashAddr, or garbage) → empty script; the caller may consult a coin-specific decoder.

The standalone payout money-paths are wired to the checked decoder — **DASH / DGB / BTC / BCH / BIP-110** stratum `work_source`. A foreign address now falls through to the existing empty-payout / redistribute / donation fallback instead of a misdirected payment, and logs a loud `REJECTED foreign-coin payout address` warning.

### Per-coin accepted version bytes (mainnet / testnet)

| Coin | P2PKH | P2SH | bech32 HRP |
|------|-------|------|-----------|
| BTC  | 0x00 / 0x6f | 0x05 / 0xc4 | bc / tb |
| LTC  | 0x30 | 0x32, 0x05 (legacy) | ltc |
| DOGE | 0x1e | 0x16 | — |
| DASH | 0x4c / 0x8c | 0x10 / 0x13 | — |
| BCH  | 0x00 / 0x6f (legacy) | 0x05 / 0xc4 | — (CashAddr via decoder) |
| DGB  | 0x1e / 0x7e | 0x3f / 0x8c | dgb / dgbt |

Inherent collisions (BTC/BCH share 0x00,0x05; DOGE/DGB share 0x1e) are same-hash160/same-key and produce byte-identical scripts — not a misdirection — and are handled explicitly by the KAT.

## Reward-safety

Only the derivation of `payout_script` from the miner's stratum username changed. No coinbase construction, subsidy, PPLNS weighting, share serialization, or donation logic is touched (`git diff` of added lines contains none of those terms). Own-coin scripts are byte-identical to the previous `address_to_script()` output.

## Tests

`src/core/test/address_coin_validation_test.cpp`, folded into the allowlisted `core_test` target (no new NOT_BUILT-prone executable), proves **accept-own / reject-foreign across BTC/LTC/DOGE/DASH/BCH/DGB**:
- own P2PKH / P2SH / bech32 accepted with the correct script,
- full cross-product base58 matrix (foreign version → Foreign + empty script),
- foreign bech32 rejected; coins without segwit reject every bech32,
- concrete real-address money-leak cases (BTC genesis / BIP173 bech32 Foreign on DASH/DGB/LTC; CashAddr → Invalid).

The core primitive + KAT logic were compiled under C++20 and all assertions pass.

## Scope note

`src/core/stratum_server.cpp` (the LTC + merged-mining stratum) intentionally accepts non-LTC addresses for **configured** merged chains (DOGE/PEP/… reuse the same hash160 across chains that share secp256k1 keys — a deliberate p2pool feature), so it is left as-is; the KAT still covers LTC/DOGE at the primitive level.