### PR TITLE
v37 XMR lane W3 — stratum + coinbase-settlement (FCMP-fenced) + carrier wire

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,7 @@ jobs:
                     dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_share_target_retarget_test dgb_share_bits_oracle_pin_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test dgb_think_p1_desired_emit_test dgb_think_p6_desired_cutoff_test dgb_think_p4_head_keys_test dgb_think_p3_best_head_test dgb_g1_oracle_byte_parity_test dgb_think_p2_walk_bounds_test dgb_expected_time_to_block_test dgb_tail_score_endpoints_test dgb_pool_attempts_per_second_test dgb_pool_efficiency_test dgb_think_p5_best_share_punish_test dgb_auto_ratchet_tail_guard_test dgb_auto_ratchet_sim_test dgb_binomial_conf_interval_test dgb_desired_version_tally_test dgb_min_protocol_ratchet_test dgb_get_height_and_last_endpoints_test dgb_chain_walk_window_test dgb_redistribute_delegate_ghal_test dgb_share_weight_decay_test dgb_naughty_propagation_test dgb_hash_format_parity_test dgb_emergency_decay_saturation_test dgb_arith256_muldiv_kat_test dgb_share_tx_relay_refs_test dgb_coin_peer_rearm_test v37_test v37_executor_test v37_scaffold_test v37_w2_ingestion_test v37_w4_prereq_test v37_w4_settlement_test v37_w5_coinbase_test v37_w3_relay_test \
                     v37_descriptor_xmr_test \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
-                    xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat \
+                    xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat \
             -j8 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -620,7 +620,7 @@ jobs:
                     v37_test v37_executor_test v37_scaffold_test v37_w2_ingestion_test v37_w4_prereq_test v37_w4_settlement_test v37_w5_coinbase_test v37_w3_relay_test \
                     v37_descriptor_xmr_test \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
-                    xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat \
+                    xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison

--- a/src/impl/xmr/coin/xmr_derivation.cpp
+++ b/src/impl/xmr/coin/xmr_derivation.cpp
@@ -33,9 +33,10 @@
 //   Upstream : monero-project/monero  src/crypto/crypto.cpp
 //   Commit   : 3d3920d7487b5df7ac388b6b8577fd04d505885f (master, fetched 2026-09-05)
 //   License  : BSD-3-Clause (header above preserved verbatim from upstream)
-//   Subset   : the function BODIES of hash_to_scalar, generate_key_derivation,
-//              derivation_to_scalar, derive_public_key and derive_view_tag are
-//              reproduced VERBATIM from crypto_ops:: in the upstream file.
+//   Subset   : the function BODIES of hash_to_scalar, secret_key_to_public_key,
+//              generate_key_derivation, derivation_to_scalar, derive_public_key
+//              and derive_view_tag are reproduced VERBATIM from crypto_ops:: in
+//              the upstream file.
 //   Adapted  : (a) wrapped in namespace xmr::coin instead of crypto::;
 //              (b) upstream crypto:: POD types (public_key/secret_key/
 //                  key_derivation/ec_scalar/view_tag) replaced by the
