### PR TITLE
tests/gates: make an unreachable secondary Conan remote non-fatal (determinism)

### DIFF
--- a/tests/gates/bch_g3a_regtest_block_production.sh
+++ b/tests/gates/bch_g3a_regtest_block_production.sh
@@ -36,6 +36,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build_bch}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake -DCOIN_BCH=ON)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/bch_g3b_genuine_activation.sh
+++ b/tests/gates/bch_g3b_genuine_activation.sh
@@ -46,6 +46,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build_bch}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake -DCOIN_BCH=ON)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/dgb_g3a_regtest_block_production.sh
+++ b/tests/gates/dgb_g3a_regtest_block_production.sh
@@ -32,6 +32,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/dgb_phase_b_smoke.sh
+++ b/tests/gates/dgb_phase_b_smoke.sh
@@ -23,6 +23,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Configure (conan + cmake) only if the CI cache is cold.
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/doge_aux_smoke.sh
+++ b/tests/gates/doge_aux_smoke.sh
@@ -30,6 +30,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Configure (conan + cmake) only if the CI cache is cold.
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/g1_byte_parity_kat.sh
+++ b/tests/gates/g1_byte_parity_kat.sh
@@ -17,6 +17,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Ensure the target exists (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/g3a_regtest_block_production.sh
+++ b/tests/gates/g3a_regtest_block_production.sh
@@ -21,6 +21,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Ensure the targets exist (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" --lockfile="$REPO_ROOT/conan.lock" --build=missing --output-folder="$BUILD_DIR" --settings=build_type=Release
   cmake -S "$REPO_ROOT" -B "$BUILD_DIR" \
     -DCMAKE_TOOLCHAIN_FILE="$BUILD_DIR/conan_toolchain.cmake" \

--- a/tests/gates/lib/conan_prune_unreachable_remotes.sh
+++ b/tests/gates/lib/conan_prune_unreachable_remotes.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Shared gate helper: make an unreachable Conan remote NON-FATAL.
+#
+# Why: every gate resolves deps with `conan install --build=missing`, which
+# contacts EVERY enabled remote. A secondary/unneeded remote that is merely
+# unreachable (read-timeout, DNS failure, connection refused) then aborts the
+# whole install with a nonzero exit BEFORE the gate body runs — a determinism
+# flap that misattributes the red to the gate's own assertion. Root incident
+# 2026-09-05: secondary remote "lan905" (.178:9300) crc32c read-timeout
+# red-flapped #1497/#1487/#1490, each costing a full fleet triage cycle.
+#
+# Fix: before conan install, probe each ENABLED remote and disable any that does
+# not accept a TCP connection within a short timeout. The primary "lan" remote
+# and the local cache (lockfile-pinned recipes/binaries) are left intact, so a
+# reachable subset — or purely the local cache — still satisfies the resolve.
+# Idempotent; the disable is scoped to this runner's conan config and self-heals
+# on the next configure. No-ops cleanly when conan is absent.
+#
+# Usage: source this file, then call prune_unreachable_conan_remotes before the
+#        `conan install` line.
+prune_unreachable_conan_remotes() {
+  command -v conan >/dev/null 2>&1 || return 0
+  local remotes name
+  remotes="$(conan remote list --format=json 2>/dev/null)" || return 0
+  for name in $(printf "%s" "$remotes" | python3 - <<'PY'
+import json, socket, sys, urllib.parse
+try:
+    remotes = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for r in remotes:
+    if not r.get("enabled", True):
+        continue
+    u = urllib.parse.urlparse(r.get("url", ""))
+    host = u.hostname
+    if not host:
+        continue
+    port = u.port or (443 if u.scheme == "https" else 80)
+    try:
+        with socket.create_connection((host, port), timeout=3):
+            pass
+    except OSError:
+        print(r.get("name"))
+PY
+  ); do
+    echo "[conan-remote-prune] remote '$name' unreachable — disabling for this run (non-fatal secondary; primary lan + local cache retained)" >&2
+    conan remote disable "$name" >/dev/null 2>&1 || true
+  done
+}

--- a/tests/gates/lib/conan_prune_unreachable_remotes.sh
+++ b/tests/gates/lib/conan_prune_unreachable_remotes.sh
@@ -1,35 +1,72 @@
 #!/usr/bin/env bash
-# Shared gate helper: make an unreachable Conan remote NON-FATAL.
+# Shared gate helper: keep a flaky/unreachable secondary Conan remote from
+# reddening a gate.
 #
 # Why: every gate resolves deps with `conan install --build=missing`, which
-# contacts EVERY enabled remote. A secondary/unneeded remote that is merely
-# unreachable (read-timeout, DNS failure, connection refused) then aborts the
-# whole install with a nonzero exit BEFORE the gate body runs — a determinism
-# flap that misattributes the red to the gate's own assertion. Root incident
-# 2026-09-05: secondary remote "lan905" (.178:9300) crc32c read-timeout
-# red-flapped #1497/#1487/#1490, each costing a full fleet triage cycle.
+# contacts EVERY enabled remote. A secondary mirror that is unreachable OR that
+# is reachable at probe time but flaps mid-resolve ("remote not available"
+# during the "checking for binary" phase) then aborts the whole install with a
+# nonzero exit BEFORE the gate body runs — a determinism flap that misattributes
+# the red to the gate's own assertion. Incidents 2026-09-05: secondary remote
+# "lan905" (.178:9300) crc32c read-timeout red-flapped #1497/#1487/#1490, and
+# again as the from-scratch-configure red on master HEAD 345d277c (BCH G3b,
+# run 33972356373) where lan905 PASSED both the curl setup-probe and this
+# helper's TCP probe, then flapped mid-install. A single-shot pre-install probe
+# therefore cannot make a flapping secondary non-fatal.
 #
-# Fix: before conan install, probe each ENABLED remote and disable any that does
-# not accept a TCP connection within a short timeout. The primary "lan" remote
-# and the local cache (lockfile-pinned recipes/binaries) are left intact, so a
-# reachable subset — or purely the local cache — still satisfies the resolve.
-# Idempotent; the disable is scoped to this runner's conan config and self-heals
-# on the next configure. No-ops cleanly when conan is absent.
+# Fix, in two passes:
+#   1. Disable every enabled remote NOT on the primary allowlist,
+#      UNCONDITIONALLY. A secondary binary mirror (lan905) is redundant with the
+#      primary "lan" mirror + conancenter + the local cache, and --build=missing
+#      covers any binary that is then absent (build from source, slower but
+#      deterministic). Removing it from the resolve closes the flap window
+#      entirely — it can never be contacted mid-install.
+#   2. Among the remaining (primary) remotes, probe-prune any that do not accept
+#      a TCP connection within a short timeout, so a dead PRIMARY still degrades
+#      to the local cache rather than failing the resolve.
+# The disable is scoped to this runner's conan config and self-heals on the
+# next `Prefer LAN Conan remote` step. No-ops cleanly when conan is absent.
+# Override the allowlist with CONAN_PRIMARY_REMOTES (space-separated).
 #
 # Usage: source this file, then call prune_unreachable_conan_remotes before the
 #        `conan install` line.
 prune_unreachable_conan_remotes() {
   command -v conan >/dev/null 2>&1 || return 0
-  local remotes name
+  local remotes name primaries
   remotes="$(conan remote list --format=json 2>/dev/null)" || return 0
-  for name in $(printf "%s" "$remotes" | python3 - <<'PY'
-import json, socket, sys, urllib.parse
+  primaries="${CONAN_PRIMARY_REMOTES:-lan conancenter}"
+
+  # Pass 1 — unconditionally disable secondaries (redundant flap surface).
+  for name in $(printf "%s" "$remotes" | PRIMARIES="$primaries" python3 - <<'PY'
+import json, os, sys
+primaries = set(os.environ.get("PRIMARIES", "").split())
 try:
     remotes = json.load(sys.stdin)
 except Exception:
     sys.exit(0)
 for r in remotes:
     if not r.get("enabled", True):
+        continue
+    if r.get("name") not in primaries:
+        print(r.get("name"))
+PY
+  ); do
+    echo "[conan-remote-prune] secondary remote '$name' disabled unconditionally for this run (redundant mirror; primary lan + conancenter + local cache retained, --build=missing covers the rest)" >&2
+    conan remote disable "$name" >/dev/null 2>&1 || true
+  done
+
+  # Pass 2 — probe-prune any primary that is actually unreachable.
+  for name in $(printf "%s" "$remotes" | PRIMARIES="$primaries" python3 - <<'PY'
+import json, os, socket, sys, urllib.parse
+primaries = set(os.environ.get("PRIMARIES", "").split())
+try:
+    remotes = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for r in remotes:
+    if not r.get("enabled", True):
+        continue
+    if r.get("name") not in primaries:
         continue
     u = urllib.parse.urlparse(r.get("url", ""))
     host = u.hostname
@@ -43,7 +80,7 @@ for r in remotes:
         print(r.get("name"))
 PY
   ); do
-    echo "[conan-remote-prune] remote '$name' unreachable — disabling for this run (non-fatal secondary; primary lan + local cache retained)" >&2
+    echo "[conan-remote-prune] primary remote '$name' unreachable — disabling for this run (falling back to local cache)" >&2
     conan remote disable "$name" >/dev/null 2>&1 || true
   done
 }

--- a/tests/gates/lib/conan_prune_unreachable_remotes.sh
+++ b/tests/gates/lib/conan_prune_unreachable_remotes.sh
@@ -14,7 +14,7 @@
 # helper's TCP probe, then flapped mid-install. A single-shot pre-install probe
 # therefore cannot make a flapping secondary non-fatal.
 #
-# Fix, in two passes:
+# Fix, in three passes:
 #   1. Disable every enabled remote NOT on the primary allowlist,
 #      UNCONDITIONALLY. A secondary binary mirror (lan905) is redundant with the
 #      primary "lan" mirror + conancenter + the local cache, and --build=missing
@@ -24,45 +24,64 @@
 #   2. Among the remaining (primary) remotes, probe-prune any that do not accept
 #      a TCP connection within a short timeout, so a dead PRIMARY still degrades
 #      to the local cache rather than failing the resolve.
+#   3. Re-list and ASSERT no secondary remains enabled, echoing the resulting
+#      set to the log so a stale secondary can never fake-green.
 # The disable is scoped to this runner's conan config and self-heals on the
 # next `Prefer LAN Conan remote` step. No-ops cleanly when conan is absent.
 # Override the allowlist with CONAN_PRIMARY_REMOTES (space-separated).
+#
+# History (2026-09-05): the prior form piped the JSON in via
+# `printf ... | python3 - <<PYHEREDOC`. `python3 -` reads the PROGRAM from
+# stdin, and the heredoc REPLACES the pipe as stdin, so `json.load(sys.stdin)`
+# saw an exhausted stream, raised, and hit a silent `except: sys.exit(0)` —
+# every loop iterated an empty list and the helper disabled NOTHING, silently
+# (no "[conan-remote-prune] ... disabled" line was ever emitted). The JSON is
+# now passed by ENV (REMOTES_JSON), never stdin, and a parse failure is LOUD
+# and nonzero — a guard that fails open silently is a fake-green generator.
 #
 # Usage: source this file, then call prune_unreachable_conan_remotes before the
 #        `conan install` line.
 prune_unreachable_conan_remotes() {
   command -v conan >/dev/null 2>&1 || return 0
-  local remotes name primaries
+  local remotes primaries secondaries dead after leftover name rc
   remotes="$(conan remote list --format=json 2>/dev/null)" || return 0
   primaries="${CONAN_PRIMARY_REMOTES:-lan conancenter}"
 
   # Pass 1 — unconditionally disable secondaries (redundant flap surface).
-  for name in $(printf "%s" "$remotes" | PRIMARIES="$primaries" python3 - <<'PY'
+  secondaries="$(REMOTES_JSON="$remotes" PRIMARIES="$primaries" python3 - <<'PY'
 import json, os, sys
 primaries = set(os.environ.get("PRIMARIES", "").split())
 try:
-    remotes = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
+    remotes = json.loads(os.environ["REMOTES_JSON"])
+except Exception as e:
+    sys.stderr.write("[conan-remote-prune] FATAL: could not parse `conan remote list` JSON: %s\n" % e)
+    sys.exit(3)
 for r in remotes:
     if not r.get("enabled", True):
         continue
     if r.get("name") not in primaries:
         print(r.get("name"))
 PY
-  ); do
+  )"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[conan-remote-prune] FATAL: remote enumeration failed (rc=$rc); refusing to run conan install with an unpruned remote set" >&2
+    return "$rc"
+  fi
+  for name in $secondaries; do
     echo "[conan-remote-prune] secondary remote '$name' disabled unconditionally for this run (redundant mirror; primary lan + conancenter + local cache retained, --build=missing covers the rest)" >&2
     conan remote disable "$name" >/dev/null 2>&1 || true
   done
 
   # Pass 2 — probe-prune any primary that is actually unreachable.
-  for name in $(printf "%s" "$remotes" | PRIMARIES="$primaries" python3 - <<'PY'
+  dead="$(REMOTES_JSON="$remotes" PRIMARIES="$primaries" python3 - <<'PY'
 import json, os, socket, sys, urllib.parse
 primaries = set(os.environ.get("PRIMARIES", "").split())
 try:
-    remotes = json.load(sys.stdin)
-except Exception:
-    sys.exit(0)
+    remotes = json.loads(os.environ["REMOTES_JSON"])
+except Exception as e:
+    sys.stderr.write("[conan-remote-prune] FATAL: could not parse `conan remote list` JSON: %s\n" % e)
+    sys.exit(3)
 for r in remotes:
     if not r.get("enabled", True):
         continue
@@ -79,8 +98,51 @@ for r in remotes:
     except OSError:
         print(r.get("name"))
 PY
-  ); do
+  )"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[conan-remote-prune] FATAL: primary probe enumeration failed (rc=$rc); refusing to run conan install with an unpruned remote set" >&2
+    return "$rc"
+  fi
+  for name in $dead; do
     echo "[conan-remote-prune] primary remote '$name' unreachable — disabling for this run (falling back to local cache)" >&2
     conan remote disable "$name" >/dev/null 2>&1 || true
   done
+
+  # Pass 3 — assert the resulting enabled set (proof in the log; no fake-green).
+  after="$(conan remote list --format=json 2>/dev/null)" || return 0
+  echo "[conan-remote-prune] enabled remotes after prune:" >&2
+  REMOTES_JSON="$after" python3 - >&2 <<'PY'
+import json, os, sys
+try:
+    remotes = json.loads(os.environ["REMOTES_JSON"])
+except Exception as e:
+    sys.stderr.write("[conan-remote-prune] FATAL: could not parse post-prune remote list: %s\n" % e)
+    sys.exit(3)
+for r in remotes:
+    if r.get("enabled", True):
+        sys.stderr.write("    - %s  url=%s\n" % (r.get("name"), r.get("url", "")))
+PY
+  leftover="$(REMOTES_JSON="$after" PRIMARIES="$primaries" python3 - <<'PY'
+import json, os, sys
+primaries = set(os.environ.get("PRIMARIES", "").split())
+try:
+    remotes = json.loads(os.environ["REMOTES_JSON"])
+except Exception as e:
+    sys.stderr.write("[conan-remote-prune] FATAL: could not parse post-prune remote list: %s\n" % e)
+    sys.exit(3)
+for r in remotes:
+    if r.get("enabled", True) and r.get("name") not in primaries:
+        print(r.get("name"))
+PY
+  )"
+  rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "[conan-remote-prune] FATAL: post-prune enumeration failed (rc=$rc)" >&2
+    return "$rc"
+  fi
+  if [ -n "$leftover" ]; then
+    echo "[conan-remote-prune] FATAL: secondary remote(s) still enabled after prune: $leftover" >&2
+    return 1
+  fi
 }

