### PR TITLE
nmc/dgb/bch/ltc: port #1494 topological parent-presence + per-template spent-outpoint tx selection (#1437)

### DIFF
--- a/src/impl/bch/coin/mempool.hpp
+++ b/src/impl/bch/coin/mempool.hpp
@@ -377,6 +377,28 @@ public:
     /// Return transactions sorted by feerate (highest first), up to max_bytes.
     /// Transactions with known fees are prioritized; unknown-fee txs fill remaining space.
     /// Returns total_fees across all selected transactions (known fees only).
+    ///
+    /// #1437 — template validity: the selected set MUST be a self-consistent
+    /// block body or the daemon rejects the whole template
+    /// (bad-txns-inputs-missingorspent) and the found block is LOST. Two hazards
+    /// the naive highest-feerate-first pass admits:
+    ///   (a) child-without-parent — an input funded by another MEMPOOL tx (the
+    ///       parent) selected AFTER the child, or not selected at all. A block
+    ///       must place every parent before its children; a CPFP child normally
+    ///       out-feerates its parent, so pure feerate order emits the child
+    ///       first. Fix: a tx is admissible only once every one of its in-
+    ///       mempool parents is already selected (parents-before-children), and
+    ///       a fixed-point re-scan lets the high-feerate child still land in a
+    ///       later pass — never dropped, never mis-ordered. (BCH block order is
+    ///       canonical txid, but parent-PRESENCE is still required.)
+    ///   (b) intra-template double-spend — m_spent_outputs keeps only the LAST
+    ///       writer per outpoint, so two mempool txs spending the same outpoint
+    ///       both stay selectable. An outpoint may be spent by at most one tx in
+    ///       a block. Fix: a per-template consumed-outpoint set refuses the
+    ///       second spender (the lower-feerate one, visited later).
+    /// Reward-neutral: total_fees sums only INCLUDED txs' known fees, so
+    /// coinbasevalue tracks exactly the txs that ship — excluding an invalid tx
+    /// correctly excludes its fee (an invalid tx could never have paid it).
     std::pair<std::vector<SelectedTx>, uint64_t>
     get_sorted_txs_with_fees(uint32_t max_bytes) const {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -385,39 +407,71 @@ public:
         uint64_t total_fees = 0;
         uint32_t total_bytes = 0;
         std::set<uint256> selected;
+        // Per-template consumed outpoints — (a) prevents intra-template
+        // double-spend (b). One entry per input of every already-selected tx.
+        std::set<std::pair<uint256, uint32_t>> consumed;
 
-        // Pass 1: highest feerate first (known-fee txs)
         auto* utxo = m_utxo.load();
-        for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
-            auto pit = m_pool.find(it->second);
-            if (pit == m_pool.end()) continue;
-            const auto& entry = pit->second;
-            if (!entry.fee_known) continue;
-            if (total_bytes + entry.byte_size > max_bytes) continue;
 
-            // Guard: verify inputs still exist in UTXO (or parent mempool tx).
-            // Catches stale txs in the window between tip-change and full_block arrival.
-            if (utxo) {
-                bool inputs_ok = true;
-                for (const auto& vin : entry.tx.vin) {
-                    core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
+        // Can `entry` join the template given the current selection state?
+        //   - refuse if any input outpoint is already consumed (double-spend)
+        //   - if an input is funded by another MEMPOOL tx (parent), that parent
+        //     must already be selected (topological: parents before children);
+        //     otherwise defer — a later fixed-point pass admits it once the
+        //     parent lands.
+        //   - with a UTXO view: an input in neither the UTXO set nor a mempool
+        //     parent is stale/orphan — refuse (unchanged pre-#1437 guard).
+        //   - without a UTXO view: an input with no mempool parent is assumed a
+        //     confirmed coin we cannot see (unchanged legacy behaviour; the fee
+        //     was computable, so the input resolved at add time).
+        auto admissible = [&](const MempoolEntry& entry) -> bool {
+            for (const auto& vin : entry.tx.vin) {
+                std::pair<uint256, uint32_t> op(vin.prevout.hash, vin.prevout.index);
+                if (consumed.count(op)) return false;  // intra-template double-spend
+
+                auto parent = m_pool.find(vin.prevout.hash);
+                const bool has_mempool_parent =
+                    parent != m_pool.end() &&
+                    vin.prevout.index < parent->second.tx.vout.size();
+
+                if (has_mempool_parent) {
+                    if (!selected.count(vin.prevout.hash))
+                        return false;  // parent not yet in template — defer
+                } else if (utxo) {
+                    core::coin::Outpoint uop(vin.prevout.hash, vin.prevout.index);
                     core::coin::Coin coin;
-                    if (!utxo->get_coin(op, coin)) {
-                        // Check if parent is in mempool (CPFP chain)
-                        if (!m_pool.count(vin.prevout.hash) ||
-                            vin.prevout.index >= m_pool.at(vin.prevout.hash).tx.vout.size()) {
-                            inputs_ok = false;
-                            break;
-                        }
-                    }
+                    if (!utxo->get_coin(uop, coin))
+                        return false;  // absent from UTXO and mempool — stale
                 }
-                if (!inputs_ok) continue;  // skip stale tx
             }
+            return true;
+        };
 
-            total_bytes += entry.byte_size;
-            total_fees += entry.fee;
-            result.push_back({entry.tx, entry.fee, true});
-            selected.insert(entry.txid);
+        // Fixed-point selection over the feerate index (highest first). Each
+        // pass admits every currently-admissible fee-known tx; passes repeat
+        // until one adds nothing, so a high-feerate CPFP child admitted only
+        // after its lower-feerate parent still lands — parent first, never
+        // dropped. Bounded by the tx count (each pass adds ≥1 or terminates).
+        bool progress = true;
+        while (progress) {
+            progress = false;
+            for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
+                if (selected.count(it->second)) continue;  // already in template
+                auto pit = m_pool.find(it->second);
+                if (pit == m_pool.end()) continue;
+                const auto& entry = pit->second;
+                if (!entry.fee_known) continue;
+                if (total_bytes + entry.byte_size > max_bytes) continue;
+                if (!admissible(entry)) continue;
+
+                total_bytes += entry.byte_size;
+                total_fees += entry.fee;
+                result.push_back({entry.tx, entry.fee, true});
+                selected.insert(entry.txid);
+                for (const auto& vin : entry.tx.vin)
+                    consumed.emplace(vin.prevout.hash, vin.prevout.index);
+                progress = true;
+            }
         }
 
         // Unknown-fee txs excluded from template — they'll be included

--- a/src/impl/bch/test/CMakeLists.txt
+++ b/src/impl/bch/test/CMakeLists.txt
@@ -256,8 +256,13 @@ if(BUILD_TESTING)
     # add, which CTest would then report as a silently-passing NOT_BUILT sentinel.
     target_sources(bch_embedded_block_broadcast_test PRIVATE broadcast_gate_test.cpp)
 
+    # #1437 topology KAT (child-without-parent + intra-template double-spend)
+    # rides this EXISTING allowlisted target (bch tree is plain main()/CHECK,
+    # no GTest); run_template_topology_spend_checks() is invoked from the
+    # roundtrip test's main (no new executable / no #143 NOT_BUILT trap).
     add_executable(bch_g2_block_assembly_roundtrip_test
         g2_block_assembly_roundtrip_test.cpp
+        template_topology_spend_test.cpp
         ${CMAKE_SOURCE_DIR}/src/impl/bch/coin/transaction.cpp)
     target_include_directories(bch_g2_block_assembly_roundtrip_test PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_link_libraries(bch_g2_block_assembly_roundtrip_test PRIVATE

--- a/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
+++ b/src/impl/bch/test/g2_block_assembly_roundtrip_test.cpp
@@ -536,6 +536,9 @@ void test_won_block_undecodable_username_refuses_share()
 
 } // namespace
 
+// #1437 topology KAT, defined in template_topology_spend_test.cpp (same target).
+int run_template_topology_spend_checks();
+
 int main()
 {
     test_roundtrip_ok();
@@ -547,6 +550,9 @@ int main()
     test_won_block_survives_throwing_share_write();
     test_plain_share_still_writes_and_does_not_broadcast();
     test_won_block_undecodable_username_refuses_share();
+
+    // #1437: mempool tx-selection topology + intra-template double-spend guard.
+    failures += run_template_topology_spend_checks();
 
     if (failures) {
         std::cerr << failures << " CHECK(s) failed\n";

--- a/src/impl/bch/test/template_topology_spend_test.cpp
+++ b/src/impl/bch/test/template_topology_spend_test.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// bch_template_topology_spend (rides bch_g2_block_assembly_roundtrip_test)
+// -- #1437 KAT.
+//
+// Pins bch::coin::Mempool::get_sorted_txs_with_fees() as a producer of a
+// SELF-CONSISTENT block body. The embedded template builder feeds this set
+// straight into transactions[] and the tx-merkle; if the set is not a valid
+// block body, the daemon rejects the whole template
+// (bad-txns-inputs-missingorspent) and the found block is LOST. BCH block order
+// is canonical txid, but parent-PRESENCE and no-double-spend are still block
+// validity invariants the naive selector violated.
+//
+// Two hazards the naive highest-feerate-first selector admitted, both proven
+// here as regression witnesses and then proven fixed:
+//   (a) child-without-parent -- a tx funded by another mempool tx (the parent)
+//       absent from / ordered after the child.
+//   (b) intra-template double-spend -- two mempool txs spending the SAME
+//       outpoint both selected.
+//
+// HARNESS: the bch test tree is plain int main()/assert (no GTest), so this TU
+// exposes run_template_topology_spend_checks() and rides the already-allowlisted
+// bch_g2_block_assembly_roundtrip_test executable -- no build.yml --target
+// allowlist change. Consensus surface: NONE (tx SELECTION only; minting/payout
+// untouched). Per-coin isolation: src/impl/bch/ only.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <iostream>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+#include <impl/bch/coin/mempool.hpp>
+#include <impl/bch/coin/merkle.hpp>
+#include <impl/bch/coin/transaction.hpp>
+
+namespace {
+
+using bch::coin::Mempool;
+using bch::coin::MutableTransaction;
+using bch::coin::TxIn;
+using bch::coin::TxOut;
+using bch::coin::compute_txid;
+using bch::coin::compute_merkle_root;
+
+int g_failures = 0;
+
+void check(bool ok, const char* what)
+{
+    if (!ok) {
+        ++g_failures;
+        std::cerr << "  FAIL: " << what << "\n";
+    }
+}
+
+// One-in, one-out payment. The output value tags the tx so distinct txids fall
+// out even when two txs spend the same input (the double-spend pair).
+MutableTransaction pay(const uint256& prev_hash, uint32_t prev_index, int64_t out_value)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash  = prev_hash;
+    in.prevout.index = prev_index;
+    in.sequence      = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = out_value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+uint256 h(const char* hex) { uint256 v; v.SetHex(hex); return v; }
+
+const uint256 CONFIRMED_A = h("00000000000000000000000000000000000000000000000000000000000000a1");
+const uint256 CONFIRMED_X = h("00000000000000000000000000000000000000000000000000000000000000b2");
+
+std::set<uint256> txid_set(const std::vector<Mempool::SelectedTx>& sel)
+{
+    std::set<uint256> s;
+    for (const auto& t : sel) s.insert(compute_txid(t.tx));
+    return s;
+}
+
+bool has(const std::set<uint256>& s, const uint256& id) { return s.count(id) != 0; }
+
+// BCH selection uses raw bytes as the budget; cap large enough to admit all.
+const uint32_t BCH_CAP = 32'000'000u;
+
+} // namespace
+
+int run_template_topology_spend_checks()
+{
+    g_failures = 0;
+
+    // -- Test 1b: child whose parent cannot be selected is EXCLUDED -----------
+    {
+        Mempool mp;
+        MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+        uint256 pid = compute_txid(P);
+        MutableTransaction C = pay(pid, 0, 90000);
+        uint256 cid = compute_txid(C);
+
+        check(mp.add_tx(P), "1b: add parent (fee unknown)");
+        check(mp.add_tx(C), "1b: add child");
+        mp.set_tx_fee(cid, 8000);   // child fee known; parent stays unknown
+
+        auto [sel, fees] = mp.get_sorted_txs_with_fees(BCH_CAP);
+        auto s = txid_set(sel);
+        check(!has(s, cid), "1b: child-without-parent excluded (else lost block)");
+        check(!has(s, pid), "1b: unknown-fee parent not selected");
+        check(sel.empty(), "1b: empty template");
+        check(fees == 0u, "1b: zero fees");
+    }
+
+    // -- Test 1a: CPFP child selected alongside its parent (both present) ------
+    {
+        Mempool mp;
+        MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+        uint256 pid = compute_txid(P);
+        MutableTransaction C = pay(pid, 0, 90000);
+        uint256 cid = compute_txid(C);
+
+        check(mp.add_tx(P), "1a: add parent");
+        check(mp.add_tx(C), "1a: add child");
+        mp.set_tx_fee(pid, 200);    // low feerate parent
+        mp.set_tx_fee(cid, 8000);   // high feerate child (CPFP)
+
+        auto [sel, fees] = mp.get_sorted_txs_with_fees(BCH_CAP);
+        auto s = txid_set(sel);
+        check(sel.size() == 2u, "1a: both parent and child ship");
+        check(has(s, pid) && has(s, cid), "1a: parent present with child");
+        check(fees == 200u + 8000u, "1a: both fees counted (reward-neutral)");
+    }
+
+    // -- Test 2: intra-template double-spend -> only one spender ships --------
+    {
+        Mempool mp;
+        MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+        MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);   // same input
+        uint256 d1 = compute_txid(D1);
+        uint256 d2 = compute_txid(D2);
+        check(d1 != d2, "2: distinct double-spend txids");
+
+        check(mp.add_tx(D1), "2: add D1");
+        check(mp.add_tx(D2), "2: add D2");
+        mp.set_tx_fee(d1, 5000);    // higher feerate -> visited first -> wins
+        mp.set_tx_fee(d2, 1000);
+
+        auto [sel, fees] = mp.get_sorted_txs_with_fees(BCH_CAP);
+        check(sel.size() == 1u, "2: only one double-spender admitted (else lost block)");
+        check(!sel.empty() && compute_txid(sel[0].tx) == d1, "2: higher-feerate spender wins");
+        check(fees == 5000u, "2: winner's fee only");
+
+        int consumers = 0;
+        for (const auto& t : sel)
+            for (const auto& vin : t.tx.vin)
+                if (vin.prevout.hash == CONFIRMED_X && vin.prevout.index == 0) ++consumers;
+        check(consumers == 1, "2: shared outpoint consumed exactly once");
+    }
+
+    // -- Test 3: pruned set is a valid body + tx-merkle over exactly that set --
+    {
+        Mempool mp;
+        MutableTransaction A = pay(h("00000000000000000000000000000000000000000000000000000000000000c3"), 0, 50000);
+        uint256 aid = compute_txid(A);
+        MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+        MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);
+        uint256 d1 = compute_txid(D1), d2 = compute_txid(D2);
+        MutableTransaction OP = pay(CONFIRMED_A, 0, 70000);
+        uint256 opid = compute_txid(OP);
+        MutableTransaction OC = pay(opid, 0, 60000);
+        uint256 ocid = compute_txid(OC);
+
+        check(mp.add_tx(A), "3: add A");
+        check(mp.add_tx(D1), "3: add D1");
+        check(mp.add_tx(D2), "3: add D2");
+        check(mp.add_tx(OP), "3: add OP (fee unknown)");
+        check(mp.add_tx(OC), "3: add OC");
+        mp.set_tx_fee(aid, 3000);
+        mp.set_tx_fee(d1, 5000);
+        mp.set_tx_fee(d2, 4000);
+        mp.set_tx_fee(ocid, 8000);
+
+        auto [sel, fees] = mp.get_sorted_txs_with_fees(BCH_CAP);
+        auto s = txid_set(sel);
+        check(!has(s, d2), "3: losing double-spender excluded");
+        check(!has(s, ocid), "3: orphan child excluded");
+        check(!has(s, opid), "3: unknown-fee parent excluded");
+        check(has(s, aid), "3: clean tx included");
+        check(has(s, d1), "3: winning double-spender included");
+        check(fees == 3000u + 5000u, "3: fees == included known fees");
+
+        // Invariant (i): no shared input across the selected set.
+        std::set<std::pair<uint256, uint32_t>> consumed;
+        bool no_dup = true;
+        for (const auto& t : sel)
+            for (const auto& vin : t.tx.vin) {
+                auto op = std::make_pair(vin.prevout.hash, vin.prevout.index);
+                if (consumed.count(op)) no_dup = false;
+                consumed.insert(op);
+            }
+        check(no_dup, "3: no double-spend survived pruning");
+
+        // Invariant (ii): any selected tx whose input funds from a MEMPOOL tx
+        // must have that parent in the selected set (BCH order is canonical
+        // txid, so we assert presence, not position). A selected tx spending
+        // the excluded orphan parent OP would fail this.
+        const std::set<uint256> pool_ids{aid, d1, d2, opid, ocid};
+        bool parents_present = true;
+        for (const auto& t : sel)
+            for (const auto& vin : t.tx.vin)
+                if (pool_ids.count(vin.prevout.hash) && !has(s, vin.prevout.hash))
+                    parents_present = false;   // selected child of an unselected mempool parent
+        check(parents_present, "3: every mempool parent of a selected tx is present");
+
+        // Invariant (iii): tx-merkle over exactly the pruned set is well-defined
+        // and differs from the merkle over the invalid full set.
+        std::vector<uint256> leaves;
+        for (const auto& t : sel) leaves.push_back(compute_txid(t.tx));
+        uint256 pruned_root = compute_merkle_root(leaves);
+        check(pruned_root != uint256::ZERO, "3: pruned merkle non-zero");
+        check(pruned_root == compute_merkle_root(leaves), "3: pruned merkle deterministic");
+
+        std::vector<uint256> with_bad = leaves;
+        with_bad.push_back(d2);
+        with_bad.push_back(ocid);
+        check(pruned_root != compute_merkle_root(with_bad),
+              "3: merkle over the invalid full set differs from the pruned set");
+    }
+
+    if (g_failures == 0)
+        std::cout << "  template_topology_spend: all checks passed\n";
+    return g_failures;
+}

--- a/src/impl/dgb/coin/mempool.hpp
+++ b/src/impl/dgb/coin/mempool.hpp
@@ -347,6 +347,27 @@ public:
     /// Return transactions sorted by feerate (highest first), up to max_weight.
     /// Transactions with known fees are prioritized; unknown-fee txs fill remaining space.
     /// Returns total_fees across all selected transactions (known fees only).
+    ///
+    /// #1437 — template validity: the selected set MUST be a self-consistent
+    /// block body or the daemon rejects the whole template
+    /// (bad-txns-inputs-missingorspent) and the found block is LOST. Two hazards
+    /// the naive highest-feerate-first pass admits:
+    ///   (a) child-without-parent — an input funded by another MEMPOOL tx (the
+    ///       parent) selected AFTER the child, or not selected at all. A block
+    ///       must place every parent before its children; a CPFP child normally
+    ///       out-feerates its parent, so pure feerate order emits the child
+    ///       first. Fix: a tx is admissible only once every one of its in-
+    ///       mempool parents is already selected (parents-before-children), and
+    ///       a fixed-point re-scan lets the high-feerate child still land in a
+    ///       later pass — never dropped, never mis-ordered.
+    ///   (b) intra-template double-spend — m_spent_outputs keeps only the LAST
+    ///       writer per outpoint, so two mempool txs spending the same outpoint
+    ///       both stay selectable. An outpoint may be spent by at most one tx in
+    ///       a block. Fix: a per-template consumed-outpoint set refuses the
+    ///       second spender (the lower-feerate one, visited later).
+    /// Reward-neutral: total_fees sums only INCLUDED txs' known fees, so
+    /// coinbasevalue tracks exactly the txs that ship — excluding an invalid tx
+    /// correctly excludes its fee (an invalid tx could never have paid it).
     std::pair<std::vector<SelectedTx>, uint64_t>
     get_sorted_txs_with_fees(uint32_t max_weight) const {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -355,39 +376,71 @@ public:
         uint64_t total_fees = 0;
         uint32_t total_weight = 0;
         std::set<uint256> selected;
+        // Per-template consumed outpoints — (a) prevents intra-template
+        // double-spend (b). One entry per input of every already-selected tx.
+        std::set<std::pair<uint256, uint32_t>> consumed;
 
-        // Pass 1: highest feerate first (known-fee txs)
         auto* utxo = m_utxo.load();
-        for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
-            auto pit = m_pool.find(it->second);
-            if (pit == m_pool.end()) continue;
-            const auto& entry = pit->second;
-            if (!entry.fee_known) continue;
-            if (total_weight + entry.weight > max_weight) continue;
 
-            // Guard: verify inputs still exist in UTXO (or parent mempool tx).
-            // Catches stale txs in the window between tip-change and full_block arrival.
-            if (utxo) {
-                bool inputs_ok = true;
-                for (const auto& vin : entry.tx.vin) {
-                    core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
+        // Can `entry` join the template given the current selection state?
+        //   - refuse if any input outpoint is already consumed (double-spend)
+        //   - if an input is funded by another MEMPOOL tx (parent), that parent
+        //     must already be selected (topological: parents before children);
+        //     otherwise defer — a later fixed-point pass admits it once the
+        //     parent lands.
+        //   - with a UTXO view: an input in neither the UTXO set nor a mempool
+        //     parent is stale/orphan — refuse (unchanged pre-#1437 guard).
+        //   - without a UTXO view: an input with no mempool parent is assumed a
+        //     confirmed coin we cannot see (unchanged legacy behaviour; the fee
+        //     was computable, so the input resolved at add time).
+        auto admissible = [&](const MempoolEntry& entry) -> bool {
+            for (const auto& vin : entry.tx.vin) {
+                std::pair<uint256, uint32_t> op(vin.prevout.hash, vin.prevout.index);
+                if (consumed.count(op)) return false;  // intra-template double-spend
+
+                auto parent = m_pool.find(vin.prevout.hash);
+                const bool has_mempool_parent =
+                    parent != m_pool.end() &&
+                    vin.prevout.index < parent->second.tx.vout.size();
+
+                if (has_mempool_parent) {
+                    if (!selected.count(vin.prevout.hash))
+                        return false;  // parent not yet in template — defer
+                } else if (utxo) {
+                    core::coin::Outpoint uop(vin.prevout.hash, vin.prevout.index);
                     core::coin::Coin coin;
-                    if (!utxo->get_coin(op, coin)) {
-                        // Check if parent is in mempool (CPFP chain)
-                        if (!m_pool.count(vin.prevout.hash) ||
-                            vin.prevout.index >= m_pool.at(vin.prevout.hash).tx.vout.size()) {
-                            inputs_ok = false;
-                            break;
-                        }
-                    }
+                    if (!utxo->get_coin(uop, coin))
+                        return false;  // absent from UTXO and mempool — stale
                 }
-                if (!inputs_ok) continue;  // skip stale tx
             }
+            return true;
+        };
 
-            total_weight += entry.weight;
-            total_fees += entry.fee;
-            result.push_back({entry.tx, entry.fee, true});
-            selected.insert(entry.txid);
+        // Fixed-point selection over the feerate index (highest first). Each
+        // pass admits every currently-admissible fee-known tx; passes repeat
+        // until one adds nothing, so a high-feerate CPFP child admitted only
+        // after its lower-feerate parent still lands — parent first, never
+        // dropped. Bounded by the tx count (each pass adds ≥1 or terminates).
+        bool progress = true;
+        while (progress) {
+            progress = false;
+            for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
+                if (selected.count(it->second)) continue;  // already in template
+                auto pit = m_pool.find(it->second);
+                if (pit == m_pool.end()) continue;
+                const auto& entry = pit->second;
+                if (!entry.fee_known) continue;
+                if (total_weight + entry.weight > max_weight) continue;
+                if (!admissible(entry)) continue;
+
+                total_weight += entry.weight;
+                total_fees += entry.fee;
+                result.push_back({entry.tx, entry.fee, true});
+                selected.insert(entry.txid);
+                for (const auto& vin : entry.tx.vin)
+                    consumed.emplace(vin.prevout.hash, vin.prevout.index);
+                progress = true;
+            }
         }
 
         // Unknown-fee txs excluded from template — they'll be included

--- a/src/impl/dgb/test/CMakeLists.txt
+++ b/src/impl/dgb/test/CMakeLists.txt
@@ -374,7 +374,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     # the tx serialization codec, so it links the same proven SCC set as
     # dgb_embedded_coin_node_test. MUST also be in BOTH build.yml --target
     # allowlists (#143 NOT_BUILT trap).
-    add_executable(dgb_embedded_tx_select_test embedded_tx_select_test.cpp)
+    # #1437 topology KAT (child-without-parent + intra-template double-spend)
+    # folds into this EXISTING allowlisted target; gtest_add_tests AUTO discovers
+    # its TEST() cases (no new executable / no #143 NOT_BUILT trap).
+    add_executable(dgb_embedded_tx_select_test embedded_tx_select_test.cpp template_topology_spend_test.cpp)
     target_link_libraries(dgb_embedded_tx_select_test PRIVATE
         GTest::gtest_main GTest::gtest
         core dgb dgb_stratum

--- a/src/impl/dgb/test/template_topology_spend_test.cpp
+++ b/src/impl/dgb/test/template_topology_spend_test.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// dgb_template_topology_spend (rides dgb_template_builder_test) -- #1437 KAT.
+//
+// Pins dgb::coin::Mempool::get_sorted_txs_with_fees() as a producer of a
+// SELF-CONSISTENT block body. The embedded template builder feeds this set
+// straight into transactions[] and the tx-merkle; if the set is not a valid
+// block body, the daemon rejects the whole template
+// (bad-txns-inputs-missingorspent) and the found block is LOST.
+//
+// Two hazards the naive highest-feerate-first selector admitted, both proven
+// here as regression witnesses (the OLD, pure-feerate admission would have
+// shipped the invalid set) and then proven fixed:
+//   (a) child-without-parent -- a tx funded by another mempool tx (the parent)
+//       ordered after the child, or absent from the template entirely.
+//   (b) intra-template double-spend -- two mempool txs spending the SAME
+//       outpoint both selected.
+// Plus: the tx-merkle over the pruned set is well-defined and the pruned set
+// upholds both invariants (no double-spend, parents-before-children).
+//
+// UTXO-free: fees are pinned with Mempool::set_tx_fee (utxo view = null), the
+// exact legacy no-UTXO path the old selector treated as "admit every fee-known
+// tx in feerate order". Per-coin isolation: src/impl/dgb/ only.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+#include <impl/dgb/coin/mempool.hpp>
+#include <impl/dgb/coin/merkle_root.hpp>
+#include <impl/dgb/coin/transaction.hpp>
+
+namespace {
+
+using dgb::coin::Mempool;
+using dgb::coin::MutableTransaction;
+using dgb::coin::TxIn;
+using dgb::coin::TxOut;
+using dgb::coin::compute_txid;
+using dgb::coin::build_block_merkle_root;
+
+// One-in, one-out payment. The output value tags the tx so distinct txids fall
+// out even when two txs spend the same input (the double-spend pair).
+MutableTransaction pay(const uint256& prev_hash, uint32_t prev_index, int64_t out_value)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash  = prev_hash;
+    in.prevout.index = prev_index;
+    in.sequence      = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = out_value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+uint256 h(const char* hex)
+{
+    uint256 v;
+    v.SetHex(hex);
+    return v;
+}
+
+// A confirmed-looking funding outpoint hash NOT present in the mempool.
+const uint256 CONFIRMED_A = h("00000000000000000000000000000000000000000000000000000000000000a1");
+const uint256 CONFIRMED_X = h("00000000000000000000000000000000000000000000000000000000000000b2");
+
+std::set<uint256> txid_set(const std::vector<Mempool::SelectedTx>& sel)
+{
+    std::set<uint256> s;
+    for (const auto& t : sel) s.insert(compute_txid(t.tx));
+    return s;
+}
+
+int index_of(const std::vector<Mempool::SelectedTx>& sel, const uint256& id)
+{
+    for (int i = 0; i < static_cast<int>(sel.size()); ++i)
+        if (compute_txid(sel[i].tx) == id) return i;
+    return -1;
+}
+
+} // namespace
+
+// --- Test 1a: CPFP child never precedes its parent (topological order) --------
+TEST(DgbTemplateTopologySpend, CpfpChildOrderedAfterParent)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);      // spends P's output 0
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(pid, 200);    // low feerate parent
+    mp.set_tx_fee(cid, 8000);   // high feerate child (CPFP)
+
+    auto pe = mp.get_entry(pid);
+    auto ce = mp.get_entry(cid);
+    ASSERT_TRUE(pe && ce);
+    ASSERT_GT(ce->feerate(), pe->feerate());
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    ASSERT_EQ(sel.size(), 2u);
+    int ip = index_of(sel, pid), ic = index_of(sel, cid);
+    ASSERT_GE(ip, 0);
+    ASSERT_GE(ic, 0);
+    EXPECT_LT(ip, ic) << "child emitted before its parent -> bad-txns-inputs-missingorspent";
+    EXPECT_EQ(fees, 200u + 8000u);   // both fees counted; reward-neutral
+}
+
+// --- Test 1b: child whose parent cannot be selected is EXCLUDED ---------------
+TEST(DgbTemplateTopologySpend, ChildWithoutSelectableParentExcluded)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));   // fee UNKNOWN -> never selected
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(cid, 8000);    // child fee known
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(cid), 0u) << "child-without-parent admitted -> lost block";
+    EXPECT_EQ(s.count(pid), 0u);
+    EXPECT_TRUE(sel.empty());
+    EXPECT_EQ(fees, 0u);
+}
+
+// --- Test 2: intra-template double-spend -> only one spender ships ------------
+TEST(DgbTemplateTopologySpend, IntraTemplateDoubleSpendPruned)
+{
+    Mempool mp;
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);   // same input, different txid
+    uint256 d1 = compute_txid(D1);
+    uint256 d2 = compute_txid(D2);
+    ASSERT_NE(d1, d2);
+
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    mp.set_tx_fee(d1, 5000);    // higher feerate -> visited first -> wins
+    mp.set_tx_fee(d2, 1000);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    ASSERT_EQ(sel.size(), 1u) << "both double-spenders admitted -> lost block";
+    EXPECT_EQ(compute_txid(sel[0].tx), d1);   // the higher-feerate spender
+    EXPECT_EQ(fees, 5000u);
+
+    int consumers = 0;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin)
+            if (vin.prevout.hash == CONFIRMED_X && vin.prevout.index == 0) ++consumers;
+    EXPECT_EQ(consumers, 1);
+}
+
+// --- Test 3: pruned set is a valid body + tx-merkle over exactly that set -----
+TEST(DgbTemplateTopologySpend, PrunedSetIsValidBodyAndMerkleMatches)
+{
+    Mempool mp;
+
+    MutableTransaction A = pay(h("00000000000000000000000000000000000000000000000000000000000000c3"), 0, 50000);
+    uint256 aid = compute_txid(A);
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);
+    uint256 d1 = compute_txid(D1), d2 = compute_txid(D2);
+
+    MutableTransaction OP = pay(CONFIRMED_A, 0, 70000);
+    uint256 opid = compute_txid(OP);
+    MutableTransaction OC = pay(opid, 0, 60000);
+    uint256 ocid = compute_txid(OC);
+
+    ASSERT_TRUE(mp.add_tx(A));
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    ASSERT_TRUE(mp.add_tx(OP));       // fee unknown
+    ASSERT_TRUE(mp.add_tx(OC));
+    mp.set_tx_fee(aid, 3000);
+    mp.set_tx_fee(d1, 5000);
+    mp.set_tx_fee(d2, 4000);
+    mp.set_tx_fee(ocid, 8000);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(d2), 0u);
+    EXPECT_EQ(s.count(ocid), 0u);
+    EXPECT_EQ(s.count(opid), 0u);
+    EXPECT_EQ(s.count(aid), 1u);
+    EXPECT_EQ(s.count(d1), 1u);
+    EXPECT_EQ(fees, 3000u + 5000u);
+
+    // Invariant (i): no shared input across the selected set.
+    std::set<std::pair<uint256, uint32_t>> consumed;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin) {
+            auto op = std::make_pair(vin.prevout.hash, vin.prevout.index);
+            EXPECT_EQ(consumed.count(op), 0u) << "double-spend survived pruning";
+            consumed.insert(op);
+        }
+
+    // Invariant (ii): every in-selected-set parent precedes its child.
+    for (int i = 0; i < static_cast<int>(sel.size()); ++i)
+        for (const auto& vin : sel[i].tx.vin) {
+            int pj = index_of(sel, vin.prevout.hash);
+            if (pj >= 0) EXPECT_LT(pj, i) << "child precedes parent in pruned set";
+        }
+
+    // Invariant (iii): tx-merkle over exactly the pruned set is well-defined.
+    std::vector<uint256> leaves;
+    for (const auto& t : sel) leaves.push_back(compute_txid(t.tx));
+    uint256 pruned_root = build_block_merkle_root(leaves);
+    EXPECT_NE(pruned_root, uint256::ZERO);
+    EXPECT_EQ(pruned_root, build_block_merkle_root(leaves));   // deterministic
+
+    std::vector<uint256> with_bad = leaves;
+    with_bad.push_back(d2);
+    with_bad.push_back(ocid);
+    EXPECT_NE(pruned_root, build_block_merkle_root(with_bad));
+}

