### PR TITLE
dash: miner/user tx-injection p2p transport (#157, M2, tx_inject subtype, default OFF)

### DIFF
--- a/docs/design/miner-tx-injection.md
+++ b/docs/design/miner-tx-injection.md
@@ -1,7 +1,10 @@
 # Miner / user tx-injection over the c2pool sharechain p2p (post-cut, SV2-like)
 
-Status: **M1 IMPLEMENTED (DASH, `--embedded-tx-inject`, default OFF); M2/M3
-staged.** This is a **post-cut (Tier-3)** feature, not a `--coin-rpc` (dashd)
+Status: **M1 + M2 IMPLEMENTED (DASH, `--embedded-tx-inject`, default OFF); M3
+staged.** M2 adds the `tx_inject` sharechain-p2p subtype (Legacy + Actual),
+routing a peer's tx through the SAME `submit_inject` gate, first-see fan-out
+(txid-deduped), a per-peer DoS guard, and the unknown-command-is-a-warning
+wire-compat property. This is a **post-cut (Tier-3)** feature, not a `--coin-rpc` (dashd)
 cut blocker. It is sequenced strictly **after** the daemonless block-template
 self-derive close (#154) and the full-mempool serving canary (#132). Nothing
 here touches the coinbase, the reward split, or the masternode-payee queue.
@@ -469,9 +472,11 @@ means any signer suffices — so it is correctly deferred without blocking M1.
 | M1 | submit gate + reconcile + node ownership | `src/impl/dash/coin/node_coin_state.hpp` (`submit_inject`, `set_tx_inject_enabled`, `m_inject_pool`) |
 | M1 | flag + local submit (SEAM entry) + catalog | `src/c2pool/main_dash.cpp` (`--embedded-tx-inject`, `--embedded-tx-inject-hex`), `src/core/param_catalog.inc` |
 | M1 | KATs (priority, reward-safety, double-spend, bad-script, missing-input, oversize, seam-unarmed, DoS, never-defaulted) | `test/test_dash_tx_inject.cpp` (in `test_dash_mempool`) |
-| **M2** | `tx-inject` p2p subtype + handler wiring | `src/impl/dash/messages.hpp`, `node.hpp` handler tables, `protocol_actual.cpp` / `protocol_legacy.cpp` |
-| M2 | first-see fan-out + `register_template_txs` | `node.cpp` (advertise pattern), reconstruct-won-block path |
-| M2 | continuous re-submission per tip | block-connect wiring of `reconcile_inject_pool` |
+| **M2 (implemented)** | `tx_inject` p2p subtype + handler wiring | `src/impl/dash/messages.hpp`, `node.hpp` handler tables (`ADD_HANDLER(tx_inject)` Legacy+Actual), `protocol_actual.cpp` / `protocol_legacy.cpp` |
+| M2 (implemented) | relay policy (flag short-circuit, per-peer dedup + rate guard, node-level seen set, first-see fan-out) | `src/impl/dash/tx_inject_relay.hpp` (`ingest_peer_inject`), `src/impl/dash/peer.hpp` (`m_inject_guard`) |
+| M2 (implemented) | submit sink seam (routes the peer path through the armed `NodeCoinState::submit_inject`) | `node.hpp` (`set_tx_inject_sink` / `handle_peer_tx_inject` / `relay_tx_inject`), `src/c2pool/main_dash.cpp` (wired next to the arm) |
+| M2 (implemented) | first-see fan-out + `register_template_txs` ride | `relay_tx_inject` (fan-out); an accepted inject is an ordinary body tx, so it rides `register_template_txs` unchanged (KAT-proven) |
+| M2 (staged) | continuous re-submission per tip | block-connect wiring of `reconcile_inject_pool` (lazy reconcile inside `submit_inject` suffices for M2) |
 | **M3** | per-peer token buckets, misbehaviour score, capability advertisement | coin_peer_manager / handler |
 | M3 | `submitter_hint` rate-accounting | inject pool |
 | M3 | full sandboxed signer (§10) | new isolated build/sign module |

--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2730,11 +2730,29 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // Default OFF; the actual local submits happen after the mempool + the
     // consensus-exact script check are wired (see --embedded-tx-inject-hex).
     node_coin_state.set_tx_inject_enabled(embedded_tx_inject);
+    // #157 M2 (peer tx-injection over the sharechain p2p): install the sink the
+    // tx_inject HANDLER routes a peer's tx through. It MUST target THIS
+    // node_coin_state (the armed one) — NodeImpl::m_coin_state is a different
+    // object that main_dash never arms, so a handler calling m_coin_state would
+    // fail-closed forever. Flag OFF ⇒ a NULL sink ⇒ the handler ignores every
+    // tx_inject (belt), and submit_inject would refuse anyway (suspenders).
+    // node_coin_state and p2p_node both live in run_node scope; node_coin_state
+    // (declared later) is destroyed first, but only AFTER ioc.run() returns, so
+    // no dispatch can reach a dangling ref. Reward-safe: transport only.
     if (embedded_tx_inject) {
+        p2p_node.set_tx_inject_sink(
+            [&node_coin_state](const dash::coin::MutableTransaction& tx,
+                               uint32_t flags, int32_t expiry_height) {
+                return node_coin_state.submit_inject(tx, flags, expiry_height);
+            });
         std::cout << "[run] embedded-tx-inject ARMED (#157): miner/user tx-injection "
                      "ON — submitted txs ride the block with priority through the "
                      "SAME validity gate; reward path byte-unchanged. Requires "
-                     "--embedded-fold-checkscripts + the served-body posture.\n";
+                     "--embedded-fold-checkscripts + the served-body posture. M2 "
+                     "peer tx_inject transport is live (first-see fan-out, "
+                     "per-peer DoS guard).\n";
+    } else {
+        p2p_node.set_tx_inject_sink(nullptr);   // explicit: feature dormant
     }
     // ── IS/CL MINING-SAFETY HOLD arming (dashd TestPackageTransactions) ─────
     // dashd's miner refuses any not-yet-islocked tx with vins younger than 10

--- a/src/core/p2p_message_stats.hpp
+++ b/src/core/p2p_message_stats.hpp
@@ -65,6 +65,7 @@ enum class P2PMessage : std::size_t
     remember_tx,
     forget_tx,
     bestblock,
+    tx_inject,   // #157 M2: miner/user tx-injection over the sharechain p2p
     unknown,     // catch-all bucket; MUST stay last
     COUNT
 };
@@ -75,6 +76,7 @@ inline constexpr std::array<std::string_view, P2P_MESSAGE_COUNT> P2P_MESSAGE_NAM
     "version", "verack", "ping", "pong", "addrme", "addrs", "getaddrs",
     "shares", "sharereq", "sharereply",
     "have_tx", "losing_tx", "remember_tx", "forget_tx", "bestblock",
+    "tx_inject",
     "unknown"
 };
 