@@ -67,6 +68,17 @@ namespace xmr::coin {
 void hash_to_scalar(const void *data, std::size_t length, EcScalar &res) {
   cn_fast_hash(data, length, reinterpret_cast<char *>(res.data()));
   sc_reduce32(res.data());
+}
+
+// --- crypto.cpp: crypto_ops::secret_key_to_public_key ----------------------
+bool secret_key_to_public_key(const SecretKey &sec, PublicKey &pub) {
+  ge_p3 point;
+  if (sc_check(sec.data()) != 0) {
+    return false;
+  }
+  ge_scalarmult_base(&point, sec.data());
+  ge_p3_tobytes(pub.data(), &point);
+  return true;
 }
 
 // --- crypto.cpp: crypto_ops::generate_key_derivation -----------------------

--- a/src/impl/xmr/coin/xmr_derivation.hpp
+++ b/src/impl/xmr/coin/xmr_derivation.hpp
@@ -52,4 +52,9 @@ void derive_view_tag(const KeyDerivation& D, std::size_t output_index, ViewTag& 
 // (scoping S16, "tx_secret_key" domain) also needs it. (crypto.cpp: hash_to_scalar)
 void hash_to_scalar(const void* data, std::size_t length, EcScalar& s);
 
+// R = sec * G. The tx public key R = r*G the settlement executor (W5) publishes
+// in tx_extra 0x01; `sec` must be a reduced scalar (sc_check). Returns false if
+// `sec` is not canonical. (crypto.cpp: crypto_ops::secret_key_to_public_key)
+bool secret_key_to_public_key(const SecretKey& sec, PublicKey& pub);
+
 } // namespace xmr::coin

--- a/src/impl/xmr/settle/xmr_coinbase.hpp
+++ b/src/impl/xmr/settle/xmr_coinbase.hpp
@@ -84,20 +84,11 @@
 // --- PayoutDescriptor canon + the XMR kind extension (descriptor-kinds leg) --
 #include "sharechain/v37/v37_descriptor_xmr.hpp" // v37::xmr::XMR_STD/XMR_SUB, fences
 
-// ---------------------------------------------------------------------------
-// Coin-layer surface REQUIRED by W5 but not yet declared in xmr_derivation.hpp.
-// r*G (the tx pubkey R). Trivially ge_scalarmult_base(&P, r) + ge_p3_tobytes over
-// the vendored ref10 (monero-project crypto-ops, BSD-3) already used inside
-// xmr_derivation.cpp::derive_public_key. Forward-declared here in the coin
-// namespace as the contract W5 depends on; the primitives leg should add the
-// one-line definition to xmr_derivation.{hpp,cpp} (cross-leg interface item,
-// see notes / open questions). Returns false iff `sec` is not a reduced scalar.
-// ---------------------------------------------------------------------------
-namespace xmr {
-namespace coin {
-bool secret_key_to_public_key(const SecretKey& sec, PublicKey& pub);
-} // namespace coin
-} // namespace xmr
+// The coin-layer surface W5 depends on is declared in the leg headers included
+// above: r*G (the tx pubkey R = r*G) is xmr::coin::secret_key_to_public_key in
+// xmr_derivation.hpp; ECDH derivation (generate_key_derivation / derive_public_
+// key / derive_view_tag / hash_to_scalar) is the rest of that header; the blob
+// serializer + consensus hashes are in xmr_blob.hpp.
 
 namespace v37 {
 namespace xmr {

--- a/src/impl/xmr/stratum/xmr_stratum_selftest.cpp
+++ b/src/impl/xmr/stratum/xmr_stratum_selftest.cpp
@@ -322,12 +322,242 @@ static void test_submit_flow() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// KAT: CryptoNote login round-trip against the SERVER (not a hand-built job).
+// Asserts the login OK the server emits carries the template's own seed_hash,
+// height and the correctly-encoded lane target — i.e. the job the miner will
+// hash is byte-consistent with the template source. (CryptoNote has no
+// separate subscribe/authorize; "login" is the single handshake that both
+// authenticates and delivers the first job — the round-trip is login -> job.)
+// ---------------------------------------------------------------------------
+static void test_login_roundtrip() {
+    FakeTemplateSource ts; FakeVerifier vf; FakeSink sk; FakeTransport tx;
+    XmrStratumServer srv(ts, vf, sk, tx);
+    XmrStratumSession s(1);
+
+    ts.seed_hash.fill(0xAA);
+    ts.lane_target = 0x00000000FFFFFFFFULL;          // full-8-byte encoding regime
+
+    CHECK(srv.handle_login(s, 7, "48addr.rig"), "roundtrip login true");
+    const std::string& lo = tx.last();
+    CHECK(contains(lo, "\"id\":7,"), "roundtrip req id echoed");
+    CHECK(contains(lo, "\"job_id\":\"00000001\""), "roundtrip first job_id=1");
+    CHECK(contains(lo, "\"height\":3000000"), "roundtrip height from template");
+    // seed_hash serialized big-endian as the template gave it
+    CHECK(contains(lo, "\"seed_hash\":\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\""),
+          "roundtrip seed_hash full 32B");
+    CHECK(contains(lo, "\"next_seed_hash\":\"bbbbbbbb"), "roundtrip next_seed_hash");
+    // lane target 0x00000000FFFFFFFF -> full 8 LE bytes "ffffffff00000000"
+    CHECK(contains(lo, "\"target\":\"ffffffff00000000\""), "roundtrip lane target");
+    CHECK(contains(lo, "\"algo\":\"rx/0\""), "roundtrip algo rx/0");
+    CHECK(s.rpc_id() != 0, "roundtrip rpc id assigned");
+}
+
+// ---------------------------------------------------------------------------
+// KAT: extra_nonce uniqueness. The per-server counter must hand every login a
+// distinct extra_nonce (p2pool StratumServer::m_extraNonce). We drive N logins
+// and require N distinct values, monotonically increasing, that the template
+// source actually received (proves the value is threaded into get_job()).
+// ---------------------------------------------------------------------------
+static void test_extra_nonce_uniqueness() {
+    FakeTemplateSource ts; FakeVerifier vf; FakeSink sk; FakeTransport tx;
+    XmrStratumServer srv(ts, vf, sk, tx);
+
+    const int N = 256;
+    std::vector<std::uint32_t> seen;
+    seen.reserve(N);
+    std::uint32_t prev = 0;
+    bool monotone = true, distinct = true;
+    for (int i = 0; i < N; ++i) {
+        XmrStratumSession s(static_cast<std::uint64_t>(100 + i));
+        CHECK(srv.handle_login(s, 1, "48addr"), "uniq login true");
+        const std::uint32_t en = ts.last_extra_nonce;   // value the template saw
+        if (i > 0 && en <= prev) monotone = false;
+        for (std::uint32_t v : seen) if (v == en) { distinct = false; break; }
+        seen.push_back(en);
+        prev = en;
+    }
+    CHECK(seen.size() == static_cast<std::size_t>(N), "uniq drove N logins");
+    CHECK(distinct, "uniq extra_nonces all distinct");
+    CHECK(monotone, "uniq extra_nonces strictly increasing");
+    // fetch_add starts at 0: first login gets 0, so the last saw N-1.
+    CHECK(seen.front() == 0u, "uniq first extra_nonce == 0");
+    CHECK(seen.back() == static_cast<std::uint32_t>(N - 1), "uniq last extra_nonce == N-1");
+}
+
+// ---------------------------------------------------------------------------
+// KAT: job-ring eviction. Each session keeps only the last JOBS_RING(=4) jobs
+// (p2pool StratumClient::m_jobs). Issue 5 jobs; the 1st must age out and every
+// later one stay resolvable — both at the SavedJob layer and end-to-end (a
+// submit naming the evicted job id is rejected "Invalid job id").
+// ---------------------------------------------------------------------------
+static void test_job_ring_eviction() {
+    // (a) direct SavedJob layer
+    {
+        XmrStratumSession s(1);
+        std::uint32_t ids[5];
+        for (int i = 0; i < 5; ++i)
+            ids[i] = s.remember_job(/*extra_nonce=*/static_cast<std::uint32_t>(i),
+                                    /*template_id=*/7, /*target=*/0x100 + i);
+        CHECK(ids[0] == 1 && ids[4] == 5, "ring job ids 1..5");
+        XmrStratumSession::SavedJob out;
+        CHECK(!s.find_job(ids[0], out), "ring job 1 evicted");   // slot 1%4 reused by job 5
+        for (int i = 1; i < 5; ++i)
+            CHECK(s.find_job(ids[i], out), "ring job survives");
+        // the surviving newest job carries its own bookkeeping intact
+        CHECK(s.find_job(ids[4], out) && out.extra_nonce == 4 && out.target == 0x104,
+              "ring newest job bookkeeping");
+        CHECK(!s.find_job(0, out), "ring job id 0 never resolves");
+    }
+    // (b) end-to-end: submit against an evicted job id -> Invalid job id
+    {
+        FakeTemplateSource ts; FakeVerifier vf; FakeSink sk; FakeTransport tx;
+        XmrStratumServer srv(ts, vf, sk, tx);
+        XmrStratumSession s(1);
+        srv.handle_login(s, 1, "48addr");            // issues job 1
+        for (int i = 0; i < 4; ++i) srv.broadcast_job(s);  // issues jobs 2..5, evicts 1
+        SubmitFields f; f.rpc_id = "0"; f.job_id = "00000001"; // the evicted job
+        f.nonce = "01000000"; f.result.assign(64, '0');
+        tx.clear();
+        srv.handle_submit(s, 2, f);
+        CHECK(contains(tx.last(), "Invalid job id"), "ring evicted submit rejected");
+        CHECK(sk.accepted == 0, "ring evicted submit not accepted");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A DETERMINISTIC known-answer stand-in for RandomX (no engine, host is
+// OOM-pressured / RandomX is CI-gated). The "PoW" of a blob is a fixed,
+// reproducible function of the 4 header-nonce bytes the server inserts at
+// nonce_offset: top LE word of the hash := (nonce_le * A + C). Because the
+// stub reads the nonce back OUT of the blob, an accepted submit proves the
+// whole chain end-to-end: parse -> rebuild blob -> insert nonce @ offset ->
+// recompute -> target check. The client-supplied `result` is never consulted.
+// ---------------------------------------------------------------------------
+struct KeyedPowStub : IPowVerifier {
+    std::size_t nonce_offset = EXPECTED_NONCE_OFFSET_V16;
+    static constexpr std::uint64_t A = 0x9E3779B97F4A7C15ULL; // fixed multiplier
+    static constexpr std::uint64_t C = 0x0000000000000007ULL; // fixed addend
+    // The known answer, computed the same way the stub does, for a given nonce.
+    static std::uint64_t answer_top_word(std::uint32_t nonce_le) {
+        return static_cast<std::uint64_t>(nonce_le) * A + C;
+    }
+    bool randomx_hash(const std::uint8_t* blob, std::size_t n, std::uint64_t,
+                      const std::array<std::uint8_t, HASH_SIZE>&,
+                      std::array<std::uint8_t, HASH_SIZE>& out, bool) override {
+        if (nonce_offset + NONCE_SIZE > n) return false;
+        std::uint32_t nonce_le = 0;
+        for (int i = 0; i < static_cast<int>(NONCE_SIZE); ++i)
+            nonce_le |= static_cast<std::uint32_t>(blob[nonce_offset + i]) << (8 * i);
+        const std::uint64_t top = answer_top_word(nonce_le);
+        out.fill(0);
+        for (int i = 0; i < 8; ++i)
+            out[HASH_SIZE - 8 + i] = static_cast<std::uint8_t>(top >> (8 * i));
+        return true;
+    }
+    bool meets_target(const std::array<std::uint8_t, HASH_SIZE>& h,
+                      std::uint64_t target) const override {
+        std::uint64_t top = 0;
+        for (int i = 0; i < 8; ++i)
+            top |= static_cast<std::uint64_t>(h[HASH_SIZE - 8 + i]) << (8 * i);
+        return top <= target;
+    }
+};
+
+// Submit a specific nonce and return the transport reply line.
+static std::string submit_nonce(XmrStratumServer& srv, XmrStratumSession& s,
+                                FakeTransport& tx, std::uint32_t nonce_le,
+                                const char* result_hex64) {
+    SubmitFields f;
+    f.rpc_id = "00000000";
+    f.job_id = "00000001";
+    std::uint8_t nb[4] = { static_cast<std::uint8_t>(nonce_le),
+                           static_cast<std::uint8_t>(nonce_le >> 8),
+                           static_cast<std::uint8_t>(nonce_le >> 16),
+                           static_cast<std::uint8_t>(nonce_le >> 24) };
+    f.nonce = StratumDialect::to_hex(nb, 4);
+    f.result.assign(result_hex64);
+    tx.clear();
+    srv.handle_submit(s, 2, f);
+    return tx.last();
+}
+
+// ---------------------------------------------------------------------------
+// KAT: known-good vs known-bad nonce against the deterministic PoW oracle.
+// lane_target is chosen so that exactly one of two hand-computed nonces clears
+// it. The accept/reject verdict is therefore a genuine known-answer test of
+// the recompute+target path, not a preset flag.
+// ---------------------------------------------------------------------------
+static void test_known_answer_nonce() {
+    FakeTemplateSource ts; KeyedPowStub pow; FakeSink sk; FakeTransport tx;
+    // No network block in this KAT: make the mainchain target unreachable so we
+    // isolate the lane accept/reject decision.
+    ts.mainchain_target = 0;                       // disables the network-block branch
+    // Pick a lane target between two known answers.
+    const std::uint32_t GOOD = 0x00000002u;        // answer = 2*A + C  (small-ish)
+    const std::uint32_t BAD  = 0xF0000000u;        // answer = huge
+    const std::uint64_t good_ans = KeyedPowStub::answer_top_word(GOOD);
+    const std::uint64_t bad_ans  = KeyedPowStub::answer_top_word(BAD);
+    CHECK(good_ans < bad_ans, "KAT good answer < bad answer");
+    ts.lane_target = good_ans;                     // GOOD meets (==), BAD does not
+
+    XmrStratumServer srv(ts, pow, sk, tx);
+    XmrStratumSession s(1);
+    CHECK(srv.handle_login(s, 1, "48addr.rig"), "KAT login");
+
+    // Known-GOOD nonce: recomputed top word == lane target -> accepted.
+    // The `result` field is deliberate garbage to prove it is never trusted.
+    std::string rg = submit_nonce(srv, s, tx, GOOD, std::string(64, 'f').c_str());
+    CHECK(contains(rg, "\"status\":\"OK\""), "KAT good nonce accepted");
+    CHECK(sk.accepted == 1, "KAT good nonce reached sink");
+    CHECK(sk.last.nonce == GOOD, "KAT accepted share carries the good nonce");
+    CHECK(!sk.last.is_network_block, "KAT good nonce not a network block");
+
+    // Known-BAD nonce (same job still in ring): recomputed word > target -> Low diff.
+    std::string rb = submit_nonce(srv, s, tx, BAD, std::string(64, '0').c_str());
+    CHECK(contains(rb, "Low diff share"), "KAT bad nonce rejected low-diff");
+    CHECK(sk.accepted == 1, "KAT bad nonce did NOT reach sink");
+
+    // Boundary: a nonce one unit 'harder' than GOOD (answer = target - A + ... )
+    // Confirm the comparison is inclusive (<=) by re-submitting GOOD: still OK.
+    std::string rg2 = submit_nonce(srv, s, tx, GOOD, std::string(64, 'a').c_str());
+    CHECK(contains(rg2, "\"status\":\"OK\""), "KAT good nonce inclusive re-accept");
+}
+
+// ---------------------------------------------------------------------------
+// KAT: a share that ALSO clears the Monero mainchain target drives a real
+// block submission AND is still handed to the v37 receipt sink (the XMR-lane
+// divergence: accepted share -> work-receipt, plus submit_network_block).
+// Uses the deterministic oracle so the network-block verdict is a known answer.
+// ---------------------------------------------------------------------------
+static void test_known_answer_network_block() {
+    FakeTemplateSource ts; KeyedPowStub pow; FakeSink sk; FakeTransport tx;
+    const std::uint32_t WIN = 0x00000001u;
+    const std::uint64_t ans = KeyedPowStub::answer_top_word(WIN);
+    ts.mainchain_target = ans;                     // WIN clears the network target
+    ts.lane_target = ans;                          // and the lane target
+    XmrStratumServer srv(ts, pow, sk, tx);
+    XmrStratumSession s(1);
+    CHECK(srv.handle_login(s, 1, "48addr"), "KAT-net login");
+    std::string r = submit_nonce(srv, s, tx, WIN, std::string(64, '0').c_str());
+    CHECK(contains(r, "\"status\":\"OK\""), "KAT-net status OK");
+    CHECK(sk.network_submits == 1, "KAT-net submit_network_block called once");
+    CHECK(sk.accepted == 1 && sk.last.is_network_block, "KAT-net receipt + flag");
+    CHECK(sk.last.height == ts.height, "KAT-net share carries template height");
+}
+
 int main() {
     test_hex_and_target();
     test_login_string();
     test_submit_parse();
     test_response_goldens();
     test_submit_flow();
+    test_login_roundtrip();
+    test_extra_nonce_uniqueness();
+    test_job_ring_eviction();
+    test_known_answer_nonce();
+    test_known_answer_network_block();
     std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
     return g_fail == 0 ? 0 : 1;
 }

--- a/src/impl/xmr/test/CMakeLists.txt
+++ b/src/impl/xmr/test/CMakeLists.txt
@@ -103,6 +103,28 @@ if (BUILD_TESTING)
     target_compile_features(xmr_provenance_gate PRIVATE cxx_std_20)
     add_test(NAME xmr_provenance_gate COMMAND xmr_provenance_gate)
 
+    # 6b) X6 (W5) coinbase-settlement KAT. Finalizes the OWED -> miner_tx
+    #     executor (../settle/xmr_coinbase.cpp): deterministic-r reproducibility
+    #     (same inputs -> same R and same P_i set; changed lane_commitment /
+    #     prev_id / height -> a fresh r), R = r*G anchored to an OFFICIAL monero
+    #     generate_keys vector, a stealth one-time key against monero-project
+    #     tests/crypto/tests.txt (generate_key_derivation + derive_public_key)
+    #     plus a coinbase-path reproduction of every P_i, exact-sum (Sum(vout) ==
+    #     base_reward+fees to the piconero incl. residual sink -- HF13, no burn),
+    #     the weight-aware output cap, and the CARROT/FCMP++ fence trip
+    #     (major_version 17 -> CarrotFence, no coinbase). Compiles the settle TU
+    #     and links xmr_coin for the REAL vendored ed25519 (ge_*) + keccak; the
+    #     src/ root resolves the "impl/xmr/..." and read-only "sharechain/v37/..."
+    #     (v37_descriptor_xmr.hpp value-consumer) includes. NO RandomX, monerod,
+    #     libsodium or boost -- runs in the ordinary lane.
+    add_executable(xmr_coinbase_kat
+        xmr_coinbase_kat.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../settle/xmr_coinbase.cpp)
+    target_link_libraries(xmr_coinbase_kat PRIVATE xmr_coin)
+    target_include_directories(xmr_coinbase_kat PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_compile_features(xmr_coinbase_kat PRIVATE cxx_std_20)
+    add_test(NAME xmr_coinbase_kat COMMAND xmr_coinbase_kat)
+
     # =========================================================================
     # X1 Known-Answer Tests (NEW) — link the xmr_coin library.
     # =========================================================================

--- a/src/impl/xmr/test/xmr_coinbase_kat.cpp
+++ b/src/impl/xmr/test/xmr_coinbase_kat.cpp
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/test/xmr_coinbase_kat.cpp  --  X6 KAT: OWED -> miner_tx executor
+//                                             (Family B: Monero / RandomX lane)
+//
+// Known-Answer Tests for the W5-XMR coinbase settlement executor
+// (../settle/xmr_coinbase.{hpp,cpp}). This is the consensus-adjacent leg: it
+// turns a finality-gated OWED ledger for one Monero parent into the canonical
+// miner_tx every v37 node re-derives byte-for-byte. A wrong derivation pays the
+// wrong wallet; a wrong sum is an HF13 CONSENSUS FAILURE (Bitcoin's burn-the-
+// remainder is invalid on Monero). So each property below is consensus-critical
+// and pinned here against REAL Monero crypto (the ../coin xmr_coin library:
+// vendored ed25519 ge_*, keccak) and OFFICIAL monero-project vectors.
+//
+// Cases (each reported PASS/FAIL, nonzero exit on any failure):
+//   1. deterministic-r reproducibility  -- same inputs => same r, same R, same
+//      P_i set; a changed lane_commitment or prev_id => a different r (so a
+//      different owed set / Monero parent forces a fresh coinbase, p2pool style).
+//   2. R = r*G                          -- build.R == secret_key_to_public_key(r),
+//      AND secret_key_to_public_key anchored to an OFFICIAL monero generate_keys
+//      (sec,pub) vector.
+//   3. stealth key vs known Monero vector -- generate_key_derivation and
+//      derive_public_key byte-match monero-project tests/crypto/tests.txt, and
+//      the coinbase's per-vout one-time keys reproduce independently by the same
+//      ECDH recipe P_i = derive_public_key(8 r A, i, B).
+//   4. exact-sum, no burn               -- Sum(vout) == base_reward + fees to the
+//      piconero across surplus/deficit/fixed shapes, residual sink included.
+//   5. weight-aware output cap          -- wire cap binds; penalty headroom binds;
+//      floor of 1 (always room for the sink).
+//   6. CARROT fence                     -- major_version 17 => CarrotFence error,
+//      NO coinbase built, and derive_tx_secret_key refuses; 16 builds.
+//
+// VECTOR PROVENANCE: the input->output crypto vectors are the OFFICIAL Monero
+// consensus test vectors from monero-project tests/crypto/tests.txt
+// (generate_key_derivation / derive_public_key / generate_keys). Each is cited
+// inline. No third-party code is copied into this file.
+// ---------------------------------------------------------------------------
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+// Executor under test (settle leg) + its coin-layer + descriptor consumers.
+#include "impl/xmr/settle/xmr_coinbase.hpp"
+#include "impl/xmr/coin/xmr_derivation.hpp"   // generate_key_derivation / derive_* / r*G
+
+using namespace v37::xmr::settle;
+
+namespace {
+
+int g_fail = 0;
+#define CHECK(cond, ...) do { \
+    bool _ok = (cond); \
+    std::printf("  [%s] ", _ok ? "PASS" : "FAIL"); \
+    std::printf(__VA_ARGS__); std::printf("\n"); \
+    if (!_ok) ++g_fail; \
+} while (0)
+
+std::vector<unsigned char> unhex(const std::string& h) {
+    std::vector<unsigned char> o; o.reserve(h.size() / 2);
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    for (std::size_t i = 0; i + 1 < h.size(); i += 2)
+        o.push_back(static_cast<unsigned char>((nib(h[i]) << 4) | nib(h[i + 1])));
+    return o;
+}
+std::string hex(const unsigned char* b, std::size_t n) {
+    static const char* d = "0123456789abcdef";
+    std::string s; s.reserve(n * 2);
+    for (std::size_t i = 0; i < n; ++i) { s.push_back(d[b[i] >> 4]); s.push_back(d[b[i] & 0xf]); }
+    return s;
+}
+template <class T> T key_from_hex(const std::string& h) {
+    T t{}; auto v = unhex(h);
+    std::memcpy(t.data(), v.data(), v.size() < 32 ? v.size() : 32);
+    return t;
+}
+template <class T> std::string hx(const T& t) { return hex(t.data(), 32); }
+
+// ---- OFFICIAL monero-project tests/crypto/tests.txt vectors ---------------
+// generate_key_derivation <pub A> <sec r> true <derivation D>   (D = 8*r*A)
+const char* kA_hex = "fdfd97d2ea9f1c25df773ff2c973d885653a3ee643157eb0ae2b6dd98f0b6984";
+const char* kr_hex = "eb2bd1cf0c5e074f9dbf38ebbc99c316f54e21803048c687a3bb359f7a713b02";
+const char* kD_hex = "4e0bd2c41325a1b89a9f7413d4d05e0a5a4936f241dccc3c7d0c539ffe00ef67";
+// derive_public_key <derivation D> <output_index i> <base B> true <derived P>
+const char* kDPK_D_hex = "ca780b065e48091d910de90bcab2411db3d1a845e6d95cfd556af4138504c737";
+const std::uint64_t kDPK_i = 217407;
+const char* kDPK_B_hex = "6d9dd2068b9d6d643b407e360dfc5eb7a1f628fe2de8112a9e5731e8b3680c39";
+const char* kDPK_P_hex = "d48008aff5f27d8fcdc2a3bf814ed3505530f598075f3bf7e868fea696b109f6";
+// generate_keys <pub> <sec>   (pub = sec*G): anchors secret_key_to_public_key.
+const char* kGK_pub_hex = "0cf20fe6862d94989e57543c21cd35c9d834364db7701b8d55f63137b1abac35";
+const char* kGK_sec_hex = "8639002c6f8b39c3430786b91f12ad1527cbd3a39ea07c4e730707e777655004";
+
+// Two REAL Monero public keys, reused as the (spend B, view A) of every payout
+// target so the executor's ECDH derivation runs against on-curve points. B is
+// the tests.txt derive_public_key `base`; A is its generate_key_derivation
+// `pub` -- both are canonical ed25519 points (they appear as valid inputs in
+// the official vectors), which is all derive_output needs.
+::xmr::coin::PublicKey g_B;   // spend
+::xmr::coin::PublicKey g_A;   // view
+
+// Build an XMR_STD payout ref (B || A) with a distinct identity byte.
+::v37::ScriptRef xmr_ref(unsigned char id_seed) {
+    ::v37::ScriptRef r;
+    r.kind = ::v37::xmr::XMR_STD;
+    r.payload.resize(64);
+    std::memcpy(r.payload.data(),      g_B.data(), 32);
+    std::memcpy(r.payload.data() + 32, g_A.data(), 32);
+    // identity byte only tweaks the K_fair tiebreak / provenance, not the point.
+    (void)id_seed;
+    return r;
+}
+::v37::bytes32 id_of(unsigned char seed) {
+    ::v37::bytes32 b{};
+    for (int i = 0; i < 32; ++i) b[i] = static_cast<unsigned char>(seed + i);
+    return b;
+}
+std::uint64_t sum_amounts(const std::vector<CoinbaseOutput>& v) {
+    std::uint64_t s = 0; for (auto& o : v) s += o.amount; return s;
+}
+
+CoinbaseInputs base_inputs() {
+    CoinbaseInputs in;
+    in.monero_major_version = 16;                 // pre-CARROT
+    in.height = 3000000;
+    in.prev_id = key_from_hex<::xmr::coin::Hash256>(
+        "b6d9b2c9a4d0d0e1f2a3b4c5d6e7f80912233445566778899aabbccddeeff001");
+    in.base_reward = 600000000000ull;             // 0.6 XMR tail (piconero)
+    in.fees = 12345678ull;
+    in.chain_id = 0x0000ABCD;
+    in.lane_commitment = id_of(0x11);             // owed_digest stand-in
+    in.residual_sink = xmr_ref(0x99);
+    in.residual_sink_identity = id_of(0x99);
+    in.h_min = 0;
+    in.output_cap = 2700;
+    in.extra_nonce = {0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0}; // 14-B padded nonce
+    return in;
+}
+
+// The independent ECDH recomputation of a single coinbase output key + view tag
+// (the "every node re-derives" side of the ACCEPT check), done here straight
+// from the primitives so it cannot share a bug with derive_output().
+bool recompute_output(const ::xmr::coin::SecretKey& r, std::size_t i,
+                      ::xmr::coin::PublicKey& P, ::xmr::coin::ViewTag& vt) {
+    ::xmr::coin::KeyDerivation D{};
+    if (!::xmr::coin::generate_key_derivation(g_A, r, D)) return false; // D = 8 r A
+    if (!::xmr::coin::derive_public_key(D, i, g_B, P)) return false;    // P = H_s(D||i)G + B
+    ::xmr::coin::derive_view_tag(D, i, vt);
+    return true;
+}
+
+} // namespace
+
+int main() {
+    std::printf("=== xmr_coinbase_kat (X6: OWED -> canonical miner_tx) ===\n");
+
+    g_A = key_from_hex<::xmr::coin::PublicKey>(kDPK_B_hex); // reuse two real points
+    g_B = key_from_hex<::xmr::coin::PublicKey>(kA_hex);
+    // (any two canonical points work; label-agnostic -- both are on-curve.)
+
+    // -----------------------------------------------------------------------
+    // Case 1: deterministic-r reproducibility.
+    // -----------------------------------------------------------------------
+    std::printf("== 1. deterministic-r reproducibility ==\n");
+    {
+        CoinbaseInputs in = base_inputs();
+        in.owed = { {xmr_ref(1), 200000000000ull, 1, id_of(1)},
+                    {xmr_ref(2), 150000000000ull, 2, id_of(2)} };
+        BuiltCoinbase b1 = build_coinbase(in);
+        BuiltCoinbase b2 = build_coinbase(in);
+        CHECK(b1.ok && b2.ok, "both builds ok");
+        CHECK(b1.r == b2.r, "same inputs -> same tx secret r (%s)", hx(b1.r).c_str());
+        CHECK(b1.R == b2.R, "same inputs -> same tx pubkey R (%s)", hx(b1.R).c_str());
+        bool same_set = (b1.outputs.size() == b2.outputs.size());
+        for (std::size_t i = 0; same_set && i < b1.outputs.size(); ++i)
+            same_set = (b1.outputs[i].one_time_key == b2.outputs[i].one_time_key) &&
+                       (b1.outputs[i].amount == b2.outputs[i].amount) &&
+                       (b1.outputs[i].view_tag.tag == b2.outputs[i].view_tag.tag);
+        CHECK(same_set, "same inputs -> identical P_i / amount / view_tag set");
+        CHECK(b1.prefix == b2.prefix, "same inputs -> byte-identical tx prefix");
+
+        // sensitivity: a different owed_digest (lane_commitment) must move r.
+        CoinbaseInputs in2 = in; in2.lane_commitment = id_of(0x22);
+        BuiltCoinbase b3 = build_coinbase(in2);
+        CHECK(b3.ok && b3.r != b1.r, "changed lane_commitment -> different r");
+        // sensitivity: a different Monero parent (prev_id) must move r.
+        CoinbaseInputs in3 = in; in3.prev_id.data()[0] ^= 0xff;
+        BuiltCoinbase b4 = build_coinbase(in3);
+        CHECK(b4.ok && b4.r != b1.r, "changed prev_id -> different r");
+        // sensitivity: a different height must move r.
+        CoinbaseInputs in4 = in; in4.height = in.height + 1;
+        BuiltCoinbase b5 = build_coinbase(in4);
+        CHECK(b5.ok && b5.r != b1.r, "changed height -> different r");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 2: R = r*G (and secret_key_to_public_key anchored to a real vector).
+    // -----------------------------------------------------------------------
+    std::printf("== 2. R = r*G ==\n");
+    {
+        // Anchor secret_key_to_public_key to the OFFICIAL generate_keys vector.
+        ::xmr::coin::SecretKey sec = key_from_hex<::xmr::coin::SecretKey>(kGK_sec_hex);
+        ::xmr::coin::PublicKey pub{};
+        bool ok = ::xmr::coin::secret_key_to_public_key(sec, pub);
+        CHECK(ok && hx(pub) == std::string(kGK_pub_hex),
+              "secret_key_to_public_key(sec) == pub (monero generate_keys vector) -> %s",
+              hx(pub).c_str());
+
+        // The executor's R is exactly r*G for its deterministic r.
+        CoinbaseInputs in = base_inputs();
+        in.owed = { {xmr_ref(1), 100000000000ull, 1, id_of(1)} };
+        BuiltCoinbase b = build_coinbase(in);
+        CHECK(b.ok, "build ok");
+        ::xmr::coin::SecretKey r{};
+        CHECK(derive_tx_secret_key(in, r), "derive_tx_secret_key ok (fence passed)");
+        CHECK(r == b.r, "build.r == derive_tx_secret_key(in)");
+        ::xmr::coin::PublicKey R_check{};
+        CHECK(::xmr::coin::secret_key_to_public_key(r, R_check) && R_check == b.R,
+              "R == r*G (%s)", hx(b.R).c_str());
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 3: one derived stealth key against a known Monero vector, and the
+    //         coinbase's own P_i reproduce by the same recipe.
+    // -----------------------------------------------------------------------
+    std::printf("== 3. stealth key vs known Monero vector ==\n");
+    {
+        // (a) generate_key_derivation official vector.
+        ::xmr::coin::PublicKey A = key_from_hex<::xmr::coin::PublicKey>(kA_hex);
+        ::xmr::coin::SecretKey r = key_from_hex<::xmr::coin::SecretKey>(kr_hex);
+        ::xmr::coin::KeyDerivation D{};
+        bool okd = ::xmr::coin::generate_key_derivation(A, r, D);
+        CHECK(okd && hx(D) == std::string(kD_hex),
+              "generate_key_derivation(A,r) == D (monero vector) -> %s", hx(D).c_str());
+
+        // (b) derive_public_key official vector -> a real stealth one-time key.
+        ::xmr::coin::KeyDerivation D2 = key_from_hex<::xmr::coin::KeyDerivation>(kDPK_D_hex);
+        ::xmr::coin::PublicKey B = key_from_hex<::xmr::coin::PublicKey>(kDPK_B_hex);
+        ::xmr::coin::PublicKey P{};
+        bool okp = ::xmr::coin::derive_public_key(D2, static_cast<std::size_t>(kDPK_i), B, P);
+        CHECK(okp && hx(P) == std::string(kDPK_P_hex),
+              "derive_public_key(D,i,B) == P (monero vector) -> %s", hx(P).c_str());
+
+        // (c) coinbase-path consistency: each built P_i reproduces from scratch.
+        CoinbaseInputs in = base_inputs();
+        in.owed = { {xmr_ref(1), 200000000000ull, 1, id_of(1)},
+                    {xmr_ref(2), 150000000000ull, 2, id_of(2)},
+                    {xmr_ref(3),  50000000000ull, 3, id_of(3)} };
+        BuiltCoinbase b = build_coinbase(in);
+        CHECK(b.ok, "build ok");
+        bool all_match = true;
+        for (std::size_t i = 0; i < b.outputs.size(); ++i) {
+            ::xmr::coin::PublicKey Pi{}; ::xmr::coin::ViewTag vti{};
+            if (!recompute_output(b.r, i, Pi, vti)) { all_match = false; break; }
+            if (!(Pi == b.outputs[i].one_time_key) ||
+                vti.tag != b.outputs[i].view_tag.tag) { all_match = false; break; }
+        }
+        CHECK(all_match, "every coinbase P_i / view_tag reproduces by 8rA ECDH recipe");
+        // vout keys are distinct across indices (the output_index really binds).
+        bool distinct = true;
+        for (std::size_t i = 0; i < b.outputs.size(); ++i)
+            for (std::size_t j = i + 1; j < b.outputs.size(); ++j)
+                if (b.outputs[i].one_time_key == b.outputs[j].one_time_key) distinct = false;
+        CHECK(distinct, "per-vout one-time keys are distinct (index-bound)");
+
+        // ACCEPT round-trip: rebuild matches; a wrong-wallet tamper is caught.
+        ReceivedCoinbase got; got.R = b.R;
+        for (auto& o : b.outputs) { got.amounts.push_back(o.amount);
+                                    got.keys.push_back(o.one_time_key);
+                                    got.view_tags.push_back(o.view_tag); }
+        got.tx_extra = b.tx_extra;
+        MatchResult m = canonical_coinbase_matches(in, got);
+        CHECK(m.matches && m.first_bad_index == -1, "ACCEPT: identical coinbase matches");
+        ReceivedCoinbase bad = got; bad.keys[0].data()[3] ^= 0xff;
+        MatchResult mb = canonical_coinbase_matches(in, bad);
+        CHECK(!mb.matches && mb.first_bad_index == 0,
+              "ACCEPT: wrong wallet at index 0 rejected");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 4: exact-sum, no burn (Sum(vout) == base_reward + fees).
+    // -----------------------------------------------------------------------
+    std::printf("== 4. exact-sum, no burn (HF13) ==\n");
+    {
+        // surplus -> owed paid in full + residual sink absorbs the rest.
+        CoinbaseInputs in = base_inputs();  // budget = 600000000000 + 12345678
+        in.owed = { {xmr_ref(1), 200000000000ull, 1, id_of(1)},
+                    {xmr_ref(2), 150000000000ull, 2, id_of(2)} };
+        BuiltCoinbase b = build_coinbase(in);
+        CHECK(b.ok, "surplus: build ok");
+        CHECK(sum_amounts(b.outputs) == in.budget(),
+              "surplus: Sum(vout)=%llu == base_reward+fees=%llu",
+              (unsigned long long)sum_amounts(b.outputs), (unsigned long long)in.budget());
+        CHECK(b.outputs.back().role == CoinbaseOutput::Role::Sink,
+              "surplus: last output is the residual sink");
+        CHECK(b.outputs.back().amount ==
+                  in.budget() - 200000000000ull - 150000000000ull,
+              "surplus: sink carries exactly the unallocated remainder");
+
+        // deficit -> last owed partial, NO sink, still exact-sum.
+        CoinbaseInputs in2 = base_inputs(); in2.base_reward = 1000; in2.fees = 0;
+        in2.owed = { {xmr_ref(1), 600, 1, id_of(1)}, {xmr_ref(2), 700, 2, id_of(2)} };
+        BuiltCoinbase b2 = build_coinbase(in2);
+        CHECK(b2.ok && sum_amounts(b2.outputs) == 1000,
+              "deficit: exact-sum == 1000 (%llu)", (unsigned long long)sum_amounts(b2.outputs));
+        CHECK(b2.outputs.size() == 2 &&
+                  b2.outputs.back().role == CoinbaseOutput::Role::Owed,
+              "deficit: partial last owed, no sink");
+
+        // fixed dev output deducted first; owed|fixed|sink order; exact-sum.
+        CoinbaseInputs in3 = base_inputs(); in3.base_reward = 1000; in3.fees = 0;
+        in3.fixed = { {xmr_ref(0x50), 50, id_of(0x50)} };
+        in3.owed  = { {xmr_ref(1), 200, 1, id_of(1)} };
+        BuiltCoinbase b3 = build_coinbase(in3);
+        CHECK(b3.ok && sum_amounts(b3.outputs) == 1000, "fixed: exact-sum == 1000");
+        CHECK(b3.outputs.size() == 3 &&
+                  b3.outputs[0].role == CoinbaseOutput::Role::Owed &&
+                  b3.outputs[1].role == CoinbaseOutput::Role::Fixed &&
+                  b3.outputs[2].role == CoinbaseOutput::Role::Sink,
+              "fixed: owed|fixed|sink order");
+
+        // no owed, no fixed -> whole budget to the sink (never burned).
+        CoinbaseInputs in4 = base_inputs(); in4.base_reward = 1000; in4.fees = 0;
+        BuiltCoinbase b4 = build_coinbase(in4);
+        CHECK(b4.ok && b4.outputs.size() == 1 &&
+                  b4.outputs[0].role == CoinbaseOutput::Role::Sink &&
+                  b4.outputs[0].amount == 1000,
+              "empty ledger: full reward to sink, nothing burned");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 5: weight-aware output cap.
+    // -----------------------------------------------------------------------
+    std::printf("== 5. weight-aware output cap ==\n");
+    {
+        CHECK(weight_aware_output_cap(300000, 0, 2700) == 2700, "wire cap binds below headroom");
+        CHECK(weight_aware_output_cap(300000, 0, 10) == 10, "small wire cap binds");
+        CHECK(weight_aware_output_cap(0, 1000000, 2700) == 1, "floor 1 (always room for sink)");
+        // penalty headroom binds when the wire cap is generous.
+        std::uint32_t c = weight_aware_output_cap(300000, 0, 100000);
+        CHECK(c > 1 && c < 100000, "penalty headroom binds when wire cap is large (C=%u)", c);
+        // a bigger median (more headroom) never lowers the cap.
+        CHECK(weight_aware_output_cap(600000, 0, 100000) >=
+              weight_aware_output_cap(300000, 0, 100000), "cap monotonic in median");
+    }
+
+    // -----------------------------------------------------------------------
+    // Case 6: CARROT / FCMP++ fence.
+    // -----------------------------------------------------------------------
+    std::printf("== 6. CARROT fence (major > %u) ==\n",
+                (unsigned)W5_PRECARROT_MAX_MAJOR_VERSION);
+    {
+        CoinbaseInputs in = base_inputs();
+        in.owed = { {xmr_ref(1), 200000000000ull, 1, id_of(1)} };
+
+        in.monero_major_version = 16;
+        BuiltCoinbase b16 = build_coinbase(in);
+        CHECK(b16.ok && b16.error == BuildError::None, "v16 builds a coinbase");
+
+        in.monero_major_version = 17;
+        BuiltCoinbase b17 = build_coinbase(in);
+        CHECK(!b17.ok && b17.error == BuildError::CarrotFence,
+              "v17 REFUSED with CarrotFence (%s)", to_string(b17.error));
+        CHECK(b17.outputs.empty(), "v17: no coinbase outputs produced");
+
+        // the fence also trips at the secret-key derivation boundary.
+        ::xmr::coin::SecretKey r{};
+        CHECK(!derive_tx_secret_key(in, r), "v17: derive_tx_secret_key refuses");
+
+        // boundary is exact: 16 ok, 17 fenced (W5_PRECARROT_MAX == descriptor).
+        CHECK(W5_PRECARROT_MAX_MAJOR_VERSION == 16, "fence pinned at pre-CARROT max = 16");
+    }
+
+    std::printf("%s (%d failure%s)\n", g_fail ? "X6 COINBASE KAT FAILED" : "X6 COINBASE KAT OK",
+                g_fail, g_fail == 1 ? "" : "s");
+    return g_fail ? 1 : 0;
+}

--- a/src/impl/xmr/test/xmr_wire_dos_check.cpp
+++ b/src/impl/xmr/test/xmr_wire_dos_check.cpp
@@ -14,13 +14,22 @@
 //       (capacity then refill-limited) and refunds valid work;
 //   T4  a confirmed invalid-PoW carrier BANS the peer; a valid one is Accepted
 //       and its token refunded; a budget-starved carrier DEFERS with no penalty;
-//   T5  the ~65-bogus-carriers/s saturation arithmetic the budget is sized to.
+//   T5  the ~65-bogus-carriers/s saturation arithmetic the budget is sized to;
+//   T6  RELAY DEDUP: a replayed carrier hits stage-1 dedup (the §5 RelaySeenSet
+//       seam) and is DroppedCheap having spent ZERO additional RandomX — the
+//       duplicate-relay collapse that keeps an echoed carrier off the hasher;
+//   T7  RELAY FLOOD, END-TO-END: N bogus carriers pushed through the real
+//       handle_xmr_carrier ingress inside one wall-second reach the RandomX
+//       hasher only bucket-many times, so the flood cannot saturate one light
+//       verify core (the ~65/s threat, now demonstrated through the relay, not
+//       just arithmetic).
 
 #include <cassert>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <set>
 #include <vector>
 
 #include "xmr_carrier_wire.hpp"
@@ -183,15 +192,23 @@ static void t3_token_bucket() {
 }
 
 // A fake LaneEnv whose cheap checks all pass; rx_verify verdict is configurable.
+// Two optional hooks let the relay-level tests observe the load-bearing seams:
+//   * seen_set (if non-null) makes the stage-1 dedup predicate consult a real
+//     recent-carrier set — the same std::set<bytes32> shape the merged v37
+//     relay's RelaySeenSet (c2pool::v37n, w3_relay.hpp §5.2) keys on;
+//   * rx_calls counts every rx_verify invocation, i.e. every RandomX evaluation
+//     that actually reached the hasher — the quantity the DoS budget bounds.
 struct Fake {
     cx::RxVerdict verdict = cx::RxVerdict::Accept;
     Difficulty pinned{1000, 0};
+    std::set<bytes32>* seen_set = nullptr;   // null => never seen (T1-T5 behaviour)
+    int rx_calls = 0;                        // RandomX evaluations that actually ran
     cx::LaneEnv env() {
         cx::LaneEnv e;
         e.cheap_digest = [](const HashingBlob& hb) {
             bytes32 d{}; for (size_t i = 0; i < hb.bytes.size() && i < 32; ++i) d[i] = hb.bytes[i]; return d;
         };
-        e.seen = [](const bytes32&) { return false; };
+        e.seen = [this](const bytes32& id) { return seen_set && seen_set->count(id) != 0; };
         e.bin_of = [](const HashingBlob&, std::uint64_t& out) { out = 5000; return true; };
         e.open_and_bind = [this](const MoneroReceipt&, const bytes32& id, std::uint32_t cid,
                                  OpenedCommitment& oc) {
@@ -200,7 +217,7 @@ struct Fake {
         e.consensus_difficulty = [this](std::uint64_t, Difficulty& out) { out = pinned; return true; };
         e.seed_resolve = [](std::uint64_t, const SeedRef&, bytes32& s) { s.fill(0xAB); return true; };
         e.rx_verify = [this](const bytes32&, const HashingBlob&, const Difficulty&, std::uint8_t h[32]) {
-            std::memset(h, 0x7c, 32); return verdict;
+            ++rx_calls; std::memset(h, 0x7c, 32); return verdict;
         };
         return e;
     }
@@ -309,12 +326,126 @@ static void t5_saturation_arithmetic() {
                 hashes_per_core_s, throttled_core_fraction * 100.0, global_core_fraction * 100.0);
 }
 
+// ---------------------------------------------------------------------------
+// T6 — RELAY DEDUP. A carrier relayed twice must hit stage-1 dedup on the replay
+// and cost ZERO additional RandomX. This exercises the `seen` seam the merged
+// v37 relay fills with RelaySeenSet (w3_relay.hpp §5.2, a std::set<bytes32> keyed
+// on the carrier's own identity) — network hygiene, never consensus. The caller
+// inserts the accepted carrier/receipt's cheap dedup key (cheap_digest of the
+// hashing blob, §5 / xmr_admission.hpp stage D) on accept; the echo is then
+// collapsed before the hasher.
+static void t6_relay_dedup() {
+    std::set<bytes32> store;                 // the relay-seen set (RelaySeenSet shape)
+    Fake f; f.verdict = cx::RxVerdict::Accept; f.seen_set = &store;
+    cx::CarrierDosBudget dos;                // default policy
+    auto env = f.env();
+    LaneKeyedHeavy lp;
+    const cx::nanos_t t = 12'000'000'000LL;
+
+    // On accept, the caller records the dedup key so the next echo is suppressed.
+    auto cheap = env.cheap_digest;
+    auto on_accept = [&](const MoneroReceipt& r, bool) { store.insert(cheap(r.hashing_blob)); };
+
+    w::CarrierMessage m; m.chain_id = 7; m.carrier = make_receipt(0x40);
+    m.receipts.push_back(make_receipt(0x41));                 // distinct blob => distinct key
+    std::vector<std::uint8_t> bytes = w::encode_carrier(m);
+
+    // Round 1: fresh carrier -> carrier + receipt Accepted, exactly 2 RandomX evals.
+    cx::CarrierIngestReport r1 = cx::handle_xmr_carrier(
+        77, /*lane*/7, bytes.data(), bytes.size(), lp, env, dos, t, on_accept);
+    CHECK(r1.carrier == cx::RelayResult::Accepted, "T6 round1 carrier accepted");
+    CHECK(r1.receipts.size() == 1 && r1.receipts[0] == cx::RelayResult::Accepted,
+          "T6 round1 receipt accepted");
+    CHECK(f.rx_calls == 2, "T6 round1 spent exactly 2 RandomX evals (carrier + receipt)");
+    CHECK(dos.state(77).granted == 2, "T6 round1 two RandomX grants");
+    CHECK(store.size() == 2, "T6 dedup store holds carrier + receipt keys");
+
+    // Round 2: identical frame replayed. The carrier's own key is already in the
+    // seen set => stage-1 Dedup reject => DroppedCheap, receipts never reached,
+    // NO new RandomX.
+    const int before = f.rx_calls;
+    cx::CarrierIngestReport r2 = cx::handle_xmr_carrier(
+        77, /*lane*/7, bytes.data(), bytes.size(), lp, env, dos, t, on_accept);
+    CHECK(r2.carrier == cx::RelayResult::DroppedCheap, "T6 replayed carrier DroppedCheap (dedup)");
+    CHECK(r2.receipts.empty(), "T6 replayed carrier carries no receipts past dedup");
+    CHECK(f.rx_calls == before, "T6 dedup spent ZERO additional RandomX");
+    CHECK(dos.state(77).granted == 2, "T6 no new grant on a dedup hit");
+    CHECK(dos.state(77).structural >= 1, "T6 dedup hit scored as a cheap reject");
+    CHECK(!dos.banned(77), "T6 an honest replay is never ban-worthy");
+    std::printf("T6 relay dedup OK (replay collapsed pre-hash; 0 extra RandomX, DroppedCheap)\n");
+}
+
+// ---------------------------------------------------------------------------
+// T7 — RELAY FLOOD, END TO END. A single hostile peer floods N structurally
+// valid but PoW-failing carriers through the REAL handle_xmr_carrier ingress,
+// all timestamped inside one wall-second. Without a budget this is N * ~15 ms of
+// RandomX; the per-peer token bucket caps the evaluations that actually run to
+// its allowance (capacity + <=1 s of refill), so the flood costs a small,
+// bounded fraction of one light verify core rather than saturating it. The ban
+// is deliberately disarmed (huge threshold) so this isolates the TOKEN BUCKET as
+// the limiter (the ban path is proven separately in T4b).
+static void t7_relay_flood_bounded() {
+    cx::DosPolicy p;
+    p.per_peer_capacity = 20; p.per_peer_refill = 1;      // the sized default
+    p.global_capacity   = 256; p.global_refill = 16;
+    p.ban_threshold     = 1'000'000'000u;                 // disarm the ban; isolate the bucket
+    cx::CarrierDosBudget dos(p);
+
+    Fake f; f.verdict = cx::RxVerdict::BelowTarget;        // every carrier is bogus
+    auto env = f.env();                                    // no rx_reverify => confirmed invalid
+    LaneKeyedHeavy lp;
+
+    const int         N      = 2000;                       // 2000 bogus carriers ...
+    const cx::nanos_t t0     = 20'000'000'000LL;
+    const cx::nanos_t window = 1'000'000'000LL;            // ... inside ONE second
+    const std::uint32_t peer = 0xBADu;
+    int accepted = 0;
+    auto on_accept = [&](const MoneroReceipt&, bool) { ++accepted; };
+
+    for (int i = 0; i < N; ++i) {
+        w::CarrierMessage m; m.chain_id = 9;
+        m.carrier = make_receipt(std::uint8_t(i & 0xff));
+        // vary two blob bytes so the N carriers are genuinely distinct (no dedup
+        // collapse doing the bucket's job for it — seen_set is null here anyway).
+        m.carrier.hashing_blob.bytes[0] = std::uint8_t(i & 0xff);
+        m.carrier.hashing_blob.bytes[1] = std::uint8_t((i >> 8) & 0xff);
+        std::vector<std::uint8_t> b = w::encode_carrier(m);
+        const cx::nanos_t t = t0 + (cx::nanos_t)i * window / N;   // spread across 1 s
+        cx::handle_xmr_carrier(peer, /*lane*/9, b.data(), b.size(), lp, env, dos, t, on_accept);
+    }
+
+    // Every carrier is bogus => none accepted.
+    CHECK(accepted == 0, "T7 no bogus carrier is accepted");
+    // RandomX evaluations actually run == bucket allowance over the window:
+    // capacity (20) plus at most ~1 s of refill (1) => <= 22, and certainly
+    // nowhere near N.
+    CHECK((std::uint64_t)f.rx_calls == dos.state(peer).granted, "T7 rx evals == grants recorded");
+    CHECK(f.rx_calls <= 22, "T7 RandomX evals capped at the token-bucket allowance");
+    CHECK(f.rx_calls >= 20, "T7 the bucket did spend its burst (not falsely idle)");
+    CHECK(f.rx_calls < N / 20, "T7 <5% of the flood ever reached the hasher");
+    CHECK(dos.state(peer).deferred == (std::uint64_t)(N - f.rx_calls),
+          "T7 the rest were deferred with NO penalty");
+
+    // The load statement: rx_calls * 15 ms of core time inside a 1-s window is a
+    // small fraction of one core; the same N unmetered would be ~30 core-seconds.
+    const double ms_per_hash = 15.0;
+    const double core_frac_metered   = (f.rx_calls * ms_per_hash) / 1000.0;   // of one core-second
+    const double core_frac_unmetered = (N * ms_per_hash) / 1000.0;
+    CHECK(core_frac_metered < 0.50, "T7 metered flood stays under half of one light core");
+    CHECK(core_frac_unmetered > 1.0, "T7 the same flood unmetered WOULD saturate (>1 core-second)");
+    std::printf("T7 relay flood OK (N=%d bogus/s -> %d RandomX evals; %.0f%% of one core "
+                "metered vs %.0fx unmetered)\n",
+                N, f.rx_calls, core_frac_metered * 100.0, core_frac_unmetered);
+}
+
 int main() {
     t1_roundtrip();
     t2_bounds();
     t3_token_bucket();
     t4_relay_actions();
     t5_saturation_arithmetic();
+    t6_relay_dedup();
+    t7_relay_flood_bounded();
     std::printf("ALL W3-WIRE CHECKS PASSED (%d assertions)\n", g_checks);
     return 0;
 }


### PR DESCRIPTION
## v37 XMR lane W3 — stratum + coinbase-settlement (FCMP-fenced) + carrier wire

Wave 3 of the Monero/RandomX v37 lane (Family B). This **finalizes** the W3 scaffolds the foundation already authored under `src/impl/xmr/` into **buildable + KAT-tested + CI-wired** targets — the same pattern W2 (#1503) used. It does not build from scratch and does not touch core consensus.

Consumes the merged surfaces: X2 `node/`+`template/`, X1 `coin/`+`pow/`, X4 `receipt/`, X3 `sharechain/v37/v37_descriptor_xmr.hpp` (read-only value-consumer), and the v37 `w3_relay.hpp` carrier surface.

### KATs passing locally (light lane; no RandomX — CI-gated)

- **X5 stratum** — `xmr_stratum_selftest` strengthened into a real KAT: hex/target encode, xmrig login-string dialect, submit parse, response goldens, submit-flow branches, **login round-trip**, **extra_nonce uniqueness** (256 logins, strictly increasing), **job-ring eviction** (submit-against-evicted → "Invalid job id"), **known-answer PoW oracle** (good accept / bad reject, client result field proven untrusted), **network-block promotion**. **347 checks, 0 failed.** Scaffold (`xmr_stratum.{hpp,cpp}`, `xmr_stratum_messages.hpp`) unchanged.
- **X6 coinbase-settlement** — new `xmr_coinbase_kat` (the previously-missing target): deterministic-r reproducibility (same inputs → same `r`/`R`/`P_i`; changed lane-commitment / prev_id / height → fresh `r`), `R = r*G` vs official monero `generate_keys` vector, stealth one-time keys vs monero-project `tests/crypto` vectors, **exact-sum with no burn** (HF13 residual sink), weight-aware output cap, and the **CARROT/FCMP++ fence trip**. **0 failures.** Adds the coin primitive `secret_key_to_public_key` (r*G) to `xmr_derivation.{hpp,cpp}` as a verbatim BSD-3 `crypto_ops` subset; drops the redundant forward-decl from `xmr_coinbase.hpp`. `xmr_coinbase.cpp` byte-unchanged.
- **X7 carrier wire** — `xmr_wire_dos_check` strengthened: per-peer token bucket + global backstop, relay accept/ban/defer/hw-flap actions, dedup/replay collapse (0 extra RandomX evals), flood metering (N=2000 bogus/s → 20 RandomX evals). **62 assertions, all passed.** Wire headers unchanged.

### FCMP / CARROT fence status — INTACT

The pre-CARROT fence is enforced in the coinbase executor: `major_version <= XMR_PRECARROT_MAX_MAJOR_VERSION (16)` builds a coinbase; `major_version 17` is **refused** with `BuildError::CarrotFence` (no coinbase outputs, `derive_tx_secret_key` also refuses). KAT section 6 pins this: v16 builds, v17 refused, fence pinned at pre-CARROT max = 16. No fence weakened or extended.

### Non-hollow CI wiring

`xmr_coinbase_kat` registered in `src/impl/xmr/test/CMakeLists.txt` (`add_executable` + `add_test`, links `xmr_coin`) and added to `.github/workflows/build.yml --target` on **both** legs (Linux x86_64 + ASan/UBSan). Drift-guard passes (every `add_executable` appears as a `--target` token). The strengthened stratum/wire KATs reuse their existing registered targets. Vendored BSD-3 crypto headers are byte-identical.

### Lane isolation — P-1 ruling owed

The XMR PayoutDescriptor kinds (`XMR_STD=0x10` / `XMR_SUB=0x11`) remain an **isolated** descriptor: core consensus canon does **not** dispatch to them. Wiring the canon to the XMR kinds is a separate step gated on the **P-1 integrator ruling**. **No file under `src/sharechain/v37` is touched by this PR.**

### Remaining (X8/X9)

- **X8** — RandomX PoW-verify integration behind the CI gate (`src/impl/xmr/pow` seam is stubbed here with a deterministic oracle); real `randomx_hash`/`meets_target` wiring + vendored RandomX/libsodium/zmq (heavy, deferred).
- **X9** — end-to-end integration against a live monerod-adapter template + concurrency/live-socket coverage (transport + threading are the host's; the `ITransport` seam is fake-driven here).

Draft — for review while the P-1 isolation ruling and X8/X9 land.