--- a/src/impl/ltc/coin/mempool.hpp
+++ b/src/impl/ltc/coin/mempool.hpp
@@ -345,6 +345,28 @@ public:
     /// Return transactions sorted by feerate (highest first), up to max_weight.
     /// Transactions with known fees are prioritized; unknown-fee txs fill remaining space.
     /// Returns total_fees across all selected transactions (known fees only).
+    ///
+    /// #1437 — template validity: the selected set MUST be a self-consistent
+    /// block body or the daemon rejects the whole template
+    /// (bad-txns-inputs-missingorspent) and the found block is LOST. Two hazards
+    /// the naive highest-feerate-first pass admits (both Pass 1 AND the Pass 2
+    /// unknown-fee fill, which the DOGE template builder uses):
+    ///   (a) child-without-parent — an input funded by another MEMPOOL tx (the
+    ///       parent) selected AFTER the child, or not selected at all. A block
+    ///       must place every parent before its children; a CPFP child normally
+    ///       out-feerates its parent, so pure feerate order emits the child
+    ///       first. Fix: a tx is admissible only once every one of its in-
+    ///       mempool parents is already selected (parents-before-children), and
+    ///       a fixed-point re-scan lets the high-feerate child still land in a
+    ///       later pass — never dropped, never mis-ordered.
+    ///   (b) intra-template double-spend — m_spent_outputs keeps only the LAST
+    ///       writer per outpoint, so two mempool txs spending the same outpoint
+    ///       both stay selectable. An outpoint may be spent by at most one tx in
+    ///       a block. Fix: a per-template consumed-outpoint set (shared across
+    ///       both passes) refuses the second spender.
+    /// Reward-neutral: total_fees sums only INCLUDED txs' known fees, so
+    /// coinbasevalue tracks exactly the txs that ship; Pass 2 packs unknown-fee
+    /// txs with fee=0 (shaped as fee=null) and never touches total_fees.
     std::pair<std::vector<SelectedTx>, uint64_t>
     get_sorted_txs_with_fees(uint32_t max_weight,
                              bool fill_unknown_fee = false) const {
@@ -354,39 +376,72 @@ public:
         uint64_t total_fees = 0;
         uint32_t total_weight = 0;
         std::set<uint256> selected;
+        // Per-template consumed outpoints — shared across both passes so an
+        // unknown-fee spender can never double-spend a Pass-1 outpoint (or
+        // another Pass-2 tx's). One entry per input of every selected tx.
+        std::set<std::pair<uint256, uint32_t>> consumed;
 
-        // Pass 1: highest feerate first (known-fee txs)
         auto* utxo = m_utxo.load();
-        for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
-            auto pit = m_pool.find(it->second);
-            if (pit == m_pool.end()) continue;
-            const auto& entry = pit->second;
-            if (!entry.fee_known) continue;
-            if (total_weight + entry.weight > max_weight) continue;
 
-            // Guard: verify inputs still exist in UTXO (or parent mempool tx).
-            // Catches stale txs in the window between tip-change and full_block arrival.
-            if (utxo) {
-                bool inputs_ok = true;
-                for (const auto& vin : entry.tx.vin) {
-                    core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
+        // Can `entry` join the template given the current selection state?
+        //   - refuse if any input outpoint is already consumed (double-spend)
+        //   - if an input is funded by another MEMPOOL tx (parent), that parent
+        //     must already be selected (topological: parents before children);
+        //     otherwise defer — a later fixed-point pass admits it once the
+        //     parent lands.
+        //   - with a UTXO view: an input in neither the UTXO set nor a mempool
+        //     parent is stale/orphan — refuse (unchanged pre-#1437 guard).
+        //   - without a UTXO view: an input with no mempool parent is assumed a
+        //     confirmed coin we cannot see (unchanged legacy behaviour; the fee
+        //     was computable, so the input resolved at add time).
+        auto admissible = [&](const MempoolEntry& entry) -> bool {
+            for (const auto& vin : entry.tx.vin) {
+                std::pair<uint256, uint32_t> op(vin.prevout.hash, vin.prevout.index);
+                if (consumed.count(op)) return false;  // intra-template double-spend
+
+                auto parent = m_pool.find(vin.prevout.hash);
+                const bool has_mempool_parent =
+                    parent != m_pool.end() &&
+                    vin.prevout.index < parent->second.tx.vout.size();
+
+                if (has_mempool_parent) {
+                    if (!selected.count(vin.prevout.hash))
+                        return false;  // parent not yet in template — defer
+                } else if (utxo) {
+                    core::coin::Outpoint uop(vin.prevout.hash, vin.prevout.index);
                     core::coin::Coin coin;
-                    if (!utxo->get_coin(op, coin)) {
-                        // Check if parent is in mempool (CPFP chain)
-                        if (!m_pool.count(vin.prevout.hash) ||
-                            vin.prevout.index >= m_pool.at(vin.prevout.hash).tx.vout.size()) {
-                            inputs_ok = false;
-                            break;
-                        }
-                    }
+                    if (!utxo->get_coin(uop, coin))
+                        return false;  // absent from UTXO and mempool — stale
                 }
-                if (!inputs_ok) continue;  // skip stale tx
             }
+            return true;
+        };
 
-            total_weight += entry.weight;
-            total_fees += entry.fee;
-            result.push_back({entry.tx, entry.fee, true});
-            selected.insert(entry.txid);
+        // Pass 1: fixed-point selection over the feerate index (highest first).
+        // Each pass admits every currently-admissible fee-known tx; passes
+        // repeat until one adds nothing, so a high-feerate CPFP child admitted
+        // only after its lower-feerate parent still lands — parent first, never
+        // dropped. Bounded by the tx count (each pass adds ≥1 or terminates).
+        bool progress = true;
+        while (progress) {
+            progress = false;
+            for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
+                if (selected.count(it->second)) continue;  // already in template
+                auto pit = m_pool.find(it->second);
+                if (pit == m_pool.end()) continue;
+                const auto& entry = pit->second;
+                if (!entry.fee_known) continue;
+                if (total_weight + entry.weight > max_weight) continue;
+                if (!admissible(entry)) continue;
+
+                total_weight += entry.weight;
+                total_fees += entry.fee;
+                result.push_back({entry.tx, entry.fee, true});
+                selected.insert(entry.txid);
+                for (const auto& vin : entry.tx.vin)
+                    consumed.emplace(vin.prevout.hash, vin.prevout.index);
+                progress = true;
+            }
         }
 
         // ── Pass 2: fill remaining weight with unknown-fee txs (opt-in) ─────
@@ -401,39 +456,32 @@ public:
         // total_fees — hence coinbasevalue and the gentx — byte-for-byte
         // unchanged. Consensus-neutral for the share; opt-in so the proven LTC
         // parent path stays untouched.
+        // #1437: Pass 2 shares the same `admissible` predicate and `consumed`
+        // set as Pass 1, and runs as its own fixed point so an unknown-fee child
+        // of an unknown-fee parent still lands parent-first (topological), and no
+        // unknown-fee spender can double-spend an outpoint a Pass-1 tx already
+        // consumed (or another Pass-2 tx's). total_fees is never touched here.
         if (fill_unknown_fee) {
-            auto* utxo2 = m_utxo.load();
-            for (const auto& [ts, txid] : m_time_index) {
-                if (selected.count(txid)) continue;                 // in Pass 1 already
-                auto pit = m_pool.find(txid);
-                if (pit == m_pool.end()) continue;
-                const auto& entry = pit->second;
-                if (entry.fee_known) continue;                      // Pass 1 territory
-                if (total_weight + entry.weight > max_weight) continue;
+            bool progress2 = true;
+            while (progress2) {
+                progress2 = false;
+                for (const auto& [ts, txid] : m_time_index) {
+                    if (selected.count(txid)) continue;                 // already selected
+                    auto pit = m_pool.find(txid);
+                    if (pit == m_pool.end()) continue;
+                    const auto& entry = pit->second;
+                    if (entry.fee_known) continue;                      // Pass 1 territory
+                    if (total_weight + entry.weight > max_weight) continue;
+                    if (!admissible(entry)) continue;
 
-                // Same input-existence guard as Pass 1: never pack a tx that
-                // spends an output absent from BOTH the UTXO set and the mempool
-                // (CPFP parent). Genuinely stale txs stay excluded.
-                if (utxo2) {
-                    bool inputs_ok = true;
-                    for (const auto& vin : entry.tx.vin) {
-                        core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
-                        core::coin::Coin coin;
-                        if (!utxo2->get_coin(op, coin)) {
-                            if (!m_pool.count(vin.prevout.hash) ||
-                                vin.prevout.index >= m_pool.at(vin.prevout.hash).tx.vout.size()) {
-                                inputs_ok = false;
-                                break;
-                            }
-                        }
-                    }
-                    if (!inputs_ok) continue;
+                    total_weight += entry.weight;
+                    // fee intentionally NOT summed — unknown, shaped as fee=null.
+                    result.push_back({entry.tx, 0, false});
+                    selected.insert(entry.txid);
+                    for (const auto& vin : entry.tx.vin)
+                        consumed.emplace(vin.prevout.hash, vin.prevout.index);
+                    progress2 = true;
                 }
-
-                total_weight += entry.weight;
-                // fee intentionally NOT summed — unknown, shaped as fee=null.
-                result.push_back({entry.tx, 0, false});
-                selected.insert(entry.txid);
             }
         }
 

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -33,7 +33,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # pool_rate_head_select.hpp, issue #1482) — verified best when live, else the
     # fastest LIVE raw head; stale-prop = stales/(lookbehind+stales). Pure
     # header-only KAT. Same folding rule: into the existing allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp pool_rate_head_select_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp pool_rate_head_select_test.cpp template_topology_spend_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/template_topology_spend_test.cpp
+++ b/src/impl/ltc/test/template_topology_spend_test.cpp
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// ltc_template_topology_spend (rides share_test) -- #1437 KAT.
+//
+// Pins ltc::coin::Mempool::get_sorted_txs_with_fees() as a producer of a
+// SELF-CONSISTENT block body. The embedded template builder feeds this set
+// straight into transactions[] and the tx-merkle; if the set is not a valid
+// block body, the daemon rejects the whole template
+// (bad-txns-inputs-missingorspent) and the found block is LOST.
+//
+// Two hazards the naive highest-feerate-first selector admitted, both proven
+// here as regression witnesses (the OLD, pure-feerate admission would have
+// shipped the invalid set) and then proven fixed:
+//   (a) child-without-parent -- a tx funded by another mempool tx (the parent)
+//       ordered after the child, or absent from the template entirely.
+//   (b) intra-template double-spend -- two mempool txs spending the SAME
+//       outpoint both selected.
+// Plus: the tx-merkle over the pruned set is well-defined and the pruned set
+// upholds both invariants (no double-spend, parents-before-children).
+//
+// UTXO-free: fees are pinned with Mempool::set_tx_fee (utxo view = null), the
+// exact legacy no-UTXO path the old selector treated as "admit every fee-known
+// tx in feerate order". Per-coin isolation: src/impl/ltc/ only.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+#include <impl/ltc/coin/mempool.hpp>
+#include <impl/ltc/coin/template_builder.hpp>
+#include <impl/ltc/coin/transaction.hpp>
+
+namespace {
+
+using ltc::coin::Mempool;
+using ltc::coin::MutableTransaction;
+using ltc::coin::TxIn;
+using ltc::coin::TxOut;
+using ltc::coin::compute_txid;
+using ltc::coin::compute_merkle_root;
+
+// One-in, one-out payment. The output value tags the tx so distinct txids fall
+// out even when two txs spend the same input (the double-spend pair).
+MutableTransaction pay(const uint256& prev_hash, uint32_t prev_index, int64_t out_value)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash  = prev_hash;
+    in.prevout.index = prev_index;
+    in.sequence      = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = out_value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+uint256 h(const char* hex)
+{
+    uint256 v;
+    v.SetHex(hex);
+    return v;
+}
+
+// A confirmed-looking funding outpoint hash NOT present in the mempool.
+const uint256 CONFIRMED_A = h("00000000000000000000000000000000000000000000000000000000000000a1");
+const uint256 CONFIRMED_X = h("00000000000000000000000000000000000000000000000000000000000000b2");
+
+std::set<uint256> txid_set(const std::vector<Mempool::SelectedTx>& sel)
+{
+    std::set<uint256> s;
+    for (const auto& t : sel) s.insert(compute_txid(t.tx));
+    return s;
+}
+
+int index_of(const std::vector<Mempool::SelectedTx>& sel, const uint256& id)
+{
+    for (int i = 0; i < static_cast<int>(sel.size()); ++i)
+        if (compute_txid(sel[i].tx) == id) return i;
+    return -1;
+}
+
+} // namespace
+
+// --- Test 1a: CPFP child never precedes its parent (topological order) --------
+TEST(LtcTemplateTopologySpend, CpfpChildOrderedAfterParent)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);      // spends P's output 0
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(pid, 200);    // low feerate parent
+    mp.set_tx_fee(cid, 8000);   // high feerate child (CPFP)
+
+    auto pe = mp.get_entry(pid);
+    auto ce = mp.get_entry(cid);
+    ASSERT_TRUE(pe && ce);
+    ASSERT_GT(ce->feerate(), pe->feerate());
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    ASSERT_EQ(sel.size(), 2u);
+    int ip = index_of(sel, pid), ic = index_of(sel, cid);
+    ASSERT_GE(ip, 0);
+    ASSERT_GE(ic, 0);
+    EXPECT_LT(ip, ic) << "child emitted before its parent -> bad-txns-inputs-missingorspent";
+    EXPECT_EQ(fees, 200u + 8000u);   // both fees counted; reward-neutral
+}
+
+// --- Test 1b: child whose parent cannot be selected is EXCLUDED ---------------
+TEST(LtcTemplateTopologySpend, ChildWithoutSelectableParentExcluded)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));   // fee UNKNOWN -> never selected
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(cid, 8000);    // child fee known
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(cid), 0u) << "child-without-parent admitted -> lost block";
+    EXPECT_EQ(s.count(pid), 0u);
+    EXPECT_TRUE(sel.empty());
+    EXPECT_EQ(fees, 0u);
+}
+
+// --- Test 2: intra-template double-spend -> only one spender ships ------------
+TEST(LtcTemplateTopologySpend, IntraTemplateDoubleSpendPruned)
+{
+    Mempool mp;
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);   // same input, different txid
+    uint256 d1 = compute_txid(D1);
+    uint256 d2 = compute_txid(D2);
+    ASSERT_NE(d1, d2);
+
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    mp.set_tx_fee(d1, 5000);    // higher feerate -> visited first -> wins
+    mp.set_tx_fee(d2, 1000);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    ASSERT_EQ(sel.size(), 1u) << "both double-spenders admitted -> lost block";
+    EXPECT_EQ(compute_txid(sel[0].tx), d1);   // the higher-feerate spender
+    EXPECT_EQ(fees, 5000u);
+
+    int consumers = 0;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin)
+            if (vin.prevout.hash == CONFIRMED_X && vin.prevout.index == 0) ++consumers;
+    EXPECT_EQ(consumers, 1);
+}
+
+// --- Test 3: pruned set is a valid body + tx-merkle over exactly that set -----
+TEST(LtcTemplateTopologySpend, PrunedSetIsValidBodyAndMerkleMatches)
+{
+    Mempool mp;
+
+    MutableTransaction A = pay(h("00000000000000000000000000000000000000000000000000000000000000c3"), 0, 50000);
+    uint256 aid = compute_txid(A);
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);
+    uint256 d1 = compute_txid(D1), d2 = compute_txid(D2);
+
+    MutableTransaction OP = pay(CONFIRMED_A, 0, 70000);
+    uint256 opid = compute_txid(OP);
+    MutableTransaction OC = pay(opid, 0, 60000);
+    uint256 ocid = compute_txid(OC);
+
+    ASSERT_TRUE(mp.add_tx(A));
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    ASSERT_TRUE(mp.add_tx(OP));       // fee unknown
+    ASSERT_TRUE(mp.add_tx(OC));
+    mp.set_tx_fee(aid, 3000);
+    mp.set_tx_fee(d1, 5000);
+    mp.set_tx_fee(d2, 4000);
+    mp.set_tx_fee(ocid, 8000);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(d2), 0u);
+    EXPECT_EQ(s.count(ocid), 0u);
+    EXPECT_EQ(s.count(opid), 0u);
+    EXPECT_EQ(s.count(aid), 1u);
+    EXPECT_EQ(s.count(d1), 1u);
+    EXPECT_EQ(fees, 3000u + 5000u);
+
+    // Invariant (i): no shared input across the selected set.
+    std::set<std::pair<uint256, uint32_t>> consumed;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin) {
+            auto op = std::make_pair(vin.prevout.hash, vin.prevout.index);
+            EXPECT_EQ(consumed.count(op), 0u) << "double-spend survived pruning";
+            consumed.insert(op);
+        }
+
+    // Invariant (ii): every in-selected-set parent precedes its child.
+    for (int i = 0; i < static_cast<int>(sel.size()); ++i)
+        for (const auto& vin : sel[i].tx.vin) {
+            int pj = index_of(sel, vin.prevout.hash);
+            if (pj >= 0) EXPECT_LT(pj, i) << "child precedes parent in pruned set";
+        }
+
+    // Invariant (iii): tx-merkle over exactly the pruned set is well-defined.
+    std::vector<uint256> leaves;
+    for (const auto& t : sel) leaves.push_back(compute_txid(t.tx));
+    uint256 pruned_root = compute_merkle_root(leaves);
+    EXPECT_NE(pruned_root, uint256::ZERO);
+    EXPECT_EQ(pruned_root, compute_merkle_root(leaves));   // deterministic
+
+    std::vector<uint256> with_bad = leaves;
+    with_bad.push_back(d2);
+    with_bad.push_back(ocid);
+    EXPECT_NE(pruned_root, compute_merkle_root(with_bad));
+}
+
+// ===========================================================================
+// DOGE Pass-2 (fill_unknown_fee=true) topology KATs.
+//
+// The DOGE embedded template builder calls get_sorted_txs_with_fees(cap, true),
+// which packs unknown-fee txs (fee=null-shaped) after the fee-known Pass 1. The
+// pre-#1437 Pass 2 walked m_time_index with only a "parent present in pool"
+// guard -> it could pack an unknown-fee child before/without its parent, or a
+// second unknown-fee spender of an already-consumed outpoint. The fix shares
+// Pass 1's `admissible` predicate and `consumed` set and runs Pass 2 as its own
+// fixed point. total_fees is never touched by Pass 2 (doge underfill invariants
+// stay green).
+// ===========================================================================
+
+// --- Test 5: unknown-fee child packed AFTER its known-fee parent --------------
+TEST(LtcTemplateTopologySpend, DogeUnknownChildOrderedAfterKnownParent)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);      // spends P's output 0
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(pid, 200);    // known-fee parent -> Pass 1
+    // C left fee-unknown -> Pass 2 fill territory
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000, /*fill_unknown_fee=*/true);
+
+    ASSERT_EQ(sel.size(), 2u);
+    int ip = index_of(sel, pid), ic = index_of(sel, cid);
+    ASSERT_GE(ip, 0);
+    ASSERT_GE(ic, 0);
+    EXPECT_LT(ip, ic) << "unknown-fee child before parent -> bad-txns-inputs-missingorspent";
+    EXPECT_EQ(fees, 200u);      // only the known-fee parent contributes; Pass 2 fee=null
+}
+
+// --- Test 6: unknown-fee second spender refused (intra-template double-spend) --
+TEST(LtcTemplateTopologySpend, DogeUnknownDoubleSpendRefused)
+{
+    Mempool mp;
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);   // known-fee -> Pass 1 wins
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);    // unknown-fee -> Pass 2 attempt
+    uint256 d1 = compute_txid(D1);
+    uint256 d2 = compute_txid(D2);
+    ASSERT_NE(d1, d2);
+
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    mp.set_tx_fee(d1, 5000);    // D1 known -> consumes CONFIRMED_X:0 in Pass 1
+    // D2 unknown -> Pass 2 must refuse the already-consumed outpoint
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000, /*fill_unknown_fee=*/true);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(d1), 1u);
+    EXPECT_EQ(s.count(d2), 0u) << "unknown-fee double-spender admitted -> lost block";
+    EXPECT_EQ(fees, 5000u);
+
+    int consumers = 0;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin)
+            if (vin.prevout.hash == CONFIRMED_X && vin.prevout.index == 0) ++consumers;
+    EXPECT_EQ(consumers, 1);
+}
+
+// --- Test 7: unknown-fee child of an unknown-fee parent -> fixed point ---------
+// Both P and C are fee-unknown; only the Pass-2 fixed point lands them, parent
+// first. A single non-iterating pass ordered by arrival could emit C before P.
+TEST(LtcTemplateTopologySpend, DogeUnknownChainFixedPointParentFirst)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);
+    uint256 cid = compute_txid(C);
+
+    // Add the child FIRST so a naive m_time_index walk would visit C before P.
+    ASSERT_TRUE(mp.add_tx(C));
+    ASSERT_TRUE(mp.add_tx(P));
+    // both fee-unknown
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000, /*fill_unknown_fee=*/true);
+
+    ASSERT_EQ(sel.size(), 2u);
+    int ip = index_of(sel, pid), ic = index_of(sel, cid);
+    ASSERT_GE(ip, 0);
+    ASSERT_GE(ic, 0);
+    EXPECT_LT(ip, ic) << "fixed point failed to order unknown-fee parent before child";
+    EXPECT_EQ(fees, 0u);        // both Pass 2 -> fee=null, total_fees untouched
+}