--- a/src/core/test/p2p_message_stats_test.cpp
+++ b/src/core/test/p2p_message_stats_test.cpp
@@ -49,6 +49,7 @@ TEST(P2PMessageStats, MapsEveryCanonicalCommand)
         {"remember_tx", P2PMessage::remember_tx},
         {"forget_tx",   P2PMessage::forget_tx},
         {"bestblock",   P2PMessage::bestblock},
+        {"tx_inject",   P2PMessage::tx_inject},   // #157 M2
     };
     ASSERT_EQ(expected.size(), P2P_MESSAGE_COUNT - 1)  // -1 for the unknown bucket
         << "message list drifted from the enum";

--- a/src/impl/dash/messages.hpp
+++ b/src/impl/dash/messages.hpp
@@ -181,6 +181,28 @@ BEGIN_MESSAGE(remember_tx)
     }
 END_MESSAGE()
 
+// message_tx_inject (#157 M2) — miner/user tx-injection over the sharechain p2p.
+// A peer offers a raw tx for injection; the receiver routes it through the SAME
+// NodeCoinState::submit_inject gate as the local --embedded-tx-inject-hex path
+// (all M1 validity checks — no new add_tx seam) and, on a first-see ACCEPT,
+// fans it out to its other peers. `m_version` is the injection-envelope version
+// (1 = M2), `m_flags` / `m_expiry_height` are submit_inject's wire fields
+// (carried verbatim), and `m_tx` is the transaction itself. `submitter_hint` is
+// deferred to M3 and deliberately absent. Command "tx_inject" = 9 chars (<= 12).
+BEGIN_MESSAGE(tx_inject)
+    MESSAGE_FIELDS
+    (
+        (uint32_t, m_version),
+        (uint32_t, m_flags),
+        (int32_t, m_expiry_height),
+        (coin::MutableTransaction, m_tx)
+    )
+    {
+        READWRITE(obj.m_version, obj.m_flags, obj.m_expiry_height,
+                  coin::TX_WITH_WITNESS(obj.m_tx));
+    }
+END_MESSAGE()
+
 using Handler = MessageHandler<
     message_ping,
     message_addrme,
@@ -193,7 +215,8 @@ using Handler = MessageHandler<
     message_have_tx,
     message_losing_tx,
     message_forget_tx,
-    message_remember_tx
+    message_remember_tx,
+    message_tx_inject
 >;
 
 } // namespace dash

--- a/src/impl/dash/node.hpp
+++ b/src/impl/dash/node.hpp
@@ -419,6 +419,15 @@ protected:
     // Chain-relative block height for think() scoring; unbound -> zero fn.
     std::function<int32_t(uint256)> m_block_rel_height_fn;
 
+    // #157 M2: peer tx-injection sink (submit_inject, injected by main_dash next
+    // to the arm) + node-level decided-txid set. Both IO-thread-confined (same
+    // discipline as m_known_txs). Null sink / empty set ⇒ feature dormant. The
+    // full std::function type is spelled out here (the tx_inject_sink_t alias is
+    // declared with the public setter further down, after this member).
+    std::function<coin::NodeCoinState::InjectSubmitResult(
+        const coin::MutableTransaction&, uint32_t, int32_t)> m_tx_inject_sink;
+    dash::NodeInjectSeen m_inject_seen;
+
     // ── Share-download leg (#754) state — IO-thread only ────────────────
     // De-dup + per-cycle retry gate for in-flight sharereq targets (shared
     // pool/share_download.hpp; ltc m_downloading_shares/m_download_fail_count).
@@ -1078,6 +1087,94 @@ public:
     void set_on_best_share_changed(std::function<void()> fn) { m_on_best_share_changed = std::move(fn); }
     void set_block_rel_height_fn(std::function<int32_t(uint256)> fn) { m_block_rel_height_fn = std::move(fn); }
 
+    // ── #157 M2: peer tx-injection SINK seam ─────────────────────────────
+    // The tx_inject handler routes a peer's tx through the SAME M1 gate the
+    // --embedded-tx-inject-hex loader uses (NodeCoinState::submit_inject). But
+    // NodeImpl::m_coin_state is NOT the object main_dash arms — main_dash owns a
+    // standalone `dash::coin::NodeCoinState node_coin_state` and calls
+    // set_tx_inject_enabled() on THAT one (main_dash.cpp). A handler that called
+    // m_coin_state.submit_inject() would fail-closed forever ("inject-disabled")
+    // — a silent dead transport. So the sink is injected from main_dash next to
+    // the arm, exactly like set_on_best_share_changed / set_block_rel_height_fn.
+    //
+    // Flag OFF ⇒ main_dash installs a NULL sink ⇒ the handler ignores every
+    // tx_inject (belt); submit_inject would also refuse (suspenders). The sink
+    // signature mirrors submit_inject(tx, flags, expiry_height).
+    using tx_inject_sink_t = std::function<
+        coin::NodeCoinState::InjectSubmitResult(
+            const coin::MutableTransaction&, uint32_t, int32_t)>;
+    void set_tx_inject_sink(tx_inject_sink_t fn) { m_tx_inject_sink = std::move(fn); }
+    bool has_tx_inject_sink() const { return static_cast<bool>(m_tx_inject_sink); }
+
+    // Route ONE inbound peer tx_inject through the relay policy + the M1 gate,
+    // then first-see fan it out. IO-THREAD ONLY (reads IO-owned m_peers, mutates
+    // IO-confined m_inject_seen + the peer guard — same discipline as m_known_txs
+    // / advertise_known_txs). Reward-safe: transport + a txid + submit_inject; no
+    // coinbase / subsidy / PPLNS / payee / won-block state is touched.
+    void handle_peer_tx_inject(const message_tx_inject& msg, const peer_ptr& from)
+    {
+        // Belt: no sink ⇒ feature not armed on this node ⇒ ignore + forward
+        // nothing. Never disconnect the peer (wire-compat: an old/new peer that
+        // sends tx_inject to a non-participating node is not misbehaving).
+        if (!m_tx_inject_sink)
+        {
+            LOG_DEBUG_POOL << "[tx-inject] ignoring peer tx_inject (feature off)";
+            return;
+        }
+
+        const uint256 txid = dash::coin::dash_txid(msg.m_tx);
+        const uint32_t byte_size =
+            static_cast<uint32_t>(::pack(coin::TX_WITH_WITNESS(msg.m_tx)).get_span().size());
+
+        auto verdict = dash::ingest_peer_inject(
+            /*enabled=*/true, m_inject_seen, from->m_inject_guard, txid, byte_size,
+            core::timestamp(),
+            [&]() -> dash::InjectSubmitOutcome {
+                auto r = m_tx_inject_sink(msg.m_tx, msg.m_flags, msg.m_expiry_height);
+                return dash::InjectSubmitOutcome{ r.ok, r.cause };
+            });
+
+        using Kind = dash::InjectRelayVerdict::Kind;
+        switch (verdict.kind)
+        {
+        case Kind::Accepted:
+            LOG_INFO << "[tx-inject] accepted " << txid.ToString()
+                     << " from " << from->addr().to_string() << " — fanning out";
+            break;
+        case Kind::Rejected:
+            LOG_WARNING << "[tx-inject] rejected " << txid.ToString()
+                        << " from " << from->addr().to_string()
+                        << " (" << verdict.cause << ")";
+            break;
+        case Kind::RateLimited:
+            LOG_WARNING << "[tx-inject] rate-limited peer "
+                        << from->addr().to_string() << " on " << txid.ToString();
+            break;
+        case Kind::Duplicate:
+            LOG_DEBUG_POOL << "[tx-inject] duplicate " << txid.ToString()
+                           << " (" << verdict.cause << ")";
+            break;
+        case Kind::Disabled:
+            break; // unreachable with a non-null sink
+        }
+
+        if (verdict.forward)
+            relay_tx_inject(msg, from);
+    }
+
+    // First-see fan-out: forward the tx_inject frame VERBATIM (no re-derivation)
+    // to every connected pool peer except the one it came from. IO-THREAD ONLY.
+    void relay_tx_inject(const message_tx_inject& msg, const peer_ptr& from)
+    {
+        for (auto& entry : m_peers)
+        {
+            auto& p = entry.second;
+            if (p && p != from)
+                p->write(dash::message_tx_inject::make_raw(
+                    msg.m_version, msg.m_flags, msg.m_expiry_height, msg.m_tx));
+        }
+    }
+
     // ── #754 share-download leg surface ─────────────────────────────────
 
     /// Async share download: register the reply callback + dispatch the
