### PR TITLE
c2pool-qt: catalog-driven per-coin flags, registry address validation, DGB/BCH run-loop controls (reward-safe)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1200,6 +1200,18 @@ jobs:
       - name: Build leak harness
         run: cmake --build build-qt --target c2pool-qt_test_embedded_leak -j8
 
+      # ── Reward-safety + address-registry gates (Qt-free / Qt-Core; no display) ─
+      # These prove the per-coin argv is reward-safe (no silent embedded arm, no
+      # forced --give-author 0, only catalog-valid flags per binary) and that the
+      # payout-address check matches the node registry. They were ctest-registered
+      # but never built/run in CI before — build + run them here.
+      - name: Build + run reward-safe launch and address-validator gates
+        run: |
+          cmake --build build-qt \
+            --target c2pool-qt_test_reward_safe_launch c2pool-qt_test_address_validator -j8
+          ./build-qt/c2pool-qt_test_reward_safe_launch
+          ./build-qt/c2pool-qt_test_address_validator
+
       - name: Run leak harness under xvfb
         continue-on-error: true
         env:

--- a/src/impl/bch/address_encoding.hpp
+++ b/src/impl/bch/address_encoding.hpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// BCH LEGACY-base58 address-encoding SSOT (issue #961 blocker #3) — LEAF header.
+//
+// Hoisted out of bch/config_coin.hpp (which pulls yaml-cpp) so the standalone
+// c2pool-qt payout validator can read BCH's legacy version bytes from the SAME
+// source as the stratum money-path acceptance set. Includes only
+// <core/address_utils.hpp> (leaf). config_coin.hpp #includes this header.
+//
+// BCH legacy base58 shares Bitcoin's version bytes (BCHN chainparams.cpp):
+// mainnet PUBKEY 0 / SCRIPT 5; testnet & regtest both PUBKEY 111 / SCRIPT 196.
+// BCH has NO segwit/bech32 — its native CashAddr is a DISTINCT format with no
+// base58 version byte (validated separately by the CashAddr codec).
+
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+
+namespace bch
+{
+
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { 0x6f };  // 111
+        a.p2sh_versions  = { 0xc4 };  // 196
+    } else {
+        a.p2pkh_versions = { 0x00 };
+        a.p2sh_versions  = { 0x05 };
+    }
+    a.bech32_hrps = {};               // BCH: no bech32 (CashAddr via fallback)
+    return a;
+}
+
+} // namespace bch

--- a/src/impl/bch/config_coin.hpp
+++ b/src/impl/bch/config_coin.hpp
@@ -21,33 +21,17 @@
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
 #include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+#include "address_encoding.hpp"     // bch::address_acceptance SSOT (leaf, shared with c2pool-qt)
 
 #include <yaml-cpp/yaml.h>
 
 namespace bch
 {
 
-// Registry-sourced LEGACY-base58 payout-address acceptance for BCH on the ACTIVE
-// network (issue #961). BCH legacy base58 shares Bitcoin's version bytes
-// (BCHN chainparams.cpp): mainnet PUBKEY 0 / SCRIPT 5; testnet & regtest both
-// PUBKEY 111 / SCRIPT 196. BCH has NO segwit/bech32 — its native CashAddr is a
-// DISTINCT format with no base58 version byte, so a CashAddr yields
-// AddressCoinMatch::Invalid here and (only then) falls through to the
-// coin-registered CashAddr decoder. Deriving from the true network keeps a
-// --regtest legacy address from being rejected as Foreign.
-inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
-{
-    core::CoinAddressAcceptance a;
-    if (testnet || regtest) {
-        a.p2pkh_versions = { 0x6f };  // 111
-        a.p2sh_versions  = { 0xc4 };  // 196
-    } else {
-        a.p2pkh_versions = { 0x00 };
-        a.p2sh_versions  = { 0x05 };
-    }
-    a.bech32_hrps = {};               // BCH: no bech32 (CashAddr via fallback)
-    return a;
-}
+// bch::address_acceptance() moved to the LEAF header bch/address_encoding.hpp
+// (included above) so the standalone c2pool-qt payout validator reads BCH's
+// legacy version bytes from the SAME source without pulling this yaml-cpp-bearing
+// config header. Every existing caller keeps working via the include.
 
 namespace config
 {

--- a/src/impl/btc/address_encoding.hpp
+++ b/src/impl/btc/address_encoding.hpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// BTC address-encoding SSOT (issue #961 blocker #3) — LEAF header.
+//
+// Hoisted out of btc/config_coin.hpp (which pulls yaml-cpp) so the standalone
+// c2pool-qt payout validator can read BTC's version bytes / bech32 HRPs from the
+// SAME source as the stratum money-path acceptance set without dragging the
+// Fileconfig/yaml graph into the Qt build. Includes only <core/address_utils.hpp>
+// (leaf). config_coin.hpp #includes this header, so every existing caller of
+// btc::address_acceptance() is untouched.
+//
+// Bitcoin Core chainparams.cpp: mainnet PUBKEY_ADDRESS=0 / SCRIPT_ADDRESS=5 /
+// bech32 "bc"; testnet & regtest both PUBKEY_ADDRESS=111 / SCRIPT_ADDRESS=196,
+// with bech32 "tb" (testnet) vs "bcrt" (regtest). Deriving the set from the true
+// network — not a mainnet-or-not bool — is what keeps a --regtest address from
+// being rejected as Foreign (blocker #2).
+
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+
+namespace btc
+{
+
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { 0x6f };  // 111 (m/n...)
+        a.p2sh_versions  = { 0xc4 };  // 196 (2...)
+        a.bech32_hrps    = { regtest ? "bcrt" : "tb" };
+    } else {
+        a.p2pkh_versions = { 0x00 };  // 1...
+        a.p2sh_versions  = { 0x05 };  // 3...
+        a.bech32_hrps    = { "bc" };
+    }
+    return a;
+}
+
+} // namespace btc

--- a/src/impl/btc/config_coin.hpp
+++ b/src/impl/btc/config_coin.hpp
@@ -5,6 +5,7 @@
 #include <core/fileconfig.hpp>
 #include <core/netaddress.hpp>
 #include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+#include "address_encoding.hpp"     // btc::address_acceptance SSOT (leaf, shared with c2pool-qt)
 #include <string>
 
 #include <yaml-cpp/yaml.h>
@@ -88,27 +89,11 @@ inline std::string sharechain_net_name(bool regtest, bool testnet)
     return "bitcoin";
 }
 