--- a/src/impl/nmc/coin/mempool.hpp
+++ b/src/impl/nmc/coin/mempool.hpp
@@ -458,6 +458,27 @@ public:
     /// Return transactions sorted by feerate (highest first), up to max_weight.
     /// Transactions with known fees are prioritized; unknown-fee txs fill remaining space.
     /// Returns total_fees across all selected transactions (known fees only).
+    ///
+    /// #1437 — template validity: the selected set MUST be a self-consistent
+    /// block body or the daemon rejects the whole template
+    /// (bad-txns-inputs-missingorspent) and the found block is LOST. Two hazards
+    /// the naive highest-feerate-first pass admits:
+    ///   (a) child-without-parent — an input funded by another MEMPOOL tx (the
+    ///       parent) selected AFTER the child, or not selected at all. A block
+    ///       must place every parent before its children; a CPFP child normally
+    ///       out-feerates its parent, so pure feerate order emits the child
+    ///       first. Fix: a tx is admissible only once every one of its in-
+    ///       mempool parents is already selected (parents-before-children), and
+    ///       a fixed-point re-scan lets the high-feerate child still land in a
+    ///       later pass — never dropped, never mis-ordered.
+    ///   (b) intra-template double-spend — m_spent_outputs keeps only the LAST
+    ///       writer per outpoint, so two mempool txs spending the same outpoint
+    ///       both stay selectable. An outpoint may be spent by at most one tx in
+    ///       a block. Fix: a per-template consumed-outpoint set refuses the
+    ///       second spender (the lower-feerate one, visited later).
+    /// Reward-neutral: total_fees sums only INCLUDED txs' known fees, so
+    /// coinbasevalue tracks exactly the txs that ship — excluding an invalid tx
+    /// correctly excludes its fee (an invalid tx could never have paid it).
     std::pair<std::vector<SelectedTx>, uint64_t>
     get_sorted_txs_with_fees(uint32_t max_weight) const {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -466,39 +487,71 @@ public:
         uint64_t total_fees = 0;
         uint32_t total_weight = 0;
         std::set<uint256> selected;
+        // Per-template consumed outpoints — (a) prevents intra-template
+        // double-spend (b). One entry per input of every already-selected tx.
+        std::set<std::pair<uint256, uint32_t>> consumed;
 
-        // Pass 1: highest feerate first (known-fee txs)
         auto* utxo = m_utxo.load();
-        for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
-            auto pit = m_pool.find(it->second);
-            if (pit == m_pool.end()) continue;
-            const auto& entry = pit->second;
-            if (!entry.fee_known) continue;
-            if (total_weight + entry.weight > max_weight) continue;
 
-            // Guard: verify inputs still exist in UTXO (or parent mempool tx).
-            // Catches stale txs in the window between tip-change and full_block arrival.
-            if (utxo) {
-                bool inputs_ok = true;
-                for (const auto& vin : entry.tx.vin) {
-                    core::coin::Outpoint op(vin.prevout.hash, vin.prevout.index);
+        // Can `entry` join the template given the current selection state?
+        //   - refuse if any input outpoint is already consumed (double-spend)
+        //   - if an input is funded by another MEMPOOL tx (parent), that parent
+        //     must already be selected (topological: parents before children);
+        //     otherwise defer — a later fixed-point pass admits it once the
+        //     parent lands.
+        //   - with a UTXO view: an input in neither the UTXO set nor a mempool
+        //     parent is stale/orphan — refuse (unchanged pre-#1437 guard).
+        //   - without a UTXO view: an input with no mempool parent is assumed a
+        //     confirmed coin we cannot see (unchanged legacy behaviour; the fee
+        //     was computable, so the input resolved at add time).
+        auto admissible = [&](const MempoolEntry& entry) -> bool {
+            for (const auto& vin : entry.tx.vin) {
+                std::pair<uint256, uint32_t> op(vin.prevout.hash, vin.prevout.index);
+                if (consumed.count(op)) return false;  // intra-template double-spend
+
+                auto parent = m_pool.find(vin.prevout.hash);
+                const bool has_mempool_parent =
+                    parent != m_pool.end() &&
+                    vin.prevout.index < parent->second.tx.vout.size();
+
+                if (has_mempool_parent) {
+                    if (!selected.count(vin.prevout.hash))
+                        return false;  // parent not yet in template — defer
+                } else if (utxo) {
+                    core::coin::Outpoint uop(vin.prevout.hash, vin.prevout.index);
                     core::coin::Coin coin;
-                    if (!utxo->get_coin(op, coin)) {
-                        // Check if parent is in mempool (CPFP chain)
-                        if (!m_pool.count(vin.prevout.hash) ||
-                            vin.prevout.index >= m_pool.at(vin.prevout.hash).tx.vout.size()) {
-                            inputs_ok = false;
-                            break;
-                        }
-                    }
+                    if (!utxo->get_coin(uop, coin))
+                        return false;  // absent from UTXO and mempool — stale
                 }
-                if (!inputs_ok) continue;  // skip stale tx
             }
+            return true;
+        };
 
-            total_weight += entry.weight;
-            total_fees += entry.fee;
-            result.push_back({entry.tx, entry.fee, true});
-            selected.insert(entry.txid);
+        // Fixed-point selection over the feerate index (highest first). Each
+        // pass admits every currently-admissible fee-known tx; passes repeat
+        // until one adds nothing, so a high-feerate CPFP child admitted only
+        // after its lower-feerate parent still lands — parent first, never
+        // dropped. Bounded by the tx count (each pass adds ≥1 or terminates).
+        bool progress = true;
+        while (progress) {
+            progress = false;
+            for (auto it = m_feerate_index.begin(); it != m_feerate_index.end(); ++it) {
+                if (selected.count(it->second)) continue;  // already in template
+                auto pit = m_pool.find(it->second);
+                if (pit == m_pool.end()) continue;
+                const auto& entry = pit->second;
+                if (!entry.fee_known) continue;
+                if (total_weight + entry.weight > max_weight) continue;
+                if (!admissible(entry)) continue;
+
+                total_weight += entry.weight;
+                total_fees += entry.fee;
+                result.push_back({entry.tx, entry.fee, true});
+                selected.insert(entry.txid);
+                for (const auto& vin : entry.tx.vin)
+                    consumed.emplace(vin.prevout.hash, vin.prevout.index);
+                progress = true;
+            }
         }
 
         // Unknown-fee txs excluded from template — they'll be included

--- a/src/impl/nmc/test/CMakeLists.txt
+++ b/src/impl/nmc/test/CMakeLists.txt
@@ -29,7 +29,10 @@ if (BUILD_TESTING AND GTest_FOUND)
     # merkle test does (core + nmc_coin for the out-of-line transaction ctor).
     # The underfill guard KAT that used to be compiled into this target now
     # lives in its own nmc_underfill_guard_test target below (btc/dash/dgb symmetry).
-    add_executable(nmc_template_builder_test nmc_template_builder_test.cpp)
+    # #1437 topology KAT (child-without-parent + intra-template double-spend)
+    # folds into this EXISTING allowlisted target (no new executable / no #143
+    # NOT_BUILT trap); gtest_add_tests AUTO below discovers its TEST() cases.
+    add_executable(nmc_template_builder_test nmc_template_builder_test.cpp template_topology_spend_test.cpp)
     target_link_libraries(nmc_template_builder_test PRIVATE
         GTest::gtest_main GTest::gtest
         core nlohmann_json::nlohmann_json)

--- a/src/impl/nmc/test/template_topology_spend_test.cpp
+++ b/src/impl/nmc/test/template_topology_spend_test.cpp
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ---------------------------------------------------------------------------
+// nmc_template_topology_spend (rides nmc_template_builder_test) -- #1437 KAT.
+//
+// Pins nmc::coin::Mempool::get_sorted_txs_with_fees() as a producer of a
+// SELF-CONSISTENT block body. The embedded template builder feeds this set
+// straight into transactions[] and the tx-merkle; if the set is not a valid
+// block body, the daemon rejects the whole template
+// (bad-txns-inputs-missingorspent) and the found block is LOST.
+//
+// Two hazards the naive highest-feerate-first selector admitted, both proven
+// here as regression witnesses (the OLD, pure-feerate admission would have
+// shipped the invalid set) and then proven fixed:
+//   (a) child-without-parent -- a tx funded by another mempool tx (the parent)
+//       ordered after the child, or absent from the template entirely.
+//   (b) intra-template double-spend -- two mempool txs spending the SAME
+//       outpoint both selected.
+// Plus: the tx-merkle over the pruned set is well-defined and the pruned set
+// upholds both invariants (no double-spend, parents-before-children).
+//
+// UTXO-free: fees are pinned with Mempool::set_tx_fee (utxo view = null), the
+// exact legacy no-UTXO path the old selector treated as "admit every fee-known
+// tx in feerate order". Per-coin isolation: src/impl/nmc/ only.
+// ---------------------------------------------------------------------------
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <set>
+#include <utility>
+#include <vector>
+
+#include <core/uint256.hpp>
+
+#include <impl/nmc/coin/mempool.hpp>
+#include <impl/nmc/coin/template_builder.hpp>
+#include <impl/nmc/coin/transaction.hpp>
+
+namespace {
+
+using nmc::coin::Mempool;
+using nmc::coin::MutableTransaction;
+using nmc::coin::TxIn;
+using nmc::coin::TxOut;
+using nmc::coin::compute_txid;
+using nmc::coin::compute_merkle_root;
+
+// One-in, one-out payment. The output value tags the tx so distinct txids fall
+// out even when two txs spend the same input (the double-spend pair).
+MutableTransaction pay(const uint256& prev_hash, uint32_t prev_index, int64_t out_value)
+{
+    MutableTransaction tx;
+    tx.version = 1;
+    tx.locktime = 0;
+    TxIn in;
+    in.prevout.hash  = prev_hash;
+    in.prevout.index = prev_index;
+    in.sequence      = 0xffffffff;
+    tx.vin.push_back(in);
+    TxOut out;
+    out.value = out_value;
+    tx.vout.push_back(out);
+    return tx;
+}
+
+uint256 h(const char* hex)
+{
+    uint256 v;
+    v.SetHex(hex);
+    return v;
+}
+
+// A confirmed-looking funding outpoint hash NOT present in the mempool.
+const uint256 CONFIRMED_A = h("00000000000000000000000000000000000000000000000000000000000000a1");
+const uint256 CONFIRMED_X = h("00000000000000000000000000000000000000000000000000000000000000b2");
+
+std::set<uint256> txid_set(const std::vector<Mempool::SelectedTx>& sel)
+{
+    std::set<uint256> s;
+    for (const auto& t : sel) s.insert(compute_txid(t.tx));
+    return s;
+}
+
+int index_of(const std::vector<Mempool::SelectedTx>& sel, const uint256& id)
+{
+    for (int i = 0; i < static_cast<int>(sel.size()); ++i)
+        if (compute_txid(sel[i].tx) == id) return i;
+    return -1;
+}
+
+} // namespace
+
+// --- Test 1a: CPFP child never precedes its parent (topological order) --------
+TEST(NmcTemplateTopologySpend, CpfpChildOrderedAfterParent)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);      // spends P's output 0
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(pid, 200);    // low feerate parent
+    mp.set_tx_fee(cid, 8000);   // high feerate child (CPFP)
+
+    auto pe = mp.get_entry(pid);
+    auto ce = mp.get_entry(cid);
+    ASSERT_TRUE(pe && ce);
+    ASSERT_GT(ce->feerate(), pe->feerate());
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    ASSERT_EQ(sel.size(), 2u);
+    int ip = index_of(sel, pid), ic = index_of(sel, cid);
+    ASSERT_GE(ip, 0);
+    ASSERT_GE(ic, 0);
+    EXPECT_LT(ip, ic) << "child emitted before its parent -> bad-txns-inputs-missingorspent";
+    EXPECT_EQ(fees, 200u + 8000u);   // both fees counted; reward-neutral
+}
+
+// --- Test 1b: child whose parent cannot be selected is EXCLUDED ---------------
+TEST(NmcTemplateTopologySpend, ChildWithoutSelectableParentExcluded)
+{
+    Mempool mp;
+
+    MutableTransaction P = pay(CONFIRMED_A, 0, 100000);
+    uint256 pid = compute_txid(P);
+    MutableTransaction C = pay(pid, 0, 90000);
+    uint256 cid = compute_txid(C);
+
+    ASSERT_TRUE(mp.add_tx(P));   // fee UNKNOWN -> never selected
+    ASSERT_TRUE(mp.add_tx(C));
+    mp.set_tx_fee(cid, 8000);    // child fee known
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(cid), 0u) << "child-without-parent admitted -> lost block";
+    EXPECT_EQ(s.count(pid), 0u);
+    EXPECT_TRUE(sel.empty());
+    EXPECT_EQ(fees, 0u);
+}
+
+// --- Test 2: intra-template double-spend -> only one spender ships ------------
+TEST(NmcTemplateTopologySpend, IntraTemplateDoubleSpendPruned)
+{
+    Mempool mp;
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);   // same input, different txid
+    uint256 d1 = compute_txid(D1);
+    uint256 d2 = compute_txid(D2);
+    ASSERT_NE(d1, d2);
+
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    mp.set_tx_fee(d1, 5000);    // higher feerate -> visited first -> wins
+    mp.set_tx_fee(d2, 1000);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    ASSERT_EQ(sel.size(), 1u) << "both double-spenders admitted -> lost block";
+    EXPECT_EQ(compute_txid(sel[0].tx), d1);   // the higher-feerate spender
+    EXPECT_EQ(fees, 5000u);
+
+    int consumers = 0;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin)
+            if (vin.prevout.hash == CONFIRMED_X && vin.prevout.index == 0) ++consumers;
+    EXPECT_EQ(consumers, 1);
+}
+
+// --- Test 3: pruned set is a valid body + tx-merkle over exactly that set -----
+TEST(NmcTemplateTopologySpend, PrunedSetIsValidBodyAndMerkleMatches)
+{
+    Mempool mp;
+
+    MutableTransaction A = pay(h("00000000000000000000000000000000000000000000000000000000000000c3"), 0, 50000);
+    uint256 aid = compute_txid(A);
+
+    MutableTransaction D1 = pay(CONFIRMED_X, 0, 100000);
+    MutableTransaction D2 = pay(CONFIRMED_X, 0, 90000);
+    uint256 d1 = compute_txid(D1), d2 = compute_txid(D2);
+
+    MutableTransaction OP = pay(CONFIRMED_A, 0, 70000);
+    uint256 opid = compute_txid(OP);
+    MutableTransaction OC = pay(opid, 0, 60000);
+    uint256 ocid = compute_txid(OC);
+
+    ASSERT_TRUE(mp.add_tx(A));
+    ASSERT_TRUE(mp.add_tx(D1));
+    ASSERT_TRUE(mp.add_tx(D2));
+    ASSERT_TRUE(mp.add_tx(OP));       // fee unknown
+    ASSERT_TRUE(mp.add_tx(OC));
+    mp.set_tx_fee(aid, 3000);
+    mp.set_tx_fee(d1, 5000);
+    mp.set_tx_fee(d2, 4000);
+    mp.set_tx_fee(ocid, 8000);
+
+    auto [sel, fees] = mp.get_sorted_txs_with_fees(4'000'000);
+
+    auto s = txid_set(sel);
+    EXPECT_EQ(s.count(d2), 0u);
+    EXPECT_EQ(s.count(ocid), 0u);
+    EXPECT_EQ(s.count(opid), 0u);
+    EXPECT_EQ(s.count(aid), 1u);
+    EXPECT_EQ(s.count(d1), 1u);
+    EXPECT_EQ(fees, 3000u + 5000u);
+
+    // Invariant (i): no shared input across the selected set.
+    std::set<std::pair<uint256, uint32_t>> consumed;
+    for (const auto& t : sel)
+        for (const auto& vin : t.tx.vin) {
+            auto op = std::make_pair(vin.prevout.hash, vin.prevout.index);
+            EXPECT_EQ(consumed.count(op), 0u) << "double-spend survived pruning";
+            consumed.insert(op);
+        }
+
+    // Invariant (ii): every in-selected-set parent precedes its child.
+    for (int i = 0; i < static_cast<int>(sel.size()); ++i)
+        for (const auto& vin : sel[i].tx.vin) {
+            int pj = index_of(sel, vin.prevout.hash);
+            if (pj >= 0) EXPECT_LT(pj, i) << "child precedes parent in pruned set";
+        }
+
+    // Invariant (iii): tx-merkle over exactly the pruned set is well-defined.
+    std::vector<uint256> leaves;
+    for (const auto& t : sel) leaves.push_back(compute_txid(t.tx));
+    uint256 pruned_root = compute_merkle_root(leaves);
+    EXPECT_NE(pruned_root, uint256::ZERO);
+    EXPECT_EQ(pruned_root, compute_merkle_root(leaves));   // deterministic
+
+    std::vector<uint256> with_bad = leaves;
+    with_bad.push_back(d2);
+    with_bad.push_back(ocid);
+    EXPECT_NE(pruned_root, compute_merkle_root(with_bad));
+}


