### PR TITLE
doge(assembler): standalone DOGE-aux submit-block assembler + byte-exact KAT

### DIFF
--- a/src/impl/doge/coin/aux_block_assembler.hpp
+++ b/src/impl/doge/coin/aux_block_assembler.hpp
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+// ---------------------------------------------------------------------------
+// doge::coin -- STANDALONE DOGE-aux SUBMIT-BLOCK ASSEMBLER (parent-agnostic).
+//
+// Assembles the full DOGE submit-block hex for a won DOGE-aux target hit, in the
+// EXACT byte layout the canonical LTC+DOGE primary submit path emits
+// (src/c2pool/merged/merged_mining.cpp try_submit_merged_blocks -- the path that
+// found live merged DOGE block #6308393):
+//
+//     header80(AuxPoW bit 0x100 set) || CAuxPow proof || varint(n_tx)
+//       || coinbase || template txs                 (n_tx = 1 + template txs)
+//
+// PARENT-AGNOSTIC (integrator scope, 2026-09-06). This module carries NO parent
+// (LTC/DGB) state: no MM-manager binding, no dgb include. It takes a frozen DOGE
+// child-block template snapshot (the fields build_template froze) plus the
+// parent-built CAuxPow proof (already serialized by the parent-neutral producer
+// c2pool::merged::build_auxpow_proof -- passed in as hex, NEVER rebuilt here) and
+// produces the block hex. That keeps it consumable by EITHER a merged LTC parent
+// OR a DGB parent (dgb binds the closure on their side, cf.
+// src/impl/dgb/coin/aux_doge_submit.hpp) without either reaching into the other's
+// submit path.
+//
+// SEAM SHAPE. make_doge_aux_block_assembler() adapts a template-provider callback
+// into the (share_hash, auxpow_hex) -> optional<block_hex> closure shape -- the
+// same std::function injection dgb::coin::AuxDogeBlockAssembler expects, defined
+// here INDEPENDENTLY (no dgb include) so the doge module stays leaf-side.
+//
+// ISOLATION. src/impl/doge/coin/ only. Reuses the established doge<-ltc coin-type
+// sharing (ltc::coin::compute_merkle_root is the SSOT merkle used by the parent
+// submit path) + core hashing; touches nothing in src/c2pool/merged/ or
+// src/impl/dgb/. No parent share format, PoW hash, coinbase commitment, or PPLNS
+// math is read or written.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <core/hash.hpp>       // Hash()
+#include <core/uint256.hpp>
+
+#include <impl/ltc/coin/template_builder.hpp>  // ltc::coin::compute_merkle_root (SSOT)
+
+namespace doge
+{
+namespace coin
+{
+
+// ─── frozen DOGE child-block template snapshot ──────────────────────────────
+// The exact fields the primary submit path reads out of the frozen GBT template
+// + the separately-frozen coinbase. Parent-agnostic: DOGE child state only.
+struct DogeSubmitTemplate
+{
+    uint32_t                 version = 0;   // GBT block version; the assembler ORs the AuxPoW bit
+    uint256                  prev_hash;     // previousblockhash (as parsed by SetHex)
+    uint32_t                 curtime = 0;
+    uint32_t                 nbits = 0;
+    std::string              coinbase_hex;  // full serialized DOGE coinbase tx (wire hex)
+    std::vector<std::string> tx_data_hex;   // template txs, raw wire hex, in template order
+    std::vector<uint256>     tx_ids;        // matching txids (as parsed by SetHex). Either empty
+                                            // (assembler computes each from tx_data_hex) or exactly
+                                            // tx_data_hex.size() entries.
+};
+
+// AuxPoW child-block version bit. A DOGE block carrying an AuxPoW proof sets bit 8
+// (0x100) in nVersion; mirrors merged_mining.cpp's `version | 0x100`.
+static constexpr uint32_t DOGE_AUXPOW_VERSION_BIT = 0x100u;
+
+namespace detail
+{
+
+inline std::string to_hex(const uint8_t* data, size_t len)
+{
+    static const char* H = "0123456789abcdef";
+    std::string s;
+    s.reserve(len * 2);
+    for (size_t i = 0; i < len; ++i) {
+        s.push_back(H[data[i] >> 4]);
+        s.push_back(H[data[i] & 0xf]);
+    }
+    return s;
+}
+
+inline std::vector<uint8_t> from_hex(const std::string& hex)
+{
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return 0;
+    };
+    std::vector<uint8_t> v;
+    v.reserve(hex.size() / 2);
+    for (size_t i = 0; i + 1 < hex.size(); i += 2)
+        v.push_back(static_cast<uint8_t>((nib(hex[i]) << 4) | nib(hex[i + 1])));
+    return v;
+}
+
+// Bitcoin CompactSize varint -- byte-identical to merged_mining.cpp's encoder.
+inline std::string varint_hex(uint64_t n)
+{
+    if (n < 0xfd) {
+        uint8_t b[1] = { static_cast<uint8_t>(n) };
+        return to_hex(b, 1);
+    } else if (n <= 0xffff) {
+        uint8_t b[3] = { 0xfd, static_cast<uint8_t>(n & 0xff), static_cast<uint8_t>((n >> 8) & 0xff) };
+        return to_hex(b, 3);
+    } else if (n <= 0xffffffffull) {
+        uint8_t b[5];
+        b[0] = 0xfe;
+        for (int i = 0; i < 4; ++i) b[1 + i] = (n >> (8 * i)) & 0xff;
+        return to_hex(b, 5);
+    } else {
+        uint8_t b[9];
+        b[0] = 0xff;
+        for (int i = 0; i < 8; ++i) b[1 + i] = (n >> (8 * i)) & 0xff;
+        return to_hex(b, 9);
+    }
+}
+
+inline std::string encode_le32(uint32_t v)
+{
+    uint8_t b[4] = { static_cast<uint8_t>(v & 0xFF), static_cast<uint8_t>((v >> 8) & 0xFF),
+                     static_cast<uint8_t>((v >> 16) & 0xFF), static_cast<uint8_t>((v >> 24) & 0xFF) };
+    return to_hex(b, 4);
+}
+
+} // namespace detail
+
+// ─── the assembler ──────────────────────────────────────────────────────────
+// Assemble the full DOGE submit-block hex. Returns "" (unassemblable) when the
+// coinbase or the AuxPoW proof is missing -- the two inputs a won-block submit
+// cannot proceed without. The 80-byte header is rebuilt here (NOT taken from the
+// caller) so the AuxPoW bit and the tx-merkle-root are guaranteed consistent with
+// the body we emit -- the same self-consistency the primary path verifies before
+// submit.
+inline std::string assemble_doge_submit_block_hex(const DogeSubmitTemplate& t,
+                                                  const std::string& auxpow_hex)
+{
+    if (t.coinbase_hex.empty() || auxpow_hex.empty())
+        return {};
+    if (!t.tx_ids.empty() && t.tx_ids.size() != t.tx_data_hex.size())
+        return {};
+
+    // Tx-merkle leaves: coinbase hash first, then each template txid. Mirrors
+    // merged_mining.cpp collect_tx_hashes -- use the supplied txid when present,
+    // else SHA256d the raw tx bytes.
+    std::vector<uint256> tx_hashes;
+    tx_hashes.reserve(1 + t.tx_data_hex.size());
+    tx_hashes.push_back(Hash(detail::from_hex(t.coinbase_hex)));
+    for (size_t i = 0; i < t.tx_data_hex.size(); ++i) {
+        if (!t.tx_ids.empty())
+            tx_hashes.push_back(t.tx_ids[i]);
+        else
+            tx_hashes.push_back(Hash(detail::from_hex(t.tx_data_hex[i])));
+    }
+    const uint256 merkle_root = ltc::coin::compute_merkle_root(tx_hashes);
+
+    // 80-byte header: version|0x100 || prev(32) || merkle(32) || time || bits || nonce=0.
+    const uint32_t version = t.version | DOGE_AUXPOW_VERSION_BIT;
+    const uint32_t nonce = 0;
+    uint8_t hdr[80];
+    uint8_t* p = hdr;
+    std::memcpy(p, &version, 4);            p += 4;
+    std::memcpy(p, t.prev_hash.data(), 32); p += 32;
+    std::memcpy(p, merkle_root.data(), 32); p += 32;
+    std::memcpy(p, &t.curtime, 4);          p += 4;
+    std::memcpy(p, &t.nbits, 4);            p += 4;
+    std::memcpy(p, &nonce, 4);
+
+    const size_t n_tx = 1 + t.tx_data_hex.size();  // coinbase + template txs
+
+    std::string blk;
+    blk += detail::to_hex(hdr, 80);
+    blk += auxpow_hex;
+    blk += detail::varint_hex(n_tx);
+    blk += t.coinbase_hex;
+    for (const auto& tx : t.tx_data_hex)
+        blk += tx;
+    return blk;
+}
+
+// ─── seam shapes ─────────────────────────────────────────────────────────────
+// Defined here independently of dgb (no dgb include); signature-compatible with
+// dgb::coin::AuxDogeBlockAssembler so a parent can bind either.
+using AuxDogeBlockAssembler =
+    std::function<std::optional<std::string>(const uint256& /*share_hash*/,
+                                             const std::string& /*auxpow_hex*/)>;
+
+// Yields the frozen DOGE template for the winning share (parent-side lookup),
+// injected so this module never reaches into a parent's frozen-work store.
+using DogeSubmitTemplateProvider =
+    std::function<std::optional<DogeSubmitTemplate>(const uint256& /*share_hash*/)>;
+
+// Adapt a template-provider into the (share_hash, auxpow_hex) closure the parent
+// won-block handler fires. Returns nullopt when the share has no frozen template
+// or the block cannot be assembled -- the caller logs + skips submit (never bans).
+inline AuxDogeBlockAssembler make_doge_aux_block_assembler(DogeSubmitTemplateProvider provider)
+{
+    return [provider = std::move(provider)](const uint256& share_hash,
+                                            const std::string& auxpow_hex)
+               -> std::optional<std::string>
+    {
+        if (!provider)
+            return std::nullopt;
+        auto tmpl = provider(share_hash);
+        if (!tmpl)
+            return std::nullopt;
+        auto block_hex = assemble_doge_submit_block_hex(*tmpl, auxpow_hex);
+        if (block_hex.empty())
+            return std::nullopt;
+        return block_hex;
+    };
+}
+
+} // namespace coin
+} // namespace doge