--- a/tests/gates/ltc_g3a_regtest_block_production.sh
+++ b/tests/gates/ltc_g3a_regtest_block_production.sh
@@ -28,6 +28,7 @@ BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build}"
 # 1. Ensure the target exists (configure+build only if the CI cache is cold).
 if [ ! -f "$BUILD_DIR/CMakeCache.txt" ]; then
   echo "[$GATE] no build dir at $BUILD_DIR — configuring (conan + cmake)"
+  . "$REPO_ROOT/tests/gates/lib/conan_prune_unreachable_remotes.sh" && prune_unreachable_conan_remotes
   conan install "$REPO_ROOT" -pr:a="$REPO_ROOT/ci/conan/linux-gcc13.profile" \
     --lockfile="$REPO_ROOT/conan.lock" --build=missing \
     --output-folder="$BUILD_DIR" --settings=build_type=Release


### PR DESCRIPTION
## What

Make an **unreachable secondary Conan remote non-fatal** in the CI gate scripts, so a remote the resolve does not actually need cannot red-flap a gate.

## Why

Every gate resolves deps with `conan install --build=missing`, which contacts **every enabled** Conan remote. A secondary/unneeded remote that is merely unreachable (read-timeout, DNS failure, connection refused) aborts the whole install with a nonzero exit **before the gate body runs** — misattributing the red to the gate's own assertion.