-// Registry-sourced payout-address acceptance for BTC on the ACTIVE network
-// (issue #961). Bitcoin Core chainparams.cpp: mainnet PUBKEY_ADDRESS=0 /
-// SCRIPT_ADDRESS=5 / bech32 "bc"; testnet & regtest both PUBKEY_ADDRESS=111 /
-// SCRIPT_ADDRESS=196, with bech32 "tb" (testnet) vs "bcrt" (regtest). Deriving
-// the set from the true network — not a mainnet-or-not bool — is what keeps a
-// --regtest address from being rejected as Foreign (blocker #2), and centralises
-// the version bytes out of the stratum money path (blocker #3).
-inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
-{
-    core::CoinAddressAcceptance a;
-    if (testnet || regtest) {
-        a.p2pkh_versions = { 0x6f };  // 111 (m/n...)
-        a.p2sh_versions  = { 0xc4 };  // 196 (2...)
-        a.bech32_hrps    = { regtest ? "bcrt" : "tb" };
-    } else {
-        a.p2pkh_versions = { 0x00 };  // 1...
-        a.p2sh_versions  = { 0x05 };  // 3...
-        a.bech32_hrps    = { "bc" };
-    }
-    return a;
-}
+// btc::address_acceptance() moved to the LEAF header btc/address_encoding.hpp
+// (included above) so the standalone c2pool-qt payout validator reads BTC's
+// version bytes / bech32 HRPs from the SAME source without pulling this
+// yaml-cpp-bearing config header. Every existing caller keeps working via the
+// include.
 
 class CoinConfig : protected core::Fileconfig
 {

--- a/src/impl/dash/address_encoding.hpp
+++ b/src/impl/dash/address_encoding.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DASH address-encoding SSOT (issue #961 blocker #3) — LEAF header.
+//
+// Hoisted out of dash/params.hpp so BOTH the node (params.hpp → make_coin_params
+// + the stratum money-path acceptance set) AND the standalone c2pool-qt payout
+// validator can read the SAME version bytes without dragging the node's
+// pow/x11/config_pool graph into the Qt build. This header includes only
+// <core/address_utils.hpp> (leaf: std only) + <cstdint>, so it is a pure data
+// SSOT with zero heavy transitive dependencies. dash/params.hpp #includes it,
+// so every existing caller is untouched; the Qt AddressValidator includes it
+// directly, so the UI check can NEVER drift from the node's acceptance set.
+//
+// The ONE place DASH's payout version bytes live (oracle networks/dash.py):
+// mainnet PUBKEY 76 (X...) / SCRIPT 16 (7...); testnet PUBKEY 140 (y...) /
+// SCRIPT 19. DASH has a SINGLE P2SH version and NO segwit/bech32 on any network.
+
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+
+#include <cstdint>
+
+namespace dash
+{
+
+struct AddressEncoding { uint8_t p2pkh; uint8_t p2sh; };
+inline constexpr AddressEncoding MAINNET_ADDR{ 76,  16 };  // X... / 7...
+inline constexpr AddressEncoding TESTNET_ADDR{ 140, 19 };  // y...
+inline constexpr const AddressEncoding& address_encoding(bool testnet)
+{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
+
+// Registry-sourced payout-address acceptance for DASH on the ACTIVE network
+// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
+// literals. DASH regtest (dashd CRegTestParams) reuses the testnet base58 version
+// bytes, so a --regtest payout address decodes under the testnet set rather than
+// being rejected as Foreign.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    const auto& e = address_encoding(testnet || regtest);
+    core::CoinAddressAcceptance a;
+    a.p2pkh_versions = { e.p2pkh };
+    a.p2sh_versions  = { e.p2sh };
+    a.bech32_hrps    = {};           // DASH: no bech32 on any network
+    return a;
+}
+
+} // namespace dash

--- a/src/impl/dash/params.hpp
+++ b/src/impl/dash/params.hpp
@@ -25,6 +25,7 @@
 #include <core/coin_params.hpp>
 #include <core/pow.hpp>
 #include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+#include "address_encoding.hpp"     // dash::AddressEncoding / address_acceptance SSOT (leaf)
 
 #include <optional>
 #include <string>
@@ -34,31 +35,11 @@ namespace dash
 {
 
 // ─── Address-encoding SSOT (issue #961 blocker #3) ───────────────────────────
-// The ONE place DASH's payout version bytes live (oracle networks/dash.py):
-// mainnet PUBKEY 76 (X...) / SCRIPT 16 (7...); testnet PUBKEY 140 (y...) / SCRIPT
-// 19. DASH has a SINGLE P2SH version and NO segwit/bech32 on any network. BOTH
-// make_coin_params() and address_acceptance() read these constants, so the
-// stratum money-path acceptance set can NEVER drift from the coin params.
-struct AddressEncoding { uint8_t p2pkh; uint8_t p2sh; };
-inline constexpr AddressEncoding MAINNET_ADDR{ 76,  16 };  // X... / 7...
-inline constexpr AddressEncoding TESTNET_ADDR{ 140, 19 };  // y...
-inline constexpr const AddressEncoding& address_encoding(bool testnet)
-{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
-
-// Registry-sourced payout-address acceptance for DASH on the ACTIVE network
-// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
-// literals. DASH regtest (dashd CRegTestParams) reuses the testnet base58 version
-// bytes, so a --regtest payout address decodes under the testnet set rather than
-// being rejected as Foreign.
-inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
-{
-    const auto& e = address_encoding(testnet || regtest);
-    core::CoinAddressAcceptance a;
-    a.p2pkh_versions = { e.p2pkh };
-    a.p2sh_versions  = { e.p2sh };
-    a.bech32_hrps    = {};           // DASH: no bech32 on any network
-    return a;
-}
+// Moved to the LEAF header dash/address_encoding.hpp so the standalone c2pool-qt
+// payout validator reads DASH's version bytes from the SAME source as
+// make_coin_params() and the stratum money-path acceptance set, without pulling
+// this factory's pow/x11/config_pool graph. AddressEncoding, MAINNET_ADDR,
+// TESTNET_ADDR, address_encoding() and address_acceptance() are declared there.
 
 // Runtime override seam for pool.yaml (Fileconfig consume-side, S6 follow-on).
 // ONLY operationally-tunable, NON-consensus, NON-isolation pool fields may be

--- a/src/impl/dgb/address_encoding.hpp
+++ b/src/impl/dgb/address_encoding.hpp
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DGB address-encoding SSOT (issue #961 blocker #3) — LEAF header.
+//
+// Hoisted so the standalone c2pool-qt payout validator can read DGB's version
+// bytes / bech32 HRPs without pulling dgb/config_coin.hpp (yaml-cpp) or
+// dgb/params.hpp (config_pool/pow) into the Qt build. Includes only
+// <core/address_utils.hpp> (leaf).
+//
+// These constants MIRROR dgb::CoinParams (config_coin.hpp), which stays the
+// node-side SSOT for every OTHER consumer; params.hpp binds the two with a
+// static_assert so a drift between this leaf and CoinParams is a compile error.
+// DigiByte Core: mainnet PUBKEY 0x1e (D...) / P2SH 0x3f (S...) / bech32 "dgb";
+// testnet PUBKEY 0x7e / P2SH 0x8c / bech32 "dgbt"; regtest reuses the testnet
+// base58 bytes with bech32 "dgbrt".
+
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+
+#include <cstdint>
+
+namespace dgb
+{
+namespace addr
+{
+inline constexpr uint8_t     P2PKH_MAIN     = 0x1e;  // 30  — D... (P2PKH)
+inline constexpr uint8_t     P2SH_MAIN      = 0x3f;  // 63  — S... (P2SH)
+inline constexpr uint8_t     P2PKH_TESTNET  = 0x7e;  // 126 (testnet)
+inline constexpr uint8_t     P2SH_TESTNET   = 0x8c;  // 140 (testnet P2SH)
+inline constexpr const char* BECH32_MAIN    = "dgb";
+inline constexpr const char* BECH32_TESTNET = "dgbt";
+inline constexpr const char* BECH32_REGTEST = "dgbrt";
+} // namespace addr
+
+// Registry-sourced payout-address acceptance for DGB on the ACTIVE network
+// (issue #961). Regtest is a distinct network: DigiByte Core CRegTestParams
+// reuses the TESTNET base58 version bytes and swaps the bech32 HRP to "dgbrt" —
+// deriving the set from the true network (not a mainnet-or-not bool) is what
+// stops a --regtest payout address being rejected as Foreign.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
+{
+    core::CoinAddressAcceptance a;
+    if (testnet || regtest) {
+        a.p2pkh_versions = { addr::P2PKH_TESTNET };
+        a.p2sh_versions  = { addr::P2SH_TESTNET };
+        a.bech32_hrps    = { regtest ? addr::BECH32_REGTEST : addr::BECH32_TESTNET };
+    } else {
+        a.p2pkh_versions = { addr::P2PKH_MAIN };
+        a.p2sh_versions  = { addr::P2SH_MAIN };
+        a.bech32_hrps    = { addr::BECH32_MAIN };
+    }
+    return a;
+}
+
+} // namespace dgb

--- a/src/impl/dgb/params.hpp
+++ b/src/impl/dgb/params.hpp
@@ -22,31 +22,21 @@
 #include <core/coin_params.hpp>
 #include <core/pow.hpp>
 #include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+#include "address_encoding.hpp"     // dgb::addr / address_acceptance SSOT (leaf, shared with c2pool-qt)
 
 namespace dgb
 {
 
-// Registry-sourced payout-address acceptance for DGB on the ACTIVE network
-// (issue #961). Every consensus byte comes from the dgb::CoinParams SSOT
-// (config_coin.hpp), NEVER a literal at the stratum call site. Regtest is a
-// distinct network: DigiByte Core CRegTestParams reuses the TESTNET base58
-// version bytes and swaps the bech32 HRP to "dgbrt" — deriving the set from the
-// true network (not a mainnet-or-not bool) is what stops a --regtest payout
-// address being rejected as Foreign.
-inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest)
-{
-    core::CoinAddressAcceptance a;
-    if (testnet || regtest) {
-        a.p2pkh_versions = { CoinParams::TESTNET_ADDRESS_VERSION };  // 0x7e
-        a.p2sh_versions  = { CoinParams::TESTNET_P2SH_VERSION };     // 0x8c
-        a.bech32_hrps    = { regtest ? "dgbrt" : CoinParams::TESTNET_BECH32_HRP };
-    } else {
-        a.p2pkh_versions = { CoinParams::ADDRESS_VERSION };          // 0x1e (D...)
-        a.p2sh_versions  = { CoinParams::ADDRESS_P2SH_VERSION };     // 0x3f (S...)
-        a.bech32_hrps    = { CoinParams::BECH32_HRP };               // "dgb"
-    }
-    return a;
-}
+// dgb::address_acceptance() moved to the LEAF header dgb/address_encoding.hpp
+// (included above) so the standalone c2pool-qt payout validator reads DGB's
+// version bytes / bech32 HRPs from the SAME source without pulling this
+// config_coin(yaml-cpp)/config_pool graph. The leaf mirrors the dgb::CoinParams
+// SSOT; the static_asserts below make any drift between the leaf and CoinParams a
+// compile error, so there is still exactly one authoritative set of bytes.
+static_assert(addr::P2PKH_MAIN    == CoinParams::ADDRESS_VERSION,         "DGB P2PKH mainnet drift");
+static_assert(addr::P2SH_MAIN     == CoinParams::ADDRESS_P2SH_VERSION,    "DGB P2SH mainnet drift");
+static_assert(addr::P2PKH_TESTNET == CoinParams::TESTNET_ADDRESS_VERSION, "DGB P2PKH testnet drift");
+static_assert(addr::P2SH_TESTNET  == CoinParams::TESTNET_P2SH_VERSION,    "DGB P2SH testnet drift");
 
 // --- Merged-mining aux chain identity (bucket-1 isolation primitive) ---------
 // DGB's OWN AuxPoW chain id, consumed when DGB registers an embedded backend

--- a/src/impl/doge/coin/address_encoding.hpp
+++ b/src/impl/doge/coin/address_encoding.hpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// DOGE address-encoding SSOT (issue #961) — LEAF header.
+//
+// DOGE is an aux lane carried inside the LTC/BTC binaries and has no standalone
+// coin params factory with an address_acceptance(); this header provides the ONE
+// place DOGE's payout version bytes live so BOTH the merged-mining address
+// identification (core::MergedChainAddr) AND the standalone c2pool-qt payout
+// validator read the SAME bytes. Includes only <core/address_utils.hpp> (leaf).
+//
+// Dogecoin chainparams.cpp: mainnet PUBKEY 0x1e (30, D...) / SCRIPT 0x16 (22,
+// 9.../A...); testnet PUBKEY 0x71 (113, n...) / SCRIPT 0xc4 (196). DOGE has no
+// segwit/bech32.
+
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+
+#include <cstdint>
+
+namespace doge
+{
+
+struct AddressEncoding { uint8_t p2pkh; uint8_t p2sh; };
+inline constexpr AddressEncoding MAINNET_ADDR{ 0x1e, 0x16 };  // 30 / 22
+inline constexpr AddressEncoding TESTNET_ADDR{ 0x71, 0xc4 };  // 113 / 196
+inline constexpr const AddressEncoding& address_encoding(bool testnet)
+{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
+
+// Registry-sourced payout-address acceptance for DOGE on the ACTIVE network.
+// Regtest reuses the testnet base58 bytes. No bech32 on any network.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet, bool regtest = false)
+{
+    const auto& e = address_encoding(testnet || regtest);
+    core::CoinAddressAcceptance a;
+    a.p2pkh_versions = { e.p2pkh };
+    a.p2sh_versions  = { e.p2sh };
+    a.bech32_hrps    = {};
+    return a;
+}
+
+} // namespace doge

--- a/src/impl/ltc/address_encoding.hpp
+++ b/src/impl/ltc/address_encoding.hpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// LTC address-encoding SSOT (issue #961 blocker #3) — LEAF header.
+//
+// Hoisted out of ltc/params.hpp so BOTH the node (params.hpp → make_coin_params
+// + the stratum money-path acceptance set) AND the standalone c2pool-qt payout
+// validator read the SAME version bytes / bech32 HRP without dragging the coin
+// factory into the Qt build. Includes only <core/address_utils.hpp> (leaf) +
+// <cstdint>.
+//
+// The ONE place LTC's payout version bytes / bech32 HRP live (p2pool-merged-v36):
+// mainnet PUBKEY 48 (L...) / SCRIPT {50 (M...), 5 (legacy 3...)} / bech32 "ltc";
+// testnet PUBKEY 111 / SCRIPT {196, 58 (Q...)} / bech32 "tltc". HRPs here are
+// BARE; make_coin_params() appends the bech32 separator '1' for its own
+// CoinParams.bech32_hrp convention. bech32_hrp2 is the secondary P2SH.
+
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+
+#include <cstdint>
+
+namespace ltc
+{
+
+struct AddressEncoding {
+    uint8_t     p2pkh;
+    uint8_t     p2sh;
+    uint8_t     p2sh2;      // secondary P2SH version (LTC only), 0 = none
+    const char* hrp_bare;   // BARE bech32 HRP (no trailing '1')
+};
+inline constexpr AddressEncoding MAINNET_ADDR{ 48, 50, 5,  "ltc"  };
+inline constexpr AddressEncoding TESTNET_ADDR{ 111, 196, 58, "tltc" };
+inline constexpr const AddressEncoding& address_encoding(bool testnet)
+{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
+
+// Registry-sourced payout-address acceptance for LTC on the ACTIVE network
+// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
+// literals. The legacy 0x05 P2SH is an inherent LTC/BTC collision (both encode
+// "3..." at version byte 5): an address at 0x05 maps to the SAME hash160 the
+// same key controls, so building an LTC P2SH script for it is a valid own-coin
+// payout, not a misdirection. bech32 HRPs are returned BARE.
+inline core::CoinAddressAcceptance address_acceptance(bool testnet)
+{
+    const auto& e = address_encoding(testnet);
+    core::CoinAddressAcceptance a;
+    a.p2pkh_versions = { e.p2pkh };
+    a.p2sh_versions  = { e.p2sh };
+    if (e.p2sh2 != 0) a.p2sh_versions.push_back(e.p2sh2);
+    a.bech32_hrps    = { e.hrp_bare };
+    return a;
+}
+
+} // namespace ltc

--- a/src/impl/ltc/params.hpp
+++ b/src/impl/ltc/params.hpp
@@ -7,48 +7,17 @@
 #include <core/coin_params.hpp>
 #include <core/pow.hpp>
 #include <core/address_utils.hpp>   // core::CoinAddressAcceptance (issue #961)
+#include "address_encoding.hpp"     // ltc::AddressEncoding / address_acceptance SSOT (leaf)
 
 namespace ltc
 {
 
 // ─── Address-encoding SSOT (issue #961 blocker #3) ───────────────────────────
-// The ONE place LTC's payout version bytes / bech32 HRP live (p2pool-merged-v36):
-// mainnet PUBKEY 48 (L...) / SCRIPT {50 (M...), 5 (legacy 3...)} / bech32 "ltc";
-// testnet PUBKEY 111 / SCRIPT {196, 58 (Q...)} / bech32 "tltc". BOTH make_coin_
-// params() and address_acceptance() below read these constants, so the stratum
-// money-path acceptance set can NEVER drift from the coin params (the drift risk
-// of re-typing the same literals at the call site). HRPs here are BARE; make_coin_
-// params() appends the bech32 separator '1' for its own CoinParams.bech32_hrp
-// convention. bech32_hrp2 is the secondary P2SH (LTC has two P2SH prefixes).
-struct AddressEncoding {
-    uint8_t     p2pkh;
-    uint8_t     p2sh;
-    uint8_t     p2sh2;      // secondary P2SH version (LTC only), 0 = none
-    const char* hrp_bare;   // BARE bech32 HRP (no trailing '1')
-};
-inline constexpr AddressEncoding MAINNET_ADDR{ 48, 50, 5,  "ltc"  };
-inline constexpr AddressEncoding TESTNET_ADDR{ 111, 196, 58, "tltc" };
-inline constexpr const AddressEncoding& address_encoding(bool testnet)
-{ return testnet ? TESTNET_ADDR : MAINNET_ADDR; }
-
-// Registry-sourced payout-address acceptance for LTC on the ACTIVE network
-// (issue #961). DERIVED from the AddressEncoding SSOT above — no re-typed
-// literals. The legacy 0x05 P2SH is an inherent LTC/BTC collision (both encode
-// "3..." at version byte 5): an address at 0x05 maps to the SAME hash160 the
-// same key controls, so building an LTC P2SH script for it is a valid own-coin
-// payout, not a misdirection. The core stratum server passes this set (via
-// StratumConfig.payout_*) so the per-job coinbase payout is validated at the
-// parse and never fed a foreign version byte. bech32 HRPs are returned BARE.
-inline core::CoinAddressAcceptance address_acceptance(bool testnet)
-{
-    const auto& e = address_encoding(testnet);
-    core::CoinAddressAcceptance a;
-    a.p2pkh_versions = { e.p2pkh };
-    a.p2sh_versions  = { e.p2sh };
-    if (e.p2sh2 != 0) a.p2sh_versions.push_back(e.p2sh2);
-    a.bech32_hrps    = { e.hrp_bare };
-    return a;
-}
+// Moved to the LEAF header ltc/address_encoding.hpp so the standalone c2pool-qt
+// payout validator reads LTC's version bytes / bech32 HRP from the SAME source
+// as make_coin_params() and the stratum money-path acceptance set. AddressEncoding,
+// MAINNET_ADDR, TESTNET_ADDR, address_encoding() and address_acceptance() are
+// declared there.
 
 inline core::CoinParams make_coin_params(bool testnet)
 {

--- a/ui/c2pool-qt/CMakeLists.txt
+++ b/ui/c2pool-qt/CMakeLists.txt
@@ -93,7 +93,12 @@ qt_add_resources(c2pool-qt "explorer_bundle"
         "${C2POOL_EXPLORER_DIR}/dist/pplns-view.js"
 )
 
-target_include_directories(c2pool-qt PRIVATE src)
+# The panel reads the node's parameter catalog (src/core/param_catalog.*) and the
+# per-coin address-encoding registry leaf headers (src/impl/<coin>/
+# address_encoding.hpp) so its generated argv + payout-address check can never
+# drift from the node. Both are Qt-free leaf headers; expose the node src root.
+set(C2POOL_NODE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
+target_include_directories(c2pool-qt PRIVATE src "${C2POOL_NODE_SRC}")
 
 target_link_libraries(c2pool-qt PRIVATE
     Qt6::Widgets
@@ -161,7 +166,8 @@ if(C2POOL_QT_BUILD_TESTS)
     add_executable(c2pool-qt_test_reward_safe_launch
         test/test_reward_safe_launch.cpp
     )
-    target_include_directories(c2pool-qt_test_reward_safe_launch PRIVATE src)
+    target_include_directories(c2pool-qt_test_reward_safe_launch PRIVATE
+        src "${C2POOL_NODE_SRC}")
     add_test(NAME reward_safe_launch
              COMMAND c2pool-qt_test_reward_safe_launch)
 
@@ -173,7 +179,8 @@ if(C2POOL_QT_BUILD_TESTS)
     add_executable(c2pool-qt_test_address_validator
         test/test_address_validator.cpp
     )
-    target_include_directories(c2pool-qt_test_address_validator PRIVATE src)
+    target_include_directories(c2pool-qt_test_address_validator PRIVATE
+        src "${C2POOL_NODE_SRC}")
     target_link_libraries(c2pool-qt_test_address_validator PRIVATE Qt6::Core)
     add_test(NAME address_validator
              COMMAND c2pool-qt_test_address_validator)

--- a/ui/c2pool-qt/src/AddressValidator.hpp
+++ b/ui/c2pool-qt/src/AddressValidator.hpp
@@ -1,50 +1,66 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // AddressValidator — in-UI payout-address flavor check (QP-B).
 //
-// c2pool-qt is coin-generic: the same launch form serves LTC/BTC/DOGE/
-// DASH/DGB/BCH. A payout address pasted into the wrong coin's profile is
-// a silent money mistake — miners paid to an address the winning coin's
-// nodes reject, or worse, an address that decodes to a DIFFERENT live
-// chain. This validator catches the unambiguous case: a base58check
-// address whose version byte belongs to a *known other coin*.
+// c2pool-qt is coin-generic: the same launch form serves LTC/BTC/DOGE/DASH/DGB/
+// BCH. A payout address pasted into the wrong coin's profile is a silent money
+// mistake — miners paid to an address the winning coin's nodes reject, or worse,
+// an address that decodes to a DIFFERENT live chain (issue #961). This validator
+// catches the unambiguous case and BLOCKS launch on it.
 //
-// Design (deliberately low false-positive so it never blocks a valid
-// launch):
-//   • Only base58check (25-byte, checksum-verified) addresses are judged.
-//     bech32 / cashaddr / anything else decode-fails here and is passed
-//     through UNJUDGED (NotBase58Check) — we do not model those yet and
-//     must not reject a valid segwit/cashaddr address.
-//   • WrongCoin — and only WrongCoin — is a hard launch blocker. It fires
-//     when the version byte matches NO network of the active coin but DOES
-//     match some other coin in the CoinProfiles table (e.g. a DASH 'X…'
-//     address, version 76, typed into a Litecoin profile).
-//   • Version-byte collisions between coins (BTC/BCH share 0/5; DOGE/DGB
-//     share 30) resolve in the user's favour: if the version is valid for
-//     the active coin under ANY network, the verdict is Ok.
+// ★ NO DRIFT TABLE. The accepted version bytes / bech32 HRPs are read from the
+// SAME node registry the stratum money-path uses — each coin's
+// <coin>::address_acceptance() (issue #961), hoisted into leaf headers
+// (src/impl/<coin>/address_encoding.hpp) that carry ONLY the encoding SSOT so
+// they link into this standalone Qt build without the node's pow/config graph.
+// There is exactly one place each coin's bytes live; the Qt check can never drift
+// from the node's acceptance set (which was the pre-#961 bug: this validator's
+// old private table blocked valid LTC 3.../Q... P2SH addresses the node accepts).
 //
-// Qt Core only (QString / QByteArray / QCryptographicHash) — no Widgets,
-// no WebEngine — so it is unit-testable without a display.
+// Verdict mapping mirrors the node's core::classify_address_for_coin():
+//   • Own-coin address (any of its networks) → Ok.
+//   • Well-formed address of a DIFFERENT known coin → WrongCoin (the ONLY hard
+//     launch blocker), naming the coin it belongs to.
+//   • Well-formed but unmodelled version/HRP → UnknownVersion (advisory).
+//   • Undecodable (checksum fail / not an address we parse) → NotBase58Check
+//     (advisory) so a valid launch is never blocked by a flavor we cannot judge.
+//
+// base58check, bech32/bech32m and BCH CashAddr are all decoded here, so a
+// segwit or cashaddr address in a wrong-coin profile is caught the same way the
+// node would (bech32 HRP mismatch / cashaddr prefix mismatch), not waved through.
+//
+// Qt Core only (QString / QByteArray / QCryptographicHash) — no Widgets, no
+// WebEngine — so it is unit-testable without a display.
 
 #pragma once
 
 #include "CoinProfiles.hpp"
+
+#include <impl/dash/address_encoding.hpp>
+#include <impl/ltc/address_encoding.hpp>
+#include <impl/btc/address_encoding.hpp>
+#include <impl/bch/address_encoding.hpp>
+#include <impl/dgb/address_encoding.hpp>
+#include <impl/doge/coin/address_encoding.hpp>
+#include <core/address_utils.hpp>   // core::CoinAddressAcceptance
 
 #include <QByteArray>
 #include <QCryptographicHash>
 #include <QLatin1String>
 #include <QString>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <string>
 #include <vector>
 
 namespace c2pool_qt {
 
 enum class AddressVerdict {
-    Ok,             ///< base58check valid; version belongs to the active coin
-    WrongCoin,      ///< base58check valid; version belongs to a DIFFERENT coin
-    UnknownVersion, ///< base58check valid; version not in our coin table
-    NotBase58Check, ///< empty / bech32 / cashaddr / not a 25-byte b58check payload
+    Ok,             ///< valid; version/HRP belongs to the active coin
+    WrongCoin,      ///< valid; version/HRP belongs to a DIFFERENT coin
+    UnknownVersion, ///< valid; version/HRP not in our coin registry
+    NotBase58Check, ///< empty / undecodable / checksum failure (advisory)
 };
 
 struct AddressCheck {
@@ -52,17 +68,65 @@ struct AddressCheck {
     QString        detectedCoinLabel;  ///< set when WrongCoin (the coin it belongs to)
     QString        message;            ///< human-readable; empty on Ok / empty input
 
-    /// The ONLY blocking condition — a positively-identified wrong-coin
-    /// address. Everything else is advisory so a valid launch is never
-    /// stopped by a coin we simply do not model.
+    /// The ONLY blocking condition — a positively-identified wrong-coin address.
     bool blocksLaunch() const { return verdict == AddressVerdict::WrongCoin; }
 };
 
 namespace detail {
 
+/// Union of a coin's mainnet ∪ testnet ∪ regtest acceptance sets, read straight
+/// from the node registry leaf headers. Any-network membership favours the user
+/// (a mainnet/testnet slip is not a wrong-coin block).
+inline core::CoinAddressAcceptance registryAcceptance(const QString& symbol)
+{
+    auto merge = [](core::CoinAddressAcceptance& into,
+                    const core::CoinAddressAcceptance& src) {
+        for (auto v : src.p2pkh_versions) into.p2pkh_versions.push_back(v);
+        for (auto v : src.p2sh_versions)  into.p2sh_versions.push_back(v);
+        for (const auto& h : src.bech32_hrps) into.bech32_hrps.push_back(h);
+    };
+    core::CoinAddressAcceptance acc;
+    if (symbol == QLatin1String("litecoin")) {
+        merge(acc, ltc::address_acceptance(false));
+        merge(acc, ltc::address_acceptance(true));
+    } else if (symbol == QLatin1String("bitcoin")) {
+        merge(acc, btc::address_acceptance(false, false));
+        merge(acc, btc::address_acceptance(true,  false));
+        merge(acc, btc::address_acceptance(false, true));
+    } else if (symbol == QLatin1String("dogecoin")) {
+        merge(acc, doge::address_acceptance(false));
+        merge(acc, doge::address_acceptance(true));
+    } else if (symbol == QLatin1String("dash")) {
+        merge(acc, dash::address_acceptance(false, false));
+        merge(acc, dash::address_acceptance(true,  false));
+    } else if (symbol == QLatin1String("digibyte")) {
+        merge(acc, dgb::address_acceptance(false, false));
+        merge(acc, dgb::address_acceptance(true,  false));
+        merge(acc, dgb::address_acceptance(false, true));
+    } else if (symbol == QLatin1String("bitcoincash")) {
+        merge(acc, bch::address_acceptance(false, false));
+        merge(acc, bch::address_acceptance(true,  false));
+    }
+    return acc;
+}
+
+inline bool versionAccepted(const core::CoinAddressAcceptance& acc, int version)
+{
+    const auto v = static_cast<uint8_t>(version);
+    return std::find(acc.p2pkh_versions.begin(), acc.p2pkh_versions.end(), v)
+               != acc.p2pkh_versions.end()
+        || std::find(acc.p2sh_versions.begin(), acc.p2sh_versions.end(), v)
+               != acc.p2sh_versions.end();
+}
+
+inline bool hrpAccepted(const core::CoinAddressAcceptance& acc, const std::string& hrp)
+{
+    return std::find(acc.bech32_hrps.begin(), acc.bech32_hrps.end(), hrp)
+               != acc.bech32_hrps.end();
+}
+
 /// Decode a base58 string into raw bytes (big-endian). Returns false on any
-/// character outside the base58 alphabet (which cleanly rejects bech32 —
-/// '0','1','O','I','l' are not in the alphabet — and cashaddr's ':').
+/// character outside the base58 alphabet (cleanly rejecting bech32 / cashaddr).
 inline bool decodeBase58(const QString& in, std::vector<uint8_t>& out)
 {
     static const char kAlphabet[] =
@@ -70,11 +134,11 @@ inline bool decodeBase58(const QString& in, std::vector<uint8_t>& out)
     out.clear();
     if (in.isEmpty()) return false;
 
-    std::vector<uint8_t> num;  // big-endian base-256 accumulator
+    std::vector<uint8_t> num;
     num.reserve(in.size());
     for (QChar qc : in) {
         const char c = qc.toLatin1();
-        if (c == 0) return false;  // non-latin1 => not base58
+        if (c == 0) return false;
         const char* p = std::strchr(kAlphabet, c);
         if (p == nullptr || c == '\0') return false;
         int carry = static_cast<int>(p - kAlphabet);
@@ -88,7 +152,6 @@ inline bool decodeBase58(const QString& in, std::vector<uint8_t>& out)
             carry >>= 8;
         }
     }
-    // Each leading '1' is a leading zero byte.
     int leadingOnes = 0;
     for (QChar qc : in) {
         if (qc == QLatin1Char('1')) ++leadingOnes; else break;
@@ -98,21 +161,84 @@ inline bool decodeBase58(const QString& in, std::vector<uint8_t>& out)
     return true;
 }
 
-/// True when `version` is a valid base58 address prefix for `p` on ANY
-/// network (mainnet or testnet, P2PKH or P2SH). -1 fields never match.
-inline bool versionMatchesCoin(const CoinProfile& p, int version)
+// ── bech32 / bech32m decode (BIP-173 / BIP-350), HRP extraction ──────────────
+inline uint32_t bech32Polymod(const std::vector<uint8_t>& values)
 {
-    return version == p.p2pkhVersionMainnet
-        || version == p.p2shVersionMainnet
-        || version == p.p2pkhVersionTestnet
-        || version == p.p2shVersionTestnet;
+    static const uint32_t GEN[5] = {
+        0x3b6a57b2u, 0x26508e6du, 0x1ea119fau, 0x3d4233ddu, 0x2a1462b3u};
+    uint32_t chk = 1;
+    for (uint8_t v : values) {
+        uint8_t top = static_cast<uint8_t>(chk >> 25);
+        chk = ((chk & 0x1ffffffu) << 5) ^ v;
+        for (int i = 0; i < 5; ++i)
+            if ((top >> i) & 1) chk ^= GEN[i];
+    }
+    return chk;
+}
+
+/// Structurally decode a bech32/bech32m address; on success set `hrp` (lowered)
+/// and return true (checksum verified against either constant). Low-false-
+/// positive: a typo that breaks the checksum returns false → treated as
+/// undecodable, never a wrong-coin block.
+inline bool decodeBech32(const QString& in, std::string& hrp)
+{
+    static const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+    const std::string s = in.trimmed().toStdString();
+    if (s.size() < 8 || s.size() > 100) return false;
+
+    // Reject mixed case (BIP-173) and normalise to lower.
+    bool hasLower = false, hasUpper = false;
+    for (char c : s) {
+        if (c >= 'a' && c <= 'z') hasLower = true;
+        else if (c >= 'A' && c <= 'Z') hasUpper = true;
+        else if (c < 33 || c > 126) return false;
+    }
+    if (hasLower && hasUpper) return false;
+    std::string ls;
+    ls.reserve(s.size());
+    for (char c : s) ls.push_back((c >= 'A' && c <= 'Z') ? char(c + 32) : c);
+
+    const auto sep = ls.rfind('1');
+    if (sep == std::string::npos || sep == 0 || sep + 7 > ls.size()) return false;
+    const std::string hrpPart = ls.substr(0, sep);
+    const std::string data = ls.substr(sep + 1);
+
+    std::vector<uint8_t> values;
+    values.reserve(hrpPart.size() * 2 + 1 + data.size());
+    for (char c : hrpPart) values.push_back(static_cast<uint8_t>(c) >> 5);
+    values.push_back(0);
+    for (char c : hrpPart) values.push_back(static_cast<uint8_t>(c) & 0x1f);
+    for (char c : data) {
+        const char* p = std::strchr(CHARSET, c);
+        if (!p) return false;
+        values.push_back(static_cast<uint8_t>(p - CHARSET));
+    }
+    const uint32_t chk = bech32Polymod(values);
+    if (chk != 1u && chk != 0x2bc830a3u) return false;  // bech32 or bech32m
+    hrp = hrpPart;
+    return true;
+}
+
+/// A BCH CashAddr carries an explicit or implicit prefix. We recognise the three
+/// canonical BCH prefixes; membership is enough for a low-false-positive UI
+/// verdict (the node reaches the same Own/Foreign split via its CashAddr codec).
+inline bool isCashAddr(const QString& in, std::string& prefix)
+{
+    const std::string s = in.trimmed().toStdString();
+    const auto colon = s.find(':');
+    if (colon == std::string::npos) return false;
+    std::string pfx = s.substr(0, colon);
+    for (char& c : pfx) if (c >= 'A' && c <= 'Z') c = char(c + 32);
+    if (pfx == "bitcoincash" || pfx == "bchtest" || pfx == "bchreg") {
+        prefix = pfx;
+        return true;
+    }
+    return false;
 }
 
 } // namespace detail
 
 /// Validate a payout address for the coin identified by `activeSymbol`.
-/// `testnet` currently only shapes messaging; matching accepts either
-/// network of the active coin so a mainnet/testnet slip is not blocked.
 inline AddressCheck validatePayoutAddress(const QString& address,
                                           const QString& activeSymbol,
                                           bool /*testnet*/ = false)
@@ -120,48 +246,92 @@ inline AddressCheck validatePayoutAddress(const QString& address,
     AddressCheck result;
     const QString addr = address.trimmed();
     if (addr.isEmpty()) {
-        // Empty is fine — PageLaunch only emits --address when non-empty
-        // (and can auto-detect from the wallet).
         result.verdict = AddressVerdict::NotBase58Check;
         return result;
     }
 
+    const CoinProfile& active = coinProfile(activeSymbol);
+    const core::CoinAddressAcceptance activeAcc =
+        detail::registryAcceptance(active.symbol);
+
+    int profileCount = 0;
+    const CoinProfile* profiles = coinProfiles(profileCount);
+
+    // ── BCH CashAddr (distinct format; no base58 version / bech32 HRP) ────────
+    {
+        std::string cashPrefix;
+        if (detail::isCashAddr(addr, cashPrefix)) {
+            if (active.symbol == QLatin1String("bitcoincash")) {
+                result.verdict = AddressVerdict::Ok;
+                return result;
+            }
+            result.verdict = AddressVerdict::WrongCoin;
+            result.detectedCoinLabel = QStringLiteral("Bitcoin Cash");
+            result.message = QStringLiteral(
+                "This is a Bitcoin Cash CashAddr (%1:…), but the active coin is "
+                "%2. Enter a %2 payout address or switch profiles.")
+                .arg(QString::fromStdString(cashPrefix), active.displayLabel);
+            return result;
+        }
+    }
+
+    // ── bech32 / bech32m (segwit) ─────────────────────────────────────────────
+    {
+        std::string hrp;
+        if (detail::decodeBech32(addr, hrp)) {
+            if (detail::hrpAccepted(activeAcc, hrp)) {
+                result.verdict = AddressVerdict::Ok;
+                return result;
+            }
+            for (int i = 0; i < profileCount; ++i) {
+                const CoinProfile& p = profiles[i];
+                if (p.symbol == active.symbol) continue;
+                if (detail::hrpAccepted(detail::registryAcceptance(p.symbol), hrp)) {
+                    result.verdict = AddressVerdict::WrongCoin;
+                    result.detectedCoinLabel = p.displayLabel;
+                    result.message = QStringLiteral(
+                        "This is a %1 bech32 address (hrp \"%2\"), but the active "
+                        "coin is %3. Enter a %3 payout address or switch profiles.")
+                        .arg(p.displayLabel, QString::fromStdString(hrp),
+                             active.displayLabel);
+                    return result;
+                }
+            }
+            result.verdict = AddressVerdict::UnknownVersion;
+            result.message = QStringLiteral(
+                "Unrecognised bech32 prefix \"%1\" — cannot confirm this is a "
+                "valid %2 address.")
+                .arg(QString::fromStdString(hrp), active.displayLabel);
+            return result;
+        }
+    }
+
+    // ── base58check ──────────────────────────────────────────────────────────
     std::vector<uint8_t> raw;
     if (!detail::decodeBase58(addr, raw) || raw.size() != 25) {
-        // Not a base58check address (bech32 / cashaddr / malformed). We do
-        // not model those, so pass through unjudged.
         result.verdict = AddressVerdict::NotBase58Check;
         return result;
     }
 
     // base58check = 1 version byte + 20 payload bytes + 4 checksum bytes.
-    // checksum = first 4 bytes of SHA256d(version||payload).
     const QByteArray body(reinterpret_cast<const char*>(raw.data()), 21);
     const QByteArray h1 = QCryptographicHash::hash(body, QCryptographicHash::Sha256);
     const QByteArray h2 = QCryptographicHash::hash(h1, QCryptographicHash::Sha256);
     if (std::memcmp(h2.constData(), raw.data() + 21, 4) != 0) {
-        // Looks base58 but the checksum fails — most likely a typo. Advisory
-        // only (never a hard block, to stay low false-positive).
         result.verdict = AddressVerdict::NotBase58Check;
         return result;
     }
 
     const int version = raw[0];
-    const CoinProfile& active = coinProfile(activeSymbol);
-
-    if (detail::versionMatchesCoin(active, version)) {
+    if (detail::versionAccepted(activeAcc, version)) {
         result.verdict = AddressVerdict::Ok;
         return result;
     }
 
-    // Version does not belong to the active coin. Does it belong to a
-    // known other coin? If so this is the money-mistake we must block.
-    int count = 0;
-    const CoinProfile* profiles = coinProfiles(count);
-    for (int i = 0; i < count; ++i) {
+    for (int i = 0; i < profileCount; ++i) {
         const CoinProfile& p = profiles[i];
         if (p.symbol == active.symbol) continue;
-        if (detail::versionMatchesCoin(p, version)) {
+        if (detail::versionAccepted(detail::registryAcceptance(p.symbol), version)) {
             result.verdict = AddressVerdict::WrongCoin;
             result.detectedCoinLabel = p.displayLabel;
             result.message = QStringLiteral(
@@ -174,7 +344,6 @@ inline AddressCheck validatePayoutAddress(const QString& address,
         }
     }
 
-    // Valid base58check, but a version we do not model. Advisory only.
     result.verdict = AddressVerdict::UnknownVersion;
     result.message = QStringLiteral(
         "Unrecognised address version %1 — cannot confirm this is a valid %2 "

--- a/ui/c2pool-qt/src/CoinProfiles.hpp
+++ b/ui/c2pool-qt/src/CoinProfiles.hpp
@@ -36,6 +36,8 @@
 
 #pragma once
 
+#include <core/param_catalog.hpp>   // c2pool::catalog::Bin (per-coin binary key)
+
 #include <QLatin1String>
 #include <QString>
 
@@ -60,6 +62,13 @@ struct CoinProfile {
     CliFamily cli;          ///< which launch CLI family this coin uses
     QString   subcommand;   ///< PerCoinRun run-loop subcommand ("--run"/"--pool"); empty for legacy
 
+    /// Which node binary this coin maps to in the parameter catalog
+    /// (src/core/param_catalog.inc). LaunchCommand keys every flag spelling on
+    /// this so the panel emits ONLY flags the target binary accepts. For the
+    /// LegacyUnified `c2pool --net …` coins it records the closest catalog binary
+    /// (unused on that path, which builds the Python-p2pool-compatible argv).
+    c2pool::catalog::Bin bin;
+
     // Parent-daemon RPC link (PerCoinRun). For LegacyUnified these are the
     // --coind-rpc-port defaults; PageLaunch maps them to the right flag.
     int rpcPortMainnet;
@@ -81,15 +90,11 @@ struct CoinProfile {
     bool masternodePayee;   ///< coin pays a masternode/founder split (DASH) — surfaced as a note
     bool experimental;      ///< PerCoinRun binary still stabilising (DGB/BCH) — surfaced as a note
 
-    // Base58 address version bytes (P2PKH / P2SH, mainnet / testnet), used by
-    // AddressValidator to reject a wrong-coin payout address in the UI. Values
-    // mirror the node's impl/<coin>/params.hpp base58Prefixes and CoinBridge's
-    // JS descriptor table. DASH cross-checked vs dashpay/dash chainparams.cpp
-    // (mainnet 76/16, testnet 140/19).
-    int p2pkhVersionMainnet;
-    int p2shVersionMainnet;
-    int p2pkhVersionTestnet;
-    int p2shVersionTestnet;
+    // NOTE: this table no longer carries base58 version bytes. AddressValidator
+    // reads the accepted version bytes / bech32 HRPs straight from the node
+    // registry (src/impl/<coin>/address_encoding.hpp — the same
+    // <coin>::address_acceptance() the stratum money-path uses, issue #961), so
+    // the UI check can never drift from the node. See AddressValidator.hpp.
 };
 
 /// Ordered profile table. Order drives the chain combo. DASH is first-class.
@@ -99,59 +104,53 @@ inline const CoinProfile* coinProfiles(int& countOut)
         // ── LegacyUnified: unified `c2pool` binary, chain via --net ──────────
         {"litecoin", "Litecoin", "c2pool", "litecoind", "Scrypt",
          "L… / M… (P2PKH/P2SH)",
-         CliFamily::LegacyUnified, "",
+         CliFamily::LegacyUnified, "", c2pool::catalog::Bin::BIN_LTC,
          9332, 19332,
          "", "", "", "", false, true,
-         0, 0, false, false,
-         48, 50, 111, 58},
+         0, 0, false, false},
         {"bitcoin", "Bitcoin", "c2pool", "bitcoind", "SHA-256d",
          "1… / bc1… (P2PKH/bech32)",
-         CliFamily::LegacyUnified, "",
+         CliFamily::LegacyUnified, "", c2pool::catalog::Bin::BIN_BTC,
          8332, 18332,
          "", "", "", "", false, true,
-         0, 0, false, false,
-         0, 5, 111, 196},
+         0, 0, false, false},
         {"dogecoin", "Dogecoin", "c2pool", "dogecoind", "Scrypt (AuxPoW)",
          "D… (P2PKH)",
-         CliFamily::LegacyUnified, "",
+         CliFamily::LegacyUnified, "", c2pool::catalog::Bin::BIN_LTC,
          22555, 44555,
          "", "", "", "", false, true,
-         0, 0, false, false,
-         30, 22, 113, 196},
+         0, 0, false, false},
 
         // ── PerCoinRun: dedicated per-coin binaries ──────────────────────────
         // DASH — X11, masternode-payee coin, dashd parent. Default launch is
         // the reward-SAFE dashd-RPC arm; embedded P2P is opt-in only.
         {"dash", "Dash", "c2pool-dash", "dashd", "X11",
          "X… / 7… (P2PKH/P2SH)",
-         CliFamily::PerCoinRun, "--run",
+         CliFamily::PerCoinRun, "--run", c2pool::catalog::Bin::BIN_DASH,
          9998, 19998,
          "--coin-rpc", "--coin-rpc-auth", "~/.dashcore/dash.conf",
          "--listen", /*testnet*/ true, /*webPort*/ true,
-         3333, 8080, /*masternode*/ true, /*experimental*/ false,
-         76, 16, 140, 19},
+         3333, 8080, /*masternode*/ true, /*experimental*/ false},
 
         // DigiByte — multi-algo (Scrypt here), digibyted parent. No --testnet
         // flag (mainnet/regtest only) and no --web-port on this binary.
         {"digibyte", "DigiByte", "c2pool-dgb", "digibyted", "Scrypt",
          "D… / S… (P2PKH/P2SH)",
-         CliFamily::PerCoinRun, "--run",
+         CliFamily::PerCoinRun, "--run", c2pool::catalog::Bin::BIN_DGB,
          14024, 14025,
          "--coin-rpc", "--coin-rpc-auth", "~/.digibyte/digibyte.conf",
          "--sharechain-port", /*testnet*/ false, /*webPort*/ false,
-         5022, 0, /*masternode*/ false, /*experimental*/ true,
-         30, 63, 126, 140},
+         5022, 0, /*masternode*/ false, /*experimental*/ true},
 
         // Bitcoin Cash — BCHN parent. Uses `--pool`, creds via --rpc-conf
         // (no --coin-rpc endpoint override), --p2p-port for the sharechain.
         {"bitcoincash", "Bitcoin Cash", "c2pool-bch", "bitcoind (BCHN)", "SHA-256d",
          "1… / q… (legacy/cashaddr)",
-         CliFamily::PerCoinRun, "--pool",
+         CliFamily::PerCoinRun, "--pool", c2pool::catalog::Bin::BIN_BCH,
          8332, 18332,
          "", "--rpc-conf", "~/.bitcoin/bitcoin.conf",
          "--p2p-port", /*testnet*/ true, /*webPort*/ false,
-         3333, 0, /*masternode*/ false, /*experimental*/ true,
-         0, 5, 111, 196},
+         3333, 0, /*masternode*/ false, /*experimental*/ true},
     };
     countOut = static_cast<int>(sizeof(kProfiles) / sizeof(kProfiles[0]));
     return kProfiles;

--- a/ui/c2pool-qt/src/LaunchCommand.hpp
+++ b/ui/c2pool-qt/src/LaunchCommand.hpp
@@ -2,142 +2,260 @@
 // LaunchCommand — Qt-free core that assembles the per-coin (PerCoinRun)
 // c2pool command line from plain parameters.
 //
-// Kept deliberately independent of Qt (std::string / std::vector only) so
-// the ★ reward-safety invariant can be unit-tested WITHOUT a display,
-// QApplication, or the widget stack:
+// Kept deliberately independent of Qt (std::string / std::vector only) so the
+// ★ reward-safety invariant can be unit-tested WITHOUT a display, QApplication,
+// or the widget stack. See test/test_reward_safe_launch.cpp.
 //
-//   With the embedded opt-ins OFF (their default), the generated argv for
-//   ANY coin NEVER contains --coin-p2p-connect or --embedded-mainnet, and
-//   the default parent-daemon link is the reward-SAFE --coin-rpc arm.
+// Every flag SPELLING is resolved from the node's parameter catalog
+// (ParamCatalogView → src/core/param_catalog.inc), keyed by (binary, canonical
+// param). This has two consequences that matter:
 //
-// PageLaunch fills PerCoinParams from the form + the active CoinProfile and
-// calls build_percoin_argv(); this file is where the ordering and the
-// embedded-arm gating actually live. See test/test_reward_safe_launch.cpp.
+//   1. A flag is emitted for a binary ONLY when the catalog carries an alias row
+//      for that binary — so the panel can NEVER emit a flag the target binary
+//      rejects (BCH has no money flags; DGB/BCH spell "add peer" as
+//      --sharechain-addnode, not --addnode; DGB/BCH/BTC bind the web port as a
+//      combined --http [HOST:]PORT). This is the fix for the launch-failure class
+//      where every PerCoinRun coin was fed the DASH flag spellings verbatim.
+//
+//   2. ★ REWARD SAFETY. With the embedded opt-ins OFF (their default) the
+//      generated argv for ANY coin NEVER contains --coin-p2p-connect / --peer /
+//      --embedded-mainnet / a coin-magic override, and the default parent-daemon
+//      link is the reward-SAFE --coin-rpc arm. The author donation is left to the
+//      binary default (0.1% / BTC 0.5%) unless the operator explicitly sets it;
+//      --give-author 0 is emitted ONLY behind an explicit opt-in ack, never as a
+//      default for a public node. validate_percoin() additionally refuses a DASH
+//      launch whose blank RPC endpoint would silently run daemonless (embedded
+//      MAINNET auto-ON) without an explicit embedded opt-in.
 
 #pragma once
 
+#include "ParamCatalogView.hpp"
+
 #include <cstdio>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace c2pool_qt {
 
+using c2pool::catalog::Bin;
+using c2pool::catalog::AliasStyle;
+
 struct PerCoinParams {
-    std::string binary;       ///< e.g. "./build/bin/c2pool-dash"
-    std::string subcommand;   ///< "--run" / "--pool" / ""
+    Bin         bin = Bin::BIN_DASH;   ///< which per-coin binary (catalog key)
+    std::string binary;                ///< e.g. "./build/bin/c2pool-dash"
+    std::string subcommand;            ///< "--run" / "--pool" / ""
 
-    std::string dataDir;      ///< --data-dir PATH (empty ⇒ omit)
+    std::string dataDir;               ///< meta.data_dir PATH (empty ⇒ omit)
 
-    bool testnet = false;
-    bool supportsTestnetFlag = false;  ///< binary accepts --testnet
+    bool testnet = false;              ///< network.testnet (emitted iff the bin has the alias)
+    bool regtest = false;              ///< network.regtest
 
-    // Reward-SAFE parent-daemon RPC arm.
-    std::string coinRpcFlag;  ///< "--coin-rpc" (empty ⇒ binary has no endpoint override, e.g. BCH)
+    // Reward-SAFE parent-daemon RPC arm. Host+port ⇒ daemon_rpc.endpoint (DASH
+    // --coin-rpc / BTC --bitcoind) or daemon_rpc.submit_endpoint (DGB --coin-rpc).
+    // confPath ⇒ daemon_rpc.auth_file (--coin-rpc-auth / --rpc-conf). The
+    // rpcpassword NEVER touches argv — it is read from the coin's .conf.
     std::string rpcHost;
     int         rpcPort = 0;
-    std::string rpcAuthFlag;  ///< "--coin-rpc-auth" / "--rpc-conf"
-    std::string confPath;     ///< creds file PATH (rpcpassword stays off argv)
+    std::string confPath;
 
-    int stratumPort = 0;      ///< --stratum PORT (0 ⇒ omit / disabled)
+    int         stratumPort = 0;       ///< stratum.bind PORT (0 ⇒ omit)
 
-    bool        supportsWebPort = false;
-    int         webPort = 0;  ///< --web-port PORT
-    std::string webHost;      ///< --web-host ADDR (omit when default 0.0.0.0)
+    int         webPort = 0;           ///< web.port (0 ⇒ omit)
+    std::string webHost;               ///< web.host / combined --http host
 
-    std::string              sharechainPortFlag; ///< "--listen"/"--sharechain-port"/"--p2p-port"
-    int                      sharechainPort = 0;
-    std::vector<std::string> addnodes;           ///< --addnode HOST:PORT (repeatable)
+    int                      sharechainPort = 0;   ///< sharechain.listen
+    std::vector<std::string> addnodes;             ///< sharechain.addnodes (repeatable)
 
-    // Payout / fee / donation.
-    std::string payoutAddress;    ///< --node-owner-address ADDR
-    double      fee = 0.0;        ///< -f PCT
-    double      giveAuthor = 0.0; ///< --give-author PCT
-    std::string redistribute;     ///< --redistribute MODE (omit when "pplns")
+    // Payout / fee / donation (money.*). Reward-safe tri-state on give-author.
+    std::string payoutAddress;                 ///< money.node_owner_address
+    double      fee = 0.0;                      ///< money.node_owner_fee_pct (emit iff > 0)
+    bool        giveAuthorSet = false;          ///< operator explicitly overrides the binary default
+    double      giveAuthor = 0.0;               ///< money.give_author_pct value
+    bool        giveAuthorExplicitZeroAck = false; ///< required to emit an explicit 0
+    std::string redistribute;                   ///< money.redistribute (omit when "pplns")
 
-    std::string messageBlob;      ///< --message-blob-hex HEX
+    std::string messageBlob;                    ///< global.message_blob_hex
 
-    // ── ★ Embedded reward-UNSAFE arm — OPT-IN, default OFF ────────────────
-    bool                     embeddedP2p = false;      ///< gate for --coin-p2p-connect
+    // ── DGB/BCH deeper run-loop controls (PR-1) ──────────────────────────────
+    bool        coinP2pDiscover = false;   ///< coin_p2p.discover (transport, reward-neutral)
+    bool        noP2pRelay = false;        ///< sharechain.no_p2p_relay
+    std::string bchAnchor;                 ///< embedded.anchor (BCH cold-start ABLA floor)
+
+    // ── ★ Embedded reward-UNSAFE arm — OPT-IN, default OFF ────────────────────
+    bool                     embeddedP2p = false;      ///< coin_p2p.connect (DASH --coin-p2p-connect / BCH --peer)
     std::vector<std::string> embeddedP2pPeers;         ///< HOST:PORT peers
-    bool                     embeddedMainnet = false;  ///< --embedded-mainnet (DASH)
+    bool                     embeddedMainnet = false;  ///< embedded.mainnet (DASH)
+    std::string              coinDaemon;               ///< coin_p2p.producer_target (DGB --coin-daemon)
+    std::string              coinMagic;                ///< coin_p2p.magic (DASH --coin-p2p-magic / DGB --coin-magic)
+    std::string              coinGenesis;              ///< network.coin_genesis (DGB)
 };
 
-/// Assemble the argv (binary first). The embedded reward-UNSAFE flags are
-/// appended ONLY when their opt-in bools are true — this is the single
-/// choke point that enforces the reward-safe default.
-inline std::vector<std::string> build_percoin_argv(const PerCoinParams& p)
+namespace detail {
+
+inline std::string trim(const std::string& s)
 {
-    std::vector<std::string> a;
-    auto trimmed = [](const std::string& s) {
-        const auto b = s.find_first_not_of(" \t\r\n");
-        if (b == std::string::npos) return std::string();
-        const auto e = s.find_last_not_of(" \t\r\n");
-        return s.substr(b, e - b + 1);
-    };
-    auto fmtPct = [](double v) {
-        char buf[32];
-        std::snprintf(buf, sizeof(buf), "%.2f", v);
-        return std::string(buf);
-    };
+    const auto b = s.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) return std::string();
+    const auto e = s.find_last_not_of(" \t\r\n");
+    return s.substr(b, e - b + 1);
+}
 
-    a.push_back(trimmed(p.binary));
-    if (!p.subcommand.empty()) a.push_back(p.subcommand);
+inline std::string fmt_pct(double v)
+{
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.2f", v);
+    return std::string(buf);
+}
 
-    if (!trimmed(p.dataDir).empty()) { a.push_back("--data-dir"); a.push_back(trimmed(p.dataDir)); }
+// Append "<spelling> <value>" iff the binary has an alias for `canon` and the
+// value is non-empty. A canon with no alias for this binary emits NOTHING —
+// the single mechanism that stops a wrong-binary flag from being generated.
+inline void emit_value(std::vector<std::string>& a, Bin bin,
+                       const char* canon, const std::string& value)
+{
+    if (value.empty()) return;
+    auto s = catview::spelling_for(bin, canon);
+    if (!s) return;
+    a.push_back(s->first);
+    a.push_back(value);
+}
 
-    if (p.testnet && p.supportsTestnetFlag) a.push_back("--testnet");
+// Append a bare "<spelling>" flag iff the binary has an alias for `canon`.
+inline void emit_flag(std::vector<std::string>& a, Bin bin, const char* canon)
+{
+    auto s = catview::spelling_for(bin, canon);
+    if (!s) return;
+    a.push_back(s->first);
+}
 
-    // Reward-SAFE RPC arm (endpoint carries no secret; creds via conf file).
-    if (!p.coinRpcFlag.empty() && !trimmed(p.rpcHost).empty() && p.rpcPort > 0) {
-        a.push_back(p.coinRpcFlag);
-        a.push_back(trimmed(p.rpcHost) + ":" + std::to_string(p.rpcPort));
-    }
-    if (!p.rpcAuthFlag.empty() && !trimmed(p.confPath).empty()) {
-        a.push_back(p.rpcAuthFlag);
-        a.push_back(trimmed(p.confPath));
-    }
+} // namespace detail
 
-    if (p.stratumPort > 0) { a.push_back("--stratum"); a.push_back(std::to_string(p.stratumPort)); }
-
-    if (p.supportsWebPort && p.webPort > 0) {
-        a.push_back("--web-port");
-        a.push_back(std::to_string(p.webPort));
-        const std::string wh = trimmed(p.webHost);
-        if (!wh.empty() && wh != "0.0.0.0") { a.push_back("--web-host"); a.push_back(wh); }
-    }
-
-    if (!p.sharechainPortFlag.empty() && p.sharechainPort > 0) {
-        a.push_back(p.sharechainPortFlag);
-        a.push_back(std::to_string(p.sharechainPort));
-    }
-    for (const auto& n : p.addnodes) {
-        const std::string t = trimmed(n);
-        if (!t.empty()) { a.push_back("--addnode"); a.push_back(t); }
-    }
-
-    if (!trimmed(p.payoutAddress).empty()) {
-        a.push_back("--node-owner-address");
-        a.push_back(trimmed(p.payoutAddress));
-    }
-    if (p.fee > 0.0)        { a.push_back("-f"); a.push_back(fmtPct(p.fee)); }
-    if (p.giveAuthor > 0.0) { a.push_back("--give-author"); a.push_back(fmtPct(p.giveAuthor)); }
-    if (!p.redistribute.empty() && p.redistribute != "pplns") {
-        a.push_back("--redistribute");
-        a.push_back(p.redistribute);
-    }
-    if (!trimmed(p.messageBlob).empty()) {
-        a.push_back("--message-blob-hex");
-        a.push_back(trimmed(p.messageBlob));
-    }
-
-    // ── ★ Embedded reward-UNSAFE arm — appended ONLY when opted in ────────
-    if (p.embeddedP2p) {
-        for (const auto& peer : p.embeddedP2pPeers) {
-            const std::string t = trimmed(peer);
-            if (!t.empty()) { a.push_back("--coin-p2p-connect"); a.push_back(t); }
+/// Reward-safety / launchability precheck. Returns "" when the params are safe
+/// to launch, else a human-readable reason PageLaunch surfaces and refuses on.
+inline std::string validate_percoin(const PerCoinParams& p)
+{
+    // ★ F5 — DASH daemonless guard. On DASH, the ABSENCE of a --coin-rpc arm
+    // means daemonless == embedded MAINNET block production auto-ON, which is
+    // reward-UNSAFE. Refuse a blank RPC endpoint UNLESS an embedded arm was
+    // explicitly opted into (then the operator owns the risk knowingly).
+    if (p.bin == Bin::BIN_DASH) {
+        const bool haveRpc = !detail::trim(p.rpcHost).empty() && p.rpcPort > 0;
+        const bool embeddedOptIn = p.embeddedP2p || p.embeddedMainnet;
+        if (!haveRpc && !embeddedOptIn) {
+            return "DASH needs a --coin-rpc HOST:PORT (dashd RPC arm). A blank RPC "
+                   "endpoint runs the node DAEMONLESS with embedded MAINNET block "
+                   "production auto-ON — reward-UNSAFE. Set the RPC host/port, or "
+                   "explicitly enable the embedded arm below.";
         }
     }
-    if (p.embeddedMainnet) a.push_back("--embedded-mainnet");
+    return "";
+}
+
+/// Assemble the argv (binary first). The embedded reward-UNSAFE flags are
+/// appended ONLY when their opt-in bools are true — the single choke point that
+/// enforces the reward-safe default.
+inline std::vector<std::string> build_percoin_argv(const PerCoinParams& p)
+{
+    using detail::trim;
+    using detail::fmt_pct;
+    using detail::emit_value;
+    using detail::emit_flag;
+
+    std::vector<std::string> a;
+    const Bin bin = p.bin;
+
+    a.push_back(trim(p.binary));
+    if (!p.subcommand.empty()) a.push_back(p.subcommand);
+
+    emit_value(a, bin, "meta.data_dir", trim(p.dataDir));
+
+    if (p.testnet) emit_flag(a, bin, "network.testnet");
+    if (p.regtest) emit_flag(a, bin, "network.regtest");
+
+    // Reward-SAFE RPC arm. daemon_rpc.endpoint (DASH --coin-rpc / BTC --bitcoind)
+    // where the bin has it; else daemon_rpc.submit_endpoint (DGB --coin-rpc).
+    // BCH has neither and links creds only via --rpc-conf.
+    if (!trim(p.rpcHost).empty() && p.rpcPort > 0) {
+        const std::string ep = trim(p.rpcHost) + ":" + std::to_string(p.rpcPort);
+        if (catview::spelling_for(bin, "daemon_rpc.endpoint"))
+            emit_value(a, bin, "daemon_rpc.endpoint", ep);
+        else
+            emit_value(a, bin, "daemon_rpc.submit_endpoint", ep);
+    }
+    emit_value(a, bin, "daemon_rpc.auth_file", trim(p.confPath));
+
+    if (p.stratumPort > 0)
+        emit_value(a, bin, "stratum.bind", std::to_string(p.stratumPort));
+
+    // web.port — combined --http [HOST:]PORT for DGB/BCH/BTC; separate
+    // --web-port / --web-host for DASH/LTC.
+    if (p.webPort > 0) {
+        auto webS = catview::spelling_for(bin, "web.port");
+        if (webS) {
+            const std::string wh = trim(p.webHost);
+            const std::string port = std::to_string(p.webPort);
+            if (webS->second == AliasStyle::VALUE_HOSTPORT_COMBINED) {
+                const std::string v =
+                    (!wh.empty() && wh != "0.0.0.0") ? wh + ":" + port : port;
+                a.push_back(webS->first);
+                a.push_back(v);
+            } else {
+                a.push_back(webS->first);
+                a.push_back(port);
+                if (!wh.empty() && wh != "0.0.0.0")
+                    emit_value(a, bin, "web.host", wh);
+            }
+        }
+    }
+
+    if (p.sharechainPort > 0)
+        emit_value(a, bin, "sharechain.listen", std::to_string(p.sharechainPort));
+    for (const auto& n : p.addnodes) {
+        const std::string t = trim(n);
+        if (!t.empty()) emit_value(a, bin, "sharechain.addnodes", t);
+    }
+
+    if (p.coinP2pDiscover) emit_flag(a, bin, "coin_p2p.discover");
+    if (p.noP2pRelay)      emit_flag(a, bin, "sharechain.no_p2p_relay");
+    emit_value(a, bin, "embedded.anchor", trim(p.bchAnchor));
+
+    // ── Money (only where the catalog carries the alias for this binary) ──────
+    emit_value(a, bin, "money.node_owner_address", trim(p.payoutAddress));
+    if (p.fee > 0.0)
+        emit_value(a, bin, "money.node_owner_fee_pct", fmt_pct(p.fee));
+
+    // ★ give-author tri-state (F6). Default = OMIT ⇒ the binary default applies
+    // (DASH/LTC/BIP110 0.1%, BTC 0.5%). An explicit value is emitted only when
+    // the operator overrode it, and an explicit ZERO ONLY behind an ack — never
+    // a silent --give-author 0 for a public node.
+    if (p.giveAuthorSet) {
+        if (p.giveAuthor > 0.0)
+            emit_value(a, bin, "money.give_author_pct", fmt_pct(p.giveAuthor));
+        else if (p.giveAuthorExplicitZeroAck)
+            emit_value(a, bin, "money.give_author_pct", fmt_pct(0.0));
+    }
+
+    {
+        const std::string rd = trim(p.redistribute);
+        if (!rd.empty() && rd != "pplns")
+            emit_value(a, bin, "money.redistribute", rd);
+    }
+
+    emit_value(a, bin, "global.message_blob_hex", trim(p.messageBlob));
+
+    // ── ★ Embedded reward-UNSAFE arm — appended ONLY when opted in ────────────
+    if (p.embeddedP2p) {
+        for (const auto& peer : p.embeddedP2pPeers) {
+            const std::string t = trim(peer);
+            if (!t.empty()) emit_value(a, bin, "coin_p2p.connect", t);
+        }
+        emit_value(a, bin, "coin_p2p.producer_target", trim(p.coinDaemon));
+        emit_value(a, bin, "coin_p2p.magic", trim(p.coinMagic));
+        emit_value(a, bin, "network.coin_genesis", trim(p.coinGenesis));
+    }
+    if (p.embeddedMainnet) emit_flag(a, bin, "embedded.mainnet");
 
     return a;
 }

--- a/ui/c2pool-qt/src/PageLaunch.cpp
+++ b/ui/c2pool-qt/src/PageLaunch.cpp
@@ -319,8 +319,27 @@ void PageLaunch::setupUi()
         giveAuthorSpinBox_->setDecimals(2);
         giveAuthorSpinBox_->setSuffix(" %");
         giveAuthorSpinBox_->setValue(0.0);
-        giveAuthorSpinBox_->setToolTip("--give-author / --dev-donation");
+        // ★ Tri-state / reward-safety: at 0.00 the flag is OMITTED so the
+        // binary default applies (0.1% for DASH/LTC/BIP110, 0.5% for BTC). The
+        // special-value text says so; an explicit 0 requires the ack below.
+        giveAuthorSpinBox_->setSpecialValueText("binary default (0.1% / BTC 0.5%)");
+        giveAuthorSpinBox_->setToolTip(
+            "--give-author / --dev-donation\n"
+            "0.00 ⇒ OMITTED (binary default author donation applies).\n"
+            "Set a value to override, or tick the box below to donate 0% "
+            "explicitly (opt-in — never a silent default for a public node).");
         form->addRow("Dev donation (--give-author):", giveAuthorSpinBox_);
+
+        giveAuthorZeroAckCheck_ = new QCheckBox(
+            "Donate 0% to the author explicitly (opt-in; emits --give-author 0)");
+        giveAuthorZeroAckCheck_->setChecked(false);
+        giveAuthorZeroAckCheck_->setToolTip(
+            "Reward-safety guard. Only with this ticked does the panel emit "
+            "--give-author 0. Left unticked, a 0.00 spin value means \"use the "
+            "binary default\", never a forced zero.");
+        form->addRow("", giveAuthorZeroAckCheck_);
+        connect(giveAuthorZeroAckCheck_, &QCheckBox::stateChanged, this,
+                [this](int) { onBuildPreview(); });
 
         redistributeCombo_ = new QComboBox;
         redistributeCombo_->addItems({"pplns", "fee", "boost", "donate"});
@@ -500,6 +519,48 @@ void PageLaunch::setupUi()
         vbox->addWidget(g);
     }
 
+    // ── 9b. PerCoinRun run-loop controls (DASH/DGB/BCH) ──────────────────────
+    // Deeper, reward-NEUTRAL run-loop knobs for the dedicated per-coin binaries.
+    // Every flag is catalog-gated on the active binary, so a control that the
+    // selected coin's binary does not accept is simply not emitted (and the row
+    // is greyed out by applyProfileUi()). Shown only for PerCoinRun coins.
+    {
+        auto* g = makeGroup("Run-loop controls (per-coin binary)");
+        runLoopGroup_ = g;
+        auto* form = new QFormLayout(g);
+
+        coinP2pDiscoverCheck_ = new QCheckBox(
+            "Scored coin-P2P peer discovery (--coin-p2p-discover)");
+        coinP2pDiscoverCheck_->setToolTip(
+            "--coin-p2p-discover — diverse/scored coin-network peer discovery. "
+            "Transport only; reward-neutral (never moves the block-producing arm). "
+            "DASH/DGB.");
+        form->addRow("Peer discovery:", coinP2pDiscoverCheck_);
+
+        noP2pRelayCheck_ = new QCheckBox(
+            "Suppress embedded won-block relay (--no-p2p-relay)");
+        noP2pRelayCheck_->setToolTip(
+            "--no-p2p-relay — do not relay a won block over the embedded coin "
+            "P2P arm (RPC submit still happens). DASH/DGB.");
+        form->addRow("Won-block relay:", noP2pRelayCheck_);
+
+        bchAnchorEdit_ = new QLineEdit;
+        bchAnchorEdit_->setPlaceholderText("HEIGHT:HASH (BCH cold-start ABLA floor, optional)");
+        bchAnchorEdit_->setToolTip(
+            "--anchor HEIGHT:HASH — BCH cold-start ABLA (adaptive blocksize) "
+            "anchor. Reward-neutral bootstrap hint; BCH only.");
+        form->addRow("BCH anchor:", bchAnchorEdit_);
+
+        connect(coinP2pDiscoverCheck_, &QCheckBox::stateChanged, this,
+                [this](int) { onBuildPreview(); });
+        connect(noP2pRelayCheck_, &QCheckBox::stateChanged, this,
+                [this](int) { onBuildPreview(); });
+        connect(bchAnchorEdit_, &QLineEdit::textChanged, this,
+                [this]() { onBuildPreview(); });
+
+        vbox->addWidget(g);
+    }
+
     // ── 10. ★ Advanced / embedded (opt-in, REWARD-UNSAFE) ────────────────────
     // Default OFF. This is the ONLY place --coin-p2p-connect /
     // --embedded-mainnet may be emitted. The default per-coin launch is the
@@ -550,10 +611,46 @@ void PageLaunch::setupUi()
             "Reward-unsafe until validated. Default OFF.");
         gLayout->addWidget(embeddedMainnetCheck_);
 
+        // DGB embedded coin-network producer target (--coin-daemon + --coin-magic
+        // + --coin-genesis). Emitted ONLY when the embedded-P2P opt-in is on and
+        // only where the catalog carries the alias for the active binary.
+        auto* embForm = new QFormLayout;
+        embeddedCoinDaemonEdit_ = new QLineEdit;
+        embeddedCoinDaemonEdit_->setEnabled(false);
+        embeddedCoinDaemonEdit_->setPlaceholderText("HOST:PORT (DGB --coin-daemon producer target)");
+        embeddedCoinDaemonEdit_->setToolTip(
+            "--coin-daemon HOST:PORT — DGB embedded-P2P producer target. "
+            "Reward-unsafe embedded arm; emitted only with the opt-in above.");
+        embForm->addRow("Coin daemon (DGB):", embeddedCoinDaemonEdit_);
+
+        embeddedCoinMagicEdit_ = new QLineEdit;
+        embeddedCoinMagicEdit_->setEnabled(false);
+        embeddedCoinMagicEdit_->setPlaceholderText("HEX wire magic (regtest/embedded override)");
+        embeddedCoinMagicEdit_->setToolTip(
+            "--coin-magic / --coin-p2p-magic HEX — wire magic override for the "
+            "embedded coin P2P (MONEY_RESTART). Emitted only with the opt-in above.");
+        embForm->addRow("Coin magic:", embeddedCoinMagicEdit_);
+
+        embeddedCoinGenesisEdit_ = new QLineEdit;
+        embeddedCoinGenesisEdit_->setEnabled(false);
+        embeddedCoinGenesisEdit_->setPlaceholderText("HASH (DGB --coin-genesis override)");
+        embeddedCoinGenesisEdit_->setToolTip(
+            "--coin-genesis HASH — DGB genesis override for the embedded arm. "
+            "Emitted only with the opt-in above.");
+        embForm->addRow("Coin genesis (DGB):", embeddedCoinGenesisEdit_);
+        gLayout->addLayout(embForm);
+
         connect(embeddedP2pCheck_, &QCheckBox::stateChanged, this, [this](int st) {
-            embeddedP2pPeersEdit_->setEnabled(st == Qt::Checked);
+            const bool on = (st == Qt::Checked);
+            embeddedP2pPeersEdit_->setEnabled(on);
+            embeddedCoinDaemonEdit_->setEnabled(on);
+            embeddedCoinMagicEdit_->setEnabled(on);
+            embeddedCoinGenesisEdit_->setEnabled(on);
             onBuildPreview();
         });
+        connect(embeddedCoinDaemonEdit_,  &QLineEdit::textChanged, this, [this]() { onBuildPreview(); });
+        connect(embeddedCoinMagicEdit_,   &QLineEdit::textChanged, this, [this]() { onBuildPreview(); });
+        connect(embeddedCoinGenesisEdit_, &QLineEdit::textChanged, this, [this]() { onBuildPreview(); });
         connect(embeddedMainnetCheck_, &QCheckBox::stateChanged, this,
                 [this](int) { onBuildPreview(); });
         connect(embeddedP2pPeersEdit_, &QPlainTextEdit::textChanged, this,
@@ -783,36 +880,58 @@ QString PageLaunch::buildPerCoinCommand() const
     // Marshal form + profile state into the Qt-free command core. The
     // reward-safety invariant (embedded flags gated behind default-OFF
     // opt-ins) lives in build_percoin_argv() and is unit-tested there.
+    c2pool_qt::PerCoinParams pp = marshalPerCoinParams();
+    return QString::fromStdString(
+        c2pool_qt::join_argv(c2pool_qt::build_percoin_argv(pp)));
+}
+
+// Marshal the form + active profile into the Qt-free command core. Every flag
+// SPELLING is chosen by build_percoin_argv() from the parameter catalog keyed on
+// prof.bin, so the panel emits only flags the target binary accepts. Shared by
+// buildPerCoinCommand() and launch()'s validate_percoin() precheck.
+c2pool_qt::PerCoinParams PageLaunch::marshalPerCoinParams() const
+{
+    const QString chain = currentChain();
+    const c2pool_qt::CoinProfile& prof = c2pool_qt::coinProfile(chain);
+
     c2pool_qt::PerCoinParams pp;
+    pp.bin        = prof.bin;
     pp.binary     = binaryEdit_->text().trimmed().toStdString();
     pp.subcommand = prof.subcommand.toStdString();
     if (dataDirEdit_) pp.dataDir = dataDirEdit_->text().trimmed().toStdString();
 
-    pp.testnet             = testnetCheck_->isChecked();
-    pp.supportsTestnetFlag = prof.supportsTestnetFlag;
+    pp.testnet = testnetCheck_->isChecked();
 
-    pp.coinRpcFlag = prof.coinRpcFlag.toStdString();
-    pp.rpcHost     = coindHostEdit_->text().trimmed().toStdString();
-    pp.rpcPort     = coindPortSpin_->value();
-    pp.rpcAuthFlag = prof.rpcAuthFlag.toStdString();
+    pp.rpcHost = coindHostEdit_->text().trimmed().toStdString();
+    pp.rpcPort = coindPortSpin_->value();
     if (rpcConfPathEdit_) pp.confPath = rpcConfPathEdit_->text().trimmed().toStdString();
 
     pp.stratumPort = stratumPortSpin_->value();
 
-    pp.supportsWebPort = prof.supportsWebPort;
-    pp.webPort         = httpPortSpin_->value();
-    pp.webHost         = httpHostEdit_->text().trimmed().toStdString();
+    pp.webPort = httpPortSpin_->value();
+    pp.webHost = httpHostEdit_->text().trimmed().toStdString();
 
-    pp.sharechainPortFlag = prof.sharechainPortFlag.toStdString();
-    pp.sharechainPort     = p2pPortSpin_->value();
+    pp.sharechainPort = p2pPortSpin_->value();
     for (const QString& line : seedNodesEdit_->toPlainText().split('\n', Qt::SkipEmptyParts))
         pp.addnodes.push_back(line.trimmed().toStdString());
 
     pp.payoutAddress = addressEdit_->text().trimmed().toStdString();
     pp.fee           = feeSpinBox_->value();
+    // ★ give-author tri-state: default OMIT (binary default). An explicit value
+    // is emitted only when the operator overrode it, and an explicit ZERO only
+    // behind the ack checkbox — never a silent --give-author 0 (reward-safety).
     pp.giveAuthor    = giveAuthorSpinBox_->value();
+    pp.giveAuthorExplicitZeroAck =
+        giveAuthorZeroAckCheck_ && giveAuthorZeroAckCheck_->isChecked();
+    pp.giveAuthorSet = pp.giveAuthor > 0.0 || pp.giveAuthorExplicitZeroAck;
     pp.redistribute  = redistributeCombo_->currentText().toStdString();
     pp.messageBlob   = messageBlobEdit_->text().trimmed().toStdString();
+
+    // ── DGB/BCH deeper run-loop controls (emitted only where the catalog has
+    //    the alias for this binary — a no-op on coins that lack the flag). ──
+    pp.coinP2pDiscover = coinP2pDiscoverCheck_ && coinP2pDiscoverCheck_->isChecked();
+    pp.noP2pRelay      = noP2pRelayCheck_ && noP2pRelayCheck_->isChecked();
+    if (bchAnchorEdit_) pp.bchAnchor = bchAnchorEdit_->text().trimmed().toStdString();
 
     // ── ★ Embedded reward-UNSAFE arm — OPT-IN ONLY (default OFF) ──────────
     pp.embeddedP2p = embeddedP2pCheck_ && embeddedP2pCheck_->isChecked();
@@ -821,10 +940,17 @@ QString PageLaunch::buildPerCoinCommand() const
              embeddedP2pPeersEdit_->toPlainText().split('\n', Qt::SkipEmptyParts))
             pp.embeddedP2pPeers.push_back(line.trimmed().toStdString());
     }
+    if (pp.embeddedP2p) {
+        if (embeddedCoinDaemonEdit_)
+            pp.coinDaemon = embeddedCoinDaemonEdit_->text().trimmed().toStdString();
+        if (embeddedCoinMagicEdit_)
+            pp.coinMagic = embeddedCoinMagicEdit_->text().trimmed().toStdString();
+        if (embeddedCoinGenesisEdit_)
+            pp.coinGenesis = embeddedCoinGenesisEdit_->text().trimmed().toStdString();
+    }
     pp.embeddedMainnet = embeddedMainnetCheck_ && embeddedMainnetCheck_->isChecked();
 
-    return QString::fromStdString(
-        c2pool_qt::join_argv(c2pool_qt::build_percoin_argv(pp)));
+    return pp;
 }
 
 QString PageLaunch::suggestedApiBaseUrl() const
@@ -891,6 +1017,54 @@ void PageLaunch::applyProfileUi()
         embeddedGroup_->setVisible(perCoin);
     if (embeddedMainnetCheck_)
         embeddedMainnetCheck_->setVisible(chain == QStringLiteral("dash"));
+    // Embedded DGB producer-target fields are DGB-only.
+    {
+        const bool isDgb = (chain == QStringLiteral("digibyte"));
+        if (embeddedCoinDaemonEdit_)  embeddedCoinDaemonEdit_->setVisible(isDgb);
+        if (embeddedCoinGenesisEdit_) embeddedCoinGenesisEdit_->setVisible(isDgb);
+        // --coin-magic exists for DASH and DGB.
+        if (embeddedCoinMagicEdit_)
+            embeddedCoinMagicEdit_->setVisible(
+                isDgb || chain == QStringLiteral("dash"));
+    }
+
+    // ── Catalog-driven per-coin control gating ────────────────────────────────
+    // For a PerCoinRun coin, grey out any flag its binary does not accept per the
+    // parameter catalog (keyed on prof.bin), so the form can never invite the
+    // operator to set a value that would be silently dropped. LegacyUnified coins
+    // keep every money widget enabled (they build the Python-p2pool argv).
+    if (perCoin) {
+        using c2pool_qt::catview::spelling_for;
+        const auto bin = prof.bin;
+        auto has = [&](const char* canon) {
+            return spelling_for(bin, canon).has_value();
+        };
+        const bool hasFee        = has("money.node_owner_fee_pct");
+        const bool hasGiveAuthor = has("money.give_author_pct");
+        const bool hasOwnerAddr  = has("money.node_owner_address");
+        const bool hasRedist     = has("money.redistribute");
+        if (feeSpinBox_)             feeSpinBox_->setEnabled(hasFee);
+        if (giveAuthorSpinBox_)      giveAuthorSpinBox_->setEnabled(hasGiveAuthor);
+        if (giveAuthorZeroAckCheck_) giveAuthorZeroAckCheck_->setEnabled(hasGiveAuthor);
+        if (nodeOwnerAddrEdit_)      nodeOwnerAddrEdit_->setEnabled(hasOwnerAddr);
+        if (redistributeCombo_)      redistributeCombo_->setEnabled(hasRedist);
+
+        // Run-loop rows: enable only where the catalog carries the alias.
+        if (coinP2pDiscoverCheck_) coinP2pDiscoverCheck_->setEnabled(has("coin_p2p.discover"));
+        if (noP2pRelayCheck_)      noP2pRelayCheck_->setEnabled(has("sharechain.no_p2p_relay"));
+        if (bchAnchorEdit_)        bchAnchorEdit_->setEnabled(has("embedded.anchor"));
+    } else {
+        // Legacy coins: money widgets always available.
+        if (feeSpinBox_)             feeSpinBox_->setEnabled(true);
+        if (giveAuthorSpinBox_)      giveAuthorSpinBox_->setEnabled(true);
+        if (giveAuthorZeroAckCheck_) giveAuthorZeroAckCheck_->setEnabled(true);
+        if (nodeOwnerAddrEdit_)      nodeOwnerAddrEdit_->setEnabled(true);
+        if (redistributeCombo_)      redistributeCombo_->setEnabled(true);
+    }
+
+    // Run-loop group is only meaningful for PerCoinRun binaries.
+    if (runLoopGroup_)
+        runLoopGroup_->setVisible(perCoin);
 
     // Per-coin note: CLI arm, masternode-payee, experimental status.
     if (coinNoteLabel_) {
@@ -902,6 +1076,13 @@ void PageLaunch::applyProfileUi()
                             prof.rpcAuthFlag.isEmpty() ? QStringLiteral("RPC")
                                                        : prof.rpcAuthFlag,
                             prof.confHint);
+            if (chain == QStringLiteral("bitcoincash"))
+                note += QStringLiteral("  c2pool-bch has no operator fee surface "
+                                       "(param catalog) — fee/donation/redistribute "
+                                       "are disabled.");
+            else if (chain == QStringLiteral("digibyte"))
+                note += QStringLiteral("  c2pool-dgb: node-owner address + "
+                                       "redistribute live; no author-fee surface.");
         } else {
             note = QStringLiteral("%1 · %2 · unified c2pool binary (--net %3).")
                        .arg(prof.displayLabel, prof.algoLabel, prof.symbol);
@@ -910,8 +1091,7 @@ void PageLaunch::applyProfileUi()
             note += QStringLiteral("  Masternode-payee coin (block reward is split "
                                    "with the masternode network).");
         if (prof.experimental)
-            note += QStringLiteral("  ⚠ per-coin binary still stabilising — deeper "
-                                   "controls are TODO (qt-steward).");
+            note += QStringLiteral("  ⚠ per-coin binary still stabilising.");
         coinNoteLabel_->setText(note);
     }
 }
@@ -1023,6 +1203,23 @@ void PageLaunch::launch()
         return;
     }
 
+    // ── ★ Reward-safety precheck (PerCoinRun) ─────────────────────────────────
+    // F5: a DASH launch with a blank --coin-rpc endpoint and no explicit embedded
+    // opt-in would run daemonless with embedded MAINNET block production auto-ON
+    // (reward-UNSAFE). validate_percoin() catches that (and any future per-coin
+    // reward guard) BEFORE build_percoin_argv() is ever run.
+    if (c2pool_qt::coinProfile(chain).cli == c2pool_qt::CliFamily::PerCoinRun) {
+        const std::string reason =
+            c2pool_qt::validate_percoin(marshalPerCoinParams());
+        if (!reason.empty()) {
+            emit daemonStateChanged(
+                QStringLiteral("Daemon: refused — %1")
+                    .arg(QString::fromStdString(reason)),
+                "color: #b04020;");
+            return;
+        }
+    }
+
     onBuildPreview();
     const QString cmd = buildCommand();
     if (cmd.trimmed().isEmpty()) {
@@ -1105,6 +1302,14 @@ void PageLaunch::saveSettings() const
     if (embeddedP2pCheck_)     s.setValue("embeddedP2p",      embeddedP2pCheck_->isChecked());
     if (embeddedP2pPeersEdit_) s.setValue("embeddedP2pPeers", embeddedP2pPeersEdit_->toPlainText());
     if (embeddedMainnetCheck_) s.setValue("embeddedMainnet",  embeddedMainnetCheck_->isChecked());
+    if (embeddedCoinDaemonEdit_)  s.setValue("embeddedCoinDaemon",  embeddedCoinDaemonEdit_->text());
+    if (embeddedCoinMagicEdit_)   s.setValue("embeddedCoinMagic",   embeddedCoinMagicEdit_->text());
+    if (embeddedCoinGenesisEdit_) s.setValue("embeddedCoinGenesis", embeddedCoinGenesisEdit_->text());
+    // give-author explicit-zero ack + run-loop controls
+    if (giveAuthorZeroAckCheck_) s.setValue("giveAuthorZeroAck", giveAuthorZeroAckCheck_->isChecked());
+    if (coinP2pDiscoverCheck_)   s.setValue("coinP2pDiscover",  coinP2pDiscoverCheck_->isChecked());
+    if (noP2pRelayCheck_)        s.setValue("noP2pRelay",       noP2pRelayCheck_->isChecked());
+    if (bchAnchorEdit_)          s.setValue("bchAnchor",        bchAnchorEdit_->text());
 
     // Merged chains
     s.remove("merged");
@@ -1174,6 +1379,24 @@ void PageLaunch::loadSettings()
     }
     if (embeddedMainnetCheck_)
         embeddedMainnetCheck_->setChecked(s.value("embeddedMainnet", false).toBool());
+    if (embeddedCoinDaemonEdit_)  embeddedCoinDaemonEdit_->setText(s.value("embeddedCoinDaemon").toString());
+    if (embeddedCoinMagicEdit_)   embeddedCoinMagicEdit_->setText(s.value("embeddedCoinMagic").toString());
+    if (embeddedCoinGenesisEdit_) embeddedCoinGenesisEdit_->setText(s.value("embeddedCoinGenesis").toString());
+    if (embeddedCoinDaemonEdit_ && embeddedP2pCheck_)
+        embeddedCoinDaemonEdit_->setEnabled(embeddedP2pCheck_->isChecked());
+    if (embeddedCoinMagicEdit_ && embeddedP2pCheck_)
+        embeddedCoinMagicEdit_->setEnabled(embeddedP2pCheck_->isChecked());
+    if (embeddedCoinGenesisEdit_ && embeddedP2pCheck_)
+        embeddedCoinGenesisEdit_->setEnabled(embeddedP2pCheck_->isChecked());
+    // give-author explicit-zero ack + run-loop controls (default OFF / empty).
+    if (giveAuthorZeroAckCheck_)
+        giveAuthorZeroAckCheck_->setChecked(s.value("giveAuthorZeroAck", false).toBool());
+    if (coinP2pDiscoverCheck_)
+        coinP2pDiscoverCheck_->setChecked(s.value("coinP2pDiscover", false).toBool());
+    if (noP2pRelayCheck_)
+        noP2pRelayCheck_->setChecked(s.value("noP2pRelay", false).toBool());
+    if (bchAnchorEdit_)
+        bchAnchorEdit_->setText(s.value("bchAnchor").toString());
 
     // Merged chains
     mergedTable_->setRowCount(0);

--- a/ui/c2pool-qt/src/PageLaunch.hpp
+++ b/ui/c2pool-qt/src/PageLaunch.hpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #pragma once
 
+#include "LaunchCommand.hpp"   // c2pool_qt::PerCoinParams (marshal target)
+
 #include <QCheckBox>
 #include <QComboBox>
 #include <QDoubleSpinBox>
@@ -94,6 +96,9 @@ private:
     /// Build the command line for a PerCoinRun coin (c2pool-dash/-dgb/-bch,
     /// reward-SAFE dashd-RPC arm; embedded arm only when opted in).
     QString buildPerCoinCommand() const;
+    /// Marshal the form + active profile into the Qt-free command core. Shared
+    /// by buildPerCoinCommand() and launch()'s reward-safety precheck.
+    c2pool_qt::PerCoinParams marshalPerCoinParams() const;
     /// Currently-selected chain symbol (chain combo userData/text).
     QString currentChain() const;
     /// Apply profile-driven UI state (daemon-group label, per-coin note,
@@ -142,6 +147,7 @@ private:
     QCheckBox*     autoDetectWalletCheck_; ///< --auto-detect-wallet (default on)
     QDoubleSpinBox* feeSpinBox_;        ///< -f / --fee (node-owner fee %)
     QDoubleSpinBox* giveAuthorSpinBox_; ///< --give-author (dev donation %)
+    QCheckBox*     giveAuthorZeroAckCheck_{nullptr}; ///< explicit 0% opt-in (reward-safety ack)
     QLineEdit*     nodeOwnerAddrEdit_;
     QLineEdit*     nodeOwnerScriptEdit_; ///< --node-owner-script (hex)
     QComboBox*     redistributeCombo_;  ///< pplns / fee / boost / donate
@@ -169,6 +175,12 @@ private:
     QLineEdit* messageBlobEdit_;     ///< --message-blob-hex
     QLineEdit* coinbaseTextEdit_;    ///< --coinbase-text
 
+    // ── PerCoinRun run-loop controls (DASH/DGB/BCH; catalog-gated per binary) ─
+    QGroupBox* runLoopGroup_{nullptr};        ///< shown only for PerCoinRun coins
+    QCheckBox* coinP2pDiscoverCheck_{nullptr};///< --coin-p2p-discover (transport, reward-neutral)
+    QCheckBox* noP2pRelayCheck_{nullptr};     ///< --no-p2p-relay (DASH/DGB)
+    QLineEdit* bchAnchorEdit_{nullptr};       ///< --anchor H:HASH (BCH cold-start ABLA floor)
+
     // ── ★ Advanced / embedded (opt-in, REWARD-UNSAFE) ────────────────────────
     // Default OFF. This is the ONLY place --coin-p2p-connect /
     // --embedded-mainnet may be emitted. Guarded per the DASH hotel
@@ -178,6 +190,11 @@ private:
     QPlainTextEdit* embeddedP2pPeersEdit_{nullptr}; ///< HOST:PORT per line
     QCheckBox*      embeddedMainnetCheck_{nullptr}; ///< enables --embedded-mainnet (default OFF, DASH)
     QLabel*         embeddedWarnLabel_{nullptr};
+    // Embedded coin-network producer target (DGB --coin-daemon + --coin-magic +
+    // --coin-genesis). Emitted ONLY when embeddedP2pCheck_ is on.
+    QLineEdit*      embeddedCoinDaemonEdit_{nullptr};  ///< --coin-daemon HOST:PORT (DGB)
+    QLineEdit*      embeddedCoinMagicEdit_{nullptr};   ///< --coin-magic / --coin-p2p-magic HEX
+    QLineEdit*      embeddedCoinGenesisEdit_{nullptr}; ///< --coin-genesis HASH (DGB)
 
     // ── Command Preview ─────────────────────────────────────────────────────
     QTextEdit*   cmdPreview_;

--- a/ui/c2pool-qt/src/ParamCatalogView.hpp
+++ b/ui/c2pool-qt/src/ParamCatalogView.hpp
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// ParamCatalogView — Qt-free, header-only view over the node's canonical
+// parameter catalog (src/core/param_catalog.inc), consumed by LaunchCommand so
+// the per-coin argv the panel generates is DRIVEN by the same X-macro catalog
+// the node's mains are checked against (ci/check_param_catalog.py). No flag
+// spelling is retyped in the Qt tree: a flag is emitted for a binary ONLY when
+// the catalog carries an alias row for that (binary, canonical) pair, which is
+// exactly what stops the panel emitting a flag the target binary rejects
+// (e.g. --addnode where DGB/BCH want --sharechain-addnode, or the money flags
+// on BCH which has none). See LaunchCommand.hpp.
+//
+// The catalog's typed enums live in <core/param_catalog.hpp> (Qt-free,
+// boost-free). This header re-materialises the .inc with local X-macros into a
+// std-only static table so the reward-safe-launch unit test links WITHOUT
+// compiling param_catalog.cpp — the .inc is the single source and the Qt build
+// stays standalone.
+
+#pragma once
+
+#include <core/param_catalog.hpp>   // c2pool::catalog enums (Bin, CoinBit, Mut, …)
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace c2pool_qt {
+namespace catview {
+
+using c2pool::catalog::Bin;
+using c2pool::catalog::CoinBit;
+using c2pool::catalog::Mut;
+using c2pool::catalog::AliasStyle;
+
+struct AliasView {
+    Bin         binary;
+    std::string spelling;
+    AliasStyle  style;
+};
+
+struct RowView {
+    std::string            canon;
+    Mut                    mutability;
+    uint32_t               applic_mask;
+    std::vector<AliasView> aliases;
+
+    bool is_money() const {
+        return mutability == Mut::MONEY_LIVE || mutability == Mut::MONEY_RESTART;
+    }
+    bool applies_to(CoinBit c) const { return (applic_mask & c) != 0; }
+};
+
+inline const std::vector<RowView>& rows()
+{
+    static const std::vector<RowView> table = [] {
+        using namespace c2pool::catalog;   // Sec::*, PType::*, Mut::*, CoinBit, Bin::*, AliasStyle::*
+        std::vector<RowView> rows;
+
+#define C2P_PARAM(canon, section, type, mut, applic, dkind, dlit, val, help) \
+        rows.push_back(RowView{ canon, Mut::mut,                             \
+            static_cast<uint32_t>(applic), {} });
+#define C2P_ALIAS(canon, binary, spelling, style) \
+        rows.back().aliases.push_back(AliasView{ Bin::binary, spelling, AliasStyle::style });
+
+#include <core/param_catalog.inc>
+
+#undef C2P_PARAM
+#undef C2P_ALIAS
+        return rows;
+    }();
+    return table;
+}
+
+inline const RowView* find(const std::string& canon)
+{
+    for (const auto& r : rows())
+        if (r.canon == canon) return &r;
+    return nullptr;
+}
+
+/// The CLI spelling (and style) a given binary uses for a canonical param, or
+/// nullopt when that binary has no alias for it — the caller then emits nothing.
+inline std::optional<std::pair<std::string, AliasStyle>>
+spelling_for(Bin binary, const std::string& canon)
+{
+    const RowView* r = find(canon);
+    if (!r) return std::nullopt;
+    for (const auto& a : r->aliases)
+        if (a.binary == binary) return std::make_pair(a.spelling, a.style);
+    return std::nullopt;
+}
+
+/// True when the canonical param applies to the given coin bit (catalog mask).
+inline bool applies(const std::string& canon, CoinBit c)
+{
+    const RowView* r = find(canon);
+    return r && r->applies_to(c);
+}
+
+/// True when the canonical param is money-class (MONEY_LIVE / MONEY_RESTART).
+inline bool is_money(const std::string& canon)
+{
+    const RowView* r = find(canon);
+    return r && r->is_money();
+}
+
+} // namespace catview
+} // namespace c2pool_qt

--- a/ui/c2pool-qt/test/test_address_validator.cpp
+++ b/ui/c2pool-qt/test/test_address_validator.cpp
@@ -1,25 +1,29 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // test_address_validator — QP-B acceptance gate.
 //
-// Proves the in-UI payout-address flavor check:
-//   • accepts an address whose base58 version belongs to the active coin
-//     (either network — mainnet/testnet slips are not blocked);
-//   • BLOCKS a base58 address that belongs to a DIFFERENT known coin
-//     (the "DASH address typed into a Litecoin profile" case), naming the
-//     coin it actually belongs to;
-//   • passes bech32 / cashaddr / malformed / checksum-failing input through
-//     UNJUDGED (NotBase58Check) so a valid launch is never blocked by a
-//     flavor we do not model;
-//   • treats cross-coin version-byte collisions (BTC/BCH 0/5, DOGE/DGB 30)
-//     in the user's favour.
+// Proves the in-UI payout-address flavor check now reads the SAME node registry
+// the stratum money-path uses (each coin's <coin>::address_acceptance(), issue
+// #961, via the src/impl/<coin>/address_encoding.hpp leaf headers). The gate:
+//   • EVERY accepted base58 version byte for a coin (all networks) → Ok — this is
+//     the registry-match property that was RED on master, where the old private
+//     table blocked valid LTC legacy P2SH (version 5) and testnet P2SH (196);
+//   • a base58 address of a DIFFERENT known coin → WrongCoin (naming it);
+//   • bech32 own-HRP → Ok, foreign HRP → WrongCoin;
+//   • BCH CashAddr → Ok in bitcoincash, WrongCoin elsewhere;
+//   • DOGE/DGB 0x1e collision → Ok in both (favour the user);
+//   • checksum-fail / empty / bech32-checksum-fail → NotBase58Check (advisory).
 //
 // Links Qt6::Core only (no Widgets / WebEngine) so it runs headless in CI.
-// Test addresses are generated in-process by base58check-ENCODING a known
-// payload with each coin's version byte — self-consistent, no external
-// fixture strings that could rot.
 
 #include "../src/AddressValidator.hpp"
 #include "../src/CoinProfiles.hpp"
+
+#include <impl/dash/address_encoding.hpp>
+#include <impl/ltc/address_encoding.hpp>
+#include <impl/btc/address_encoding.hpp>
+#include <impl/bch/address_encoding.hpp>
+#include <impl/dgb/address_encoding.hpp>
+#include <impl/doge/coin/address_encoding.hpp>
 
 #include <QByteArray>
 #include <QCryptographicHash>
@@ -27,6 +31,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <string>
 #include <vector>
 
 using c2pool_qt::AddressVerdict;
@@ -42,12 +47,11 @@ void check(bool cond, const char* what)
     if (!cond) ++failures;
 }
 
-// base58 encode raw bytes (big-endian). Mirror of Bitcoin's EncodeBase58.
 QString encodeBase58(const std::vector<uint8_t>& in)
 {
     static const char kAlphabet[] =
         "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-    std::vector<uint8_t> digits;  // big-endian base-58
+    std::vector<uint8_t> digits;
     for (uint8_t byte : in) {
         int carry = byte;
         for (auto it = digits.rbegin(); it != digits.rend(); ++it) {
@@ -61,14 +65,12 @@ QString encodeBase58(const std::vector<uint8_t>& in)
         }
     }
     QString out;
-    for (uint8_t b : in) {
-        if (b == 0) out.append(QLatin1Char('1')); else break;
-    }
+    for (uint8_t b : in) { if (b == 0) out.append(QLatin1Char('1')); else break; }
     for (uint8_t d : digits) out.append(QLatin1Char(kAlphabet[d]));
     return out;
 }
 
-// Build a valid base58check address: version || 20-byte payload || sha256d[:4].
+// Valid base58check: version || 20-byte payload || sha256d[:4].
 QString makeAddress(int version, uint8_t fill = 0x11)
 {
     std::vector<uint8_t> body;
@@ -83,110 +85,195 @@ QString makeAddress(int version, uint8_t fill = 0x11)
     return encodeBase58(full);
 }
 
+// Minimal BIP-173 bech32 v0 encoder (20-byte program) for a given HRP, so the
+// validator's decoder is exercised against a checksum-correct address.
+uint32_t bech32Polymod(const std::vector<uint8_t>& v)
+{
+    static const uint32_t GEN[5] = {
+        0x3b6a57b2u, 0x26508e6du, 0x1ea119fau, 0x3d4233ddu, 0x2a1462b3u};
+    uint32_t chk = 1;
+    for (uint8_t p : v) {
+        uint8_t top = static_cast<uint8_t>(chk >> 25);
+        chk = ((chk & 0x1ffffffu) << 5) ^ p;
+        for (int i = 0; i < 5; ++i) if ((top >> i) & 1) chk ^= GEN[i];
+    }
+    return chk;
+}
+
+QString makeBech32(const std::string& hrp)
+{
+    static const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+    // 20-byte program (all 0x11) → 5-bit groups.
+    std::vector<uint8_t> prog(20, 0x11);
+    std::vector<uint8_t> data;
+    data.push_back(0);   // witness version 0
+    int acc = 0, bits = 0;
+    for (uint8_t b : prog) {
+        acc = (acc << 8) | b; bits += 8;
+        while (bits >= 5) { bits -= 5; data.push_back((acc >> bits) & 0x1f); }
+    }
+    if (bits > 0) data.push_back((acc << (5 - bits)) & 0x1f);
+    // checksum
+    std::vector<uint8_t> values;
+    for (char c : hrp) values.push_back(static_cast<uint8_t>(c) >> 5);
+    values.push_back(0);
+    for (char c : hrp) values.push_back(static_cast<uint8_t>(c) & 0x1f);
+    for (uint8_t d : data) values.push_back(d);
+    for (int i = 0; i < 6; ++i) values.push_back(0);
+    const uint32_t mod = bech32Polymod(values) ^ 1u;
+    std::vector<uint8_t> checksum;
+    for (int i = 0; i < 6; ++i) checksum.push_back((mod >> (5 * (5 - i))) & 0x1f);
+    QString out = QString::fromStdString(hrp) + QLatin1Char('1');
+    for (uint8_t d : data)     out.append(QLatin1Char(CHARSET[d]));
+    for (uint8_t d : checksum) out.append(QLatin1Char(CHARSET[d]));
+    return out;
+}
+
+std::vector<int> acceptedVersions(const QString& symbol)
+{
+    const core::CoinAddressAcceptance a =
+        c2pool_qt::detail::registryAcceptance(symbol);
+    std::vector<int> vs;
+    for (auto v : a.p2pkh_versions) vs.push_back(v);
+    for (auto v : a.p2sh_versions)  vs.push_back(v);
+    return vs;
+}
+
 } // namespace
 
 int main()
 {
     std::printf("test_address_validator\n");
 
-    // ── Sanity: version bytes loaded into CoinProfiles are the expected ones.
-    check(c2pool_qt::coinProfile("dash").p2pkhVersionMainnet == 76,
-          "CoinProfiles: DASH mainnet P2PKH version == 76");
-    check(c2pool_qt::coinProfile("dash").p2shVersionMainnet == 16,
-          "CoinProfiles: DASH mainnet P2SH version == 16");
-    check(c2pool_qt::coinProfile("litecoin").p2pkhVersionMainnet == 48,
-          "CoinProfiles: LTC mainnet P2PKH version == 48");
-
-    // ── Ok: right coin.
+    // ── Registry-match: EVERY accepted version of a coin → Ok (all networks). ──
+    // Directly exercises the drift fix (LTC 5 / 196 / 58 were blocked on master).
     {
-        const QString dashAddr = makeAddress(76);
-        auto r = validatePayoutAddress(dashAddr, "dash", false);
-        check(r.verdict == AddressVerdict::Ok, "DASH P2PKH addr in DASH profile → Ok");
-        check(!r.blocksLaunch(), "DASH addr in DASH profile does not block launch");
+        int n = 0;
+        const c2pool_qt::CoinProfile* profs = c2pool_qt::coinProfiles(n);
+        for (int i = 0; i < n; ++i) {
+            const QString sym = profs[i].symbol;
+            for (int v : acceptedVersions(sym)) {
+                const QString addr = makeAddress(v);
+                auto r = validatePayoutAddress(addr, sym, false);
+                char msg[128];
+                std::snprintf(msg, sizeof(msg),
+                    "%s: accepted version %d ⇒ Ok",
+                    sym.toStdString().c_str(), v);
+                check(r.verdict == AddressVerdict::Ok && !r.blocksLaunch(), msg);
+            }
+        }
     }
 
-    // ── ★ Core QP-B case: DASH address typed into a Litecoin profile.
+    // ── LTC legacy P2SH (version 5) + testnet P2SH (196) — RED on master. ──
     {
-        const QString dashAddr = makeAddress(76);
-        auto r = validatePayoutAddress(dashAddr, "litecoin", false);
-        check(r.verdict == AddressVerdict::WrongCoin,
-              "DASH addr in LTC profile → WrongCoin");
+        auto r5 = validatePayoutAddress(makeAddress(5), "litecoin", false);
+        check(r5.verdict == AddressVerdict::Ok,
+              "LTC legacy P2SH (version 5) ⇒ Ok (was WrongCoin on master)");
+        auto r196 = validatePayoutAddress(makeAddress(196), "litecoin", false);
+        check(r196.verdict == AddressVerdict::Ok,
+              "LTC testnet P2SH (version 196) ⇒ Ok (was WrongCoin on master)");
+    }
+
+    // ── Core QP-B: a DASH address in a Litecoin profile → WrongCoin. ──
+    {
+        auto r = validatePayoutAddress(makeAddress(76), "litecoin", false);
+        check(r.verdict == AddressVerdict::WrongCoin, "DASH addr in LTC profile → WrongCoin");
         check(r.blocksLaunch(), "wrong-coin addr BLOCKS launch");
-        check(r.detectedCoinLabel == QStringLiteral("Dash"),
-              "wrong-coin detected as Dash");
-        check(!r.message.isEmpty(), "wrong-coin carries a message");
+        check(r.detectedCoinLabel == QStringLiteral("Dash"), "wrong-coin detected as Dash");
+    }
+    // Symmetric: LTC address in a DASH profile → WrongCoin.
+    {
+        auto r = validatePayoutAddress(makeAddress(48), "dash", false);
+        check(r.verdict == AddressVerdict::WrongCoin, "LTC addr in DASH profile → WrongCoin");
+        check(r.detectedCoinLabel == QStringLiteral("Litecoin"), "detected as Litecoin");
     }
 
-    // ── Symmetric: LTC address typed into a DASH profile.
+    // ── DASH testnet-version addr in a mainnet DASH profile → Ok (any-network). ──
     {
-        const QString ltcAddr = makeAddress(48);
-        auto r = validatePayoutAddress(ltcAddr, "dash", false);
-        check(r.verdict == AddressVerdict::WrongCoin,
-              "LTC addr in DASH profile → WrongCoin");
-        check(r.detectedCoinLabel == QStringLiteral("Litecoin"),
-              "wrong-coin detected as Litecoin");
-    }
-
-    // ── DASH P2SH ('7…', version 16) in DASH profile → Ok.
-    {
-        const QString dashScript = makeAddress(16);
-        auto r = validatePayoutAddress(dashScript, "dash", false);
-        check(r.verdict == AddressVerdict::Ok, "DASH P2SH addr in DASH profile → Ok");
-    }
-
-    // ── Any-network acceptance: DASH testnet version (140) in a mainnet
-    //    (testnet=false) DASH profile is NOT blocked.
-    {
-        const QString dashTestnet = makeAddress(140);
-        auto r = validatePayoutAddress(dashTestnet, "dash", false);
+        auto r = validatePayoutAddress(makeAddress(140), "dash", false);
         check(r.verdict == AddressVerdict::Ok,
-              "DASH testnet-version addr in mainnet DASH profile → Ok (not blocked)");
+              "DASH testnet-version addr in mainnet DASH profile → Ok");
     }
 
-    // ── Collision favours the user: BTC version (0) in a BCH profile → Ok
-    //    (BCH legacy addresses share BTC's version bytes).
+    // ── DOGE/DGB 0x1e (30) collision → Ok in BOTH. ──
     {
-        const QString btcAddr = makeAddress(0);
-        auto r = validatePayoutAddress(btcAddr, "bitcoincash", false);
+        auto rd = validatePayoutAddress(makeAddress(30), "dogecoin", false);
+        auto rg = validatePayoutAddress(makeAddress(30), "digibyte", false);
+        check(rd.verdict == AddressVerdict::Ok, "version 30 in dogecoin → Ok (collision)");
+        check(rg.verdict == AddressVerdict::Ok, "version 30 in digibyte → Ok (collision)");
+    }
+
+    // ── BTC/BCH shared version (0) → Ok in BCH profile (favour user). ──
+    {
+        auto r = validatePayoutAddress(makeAddress(0), "bitcoincash", false);
         check(r.verdict == AddressVerdict::Ok,
-              "BTC-version addr in BCH profile → Ok (shared version, favour user)");
+              "BTC-version addr in BCH profile → Ok (shared version)");
     }
 
-    // ── Unknown version: never a hard block, only advisory.
+    // ── bech32 own HRP → Ok; foreign HRP → WrongCoin. ──
     {
-        const QString weird = makeAddress(99);
-        auto r = validatePayoutAddress(weird, "dash", false);
-        check(r.verdict == AddressVerdict::UnknownVersion,
-              "unmodelled version → UnknownVersion");
+        auto lok = validatePayoutAddress(makeBech32("ltc"), "litecoin", false);
+        check(lok.verdict == AddressVerdict::Ok, "ltc1… bech32 in LTC profile → Ok");
+        auto lwrong = validatePayoutAddress(makeBech32("ltc"), "bitcoin", false);
+        check(lwrong.verdict == AddressVerdict::WrongCoin,
+              "ltc1… bech32 in BTC profile → WrongCoin");
+        check(lwrong.detectedCoinLabel == QStringLiteral("Litecoin"),
+              "ltc bech32 detected as Litecoin");
+        auto bok = validatePayoutAddress(makeBech32("bc"), "bitcoin", false);
+        check(bok.verdict == AddressVerdict::Ok, "bc1… bech32 in BTC profile → Ok");
+        auto bwrong = validatePayoutAddress(makeBech32("bc"), "litecoin", false);
+        check(bwrong.verdict == AddressVerdict::WrongCoin,
+              "bc1… bech32 in LTC profile → WrongCoin");
+        auto dok = validatePayoutAddress(makeBech32("dgb"), "digibyte", false);
+        check(dok.verdict == AddressVerdict::Ok, "dgb1… bech32 in DGB profile → Ok");
+    }
+
+    // ── bech32 with a broken checksum → NotBase58Check (advisory, never a block). ──
+    {
+        QString b = makeBech32("ltc");
+        b[b.size() - 1] = (b[b.size() - 1] == QLatin1Char('q')) ? QLatin1Char('p')
+                                                                : QLatin1Char('q');
+        auto r = validatePayoutAddress(b, "litecoin", false);
+        check(r.verdict == AddressVerdict::NotBase58Check,
+              "bech32 with broken checksum → NotBase58Check (not blocked)");
+        check(!r.blocksLaunch(), "broken bech32 does not block launch");
+    }
+
+    // ── BCH CashAddr → Ok in bitcoincash, WrongCoin elsewhere. ──
+    {
+        const QString cash = "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a";
+        auto ok = validatePayoutAddress(cash, "bitcoincash", false);
+        check(ok.verdict == AddressVerdict::Ok, "cashaddr in bitcoincash profile → Ok");
+        auto wrong = validatePayoutAddress(cash, "bitcoin", false);
+        check(wrong.verdict == AddressVerdict::WrongCoin,
+              "cashaddr in bitcoin profile → WrongCoin");
+        check(wrong.detectedCoinLabel == QStringLiteral("Bitcoin Cash"),
+              "cashaddr detected as Bitcoin Cash");
+    }
+
+    // ── Unknown version: advisory, never a hard block. ──
+    {
+        auto r = validatePayoutAddress(makeAddress(99), "dash", false);
+        check(r.verdict == AddressVerdict::UnknownVersion, "unmodelled version → UnknownVersion");
         check(!r.blocksLaunch(), "unknown version does not block launch");
     }
 
-    // ── Empty input → NotBase58Check, no block.
+    // ── Empty input → NotBase58Check, no block. ──
     {
         auto r = validatePayoutAddress("   ", "dash", false);
         check(r.verdict == AddressVerdict::NotBase58Check, "empty addr → NotBase58Check");
         check(!r.blocksLaunch(), "empty addr does not block launch");
     }
 
-    // ── bech32 (contains '0', outside base58) → passed through unjudged.
-    {
-        auto r = validatePayoutAddress(
-            "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", "bitcoin", false);
-        check(r.verdict == AddressVerdict::NotBase58Check,
-              "bech32 addr → NotBase58Check (not blocked)");
-        check(!r.blocksLaunch(), "bech32 addr does not block launch");
-    }
-
-    // ── Checksum failure (valid DASH addr with one char mangled) → unjudged.
+    // ── Checksum failure (valid DASH addr with one char mangled) → unjudged. ──
     {
         QString dashAddr = makeAddress(76);
-        // Flip a middle character to a different base58 digit.
         const int mid = dashAddr.size() / 2;
         dashAddr[mid] = (dashAddr[mid] == QLatin1Char('A')) ? QLatin1Char('B')
                                                             : QLatin1Char('A');
         auto r = validatePayoutAddress(dashAddr, "dash", false);
         check(r.verdict == AddressVerdict::NotBase58Check,
-              "checksum-broken addr → NotBase58Check (advisory, not a block)");
+              "checksum-broken addr → NotBase58Check (advisory)");
         check(!r.blocksLaunch(), "checksum-broken addr does not block launch");
     }
 

--- a/ui/c2pool-qt/test/test_reward_safe_launch.cpp
+++ b/ui/c2pool-qt/test/test_reward_safe_launch.cpp
@@ -1,16 +1,26 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // test_reward_safe_launch — ★ #1 acceptance criterion.
 //
-// Proves the per-coin launch command core NEVER emits the reward-UNSAFE
-// embedded arm (--coin-p2p-connect / --embedded-mainnet) by default, and
-// that the default parent-daemon link is the reward-SAFE --coin-rpc arm.
-// Qt-free: builds and runs with a plain C++17 compiler (no display).
+// Proves the per-coin launch command core (LaunchCommand.hpp), now driven by the
+// node parameter catalog (ParamCatalogView → src/core/param_catalog.inc):
+//   • NEVER emits the reward-UNSAFE embedded arm by default (--coin-p2p-connect /
+//     --peer / --embedded-mainnet / --coin-magic), and the default parent-daemon
+//     link is the reward-SAFE --coin-rpc arm;
+//   • leaves the author donation to the binary default unless explicitly set, and
+//     emits --give-author 0 ONLY behind an explicit ack (never a silent zero);
+//   • emits, for EACH binary, only flag spellings the catalog carries for that
+//     binary — so BCH argv has none of -f/--give-author/--node-owner-address/
+//     --redistribute/--message-blob-hex/--addnode, DGB uses --sharechain-addnode
+//     and --http, etc.;
+//   • refuses (validate_percoin) a DASH launch whose blank RPC endpoint would run
+//     daemonless with embedded MAINNET auto-ON.
 //
-// Mirrors PageLaunch's DASH default (dashd-RPC arm, embedded opt-ins OFF).
+// Qt-free: builds and runs with a plain C++17 compiler (no display).
 //
 // Exit: 0 = all pass, 1 = a reward-safety assertion failed.
 
 #include "../src/LaunchCommand.hpp"
+#include "../src/ParamCatalogView.hpp"
 
 #include <cstdio>
 #include <string>
@@ -19,6 +29,8 @@
 using c2pool_qt::PerCoinParams;
 using c2pool_qt::build_percoin_argv;
 using c2pool_qt::join_argv;
+using c2pool_qt::validate_percoin;
+using Bin = c2pool::catalog::Bin;
 
 namespace {
 
@@ -36,27 +48,85 @@ void check(bool cond, const char* what)
     if (!cond) ++failures;
 }
 
-// The DASH default profile as PageLaunch fills it: reward-SAFE dashd-RPC
-// arm, embedded opt-ins OFF.
+// Reverse catalog lookup: is `spelling` a real alias of `bin` in the catalog?
+bool aliasInCatalog(Bin bin, const std::string& spelling)
+{
+    for (const auto& r : c2pool_qt::catview::rows())
+        for (const auto& a : r.aliases)
+            if (a.binary == bin && a.spelling == spelling) return true;
+    return false;
+}
+
+// Every flag-looking token in argv (a "-"/"--" token, not argv[0], not a value)
+// must be a catalog alias for that binary — the F4 anti-drift gate.
+void checkEveryFlagInCatalog(Bin bin, const std::vector<std::string>& argv,
+                             const char* label)
+{
+    bool ok = true;
+    std::string bad;
+    for (std::size_t i = 1; i < argv.size(); ++i) {   // skip argv[0] (binary path)
+        const std::string& t = argv[i];
+        if (t.size() >= 2 && t[0] == '-' && (t[1] == '-' || (t[1] >= 'a' && t[1] <= 'z'))) {
+            if (!aliasInCatalog(bin, t)) { ok = false; bad = t; break; }
+        }
+    }
+    if (!ok) std::printf("     offending flag: %s\n", bad.c_str());
+    check(ok, label);
+}
+
 PerCoinParams dashDefault()
 {
     PerCoinParams p;
+    p.bin = Bin::BIN_DASH;
     p.binary = "./build/bin/c2pool-dash";
     p.subcommand = "--run";
-    p.testnet = false;
-    p.supportsTestnetFlag = true;
-    p.coinRpcFlag = "--coin-rpc";
     p.rpcHost = "127.0.0.1";
     p.rpcPort = 9998;                 // dashd mainnet RPC
-    p.rpcAuthFlag = "--coin-rpc-auth";
     p.confPath = "";                  // blank ⇒ dashd default conf, off argv
     p.stratumPort = 3333;
-    p.supportsWebPort = true;
     p.webPort = 8080;
     p.webHost = "0.0.0.0";
-    p.sharechainPortFlag = "--listen";
     p.sharechainPort = 9339;
     // embeddedP2p / embeddedMainnet default false
+    return p;
+}
+
+PerCoinParams bchDefault()
+{
+    PerCoinParams p;
+    p.bin = Bin::BIN_BCH;
+    p.binary = "./build/bin/c2pool-bch";
+    p.subcommand = "--pool";
+    p.confPath = "/home/u/.bitcoin/bitcoin.conf";
+    p.stratumPort = 3333;
+    p.webPort = 8083;
+    p.webHost = "0.0.0.0";
+    p.sharechainPort = 9348;
+    p.addnodes = {"1.2.3.4:9348"};
+    // BCH has no money surface — set money fields anyway to prove they are dropped.
+    p.payoutAddress = "bitcoincash:qexample";
+    p.fee = 1.0;
+    p.giveAuthorSet = true; p.giveAuthor = 0.5;
+    p.redistribute = "fee";
+    p.messageBlob = "deadbeef";
+    return p;
+}
+
+PerCoinParams dgbDefault()
+{
+    PerCoinParams p;
+    p.bin = Bin::BIN_DGB;
+    p.binary = "./build/bin/c2pool-dgb";
+    p.subcommand = "--run";
+    p.rpcHost = "127.0.0.1";
+    p.rpcPort = 14022;
+    p.stratumPort = 5022;
+    p.webPort = 5023;
+    p.webHost = "0.0.0.0";
+    p.sharechainPort = 5024;
+    p.addnodes = {"5.6.7.8:5024"};
+    p.payoutAddress = "DExampleDgbAddress";
+    p.redistribute = "boost:70,donate:30";
     return p;
 }
 
@@ -71,19 +141,18 @@ int main()
         const auto argv = build_percoin_argv(dashDefault());
         const std::string cmd = join_argv(argv);
         std::printf("DASH default: %s\n", cmd.c_str());
-        check(!contains(argv, "--coin-p2p-connect"),
-              "DASH default omits --coin-p2p-connect");
-        check(!contains(argv, "--embedded-mainnet"),
-              "DASH default omits --embedded-mainnet");
-        check(contains(argv, "--coin-rpc"),
-              "DASH default uses reward-safe --coin-rpc arm");
-        check(argv.size() >= 2 && argv[0] == "./build/bin/c2pool-dash"
-                  && argv[1] == "--run",
+        check(!contains(argv, "--coin-p2p-connect"), "DASH default omits --coin-p2p-connect");
+        check(!contains(argv, "--embedded-mainnet"), "DASH default omits --embedded-mainnet");
+        check(!contains(argv, "--coin-magic") && !contains(argv, "--coin-p2p-magic"),
+              "DASH default omits coin-magic override");
+        check(contains(argv, "--coin-rpc"), "DASH default uses reward-safe --coin-rpc arm");
+        check(argv.size() >= 2 && argv[0] == "./build/bin/c2pool-dash" && argv[1] == "--run",
               "DASH default invokes c2pool-dash --run");
-        // No secret ever on argv.
-        check(cmd.find("rpcpassword") == std::string::npos
-                  && cmd.find("--rpcpassword") == std::string::npos,
+        check(cmd.find("rpcpassword") == std::string::npos,
               "DASH default carries no rpcpassword on argv");
+        check(!contains(argv, "--give-author"),
+              "DASH default omits --give-author (binary default applies)");
+        checkEveryFlagInCatalog(Bin::BIN_DASH, argv, "DASH default: every flag is a catalog alias");
     }
 
     // 2) Embedded arm appears ONLY when explicitly opted in.
@@ -93,10 +162,8 @@ int main()
         p.embeddedP2pPeers = {"127.0.0.1:9999"};
         p.embeddedMainnet = true;
         const auto argv = build_percoin_argv(p);
-        check(contains(argv, "--coin-p2p-connect"),
-              "opt-in ⇒ --coin-p2p-connect present");
-        check(contains(argv, "--embedded-mainnet"),
-              "opt-in ⇒ --embedded-mainnet present");
+        check(contains(argv, "--coin-p2p-connect"), "opt-in ⇒ --coin-p2p-connect present");
+        check(contains(argv, "--embedded-mainnet"), "opt-in ⇒ --embedded-mainnet present");
     }
 
     // 3) Opt-in checkbox ON but no peers ⇒ still no --coin-p2p-connect.
@@ -108,23 +175,95 @@ int main()
               "opt-in with empty peer list emits no --coin-p2p-connect");
     }
 
-    // 4) BCH default (creds via --rpc-conf, no --coin-rpc endpoint) stays safe.
+    // 4) ★ give-author tri-state (F6) — never a silent zero.
     {
-        PerCoinParams p;
-        p.binary = "./build/bin/c2pool-bch";
-        p.subcommand = "--pool";
-        p.supportsTestnetFlag = true;
-        p.coinRpcFlag = "";            // BCH has no endpoint override
-        p.rpcAuthFlag = "--rpc-conf";
-        p.confPath = "/home/u/.bitcoin/bitcoin.conf";
-        p.stratumPort = 3333;
-        const auto argv = build_percoin_argv(p);
-        std::printf("BCH default: %s\n", join_argv(argv).c_str());
-        check(!contains(argv, "--coin-p2p-connect")
+        PerCoinParams p = dashDefault();
+        // (a) default: not set ⇒ omitted.
+        check(!contains(build_percoin_argv(p), "--give-author"),
+              "give-author: default OMITS the flag (binary default applies)");
+        // (b) 0 without ack ⇒ still omitted (never a forced zero).
+        p.giveAuthor = 0.0; p.giveAuthorSet = false; p.giveAuthorExplicitZeroAck = false;
+        {
+            const auto argv = build_percoin_argv(p);
+            const std::string cmd = join_argv(argv);
+            check(cmd.find("--give-author 0") == std::string::npos,
+                  "give-author: 0 without ack never emits --give-author 0");
+        }
+        // (c) explicit 0 WITH ack ⇒ --give-author 0.00.
+        p.giveAuthor = 0.0; p.giveAuthorExplicitZeroAck = true;
+        p.giveAuthorSet = (p.giveAuthor > 0.0) || p.giveAuthorExplicitZeroAck;
+        {
+            const auto argv = build_percoin_argv(p);
+            check(contains(argv, "--give-author") && contains(argv, "0.00"),
+                  "give-author: explicit 0 + ack emits --give-author 0.00");
+        }
+        // (d) positive value ⇒ emitted.
+        p.giveAuthor = 0.5; p.giveAuthorExplicitZeroAck = false;
+        p.giveAuthorSet = true;
+        {
+            const auto argv = build_percoin_argv(p);
+            check(contains(argv, "--give-author") && contains(argv, "0.50"),
+                  "give-author: explicit 0.50 emits --give-author 0.50");
+        }
+    }
+
+    // 5) ★ F5 — DASH daemonless guard.
+    {
+        PerCoinParams p = dashDefault();
+        p.rpcHost = ""; p.rpcPort = 0;         // blank RPC arm
+        check(!validate_percoin(p).empty(),
+              "DASH blank RPC + embedded OFF ⇒ validate_percoin REFUSES");
+        p.embeddedMainnet = true;              // explicit embedded opt-in
+        check(validate_percoin(p).empty(),
+              "DASH blank RPC + explicit embedded opt-in ⇒ allowed");
+        check(validate_percoin(dashDefault()).empty(),
+              "DASH with RPC arm ⇒ validate_percoin OK");
+    }
+
+    // 6) BCH default: reward-safe AND carries none of the money/DASH flags it rejects.
+    {
+        const auto argv = build_percoin_argv(bchDefault());
+        const std::string cmd = join_argv(argv);
+        std::printf("BCH default: %s\n", cmd.c_str());
+        check(!contains(argv, "--coin-p2p-connect") && !contains(argv, "--peer")
                   && !contains(argv, "--embedded-mainnet"),
               "BCH default omits embedded reward-unsafe flags");
-        check(contains(argv, "--rpc-conf"),
-              "BCH default uses --rpc-conf creds arm");
+        check(contains(argv, "--rpc-conf"), "BCH default uses --rpc-conf creds arm");
+        // F4: BCH has no money surface — none of these may appear even when set.
+        check(!contains(argv, "-f") && !contains(argv, "--fee")
+                  && !contains(argv, "--give-author") && !contains(argv, "--node-owner-address")
+                  && !contains(argv, "--redistribute") && !contains(argv, "--message-blob-hex"),
+              "BCH argv omits every money flag (BCH has none)");
+        check(!contains(argv, "--addnode") && contains(argv, "--sharechain-addnode"),
+              "BCH uses --sharechain-addnode (not DASH's --addnode)");
+        check(contains(argv, "--http"), "BCH binds web via combined --http");
+        checkEveryFlagInCatalog(Bin::BIN_BCH, argv, "BCH default: every flag is a catalog alias");
+    }
+
+    // 7) DGB default: --sharechain-addnode, --http combined, hybrid redistribute, no author fee.
+    {
+        const auto argv = build_percoin_argv(dgbDefault());
+        const std::string cmd = join_argv(argv);
+        std::printf("DGB default: %s\n", cmd.c_str());
+        check(!contains(argv, "--addnode") && contains(argv, "--sharechain-addnode"),
+              "DGB uses --sharechain-addnode (not --addnode)");
+        check(contains(argv, "--http"), "DGB binds web via combined --http");
+        check(!contains(argv, "-f") && !contains(argv, "--give-author"),
+              "DGB omits author-fee flags it has no surface for");
+        check(contains(argv, "--redistribute") && contains(argv, "boost:70,donate:30"),
+              "DGB emits hybrid --redistribute SPEC");
+        check(contains(argv, "--node-owner-address"),
+              "DGB emits --node-owner-address (it has that surface)");
+        checkEveryFlagInCatalog(Bin::BIN_DGB, argv, "DGB default: every flag is a catalog alias");
+    }
+
+    // 8) --http HOST:PORT combined form when a non-default web host is set (DGB).
+    {
+        PerCoinParams p = dgbDefault();
+        p.webHost = "10.0.0.5";
+        const auto argv = build_percoin_argv(p);
+        check(contains(argv, "10.0.0.5:5023"),
+              "DGB --http emits combined HOST:PORT when web host is non-default");
     }
 
     std::printf(failures == 0 ? "ALL PASS\n" : "FAILURES: %d\n", failures);


### PR DESCRIPTION
Finishes the three c2pool-qt control-panel TODOs on top of the shipped + CI-gated panel (#47). Reward-safe: the panel generates argv only; no node coinbase/subsidy/PPLNS/payee code is touched (the node-side change is a pure address-encoding header hoist, byte-identical values).

## (1) QP-F1 — per-coin FULL flag surface → LaunchCommand / PageLaunch
- **`ParamCatalogView.hpp`** (new, Qt-free, header-only) is a view over the node's `src/core/param_catalog.inc` X-macro flag catalog (the one `ci/check_param_catalog.py` already tripwires). No flag spelling is retyped in the Qt tree.
- `build_percoin_argv()` resolves every flag by `(binary, canonical)` catalog lookup, so a flag is emitted **only when the catalog carries an alias for that binary**. This fixes the launch-failure class where every PerCoinRun coin was fed the DASH spellings: DGB/BCH now emit `--sharechain-addnode` (not `--addnode`) and combined `--http [HOST:]PORT`; BCH (no money surface) emits none of `-f`/`--give-author`/`--node-owner-address`/`--redistribute`/`--message-blob-hex`.
- `CoinProfiles` gains a catalog `Bin` per row; `PageLaunch` greys out, per coin, any money/run-loop widget whose binary lacks the alias.

## (2) Per-coin address-flavour validation → node registry (no drift table)
- Hoisted each coin's `address_acceptance()` version-byte / bech32-HRP SSOT into Qt-free leaf headers `src/impl/<coin>/address_encoding.hpp` (dash/ltc/btc/bch/dgb + new doge), included by **both** the node params/config headers (pure move; DGB locked to `CoinParams` by `static_assert`) **and** the Qt `AddressValidator`.
- `AddressValidator` now reads those registry acceptance sets instead of a private version-byte table, and adds a bech32/bech32m decoder + BCH CashAddr detection. The old table had drifted and **blocked valid LTC legacy P2SH (version 5) and testnet P2SH (196)** — now `Ok`, matching the node. The stale Qt version-byte fields are deleted from `CoinProfiles`.

## (3) DGB/BCH deeper run-loop controls
A new "Run-loop controls" group: `--coin-p2p-discover`, `--no-p2p-relay`, `--anchor` (BCH), plus the DGB embedded producer target (`--coin-daemon`/`--coin-magic`/`--coin-genesis`) inside the default-OFF reward-unsafe group.

## Reward-safety guards
- **give-author tri-state:** default OMITS the flag (binary default 0.1% / BTC 0.5% applies); an explicit value is emitted only when set, and `--give-author 0` **only behind an explicit opt-in ack** — never a silent zero for a public node.
- **`validate_percoin()`** refuses a DASH launch whose blank `--coin-rpc` endpoint would run daemonless with embedded MAINNET block production auto-ON.
- The embedded reward-UNSAFE arm stays default-OFF, opt-in only.

## Tests + CI
- `test_reward_safe_launch`: per-coin argv matrix (DASH/DGB/BCH) — default omits the embedded arm, never `--give-author 0`, **every emitted flag is a catalog alias for that binary**, `--http` combined form, DASH daemonless guard.
- `test_address_validator`: every accepted version per coin/network → `Ok` (incl. the LTC 5/196 cases red on master), foreign version/HRP → `WrongCoin`, cashaddr, DOGE/DGB `0x1e` collision, bech32 checksum.
- `build.yml` qt-webengine job now **builds + runs both gates** (previously ctest-registered but never built in CI).
- Local: 3/3 ctests pass, `ci/check_param_catalog.py` PASSED, `tools/ci/check_test_target_allowlist.py` OK, full `c2pool-qt` app builds; all six modified node headers compile clean under C++20.

## Staged (PR-3, not here)
`c2pool-btc` / `c2pool-bip110` PerCoinRun rows; the DASH embedded-only knob set; DGB `--merged`. The CoinBridge JS descriptor table (display-only, singular-per-network by design) is left as-is.