--- a/test/test_doge_chain.cpp
+++ b/test/test_doge_chain.cpp
@@ -15,6 +15,7 @@
 #include <impl/doge/coin/header_chain.hpp>
 #include <impl/doge/coin/template_builder.hpp>
 #include <impl/doge/coin/auxpow_header.hpp>
+#include <impl/doge/coin/aux_block_assembler.hpp>
 
 using namespace doge::coin;
 
@@ -899,4 +900,137 @@ TEST(DOGEFromGenesisRetargetTest, AcceptsHeader960AndWalksPast) {
     EXPECT_TRUE(make_and_add(961)) << "header 961 must be accepted";
     EXPECT_TRUE(make_and_add(962)) << "header 962 must be accepted";
     EXPECT_EQ(chain.height(), 962u);
+}
+
+// ─── DOGE-aux SUBMIT-BLOCK ASSEMBLER — byte-exact layout KAT ─────────────────
+// Mirrors dgb's assembled-block layout verifier (bff613aca) for the DOGE-owned
+// standalone assembler (impl/doge/coin/aux_block_assembler.hpp). The golden block
+// hex below was produced by an INDEPENDENT SHA256d reference (not the assembler
+// under test) over the fixed template + auxpow, so exact equality pins the full
+// on-wire layout: header80(0x100 bit) || auxpow || varint(n_tx) || coinbase || txs.
+namespace {
+
+// Fixed template shared by the byte-exact + structural cases below.
+DogeSubmitTemplate make_kat_template() {
+    DogeSubmitTemplate t;
+    t.version      = 0x00620004u;                 // chain_id 0x0062 << 16 | 4 (AuxPoW bit added by assembler)
+    t.prev_hash.SetHex("00000000000000000000000000000000000000000000000000000000000000aa");
+    t.curtime      = 0x12345678u;
+    t.nbits        = 0x1e0ffff0u;
+    t.coinbase_hex = "0100000001abcdef00";        // opaque coinbase bytes (SHA256d'd for the merkle)
+    t.tx_data_hex  = { "aa11", "bb2222", "cc333333" };
+    t.tx_ids       = {
+        uint256S("1111111111111111111111111111111111111111111111111111111111111111"),
+        uint256S("2222222222222222222222222222222222222222222222222222222222222222"),
+        uint256S("3333333333333333333333333333333333333333333333333333333333333333"),
+    };
+    return t;
+}
+
+} // namespace
+
+// 1) BYTE-EXACT assembled DOGE submit block vs an independent SHA256d reference.
+//    The acceptance criterion: known template + auxpow_hex -> expected block hex.
+TEST(DOGEAuxBlockAssemblerTest, ByteExactAssembledBlock) {
+    const std::string auxpow = "deadbeef";
+    const std::string GOLDEN =
+        "04016200aa0000000000000000000000000000000000000000000000000000000000"
+        "00000650f4892c09e21e2aa80a64f1d1071e177a551af82f0cd67e04b29836b54e55"
+        "78563412f0ff0f1e00000000"     // curtime(LE) || bits(LE) || nonce=0
+        "deadbeef"                     // CAuxPow proof (opaque, passed through verbatim)
+        "04"                           // varint(n_tx) = 1 coinbase + 3 template txs
+        "0100000001abcdef00"           // coinbase
+        "aa11bb2222cc333333";          // template txs, in order
+
+    const std::string blk = doge::coin::assemble_doge_submit_block_hex(make_kat_template(), auxpow);
+    EXPECT_EQ(blk, GOLDEN) << "assembled DOGE submit block diverged from the byte-exact reference";
+    EXPECT_EQ(blk.size() / 2, 103u) << "block byte length changed";
+}
+
+// 2) AuxPoW version bit + region offsets. The child header's nVersion MUST carry
+//    bit 0x100, and each region must land at its contracted offset.
+TEST(DOGEAuxBlockAssemblerTest, AuxPowBitAndRegionOffsets) {
+    const std::string auxpow = "deadbeef";
+    const std::string blk = doge::coin::assemble_doge_submit_block_hex(make_kat_template(), auxpow);
+    ASSERT_GE(blk.size(), 160u);
+
+    // version is the first LE32 of the 80-byte header.
+    uint32_t ver_le = static_cast<uint32_t>(std::stoul(blk.substr(0, 8), nullptr, 16));
+    uint32_t version = ((ver_le & 0xFF) << 24) | ((ver_le & 0xFF00) << 8)
+                     | ((ver_le >> 8) & 0xFF00) | ((ver_le >> 24) & 0xFF);
+    EXPECT_EQ(version & 0x100u, 0x100u) << "AuxPoW version bit (0x100) must be set";
+    EXPECT_EQ(version, 0x00620104u)     << "chain_id | base_version | auxpow bit";
+
+    const std::string HDR = blk.substr(0, 160);           // 80 bytes
+    EXPECT_EQ(blk.substr(160, auxpow.size()), auxpow)     << "auxpow follows the 80-byte header";
+    size_t off = 160 + auxpow.size();
+    EXPECT_EQ(blk.substr(off, 2), std::string("04"))      << "varint(n_tx) follows auxpow";
+    off += 2;
+    EXPECT_EQ(blk.substr(off, 18), std::string("0100000001abcdef00")) << "coinbase follows varint";
+    off += 18;
+    EXPECT_EQ(blk.substr(off), std::string("aa11bb2222cc333333")) << "template txs are the trailing region";
+    EXPECT_EQ(off + 18, blk.size()) << "no trailing bytes beyond template txs";
+}
+
+// 3) n_tx CompactSize boundaries — the varint the assembler writes for the block
+//    tx count. Pins the encoder against the 1/253/0x10000 thresholds.
+TEST(DOGEAuxBlockAssemblerTest, TxCountVarintBoundaries) {
+    using doge::coin::detail::varint_hex;
+    EXPECT_EQ(varint_hex(1),       std::string("01"));
+    EXPECT_EQ(varint_hex(0xfc),    std::string("fc"));
+    EXPECT_EQ(varint_hex(0xfd),    std::string("fdfd00"));
+    EXPECT_EQ(varint_hex(0xffff),  std::string("fdffff"));
+    EXPECT_EQ(varint_hex(0x10000), std::string("fe00000100"));
+}
+
+// 4) Coinbase-only template (n_tx=1): merkle root == coinbase hash, varint 01.
+TEST(DOGEAuxBlockAssemblerTest, CoinbaseOnlyTemplate) {
+    DogeSubmitTemplate t = make_kat_template();
+    t.tx_data_hex.clear();
+    t.tx_ids.clear();
+    const std::string blk = doge::coin::assemble_doge_submit_block_hex(t, "deadbeef");
+    ASSERT_GE(blk.size(), 162u);
+    // header(160) || auxpow(8) || varint(01) || coinbase
+    EXPECT_EQ(blk.substr(160, 8), std::string("deadbeef"));
+    EXPECT_EQ(blk.substr(168, 2), std::string("01")) << "n_tx = 1 (coinbase only)";
+    EXPECT_EQ(blk.substr(170), std::string("0100000001abcdef00")) << "coinbase is the only body tx";
+}
+
+// 5) Unassemblable guards — a won-block submit cannot proceed without a coinbase
+//    or an AuxPoW proof; a txid/txdata length mismatch is malformed. All -> "".
+TEST(DOGEAuxBlockAssemblerTest, UnassemblableGuards) {
+    DogeSubmitTemplate t = make_kat_template();
+
+    DogeSubmitTemplate no_cb = t; no_cb.coinbase_hex.clear();
+    EXPECT_TRUE(doge::coin::assemble_doge_submit_block_hex(no_cb, "deadbeef").empty())
+        << "missing coinbase is unassemblable";
+
+    EXPECT_TRUE(doge::coin::assemble_doge_submit_block_hex(t, "").empty())
+        << "missing auxpow proof is unassemblable";
+
+    DogeSubmitTemplate bad_ids = t; bad_ids.tx_ids.pop_back();
+    EXPECT_TRUE(doge::coin::assemble_doge_submit_block_hex(bad_ids, "deadbeef").empty())
+        << "tx_ids size must equal tx_data_hex size (or be empty)";
+}
+
+// 6) Factory closure shape — make_doge_aux_block_assembler adapts a provider into
+//    the (share_hash, auxpow_hex) -> optional<block_hex> seam dgb binds.
+TEST(DOGEAuxBlockAssemblerTest, FactoryClosureShape) {
+    const uint256 win = uint256S("00000000000000000000000000000000000000000000000000000000000000ff");
+
+    // Bound provider -> assembled block for the winning share.
+    auto ok = doge::coin::make_doge_aux_block_assembler(
+        [&](const uint256&) -> std::optional<DogeSubmitTemplate> { return make_kat_template(); });
+    auto out = ok(win, "deadbeef");
+    ASSERT_TRUE(out.has_value());
+    EXPECT_EQ(*out, doge::coin::assemble_doge_submit_block_hex(make_kat_template(), "deadbeef"));
+
+    // Provider with no frozen template for the share -> nullopt (skip, never ban).
+    auto none = doge::coin::make_doge_aux_block_assembler(
+        [](const uint256&) -> std::optional<DogeSubmitTemplate> { return std::nullopt; });
+    EXPECT_FALSE(none(win, "deadbeef").has_value());
+
+    // Null provider -> nullopt.
+    doge::coin::AuxDogeBlockAssembler empty = doge::coin::make_doge_aux_block_assembler({});
+    EXPECT_FALSE(empty(win, "deadbeef").has_value());
 }