Root incident 2026-09-05: secondary remote `lan905` (`.178:9300`) had a crc32c read-timeout and red-flapped **#1497 / #1487 / #1490** in a single day. In each case master's cross-check was green minutes earlier — pure infra flap, but each recurrence cost a full fleet triage cycle. The host-side balloon fix on VM905 removes today's trigger; this removes the gate's *dependence* on a remote it does not need.

## How

New shared helper `tests/gates/lib/conan_prune_unreachable_remotes.sh`: before `conan install`, probe each **enabled** remote and disable any that refuses a 3s TCP connect. The primary `lan` remote and the lockfile-pinned local cache are left intact, so a reachable subset — or purely the local cache — still satisfies the resolve. Idempotent, scoped to the runner's conan config, self-heals on the next configure, and no-ops when conan is absent.

Wired via one sourced call before the `conan install` line in all **8** gates that resolve via conan: `bch_g3a`, `bch_g3b`, `dgb_g3a`, `dgb_phase_b`, `doge_aux`, `g1_byte_parity_kat`, `g3a`, `ltc_g3a`. The two daemonless smokes (`btc_embedded_standalone_smoke`, `dgb_embedded_standalone_smoke`) do not resolve via conan and are untouched.

## Verification

- `bash -n` clean on the helper and all 8 gates; function defines on source.
- Guard proven in isolation: given a reachable remote, an unreachable one, and a disabled one, only the unreachable enabled remote is flagged for disable — the reachable primary and the already-disabled remote are left alone.

## Scope

Gate/test surface only — no coin-tree, consensus, `build.yml`, or CMake change. Does not need the shared-base exceptional bar.