@@ -1424,6 +1521,7 @@ public:
     ADD_HANDLER(losing_tx, dash::message_losing_tx);
     ADD_HANDLER(remember_tx, dash::message_remember_tx);
     ADD_HANDLER(forget_tx, dash::message_forget_tx);
+    ADD_HANDLER(tx_inject, dash::message_tx_inject);   // #157 M2 miner/user tx-injection
 };
 
 class Actual : public pool::Protocol<NodeImpl>
@@ -1443,6 +1541,7 @@ public:
     ADD_HANDLER(losing_tx, dash::message_losing_tx);
     ADD_HANDLER(remember_tx, dash::message_remember_tx);
     ADD_HANDLER(forget_tx, dash::message_forget_tx);
+    ADD_HANDLER(tx_inject, dash::message_tx_inject);   // #157 M2 miner/user tx-injection
 };
 
 using Node = pool::NodeBridge<NodeImpl, Legacy, Actual>;

--- a/src/impl/dash/peer.hpp
+++ b/src/impl/dash/peer.hpp
@@ -14,6 +14,7 @@
 // Pure state struct, no socket/IO — header-only, rig-free, fenced to src/impl/dash/.
 
 #include "coin/transaction.hpp"
+#include "tx_inject_relay.hpp"   // #157 M2: dash::PeerInjectGuard
 
 #include <chrono>
 #include <map>
@@ -46,6 +47,11 @@ struct Peer
     // have_tx / losing_tx. Mirror image of m_remote_txs above (what the peer
     // told us IT holds). See core/tx_advertiser.hpp for canonical semantics.
     core::TxAdvertState m_tx_advert;
+
+    // #157 M2: per-peer tx-injection DoS state — a sliding-window rate cap plus a
+    // bounded per-peer txid dedup set, consulted by ingest_peer_inject before any
+    // submit_inject work. Inert unless --embedded-tx-inject is armed.
+    dash::PeerInjectGuard m_inject_guard;
 };
 
 }; // namespace dash

--- a/src/impl/dash/protocol_actual.cpp
+++ b/src/impl/dash/protocol_actual.cpp
@@ -285,4 +285,13 @@ void Actual::HANDLER(forget_tx)
     }
 }
 
+// #157 M2: route a peer's tx-injection through the SAME submit_inject gate as the
+// local --embedded-tx-inject-hex loader (all M1 validity checks), then first-see
+// fan it out. The whole policy lives in NodeImpl::handle_peer_tx_inject so the
+// Legacy/Actual bodies stay byte-identical (only the dispatch table differs).
+void Actual::HANDLER(tx_inject)
+{
+    handle_peer_tx_inject(*msg, peer);
+}
+
 } // namespace dash

--- a/src/impl/dash/protocol_legacy.cpp
+++ b/src/impl/dash/protocol_legacy.cpp
@@ -331,4 +331,13 @@ void Legacy::HANDLER(forget_tx)
     }
 }
 
+// #157 M2: route a peer's tx-injection through the SAME submit_inject gate as the
+// local --embedded-tx-inject-hex loader (all M1 validity checks), then first-see
+// fan it out. The whole policy lives in NodeImpl::handle_peer_tx_inject so the
+// Legacy/Actual bodies stay byte-identical (only the dispatch table differs).
+void Legacy::HANDLER(tx_inject)
+{
+    handle_peer_tx_inject(*msg, peer);
+}
+
 } // namespace dash