--- a/tests/gates/doge_aux_smoke.sh
+++ b/tests/gates/doge_aux_smoke.sh
@@ -21,7 +21,7 @@ GATE="DOGE AuxPoW smoke"
 # DOGE-specific suites in test_doge_chain: AuxPoW parent-link (structured +
 # real-block KAT), the parser, and the coin_params/consensus-era load. These are
 # the embedded impl/doge/coin/* surfaces the merged c2pool-ltc binary depends on.
-TEST_REGEX="^(AuxPowKnownAnswer|AuxPowStructured|AuxPowParser|DOGEChainParams|DOGESubsidy|DigiShield|MersenneTwister)Test\."
+TEST_REGEX="^(AuxPowKnownAnswer|AuxPowStructured|AuxPowParser|DOGEChainParams|DOGESubsidy|DigiShield|MersenneTwister|DOGEAuxBlockAssembler)Test\."
 TARGETS=(test_doge_chain)
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"


### PR DESCRIPTION
## What

Additive, **doge-only** milestone (integrator scope 2026-09-06): the DOGE-owned, parent-agnostic assembler that builds the full DOGE submit-block hex for a won DOGE-aux target hit, in the exact byte layout the canonical LTC+DOGE primary submit path emits (`merged_mining.cpp` `try_submit_merged_blocks` — the path that found live merged DOGE block #6308393):

```
header80(AuxPoW bit 0x100 set) || CAuxPow proof || varint(n_tx) || coinbase || template txs   (n_tx = 1 + template txs)
```

### New `src/impl/doge/coin/aux_block_assembler.hpp` (header-only)
- `assemble_doge_submit_block_hex(DogeSubmitTemplate, auxpow_hex)` — rebuilds the 80-byte header (sets nVersion bit `0x100`, computes the tx-merkle root via the SSOT `ltc::coin::compute_merkle_root` so header/body stay self-consistent) and concatenates the primary-path layout. Returns `""` (unassemblable) when the coinbase or the AuxPoW proof is absent.
- `make_doge_aux_block_assembler(provider)` — adapts a template-provider into the `(share_hash, auxpow_hex) -> optional<block_hex>` closure a parent won-block handler binds; signature-compatible with `dgb::coin::AuxDogeBlockAssembler` but defined here **independently (no dgb include)**.

### Isolation
Parent-agnostic: no LTC/DGB MM-manager binding, **no dgb include, no dgb edit**; the CAuxPow proof is passed in (already built by the parent-neutral `c2pool::merged::build_auxpow_proof`), never rebuilt. Reuses only the established doge←ltc coin-type sharing + core hashing. Touches nothing in `src/c2pool/merged/` or `src/impl/dgb/`. The frozen canonical LTC+DOGE submit path is untouched.

## Byte-exact KAT
`DOGEAuxBlockAssemblerTest` in `test/test_doge_chain.cpp` (mirrors dgb `bff613aca` layout verifier). A known template + `auxpow_hex` asserts equality with a golden block hex produced by an **independent SHA256d reference** (not the assembler under test), pinning: full on-wire layout, AuxPoW version bit, region offsets, `n_tx` CompactSize boundaries (1 / 0xfd / 0xffff / 0x10000), the coinbase-only (n_tx=1) case, unassemblable guards, and the factory closure shape. Registered in the DOGE aux smoke regex (`tests/gates/doge_aux_smoke.sh`).

## Evidence
- `test_doge_chain` builds + links clean (links `ltc_coin` / `ltc` / `c2pool_merged_mining` / `core` / `pool`).
- DOGE aux smoke: **38/38 green** (+6 new). New suite: 6/6.
- Branch off today's master (`ced627e5a`); GPG-signed `50AB1379285EFE76`; zero attribution.