### PR TITLE
dash: miner/user tx-injection runtime (#157, M1, --embedded-tx-inject default OFF)

### DIFF
--- a/docs/design/miner-tx-injection.md
+++ b/docs/design/miner-tx-injection.md
@@ -1,10 +1,17 @@
 # Miner / user tx-injection over the c2pool sharechain p2p (post-cut, SV2-like)
 
-Status: **DESIGN ONLY. Not implemented.** This is a **post-cut (Tier-3)** feature,
-not a `--coin-rpc` (dashd) cut blocker. It is sequenced strictly **after** the
-daemonless block-template self-derive close (#154) and the full-mempool serving
-canary (#132). Nothing here touches the coinbase, the reward split, or the
-masternode-payee queue.
+Status: **M1 IMPLEMENTED (DASH, `--embedded-tx-inject`, default OFF); M2/M3
+staged.** This is a **post-cut (Tier-3)** feature, not a `--coin-rpc` (dashd)
+cut blocker. It is sequenced strictly **after** the daemonless block-template
+self-derive close (#154) and the full-mempool serving canary (#132). Nothing
+here touches the coinbase, the reward split, or the masternode-payee queue.
+
+M1 (this PR) lands the runtime: the inject pool, the validation gate, the
+priority class, the DoS caps, the local submit path, and — see §9/§10 below —
+the isolated-signer SEAM and the design for sandboxed tx-blob construction. The
+`tx-inject` p2p transport (§4.2) and its first-see fan-out (§4.5) are M2;
+per-peer token buckets / capability advertisement (§4.6) and the full sandboxed
+signer are M3. §11 is the exact per-milestone code map.
 
 Scope: DASH first, but the transport (`tx-inject` p2p subtype) and the
 validation gate are coin-agnostic and reuse existing core/ infrastructure.
@@ -353,3 +360,123 @@ per repo convention for anything near the reward path.
 6. **Expiry vs. persistence.** Should injects survive a node restart (persisted
    inject pool) or be intentionally ephemeral? Ephemeral is simpler and limits
    liability; persistence is friendlier to a user who submitted and went away.
+
+---
+
+## 9. Embedded-daemon tx-blob construction + isolated signing modules
+
+The proof-of-capability in §6 (the daemonless donation at block 2518186)
+established that c2pool can construct, sign, and broadcast an arbitrary tx with
+no daemon in the loop. tx-injection generalises that: a miner or user must be
+able to build a raw, consensus-valid transaction — including the non-standard
+and 0-fee shapes a public mempool refuses — and hand it to c2pool for inclusion.
+This section specifies **where the signing happens** and the **module boundary**
+that keeps private keys out of the injection runtime.
+
+### 9.1 The runtime accepts an ALREADY-SIGNED blob (the SEAM)
+
+The injection runtime — `Mempool::add_inject`, the inject pool, the p2p
+`tx-inject` transport, the fan-out — operates **exclusively on fully-serialized,
+already-signed transaction bytes**. It never sees a private key, never
+constructs a scriptSig, and never re-serializes or mutates the tx: `tx_bytes` is
+the exact bytes that will appear in the block, and `sha256d(tx_bytes)` is the
+txid used for dedup/gossip. This is the **isolated-signer SEAM**:
+
+```
+   ┌─────────────────────────┐        signed raw tx bytes        ┌──────────────────────┐
+   │  tx-blob construction +  │  ───────────────────────────────▶ │  injection runtime    │
+   │  signing (isolated,      │      (opaque, never mutated)      │  (add_inject, pool,   │
+   │  key-bearing)            │                                   │   p2p, fan-out)       │
+   └─────────────────────────┘                                   └──────────────────────┘
+        holds keys                                                    holds NO keys
+```
+
+Consequences of the seam:
+
+- **The runtime is key-free.** A compromise of the injection path (a malicious
+  peer flooding `tx-inject`, a bug in the pool) cannot reach signing material —
+  there is none on that side of the seam.
+- **The signer is swappable.** Any external tool that emits a signed raw tx —
+  a dashd `createrawtransaction`+`signrawtransactionwithkey`, a hardware wallet,
+  the c2wallet PIN-TX offline signer already used for the donation lane, or the
+  sandboxed builder of §10 — satisfies the seam. The runtime is indifferent to
+  which produced the bytes.
+- **Validity is re-checked regardless of origin.** Because the runtime trusts no
+  signer, every injected blob passes the SAME consensus gate as any mempool tx
+  (script-verify, topology, double-spend, finality, sigops, maturity) at
+  template build — a mis-signed or malicious blob is dropped, never served.
+
+### 9.2 M1 seam implementation (this PR)
+
+M1 wires the seam at two entry points, both taking already-signed bytes:
+
+- **`--embedded-tx-inject-hex FILE`** — a local operator/miner submit: one raw
+  signed tx hex per line (classic type-0, all-or-nothing at load, mirroring the
+  proven `--pin-local-tx-hex` loader). Each line is deserialized and handed to
+  `NodeCoinState::submit_inject`, which runs the gate and reports a named verdict.
+- **`NodeCoinState::submit_inject(tx, flags, expiry_height)`** — the in-process
+  API the file loader (M1) and the p2p handler (M2) both call. It takes a
+  deserialized `MutableTransaction` whose scriptSigs are already populated; it
+  never signs.
+
+A minimal build/sign helper for producing the blob is intentionally **out of the
+runtime**: for M1 the operator uses the existing offline path (c2wallet PIN-TX
+procedure / dashd `signrawtransactionwithkey`) — the same tooling that signed the
+2518186 donation — and drops the resulting hex into the file. This keeps PR-1
+key-free while delivering an end-to-end submit path.
+
+### 9.3 Reward isolation restated for the seam
+
+The signer produces `tx_bytes`; the runtime places those bytes **only** into the
+block body (tx-merkle / fee-total). Neither side writes the coinbase, subsidy,
+PPLNS, donation, payee queue, or `give_author`. The `submitter_hint` (§4.2), when
+it arrives on the wire in M2, is a **local DoS-accounting label only** — it is
+never a reward key and never influences funds, because the runtime never
+rewrites the tx to pay it.
+
+## 10. Sandboxed tx-blob construction (staged to M3)
+
+M1 ships the SEAM; the **full sandboxed signer** — a self-contained builder that
+constructs and signs the blob inside an isolation boundary — is staged. Its
+design:
+
+- **A separate process / module** with the sole capability of turning a
+  (inputs, outputs, keys) request into signed raw tx bytes. It links the
+  consensus-exact script/sighash primitives already vendored for c2pool
+  (`dash_scriptcheck.so` / the c2pool_dash_* legacy-sighash + secp256k1 path the
+  M1 KATs sign against), so a blob it produces verifies under the very
+  interpreter the runtime re-checks it with.
+- **No network, no mempool, no sharechain access.** The sandbox cannot see peers
+  or the pool; it emits bytes on a single pipe. This bounds the blast radius of a
+  signing bug to the blob itself.
+- **Immature-coinbase + maturity filtering at build** (the lesson from the PIN
+  consolidation lane): the builder refuses to spend an immature coinbase input,
+  so a blob never fails maturity at template build.
+- **All-or-nothing, offline-first**: the builder is usable fully offline (the
+  donation precedent), so a user can construct a 0-fee sweep / non-standard tx
+  without exposing keys to any online component.
+
+The sandbox is **not** required for the runtime to function — the seam (§9.1)
+means any signer suffices — so it is correctly deferred without blocking M1.
+
+## 11. Per-milestone code map (implementation reality)
+
+| Milestone | Component | Where |
+|-----------|-----------|-------|
+| **M1 (this PR)** | inject pool (cap/expiry/dedup, DoS) | `src/impl/dash/coin/tx_inject_pool.hpp` |
+| M1 | priority delta + gate + `add_inject` | `src/impl/dash/coin/mempool.hpp` (`INJECT_FEE_DELTA`, `InjectGate`, `add_inject`, `kMaxInjectTxBytes`) |
+| M1 | intra-template double-spend guard (`consumed`) | `src/impl/dash/coin/mempool.hpp` `get_sorted_txs_with_fees` |
+| M1 | submit gate + reconcile + node ownership | `src/impl/dash/coin/node_coin_state.hpp` (`submit_inject`, `set_tx_inject_enabled`, `m_inject_pool`) |
+| M1 | flag + local submit (SEAM entry) + catalog | `src/c2pool/main_dash.cpp` (`--embedded-tx-inject`, `--embedded-tx-inject-hex`), `src/core/param_catalog.inc` |
+| M1 | KATs (priority, reward-safety, double-spend, bad-script, missing-input, oversize, seam-unarmed, DoS, never-defaulted) | `test/test_dash_tx_inject.cpp` (in `test_dash_mempool`) |
+| **M2** | `tx-inject` p2p subtype + handler wiring | `src/impl/dash/messages.hpp`, `node.hpp` handler tables, `protocol_actual.cpp` / `protocol_legacy.cpp` |
+| M2 | first-see fan-out + `register_template_txs` | `node.cpp` (advertise pattern), reconstruct-won-block path |
+| M2 | continuous re-submission per tip | block-connect wiring of `reconcile_inject_pool` |
+| **M3** | per-peer token buckets, misbehaviour score, capability advertisement | coin_peer_manager / handler |
+| M3 | `submitter_hint` rate-accounting | inject pool |
+| M3 | full sandboxed signer (§10) | new isolated build/sign module |
+
+### Reward-safety proof obligation (every milestone)
+
+`git diff master --stat -- src/impl/dash/coinbase_builder.hpp src/core/coinbase_builder.hpp src/impl/dash/coin/gentx_coinbase.hpp src/impl/dash/coin/subsidy.hpp src/impl/dash/pplns.hpp src/core/donation.hpp`
+must be **empty**, and `grep -n "give_author\|donation\|payee\|m_payment_amount\|subsidy"` over the injection files must be **empty**. An injected tx enters ONLY the block body; the coinbase is `subsidy + Σ base-fees` exactly, and the priority delta is scoring-only (`total_fees` reads base `fee`).

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -491,6 +491,7 @@ void print_banner(const char* argv0)
         << "           [--embedded-getmnlistd-tracker]\n"
         << "           [--embedded-fold-live PATH] [--embedded-fold-live-expect HASH]\n"
         << "           [--embedded-fold-checkscripts]\n"
+        << "           [--embedded-tx-inject] [--embedded-tx-inject-hex FILE]\n"
         << "           [--embedded-accrue-asset-locks] [--embedded-accrue-asset-unlocks]\n"
         << "           [--embedded-ingest-isdlock] [--embedded-ingest-dstx]\n"
         << "           [--embedded-proactive-rotate]\n"
@@ -1079,6 +1080,26 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
              // armed (fold_live_db). DEFAULT false => no check, byte-
              // identical to master.
              bool embedded_fold_checkscripts = false,
+             // --embedded-tx-inject (#157, post-cut Tier-3): opt-in miner/user
+             // tx-injection. A raw consensus-valid tx handed to c2pool is
+             // admitted to the mempool with PRIORITY (a large mapDeltas delta)
+             // so it lands in the block c2pool mines regardless of fee rate and
+             // is non-standard-tolerant — the only gate is consensus-validity,
+             // enforced by the SAME selector guards every body tx passes.
+             // DEFAULT OFF. REWARD-SAFE: an inject is an ordinary body tx; the
+             // coinbase / subsidy / PPLNS / payee path is byte-unchanged (a
+             // 0-fee inject adds 0 to fees). Injects ride the served-body path,
+             // so this augments the daemonless / --embedded-serve-mempool-txs
+             // serve posture and requires the consensus-exact input-script check
+             // (--embedded-fold-checkscripts) to be armed (new ingestion seam).
+             bool embedded_tx_inject = false,
+             // --embedded-tx-inject-hex FILE: local submit path (M1). One raw
+             // tx hex per line (classic type-0 only, all-or-nothing at load),
+             // mirroring --pin-local-tx-hex. Each is submitted through the
+             // validation + priority gate at wiring time and its named verdict
+             // logged; continuous re-submission + the p2p tx-inject transport
+             // are M2. Empty (default) => no local injects.
+             const std::string& embedded_tx_inject_hex_path = std::string(),
              // --embedded-utxo-fold-fees DBPATH (+ REQUIRED
              // --embedded-utxo-fold-expect HEX): W5-A. Open the W3 full-
              // history UTXO fold at DBPATH and install FoldFeeSource as the
@@ -2705,6 +2726,16 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // never coincide) and blind to a strict SUBSET that contains an invalid
     // transaction, which is exactly the case that costs a whole block.
     node_coin_state.set_serve_mempool_txs(embedded_serve_mempool_txs);
+    // #157 (--embedded-tx-inject): arm the opt-in miner/user tx-injection lane.
+    // Default OFF; the actual local submits happen after the mempool + the
+    // consensus-exact script check are wired (see --embedded-tx-inject-hex).
+    node_coin_state.set_tx_inject_enabled(embedded_tx_inject);
+    if (embedded_tx_inject) {
+        std::cout << "[run] embedded-tx-inject ARMED (#157): miner/user tx-injection "
+                     "ON — submitted txs ride the block with priority through the "
+                     "SAME validity gate; reward path byte-unchanged. Requires "
+                     "--embedded-fold-checkscripts + the served-body posture.\n";
+    }
     // ── IS/CL MINING-SAFETY HOLD arming (dashd TestPackageTransactions) ─────
     // dashd's miner refuses any not-yet-islocked tx with vins younger than 10
     // minutes when spork2 (InstantSend) AND spork3 (RejectConflictingBlocks)
@@ -6585,6 +6616,60 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
                          "advance-on-connect + reorg-undo + at-tip serving guard "
                          "(fold consulted only while fold_height >= serve_tip and "
                          "chain-identical; behind tip => fee-unknown = master)\n";
+        }
+
+        // #157 (--embedded-tx-inject-hex): local submit path (M1). Parse the
+        // file (one classic raw tx hex per line, all-or-nothing) and submit each
+        // through the validation + priority gate now that the mempool + the
+        // consensus-exact script check are wired. Every verdict is logged by
+        // name (DEF3). An inject whose inputs are not yet in the view is refused
+        // "inject-unpriceable" and NOT retried here — continuous re-submission
+        // and the p2p tx-inject transport are M2. Reward path untouched.
+        if (embedded_tx_inject && !embedded_tx_inject_hex_path.empty()) {
+            std::ifstream inf(embedded_tx_inject_hex_path);
+            std::vector<dash::coin::MutableTransaction> inj_txs;
+            bool inj_load_ok = true;
+            std::string iline;
+            unsigned ilineno = 0;
+            while (std::getline(inf, iline)) {
+                ++ilineno;
+                iline.erase(std::remove_if(iline.begin(), iline.end(),
+                                [](unsigned char c) { return std::isspace(c); }),
+                            iline.end());
+                if (iline.empty()) continue;
+                if (iline.size() % 2 != 0) {
+                    std::cout << "[run] --embedded-tx-inject-hex line " << ilineno
+                              << ": odd hex length — injects DISABLED\n";
+                    inj_txs.clear(); inj_load_ok = false; break;
+                }
+                try {
+                    auto raw = ParseHex(iline);
+                    PackStream ps(raw);
+                    dash::coin::MutableTransaction tx;
+                    ps >> tx;
+                    if (tx.type != 0 || tx.vin.empty() || tx.vout.empty()) {
+                        std::cout << "[run] --embedded-tx-inject-hex line " << ilineno
+                                  << ": not a classic non-empty tx — injects DISABLED\n";
+                        inj_txs.clear(); inj_load_ok = false; break;
+                    }
+                    inj_txs.push_back(std::move(tx));
+                } catch (const std::exception& e) {
+                    std::cout << "[run] --embedded-tx-inject-hex line " << ilineno
+                              << " PARSE FAILED (" << e.what() << ") — injects DISABLED\n";
+                    inj_txs.clear(); inj_load_ok = false; break;
+                }
+            }
+            if (inj_load_ok && !inj_txs.empty()) {
+                for (auto& tx : inj_txs) {
+                    auto r = node_coin_state.submit_inject(tx);
+                    std::cout << "[run] tx-inject submit txid="
+                              << r.txid.GetHex().substr(0, 16)
+                              << " => " << r.cause
+                              << (r.ok ? " (prioritised; validated at template build)"
+                                       : " (refused, not served)")
+                              << "\n";
+                }
+            }
         }
 
         // new_block(inv hash) -> pull the headers THEN the full block from the
@@ -10845,6 +10930,12 @@ int main(int argc, char** argv)
     bool embedded_serve_mempool_txs_off = false;  // --embedded-serve-mempool-txs=false
     bool embedded_tx_serve_own_set = false;  // --embedded-tx-serve-own-set; daemonless default ON
     bool embedded_tx_serve_own_set_off = false;   // --embedded-tx-serve-own-set=false
+    // #157 (--embedded-tx-inject): opt-in miner/user tx-injection. DEFAULT OFF
+    // and NEVER a good-citizen default (NOT in TxServeLevers): it changes which
+    // consensus-valid txs a node prioritises into its own block and must always
+    // be an explicit operator decision. Reward path is byte-unchanged.
+    bool embedded_tx_inject = false;
+    std::string embedded_tx_inject_hex_path;   // --embedded-tx-inject-hex FILE (local M1 submit)
     // #107 PHASE 2 (--embedded-accrue-asset-locks): type-8 asset-lock accrual.
     // DAEMONLESS DEFAULT ON (good_citizen_defaults.hpp): body membership and the
     // CbTx creditPool accrual are the SAME bit (embedded_gbt.hpp allow_locks ==
@@ -11126,6 +11217,10 @@ int main(int argc, char** argv)
         else if (std::strcmp(argv[i],
                              "--embedded-creditpool-publish-at-serve-tip") == 0)
             embedded_creditpool_publish_at_serve_tip = true;
+        else if (std::strcmp(argv[i], "--embedded-tx-inject") == 0)
+            embedded_tx_inject = true;   // #157: opt-in miner/user tx-injection (default OFF)
+        else if (std::strcmp(argv[i], "--embedded-tx-inject-hex") == 0 && i + 1 < argc)
+            embedded_tx_inject_hex_path = argv[++i];   // #157 local M1 submit file
         else if (std::strcmp(argv[i], "--pin-local-tx-hex") == 0 && i + 1 < argc)
             pin_local_tx_hex_path = argv[++i];
         else if (std::strcmp(argv[i], "--pin-splice-xcheck-arm") == 0)
@@ -11620,6 +11715,8 @@ int main(int argc, char** argv)
                         embedded_fold_live_db,         // PR-C1 embedded-fold-live
                         embedded_fold_live_expect,     // PR-C1 store-verify hash
                         embedded_fold_checkscripts,   // PR-C4 input-script check
+                        embedded_tx_inject,            // #157 miner/user tx-injection (default OFF)
+                        embedded_tx_inject_hex_path,   // #157 local M1 submit file
                         embedded_utxo_fold_fees_db,    // W5-A fold fee source
                         embedded_utxo_fold_expect,     // W5-A anchor restatement
                         explorer_enabled,             // /api/explorer surface (default ON)

--- a/src/core/param_catalog.inc
+++ b/src/core/param_catalog.inc
@@ -538,6 +538,12 @@ C2P_PARAM("embedded.fold_live_expect", Embedded, HEX, RESTART, C_DASH, LIT, "", 
 C2P_PARAM("embedded.fold_checkscripts", Embedded, BOOL, RESTART, C_DASH, LIT, "false", NONE, "consensus-exact input-script check")
   C2P_ALIAS("embedded.fold_checkscripts", BIN_DASH, "--embedded-fold-checkscripts", FLAG)
 
+C2P_PARAM("embedded.tx_inject", Embedded, BOOL, RESTART, C_DASH, LIT, "false", NONE, "#157 miner/user tx-injection (opt-in, default OFF, reward-neutral)")
+  C2P_ALIAS("embedded.tx_inject", BIN_DASH, "--embedded-tx-inject", FLAG)
+
+C2P_PARAM("embedded.tx_inject_hex", Embedded, PATH, RESTART, C_DASH, LIT, "", NONE, "#157 local tx-inject submit file (raw tx hex per line)")
+  C2P_ALIAS("embedded.tx_inject_hex", BIN_DASH, "--embedded-tx-inject-hex", VALUE)
+
 C2P_PARAM("embedded.utxo_fold_fees", Embedded, PATH, RESTART, C_DASH, LIT, "", NONE, "W5 fold fee pricing path (pairs with expect)")
   C2P_ALIAS("embedded.utxo_fold_fees", BIN_DASH, "--embedded-utxo-fold-fees", VALUE)
 

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -557,6 +557,19 @@ public:
     /// body tx would — the delta cannot inflate a single duff of reward.
     static constexpr uint64_t INJECT_FEE_DELTA = 100'000'000'000ULL;   // 1000 DASH, duffs
 
+    /// dashcore consensus/amount.h: MAX_MONEY = 21e6 * COIN (COIN = 1e8 duffs).
+    /// MoneyRange(v) := 0 <= v <= MAX_MONEY — the exact CheckTransaction /
+    /// GetValueOut value-range predicate (vendor/dashscript consensus/amount.h).
+    static constexpr int64_t DASH_MAX_MONEY = 21'000'000LL * 100'000'000LL;
+    static constexpr bool money_range(int64_t v) {
+        return v >= 0 && v <= DASH_MAX_MONEY;
+    }
+
+    /// BIP68 relative-locktime opt-in sentinel (dashcore consensus/txinfo.h
+    /// CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG). A vin whose nSequence has this
+    /// bit CLEAR (and a tx of nVersion >= 2) opts into a relative time-lock.
+    static constexpr uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = 0x80000000u;
+
     /// Every add_inject refusal is NAMED (DEF3 discipline — no silent drops).
     enum class InjectGate : uint8_t {
         Ok = 0,
@@ -567,6 +580,16 @@ public:
         AlreadyConfirmed,    // #125 own-output-present: the tx is already mined
         Unpriceable,         // inputs not present in our view/fold → fee not
                              // fold-proven → would be template-excluded silently
+        Bip68Unsupported,    // GAP-1: nVersion>=2 with a BIP68 relative-lock input.
+                             // The new ingestion seam breaks the sole-ingestion-
+                             // path invariant's "relay-admitted txs are final at
+                             // admission" premise (bad-txns-nonfinal). Full
+                             // SequenceLocks is M2; until then FAIL-CLOSED.
+        BadVoutRange,        // GAP-2: a vout value outside MoneyRange. Admitting
+                             // it lets the uint64 cast in compute_fee wrap out_sum
+                             // (INT64_MIN → huge) → inflated total_fees → the
+                             // coinbase value moves → an invalid, reward-unsafe
+                             // block (CheckTransaction bad-txns-vout-* / -txouttotal).
     };
     static const char* inject_gate_name(InjectGate g) {
         switch (g) {
@@ -576,6 +599,8 @@ public:
             case InjectGate::AlreadyKnown:       return "inject-already-known";
             case InjectGate::AlreadyConfirmed:   return "inject-already-confirmed";
             case InjectGate::Unpriceable:        return "inject-unpriceable";
+            case InjectGate::Bip68Unsupported:   return "inject-bip68-unsupported";
+            case InjectGate::BadVoutRange:       return "inject-bad-txns-vout-range";
         }
         return "inject-unknown";
     }
@@ -608,6 +633,39 @@ public:
         // (2) new-seam script-verify requirement (fail-closed).
         if (!m_script_check)
             return InjectGate::ScriptCheckUnarmed;
+        // (2a) GAP-1 — BIP68 relative-locktime FAIL-CLOSED. This is a NEW
+        //     ingestion seam, so the sole-ingestion-path invariant's argument
+        //     that bad-txns-nonfinal is N/A ("relay-admitted txs are final at
+        //     admission") no longer holds: a directly-injected tx never passed a
+        //     relaying dashd's SequenceLocks. We port absolute-locktime finality
+        //     (is_final_tx, run in the selector), but NOT relative BIP68
+        //     SequenceLocks (that is M2). Until then, refuse any tx that OPTS IN
+        //     to a relative lock — nVersion >= 2 with an input whose nSequence
+        //     leaves SEQUENCE_LOCKTIME_DISABLE_FLAG clear — rather than risk
+        //     selecting a bad-txns-nonfinal tx into a template. Chain-state
+        //     independent, so it sits with the other cheap pre-admission gates.
+        if (tx.version >= 2) {
+            for (const auto& vin : tx.vin) {
+                if ((vin.sequence & SEQUENCE_LOCKTIME_DISABLE_FLAG) == 0)
+                    return InjectGate::Bip68Unsupported;
+            }
+        }
+        // (2b) GAP-2 — CheckTransaction output value-range (bad-txns-vout-*).
+        //     dashcore CheckTransaction / CTransaction::GetValueOut reject any
+        //     vout outside MoneyRange and any running-sum overflow BEFORE the tx
+        //     is priced. compute_fee_locked casts vout.value to uint64 for
+        //     out_sum, so an out-of-range value (e.g. INT64_MIN) would wrap the
+        //     sum and inflate in_sum - out_sum → total_fees → the coinbase.
+        //     Refuse by name here, ahead of admission/pricing. No-op for any
+        //     valid tx (every vout already in range).
+        {
+            int64_t vout_running = 0;
+            for (const auto& vout : tx.vout) {
+                if (!money_range(vout.value) || !money_range(vout_running + vout.value))
+                    return InjectGate::BadVoutRange;
+                vout_running += vout.value;
+            }
+        }
         const uint256 txid = dash_txid(tx);
         // (3) dedup against our own pool.
         if (m_pool.count(txid))
@@ -2347,6 +2405,21 @@ private:
             return false;
         }
         for (const auto& vout : entry.tx.vout) {
+            // GAP-2 — MoneyRange guard (CheckTransaction bad-txns-vout-*). Any
+            // ingestion seam other than add_inject (relay add_tx, BIP35 drain,
+            // …) reaches this pricing path WITHOUT the add_inject range gate, so
+            // an out-of-range vout must be caught HERE too: static_cast<uint64_t>
+            // of a negative value (INT64_MIN → 2^63) wraps out_sum, so
+            // in_sum - out_sum would report a fabricated positive fee, a value-
+            // creating hole that moves the coinbase. Fail-closed: unpriced,
+            // fee_fold_proven stays false → template-excluded. No-op for any
+            // valid tx (every vout already in MoneyRange).
+            if (!money_range(vout.value)) {
+                entry.fee_known = false;
+                entry.fee_fold_proven = false;
+                entry.fee = 0;
+                return false;
+            }
             out_sum += static_cast<uint64_t>(vout.value);
         }
         if (in_sum < out_sum) {

--- a/src/impl/dash/coin/mempool.hpp
+++ b/src/impl/dash/coin/mempool.hpp
@@ -532,6 +532,112 @@ public:
         return add_tx_locked(tx, m_utxo.load(), /*is_dstx=*/true);
     }
 
+    // ── MINER/USER TX-INJECTION (#157, post-cut Tier-3, --embedded-tx-inject) ──
+    /// The single consensus maximum an injected tx may occupy — mirrors the
+    /// PIN lane's kMaxPinnedTxBytes (Dash rejects an oversize tx at CONSENSUS,
+    /// "bad-txns-oversize"; that once cost block 2517855). Checked first in
+    /// add_inject because it is the cheapest verdict and true against any
+    /// chain state.
+    static constexpr size_t kMaxInjectTxBytes = 100000;
+
+    /// INJECTION PRIORITY DELTA (W5-B mapDeltas, dashd PrioritiseTransaction).
+    /// An injected tx is prioritised by recording this delta, exactly the
+    /// mechanism dashd uses for DSTX (+0.1 COIN) and MNHF-signal txs. It lifts
+    /// the tx's MODIFIED fee so it sorts to the very top of the ancestor-score
+    /// index AND clears the blockMinFeeRate floor even at base fee 0 — the tx
+    /// is OFFERED FIRST, never guard-bypassed. 1000 DASH in duffs dominates any
+    /// real mempool fee; INJECT_POOL_MAX_ENTRIES bounds how many can be pooled,
+    /// keeping the modfee_wa ancestor aggregation far below uint64 overflow.
+    ///
+    /// REWARD-SAFE BY CONSTRUCTION: modified_fee() feeds ONLY scoring /
+    /// ordering / the blockMinFeeRate gate (dashd nModFeesWithAncestors). The
+    /// base `fee` that feeds total_fees → coinbasevalue / SelectedTx.fee is
+    /// UNTOUCHED (see get_sorted_txs_with_fees total_fees += e->fee). A 0-fee
+    /// inject therefore contributes exactly 0 to the coinbase, as any 0-fee
+    /// body tx would — the delta cannot inflate a single duff of reward.
+    static constexpr uint64_t INJECT_FEE_DELTA = 100'000'000'000ULL;   // 1000 DASH, duffs
+
+    /// Every add_inject refusal is NAMED (DEF3 discipline — no silent drops).
+    enum class InjectGate : uint8_t {
+        Ok = 0,
+        TooLarge,            // serialized size > kMaxInjectTxBytes
+        ScriptCheckUnarmed,  // has_script_check()==false — a NEW ingestion seam
+                             // MUST script-verify (sole-ingestion-path invariant)
+        AlreadyKnown,        // txid already in our pool
+        AlreadyConfirmed,    // #125 own-output-present: the tx is already mined
+        Unpriceable,         // inputs not present in our view/fold → fee not
+                             // fold-proven → would be template-excluded silently
+    };
+    static const char* inject_gate_name(InjectGate g) {
+        switch (g) {
+            case InjectGate::Ok:                 return "ok";
+            case InjectGate::TooLarge:           return "inject-oversize";
+            case InjectGate::ScriptCheckUnarmed: return "inject-script-check-unarmed";
+            case InjectGate::AlreadyKnown:       return "inject-already-known";
+            case InjectGate::AlreadyConfirmed:   return "inject-already-confirmed";
+            case InjectGate::Unpriceable:        return "inject-unpriceable";
+        }
+        return "inject-unknown";
+    }
+
+    /// Admit an INJECTED transaction into the mempool with priority.
+    ///
+    /// An inject rides the SAME add_tx path and the SAME selector as any other
+    /// mempool tx — the topology (G1), double-spend (`consumed`), script
+    /// (CheckInputScripts), finality (IsFinalTx), sigop (G2), coinbase-maturity
+    /// (G3) and islock (G4) guards in get_sorted_txs_with_fees all run over it
+    /// UNCHANGED. Priority = the tx is OFFERED FIRST (a large mapDeltas delta
+    /// so it out-sorts the fee market and clears the min-fee floor); it is NOT
+    /// a guard bypass. An invalid inject is DROPPED by the selector, never
+    /// served — its only effect is having occupied a pool slot.
+    ///
+    /// This is a new ingestion seam, so per the sole-ingestion-path invariant
+    /// at the top of this header it REFUSES unless the consensus-exact
+    /// CheckInputScripts callback is wired (has_script_check()); the selector
+    /// then script-verifies it, and IsFinalTx runs when the caller passes a
+    /// non-zero lock_time_cutoff (the embedded GBT always does). An inject
+    /// whose inputs cannot be fold-priced is REFUSED here BY NAME (never left
+    /// in the pool to be silently template-excluded).
+    ///
+    /// Caller holds no lock. Returns a named InjectGate verdict.
+    InjectGate add_inject(const MutableTransaction& tx) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        // (1) size — cheapest, chain-state-independent.
+        if (::pack(tx).get_span().size() > kMaxInjectTxBytes)
+            return InjectGate::TooLarge;
+        // (2) new-seam script-verify requirement (fail-closed).
+        if (!m_script_check)
+            return InjectGate::ScriptCheckUnarmed;
+        const uint256 txid = dash_txid(tx);
+        // (3) dedup against our own pool.
+        if (m_pool.count(txid))
+            return InjectGate::AlreadyKnown;
+        // (4) record the priority delta BEFORE admission — dashd mapDeltas
+        //     order (the delta pre-dates and survives acceptance; add_tx_locked
+        //     picks it up into entry.fee_delta). REWARD-SAFE: scoring-only.
+        record_fee_delta_locked(txid, INJECT_FEE_DELTA);
+        // (5) admit through the SAME path as any tx (runs the #125
+        //     already-confirmed reject). A false return here, after the pool
+        //     dedup above, is the own-output-present (already-mined) case.
+        if (!add_tx_locked(tx, m_utxo.load(), /*is_dstx=*/false)) {
+            m_fee_deltas.erase(txid);            // undo the speculative delta
+            return InjectGate::AlreadyConfirmed;
+        }
+        // (6) the tx MUST be fold-priced (inputs present, in_sum >= out_sum) or
+        //     the selector's fee_fold_proven gate would silently exclude it.
+        //     Refuse by name and roll back rather than leave a dead entry.
+        auto it = m_pool.find(txid);
+        if (it == m_pool.end() || !it->second.fee_fold_proven) {
+            remove_tx_locked(txid);
+            m_fee_deltas.erase(txid);
+            return InjectGate::Unpriceable;
+        }
+        LOG_INFO << "[MEMPOOL] inject admitted txid=" << txid.GetHex().substr(0, 16)
+                 << " base_fee=" << it->second.fee
+                 << " prioritised (delta=" << INJECT_FEE_DELTA << " duffs, scoring-only)";
+        return InjectGate::Ok;
+    }
+
 private:
     bool add_tx_locked(const MutableTransaction& tx,
                        ::core::coin::UTXOViewCache* utxo,
@@ -1202,6 +1308,18 @@ public:
         std::lock_guard<std::mutex> lock(m_mutex);
         std::vector<SelectedTx> result;
         std::set<uint256> selected;   // G1: the parent-in-selected-set check
+        // INTRA-TEMPLATE DOUBLE-SPEND GUARD (the #1494/#1497 `consumed` set,
+        // ported into DASH's richer dashd-port selector — DASH had no per-
+        // template consumed-outpoint set: m_spent_outputs is last-writer, so two
+        // pool txs spending the same outpoint could BOTH be selected and produce
+        // a bad-txns-inputs-* (double-spent) INVALID block). Every outpoint an
+        // already-selected package spends is recorded here; a later package whose
+        // member spends the same outpoint is DROPPED (kept: the higher
+        // ancestor-score one, selected first). Load-bearing for tx-injection —
+        // a double-spending inject is dropped PER-TX, never per-template — and a
+        // latent correctness fix for the whole serve path. Reward-safe: dropping
+        // a conflicting tx can only lower total_fees, and the coinbase follows.
+        std::set<std::pair<uint256, uint32_t>> consumed;
         uint64_t total_fees   = 0;
         uint32_t total_bytes  = 0;
         uint32_t total_sigops = DASH_COINBASE_SIGOPS_RESERVE;   // G2
@@ -1406,6 +1524,15 @@ public:
             std::set<uint256> in_package;
             for (const auto* e : package) in_package.insert(e->txid);
 
+            // Outpoints THIS package spends. Seeded empty; every member's vin is
+            // checked against the committed `consumed` set (a prior selected
+            // package) AND against this set (two members of the same package
+            // spending one outpoint), then inserted. Merged into `consumed` only
+            // if the whole package is admitted (block h). This is the per-tx
+            // double-spend drop — a conflicting tx is excluded, never the
+            // template refused.
+            std::set<std::pair<uint256, uint32_t>> pkg_spends;
+
             // ── (f) Validate the WHOLE package; any failing member drops the
             // candidate (never a partial package — that is exactly the
             // childless-parent / parentless-child shape G1 forbids). This block
@@ -1512,6 +1639,21 @@ public:
                     auto lk = m_islock_outpoints.find(opkey);
                     if (lk != m_islock_outpoints.end()
                         && lk->second != e->txid) {
+                        ok = false;
+                        break;
+                    }
+
+                    // INTRA-TEMPLATE DOUBLE-SPEND: this outpoint is already
+                    // spent by an ALREADY-SELECTED package (`consumed`), or by
+                    // an earlier member of THIS package (pkg_spends insert
+                    // fails) → drop the whole candidate. Two txs spending one
+                    // coin cannot both be valid in a block; the higher-scored
+                    // one won selection first, so this drop is deterministic.
+                    // (An in-package parent's OUTPUT is a distinct outpoint from
+                    // any coin's, so a normal parent→child spend never trips
+                    // this — only a genuine conflict does.)
+                    if (consumed.count(opkey)
+                        || !pkg_spends.insert(opkey).second) {
                         ok = false;
                         break;
                     }
@@ -1648,6 +1790,9 @@ public:
             // counter ONCE per admitted PACKAGE (dashd miner.cpp:625, before
             // SortForBlock), not per-tx.
             nConsecutiveFailed = 0;
+            // COMMIT this package's spends so a later package that double-spends
+            // any of them is dropped in block (f) above.
+            consumed.insert(pkg_spends.begin(), pkg_spends.end());
             sort_package_for_block(package, anc);
             for (const auto* e : package) {
                 selected.insert(e->txid);

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -22,6 +22,7 @@
 #include <impl/dash/coin/work_source.hpp>        // EmbeddedWorkInputs, select_dash_work, WorkSelection
 #include <impl/dash/coin/mn_state_machine.hpp>   // MnStateMachine
 #include <impl/dash/coin/mempool.hpp>            // Mempool
+#include <impl/dash/coin/tx_inject_pool.hpp>     // TxInjectPool (#157 miner/user tx-injection)
 #include <impl/dash/coin/rpc_data.hpp>           // DashWorkData
 #include <impl/dash/coin/quorum_manager.hpp>     // QuorumManager (merkleRootQuorums source)
 #include <impl/dash/coin/quorum_root.hpp>        // compute_merkle_root_quorums (pre-emit recompute)
@@ -579,6 +580,89 @@ public:
     /// implicit consequence of the UTXO lane maturing.
     void set_serve_mempool_txs(bool on) { m_serve_mempool_txs = on; }
     bool serve_mempool_txs() const { return m_serve_mempool_txs; }
+
+    /// ── MINER/USER TX-INJECTION (#157, --embedded-tx-inject, default OFF) ────
+    /// Opt-in, post-cut Tier-3. A submitted consensus-valid tx is admitted to
+    /// the mempool with PRIORITY (Mempool::add_inject → a large mapDeltas delta)
+    /// so it lands in the block c2pool mines regardless of its fee rate, and is
+    /// non-standard-tolerant — the ONLY gate is consensus-validity, enforced by
+    /// the SAME get_sorted_txs_with_fees selector guards (topology, double-spend,
+    /// script, finality, sigops, maturity, islock) that every served body tx
+    /// passes. REWARD-SAFE: an inject is an ordinary body tx; the coinbase /
+    /// subsidy / PPLNS / payee path is byte-unchanged (a 0-fee inject adds 0 to
+    /// total_fees). Injected txs ride the served-body path, so this augments —
+    /// and requires — the serve-mempool-txs / daemonless serve posture.
+    void set_tx_inject_enabled(bool on) { m_tx_inject_enabled = on; }
+    bool tx_inject_enabled() const { return m_tx_inject_enabled; }
+
+    /// Named outcome of a submit_inject call — every refusal carries its cause
+    /// (DEF3 discipline: no silent drops).
+    struct InjectSubmitResult {
+        bool        ok{false};
+        std::string cause;    // "ok" or a named refusal
+        uint256     txid;
+    };
+
+    /// Submit a raw transaction for injection. Cheapest-checks-first gate
+    /// (design §4.3): feature-enabled → DoS caps (pool full / total bytes / per-
+    /// tx size, TxInjectPool) → mempool admission (Mempool::add_inject: size,
+    /// script-check-armed, dedup, already-confirmed, priceable). Priority is
+    /// applied by add_inject; the authoritative consensus validation (scripts /
+    /// finality / double-spend) runs at template build and DROPS an invalid
+    /// inject there — it is never served. `flags` and `expiry_height` are the
+    /// design's wire fields (carried for M2/M3). io-thread only.
+    InjectSubmitResult submit_inject(const MutableTransaction& tx,
+                                     uint32_t flags = 0,
+                                     int32_t expiry_height = 0) {
+        InjectSubmitResult r;
+        r.txid = dash::coin::dash_txid(tx);
+        if (!m_tx_inject_enabled) { r.cause = "inject-disabled"; return r; }
+        // PR-1: classic (type-0) txs only. Special types interact with the CbTx
+        // roots the template commits; refuse by name (staged to a later PR).
+        if (tx.type != 0 || tx.vin.empty() || tx.vout.empty()) {
+            r.cause = "inject-type-unsupported"; return r;
+        }
+        // Lazily reconcile the pool with the mempool before admitting: forget
+        // any tracked inject no longer in the mempool (confirmed / evicted) and
+        // reap expired ones, so the caps reflect what is actually live.
+        reconcile_inject_pool();
+        const uint32_t byte_size =
+            static_cast<uint32_t>(::pack(tx).get_span().size());
+        // DoS caps FIRST (cheap, no consensus work): a full / over-cap pool
+        // refuses before the mempool pays for pricing.
+        auto pv = m_inject_pool.would_admit(r.txid, byte_size);
+        if (pv != dash::coin::TxInjectPool::Admit::Ok) {
+            r.cause = dash::coin::TxInjectPool::admit_name(pv); return r;
+        }
+        // Mempool admission with priority (runs the validity/dedup/script-armed
+        // gate). Priority = offered first, NOT a guard bypass.
+        auto gv = m_mempool.add_inject(tx);
+        if (gv != dash::coin::Mempool::InjectGate::Ok) {
+            r.cause = dash::coin::Mempool::inject_gate_name(gv); return r;
+        }
+        // Track it for DoS accounting + expiry.
+        m_inject_pool.admit(r.txid, flags, expiry_height, byte_size);
+        r.ok = true;
+        r.cause = "ok";
+        return r;
+    }
+
+    /// Reconcile the inject ledger with the live mempool + tip: drop tracked
+    /// injects that have left the mempool (confirmed / conflict-evicted) or have
+    /// expired, evicting the expired ones from the mempool too. Called lazily
+    /// from submit_inject and exposed for a block-connect wiring in a later PR.
+    void reconcile_inject_pool() {
+        if (m_inject_pool.empty()) return;
+        // Expiry against our own tip.
+        if (m_prev_height != 0) {
+            for (const auto& id : m_inject_pool.reap_expired(
+                     static_cast<int32_t>(m_prev_height + 1))) {
+                m_mempool.remove_tx(id);
+            }
+        }
+    }
+
+    size_t inject_pool_size() const { return m_inject_pool.size(); }
 
     /// PINNED LOCAL TX (--pin-local-tx-hex, donation-dust consolidation): an
     /// operator-supplied, externally-signed, zero-fee tx that can only reach
@@ -1927,6 +2011,11 @@ private:
     // fee-carrying mempool-tx body path is an explicit operator opt-in (see
     // set_serve_mempool_txs).
     bool m_serve_mempool_txs{false};
+    // #157 (--embedded-tx-inject): DEFAULT OFF — opt-in miner/user tx-injection.
+    // The bounded inject ledger (DoS caps + expiry); template inclusion is via
+    // m_mempool (Mempool::add_inject priority), not this structure.
+    bool                         m_tx_inject_enabled{false};
+    dash::coin::TxInjectPool     m_inject_pool;
     // #107 PHASE 2 (--embedded-accrue-asset-locks): DEFAULT OFF — accrue the
     // pending type-8 asset-lock term into the CbTx creditPoolBalance. See
     // set_accrue_pending_asset_locks. Consumed by make_embedded_work_inputs

--- a/src/impl/dash/coin/tx_inject_pool.hpp
+++ b/src/impl/dash/coin/tx_inject_pool.hpp
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+/// #157 — miner/user tx-injection: the bounded, opt-in INJECT POOL (M1).
+///
+/// A small, capped, per-node ledger of the injected transactions this node has
+/// accepted into its mempool with priority (--embedded-tx-inject, default OFF).
+/// It is NOT the template-inclusion mechanism — that is the mempool: an accepted
+/// inject rides Mempool::add_inject (a large mapDeltas priority delta) and the
+/// SAME get_sorted_txs_with_fees selector guards as any other body tx. This pool
+/// is the DoS-accounting + expiry ledger the design's §4.6 guards need:
+///
+///   * INJECT_POOL_MAX_ENTRIES — a hard cap on how many injects are tracked;
+///   * kMaxInjectTotalBytes     — a cumulative byte cap (the PR-1 stand-in for
+///                                the §4.4 INJECT_MAX_BLOCK_FRACTION reservation:
+///                                bound how much block space injects can claim,
+///                                enforced in the pool rather than as a selector
+///                                reservation — the selector already yields the
+///                                fee-sorted remainder);
+///   * kMaxInjectTxBytes        — a per-tx size cap (mirrors the mempool's own
+///                                consensus bad-txns-oversize guard);
+///   * expiry_height            — drop an inject a node no longer re-offers.
+///
+/// REWARD SAFETY: this structure holds txids + metadata ONLY. It has NO write
+/// path to the coinbase, subsidy, PPLNS, donation, payee queue, or give_author —
+/// it can only bound how many consensus-valid body txs the mempool prioritises.
+///
+/// THREADING: io-thread confined, same discipline as NodeCoinState's
+/// m_pinned_local_txs. No internal lock; the owner serialises access.
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <ctime>
+#include <deque>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace dash {
+namespace coin {
+
+/// One accepted inject's bookkeeping. `flags` mirror the design's wire flags
+/// (bit0 zero-fee-intent, bit1 non-standard-intent, bit2 priority-request) and
+/// are carried for M2/M3 (fan-out / rate-accounting); PR-1 stores them but the
+/// priority is uniform (see Mempool::INJECT_FEE_DELTA).
+struct InjectEntry {
+    uint256  txid;
+    uint32_t flags{0};
+    int32_t  expiry_height{0};   // 0 = never auto-expires
+    uint32_t byte_size{0};
+    time_t   submit_time{0};
+};
+
+class TxInjectPool {
+public:
+    /// Hard cap on tracked injects (§4.6 INJECT_POOL_MAX_ENTRIES).
+    static constexpr size_t INJECT_POOL_MAX_ENTRIES = 1024;
+    /// Cumulative byte ceiling across ALL tracked injects — the PR-1 stand-in
+    /// for the block-fraction reservation. Mirrors Mempool::kMaxPinnedTotalBytes
+    /// (well under Dash's 2 MB block limit; injects are never the whole block).
+    static constexpr size_t kMaxInjectTotalBytes = 400000;
+    /// Per-tx size cap (mirrors Mempool::kMaxInjectTxBytes / bad-txns-oversize).
+    static constexpr size_t kMaxInjectTxBytes = 100000;
+
+    /// Every admission refusal is NAMED (DEF3 discipline).
+    enum class Admit : uint8_t {
+        Ok = 0,
+        Duplicate,           // txid already tracked
+        PoolFull,            // INJECT_POOL_MAX_ENTRIES reached
+        TotalBytesExceeded,  // would exceed kMaxInjectTotalBytes
+        TooLarge,            // byte_size > kMaxInjectTxBytes
+    };
+    static const char* admit_name(Admit a) {
+        switch (a) {
+            case Admit::Ok:                 return "ok";
+            case Admit::Duplicate:          return "inject-pool-duplicate";
+            case Admit::PoolFull:           return "inject-pool-full";
+            case Admit::TotalBytesExceeded: return "inject-pool-total-bytes-exceeded";
+            case Admit::TooLarge:           return "inject-pool-oversize";
+        }
+        return "inject-pool-unknown";
+    }
+
+    bool   contains(const uint256& txid) const { return m_entries.count(txid) != 0; }
+    size_t size() const { return m_entries.size(); }
+    size_t total_bytes() const { return m_total_bytes; }
+    bool   empty() const { return m_entries.empty(); }
+
+    /// Would-admit check WITHOUT mutating — the caller runs it before the more
+    /// expensive mempool admission so a full/over-cap pool refuses cheaply.
+    Admit would_admit(const uint256& txid, uint32_t byte_size) const {
+        if (byte_size > kMaxInjectTxBytes) return Admit::TooLarge;
+        if (m_entries.count(txid))         return Admit::Duplicate;
+        if (m_entries.size() >= INJECT_POOL_MAX_ENTRIES) return Admit::PoolFull;
+        if (m_total_bytes + byte_size > kMaxInjectTotalBytes)
+            return Admit::TotalBytesExceeded;
+        return Admit::Ok;
+    }
+
+    /// Record an accepted inject. Returns the named verdict; on Ok the entry is
+    /// tracked and its bytes count toward the cumulative cap.
+    Admit admit(const uint256& txid, uint32_t flags,
+                int32_t expiry_height, uint32_t byte_size) {
+        Admit v = would_admit(txid, byte_size);
+        if (v != Admit::Ok) return v;
+        InjectEntry e;
+        e.txid = txid;
+        e.flags = flags;
+        e.expiry_height = expiry_height;
+        e.byte_size = byte_size;
+        e.submit_time = std::time(nullptr);
+        m_order.push_back(txid);
+        m_entries.emplace(txid, e);
+        m_total_bytes += byte_size;
+        return Admit::Ok;
+    }
+
+    /// Forget one inject (confirmed, evicted from mempool, or expired). No-op if
+    /// untracked. Returns true if it was tracked.
+    bool forget(const uint256& txid) {
+        auto it = m_entries.find(txid);
+        if (it == m_entries.end()) return false;
+        m_total_bytes -= it->second.byte_size;
+        m_entries.erase(it);
+        // m_order keeps the txid until the next reap pops it (cheap FIFO; a
+        // stale txid there is harmless — reap skips txids no longer in m_entries).
+        return true;
+    }
+
+    /// Drop injects whose expiry_height has passed (height > expiry_height, for
+    /// entries with expiry_height != 0). Returns the dropped txids so the caller
+    /// can evict them from the mempool too. Also compacts the FIFO order deque.
+    std::vector<uint256> reap_expired(int32_t height) {
+        std::vector<uint256> dropped;
+        std::deque<uint256> keep;
+        for (const uint256& id : m_order) {
+            auto it = m_entries.find(id);
+            if (it == m_entries.end()) continue;   // already forgotten
+            const InjectEntry& e = it->second;
+            if (e.expiry_height != 0 && height > e.expiry_height) {
+                m_total_bytes -= e.byte_size;
+                m_entries.erase(it);
+                dropped.push_back(id);
+            } else {
+                keep.push_back(id);
+            }
+        }
+        m_order.swap(keep);
+        return dropped;
+    }
+
+    void clear() {
+        m_entries.clear();
+        m_order.clear();
+        m_total_bytes = 0;
+    }
+
+private:
+    std::map<uint256, InjectEntry> m_entries;
+    std::deque<uint256>            m_order;   // FIFO for compaction / reap
+    size_t                         m_total_bytes{0};
+};
+
+} // namespace coin
+} // namespace dash

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -668,6 +668,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     add_executable(test_dash_mempool test_dash_mempool.cpp test_dash_replay_utxo_fold.cpp
         test_dash_mempool_validity_gate.cpp
         test_dash_checkinputscripts.cpp   # PR-C4: consensus-exact CheckInputScripts KAT
+        test_dash_tx_inject.cpp           # #157: miner/user tx-injection (priority + validity + DoS)
         test_dash_fold_fee_source.cpp)    # W5-A: fold-backed fee pricing source
     target_link_libraries(test_dash_mempool PRIVATE
         GTest::gtest_main GTest::gtest

--- a/test/test_dash_tx_inject.cpp
+++ b/test/test_dash_tx_inject.cpp
@@ -21,7 +21,15 @@
 //        * a missing-input inject is REFUSED at submit (unpriceable, by name).
 //   4. DoS + SEAM DISCIPLINE — oversize is refused by name; a new ingestion
 //      seam refuses unless the consensus-exact CheckInputScripts callback is
-//      armed (sole-ingestion-path invariant).
+//      armed (sole-ingestion-path invariant). The seam ALSO closes the two
+//      admission rows the invariant used to argue N-A on relay-only ingestion:
+//        * FAIL-CLOSED BIP68 (bad-txns-nonfinal) — a v2 inject that opts into a
+//          relative sequence-lock is refused (inject-bip68-unsupported), since
+//          SequenceLocks is not yet ported (M2);
+//        * REWARD-SAFE value range (bad-txns-vout-*) — an inject with a vout
+//          outside MoneyRange is refused (inject-bad-txns-vout-range), and the
+//          shared compute_fee pricing path MoneyRange-guards out_sum so a
+//          relay/BIP35 tx cannot wrap the sum into a fabricated coinbase fee.
 //
 // The signed-spend + script-verify scaffolding is the SAME dashcore VerifyScript
 // (dash_scriptcheck.so) the KAT signs a real P2PKH spend against — no hand-rolled
@@ -346,6 +354,120 @@ TEST(DashTxInject, InjectPoolDoSCaps)
     auto d2 = pool.reap_expired(/*height=*/101);
     ASSERT_EQ(d2.size(), 1u);
     EXPECT_EQ(d2[0], tExp);
+}
+
+// (4d) GAP-1 FAIL-CLOSED — BIP68 relative-locktime. This is a NEW ingestion
+//      seam, so the sole-ingestion-path invariant's "relay-admitted txs are
+//      final at admission" premise no longer holds: a directly-injected tx
+//      never passed a relaying dashd's SequenceLocks. We port absolute-locktime
+//      finality (is_final_tx) but NOT relative BIP68 (that is M2), so an inject
+//      that OPTS IN to a relative lock — nVersion>=2 with an input whose
+//      nSequence leaves SEQUENCE_LOCKTIME_DISABLE_FLAG clear — is FAIL-CLOSED
+//      refused by name rather than risked into a bad-txns-nonfinal template.
+//      RED on 9e859686: InjectGate::Bip68Unsupported does not exist and the tx
+//      is admitted (Ok) → selectable → an invalid block. GREEN after: refused.
+TEST(DashTxInject, Bip68RelativeLockInjectRefusedFailClosed)
+{
+    Key k(0x88);
+    uint256 prev = prevhash(0xba);
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+
+    // NEGATIVE: nVersion==2 with a BIP68 relative-lock input (bit 31 clear).
+    auto rel = make_signed_spend(k, prev, 90'000);
+    rel.version = 2;
+    rel.vin[0].sequence = 0x0000000au;   // disable-flag clear ⇒ relative lock ON
+    EXPECT_EQ(mp.add_inject(rel), Mempool::InjectGate::Bip68Unsupported)
+        << "a v2 inject that opts into a BIP68 relative lock must be fail-closed refused";
+
+    // POSITIVE TWIN 1: nVersion==2 but every input disables the relative lock
+    // (SEQUENCE_FINAL has bit 31 set) ⇒ no BIP68 opt-in ⇒ admitted.
+    auto v2_final = make_signed_spend(k, prev, 90'000);
+    v2_final.version = 2;                 // vin sequence stays 0xffffffff
+    EXPECT_EQ(mp.add_inject(v2_final), Mempool::InjectGate::Ok)
+        << "a v2 inject with no relative-lock input rides the normal path";
+
+    // POSITIVE TWIN 2: nVersion==1 never activates BIP68, even with the same
+    // relative-lock sequence bits — version-gated, exactly as consensus does it.
+    uint256 prev2 = prevhash(0xbb);
+    utxo.add_coin(Outpoint(prev2, 0), Coin(100'000, to_script(k.spk), 1, false));
+    auto v1_rel = make_signed_spend(k, prev2, 90'000);
+    v1_rel.version = 1;
+    v1_rel.vin[0].sequence = 0x0000000au;
+    EXPECT_EQ(mp.add_inject(v1_rel), Mempool::InjectGate::Ok)
+        << "BIP68 is nVersion>=2 only; a v1 inject is unaffected";
+}
+
+// (4e) GAP-2 REWARD-SAFETY — CheckTransaction output value-range (MoneyRange).
+//      compute_fee casts vout.value to uint64 for out_sum, so an out-of-range
+//      value (INT64_MIN) wraps the sum and fabricates a positive fee → inflated
+//      total_fees → the coinbase value MOVES → an invalid, reward-unsafe block.
+//      Two guards close it: add_inject refuses by name BEFORE pricing, and
+//      compute_fee_locked (the shared pricing path every ingestion seam uses)
+//      MoneyRange-guards out_sum so a relay/BIP35 tx is template-EXCLUDED.
+//      RED on 9e859686: InjectGate::BadVoutRange does not exist, the inject is
+//      admitted, and a 2×INT64_MIN relay tx prices to a fabricated fee and is
+//      SELECTED. GREEN after: refused / excluded, coinbase untouched.
+TEST(DashTxInject, VoutValueRangeInjectRefusedAndPricingFailClosed)
+{
+    Key k(0x99);
+    uint256 prev = prevhash(0xca);
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+
+    // NEGATIVE (add_inject gate): a vout outside MoneyRange (INT64_MIN — the
+    // exact wrap value) is refused by name, ahead of admission/pricing.
+    auto badneg = make_signed_spend(k, prev, 90'000);
+    badneg.vout[0].value = INT64_MIN;
+    EXPECT_EQ(mp.add_inject(badneg), Mempool::InjectGate::BadVoutRange)
+        << "an inject with a vout below MoneyRange must be refused by name";
+
+    // NEGATIVE (upper bound): a vout above MAX_MONEY is equally refused.
+    auto badhi = make_signed_spend(k, prev, 90'000);
+    badhi.vout[0].value = Mempool::DASH_MAX_MONEY + 1;
+    EXPECT_EQ(mp.add_inject(badhi), Mempool::InjectGate::BadVoutRange)
+        << "an inject with a vout above MoneyRange must be refused by name";
+
+    // POSITIVE TWIN: an in-range inject prices normally and is served at its
+    // true base fee — the guard is a no-op for any valid tx.
+    auto good = make_signed_spend(k, prev, 90'000);   // fee 10'000
+    EXPECT_EQ(mp.add_inject(good), Mempool::InjectGate::Ok);
+    {
+        auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+        ASSERT_EQ(selected.size(), 1u);
+        EXPECT_EQ(dash_txid(selected[0].tx), dash_txid(good));
+        EXPECT_EQ(fees, 10'000u) << "a valid inject prices to its true base fee (guard is a no-op)";
+    }
+
+    // compute_fee_locked GUARD via the RELAY seam (add_tx), which has NO inject
+    // gate: two INT64_MIN vouts wrap out_sum to 0, so on 9e859686 the tx prices
+    // to a fabricated fee (in_sum) and is SELECTED — a value-creating block.
+    // Script-check is left UNARMED so the selector's fee_fold_proven gate is the
+    // sole discriminator (no signature confound). GREEN after: MoneyRange makes
+    // the tx unpriceable ⇒ fee_fold_proven false ⇒ template-excluded.
+    uint256 prevW = prevhash(0xcb);
+    UTXOViewCache utxo2(nullptr);
+    utxo2.add_coin(Outpoint(prevW, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp2; mp2.set_utxo(&utxo2);
+    // NO arm_script_check — isolate the pricing guard.
+    MutableTransaction wrap;
+    wrap.version = 1; wrap.type = 0; wrap.locktime = 0;
+    TxIn win; win.prevout.hash = prevW; win.prevout.index = 0; win.sequence = 0xffffffffu;
+    win.scriptSig = to_script(k.spk);
+    wrap.vin.push_back(win);
+    TxOut wo1; wo1.value = INT64_MIN; wo1.scriptPubKey = to_script(k.spk); wrap.vout.push_back(wo1);
+    TxOut wo2; wo2.value = INT64_MIN; wo2.scriptPubKey = to_script(k.spk); wrap.vout.push_back(wo2);
+    ASSERT_TRUE(mp2.add_tx(wrap));   // admitted (unpriceable txs are admitted, then excluded)
+    auto [sel2, fees2] = mp2.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    EXPECT_EQ(sel2.size(), 0u)
+        << "a relay tx whose vouts wrap out_sum must be template-excluded, not priced to a fake fee";
+    EXPECT_EQ(fees2, 0u) << "the fabricated fee must never reach total_fees / the coinbase";
 }
 
 // (5) GOOD-CITIZEN: injection is opt-in ONLY. It is NOT a TxServeLever, so the

--- a/test/test_dash_tx_inject.cpp
+++ b/test/test_dash_tx_inject.cpp
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// #157 — miner/user TX-INJECTION runtime (M1: inject pool + validation + priority).
+//
+// Proves the four load-bearing properties of the injection runtime, each
+// RED-on-master (master has no Mempool::add_inject and no `consumed` double-spend
+// set) / GREEN-after:
+//
+//   1. PRIORITY — a 0-fee injected tx is selected AHEAD of a fee-paying tx and
+//      clears the blockMinFeeRate floor (on master a 0-fee tx sinks below the
+//      floor and is never selected). The priority is a scoring-only mapDeltas
+//      delta: it does NOT touch the base fee that feeds the coinbase.
+//   2. REWARD-SAFETY — an inject with a real fee f contributes exactly f (its
+//      BASE fee) to total_fees, never f + INJECT_FEE_DELTA. The coinbase is
+//      derived from total_fees, so the delta cannot inflate a single duff.
+//   3. VALIDITY, NOT BYPASS — an injected tx rides the SAME selector guards:
+//        * a double-spending inject is DROPPED per-tx (the `consumed` set),
+//          the template is NOT refused (on master both would be selected → an
+//          invalid bad-txns-inputs-* block);
+//        * a bad-script inject is admitted to the pool but DROPPED at template
+//          build (never served);
+//        * a missing-input inject is REFUSED at submit (unpriceable, by name).
+//   4. DoS + SEAM DISCIPLINE — oversize is refused by name; a new ingestion
+//      seam refuses unless the consensus-exact CheckInputScripts callback is
+//      armed (sole-ingestion-path invariant).
+//
+// The signed-spend + script-verify scaffolding is the SAME dashcore VerifyScript
+// (dash_scriptcheck.so) the KAT signs a real P2PKH spend against — no hand-rolled
+// fixture. Folded into the test_dash_mempool executable (build.yml allowlisted).
+
+#include <gtest/gtest.h>
+
+#include <impl/dash/coin/mempool.hpp>
+#include <impl/dash/coin/tx_inject_pool.hpp>
+#include <impl/dash/coin/good_citizen_defaults.hpp>
+#include <impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.h>
+
+#include <core/uint256.hpp>
+#include <core/coin/utxo_view_cache.hpp>
+
+#include <secp256k1.h>
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+using dash::coin::Mempool;
+using dash::coin::TxInjectPool;
+using dash::coin::MutableTransaction;
+using dash::coin::dash_txid;
+using ::core::coin::UTXOViewCache;
+using ::core::coin::Outpoint;
+using ::core::coin::Coin;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+namespace {
+
+std::vector<uint8_t> ser(const MutableTransaction& tx) {
+    auto ps = ::pack(tx);
+    auto sp = ps.get_span();
+    const auto* b = reinterpret_cast<const uint8_t*>(sp.data());
+    return std::vector<uint8_t>(b, b + sp.size());
+}
+
+OPScript to_script(const std::vector<uint8_t>& v) {
+    return OPScript(v.data(), v.data() + v.size());
+}
+
+// One deterministic P2PKH keypair + scriptPubKey (mirrors test_dash_checkinputscripts).
+struct Key {
+    secp256k1_context* ctx;
+    uint8_t seckey[32];
+    uint8_t pub[33];
+    size_t publen = 33;
+    std::vector<uint8_t> spk;
+
+    Key(uint8_t seed) {
+        ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+        std::memset(seckey, seed, 32);
+        secp256k1_pubkey p;
+        EXPECT_EQ(secp256k1_ec_pubkey_create(ctx, &p, seckey), 1);
+        secp256k1_ec_pubkey_serialize(ctx, pub, &publen, &p, SECP256K1_EC_COMPRESSED);
+        uint8_t h160[20];
+        c2pool_dash_hash160(pub, (unsigned)publen, h160);
+        spk = {0x76, 0xa9, 0x14};
+        spk.insert(spk.end(), h160, h160 + 20);
+        spk.push_back(0x88);
+        spk.push_back(0xac);
+    }
+    ~Key() { secp256k1_context_destroy(ctx); }
+
+    std::vector<uint8_t> sign_scriptsig(const std::vector<uint8_t>& sighash32) const {
+        secp256k1_ecdsa_signature sig;
+        EXPECT_EQ(secp256k1_ecdsa_sign(ctx, &sig, sighash32.data(), seckey, nullptr, nullptr), 1);
+        uint8_t der[72]; size_t derlen = 72;
+        secp256k1_ecdsa_signature_serialize_der(ctx, der, &derlen, &sig);
+        std::vector<uint8_t> ss;
+        ss.push_back((uint8_t)(derlen + 1));
+        ss.insert(ss.end(), der, der + derlen);
+        ss.push_back(0x01);                       // SIGHASH_ALL
+        ss.push_back((uint8_t)publen);
+        ss.insert(ss.end(), pub, pub + publen);
+        return ss;
+    }
+};
+
+// Signed 1-in 1-out P2PKH spend of (prev:0). Coin value = out + fee.
+MutableTransaction make_signed_spend(const Key& k, const uint256& prev,
+                                     int64_t out_value) {
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 0;
+    TxIn in; in.prevout.hash = prev; in.prevout.index = 0; in.sequence = 0xffffffffu;
+    in.scriptSig = to_script(k.spk);
+    tx.vin.push_back(in);
+    TxOut out; out.value = out_value; tx.vout.push_back(out);
+
+    auto unsigned_bytes = ser(tx);
+    uint8_t sighash[32];
+    EXPECT_EQ(c2pool_dash_legacy_sighash(unsigned_bytes.data(), (unsigned)unsigned_bytes.size(),
+                                         0, k.spk.data(), (unsigned)k.spk.size(),
+                                         1, sighash), 1);
+    auto ss = k.sign_scriptsig(std::vector<uint8_t>(sighash, sighash + 32));
+    tx.vin[0].scriptSig = to_script(ss);
+    return tx;
+}
+
+uint256 prevhash(uint8_t b) { uint256 h; std::memset(h.begin(), b, 32); return h; }
+
+// Wire the consensus-exact CheckInputScripts callback (dashcore VerifyScript).
+void arm_script_check(Mempool& mp) {
+    mp.set_script_check([](const std::vector<uint8_t>& t, uint32_t n,
+                           const std::vector<uint8_t>& s, uint32_t f) {
+        return c2pool_dash_verify_input(s.data(), (unsigned)s.size(),
+                                        t.data(), (unsigned)t.size(), n, f) == 1;
+    });
+}
+
+} // namespace
+
+// (1) PRIORITY: a 0-fee inject is selected AHEAD of a fee-paying tx and clears
+//     the min-fee floor. RED on master: no add_inject; a 0-fee tx is below the
+//     blockMinFeeRate floor and never selected.
+TEST(DashTxInject, ZeroFeeInjectSelectedAheadOfFeeSorted)
+{
+    Key k(0x11);
+    uint256 prevFee = prevhash(0xa1);
+    uint256 prevInj = prevhash(0xa2);
+    auto tx_fee = make_signed_spend(k, prevFee, 90'000);   // fee 10'000
+    auto tx_inj = make_signed_spend(k, prevInj, 100'000);  // fee 0
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prevFee, 0), Coin(100'000, to_script(k.spk), 1, false));
+    utxo.add_coin(Outpoint(prevInj, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+
+    ASSERT_TRUE(mp.add_tx(tx_fee));
+    ASSERT_EQ(mp.add_inject(tx_inj), Mempool::InjectGate::Ok);
+
+    auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    ASSERT_EQ(selected.size(), 2u) << "both the fee tx and the prioritised 0-fee inject must be in the body";
+    // The inject sorts FIRST (its modified feerate dominates).
+    EXPECT_EQ(dash_txid(selected[0].tx), dash_txid(tx_inj))
+        << "the injected tx must be offered FIRST (priority class)";
+    // REWARD-SAFETY: the 0-fee inject contributes 0; total_fees is the fee tx's
+    // base fee only — the priority delta never reaches the coinbase.
+    EXPECT_EQ(fees, 10'000u);
+}
+
+// (2) REWARD-SAFETY: an inject with a real fee f contributes exactly f (base),
+//     NOT f + INJECT_FEE_DELTA.
+TEST(DashTxInject, InjectFeeDeltaNeverInflatesCoinbase)
+{
+    Key k(0x22);
+    uint256 prev = prevhash(0xb1);
+    auto tx = make_signed_spend(k, prev, 95'000);          // real fee 5'000
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+    ASSERT_EQ(mp.add_inject(tx), Mempool::InjectGate::Ok);
+
+    auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    ASSERT_EQ(selected.size(), 1u);
+    EXPECT_EQ(selected[0].fee, 5'000u) << "SelectedTx.fee is the BASE fee, delta excluded";
+    EXPECT_EQ(fees, 5'000u) << "total_fees (→ coinbasevalue) must be the base fee, never base+delta";
+}
+
+// (3a) VALIDITY: a double-spending tx is DROPPED per-tx by the `consumed` set,
+//      the template is NOT refused. RED on master: no consumed set → BOTH txs
+//      are selected → an invalid intra-block double-spend.
+TEST(DashTxInject, DoubleSpendIsDroppedPerTxNotTemplate)
+{
+    Key k(0x33);
+    uint256 prev = prevhash(0xc1);
+    // Two distinct txs (different output value ⇒ different txid) spending the
+    // SAME outpoint (prev:0). Both are individually consensus-priceable.
+    auto a = make_signed_spend(k, prev, 90'000);   // fee 10'000
+    auto b = make_signed_spend(k, prev, 80'000);   // fee 20'000 (higher — wins)
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+    ASSERT_TRUE(mp.add_tx(a));
+    ASSERT_TRUE(mp.add_tx(b));
+
+    auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    ASSERT_EQ(selected.size(), 1u)
+        << "exactly ONE of two conflicting txs may be in the body (the other is dropped)";
+    // The higher-feerate one (b, fee 20'000) is selected first and wins.
+    EXPECT_EQ(dash_txid(selected[0].tx), dash_txid(b));
+    EXPECT_EQ(fees, 20'000u);
+}
+
+// (3b) VALIDITY: even with the injection PRIORITY delta, a double-spending inject
+//      cannot force BOTH into the block — priority is offered-first, not a guard
+//      bypass. The inject wins (offered first) and the conflicting fee tx drops.
+TEST(DashTxInject, InjectDoubleSpendStillDropsTheConflict)
+{
+    Key k(0x44);
+    uint256 prev = prevhash(0xd1);
+    auto body_tx = make_signed_spend(k, prev, 80'000);   // fee 20'000 (a rich body tx)
+    auto inj_tx  = make_signed_spend(k, prev, 100'000);  // fee 0, but INJECTED (spends same coin)
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+    ASSERT_TRUE(mp.add_tx(body_tx));
+    ASSERT_EQ(mp.add_inject(inj_tx), Mempool::InjectGate::Ok);
+
+    auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    ASSERT_EQ(selected.size(), 1u) << "a conflicting inject NEVER lets both into the block";
+    EXPECT_EQ(dash_txid(selected[0].tx), dash_txid(inj_tx)) << "the inject is offered first";
+    EXPECT_EQ(fees, 0u) << "the 0-fee inject won; the fee tx it conflicts with is dropped";
+}
+
+// (3c) VALIDITY: a bad-script inject is admitted to the pool (priceable from the
+//      UTXO value) but DROPPED at template build by the ARMED script check —
+//      never served. Priority is not a guard bypass.
+TEST(DashTxInject, BadScriptInjectDroppedAtTemplateBuild)
+{
+    Key k(0x55);
+    uint256 prev = prevhash(0xe1);
+    auto good = make_signed_spend(k, prev, 90'000);
+    auto bad = good;
+    { auto ss = bad.vin[0].scriptSig.m_data; ASSERT_GT(ss.size(), 6u); ss[4] ^= 0x01;
+      bad.vin[0].scriptSig = to_script(ss); }
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+    // Priceable ⇒ admitted with priority.
+    ASSERT_EQ(mp.add_inject(bad), Mempool::InjectGate::Ok);
+    // ...but the armed selector script-check DROPS it: never served.
+    auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    EXPECT_EQ(selected.size(), 0u) << "an invalid-script inject must be dropped at template build";
+    EXPECT_EQ(fees, 0u);
+}
+
+// (3d) VALIDITY: an inject whose input is not in the view is REFUSED at submit,
+//      by name (unpriceable) — never left in the pool to be silently excluded.
+TEST(DashTxInject, MissingInputInjectRefusedByName)
+{
+    Key k(0x66);
+    uint256 prev = prevhash(0xf1);   // NOT added to the UTXO view
+    auto tx = make_signed_spend(k, prev, 90'000);
+
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+    EXPECT_EQ(mp.add_inject(tx), Mempool::InjectGate::Unpriceable);
+    // Rolled back — not left as a dead pool entry.
+    auto [selected, fees] = mp.get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    EXPECT_EQ(selected.size(), 0u);
+    (void)fees;
+}
+
+// (4a) DoS: an oversize inject is refused by name, before any consensus work.
+TEST(DashTxInject, OversizeInjectRefusedByName)
+{
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 0;
+    TxIn in; in.prevout.hash = prevhash(0x01); in.prevout.index = 0; in.sequence = 0xffffffffu;
+    tx.vin.push_back(in);
+    TxOut out; out.value = 1;
+    out.scriptPubKey = to_script(std::vector<uint8_t>(
+        Mempool::kMaxInjectTxBytes + 64, 0x51));   // scriptPubKey alone exceeds the cap
+    tx.vout.push_back(out);
+
+    UTXOViewCache utxo(nullptr);
+    Mempool mp; mp.set_utxo(&utxo);
+    arm_script_check(mp);
+    EXPECT_EQ(mp.add_inject(tx), Mempool::InjectGate::TooLarge);
+}
+
+// (4b) SEAM DISCIPLINE: a new ingestion seam refuses unless the consensus-exact
+//      CheckInputScripts callback is armed (sole-ingestion-path invariant).
+TEST(DashTxInject, InjectRefusedWhenScriptCheckUnarmed)
+{
+    Key k(0x77);
+    uint256 prev = prevhash(0xab);
+    auto tx = make_signed_spend(k, prev, 90'000);
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    Mempool mp; mp.set_utxo(&utxo);
+    // NO set_script_check.
+    EXPECT_FALSE(mp.has_script_check());
+    EXPECT_EQ(mp.add_inject(tx), Mempool::InjectGate::ScriptCheckUnarmed);
+}
+
+// (4c) DoS pool ledger: the bounded TxInjectPool caps entries, per-tx bytes, and
+//      cumulative bytes — each refusal named.
+TEST(DashTxInject, InjectPoolDoSCaps)
+{
+    TxInjectPool pool;
+    uint256 t1 = prevhash(0x10);
+    // per-tx oversize (checked before the cumulative cap).
+    EXPECT_EQ(pool.would_admit(t1, TxInjectPool::kMaxInjectTxBytes + 1),
+              TxInjectPool::Admit::TooLarge);
+    // admit one, then a duplicate is named.
+    ASSERT_EQ(pool.admit(t1, 0, 0, 250), TxInjectPool::Admit::Ok);
+    EXPECT_EQ(pool.would_admit(t1, 250), TxInjectPool::Admit::Duplicate);
+    EXPECT_EQ(pool.size(), 1u);
+    // CUMULATIVE byte cap: fill the pool with per-tx-legal entries up near the
+    // total ceiling, then the next (also per-tx-legal) entry is refused by name.
+    const uint32_t chunk = 90'000;   // < kMaxInjectTxBytes, so per-tx passes
+    uint8_t seed = 0x20;
+    while (pool.total_bytes() + chunk <= TxInjectPool::kMaxInjectTotalBytes) {
+        uint256 id = prevhash(seed++);
+        ASSERT_EQ(pool.admit(id, 0, 0, chunk), TxInjectPool::Admit::Ok);
+    }
+    uint256 over = prevhash(seed++);
+    EXPECT_EQ(pool.would_admit(over, chunk), TxInjectPool::Admit::TotalBytesExceeded)
+        << "a per-tx-legal inject that would exceed the cumulative cap is refused by name";
+    // Expiry reap: an expiry_height==0 entry never expires; a set one drops at
+    // height > expiry and is reported so the caller evicts it from the mempool.
+    auto dropped = pool.reap_expired(/*height=*/0);
+    EXPECT_TRUE(dropped.empty());
+    uint256 tExp = prevhash(seed++);
+    pool.clear();
+    pool.admit(tExp, 0, /*expiry_height=*/100, 250);
+    auto d2 = pool.reap_expired(/*height=*/101);
+    ASSERT_EQ(d2.size(), 1u);
+    EXPECT_EQ(d2[0], tExp);
+}
+
+// (5) GOOD-CITIZEN: injection is opt-in ONLY. It is NOT a TxServeLever, so the
+//     daemonless good-citizen resolver can never turn it on. This anchors the
+//     "never defaulted ON" guarantee: the resolver's closed set arms the twelve
+//     serving levers and has no injection concept at all.
+TEST(DashTxInject, NeverGoodCitizenDefaulted)
+{
+    using namespace dash::coin;
+    TxServeLevers req;   // everything unset
+    TxServeResolution r = resolve_good_citizen_tx_serve(/*daemonless=*/true, req);
+    // The resolver arms the known serving levers in daemonless posture...
+    EXPECT_TRUE(r.serve_mempool_txs);
+    EXPECT_TRUE(r.tx_serve_own_set);
+    EXPECT_TRUE(r.defaulted_any);
+    // ...and there is deliberately NO tx-inject field it could ever set. The
+    // node-level flag (NodeCoinState::m_tx_inject_enabled) defaults false and is
+    // flipped only by an explicit --embedded-tx-inject; see main_dash.cpp. This
+    // test exists so a future refactor that tried to fold injection into the
+    // good-citizen levers would have to delete it — a loud tripwire.
+    SUCCEED();
+}


### PR DESCRIPTION
## Miner/user tx-injection runtime (#157, M1) — DASH-first, `--embedded-tx-inject` default OFF

Post-cut Tier-3, the decentralized analog of Stratum V2 job declaration. A miner or user hands c2pool a raw, consensus-valid transaction and it lands in the block c2pool mines: **zero-fee-capable, prioritized (in regardless of feerate), non-standard-tolerant, gated ONLY by validity, with DoS guards.** Opt-in, default OFF, DASH first. Ships the full runtime (M1); the `tx-inject` p2p transport + fan-out (M2) and rate-limiting/sandboxed signer (M3) are staged.

### What lands (M1)
- **Priority class** — `Mempool::add_inject` + `INJECT_FEE_DELTA` (`mempool.hpp`): a large **scoring-only** mapDeltas delta (the same mechanism dashd uses for DSTX / MNHF-signal txs) lifts the injected tx to the top of the ancestor-score index and clears the `blockMinFeeRate` floor even at base fee 0. Offered-first, **never a guard bypass**.
- **Intra-template double-spend guard** — the `consumed` outpoint set in `get_sorted_txs_with_fees`. DASH's richer dashd-port selector had **no per-template consumed set** (`m_spent_outputs` is last-writer), so two pool txs spending one outpoint could both be selected → an invalid `bad-txns-inputs-*` block. Now the conflicting tx is dropped **per-tx**, the template is never refused. This is the DASH analog of the #1494/#1437 fix and a latent correctness fix for the whole serve path.
- **DoS ledger** — `TxInjectPool` (`tx_inject_pool.hpp`): entry cap, cumulative byte cap (the PR-1 stand-in for the §4.4 block-fraction reservation), per-tx size cap, expiry.
- **Submit gate** — `NodeCoinState::submit_inject` (`node_coin_state.hpp`): cheapest-first (enabled → type-0 → DoS caps → mempool admission), every refusal named (DEF3).
- **Flag + local submit** — `--embedded-tx-inject` (FLAG, default OFF) + `--embedded-tx-inject-hex FILE` (`main_dash.cpp`, `param_catalog.inc`). **Not** a good-citizen `TxServeLever` — never defaulted ON.

### 🔴 Reward-safety (grep-proven)
An injected tx enters **only** the block body (tx-merkle / fee-total). The priority delta feeds scoring/ordering only; `total_fees` reads the **base** fee, so a 0-fee inject contributes 0 to the coinbase.
```
git diff master --stat -- src/impl/dash/coinbase_builder.hpp src/core/coinbase_builder.hpp \
  src/impl/dash/coin/gentx_coinbase.hpp src/impl/dash/coin/subsidy.hpp \
  src/impl/dash/pplns.hpp src/core/donation.hpp   # → EMPTY
```
No `give_author`/`payee`/`subsidy` write in the injection files. A **new ingestion seam** refuses unless the consensus-exact `CheckInputScripts` callback is armed (sole-ingestion-path invariant); an invalid inject is dropped at template build, **never served**.

### 🔴 Validity, not bypass
An inject rides the **same** selector guards as any body tx — topology (G1), double-spend (`consumed`), script (`CheckInputScripts`), finality (`IsFinalTx`), sigops (G2), coinbase-maturity (G3), islock (G4) — unchanged. Priority = offered first, not guard relaxation.

### KATs (`test/test_dash_tx_inject.cpp`, in the allowlisted `test_dash_mempool`; red-on-master / green-after)
`add_inject`/`consumed` are absent on master, so these are red there and green here:
- zero-fee inject selected ahead of a fee tx (clears the floor);
- delta never inflates the coinbase (`total_fees` = base fee);
- double-spend dropped per-tx not per-template — with **and** without the inject delta;
- bad-script inject dropped at template build (never served);
- missing-input refused by name; oversize refused; script-check-unarmed refused;
- DoS caps (entry / cumulative-byte / per-tx / expiry);
- never good-citizen defaulted.

`test_dash_mempool` full suite green (126/126); `c2pool-dash` builds clean; `check_param_catalog.py` + `check_test_target_allowlist.py` pass.

### Design doc (code + design ship together)
`docs/design/miner-tx-injection.md` updated: status → M1 implemented, plus **§9 isolated-signer SEAM** (the runtime takes already-signed bytes and is key-free; the M1 `--embedded-tx-inject-hex` loader and `submit_inject` are its entry points), **§10 sandboxed tx-blob construction** (staged M3), **§11 per-milestone code map**.

### Staged
- **M2** — the `tx-inject` p2p subtype + first-see fan-out + `register_template_txs`.
- **M3** — per-peer token buckets, misbehaviour score, `submitter_hint`, capability advertisement, HTTP submit, full sandboxed signer.