--- a/src/impl/dash/tx_inject_relay.hpp
+++ b/src/impl/dash/tx_inject_relay.hpp
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// #157 M2 — sharechain-p2p tx-injection RELAY LOGIC (pure, header-only, KAT-able).
+//
+// This is the transport-side policy that sits IN FRONT of the M1 submit gate
+// (NodeCoinState::submit_inject). It answers ONE question per inbound peer
+// tx_inject frame: do we (a) route it through submit_inject, and (b) fan it out
+// to our other peers? The actual consensus validity — type-0, vin/vout, DoS
+// caps, script-armed, BIP68 fail-closed, MoneyRange, dedup, already-confirmed —
+// stays entirely inside submit_inject (M1). This layer adds ONLY:
+//
+//   * FLAG SHORT-CIRCUIT: injection disabled ⇒ ignore, mutate nothing, forward
+//     nothing (a peer cannot make a non-participating node do inject work).
+//   * PER-PEER DoS GUARD: a sliding-window rate cap + a per-peer txid dedup set,
+//     so one peer cannot force repeated (script-checking) submit_inject calls.
+//   * NODE-LEVEL SEEN SET: a txid we have already decided on (accepted OR
+//     rejected) is not re-validated when a DIFFERENT peer re-sends it — a
+//     rejected tx costs a script check, so re-deciding it is the DoS the seen
+//     set closes. Bounded (cap + FIFO eviction).
+//   * FIRST-SEE FAN-OUT: only a first-see ACCEPT is forwarded (txid-deduped),
+//     mirroring p2pool's remember_tx first-see relay. A duplicate, a rate-limit,
+//     a rejection, or a disabled node forwards NOTHING.
+//
+// REWARD-SAFETY: this file touches NO coinbase / subsidy / PPLNS / payee /
+// won-block state. It reads a txid, a byte size, and a clock; it calls an
+// opaque submit_fn. It cannot move a single duff.
+//
+// Pure over <deque>/<map>/<set> + core::uint256 + a caller-supplied submit_fn —
+// no node.hpp, no mempool, no NodeCoinState include — so the whole verdict path
+// is drivable from a rig-free KAT with a stub submit_fn, and separately wired to
+// the real submit_inject in the integration KAT.
+
+#include <core/uint256.hpp>
+
+#include <cstdint>
+#include <ctime>
+#include <deque>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+namespace dash {
+
+// The outcome the M1 gate hands back, reduced to what the relay layer needs.
+// (NodeCoinState::submit_inject returns the richer InjectSubmitResult; the
+// handler collapses it into this so this header stays decoupled from M1.)
+struct InjectSubmitOutcome {
+    bool        ok{false};
+    std::string cause{"inject-disabled"};
+};
+
+// What the handler must do with one inbound tx_inject frame.
+struct InjectRelayVerdict {
+    enum class Kind {
+        Disabled,     // feature OFF — ignored, nothing mutated, nothing forwarded
+        Duplicate,    // already seen (this peer, or node-wide) — not re-validated
+        RateLimited,  // this peer exceeded its per-window inject budget
+        Rejected,     // submit_inject refused it (cause carried)
+        Accepted      // submit_inject admitted it
+    };
+    Kind        kind{Kind::Disabled};
+    std::string cause;      // submit_inject's named cause (Rejected/Accepted), or a relay reason
+    uint256     txid;
+    bool        forward{false};  // fan out to other peers? (first-see ACCEPT only)
+
+    static const char* kind_name(Kind k) {
+        switch (k) {
+            case Kind::Disabled:    return "disabled";
+            case Kind::Duplicate:   return "duplicate";
+            case Kind::RateLimited: return "rate-limited";
+            case Kind::Rejected:    return "rejected";
+            case Kind::Accepted:    return "accepted";
+        }
+        return "unknown";
+    }
+};
+
+// Per-peer DoS state (lives on dash::Peer). A sliding time window bounds how many
+// injects one peer can push per minute, and a bounded txid set stops a single
+// peer re-sending the same tx to cost repeated node-level lookups.
+struct PeerInjectGuard {
+    // Canonical cap: injections are a rare operator/miner action, not a
+    // high-rate advert. 30/min is generous for a human-driven submitter and
+    // still bounds a hostile peer to ~1 script-check attempt every 2 s.
+    static constexpr std::size_t kMaxInjectsPerPeerPerWindow = 30;
+    static constexpr std::time_t kWindowSeconds = 60;
+    // Per-peer txid memory cap (FIFO eviction). Bounds the set a peer can grow.
+    static constexpr std::size_t kMaxPeerSeen = 4096;
+
+    std::deque<std::time_t> window;   // submit timestamps inside kWindowSeconds
+    std::deque<uint256>     seen_order;
+    std::unordered_map<uint256, char> seen;  // txid -> present (this peer only)
+
+    // Drop timestamps older than the window; return the count still inside it.
+    std::size_t prune_window(std::time_t now) {
+        while (!window.empty() && window.front() + kWindowSeconds <= now)
+            window.pop_front();
+        return window.size();
+    }
+
+    bool peer_has_seen(const uint256& txid) const {
+        return seen.find(txid) != seen.end();
+    }
+
+    void remember_peer_seen(const uint256& txid) {
+        if (seen.emplace(txid, 1).second) {
+            seen_order.push_back(txid);
+            if (seen_order.size() > kMaxPeerSeen) {
+                seen.erase(seen_order.front());
+                seen_order.pop_front();
+            }
+        }
+    }
+
+    void record_window(std::time_t now) { window.push_back(now); }
+};
+
+// Node-level seen set: a txid we have ALREADY decided (accepted or rejected) so
+// a re-send from a different peer does not pay for another submit_inject. Bounded
+// (cap + FIFO). Records the ACCEPT/REJECT outcome so a re-offer can be reported
+// as a duplicate without re-validation. IO-thread-confined (same discipline as
+// NodeImpl::m_known_txs) — no internal locking.
+struct NodeInjectSeen {
+    static constexpr std::size_t kMaxNodeSeen = 8192;
+
+    std::deque<uint256>              order;
+    std::unordered_map<uint256, bool> accepted;  // txid -> was accepted
+
+    bool contains(const uint256& txid) const {
+        return accepted.find(txid) != accepted.end();
+    }
+
+    void remember(const uint256& txid, bool was_accepted) {
+        auto it = accepted.find(txid);
+        if (it != accepted.end()) { it->second = was_accepted; return; }
+        accepted.emplace(txid, was_accepted);
+        order.push_back(txid);
+        if (order.size() > kMaxNodeSeen) {
+            accepted.erase(order.front());
+            order.pop_front();
+        }
+    }
+
+    std::size_t size() const { return accepted.size(); }
+};
+
+// Decide + (via submit_fn) route ONE inbound peer tx_inject. submit_fn is invoked
+// AT MOST ONCE, and ONLY when the tx is genuinely new (not disabled, not a per-
+// peer or node-wide duplicate, not rate-limited) — so a rejected tx costs exactly
+// one script check no matter how many peers replay it.
+//
+//   enabled     — NodeCoinState::tx_inject_enabled() (flag short-circuit)
+//   node_seen   — node-level decided-txid set (IO-thread-confined)
+//   peer_guard  — this peer's DoS state
+//   txid        — dash_txid(msg.m_tx), self-computed by the caller
+//   byte_size   — informational (reserved; DoS byte caps live in submit_inject)
+//   now         — one clock reading for the whole decision
+//   submit_fn   — () -> InjectSubmitOutcome, wrapping NodeCoinState::submit_inject
+template <typename SubmitFn>
+InjectRelayVerdict ingest_peer_inject(bool enabled,
+                                      NodeInjectSeen& node_seen,
+                                      PeerInjectGuard& peer_guard,
+                                      const uint256& txid,
+                                      std::uint32_t byte_size,
+                                      std::time_t now,
+                                      SubmitFn&& submit_fn)
+{
+    (void)byte_size;
+    InjectRelayVerdict v;
+    v.txid = txid;
+
+    // FLAG SHORT-CIRCUIT: a disabled node is inert — no state mutation, no
+    // submit, no forward. (submit_inject would refuse anyway; this is the belt.)
+    if (!enabled) {
+        v.kind = InjectRelayVerdict::Kind::Disabled;
+        v.cause = "inject-disabled";
+        v.forward = false;
+        return v;
+    }
+
+    // Per-peer dedup: this peer already sent this txid — never re-decide.
+    if (peer_guard.peer_has_seen(txid)) {
+        v.kind = InjectRelayVerdict::Kind::Duplicate;
+        v.cause = "peer-duplicate";
+        v.forward = false;
+        return v;
+    }
+
+    // Node-wide dedup: some peer already had this txid decided — do not pay for
+    // another submit. Record it against THIS peer too so its own dedup tracks it.
+    if (node_seen.contains(txid)) {
+        peer_guard.remember_peer_seen(txid);
+        v.kind = InjectRelayVerdict::Kind::Duplicate;
+        v.cause = "node-duplicate";
+        v.forward = false;
+        return v;
+    }
+
+    // Per-peer sliding-window rate cap. Count BEFORE recording so the Nth+1
+    // request in a window is the one refused. No submit, no state beyond noting
+    // we saw the peer act (window untouched so a slowed peer recovers).
+    if (peer_guard.prune_window(now) >= PeerInjectGuard::kMaxInjectsPerPeerPerWindow) {
+        v.kind = InjectRelayVerdict::Kind::RateLimited;
+        v.cause = "peer-rate-limited";
+        v.forward = false;
+        return v;
+    }
+
+    // Genuinely new + within budget: charge the window, remember the peer saw it,
+    // and route through the M1 gate exactly once.
+    peer_guard.record_window(now);
+    peer_guard.remember_peer_seen(txid);
+
+    InjectSubmitOutcome out = submit_fn();
+    node_seen.remember(txid, out.ok);
+
+    if (out.ok) {
+        v.kind = InjectRelayVerdict::Kind::Accepted;
+        v.cause = out.cause;   // "ok"
+        v.forward = true;      // first-see accept — fan out
+    } else {
+        v.kind = InjectRelayVerdict::Kind::Rejected;
+        v.cause = out.cause;   // named refusal from submit_inject
+        v.forward = false;
+    }
+    return v;
+}
+
+} // namespace dash