### PR DESCRIPTION
Ports the merged BTC #1494 (#1437) invalid-template fix (`32730f22`) to the four remaining embedded lanes carrying the same old single-pass selector: **nmc, dgb, bch, ltc**.

## The bug (per lane, `get_sorted_txs_with_fees`)
The naive highest-feerate-first selector could emit a block body the daemon rejects with `bad-txns-inputs-missingorspent` — the found block, and its reward, is LOST. Two hazards:
- **(a) child-without-parent** — an input funded by another mempool tx (the parent) selected AFTER the child (a CPFP child out-feerates its parent, so pure feerate order emits the child first), or not selected at all.
- **(b) intra-template double-spend** — `m_spent_outputs` keeps only the LAST writer per outpoint, so two mempool txs spending the same outpoint both stay selectable.

## The fix (`mempool.hpp` only, per lane — verbatim port of the BTC selector)
- per-template `consumed` outpoint set → refuses the second spender of any outpoint;
- `admissible` predicate → a tx joins only once every in-mempool parent is already selected (parents-before-children);
- fixed-point re-scan over the feerate index → a high-feerate CPFP child still lands, parent-first, never dropped.
- **ltc** additionally hardens the opt-in Pass 2 (DOGE unknown-fee fill): it now shares the same `admissible` predicate + `consumed` set and runs as its own fixed point.

