### PR TITLE
ltc(dashboard): anchor pool-rate + stale-prop on the live head, fix LOST-CONTACT false positive (#1482)

### DIFF
--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -57,6 +57,7 @@
 #include <impl/ltc/share_messages.hpp>
 #include <impl/ltc/coin/block.hpp>
 #include <impl/ltc/node.hpp>
+#include <sharechain/pool_rate_head_select.hpp> // sharechain::select_pool_rate_head + average_stale_prop (#1482)
 #include <impl/ltc/messages.hpp>
 // NOTE: must follow node.hpp/messages.hpp. coin_node.hpp pulls in
 // btclibs/serialize.h, which #undefs READWRITE and redefines it to the
@@ -3038,48 +3039,31 @@ int main(int argc, char* argv[]) {
                 // (think+clean holds write lock ~30% of sampling intervals).
                 web_server.get_mining_interface()->set_pool_hashrate_fn(
                     [&p2p_node]() -> double {
-                        static double s_last_good = 0.0;
-                        // ── STALENESS BOUND (#57) ─────────────────────────
-                        // The last-good latch smooths transient tracker lock
-                        // contention, but unbounded it also turns a frozen
-                        // estimator into a permanent flat plateau (the DASH
-                        // dash.voidbind.com symptom). Bound it: if no fresh
-                        // hr>0 for >10 min, publish 0 so the chart breaks the
-                        // line instead of holding a stuck value forever.
+                        // #1482: read the pool hashrate straight off the lock-free
+                        // TrackerSnapshot, which NodeImpl::publish_snapshot()
+                        // computes under the compute-thread exclusive lock every
+                        // think() cycle (over sharechain::select_pool_rate_head's
+                        // live head, DISPLAY LOOKBEHIND = min(height-1,
+                        // 3600/SHARE_PERIOD), p2pool web.py get_global_stats).
+                        // No try-lock, so no cached last-good latch and no
+                        // bit-identical repeats for the web frozen-guard to zero
+                        // into false 0-drops (the rectangular graph). The 600 s
+                        // staleness bound (#57) still applies, keyed on the
+                        // snapshot's own compute timestamp so a stalled think()
+                        // breaks the line instead of holding a frozen value.
                         // Display-only; the retarget never reads this hook.
-                        static int64_t s_last_good_ts = 0;
+                        auto snap = p2p_node->get_tracker_snapshot();
+                        if (snap.pool_hashrate <= 0.0 || snap.pool_hashrate_ts == 0)
+                            return 0.0;
                         const int64_t now_s =
                             std::chrono::duration_cast<std::chrono::seconds>(
-                                std::chrono::steady_clock::now()
+                                std::chrono::system_clock::now()
                                     .time_since_epoch())
                                 .count();
                         constexpr int64_t kStaleSeconds = 600;  // 10 min
-                        auto held = [&]() -> double {
-                            if (s_last_good_ts != 0 &&
-                                now_s - s_last_good_ts > kStaleSeconds)
-                                return 0.0;
-                            return s_last_good;
-                        };
-                        auto best = p2p_node->best_share_hash();
-                        if (best.IsNull()) return held();
-                        auto guard = p2p_node->read_tracker();
-                        if (!guard) return held();
-                        if (!guard->chain.contains(best)) return held();
-                        int height = guard->chain.get_height(best);
-                        if (height < 3) return held();
-                        // DISPLAY LOOKBEHIND (#864): p2pool web.py get_global_stats()
-                        // averages the gauge over ONE HOUR of shares --
-                        // min(height, 3600//SHARE_PERIOD) -- not TARGET_LOOKBEHIND.
-                        // DISPLAY ONLY: the CONSENSUS retarget keeps TARGET_LOOKBEHIND
-                        // (p2pool data.py:137,140) and is untouched; m_pool_hashrate_fn
-                        // is read exclusively by web_server REST handlers.
-                        const int display_lookbehind =
-                            3600 / static_cast<int>(ltc::PoolConfig::share_period());
-                        auto lookbehind = std::min(height - 1, display_lookbehind);
-                        auto aps = guard->get_pool_attempts_per_second(best, lookbehind, false);
-                        double hr = static_cast<double>(aps.GetLow64());
-                        if (hr > 0) { s_last_good = hr; s_last_good_ts = now_s; }
-                        return held();
+                        if (now_s - snap.pool_hashrate_ts > kStaleSeconds)
+                            return 0.0;
+                        return snap.pool_hashrate;
                     });
                 // pool_hashrate is derived from the sharechain tip — move off
                 // the 1 Hz periodic timer onto the tip-change signal, same
@@ -3577,12 +3561,67 @@ int main(int argc, char* argv[]) {
                 nlohmann::json result;
                 auto& chain = guard->chain;
 
-                // Use tallest chain head (not verified best) so stats stay current during sync
-                uint256 best;
-                int32_t best_height = -1;
+                // #1482: anchor the stats on the pool's best-known LIVE head, not
+                // the tallest RAW head. The tallest-raw rule flipped the anchor
+                // between two near-equal-height forks sample-to-sample, which is
+                // what made the pool-rate graph a rectangle and the stale-prop
+                // series flap. Pure SSOT sharechain::select_pool_rate_head:
+                // verified best when live, else the fastest live raw head.
+                // Display-only; the vardiff retarget never reads this.
+                const int64_t stats_now_s = static_cast<int64_t>(std::time(nullptr));
+                const int stats_share_period =
+                    static_cast<int>(ltc::PoolConfig::share_period());
+                const int stats_lookbehind =
+                    3600 / (stats_share_period > 0 ? stats_share_period : 1);
+                auto make_stat_head = [&](const uint256& hh)
+                        -> sharechain::PoolRateHead {
+                    sharechain::PoolRateHead rh;
+                    rh.hash = hh;
+                    if (hh.IsNull() || !chain.contains(hh)) return rh;
+                    rh.height = static_cast<int32_t>(chain.get_height(hh));
+                    try {
+                        auto& cd = chain.get(hh);
+                        int64_t ts = 0;
+                        cd.share.invoke([&](auto* s) {
+                            ts = static_cast<int64_t>(s->m_timestamp);
+                        });
+                        if (ts > 0) rh.newest_share_age_s = stats_now_s - ts;
+                    } catch (...) {}
+                    if (rh.height >= 3) {
+                        int lb = rh.height - 1 < stats_lookbehind
+                                     ? rh.height - 1 : stats_lookbehind;
+                        try {
+                            auto aps = guard->get_pool_attempts_per_second(hh, lb, false);
+                            rh.aps = static_cast<double>(aps.GetLow64());
+                        } catch (...) {}
+                    }
+                    return rh;
+                };
+                uint256 verified_best_stat = p2p_node->best_share_hash();
+                sharechain::PoolRateHead stat_vhead;
+                bool stat_vpresent = false;
+                if (!verified_best_stat.IsNull() && chain.contains(verified_best_stat)) {
+                    stat_vhead = make_stat_head(verified_best_stat);
+                    stat_vpresent = true;
+                }
+                std::vector<sharechain::PoolRateHead> stat_raw_heads;
                 for (const auto& [head_hash, tail_hash] : chain.get_heads()) {
-                    auto h = chain.get_height(head_hash);
-                    if (h > best_height) { best = head_hash; best_height = h; }
+                    (void)tail_hash;
+                    stat_raw_heads.push_back(make_stat_head(head_hash));
+                }
+                uint256 best = sharechain::select_pool_rate_head(
+                    stat_vhead, stat_vpresent, stat_raw_heads);
+                int32_t best_height = -1;
+                if (best.IsNull()) {
+                    // Nothing live (empty/bootstrapping tracker): fall back to the
+                    // tallest raw head so the explorer fields still populate.
+                    for (const auto& [head_hash, tail_hash] : chain.get_heads()) {
+                        (void)tail_hash;
+                        auto h = chain.get_height(head_hash);
+                        if (h > best_height) { best = head_hash; best_height = h; }
+                    }
+                } else {
+                    best_height = static_cast<int32_t>(chain.get_height(best));
                 }
 
                 result["fork_count"]      = static_cast<int>(chain.get_heads().size());
@@ -3640,6 +3679,40 @@ int main(int argc, char* argv[]) {
                 result["total_shares"]    = sr.share_count;
                 result["orphan_shares"]   = sr.orphan_count;
                 result["dead_shares"]     = sr.dead_count;
+
+                // #1482: pool_stale_prop as p2pool data.py get_average_stale_prop
+                // = stales / (lookbehind + stales), counting stales among the
+                // ANCHORED lookbehind window (min(height, 3600/SHARE_PERIOD))
+                // walking back from the selected LIVE head — NOT stales over the
+                // whole CHAIN_LENGTH window. The whole-window count-based formula
+                // (the consumer default) is what flapped 0.05<->0.40 and grossed
+                // pool_hash_rate up by 1/(1-p). Consumers (rest_global_stats,
+                // update_stat_log) prefer this field when present; absent on
+                // other coins -> they keep the legacy path. Display-only.
+                {
+                    int lb_actual = best_height > 0
+                        ? (best_height < stats_lookbehind ? best_height
+                                                          : stats_lookbehind)
+                        : 0;
+                    int stale_ct = 0;
+                    if (lb_actual > 0 && !best.IsNull()) {
+                        uint256 pos = best;
+                        for (int i = 0; i < lb_actual && !pos.IsNull(); ++i) {
+                            if (!chain.contains(pos)) break;
+                            try {
+                                auto& cd = chain.get(pos);
+                                cd.share.invoke([&](auto* s) {
+                                    int si = static_cast<int>(s->m_stale_info);
+                                    if (si == 253 || si == 254) ++stale_ct;
+                                    pos = s->m_prev_hash;
+                                });
+                            } catch (...) { break; }
+                        }
+                    }
+                    result["pool_stale_prop"] =
+                        sharechain::average_stale_prop(stale_ct, lb_actual);
+                }
+
                 result["shares_by_version"] = sr.version_counts;
                 result["shares_by_desired_version"] = sr.desired_version_counts;
                 result["shares_by_miner"]   = sr.miner_counts;

--- a/src/c2pool/main_ltc.cpp
+++ b/src/c2pool/main_ltc.cpp
@@ -3585,6 +3585,9 @@ int main(int argc, char* argv[]) {
                         cd.share.invoke([&](auto* s) {
                             ts = static_cast<int64_t>(s->m_timestamp);
                         });
+                        // Future-dated newest share (ts > now) -> NEGATIVE age,
+                        // kept verbatim (maximally live). Only ts<=0 leaves the
+                        // kUnknownAge default (not-live). Issue #1482 blocker A.
                         if (ts > 0) rh.newest_share_age_s = stats_now_s - ts;
                     } catch (...) {}
                     if (rh.height >= 3) {

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2969,6 +2969,9 @@ nlohmann::json MiningInterface::rest_global_stats()
     // while the chain is too young, so the field is emitted as null rather than
     // a literal 1.0 that reads as a real floor.
     std::optional<double> min_difficulty;
+    // #1482: the sharechain provider's anchored get_average_stale_prop, when it
+    // supplies one (see below).
+    std::optional<double> sc_pool_stale_prop;
 
     // Populate from sharechain
     if (m_sharechain_stats_fn) {
@@ -2984,6 +2987,8 @@ nlohmann::json MiningInterface::rest_global_stats()
         if (sc.contains("min_difficulty") && sc["min_difficulty"].is_number()
             && sc["min_difficulty"].get<double>() > 0.0)
             min_difficulty = sc["min_difficulty"].get<double>();
+        if (sc.contains("pool_stale_prop") && sc["pool_stale_prop"].is_number())
+            sc_pool_stale_prop = sc["pool_stale_prop"].get<double>();
         if (sc.contains("shares_by_miner") && sc["shares_by_miner"].is_object())
             unique_miners = static_cast<int>(sc["shares_by_miner"].size());
     }
@@ -3008,6 +3013,14 @@ nlohmann::json MiningInterface::rest_global_stats()
     int stales = orphan_shares + dead_shares;
     int good = total_shares - stales;
     double pool_stale_prop = (good + stales > 0) ? static_cast<double>(stales) / (good + stales) : 0.0;
+    // #1482: prefer the ANCHORED-window get_average_stale_prop the sharechain
+    // stats provider computes over min(height, 3600/SHARE_PERIOD) from the LIVE
+    // head, when it supplies one. The count-over-CHAIN_LENGTH value above flapped
+    // (0.05<->0.40) because it changed with whichever raw fork was tallest; the
+    // anchored value does not. Coin-generic: absent on lanes that don't set it,
+    // so they keep the legacy value.
+    if (sc_pool_stale_prop)
+        pool_stale_prop = *sc_pool_stale_prop;
     // p2pool web.py get_global_stats():
     //     nonstale_hash_rate      = get_pool_attempts_per_second(...)
     //     pool_nonstale_hash_rate = nonstale_hash_rate
@@ -4592,15 +4605,65 @@ nlohmann::json MiningInterface::rest_local_stats()
     {
         auto warnings = nlohmann::json::array();
 
-        // 1. LTC block source contact check (>60s since last work update)
+        // 1. Coin block-source contact check (issue #1482).
+        // The threshold is >=3x the coin block_period (from the same source as
+        // /web/currency_info), NEVER the old hardcoded 60 s: at LTC's 150 s
+        // target a 60-136 s gap is a perfectly NORMAL Poisson inter-block wait,
+        // so the banner fired routinely on a synced, advancing node. It is also
+        // gated on "coin peers > 0 AND tip not advancing over the window" -- a
+        // recent work refresh means a new block arrived (tip advancing), and no
+        // coin peers is a different condition (warning #4 covers it). The benign
+        // sub-threshold / peer-starved case is left SILENT ("awaiting next block,
+        // normal") instead of a red LOST CONTACT banner.
         auto now_s = std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::steady_clock::now().time_since_epoch()).count();
-        if (m_last_work_update_time > 0 && now_s - m_last_work_update_time > 60) {
-            std::string src = (m_coin_node && m_coin_node->is_embedded()) ? "EMBEDDED LTC NODE" : "LTC DAEMON";
-            warnings.push_back("LOST CONTACT WITH " + src + " for "
-                + std::to_string(now_s - m_last_work_update_time) + "s! "
-                + ((m_coin_node && m_coin_node->is_embedded()) ? "No new blocks received from P2P peers."
-                                   : "Check that it isn't frozen or dead!"));
+        {
+            // Coin block period in seconds, mirroring rest_web_currency_info's
+            // label-first-then-enum resolution so BCH/NMC/BIP110 (which share the
+            // BITCOIN enum) are not read as 150 s.
+            int64_t block_period = 150;  // LTC/DASH default
+            std::string cl = m_coin_label;
+            for (auto& ch : cl)
+                if (ch >= 'a' && ch <= 'z') ch = static_cast<char>(ch - 32);
+            if (cl == "BCH" || cl == "NMC" || cl == "BIP110") {
+                block_period = 600;
+            } else {
+                switch (m_blockchain) {
+                case Blockchain::LITECOIN: block_period = 150; break;
+                case Blockchain::BITCOIN:  block_period = 600; break;
+                case Blockchain::DOGECOIN: block_period = 60;  break;
+                case Blockchain::DASH:     block_period = 150; break;
+                case Blockchain::DIGIBYTE: block_period = 15;  break;
+                default: break;
+                }
+            }
+            const int64_t threshold = block_period * 3;  // >=3x mean block interval
+
+            // Coin peers: prefer the embedded coin-sync provider's peer array
+            // (the parent-chain P2P peers that actually deliver new blocks). When
+            // no provider is wired the count is unknown -> treat as "have peers"
+            // so a lane without the hook still fires on a genuine long stall
+            // (already 3x-gated); never fabricate a peer count.
+            bool have_coin_peers = true;
+            if (m_coin_sync_status_fn) {
+                auto ss = m_coin_sync_status_fn();
+                if (ss.is_object() && ss.contains("peers") && ss["peers"].is_array())
+                    have_coin_peers = !ss["peers"].empty();
+                else if (ss.is_object() && ss.contains("connected_peers")
+                         && ss["connected_peers"].is_number())
+                    have_coin_peers = ss["connected_peers"].get<int>() > 0;
+            }
+
+            const bool tip_stalled =
+                m_last_work_update_time > 0 &&
+                now_s - m_last_work_update_time > threshold;
+            if (tip_stalled && have_coin_peers) {
+                std::string src = (m_coin_node && m_coin_node->is_embedded()) ? "EMBEDDED LTC NODE" : "LTC DAEMON";
+                warnings.push_back("LOST CONTACT WITH " + src + " for "
+                    + std::to_string(now_s - m_last_work_update_time) + "s! "
+                    + ((m_coin_node && m_coin_node->is_embedded()) ? "No new blocks received from P2P peers."
+                                       : "Check that it isn't frozen or dead!"));
+            }
         }
 
         // 2. No work template yet
@@ -8009,11 +8072,20 @@ void MiningInterface::update_stat_log()
     // Pool stale proportion from sharechain orphan+dead counts
     if (m_sharechain_stats_fn) {
         auto sc = m_sharechain_stats_fn();
-        int ts = sc.value("total_shares", 0);
-        int os = sc.value("orphan_shares", 0);
-        int ds = sc.value("dead_shares", 0);
-        int st = os + ds;
-        entry.pool_stale_prop = (ts > 0) ? static_cast<double>(st) / ts : 0.0;
+        // #1482: prefer the provider's anchored get_average_stale_prop
+        // (stales/(lookbehind+stales) over min(height, 3600/SHARE_PERIOD)) when
+        // present, so the persisted graph series stops flapping with the tallest
+        // raw fork. Coin-generic: fall back to the whole-window count for lanes
+        // that don't publish the field.
+        if (sc.contains("pool_stale_prop") && sc["pool_stale_prop"].is_number()) {
+            entry.pool_stale_prop = sc["pool_stale_prop"].get<double>();
+        } else {
+            int ts = sc.value("total_shares", 0);
+            int os = sc.value("orphan_shares", 0);
+            int ds = sc.value("dead_shares", 0);
+            int st = os + ds;
+            entry.pool_stale_prop = (ts > 0) ? static_cast<double>(st) / ts : 0.0;
+        }
     } else {
         entry.pool_stale_prop = 0.0;
     }

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -4611,10 +4611,14 @@ nlohmann::json MiningInterface::rest_local_stats()
         // target a 60-136 s gap is a perfectly NORMAL Poisson inter-block wait,
         // so the banner fired routinely on a synced, advancing node. It is also
         // gated on "coin peers > 0 AND tip not advancing over the window" -- a
-        // recent work refresh means a new block arrived (tip advancing), and no
-        // coin peers is a different condition (warning #4 covers it). The benign
-        // sub-threshold / peer-starved case is left SILENT ("awaiting next block,
-        // normal") instead of a red LOST CONTACT banner.
+        // recent work refresh means a new block arrived (tip advancing). Zero
+        // coin peers is a SEPARATE, LOUDER condition: warning #4 below counts
+        // POOL (sharechain) peers, a different network, so it does NOT surface a
+        // coin-P2P isolation -- when the tip is stalled AND the coin provider
+        // reports 0 parent-chain peers, that is a genuine outage and gets its own
+        // red "NO COIN P2P PEERS" banner (blocker B). Only the benign
+        // sub-threshold gap on a still-peered node is left SILENT ("awaiting next
+        // block, normal") instead of a red LOST CONTACT banner.
         auto now_s = std::chrono::duration_cast<std::chrono::seconds>(
             std::chrono::steady_clock::now().time_since_epoch()).count();
         {
@@ -4663,6 +4667,21 @@ nlohmann::json MiningInterface::rest_local_stats()
                     + std::to_string(now_s - m_last_work_update_time) + "s! "
                     + ((m_coin_node && m_coin_node->is_embedded()) ? "No new blocks received from P2P peers."
                                        : "Check that it isn't frozen or dead!"));
+            } else if (tip_stalled && !have_coin_peers) {
+                // Tip stalled past the 3x-block-period window AND the coin sync
+                // provider reports ZERO parent-chain peers -- a real coin-network
+                // isolation, distinct from the benign "awaiting next block". This
+                // branch only reaches when the provider IS wired and returns 0
+                // (have_coin_peers defaults true without the hook), so it never
+                // fires on a lane lacking the hook. Warning #4 counts POOL peers,
+                // not these, so without this the outage would be SILENT (blocker
+                // B). Name the coin P2P peers explicitly.
+                warnings.push_back("NO COIN P2P PEERS — the "
+                    + std::string((m_coin_node && m_coin_node->is_embedded())
+                                      ? "embedded coin node" : "coin daemon")
+                    + " has 0 parent-chain peers and the tip has not advanced for "
+                    + std::to_string(now_s - m_last_work_update_time)
+                    + "s; no new blocks can arrive until a peer connects.");
             }
         }
 

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -19,6 +19,7 @@
 #include <core/reply_matcher.hpp>
 #include <core/known_txs_eviction.hpp>
 #include <sharechain/prepared_list.hpp>
+#include <sharechain/pool_rate_head_select.hpp> // sharechain::select_pool_rate_head — dashboard pool-rate head selection (#1482)
 #include <c2pool/storage/sharechain_storage.hpp>
 
 #include <atomic>
@@ -149,6 +150,11 @@ protected:
         int dead_shares{0};
         int fork_count{0};
         double pool_hashrate{0};
+        // Wall-clock seconds when pool_hashrate was last computed > 0. The web
+        // set_pool_hashrate_fn applies a 600 s staleness bound on this so a
+        // stalled think() (dead node) breaks the graph line instead of serving
+        // a frozen value forever. 0 = never computed.
+        int64_t pool_hashrate_ts{0};
     };
     void publish_snapshot() {
         TrackerSnapshot s;
@@ -156,7 +162,86 @@ protected:
         s.verified_count = static_cast<int>(m_tracker.verified.size());
         s.head_count = static_cast<int>(m_tracker.chain.get_heads().size());
         s.fork_count = s.head_count;
+
+        // ── Dashboard pool hashrate (issue #1482) ────────────────────────────
+        // Computed HERE, under the compute-thread exclusive tracker lock, so the
+        // web set_pool_hashrate_fn reads a FRESH snapshot value instead of
+        // try-locking the tracker and returning a cached last-good latch. That
+        // latch emitted bit-identical repeats whenever the try-lock lost to a
+        // think() chunk, and the web frozen-guard (kMaxIdenticalPoolRateRun) then
+        // zeroed those runs into false 0-drops — the rectangular ltc.voidbind
+        // graph. Head choice is the pure sharechain::select_pool_rate_head SSOT
+        // (verified best when live, else the fastest live raw head). Display-only:
+        // the vardiff retarget runs on the verified chain over TARGET_LOOKBEHIND
+        // and never reads this snapshot.
+        {
+            const int64_t now_s = static_cast<int64_t>(
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count());
+            const uint32_t sp = m_coin_params.share_period ? m_coin_params.share_period : 1u;
+            const int display_lookbehind = static_cast<int>(3600u / sp);
+
+            auto make_head = [&](const uint256& hh) -> sharechain::PoolRateHead {
+                sharechain::PoolRateHead rh;
+                rh.hash = hh;
+                if (hh.IsNull() || !m_tracker.chain.contains(hh)) return rh;
+                rh.height = static_cast<int32_t>(m_tracker.chain.get_height(hh));
+                try {
+                    auto& cd = m_tracker.chain.get(hh);
+                    int64_t ts = 0;
+                    cd.share.invoke([&](auto* sh) {
+                        ts = static_cast<int64_t>(sh->m_timestamp);
+                    });
+                    if (ts > 0) rh.newest_share_age_s = now_s - ts;
+                } catch (...) {}
+                if (rh.height >= 3) {
+                    int lb = rh.height - 1 < display_lookbehind
+                                 ? rh.height - 1 : display_lookbehind;
+                    try {
+                        auto aps = m_tracker.get_pool_attempts_per_second(hh, lb, false);
+                        rh.aps = static_cast<double>(aps.GetLow64());
+                    } catch (...) {}
+                }
+                return rh;
+            };
+
+            sharechain::PoolRateHead verified;
+            bool verified_present = false;
+            if (!m_best_share_hash.IsNull() &&
+                m_tracker.chain.contains(m_best_share_hash)) {
+                verified = make_head(m_best_share_hash);
+                verified_present = true;
+            }
+            std::vector<sharechain::PoolRateHead> raw_heads;
+            for (const auto& kv : m_tracker.chain.get_heads())
+                raw_heads.push_back(make_head(kv.first));
+
+            uint256 sel = sharechain::select_pool_rate_head(
+                verified, verified_present, raw_heads);
+
+            double hr = 0.0;
+            if (!sel.IsNull()) {
+                if (verified_present && verified.hash == sel)
+                    hr = verified.aps;
+                else
+                    for (const auto& rh : raw_heads)
+                        if (rh.hash == sel) { hr = rh.aps; break; }
+            }
+            if (hr > 0.0) {
+                s.pool_hashrate = hr;
+                s.pool_hashrate_ts = now_s;
+            }
+        }
+
         std::lock_guard<std::mutex> lock(m_snapshot_mutex);
+        // Carry the last-good pool hashrate forward when this cycle produced none
+        // (empty/short chain), so a transient gap does not blank the graph; the
+        // web fn applies the 600 s staleness bound on pool_hashrate_ts to break
+        // the line if think() itself has stalled.
+        if (s.pool_hashrate <= 0.0 && m_snapshot.pool_hashrate > 0.0) {
+            s.pool_hashrate = m_snapshot.pool_hashrate;
+            s.pool_hashrate_ts = m_snapshot.pool_hashrate_ts;
+        }
         m_snapshot = s;
     }
     mutable std::mutex m_snapshot_mutex;

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -192,6 +192,10 @@ protected:
                     cd.share.invoke([&](auto* sh) {
                         ts = static_cast<int64_t>(sh->m_timestamp);
                     });
+                    // A future-dated newest share (ts > now) yields a NEGATIVE
+                    // age; keep it verbatim -- it is maximally live, not dead.
+                    // Only an undatable share (ts<=0) leaves the kUnknownAge
+                    // default (the not-live sentinel). Issue #1482 blocker A.
                     if (ts > 0) rh.newest_share_age_s = now_s - ts;
                 } catch (...) {}
                 if (rh.height >= 3) {

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -27,7 +27,13 @@ if (BUILD_TESTING AND GTest_FOUND)
     # RED on master semantics, GREEN after the fix. Same folding rule: into the
     # existing allowlisted target (a standalone add_executable would be absent
     # from build.yml's --target list and silently Not-Run — the #769 trap).
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp)
+    #
+    # pool_rate_head_select_test.cpp: the coin-generic dashboard pool-rate
+    # HEAD-SELECTION + get_average_stale_prop SSOT (sharechain/
+    # pool_rate_head_select.hpp, issue #1482) — verified best when live, else the
+    # fastest LIVE raw head; stale-prop = stales/(lookbehind+stales). Pure
+    # header-only KAT. Same folding rule: into the existing allowlisted target.
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp pool_rate_head_select_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/pool_rate_head_select_test.cpp
+++ b/src/impl/ltc/test/pool_rate_head_select_test.cpp
@@ -71,6 +71,42 @@ TEST(PoolRateHeadSelect, VerifiedBestLiveWins) {
     EXPECT_EQ(select_pool_rate_head(verified, /*present=*/true, raw), H(7));
 }
 
+// ---- (1b) FUTURE-DATED head is LIVE, not dead (blocker A) ----------------
+
+TEST(PoolRateHeadSelect, FutureDatedHeadIsLive) {
+    // A newest share dated a few seconds AHEAD of the sampling clock (clock skew
+    // or a legitimately future-dated share) makes now-ts NEGATIVE. That head is
+    // maximally live -- it MUST stay anchorable. The pre-fix code overloaded the
+    // -1 "undatable" sentinel with any negative age, so a share 1 s in the future
+    // read as DEAD, the verified head lost liveness, and the anchor flipped off
+    // it (the #1482 symptom). With kUnknownAge = INT64_MIN the two are distinct.
+    using sharechain::pool_rate_head_is_live;
+    using sharechain::kUnknownAge;
+
+    // A future-dated head is live at any negative age; the undatable sentinel is
+    // NOT live even though it too is "negative".
+    EXPECT_TRUE(pool_rate_head_is_live(mk(1, 100, /*age*/ -5, 10.0), 600));
+    EXPECT_TRUE(pool_rate_head_is_live(mk(2, 100, /*age*/ -1, 10.0), 600));
+    PoolRateHead undatable = mk(3, 100, /*age*/ 0, 10.0);
+    undatable.newest_share_age_s = kUnknownAge;
+    EXPECT_FALSE(pool_rate_head_is_live(undatable, 600));
+
+    // A verified best whose newest share is 5 s in the FUTURE still wins outright
+    // -- it does not fall through to the raw-head branch.
+    PoolRateHead verified = mk(7, 900, /*age*/ -5, /*aps*/ 100.0);
+    std::vector<PoolRateHead> raw = {mk(11, 901, 5, 999.0)};
+    EXPECT_EQ(select_pool_rate_head(verified, /*present=*/true, raw), H(7));
+
+    // And a future-dated RAW head is a valid live anchor when no verified head is
+    // present (beats an undatable head that must be skipped).
+    PoolRateHead undatable_raw = mk(12, 950, /*age*/ 0, 1e9);
+    undatable_raw.newest_share_age_s = kUnknownAge;
+    std::vector<PoolRateHead> raw2 = {undatable_raw,
+                                      mk(13, 400, /*age*/ -3, 42.0)};
+    EXPECT_EQ(select_pool_rate_head(PoolRateHead{}, /*present=*/false, raw2),
+              H(13));
+}
+
 // ---- (2) STALE verified best -> fastest LIVE raw head --------------------
 
 TEST(PoolRateHeadSelect, StaleVerifiedBestYieldsFastestLiveRawHead) {

--- a/src/impl/ltc/test/pool_rate_head_select_test.cpp
+++ b/src/impl/ltc/test/pool_rate_head_select_test.cpp
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// sharechain::select_pool_rate_head + average_stale_prop -- dashboard pool-rate
+// head-selection KAT (issue #1482).
+//
+// Pins the pure decision of WHICH sharechain head the dashboard pool-hashrate
+// estimator (and the pool_stale_prop series) anchors on. This is the load-
+// bearing new logic behind un-flapping the ltc.voidbind graph: the estimator
+// (get_pool_attempts_per_second) is unchanged; the fix is that the head is now
+// the pool's best-known LIVE head -- verified best when live, else the fastest
+// LIVE raw head -- instead of the tallest RAW head (which flipped between two
+// near-equal-height forks sample-to-sample).
+//
+// Oracle (mirrors p2pool web.py feeding the graph off the node's best-known
+// live head, and data.py get_average_stale_prop):
+//   1. verified best present AND live (newest share within the horizon) -> it,
+//      unconditionally (even if a raw head has a larger APS).
+//   2. verified best absent OR stale -> the LIVE raw head with the greatest
+//      get_pool_attempts_per_second; ties -> greater height -> first-seen.
+//   3. a raw head older than the horizon is DEAD and ignored even if its APS
+//      is larger (never anchor the live graph on a dead foreign fork).
+//   4. nothing live -> null (the caller holds its last-good value).
+//   5. average_stale_prop(stales, lookbehind) == stales / (lookbehind + stales).
+//
+// All expectations are hand-derived from that oracle, not produced by calling
+// the helper under test, so the KAT is non-circular. The pre-#1482 behaviour
+// (verified-best-unconditional / tallest-raw, whole-window stale count) would
+// FAIL cases (2) and (5) -- that divergence is the fix.
+//
+// FOLDED into the already-allowlisted `share_test` target (a fresh
+// add_executable would trip CI's NOT_BUILT sentinel, #143/#883/#893). Pure
+// header-only logic; no NodeImpl / ShareTracker / socket standup.
+
+#include <sharechain/pool_rate_head_select.hpp>
+
+#include <cstdio>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using sharechain::PoolRateHead;
+using sharechain::select_pool_rate_head;
+using sharechain::average_stale_prop;
+
+// Distinct non-null test hashes: n encoded as a hex uint256.
+uint256 H(uint32_t n) {
+    char buf[9];
+    std::snprintf(buf, sizeof(buf), "%08x", n);
+    uint256 x;
+    x.SetHex(buf);
+    return x;
+}
+
+PoolRateHead mk(uint32_t n, int32_t height, int64_t age_s, double aps) {
+    PoolRateHead h;
+    h.hash = H(n);
+    h.height = height;
+    h.newest_share_age_s = age_s;
+    h.aps = aps;
+    return h;
+}
+
+// ---- (1) verified best present + LIVE wins outright ----------------------
+
+TEST(PoolRateHeadSelect, VerifiedBestLiveWins) {
+    // Verified best is live (age 10 s). A raw head has a LARGER APS, but the
+    // live verified head still wins -- p2pool anchors on best_share_hash when it
+    // is current.
+    PoolRateHead verified = mk(7, 900, /*age*/ 10, /*aps*/ 100.0);
+    std::vector<PoolRateHead> raw = {mk(11, 901, 5, 999.0)};
+    EXPECT_EQ(select_pool_rate_head(verified, /*present=*/true, raw), H(7));
+}
+
+// ---- (2) STALE verified best -> fastest LIVE raw head --------------------
+
+TEST(PoolRateHeadSelect, StaleVerifiedBestYieldsFastestLiveRawHead) {
+    // THE #1482 CASE: the verified best-share election froze (its newest share
+    // is 700 s old, past the 600 s horizon), so it is stale. Among the LIVE raw
+    // heads pick the one with the greatest APS -- h(12) at aps 500 beats h(11)
+    // at aps 120, regardless of height. Pre-#1482 (verified-best-unconditional,
+    // or tallest-raw = h(11) at height 950) picks a different head: RED there.
+    PoolRateHead verified = mk(7, 900, /*age*/ 700, /*aps*/ 80.0);
+    std::vector<PoolRateHead> raw = {
+        mk(11, 950, /*age*/ 30, /*aps*/ 120.0),   // tallest, but slower
+        mk(12, 900, /*age*/ 30, /*aps*/ 500.0),   // fastest LIVE -> chosen
+    };
+    EXPECT_EQ(select_pool_rate_head(verified, /*present=*/true, raw), H(12));
+}
+
+// ---- (3) a DEAD (stale) foreign head is ignored even if fast -------------
+
+TEST(PoolRateHeadSelect, DeadForeignHeadIgnored) {
+    // No verified head. Two raw heads: h(20) has a HUGE APS but its newest share
+    // is 700 s old (dead foreign fork nobody extends); h(21) is slower but LIVE
+    // (age 90 s). The live-but-slower head must win; the dead fast head is never
+    // anchored on.
+    std::vector<PoolRateHead> raw = {
+        mk(20, 1000, /*age*/ 700, /*aps*/ 1e9),   // dead: ignored
+        mk(21,  400, /*age*/  90, /*aps*/ 42.0),  // live: chosen
+    };
+    EXPECT_EQ(select_pool_rate_head(PoolRateHead{}, /*present=*/false, raw),
+              H(21));
+}
+
+// ---- (4) nothing live -> null (caller holds last-good) -------------------
+
+TEST(PoolRateHeadSelect, EmptyTrackerReturnsNull) {
+    std::vector<PoolRateHead> none;
+    EXPECT_TRUE(
+        select_pool_rate_head(PoolRateHead{}, /*present=*/false, none).IsNull());
+}
+
+TEST(PoolRateHeadSelect, AllRawHeadsDeadReturnsNull) {
+    // Every raw head is past the horizon, and there is no verified head: null.
+    std::vector<PoolRateHead> raw = {
+        mk(30, 500, /*age*/ 601, 10.0),
+        mk(31, 900, /*age*/ 5000, 99.0),
+    };
+    EXPECT_TRUE(
+        select_pool_rate_head(PoolRateHead{}, /*present=*/false, raw).IsNull());
+}
+
+TEST(PoolRateHeadSelect, StaleVerifiedAndNoLiveRawReturnsNull) {
+    // Verified present but stale, and no raw head is live -> null (hold).
+    PoolRateHead verified = mk(7, 900, /*age*/ 700, 80.0);
+    std::vector<PoolRateHead> raw = {mk(11, 950, /*age*/ 900, 120.0)};
+    EXPECT_TRUE(select_pool_rate_head(verified, /*present=*/true, raw).IsNull());
+}
+
+// ---- selection determinism (tie-break + null-hash skip) ------------------
+
+TEST(PoolRateHeadSelect, EqualApsBreaksToGreaterHeightThenFirstSeen) {
+    // Two live raw heads with EQUAL aps: the greater height wins.
+    std::vector<PoolRateHead> raw = {
+        mk(40, 800, 10, 50.0),
+        mk(41, 900, 10, 50.0),   // taller at equal aps -> chosen
+    };
+    EXPECT_EQ(select_pool_rate_head(PoolRateHead{}, false, raw), H(41));
+}
+
+TEST(PoolRateHeadSelect, NullHashRawHeadsAreSkipped) {
+    PoolRateHead nullhead;            // null hash, but "fast" and "live"
+    nullhead.height = 999;
+    nullhead.newest_share_age_s = 1;
+    nullhead.aps = 1e9;
+    std::vector<PoolRateHead> raw = {nullhead, mk(50, 300, 30, 12.0)};
+    EXPECT_EQ(select_pool_rate_head(PoolRateHead{}, false, raw), H(50));
+}
+
+TEST(PoolRateHeadSelect, VerifiedPresentButNullHashFallsToLiveRaw) {
+    // "present" true but the hash is null (defensive): treated as absent.
+    PoolRateHead verified;           // null hash
+    verified.newest_share_age_s = 5; // "live" but null -> not usable
+    std::vector<PoolRateHead> raw = {mk(60, 300, 30, 7.0)};
+    EXPECT_EQ(select_pool_rate_head(verified, /*present=*/true, raw), H(60));
+}
+
+// ---- (5) p2pool get_average_stale_prop formula ---------------------------
+
+TEST(PoolRateHeadSelect, StalePropFormulaMatchesP2pool) {
+    // p2pool data.py get_average_stale_prop == stales / (lookbehind + stales).
+    // Hand-derived oracle values (NOT the count-over-whole-window formula that
+    // flapped 0.05<->0.40 pre-#1482).
+    EXPECT_DOUBLE_EQ(average_stale_prop(0, 360), 0.0);
+    EXPECT_DOUBLE_EQ(average_stale_prop(3, 360), 3.0 / 363.0);
+    EXPECT_DOUBLE_EQ(average_stale_prop(40, 360), 40.0 / 400.0);   // 0.10
+    // Degenerate: no window and no stales -> 0, never a divide-by-zero.
+    EXPECT_DOUBLE_EQ(average_stale_prop(0, 0), 0.0);
+    // All stale (lookbehind 0, stales 5) -> 5/(0+5) = 1.0.
+    EXPECT_DOUBLE_EQ(average_stale_prop(5, 0), 1.0);
+    // Negative inputs are clamped to 0 (defensive), never negative prop.
+    EXPECT_DOUBLE_EQ(average_stale_prop(-3, 360), 0.0);
+}
+
+}  // namespace

--- a/src/sharechain/pool_rate_head_select.hpp
+++ b/src/sharechain/pool_rate_head_select.hpp
@@ -59,6 +59,18 @@
 
 namespace sharechain {
 
+// Sentinel age: this head has NO datable newest share (its timestamp was
+// absent / non-positive), so it can never be anchored on. It must be a value
+// no real (now - ts) difference can ever equal -- and in particular NOT a small
+// negative number, because a share whose timestamp is a few seconds AHEAD of
+// the sampling clock (clock skew / a legitimately future-dated newest share)
+// produces a small NEGATIVE age that is maximally LIVE, not undatable. INT64_MIN
+// is unreachable by any wall-clock subtraction, so it can never collide with a
+// real age. (The pre-fix sentinel of -1 collided with a share dated 1 s in the
+// future: it was mis-read as "undatable" -> the head went DEAD -> the anchor
+// flipped off the live verified head. Issue #1482 / PR #1495 blocker A.)
+inline constexpr int64_t kUnknownAge = INT64_MIN;
+
 // A candidate sharechain head for the dashboard pool-rate estimator. The caller
 // fills these from ShareChain::get_heads() + get_height() + the head share's
 // timestamp + ShareTracker::get_pool_attempts_per_second(), all under the
@@ -66,17 +78,22 @@ namespace sharechain {
 struct PoolRateHead {
     uint256 hash;
     int32_t height{0};
-    // Seconds between now and the newest share on this head. NEGATIVE means
-    // "unknown / no datable share" -> treated as NOT live (never anchored on).
-    int64_t newest_share_age_s{-1};
+    // Seconds between now and the newest share on this head. kUnknownAge means
+    // "no datable share" -> treated as NOT live (never anchored on). A NEGATIVE
+    // value (a future-dated newest share, now < ts) is maximally live, NOT dead.
+    int64_t newest_share_age_s{kUnknownAge};
     // get_pool_attempts_per_second over the display lookbehind on this head.
     double  aps{0.0};
 };
 
-// A head is LIVE when its newest share is datable and within the horizon.
+// A head is LIVE when its newest share is datable and no OLDER than the horizon.
+// A negative age (future-dated share) is maximally live; only kUnknownAge (and
+// an age strictly past the horizon) is not live. Guarding on kUnknownAge rather
+// than `>= 0` is blocker-A's fix: a future-dated head must stay anchorable.
 inline bool pool_rate_head_is_live(const PoolRateHead& h, int64_t horizon_s)
 {
-    return h.newest_share_age_s >= 0 && h.newest_share_age_s <= horizon_s;
+    return h.newest_share_age_s != kUnknownAge &&
+           h.newest_share_age_s <= horizon_s;
 }
 
 // Choose the head to anchor the dashboard pool-rate estimator on (see header).

--- a/src/sharechain/pool_rate_head_select.hpp
+++ b/src/sharechain/pool_rate_head_select.hpp
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// SSOT for the DASHBOARD POOL-RATE HEAD SELECTION -- the pure decision of WHICH
+// sharechain head the pool-hashrate estimator (and the pool_stale_prop series)
+// anchors on when the dashboard samples them. Coin-generic: the LTC lane wires
+// it first (issue #1482); any coin can reuse the same pure rule.
+//
+// The estimator itself (ShareTracker::get_pool_attempts_per_second) is
+// unchanged -- it sums per-share work over a window and divides by the window
+// timespan (p2pool data.py get_pool_attempts_per_second). What THIS header
+// fixes is the HEAD that estimator is anchored to, and it captures p2pool's
+// "best-known LIVE head" rule.
+//
+// PROBLEM (ltc.voidbind.com, issue #1482): the dashboard feeds anchored on the
+// TALLEST RAW head. Between two raw heads at (near-)equal height the anchor
+// FLIPS sample-to-sample, so the pool-rate graph draws a rectangle and the
+// pool_stale_prop series flaps (0.05 <-> 0.29 <-> 0.40). p2pool's web.py
+// add_point() instead feeds the graph off the node's best-known LIVE head --
+// the verified best share when it is live, else the fastest live raw head --
+// which is stable because it tracks the chain the pool is actually extending,
+// not whichever transient fork happens to be one share taller this instant.
+//
+// THE RULE (mirrors p2pool web.py get_local_rates / get_global_stats feeding
+// the graph off tracker.get_pool_attempts_per_second(best_share_hash, ...)):
+//   1. If the VERIFIED best-share head is present (non-null) AND LIVE -- its
+//      newest share is within `liveness_horizon_s` seconds of now -- anchor on
+//      it verbatim. This is the steady state on a live-mining node and matches
+//      p2pool feeding the graph off best_share_hash.
+//   2. Otherwise (no verified head yet -- the zero-local-miner relay bootstrap
+//      -- OR the verified election has frozen so its head is now STALE) anchor
+//      on the LIVE raw head with the greatest get_pool_attempts_per_second.
+//      Using APS (not raw height) is what makes the choice stable: the head
+//      carrying the pool's actual work wins, and a one-share height lead on a
+//      near-empty transient fork does not flip the anchor.
+//   3. A raw head whose newest share is OLDER than the liveness horizon is
+//      DEAD (a stale foreign fork nobody is extending) and is ignored even if
+//      its windowed APS looks high -- never anchor the live graph on a dead
+//      chain.
+//   4. If no head is live at all (empty tracker, or every head dead), return
+//      null -- the caller then HOLDS its last-good value rather than publishing
+//      a spurious 0.
+//
+// Consensus/reward-NEUTRAL: the value produced here feeds ONLY the web_server
+// REST handlers (pool_hash_rate / pool_rates graph series, pool_stale_prop and
+// /global_stats). The vardiff retarget runs on the VERIFIED chain over
+// TARGET_LOOKBEHIND (p2pool data.py:137,140) and never reads this hook.
+// Display/data only.
+//
+// Pure function over already-collected inputs (the caller walks the tracker
+// under its lock and hands the resolved verified head + the raw heads, each
+// with its newest-share age and windowed APS, here), so a KAT can pin the
+// selection with no NodeImpl / ShareTracker / socket standup.
+
+#include <cstdint>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+namespace sharechain {
+
+// A candidate sharechain head for the dashboard pool-rate estimator. The caller
+// fills these from ShareChain::get_heads() + get_height() + the head share's
+// timestamp + ShareTracker::get_pool_attempts_per_second(), all under the
+// tracker lock.
+struct PoolRateHead {
+    uint256 hash;
+    int32_t height{0};
+    // Seconds between now and the newest share on this head. NEGATIVE means
+    // "unknown / no datable share" -> treated as NOT live (never anchored on).
+    int64_t newest_share_age_s{-1};
+    // get_pool_attempts_per_second over the display lookbehind on this head.
+    double  aps{0.0};
+};
+
+// A head is LIVE when its newest share is datable and within the horizon.
+inline bool pool_rate_head_is_live(const PoolRateHead& h, int64_t horizon_s)
+{
+    return h.newest_share_age_s >= 0 && h.newest_share_age_s <= horizon_s;
+}
+
+// Choose the head to anchor the dashboard pool-rate estimator on (see header).
+//   verified          : the verified best-share head candidate.
+//   verified_present  : false when there is no verified best (null / not in
+//                       chain) -- then `verified` is ignored entirely.
+//   raw_heads         : every raw chain head, with age + APS filled.
+//   liveness_horizon_s: max newest-share age for a head to count as live
+//                       (default 600 s, matching the estimator staleness bound).
+// Returns the chosen head hash, or a null uint256 when nothing is live.
+inline uint256 select_pool_rate_head(const PoolRateHead& verified,
+                                     bool verified_present,
+                                     const std::vector<PoolRateHead>& raw_heads,
+                                     int64_t liveness_horizon_s = 600)
+{
+    // 1. Verified best-share head, when present AND live, wins outright.
+    if (verified_present && !verified.hash.IsNull() &&
+        pool_rate_head_is_live(verified, liveness_horizon_s))
+        return verified.hash;
+
+    // 2/3. Among the LIVE raw heads, the one with the greatest windowed APS.
+    // Ties break to the greater height, then to first-seen (strictly-greater
+    // comparisons), so the choice is deterministic sample-to-sample. Dead heads
+    // (age past the horizon) are skipped even when their APS is larger.
+    uint256 best;              // null until a live raw head is found
+    bool    found = false;
+    double  best_aps = 0.0;
+    int32_t best_height = -1;
+    for (const auto& h : raw_heads) {
+        if (h.hash.IsNull())
+            continue;
+        if (!pool_rate_head_is_live(h, liveness_horizon_s))
+            continue;
+        if (!found || h.aps > best_aps ||
+            (h.aps == best_aps && h.height > best_height)) {
+            found = true;
+            best = h.hash;
+            best_aps = h.aps;
+            best_height = h.height;
+        }
+    }
+
+    // 4. Nothing live -> null; the caller holds its last-good value.
+    return found ? best : uint256{};
+}
+
+// p2pool data.py get_average_stale_prop(share, lookbehind) == an ANCHORED-window
+// stale fraction: count the stale (orphan+dead) shares among the `lookbehind`
+// shares walking back from the anchor head, then
+//     stale_prop = stales / (lookbehind + stales).
+// The denominator is the FIXED lookbehind (min(height, 3600/SHARE_PERIOD)) plus
+// the stales, NOT the whole chain-length window -- that is what stops the flap
+// and the 1/(1-p) gross-up drift the count-over-CL formula produced (#1482).
+inline double average_stale_prop(int stales, int lookbehind)
+{
+    if (stales < 0) stales = 0;
+    if (lookbehind < 0) lookbehind = 0;
+    const long denom = static_cast<long>(lookbehind) + static_cast<long>(stales);
+    return denom > 0 ? static_cast<double>(stales) / static_cast<double>(denom)
+                     : 0.0;
+}
+
+}  // namespace sharechain


### PR DESCRIPTION
Closes #1482 (follow-up to #1481).

The ltc.voidbind hashrate-graph rectangle, the stale-prop `0.05 ↔ 0.2875 ↔ 0.40` flap, and the routine `LOST CONTACT` banner are dashboard-feed artifacts, **not** convergence — at the observed moment the shared best share was verified on p2p-spb and advancing normally. All **READ-ONLY display** fixes; zero consensus / share / reward / wire surface (the vardiff retarget runs on the verified chain over `TARGET_LOOKBEHIND` and never reads any of these hooks).

## Fixes

**1. Coin-generic live-head selection SSOT** — `src/sharechain/pool_rate_head_select.hpp` (new)
`select_pool_rate_head()` anchors the pool-rate estimator on the pool's best-known **LIVE** head: the verified best share when its newest share is within the liveness horizon (600 s), else the LIVE raw head with the greatest `get_pool_attempts_per_second`. A head older than the horizon is dead and ignored even if its APS is larger; nothing live returns null so the caller holds last-good. This mirrors p2pool `web.py` feeding the graph off the node's current best head. The tallest-**RAW** rule it replaces flipped the anchor between two near-equal-height forks sample-to-sample — the rectangle.

A newest share whose timestamp is a few seconds **ahead** of the sampling clock (clock skew, or a legitimately future-dated share) produces a *negative* `now − ts` age. That is maximally **live**, not dead — but the first-cut sentinel of `-1` for "undatable" collided with it, so a share dated 1 s in the future read as undatable → the head went dead → the anchor flipped off the live verified head. Fixed with a `kUnknownAge = INT64_MIN` sentinel (unreachable by any wall-clock subtraction) and a liveness test that accepts any age ≤ horizon, negative included. KAT `FutureDatedHeadIsLive` pins it.

**2. Pool hashrate computed inside `publish_snapshot()`** — `src/impl/ltc/node.hpp`, `src/c2pool/main_ltc.cpp`
`TrackerSnapshot` now carries `pool_hashrate` + its compute timestamp, filled under the compute-thread exclusive tracker lock. `set_pool_hashrate_fn` reads the snapshot instead of try-locking and returning a cached last-good latch. That latch emitted bit-identical repeats whenever the try-lock lost to a `think()` chunk, which the web frozen-guard (`kMaxIdenticalPoolRateRun`) then zeroed into false 0-drops. The 600 s staleness bound (#57) is kept, keyed on the snapshot timestamp so a stalled `think()` still breaks the line.

**3. Anchored stale-prop** — `src/c2pool/main_ltc.cpp`, `src/core/web_server.cpp`
`sharechain_stats_fn` anchors on the same selected head and publishes `pool_stale_prop` as p2pool `data.py` `get_average_stale_prop` = `stales / (lookbehind + stales)` over `lookbehind = min(height, 3600/SHARE_PERIOD)`. `rest_global_stats` and `update_stat_log` prefer it when present. The fixed-lookbehind denominator **stabilises `p`** (stops the `0.05 ↔ 0.40` flap the count-over-whole-chain-length formula produced); the downstream `1/(1−p)` non-stale hashrate gross-up is not removed — it simply stops swinging once its `p` input is stable. Coin-generic: lanes that don't publish it keep the legacy whole-window value.

**4. `LOST CONTACT` watchdog — false positive fixed, real coin-peer stall surfaced** — `src/core/web_server.cpp` `rest_local_stats`
The stall threshold is now **≥3× the coin `block_period`** (from the `currency_info` source; LTC 150 s → 450 s) instead of a hardcoded 60 s that sat *below* one mean block interval, so a normal Poisson inter-block gap on a synced, peered node no longer fires the red banner. Zero coin peers is handled as its **own** condition rather than folded into the pool-peer warning: warning #4 counts POOL (sharechain) peers, a different network, so previously a genuine coin-P2P isolation while the tip was frozen went **silent**. When `tip_stalled && coin_peers == 0` the node now emits a red **`NO COIN P2P PEERS`** banner (only when the coin-sync provider is wired and reports 0 — lanes without the hook are unaffected). The benign sub-threshold gap on a still-peered node stays silent ("awaiting next block").

## Tests
`src/impl/ltc/test/pool_rate_head_select_test.cpp`, folded into the already-allowlisted `share_test` target (no new `add_executable`): `VerifiedBestLiveWins`, `FutureDatedHeadIsLive`, `StaleVerifiedBestYieldsFastestLiveRawHead`, `DeadForeignHeadIgnored`, `EmptyTrackerReturnsNull`, `StalePropFormulaMatchesP2pool`, plus tie-break and null-hash determinism. **PoolRateHeadSelect 11/11 green; `share_test` 125/125 green; `c2pool-ltc` builds; `check_param_catalog.py` + `check_test_target_allowlist.py` pass.**

LTC lane only. Deploy = operator binary-swap on contabo (the live node is >100 commits behind master).