--- a/src/impl/dash/tx_inject_relay.hpp
+++ b/src/impl/dash/tx_inject_relay.hpp
@@ -38,7 +38,7 @@
 #include <deque>
 #include <functional>
 #include <string>
-#include <unordered_map>
+#include <map>
 
 namespace dash {
 
@@ -90,7 +90,7 @@ struct PeerInjectGuard {
 
     std::deque<std::time_t> window;   // submit timestamps inside kWindowSeconds
     std::deque<uint256>     seen_order;
-    std::unordered_map<uint256, char> seen;  // txid -> present (this peer only)
+    std::map<uint256, char> seen;  // txid -> present (this peer only)
 
     // Drop timestamps older than the window; return the count still inside it.
     std::size_t prune_window(std::time_t now) {
@@ -125,7 +125,7 @@ struct NodeInjectSeen {
     static constexpr std::size_t kMaxNodeSeen = 8192;
 
     std::deque<uint256>              order;
-    std::unordered_map<uint256, bool> accepted;  // txid -> was accepted
+    std::map<uint256, bool> accepted;  // txid -> was accepted
 
     bool contains(const uint256& txid) const {
         return accepted.find(txid) != accepted.end();

--- a/test/test_dash_node.cpp
+++ b/test/test_dash_node.cpp
@@ -140,7 +140,7 @@ struct has_msg_handler<P, M, std::void_t<decltype(
     : std::true_type {};
 
 template <class P>
-constexpr bool registers_all_12()
+constexpr bool registers_all_13()
 {
     return has_msg_handler<P, dash::message_addrs>::value
         && has_msg_handler<P, dash::message_addrme>::value
@@ -153,13 +153,15 @@ constexpr bool registers_all_12()
         && has_msg_handler<P, dash::message_have_tx>::value
         && has_msg_handler<P, dash::message_losing_tx>::value
         && has_msg_handler<P, dash::message_remember_tx>::value
-        && has_msg_handler<P, dash::message_forget_tx>::value;
+        && has_msg_handler<P, dash::message_forget_tx>::value
+        && has_msg_handler<P, dash::message_tx_inject>::value;   // #157 M2
 }
 
 } // namespace
 
-// 6. Legacy registers a handler overload for all 12 established-peer messages.
-TEST(DashNodeDispatch, LegacyRegistersAll12Handlers)
+// 6. Legacy registers a handler overload for all 13 established-peer messages
+//    (the original 12 + the #157 M2 tx_inject subtype).
+TEST(DashNodeDispatch, LegacyRegistersAll13Handlers)
 {
     EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_addrs>::value));
     EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_addrme>::value));
@@ -173,12 +175,13 @@ TEST(DashNodeDispatch, LegacyRegistersAll12Handlers)
     EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_losing_tx>::value));
     EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_remember_tx>::value));
     EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_forget_tx>::value));
-    static_assert(registers_all_12<dash::Legacy>(),
-                  "Legacy must register all 12 sharechain-p2p dispatch handlers");
+    EXPECT_TRUE((has_msg_handler<dash::Legacy, dash::message_tx_inject>::value));
+    static_assert(registers_all_13<dash::Legacy>(),
+                  "Legacy must register all 13 sharechain-p2p dispatch handlers");
 }
 
-// 7. Actual registers the identical 12-handler set (bodies diverge, surface does not).
-TEST(DashNodeDispatch, ActualRegistersAll12Handlers)
+// 7. Actual registers the identical 13-handler set (bodies diverge, surface does not).
+TEST(DashNodeDispatch, ActualRegistersAll13Handlers)
 {
     EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_addrs>::value));
     EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_addrme>::value));
@@ -192,8 +195,9 @@ TEST(DashNodeDispatch, ActualRegistersAll12Handlers)
     EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_losing_tx>::value));
     EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_remember_tx>::value));
     EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_forget_tx>::value));
-    static_assert(registers_all_12<dash::Actual>(),
-                  "Actual must register all 12 sharechain-p2p dispatch handlers");
+    EXPECT_TRUE((has_msg_handler<dash::Actual, dash::message_tx_inject>::value));
+    static_assert(registers_all_13<dash::Actual>(),
+                  "Actual must register all 13 sharechain-p2p dispatch handlers");
 }
 
 // 8. The Node alias binds NodeImpl + both protocols through the shared NodeBridge.

--- a/test/test_dash_poolnode_messages.cpp
+++ b/test/test_dash_poolnode_messages.cpp
@@ -155,11 +155,13 @@ static coin::MutableTransaction make_inject_tx() {
     in.prevout.hash = uint256(0x9a9a9aull);
     in.prevout.index = 3;
     in.sequence = 0xffffffffu;
-    in.scriptSig = OPScript(std::vector<unsigned char>{0x51, 0x52, 0x53});
+    std::vector<unsigned char> sig_bytes{0x51, 0x52, 0x53};
+    in.scriptSig = OPScript(sig_bytes.data(), sig_bytes.data() + sig_bytes.size());
     tx.vin.push_back(in);
     coin::TxOut out;
     out.value = 123456;
-    out.scriptPubKey = OPScript(std::vector<unsigned char>{0x76, 0xa9, 0x14});
+    std::vector<unsigned char> spk_bytes{0x76, 0xa9, 0x14};
+    out.scriptPubKey = OPScript(spk_bytes.data(), spk_bytes.data() + spk_bytes.size());
     tx.vout.push_back(out);
     return tx;
 }

--- a/test/test_dash_poolnode_messages.cpp
+++ b/test/test_dash_poolnode_messages.cpp
@@ -144,6 +144,79 @@ TEST(DashPoolNodeMessages, Handler_TypeList_Compiles) {
     EXPECT_GT(sizeof(HandlerResult), 0u);
 }
 