## Lane classification
| lane | verdict |
|---|---|
| nmc, dgb, bch, ltc(+doge) | **DEFECTIVE → ported** |
| bip110 | **already-safe, not ported** — live serve path uses `block_assembler` (topo-safe, KAT-pinned by `bip110_m3_serving_kat`); the old selector is instantiated nowhere. |

## Reward-safe
Selection/validity only. `total_fees` still sums only INCLUDED known fees, so `coinbasevalue` tracks exactly the txs that ship. Diff confined to each `get_sorted_txs_with_fees` body — no subsidy / coinbase / PPLNS / payee / donation / weight / give-author change (grep-proven).

## KATs (red on master, green after)
Per-lane `template_topology_spend_test.cpp` folded into the existing allowlisted targets (no new `--target`, no `#143` NOT_BUILT trap):
- `nmc_template_builder_test`, `dgb_embedded_tx_select_test`, `share_test` (gtest), `bch_g2_block_assembly_roundtrip_test` (rides its `main()`).
- 4 witnesses each: CPFP-child-ordered-after-parent, child-without-selectable-parent-excluded, intra-template-double-spend-pruned, pruned-set-valid-body-and-merkle-matches. **ltc** adds 3 DOGE Pass-2 witnesses.

Verified locally: on master selector — nmc 4/4 FAIL, dgb 4/4 FAIL, ltc 6/7 FAIL, bch exit 1. After fix — nmc 4/4, dgb 4/4, ltc 7/7, bch exit 0. No regression: full suites `dgb_embedded_tx_select_test` 10/10, `share_test` 132/132, `nmc_auxpow_merkle_test` 92/92 (FeerateOrderedSelection), `nmc_underfill_guard_test` 11/11, `nmc_mempool_name_test` 9/9, `nmc_template_builder_test` 21/21. `ci/check_param_catalog.py` and `tools/ci/check_test_target_allowlist.py` unchanged (310/298, 254 targets).