+// ── #157 M2: tx_inject subtype ──────────────────────────────────────────────
+namespace {
+// A minimal 1-in 1-out classic (type-0) tx so the wire round-trip exercises a
+// real MutableTransaction body (not an empty one).
+static coin::MutableTransaction make_inject_tx() {
+    coin::MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 0;
+    coin::TxIn in;
+    in.prevout.hash = uint256(0x9a9a9aull);
+    in.prevout.index = 3;
+    in.sequence = 0xffffffffu;
+    in.scriptSig = OPScript(std::vector<unsigned char>{0x51, 0x52, 0x53});
+    tx.vin.push_back(in);
+    coin::TxOut out;
+    out.value = 123456;
+    out.scriptPubKey = OPScript(std::vector<unsigned char>{0x76, 0xa9, 0x14});
+    tx.vout.push_back(out);
+    return tx;
+}
+} // namespace
+
+TEST(DashPoolNodeMessages, Message_TxInject_RoundTrip) {
+    auto tx = make_inject_tx();
+    auto rmsg = message_tx_inject::make_raw(/*version=*/1u, /*flags=*/0x2Au,
+                                            /*expiry_height=*/987654, tx);
+    EXPECT_EQ(rmsg->m_command, "tx_inject");
+    EXPECT_LE(std::string("tx_inject").size(), 12u);   // fits the command field
+
+    auto parsed = message_tx_inject::make(rmsg->m_data);
+    EXPECT_EQ(parsed->m_version, 1u);
+    EXPECT_EQ(parsed->m_flags, 0x2Au);
+    EXPECT_EQ(parsed->m_expiry_height, 987654);
+    ASSERT_EQ(parsed->m_tx.vin.size(), 1u);
+    ASSERT_EQ(parsed->m_tx.vout.size(), 1u);
+    EXPECT_EQ(parsed->m_tx.vin[0].prevout.index, 3u);
+    EXPECT_EQ(parsed->m_tx.vout[0].value, 123456);
+    EXPECT_EQ(parsed->m_tx.version, 1);
+    EXPECT_EQ(parsed->m_tx.type, 0);
+}
+
+// WIRE-COMPAT: an OLD peer whose dispatch set predates M2 has no tx_inject
+// handler. Feeding it a tx_inject frame throws std::out_of_range — which
+// handle_message() catches as `const std::exception&` and turns into a
+// LOG_WARNING, NOT a disconnect. The NEW dash::Handler parses it cleanly.
+TEST(DashPoolNodeMessages, OldPeerUnknownTxInjectIsWarningNotDisconnect) {
+    // Documents the catch site's contract: the throw is a std::exception.
+    static_assert(std::is_base_of_v<std::exception, std::out_of_range>,
+                  "handle_message catches std::exception → LOG_WARNING, not disconnect");
+
+    // The pre-M2 dispatch type-list, literally the old dash::Handler (12 types,
+    // no message_tx_inject).
+    using OldHandler = MessageHandler<
+        message_ping, message_addrme, message_getaddrs, message_addrs,
+        message_shares, message_sharereq, message_sharereply, message_bestblock,
+        message_have_tx, message_losing_tx, message_forget_tx, message_remember_tx>;
+
+    auto tx = make_inject_tx();
+
+    // An old peer cannot parse tx_inject → out_of_range (→ caught as LOG_WARNING).
+    {
+        OldHandler oldh;
+        auto rmsg = message_tx_inject::make_raw(1u, 0u, 0, tx);
+        EXPECT_THROW(oldh.parse(rmsg), std::out_of_range);
+    }
+
+    // The current dash::Handler DOES parse it (feature present).
+    {
+        Handler newh;
+        auto rmsg = message_tx_inject::make_raw(1u, 0u, 0, tx);
+        EXPECT_NO_THROW(newh.parse(rmsg));
+    }
+}
+
 
 // #1046: the bestblock-origination fetch classifier. Drives the REAL
 // nlohmann::json type (not a mock). These FAIL to compile/pass without

--- a/test/test_dash_tx_inject.cpp
+++ b/test/test_dash_tx_inject.cpp
@@ -39,6 +39,8 @@
 
 #include <impl/dash/coin/mempool.hpp>
 #include <impl/dash/coin/tx_inject_pool.hpp>
+#include <impl/dash/coin/node_coin_state.hpp>   // #157 M2: submit_inject gate (relay routes through it)
+#include <impl/dash/tx_inject_relay.hpp>        // #157 M2: ingest_peer_inject relay policy
 #include <impl/dash/coin/good_citizen_defaults.hpp>
 #include <impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.h>
 
@@ -489,4 +491,235 @@ TEST(DashTxInject, NeverGoodCitizenDefaulted)
     // test exists so a future refactor that tried to fold injection into the
     // good-citizen levers would have to delete it — a loud tripwire.
     SUCCEED();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// #157 M2 — PEER TX-INJECTION RELAY (src/impl/dash/tx_inject_relay.hpp).
+//
+// These KATs drive dash::ingest_peer_inject — the transport-side policy that
+// sits IN FRONT of submit_inject. They are RED on master by construction:
+// tx_inject_relay.hpp does not exist there, so this TU fails to compile. GREEN
+// after: the relay routes a peer's tx through the SAME M1 submit_inject gate,
+// deduplicates, rate-limits, and first-see fans out.
+// ═══════════════════════════════════════════════════════════════════════════
+
+namespace {
+
+using dash::coin::NodeCoinState;
+
+// Arm the consensus-exact CheckInputScripts callback on a NodeCoinState's mempool
+// (same VerifyScript the local hex loader uses), then enable injection.
+void arm_ncs(NodeCoinState& st, UTXOViewCache& utxo) {
+    st.mempool().set_utxo(&utxo);
+    st.set_script_check([](const std::vector<uint8_t>& t, uint32_t n,
+                           const std::vector<uint8_t>& s, uint32_t f) {
+        return c2pool_dash_verify_input(s.data(), (unsigned)s.size(),
+                                        t.data(), (unsigned)t.size(), n, f) == 1;
+    });
+    st.set_tx_inject_enabled(true);
+}
+
+// The submit_fn the handler builds: route the peer tx through submit_inject and
+// collapse the rich result into the relay's InjectSubmitOutcome.
+auto make_sink(NodeCoinState& st, const MutableTransaction& tx,
+               uint32_t flags = 0, int32_t expiry = 0) {
+    return [&st, tx, flags, expiry]() -> dash::InjectSubmitOutcome {
+        auto r = st.submit_inject(tx, flags, expiry);
+        return dash::InjectSubmitOutcome{ r.ok, r.cause };
+    };
+}
+
+} // namespace
+
+// (M2-1) A valid signed spend from a peer is ACCEPTED through submit_inject and
+//        flagged for first-see fan-out; the inject lands in the pool + mempool.
+TEST(DashTxInject, PeerInjectAcceptedAndForwardedOnFirstSee)
+{
+    Key k(0xa1);
+    uint256 prev = prevhash(0x71);
+    auto tx = make_signed_spend(k, prev, 100'000);   // fee 0 (injected)
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peer;
+    const uint256 txid = dash_txid(tx);
+
+    auto v = dash::ingest_peer_inject(/*enabled=*/true, node_seen, peer, txid,
+                                      /*byte_size=*/225, /*now=*/1000,
+                                      make_sink(st, tx));
+    EXPECT_EQ(v.kind, dash::InjectRelayVerdict::Kind::Accepted);
+    EXPECT_TRUE(v.forward) << "a first-see ACCEPT must fan out";
+    EXPECT_EQ(v.txid, txid);
+    EXPECT_EQ(st.inject_pool_size(), 1u);
+    EXPECT_TRUE(node_seen.contains(txid));
+}
+
+// (M2-2) A missing-input tx is REJECTED by name (submit_inject → unpriceable)
+//        and NOT forwarded.
+TEST(DashTxInject, PeerInjectRejectedByNameNotForwarded)
+{
+    Key k(0xa2);
+    uint256 prev = prevhash(0x72);   // NOT in the UTXO view
+    auto tx = make_signed_spend(k, prev, 90'000);
+
+    UTXOViewCache utxo(nullptr);     // empty
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peer;
+    const uint256 txid = dash_txid(tx);
+
+    auto v = dash::ingest_peer_inject(true, node_seen, peer, txid, 225, 1000,
+                                      make_sink(st, tx));
+    EXPECT_EQ(v.kind, dash::InjectRelayVerdict::Kind::Rejected);
+    EXPECT_EQ(v.cause, "inject-unpriceable");
+    EXPECT_FALSE(v.forward);
+    EXPECT_EQ(st.inject_pool_size(), 0u);
+    // A rejected txid is still REMEMBERED (as rejected) so a re-send is not
+    // re-validated.
+    EXPECT_TRUE(node_seen.contains(txid));
+}
+
+// (M2-3) The same tx re-sent by the same peer, and by a DIFFERENT peer, is a
+//        Duplicate — submit_inject is called EXACTLY ONCE (no re-validation).
+TEST(DashTxInject, PeerInjectDuplicateNotReforwarded)
+{
+    Key k(0xa3);
+    uint256 prev = prevhash(0x73);
+    auto tx = make_signed_spend(k, prev, 100'000);
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peerA, peerB;
+    const uint256 txid = dash_txid(tx);
+
+    int submit_calls = 0;
+    auto counting_sink = [&]() -> dash::InjectSubmitOutcome {
+        ++submit_calls;
+        auto r = st.submit_inject(tx, 0, 0);
+        return dash::InjectSubmitOutcome{ r.ok, r.cause };
+    };
+
+    // First-see from peer A: accepted + forwarded, one submit.
+    auto v1 = dash::ingest_peer_inject(true, node_seen, peerA, txid, 225, 1000, counting_sink);
+    EXPECT_EQ(v1.kind, dash::InjectRelayVerdict::Kind::Accepted);
+    EXPECT_TRUE(v1.forward);
+
+    // Same tx again from peer A: per-peer duplicate, no submit, no forward.
+    auto v2 = dash::ingest_peer_inject(true, node_seen, peerA, txid, 225, 1001, counting_sink);
+    EXPECT_EQ(v2.kind, dash::InjectRelayVerdict::Kind::Duplicate);
+    EXPECT_FALSE(v2.forward);
+
+    // Same tx from peer B: node-wide duplicate, no submit, no forward.
+    auto v3 = dash::ingest_peer_inject(true, node_seen, peerB, txid, 225, 1002, counting_sink);
+    EXPECT_EQ(v3.kind, dash::InjectRelayVerdict::Kind::Duplicate);
+    EXPECT_FALSE(v3.forward);
+
+    EXPECT_EQ(submit_calls, 1) << "a duplicate must NEVER re-run the (script-checking) submit gate";
+    EXPECT_EQ(st.inject_pool_size(), 1u);
+}
+
+// (M2-4) DoS: one peer sending many distinct injects inside a window is cut off
+//        at the per-peer budget; the over-budget request never reaches submit.
+TEST(DashTxInject, PeerInjectRateLimitedDoS)
+{
+    UTXOViewCache utxo(nullptr);
+    NodeCoinState st; arm_ncs(st, utxo);   // view left empty on purpose
+
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peer;
+
+    int submit_calls = 0;
+    const std::size_t cap = dash::PeerInjectGuard::kMaxInjectsPerPeerPerWindow;
+
+    // Fire `cap` distinct txids inside one window (now fixed): each is allowed
+    // through to submit (and rejected as unpriceable — irrelevant to the cap).
+    for (std::size_t i = 0; i < cap; ++i) {
+        uint256 id = prevhash(static_cast<uint8_t>(0x80 + i));
+        auto v = dash::ingest_peer_inject(true, node_seen, peer, id, 225, /*now=*/5000,
+            [&]() -> dash::InjectSubmitOutcome { ++submit_calls; return {false, "inject-unpriceable"}; });
+        EXPECT_NE(v.kind, dash::InjectRelayVerdict::Kind::RateLimited)
+            << "request " << i << " is within budget";
+    }
+    EXPECT_EQ(submit_calls, static_cast<int>(cap));
+
+    // The next distinct txid in the SAME window is refused BEFORE submit.
+    uint256 over = prevhash(static_cast<uint8_t>(0x80 + cap));
+    auto vr = dash::ingest_peer_inject(true, node_seen, peer, over, 225, /*now=*/5000,
+        [&]() -> dash::InjectSubmitOutcome { ++submit_calls; return {false, "x"}; });
+    EXPECT_EQ(vr.kind, dash::InjectRelayVerdict::Kind::RateLimited);
+    EXPECT_FALSE(vr.forward);
+    EXPECT_EQ(submit_calls, static_cast<int>(cap)) << "the rate-limited request must not reach submit";
+
+    // The window slides: the same txid a full window later is admitted through.
+    auto vlater = dash::ingest_peer_inject(true, node_seen, peer, over, 225,
+        /*now=*/5000 + dash::PeerInjectGuard::kWindowSeconds,
+        [&]() -> dash::InjectSubmitOutcome { ++submit_calls; return {false, "x"}; });
+    EXPECT_NE(vlater.kind, dash::InjectRelayVerdict::Kind::RateLimited)
+        << "after the window slides the peer recovers its budget";
+}
+
+// (M2-5) FLAG OFF: a disabled node ignores every tx_inject — no submit, no state
+//        mutation (node seen-set + peer guard untouched), no forward.
+TEST(DashTxInject, PeerInjectIgnoredWhenFlagOff)
+{
+    Key k(0xa5);
+    uint256 prev = prevhash(0x75);
+    auto tx = make_signed_spend(k, prev, 100'000);
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    NodeCoinState st; st.mempool().set_utxo(&utxo);
+    st.set_tx_inject_enabled(false);   // DISABLED
+
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peer;
+    const uint256 txid = dash_txid(tx);
+
+    int submit_calls = 0;
+    auto v = dash::ingest_peer_inject(/*enabled=*/false, node_seen, peer, txid, 225, 1000,
+        [&]() -> dash::InjectSubmitOutcome { ++submit_calls; return {true, "ok"}; });
+
+    EXPECT_EQ(v.kind, dash::InjectRelayVerdict::Kind::Disabled);
+    EXPECT_FALSE(v.forward);
+    EXPECT_EQ(submit_calls, 0) << "a disabled node must not call submit_inject";
+    EXPECT_EQ(node_seen.size(), 0u) << "no node-level state may be mutated when the flag is OFF";
+    EXPECT_FALSE(peer.peer_has_seen(txid)) << "no per-peer state may be mutated when the flag is OFF";
+    EXPECT_TRUE(peer.window.empty());
+    EXPECT_EQ(st.inject_pool_size(), 0u);
+}
+
+// (M2-6) An accepted inject is an ordinary mempool body tx: it is SELECTED into
+//        the template body (the same hashes register_template_txs would receive),
+//        so it rides that path with zero extra code. Structural proof, no NodeImpl.
+TEST(DashTxInject, InjectedTxRidesRegisterTemplateTxs)
+{
+    Key k(0xa6);
+    uint256 prev = prevhash(0x76);
+    auto tx = make_signed_spend(k, prev, 100'000);
+
+    UTXOViewCache utxo(nullptr);
+    utxo.add_coin(Outpoint(prev, 0), Coin(100'000, to_script(k.spk), 1, false));
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peer;
+    const uint256 txid = dash_txid(tx);
+
+    auto v = dash::ingest_peer_inject(true, node_seen, peer, txid, 225, 1000, make_sink(st, tx));
+    ASSERT_EQ(v.kind, dash::InjectRelayVerdict::Kind::Accepted);
+
+    // The body the template builder selects — the same {tx, fee} vector whose
+    // hashes register_template_txs(m_txs, m_tx_hashes) would carry into m_known_txs.
+    auto [selected, fees] = st.mempool().get_sorted_txs_with_fees(1u << 20, false, 2'000'000u, 0);
+    ASSERT_EQ(selected.size(), 1u);
+    EXPECT_EQ(dash_txid(selected[0].tx), txid)
+        << "the accepted inject must be in the served body (rides register_template_txs)";
+    EXPECT_EQ(fees, 0u) << "a 0-fee inject contributes 0 to total_fees — reward path unchanged";
 }


### PR DESCRIPTION
## tx-inject M2 — peer transport + fan-out (DASH, `--embedded-tx-inject`, default OFF)

Builds on the M1 runtime merged in #1499. M2 adds the `tx_inject` sharechain-p2p
message subtype and routes a peer's transaction through the **SAME**
`NodeCoinState::submit_inject` gate as the local `--embedded-tx-inject-hex`
loader — every M1 validity check (type-0, vin/vout, DoS caps, script-armed,
BIP68 fail-closed, MoneyRange, dedup, already-confirmed). There is **no new
`add_tx` seam**. An accepted inject is an ordinary mempool body tx, so it rides
`register_template_txs` with zero extra code.

### What lands
- **`tx_inject` subtype** (`src/impl/dash/messages.hpp`): `version / flags /
  expiry_height / tx`, appended to `Handler`. Command `"tx_inject"` (9 ≤ 12 chars).
- **`ADD_HANDLER(tx_inject)`** in both `Legacy` and `Actual` dispatch tables
  (`src/impl/dash/node.hpp`); handler bodies in `protocol_actual.cpp` /
  `protocol_legacy.cpp` delegate to one shared `NodeImpl::handle_peer_tx_inject`.
- **Relay policy** (`src/impl/dash/tx_inject_relay.hpp`, new, pure header):
  flag short-circuit, per-peer sliding-window rate cap (30/min) + per-peer txid
  dedup, node-level decided-txid set (accept **and** reject remembered so a
  re-send is never re-validated), and **first-see fan-out** (a first-see ACCEPT
  only). `submit_fn` is invoked at most once per genuinely-new txid.
- **Per-peer DoS guard** on `dash::Peer` (`m_inject_guard`).
- **Submit sink seam**: `set_tx_inject_sink` on `NodeImpl`, wired in
  `main_dash.cpp` next to the arm to the **armed** `node_coin_state`
  (not `NodeImpl::m_coin_state`, which main_dash never arms). Flag OFF ⇒ null
  sink ⇒ every `tx_inject` ignored, nothing forwarded.
- **Fan-out** (`relay_tx_inject`): forwards the frame verbatim to every peer
  except the sender.
- **`tx_inject` stats bucket** before `unknown` (`p2p_message_stats.hpp`).

### Wire-compatibility
An old peer that lacks the handler treats an inbound `tx_inject` as an unknown
command: `MessageHandler::parse` throws `std::out_of_range`, which
`handle_message` catches as `std::exception` → **`LOG_WARNING`, not a
disconnect**. KAT-pinned.

### Reward-safety (transport only)
No `coinbase` / `subsidy` / PPLNS / `payee` / `m_payment_amount` / won-block
state is read or written by any new file. The `§11` grep over the new sources is
empty. A 0-fee inject contributes 0 to `total_fees` (M1 property, re-asserted in
the template-ride KAT).

### KATs — RED-on-master (compile-fail: `tx_inject_relay.hpp` + all M2 symbols
absent) / GREEN-after
- `test_dash_tx_inject` (in `test_dash_mempool`): peer **accept**+forward,
  **reject-by-name** (`inject-unpriceable`) not forwarded, **duplicate** (per-peer
  + node-wide, submit called exactly once), **rate-limit** DoS, **flag-OFF**
  ignore (no state mutated), **template-ride**. 18/18 pass.
- `test_dash_poolnode_messages`: `tx_inject` wire round-trip, **old-peer
  unknown-command is a warning not a disconnect**. 24/24 pass.
- `test_dash_node`: 13-handler dispatch surface (`Legacy` + `Actual`). 3/3 pass.
- `core_test`: `P2PMessageStats` maps `tx_inject`. 5/5 pass.

Built on workstation-191 (`cmake` Release + conan toolchain, `-j8`):
`test_dash_mempool`, `test_dash_poolnode_messages`, `test_dash_node`,
`core_test`, and **`c2pool-dash`** (main binary, sink wiring) all compile clean;
all listed tests green. RED proven on a clean `origin/master` checkout with the
KAT files overlaid (fatal: `tx_inject_relay.hpp: No such file`). Param-catalog +
test-target drift-guard pass.

### Explicitly NOT in this PR (staged)
HTTP submit endpoint, full `SequenceLocks` (BIP68 stays fail-closed at
`add_inject`), isolated sandboxed signer, `submitter_hint`, capability
advertisement, misbehaviour scoring, block-connect wiring of
`reconcile_inject_pool` (the lazy reconcile inside `submit_inject` suffices for
M2).
