### PR TITLE
c2pool-qt: DASH daemonless-default launch, legacy --solo, BCH widget gating (E1/E2/A4)

### DIFF
--- a/ui/c2pool-qt/CMakeLists.txt
+++ b/ui/c2pool-qt/CMakeLists.txt
@@ -158,9 +158,10 @@ if(C2POOL_QT_BUILD_TESTS)
     endif()
 
     # ── ★ Reward-safety gate ─────────────────────────────────────────────
-    # Proves the per-coin launch command core never emits the reward-UNSAFE
-    # embedded arm (--coin-p2p-connect / --embedded-mainnet) by default and
-    # that the default parent-daemon link is the reward-SAFE --coin-rpc arm.
+    # Proves the per-coin launch command core: the default DASH command is a
+    # bare --run (daemonless) and never emits the dashd/embedded arms
+    # (--coin-rpc / --coin-p2p-connect / --embedded-mainnet) unless their
+    # explicit opt-ins are set; the author donation is never silently zeroed.
     # Qt-free (LaunchCommand.hpp is std-only) so it runs anywhere.
     enable_testing()
     add_executable(c2pool-qt_test_reward_safe_launch

--- a/ui/c2pool-qt/README.md
+++ b/ui/c2pool-qt/README.md
@@ -27,7 +27,7 @@ uses, plus its binary, daemon, algo and default RPC ports:
 | litecoin | `c2pool` | litecoind | Scrypt | unified `--net litecoin` |
 | bitcoin | `c2pool` | bitcoind | SHA-256d | unified `--net bitcoin` |
 | dogecoin | `c2pool` | dogecoind | Scrypt (AuxPoW) | unified `--net dogecoin` |
-| dash | `c2pool-dash` | dashd | X11 | per-coin `--run` (masternode-payee) |
+| dash | `c2pool-dash` | dashd | X11 | per-coin `--run` (daemonless; masternode-payee) |
 | digibyte | `c2pool-dgb` | digibyted | Scrypt | per-coin `--run` (experimental) |
 | bitcoincash | `c2pool-bch` | bitcoind (BCHN) | SHA-256d | per-coin `--pool` (experimental) |
 
@@ -36,17 +36,21 @@ mirroring the coin-generic web dashboard/explorer.
 
 ## ★ Reward safety
 
-The default per-coin launch profile is the reward-SAFE dashd-RPC arm
-(`--coin-rpc HOST:PORT` + `--coin-rpc-auth PATH`; the rpcpassword is read
-from the coin's .conf and never placed on argv). The embedded coin-network
-arm (`--coin-p2p-connect` / `--embedded-mainnet`) is reward-UNSAFE until
-validated and is **default OFF** — it is emitted only from the explicit
-"Advanced / embedded (opt-in — REWARD-UNSAFE)" controls. See the DASH hotel
-incident that motivated this gate.
+The panel only assembles argv — the node's own good-citizen defaults own the
+reward decision. The default DASH launch is a bare `--run` (**daemonless** cut
+mode): with no dashd arm the node keeps its serving levers ON (embedded-mainnet
+included), so the panel does not emit `--embedded-mainnet` there. Attaching an
+external dashd (`--coin-rpc HOST:PORT` + `--coin-rpc-auth PATH`; the rpcpassword
+is read from the coin's .conf and never placed on argv) is an explicit opt-in
+("Attach external dashd"). The embedded coin-network knobs
+(`--coin-p2p-connect` / `--embedded-mainnet`) are **default OFF** — emitted only
+from the explicit "Advanced / embedded" controls (transport pinning / explicit
+gate-lift). The author donation is left to the binary default (0.1% / BTC 0.5%)
+unless explicitly overridden, and `--give-author 0` is never emitted silently.
 
 The invariant is unit-tested Qt-free in `test/test_reward_safe_launch.cpp`
-(the default DASH command omits both flags); build tests with
-`-DC2POOL_QT_BUILD_TESTS=ON` and run via `ctest`.
+(the default DASH command is a bare `--run` and omits the dashd/embedded arms);
+build tests with `-DC2POOL_QT_BUILD_TESTS=ON` and run via `ctest`.
 
 ## TODO (qt-steward)
 

--- a/ui/c2pool-qt/src/CoinProfiles.hpp
+++ b/ui/c2pool-qt/src/CoinProfiles.hpp
@@ -17,18 +17,19 @@
 //
 //   • CliFamily::PerCoinRun — the dedicated per-coin binaries
 //     (c2pool-dash / c2pool-dgb / c2pool-bch) whose run-loop is stood up
-//     with a subcommand (`--run` or `--pool`) and whose parent-daemon
-//     link is the reward-SAFE RPC arm: `--coin-rpc HOST:PORT` +
-//     `--coin-rpc-auth PATH` (or `--rpc-conf PATH` for BCHN). The
-//     rpcpassword NEVER touches argv — it is read from the coin's .conf.
+//     with a subcommand (`--run` or `--pool`). DASH's default launch is a
+//     bare `--run` (DAEMONLESS); the dashd RPC arm (`--coin-rpc HOST:PORT`
+//     + `--coin-rpc-auth PATH`) is an explicit opt-in. DGB/BCH keep their
+//     RPC arm (`--coin-rpc` / `--rpc-conf PATH`). The rpcpassword NEVER
+//     touches argv — it is read from the coin's .conf.
 //
-// ★ REWARD SAFETY: the embedded coin-network arm (`--coin-p2p-connect`
-//   and `--embedded-mainnet`) is reward-UNSAFE until validated and is
-//   NEVER emitted by default. PageLaunch only emits it from an explicit,
-//   default-OFF "Advanced / embedded (opt-in, reward-unsafe)" control.
-//   See the DASH hotel incident: an unguarded embedded arm produced
-//   reward-unsafe blocks. The default per-coin launch is the dashd-RPC
-//   arm.
+// ★ REWARD SAFETY: the panel only assembles argv; the node's own
+//   good-citizen defaults own the reward decision. The embedded
+//   coin-network knobs (`--coin-p2p-connect` / `--embedded-mainnet`) are
+//   emitted ONLY from an explicit, default-OFF "Advanced / embedded"
+//   control. DASH's daemonless default already runs the embedded arm with
+//   `--embedded-mainnet` ON in the node, so the panel does not emit it for
+//   that default.
 //
 // This header mirrors the coin-generic, profile-driven approach the web
 // dashboard/explorer already use (see CoinBridge's descriptor table):
@@ -123,7 +124,9 @@ inline const CoinProfile* coinProfiles(int& countOut)
 
         // ── PerCoinRun: dedicated per-coin binaries ──────────────────────────
         // DASH — X11, masternode-payee coin, dashd parent. Default launch is
-        // the reward-SAFE dashd-RPC arm; embedded P2P is opt-in only.
+        // bare `--run` (DAEMONLESS); the dashd RPC arm and the embedded P2P
+        // knobs are explicit opt-ins. (coinRpcFlag/rpcAuthFlag below are
+        // display-only now — the catalog drives emission.)
         {"dash", "Dash", "c2pool-dash", "dashd", "X11",
          "X… / 7… (P2PKH/P2SH)",
          CliFamily::PerCoinRun, "--run", c2pool::catalog::Bin::BIN_DASH,

--- a/ui/c2pool-qt/src/LaunchCommand.hpp
+++ b/ui/c2pool-qt/src/LaunchCommand.hpp
@@ -17,15 +17,22 @@
 //      combined --http [HOST:]PORT). This is the fix for the launch-failure class
 //      where every PerCoinRun coin was fed the DASH flag spellings verbatim.
 //
-//   2. ★ REWARD SAFETY. With the embedded opt-ins OFF (their default) the
-//      generated argv for ANY coin NEVER contains --coin-p2p-connect / --peer /
-//      --embedded-mainnet / a coin-magic override, and the default parent-daemon
-//      link is the reward-SAFE --coin-rpc arm. The author donation is left to the
-//      binary default (0.1% / BTC 0.5%) unless the operator explicitly sets it;
-//      --give-author 0 is emitted ONLY behind an explicit opt-in ack, never as a
-//      default for a public node. validate_percoin() additionally refuses a DASH
-//      launch whose blank RPC endpoint would silently run daemonless (embedded
-//      MAINNET auto-ON) without an explicit embedded opt-in.
+//   2. ★ REWARD SAFETY. The panel only ASSEMBLES argv; it never carries a
+//      reward decision — the node's own good-citizen defaults do. The default
+//      DASH launch is a bare `--run` (daemonless cut mode): with no dashd arm
+//      the node keeps its serving levers ON (embedded-mainnet + serve defaults
+//      per good_citizen_defaults.hpp), so the panel does NOT emit
+//      --embedded-mainnet for that default. The dashd/coin-RPC arm
+//      (--coin-rpc + --coin-rpc-auth) is emitted ONLY behind an explicit
+//      "attach external dashd" opt-in (PerCoinParams::externalDaemonRpc) — on
+//      DASH both --coin-rpc AND --coin-rpc-auth re-arm dashd, so auth alone is
+//      also gated. The embedded --coin-p2p-connect / coin-magic knobs stay
+//      opt-in (transport / explicit gate-lift, not "reward-UNSAFE"). The author
+//      donation is left to the binary default (0.1% / BTC 0.5%) unless the
+//      operator explicitly sets it; --give-author 0 is emitted ONLY behind an
+//      explicit opt-in ack, never as a default for a public node.
+//      validate_percoin() no longer refuses a daemonless DASH launch (that is
+//      the intended default) — it only checks launchability of an attached arm.
 
 #pragma once
 
@@ -52,13 +59,19 @@ struct PerCoinParams {
     bool testnet = false;              ///< network.testnet (emitted iff the bin has the alias)
     bool regtest = false;              ///< network.regtest
 
-    // Reward-SAFE parent-daemon RPC arm. Host+port ⇒ daemon_rpc.endpoint (DASH
-    // --coin-rpc / BTC --bitcoind) or daemon_rpc.submit_endpoint (DGB --coin-rpc).
-    // confPath ⇒ daemon_rpc.auth_file (--coin-rpc-auth / --rpc-conf). The
-    // rpcpassword NEVER touches argv — it is read from the coin's .conf.
+    // Parent-daemon RPC arm. Host+port ⇒ daemon_rpc.endpoint (DASH --coin-rpc /
+    // BTC --bitcoind) or daemon_rpc.submit_endpoint (DGB --coin-rpc). confPath ⇒
+    // daemon_rpc.auth_file (--coin-rpc-auth / --rpc-conf). The rpcpassword NEVER
+    // touches argv — it is read from the coin's .conf.
     std::string rpcHost;
     int         rpcPort = 0;
     std::string confPath;
+
+    // Explicit opt-in to the dashd/coin-RPC arm (--coin-rpc + --coin-rpc-auth).
+    // DASH: default OFF = daemonless cut mode (bare --run, node's good-citizen
+    // serving defaults). Consulted for BIN_DASH only; DGB/BCH keep their existing
+    // endpoint/auth emission (this flag is forced true for them by the marshaller).
+    bool        externalDaemonRpc = false;
 
     int         stratumPort = 0;       ///< stratum.bind PORT (0 ⇒ omit)
 
@@ -83,7 +96,10 @@ struct PerCoinParams {
     bool        noP2pRelay = false;        ///< sharechain.no_p2p_relay
     std::string bchAnchor;                 ///< embedded.anchor (BCH cold-start ABLA floor)
 
-    // ── ★ Embedded reward-UNSAFE arm — OPT-IN, default OFF ────────────────────
+    // ── ★ Embedded coin-network transport / explicit gate-lift — OPT-IN, OFF ──
+    // (DASH defaults ON daemonless: with no dashd arm the node already runs the
+    //  embedded arm with --embedded-mainnet, so these only pin peers or force the
+    //  flag explicitly — needed only when dashd is attached, where it is OFF.)
     bool                     embeddedP2p = false;      ///< coin_p2p.connect (DASH --coin-p2p-connect / BCH --peer)
     std::vector<std::string> embeddedP2pPeers;         ///< HOST:PORT peers
     bool                     embeddedMainnet = false;  ///< embedded.mainnet (DASH)
@@ -132,30 +148,28 @@ inline void emit_flag(std::vector<std::string>& a, Bin bin, const char* canon)
 
 } // namespace detail
 
-/// Reward-safety / launchability precheck. Returns "" when the params are safe
-/// to launch, else a human-readable reason PageLaunch surfaces and refuses on.
+/// Launchability precheck. Returns "" when the params are launchable, else a
+/// human-readable reason PageLaunch surfaces and refuses on. Nothing here may
+/// refuse a daemonless DASH launch — bare `--run` (no dashd arm) is the intended
+/// default cut mode. The ONLY DASH check is that an explicitly-requested external
+/// dashd attach actually carries a HOST:PORT to attach to.
 inline std::string validate_percoin(const PerCoinParams& p)
 {
-    // ★ F5 — DASH daemonless guard. On DASH, the ABSENCE of a --coin-rpc arm
-    // means daemonless == embedded MAINNET block production auto-ON, which is
-    // reward-UNSAFE. Refuse a blank RPC endpoint UNLESS an embedded arm was
-    // explicitly opted into (then the operator owns the risk knowingly).
-    if (p.bin == Bin::BIN_DASH) {
+    if (p.bin == Bin::BIN_DASH && p.externalDaemonRpc) {
         const bool haveRpc = !detail::trim(p.rpcHost).empty() && p.rpcPort > 0;
-        const bool embeddedOptIn = p.embeddedP2p || p.embeddedMainnet;
-        if (!haveRpc && !embeddedOptIn) {
-            return "DASH needs a --coin-rpc HOST:PORT (dashd RPC arm). A blank RPC "
-                   "endpoint runs the node DAEMONLESS with embedded MAINNET block "
-                   "production auto-ON — reward-UNSAFE. Set the RPC host/port, or "
-                   "explicitly enable the embedded arm below.";
+        if (!haveRpc) {
+            return "External dashd attach is ticked but no RPC HOST:PORT is set. "
+                   "Set the RPC host/port for --coin-rpc, or untick 'Attach external "
+                   "dashd' to run daemonless (the default).";
         }
     }
     return "";
 }
 
-/// Assemble the argv (binary first). The embedded reward-UNSAFE flags are
-/// appended ONLY when their opt-in bools are true — the single choke point that
-/// enforces the reward-safe default.
+/// Assemble the argv (binary first). The embedded coin-network transport /
+/// explicit gate-lift flags (DASH defaults ON daemonless) are appended ONLY when
+/// their opt-in bools are true — the single choke point that keeps the default
+/// argv minimal.
 inline std::vector<std::string> build_percoin_argv(const PerCoinParams& p)
 {
     using detail::trim;
@@ -174,17 +188,24 @@ inline std::vector<std::string> build_percoin_argv(const PerCoinParams& p)
     if (p.testnet) emit_flag(a, bin, "network.testnet");
     if (p.regtest) emit_flag(a, bin, "network.regtest");
 
-    // Reward-SAFE RPC arm. daemon_rpc.endpoint (DASH --coin-rpc / BTC --bitcoind)
-    // where the bin has it; else daemon_rpc.submit_endpoint (DGB --coin-rpc).
-    // BCH has neither and links creds only via --rpc-conf.
-    if (!trim(p.rpcHost).empty() && p.rpcPort > 0) {
+    // Parent-daemon RPC arm. daemon_rpc.endpoint (DASH --coin-rpc / BTC
+    // --bitcoind) where the bin has it; else daemon_rpc.submit_endpoint
+    // (DGB --coin-rpc). BCH has neither and links creds only via --rpc-conf.
+    //
+    // On DASH the whole arm is gated behind the explicit external-dashd opt-in:
+    // both --coin-rpc AND --coin-rpc-auth re-arm dashd (main_dash.cpp:1191-1192),
+    // so auth alone must NOT leak out and silently leave daemonless cut mode. For
+    // every other binary the arm emits as before.
+    const bool rpcArm = (bin != Bin::BIN_DASH) || p.externalDaemonRpc;
+    if (rpcArm && !trim(p.rpcHost).empty() && p.rpcPort > 0) {
         const std::string ep = trim(p.rpcHost) + ":" + std::to_string(p.rpcPort);
         if (catview::spelling_for(bin, "daemon_rpc.endpoint"))
             emit_value(a, bin, "daemon_rpc.endpoint", ep);
         else
             emit_value(a, bin, "daemon_rpc.submit_endpoint", ep);
     }
-    emit_value(a, bin, "daemon_rpc.auth_file", trim(p.confPath));
+    if (rpcArm)
+        emit_value(a, bin, "daemon_rpc.auth_file", trim(p.confPath));
 
     if (p.stratumPort > 0)
         emit_value(a, bin, "stratum.bind", std::to_string(p.stratumPort));
@@ -245,7 +266,8 @@ inline std::vector<std::string> build_percoin_argv(const PerCoinParams& p)
 
     emit_value(a, bin, "global.message_blob_hex", trim(p.messageBlob));
 
-    // ── ★ Embedded reward-UNSAFE arm — appended ONLY when opted in ────────────
+    // ── ★ Embedded coin-network transport / explicit gate-lift — opt-in only ──
+    // (DASH defaults ON daemonless; these pin peers / force the flag explicitly.)
     if (p.embeddedP2p) {
         for (const auto& peer : p.embeddedP2pPeers) {
             const std::string t = trim(peer);
@@ -269,6 +291,31 @@ inline std::string join_argv(const std::vector<std::string>& a)
         out += a[i];
     }
     return out;
+}
+
+// ── Legacy (`c2pool --net …`) operation mode ──────────────────────────────────
+// The unified binary's mode combo. Order matches the LegacyUnified mode combo in
+// PageLaunch. The flag SPELLING is resolved from the catalog (BIN_LTC mode
+// aliases in param_catalog.inc) so the panel can never drift from the node — the
+// same Qt-free seam the reward test proves. `Integrated` emits --integrated
+// explicitly (harmless; the binary default is integrated anyway); `Solo` MUST
+// emit --solo (a legacy "solo" that emitted nothing silently produced an
+// integrated PPLNS node). Returns "" only if the catalog has no alias.
+enum class LegacyMode { Integrated = 0, Sharechain = 1, Solo = 2, Custodial = 3, Standalone = 4 };
+
+inline std::string legacy_mode_flag(LegacyMode m)
+{
+    const char* canon = nullptr;
+    switch (m) {
+        case LegacyMode::Integrated: canon = "meta.mode_integrated"; break;
+        case LegacyMode::Sharechain: canon = "meta.mode_sharechain"; break;
+        case LegacyMode::Solo:       canon = "meta.mode_solo";       break;
+        case LegacyMode::Custodial:  canon = "meta.mode_custodial";  break;
+        case LegacyMode::Standalone: canon = "meta.mode_standalone"; break;
+    }
+    if (!canon) return std::string();
+    auto s = catview::spelling_for(Bin::BIN_LTC, canon);
+    return s ? s->first : std::string();
 }
 
 } // namespace c2pool_qt

--- a/ui/c2pool-qt/src/PageLaunch.cpp
+++ b/ui/c2pool-qt/src/PageLaunch.cpp
@@ -146,7 +146,15 @@ void PageLaunch::setupUi()
         auto* form = new QFormLayout(g);
 
         modeCombo_ = new QComboBox;
-        modeCombo_->addItems({"Integrated (full pool)", "Sharechain (P2P node)", "Solo (default)"});
+        // Order matches c2pool_qt::LegacyMode. Each item maps to a catalog mode
+        // alias; a legacy "solo" MUST emit --solo (emitting nothing silently ran
+        // an integrated PPLNS node). Appending custodial/standalone at 3/4 keeps
+        // older persisted `mode` indices (0/1/2) valid.
+        modeCombo_->addItems({"Integrated (full pool, binary default)",
+                              "Sharechain (P2P node)",
+                              "Solo (no sharechain, --solo)",
+                              "Custodial (--custodial, coinbase to --address)",
+                              "Standalone legacy (--standalone, no embedded SPV)"});
         modeCombo_->setCurrentIndex(1);
         form->addRow("Mode:", modeCombo_);
 
@@ -160,7 +168,8 @@ void PageLaunch::setupUi()
         chainCombo_->setToolTip(
             "Coin-generic (profile-driven). LTC/BTC/DOGE use the unified\n"
             "`c2pool --net …` binary; DASH/DGB/BCH use the dedicated per-coin\n"
-            "binary with the reward-safe --coin-rpc arm.");
+            "binary. DASH runs daemonless by default (bare --run); attaching an\n"
+            "external dashd (--coin-rpc) is an explicit opt-in.");
         form->addRow("Blockchain:", chainCombo_);
 
         testnetCheck_ = new QCheckBox("Use testnet");
@@ -218,10 +227,29 @@ void PageLaunch::setupUi()
         coindGroup_ = g;
         auto* form = new QFormLayout(g);
 
+        // DASH runs daemonless by default (bare --run). Attaching an external
+        // dashd (--coin-rpc HOST:PORT [+ --coin-rpc-auth]) is an explicit opt-in;
+        // default OFF. Shown only for DASH (applyProfileUi()).
+        dashdAttachCheck_ = new QCheckBox(
+            "Attach external dashd (--coin-rpc HOST:PORT [+ --coin-rpc-auth]) "
+            "— optional; default is daemonless");
+        dashdAttachCheck_->setChecked(false);
+        dashdAttachCheck_->setToolTip(
+            "DASH only. Left unticked (default), the node launches with a bare\n"
+            "`--run` — DAEMONLESS cut mode, with the node's good-citizen serving\n"
+            "levers ON. Tick this to attach an external dashd via --coin-rpc\n"
+            "(and --coin-rpc-auth); the RPC host/port below are then used.");
+        connect(dashdAttachCheck_, &QCheckBox::stateChanged, this, [this](int) {
+            applyProfileUi();
+            onBuildPreview();
+        });
+        form->addRow("", dashdAttachCheck_);
+
         coindHostEdit_ = new QLineEdit("127.0.0.1");
         coindHostEdit_->setToolTip(
             "Legacy (LTC/BTC/DOGE): --coind-address / --rpchost\n"
-            "Per-coin (DASH/DGB): host of --coin-rpc HOST:PORT");
+            "Per-coin (DGB): host of --coin-rpc HOST:PORT\n"
+            "Per-coin (DASH): only with 'Attach external dashd' ticked");
         form->addRow("RPC host:", coindHostEdit_);
 
         coindPortSpin_ = new QSpinBox;
@@ -561,38 +589,34 @@ void PageLaunch::setupUi()
         vbox->addWidget(g);
     }
 
-    // ── 10. ★ Advanced / embedded (opt-in, REWARD-UNSAFE) ────────────────────
-    // Default OFF. This is the ONLY place --coin-p2p-connect /
-    // --embedded-mainnet may be emitted. The default per-coin launch is the
-    // reward-SAFE dashd-RPC arm. See the DASH hotel incident: an unguarded
-    // embedded arm produced reward-unsafe blocks.
+    // ── 10. ★ Advanced / embedded coin-network (transport + gate-lift) ───────
+    // Opt-in, default OFF. This is the ONLY place --coin-p2p-connect /
+    // --embedded-mainnet may be emitted. DASH runs the embedded arm by default
+    // when daemonless (bare --run): these controls only pin peers or force the
+    // flag explicitly (needed when an external dashd is attached, where it is OFF).
     {
-        auto* g = makeGroup("Advanced / embedded (opt-in — REWARD-UNSAFE)");
+        auto* g = makeGroup("Advanced / embedded coin-network (transport + gate-lift)");
         embeddedGroup_ = g;
-        g->setStyleSheet(
-            "QGroupBox { font-weight: bold; margin-top: 6px; "
-            "  border: 1px solid #b04020; border-radius: 4px; }"
-            "QGroupBox::title { subcontrol-origin: margin; left: 8px; color: #b04020; }");
         auto* gLayout = new QVBoxLayout(g);
 
         embeddedWarnLabel_ = new QLabel(
-            "⚠ These options dial the coin's own P2P network directly and/or "
-            "let this node produce mainnet blocks WITHOUT the validated dashd-RPC "
-            "arm. They are REWARD-UNSAFE until validated for your coin and MUST "
-            "stay OFF for normal mining. Leave everything here unchecked to run "
-            "the safe RPC arm.");
+            "These options pin the coin-P2P peers the embedded arm dials "
+            "(--coin-p2p-connect) and/or force the embedded-mainnet gate open "
+            "explicitly (--embedded-mainnet). For DASH the daemonless default "
+            "(bare --run) already runs the embedded arm with --embedded-mainnet "
+            "ON — you only need these to pin specific peers, or to force the flag "
+            "when you have attached an external dashd (where it defaults OFF).");
         embeddedWarnLabel_->setWordWrap(true);
-        embeddedWarnLabel_->setStyleSheet("color: #b04020;");
+        embeddedWarnLabel_->setStyleSheet("color: #555;");
         gLayout->addWidget(embeddedWarnLabel_);
 
         embeddedP2pCheck_ = new QCheckBox(
-            "Enable embedded coin-network P2P (--coin-p2p-connect) — reward-unsafe");
+            "Pin embedded coin-network P2P peers (--coin-p2p-connect)");
         embeddedP2pCheck_->setChecked(false);   // ★ default OFF
         embeddedP2pCheck_->setToolTip(
             "--coin-p2p-connect HOST:PORT (repeatable)\n"
-            "OPT-IN. Dials the coin network directly instead of relying only on\n"
-            "the dashd-RPC submitblock arm. Default OFF — leave unchecked unless\n"
-            "you are deliberately validating the embedded arm.");
+            "Pins the coin-network peers the embedded arm dials. Optional —\n"
+            "left off, the node discovers peers on its own. Default OFF.");
         gLayout->addWidget(embeddedP2pCheck_);
 
         embeddedP2pPeersEdit_ = new QPlainTextEdit;
@@ -603,12 +627,13 @@ void PageLaunch::setupUi()
         gLayout->addWidget(embeddedP2pPeersEdit_);
 
         embeddedMainnetCheck_ = new QCheckBox(
-            "Enable embedded MAINNET block production (--embedded-mainnet) — reward-unsafe");
+            "Force embedded MAINNET block production explicitly (--embedded-mainnet)");
         embeddedMainnetCheck_->setChecked(false);   // ★ default OFF
         embeddedMainnetCheck_->setToolTip(
             "--embedded-mainnet (DASH)\n"
-            "Lifts the gate that keeps embedded mainnet block production OFF.\n"
-            "Reward-unsafe until validated. Default OFF.");
+            "Forces the embedded mainnet gate open explicitly. The daemonless\n"
+            "default (bare --run) already has it ON — this is only needed when an\n"
+            "external dashd is attached (where it defaults OFF). Default OFF.");
         gLayout->addWidget(embeddedMainnetCheck_);
 
         // DGB embedded coin-network producer target (--coin-daemon + --coin-magic
@@ -736,11 +761,12 @@ QString PageLaunch::buildLegacyCommand() const
     // Binary
     parts << binaryEdit_->text().trimmed();
 
-    // Mode
-    const int modeIdx = modeCombo_->currentIndex();
-    if (modeIdx == 0)      parts << "--integrated";
-    else if (modeIdx == 1) parts << "--sharechain";
-    // solo = default, no flag
+    // Mode — resolved via the catalog (Qt-free seam, unit-tested). A legacy
+    // "solo" MUST emit --solo: emitting nothing silently ran an integrated
+    // PPLNS node. Integrated emits --integrated explicitly (harmless).
+    const std::string mf = c2pool_qt::legacy_mode_flag(
+        static_cast<c2pool_qt::LegacyMode>(modeCombo_->currentIndex()));
+    if (!mf.empty()) parts << QString::fromStdString(mf);
 
     // Network
     if (testnetCheck_->isChecked()) parts << "--testnet";
@@ -863,14 +889,15 @@ QString PageLaunch::buildLegacyCommand() const
 // ─────────────────────────────────────────────────────────────────────────────
 // Per-coin run-loop command (c2pool-dash / -dgb / -bch)
 //
-// ★ REWARD SAFETY: builds the dashd-RPC arm by default —
-//   `<binary> <subcommand> [--testnet] --coin-rpc HOST:PORT
-//    [--coin-rpc-auth PATH] [--stratum PORT] [--web-port PORT]
-//    [--data-dir PATH] …`. The embedded reward-UNSAFE flags
-//   (--coin-p2p-connect / --embedded-mainnet) are appended ONLY when the
-//   explicit, default-OFF "Advanced / embedded (opt-in)" controls are
-//   checked. With those unchecked the generated command NEVER contains
-//   them — proven by the reward-safe launch test.
+// DASH default is DAEMONLESS — a bare `--run` (plus stratum/web/listen/etc.):
+//   `<binary> --run [--testnet] [--stratum PORT] [--web-port PORT]
+//    [--data-dir PATH] …`. With no dashd arm the node keeps its good-citizen
+//   serving levers ON (embedded-mainnet included), so the panel does NOT emit
+//   --embedded-mainnet for that default. The dashd/coin-RPC arm (--coin-rpc +
+//   --coin-rpc-auth) is appended ONLY behind the explicit "Attach external
+//   dashd" opt-in; the embedded --coin-p2p-connect / --embedded-mainnet knobs
+//   only when the "Advanced / embedded" controls are checked. All of this is
+//   assembled in the Qt-free core (build_percoin_argv) and unit-tested there.
 // ─────────────────────────────────────────────────────────────────────────────
 QString PageLaunch::buildPerCoinCommand() const
 {
@@ -906,6 +933,13 @@ c2pool_qt::PerCoinParams PageLaunch::marshalPerCoinParams() const
     pp.rpcPort = coindPortSpin_->value();
     if (rpcConfPathEdit_) pp.confPath = rpcConfPathEdit_->text().trimmed().toStdString();
 
+    // External dashd attach is an explicit opt-in on DASH only (default OFF =
+    // daemonless cut mode). For every other binary the RPC/auth arm emits as
+    // before, so force the flag true there.
+    pp.externalDaemonRpc =
+        (prof.bin != c2pool::catalog::Bin::BIN_DASH)
+        || (dashdAttachCheck_ && dashdAttachCheck_->isChecked());
+
     pp.stratumPort = stratumPortSpin_->value();
 
     pp.webPort = httpPortSpin_->value();
@@ -933,7 +967,7 @@ c2pool_qt::PerCoinParams PageLaunch::marshalPerCoinParams() const
     pp.noP2pRelay      = noP2pRelayCheck_ && noP2pRelayCheck_->isChecked();
     if (bchAnchorEdit_) pp.bchAnchor = bchAnchorEdit_->text().trimmed().toStdString();
 
-    // ── ★ Embedded reward-UNSAFE arm — OPT-IN ONLY (default OFF) ──────────
+    // ── ★ Embedded coin-network transport / gate-lift — explicit controls ──
     pp.embeddedP2p = embeddedP2pCheck_ && embeddedP2pCheck_->isChecked();
     if (pp.embeddedP2p && embeddedP2pPeersEdit_) {
         for (const QString& line :
@@ -995,10 +1029,31 @@ void PageLaunch::applyProfileUi()
     const c2pool_qt::CoinProfile& prof = c2pool_qt::coinProfile(chain);
     const bool perCoin = (prof.cli == c2pool_qt::CliFamily::PerCoinRun);
 
+    using c2pool_qt::catview::spelling_for;
+    const auto bin = prof.bin;
+    auto has = [&](const char* canon) {
+        return spelling_for(bin, canon).has_value();
+    };
+
+    // DASH runs daemonless by default (bare --run); the dashd/coin-RPC arm is an
+    // explicit opt-in. Every other per-coin binary keeps its arm always on.
+    const bool isDash = (prof.bin == c2pool::catalog::Bin::BIN_DASH);
+    const bool attach = !isDash || (dashdAttachCheck_ && dashdAttachCheck_->isChecked());
+    if (dashdAttachCheck_)
+        dashdAttachCheck_->setVisible(isDash);
+
     // Relabel the parent-daemon group with the coin's daemon name.
     if (coindGroup_)
         coindGroup_->setTitle(
             QStringLiteral("Parent Coin Daemon (%1)").arg(prof.daemonLabel));
+
+    // Daemon RPC fields: enabled only where the binary carries the alias AND (for
+    // DASH) the external-dashd attach is ticked. BCH has no endpoint alias at all
+    // (creds only via --rpc-conf), so its host/port stay disabled.
+    const bool hasRpcEndpoint =
+        has("daemon_rpc.endpoint") || has("daemon_rpc.submit_endpoint");
+    if (coindHostEdit_) coindHostEdit_->setEnabled(perCoin ? (hasRpcEndpoint && attach) : true);
+    if (coindPortSpin_) coindPortSpin_->setEnabled(perCoin ? (hasRpcEndpoint && attach) : true);
 
     // Suggest the coin's default RPC conf path (PerCoinRun only).
     if (rpcConfPathEdit_) {
@@ -1006,7 +1061,8 @@ void PageLaunch::applyProfileUi()
             perCoin && !prof.confHint.isEmpty()
                 ? QStringLiteral("%1 (default)").arg(prof.confHint)
                 : QStringLiteral("(legacy coin uses RPC user/password below)"));
-        rpcConfPathEdit_->setEnabled(perCoin);
+        rpcConfPathEdit_->setEnabled(perCoin ? (has("daemon_rpc.auth_file") && attach)
+                                             : false);
     }
     if (dataDirEdit_)
         dataDirEdit_->setEnabled(perCoin);
@@ -1034,11 +1090,6 @@ void PageLaunch::applyProfileUi()
     // operator to set a value that would be silently dropped. LegacyUnified coins
     // keep every money widget enabled (they build the Python-p2pool argv).
     if (perCoin) {
-        using c2pool_qt::catview::spelling_for;
-        const auto bin = prof.bin;
-        auto has = [&](const char* canon) {
-            return spelling_for(bin, canon).has_value();
-        };
         const bool hasFee        = has("money.node_owner_fee_pct");
         const bool hasGiveAuthor = has("money.give_author_pct");
         const bool hasOwnerAddr  = has("money.node_owner_address");
@@ -1049,17 +1100,57 @@ void PageLaunch::applyProfileUi()
         if (nodeOwnerAddrEdit_)      nodeOwnerAddrEdit_->setEnabled(hasOwnerAddr);
         if (redistributeCombo_)      redistributeCombo_->setEnabled(hasRedist);
 
+        // The "Payout address" field marshals to money.node_owner_address on the
+        // per-coin path (marshalPerCoinParams). BCH has no such alias → the value
+        // would be silently dropped, so disable the field there.
+        if (addressEdit_)     addressEdit_->setEnabled(hasOwnerAddr);
+        if (messageBlobEdit_) messageBlobEdit_->setEnabled(has("global.message_blob_hex"));
+
         // Run-loop rows: enable only where the catalog carries the alias.
         if (coinP2pDiscoverCheck_) coinP2pDiscoverCheck_->setEnabled(has("coin_p2p.discover"));
         if (noP2pRelayCheck_)      noP2pRelayCheck_->setEnabled(has("sharechain.no_p2p_relay"));
         if (bchAnchorEdit_)        bchAnchorEdit_->setEnabled(has("embedded.anchor"));
+
+        // Legacy-only widgets are never read by marshalPerCoinParams(); disable
+        // them on the per-coin path so the form cannot invite a silently-dropped
+        // value. (Re-enabled in the else branch below.)
+        if (rpcUserEdit_)          rpcUserEdit_->setEnabled(false);
+        if (rpcPassEdit_)          rpcPassEdit_->setEnabled(false);
+        if (coindP2pPortSpin_)     coindP2pPortSpin_->setEnabled(false);
+        if (coindP2pAddrEdit_)     coindP2pAddrEdit_->setEnabled(false);
+        if (nodeOwnerScriptEdit_)  nodeOwnerScriptEdit_->setEnabled(false);
+        if (autoDetectWalletCheck_) autoDetectWalletCheck_->setEnabled(false);
+        if (maxConnsSpinBox_)      maxConnsSpinBox_->setEnabled(false);
+        if (configFileEdit_)       configFileEdit_->setEnabled(false);
+        if (coinbaseTextEdit_)     coinbaseTextEdit_->setEnabled(false);
+        if (privateChainCheck_)    privateChainCheck_->setEnabled(false);
+        if (networkIdEdit_)        networkIdEdit_->setEnabled(false);
+        if (generateIdBtn_)        generateIdBtn_->setEnabled(false);
+        if (startupModeCombo_)     startupModeCombo_->setEnabled(false);
     } else {
-        // Legacy coins: money widgets always available.
+        // Legacy coins: money + Python-p2pool widgets always available.
         if (feeSpinBox_)             feeSpinBox_->setEnabled(true);
         if (giveAuthorSpinBox_)      giveAuthorSpinBox_->setEnabled(true);
         if (giveAuthorZeroAckCheck_) giveAuthorZeroAckCheck_->setEnabled(true);
         if (nodeOwnerAddrEdit_)      nodeOwnerAddrEdit_->setEnabled(true);
         if (redistributeCombo_)      redistributeCombo_->setEnabled(true);
+        if (addressEdit_)            addressEdit_->setEnabled(true);
+        if (messageBlobEdit_)        messageBlobEdit_->setEnabled(true);
+        if (rpcUserEdit_)            rpcUserEdit_->setEnabled(true);
+        if (rpcPassEdit_)            rpcPassEdit_->setEnabled(true);
+        if (coindP2pPortSpin_)       coindP2pPortSpin_->setEnabled(true);
+        if (coindP2pAddrEdit_)       coindP2pAddrEdit_->setEnabled(true);
+        if (nodeOwnerScriptEdit_)    nodeOwnerScriptEdit_->setEnabled(true);
+        if (autoDetectWalletCheck_)  autoDetectWalletCheck_->setEnabled(true);
+        if (maxConnsSpinBox_)        maxConnsSpinBox_->setEnabled(true);
+        if (configFileEdit_)         configFileEdit_->setEnabled(true);
+        if (coinbaseTextEdit_)       coinbaseTextEdit_->setEnabled(true);
+        if (privateChainCheck_)      privateChainCheck_->setEnabled(true);
+        if (startupModeCombo_)       startupModeCombo_->setEnabled(true);
+        // network-id field follows the private-chain checkbox (its own logic).
+        const bool priv = privateChainCheck_ && privateChainCheck_->isChecked();
+        if (networkIdEdit_) networkIdEdit_->setEnabled(priv);
+        if (generateIdBtn_) generateIdBtn_->setEnabled(priv);
     }
 
     // Run-loop group is only meaningful for PerCoinRun binaries.
@@ -1070,16 +1161,26 @@ void PageLaunch::applyProfileUi()
     if (coinNoteLabel_) {
         QString note;
         if (perCoin) {
-            note = QStringLiteral(
-                       "%1 · %2 · binary %3 · reward-safe %4 arm (creds from %5).")
-                       .arg(prof.displayLabel, prof.algoLabel, prof.binary,
-                            prof.rpcAuthFlag.isEmpty() ? QStringLiteral("RPC")
-                                                       : prof.rpcAuthFlag,
-                            prof.confHint);
+            if (isDash)
+                note = QStringLiteral(
+                           "%1 · %2 · binary %3 · daemonless by default (bare "
+                           "--run); tick 'Attach external dashd' to use --coin-rpc "
+                           "(creds from %4).")
+                           .arg(prof.displayLabel, prof.algoLabel, prof.binary,
+                                prof.confHint);
+            else
+                note = QStringLiteral(
+                           "%1 · %2 · binary %3 · %4 arm (creds from %5).")
+                           .arg(prof.displayLabel, prof.algoLabel, prof.binary,
+                                prof.rpcAuthFlag.isEmpty() ? QStringLiteral("RPC")
+                                                           : prof.rpcAuthFlag,
+                                prof.confHint);
             if (chain == QStringLiteral("bitcoincash"))
                 note += QStringLiteral("  c2pool-bch has no operator fee surface "
                                        "(param catalog) — fee/donation/redistribute "
-                                       "are disabled.");
+                                       "are disabled; no RPC endpoint flag either "
+                                       "(creds only via --rpc-conf), so RPC host/port "
+                                       "and the payout-address field are disabled.");
             else if (chain == QStringLiteral("digibyte"))
                 note += QStringLiteral("  c2pool-dgb: node-owner address + "
                                        "redistribute live; no author-fee surface.");
@@ -1203,11 +1304,10 @@ void PageLaunch::launch()
         return;
     }
 
-    // ── ★ Reward-safety precheck (PerCoinRun) ─────────────────────────────────
-    // F5: a DASH launch with a blank --coin-rpc endpoint and no explicit embedded
-    // opt-in would run daemonless with embedded MAINNET block production auto-ON
-    // (reward-UNSAFE). validate_percoin() catches that (and any future per-coin
-    // reward guard) BEFORE build_percoin_argv() is ever run.
+    // ── Launchability precheck (PerCoinRun) ───────────────────────────────────
+    // Only refuses when an explicitly-requested external-dashd attach carries no
+    // RPC HOST:PORT to attach to. A daemonless DASH launch (bare --run, the
+    // default) is always allowed. Runs BEFORE build_percoin_argv().
     if (c2pool_qt::coinProfile(chain).cli == c2pool_qt::CliFamily::PerCoinRun) {
         const std::string reason =
             c2pool_qt::validate_percoin(marshalPerCoinParams());
@@ -1215,6 +1315,18 @@ void PageLaunch::launch()
             emit daemonStateChanged(
                 QStringLiteral("Daemon: refused — %1")
                     .arg(QString::fromStdString(reason)),
+                "color: #b04020;");
+            return;
+        }
+    } else {
+        // Legacy custodial mode pays the coinbase to --address (main_ltc.cpp
+        // requires it). Refuse a blank payout address in that mode.
+        if (static_cast<c2pool_qt::LegacyMode>(modeCombo_->currentIndex())
+                == c2pool_qt::LegacyMode::Custodial
+            && addressEdit_->text().trimmed().isEmpty()) {
+            emit daemonStateChanged(
+                "Daemon: refused — custodial mode (--custodial) needs a payout "
+                "--address to send the coinbase to.",
                 "color: #b04020;");
             return;
         }
@@ -1297,6 +1409,8 @@ void PageLaunch::saveSettings() const
     // Per-coin run-loop fields
     if (rpcConfPathEdit_) s.setValue("rpcConfPath", rpcConfPathEdit_->text());
     if (dataDirEdit_)     s.setValue("dataDir",     dataDirEdit_->text());
+    // DASH external-dashd attach opt-in (default OFF = daemonless).
+    if (dashdAttachCheck_) s.setValue("dashdAttach", dashdAttachCheck_->isChecked());
     // Embedded reward-UNSAFE opt-in state (persisted so it is never silently
     // re-enabled; defaults stay OFF on load).
     if (embeddedP2pCheck_)     s.setValue("embeddedP2p",      embeddedP2pCheck_->isChecked());
@@ -1368,6 +1482,10 @@ void PageLaunch::loadSettings()
     // Per-coin run-loop fields
     if (rpcConfPathEdit_) rpcConfPathEdit_->setText(s.value("rpcConfPath").toString());
     if (dataDirEdit_)     dataDirEdit_->setText(s.value("dataDir").toString());
+    // DASH external-dashd attach opt-in — default false, so a profile that used
+    // to force --coin-rpc 127.0.0.1:9998 now launches daemonless (intended).
+    if (dashdAttachCheck_)
+        dashdAttachCheck_->setChecked(s.value("dashdAttach", false).toBool());
     // Embedded reward-UNSAFE opt-in — restore prior state (still defaults OFF
     // for a fresh profile).
     if (embeddedP2pCheck_)

--- a/ui/c2pool-qt/src/PageLaunch.hpp
+++ b/ui/c2pool-qt/src/PageLaunch.hpp
@@ -24,20 +24,21 @@ class SettingsStore;
 /// Coin-generic (profile-driven — see CoinProfiles.hpp). Supports both
 /// c2pool launch CLIs: the unified `c2pool --net …` binary (LTC/BTC/DOGE)
 /// and the dedicated per-coin binaries (c2pool-dash / c2pool-dgb /
-/// c2pool-bch) whose run-loop uses the reward-SAFE `--coin-rpc` /
-/// `--coin-rpc-auth` arm.
+/// c2pool-bch). DASH runs DAEMONLESS by default (bare `--run`); the dashd
+/// `--coin-rpc` / `--coin-rpc-auth` arm is an explicit opt-in ("Attach
+/// external dashd").
 ///
 /// Provides a GUI form covering the important c2pool CLI flags:
-///   • Operation mode (integrated / sharechain / solo)
+///   • Operation mode (integrated / sharechain / solo / custodial / standalone)
 ///   • Network (litecoin / bitcoin / dogecoin / dash / digibyte /
 ///     bitcoincash, testnet toggle)
 ///   • Binary path + ports (P2P, stratum, HTTP API)
-///   • Parent coin-daemon RPC credentials / conf-file path
+///   • Parent coin-daemon RPC credentials / conf-file path (DASH: opt-in)
 ///   • Payout address, node-owner fee (-f), dev donation (--give-author)
 ///   • Redistribute mode for invalid-address miners (--redistribute)
 ///   • Merged-mining chains table (--merged SYMBOL:CHAIN_ID:HOST:PORT:USER:PASS[:P2P])
-///   • ★ Advanced / embedded (opt-in, reward-UNSAFE) — default OFF; the
-///     only place --coin-p2p-connect / --embedded-mainnet can be emitted
+///   • Advanced / embedded coin-network (transport + gate-lift) — opt-in;
+///     the only place --coin-p2p-connect / --embedded-mainnet can be emitted
 ///   • Generated-command preview
 ///   • Launch / Stop / Restart daemon buttons
 ///
@@ -93,8 +94,9 @@ private:
     QGroupBox* makeGroup(const QString& title);
     /// Build the command line for a LegacyUnified coin (`c2pool --net …`).
     QString buildLegacyCommand() const;
-    /// Build the command line for a PerCoinRun coin (c2pool-dash/-dgb/-bch,
-    /// reward-SAFE dashd-RPC arm; embedded arm only when opted in).
+    /// Build the command line for a PerCoinRun coin (c2pool-dash/-dgb/-bch).
+    /// DASH default is bare `--run` (daemonless); the dashd-RPC arm and the
+    /// embedded transport knobs are emitted only when their opt-ins are on.
     QString buildPerCoinCommand() const;
     /// Marshal the form + active profile into the Qt-free command core. Shared
     /// by buildPerCoinCommand() and launch()'s reward-safety precheck.
@@ -115,7 +117,7 @@ private:
     QProcess* process_;
 
     // ── Mode / Network ──────────────────────────────────────────────────────
-    QComboBox* modeCombo_;       ///< integrated / sharechain / solo
+    QComboBox* modeCombo_;       ///< integrated / sharechain / solo / custodial / standalone
     QCheckBox* testnetCheck_;
     QComboBox* chainCombo_;      ///< coin-generic (CoinProfiles.hpp order)
     QLabel*    coinNoteLabel_{nullptr};  ///< per-coin note (masternode / experimental / CLI arm)
@@ -130,6 +132,7 @@ private:
 
     // ── Parent Coin Daemon ──────────────────────────────────────────────────
     QGroupBox* coindGroup_{nullptr}; ///< relabelled per coin (daemon name)
+    QCheckBox* dashdAttachCheck_{nullptr}; ///< DASH: attach external dashd (--coin-rpc/--coin-rpc-auth); default OFF = daemonless
     QLineEdit* coindHostEdit_;
     QSpinBox*  coindPortSpin_;       ///< 0 = auto-detect from chain
     QLineEdit* rpcUserEdit_;
@@ -181,10 +184,12 @@ private:
     QCheckBox* noP2pRelayCheck_{nullptr};     ///< --no-p2p-relay (DASH/DGB)
     QLineEdit* bchAnchorEdit_{nullptr};       ///< --anchor H:HASH (BCH cold-start ABLA floor)
 
-    // ── ★ Advanced / embedded (opt-in, REWARD-UNSAFE) ────────────────────────
-    // Default OFF. This is the ONLY place --coin-p2p-connect /
-    // --embedded-mainnet may be emitted. Guarded per the DASH hotel
-    // incident: an unguarded embedded arm produced reward-unsafe blocks.
+    // ── ★ Advanced / embedded coin-network (transport + gate-lift) ───────────
+    // Opt-in, default OFF. This is the ONLY place --coin-p2p-connect /
+    // --embedded-mainnet may be emitted. DASH runs the embedded arm by default
+    // when daemonless (bare --run, --embedded-mainnet ON in the node); these
+    // controls only pin peers or force the flag explicitly (needed when dashd is
+    // attached, where it defaults OFF).
     QGroupBox*      embeddedGroup_{nullptr};
     QCheckBox*      embeddedP2pCheck_{nullptr};   ///< enables --coin-p2p-connect (default OFF)
     QPlainTextEdit* embeddedP2pPeersEdit_{nullptr}; ///< HOST:PORT per line

--- a/ui/c2pool-qt/test/test_reward_safe_launch.cpp
+++ b/ui/c2pool-qt/test/test_reward_safe_launch.cpp
@@ -1,19 +1,24 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // test_reward_safe_launch — ★ #1 acceptance criterion.
 //
-// Proves the per-coin launch command core (LaunchCommand.hpp), now driven by the
+// Proves the per-coin launch command core (LaunchCommand.hpp), driven by the
 // node parameter catalog (ParamCatalogView → src/core/param_catalog.inc):
-//   • NEVER emits the reward-UNSAFE embedded arm by default (--coin-p2p-connect /
-//     --peer / --embedded-mainnet / --coin-magic), and the default parent-daemon
-//     link is the reward-SAFE --coin-rpc arm;
+//   • the default DASH command is a bare `--run` (DAEMONLESS cut mode): it never
+//     emits the dashd arm (--coin-rpc / --coin-rpc-auth) nor the embedded knobs
+//     (--coin-p2p-connect / --peer / --embedded-mainnet / --coin-magic) unless
+//     their explicit opt-ins are set;
+//   • the dashd arm appears only when externalDaemonRpc is ticked — and on DASH
+//     --coin-rpc-auth alone (auth without the attach opt-in) must NOT leak out;
 //   • leaves the author donation to the binary default unless explicitly set, and
 //     emits --give-author 0 ONLY behind an explicit ack (never a silent zero);
 //   • emits, for EACH binary, only flag spellings the catalog carries for that
 //     binary — so BCH argv has none of -f/--give-author/--node-owner-address/
-//     --redistribute/--message-blob-hex/--addnode, DGB uses --sharechain-addnode
-//     and --http, etc.;
-//   • refuses (validate_percoin) a DASH launch whose blank RPC endpoint would run
-//     daemonless with embedded MAINNET auto-ON.
+//     --redistribute/--message-blob-hex/--addnode/--coin-rpc, DGB uses
+//     --sharechain-addnode and --http, etc.;
+//   • the legacy operation-mode flag resolves via the catalog — "solo" MUST emit
+//     --solo (never nothing, which silently ran an integrated PPLNS node);
+//   • validate_percoin only refuses an external-dashd attach with no RPC endpoint
+//     — never a daemonless DASH launch (that is the intended default).
 //
 // Qt-free: builds and runs with a plain C++17 compiler (no display).
 //
@@ -30,6 +35,8 @@ using c2pool_qt::PerCoinParams;
 using c2pool_qt::build_percoin_argv;
 using c2pool_qt::join_argv;
 using c2pool_qt::validate_percoin;
+using c2pool_qt::legacy_mode_flag;
+using c2pool_qt::LegacyMode;
 using Bin = c2pool::catalog::Bin;
 
 namespace {
@@ -80,9 +87,13 @@ PerCoinParams dashDefault()
     p.bin = Bin::BIN_DASH;
     p.binary = "./build/bin/c2pool-dash";
     p.subcommand = "--run";
+    // The form always populates the RPC host/port (127.0.0.1:9998) — the
+    // regression-relevant shape. With externalDaemonRpc=false (the default,
+    // daemonless cut mode) the dashd arm must STILL be omitted.
     p.rpcHost = "127.0.0.1";
-    p.rpcPort = 9998;                 // dashd mainnet RPC
+    p.rpcPort = 9998;                 // dashd mainnet RPC (populated, but unused)
     p.confPath = "";                  // blank ⇒ dashd default conf, off argv
+    p.externalDaemonRpc = false;      // daemonless default (no dashd attach)
     p.stratumPort = 3333;
     p.webPort = 8080;
     p.webHost = "0.0.0.0";
@@ -98,6 +109,10 @@ PerCoinParams bchDefault()
     p.binary = "./build/bin/c2pool-bch";
     p.subcommand = "--pool";
     p.confPath = "/home/u/.bitcoin/bitcoin.conf";
+    // BCH has no endpoint/submit_endpoint alias — set an RPC host/port anyway to
+    // prove neither --coin-rpc nor the HOST:PORT leaks onto BCH argv.
+    p.rpcHost = "127.0.0.1";
+    p.rpcPort = 8332;
     p.stratumPort = 3333;
     p.webPort = 8083;
     p.webHost = "0.0.0.0";
@@ -136,23 +151,56 @@ int main()
 {
     std::printf("test_reward_safe_launch\n");
 
-    // 1) DASH default command is reward-SAFE.
+    // 1) DASH default command is DAEMONLESS (bare --run) — no dashd/embedded arm.
     {
         const auto argv = build_percoin_argv(dashDefault());
         const std::string cmd = join_argv(argv);
         std::printf("DASH default: %s\n", cmd.c_str());
+        check(!contains(argv, "--coin-rpc"),
+              "DASH default omits --coin-rpc (daemonless; RPC arm is opt-in)");
+        check(!contains(argv, "--coin-rpc-auth"), "DASH default omits --coin-rpc-auth");
+        check(!contains(argv, "--coin-daemon"), "DASH default omits --coin-daemon");
         check(!contains(argv, "--coin-p2p-connect"), "DASH default omits --coin-p2p-connect");
-        check(!contains(argv, "--embedded-mainnet"), "DASH default omits --embedded-mainnet");
+        check(!contains(argv, "--embedded-mainnet"),
+              "DASH default omits --embedded-mainnet (node default ON when daemonless)");
         check(!contains(argv, "--coin-magic") && !contains(argv, "--coin-p2p-magic"),
               "DASH default omits coin-magic override");
-        check(contains(argv, "--coin-rpc"), "DASH default uses reward-safe --coin-rpc arm");
-        check(argv.size() >= 2 && argv[0] == "./build/bin/c2pool-dash" && argv[1] == "--run",
-              "DASH default invokes c2pool-dash --run");
+        check(!contains(argv, "--give-author"),
+              "DASH default omits --give-author (0.1%% binary default preserved)");
+        check(validate_percoin(dashDefault()).empty(),
+              "DASH default (daemonless) is launchable");
+        check(cmd == "./build/bin/c2pool-dash --run --stratum 3333 --web-port 8080 --listen 9339",
+              "DASH default golden argv is exactly the daemonless bare --run form");
         check(cmd.find("rpcpassword") == std::string::npos,
               "DASH default carries no rpcpassword on argv");
-        check(!contains(argv, "--give-author"),
-              "DASH default omits --give-author (binary default applies)");
         checkEveryFlagInCatalog(Bin::BIN_DASH, argv, "DASH default: every flag is a catalog alias");
+    }
+
+    // 1b) DASH dashd attach opt-in emits the RPC arm; auth alone must NOT.
+    {
+        // externalDaemonRpc ON ⇒ --coin-rpc HOST:PORT present.
+        PerCoinParams p = dashDefault();
+        p.externalDaemonRpc = true;
+        {
+            const auto argv = build_percoin_argv(p);
+            check(contains(argv, "--coin-rpc") && contains(argv, "127.0.0.1:9998"),
+                  "DASH attach opt-in emits --coin-rpc 127.0.0.1:9998");
+        }
+        // With a conf path too ⇒ --coin-rpc-auth present.
+        p.confPath = "/x/dash.conf";
+        {
+            const auto argv = build_percoin_argv(p);
+            check(contains(argv, "--coin-rpc-auth"),
+                  "DASH attach opt-in + conf path emits --coin-rpc-auth");
+        }
+        // ★ auth path set but attach OFF ⇒ NO --coin-rpc-auth (auth alone re-arms
+        // dashd on DASH, main_dash.cpp:1191 — it must stay behind the opt-in).
+        p.externalDaemonRpc = false;
+        {
+            const auto argv = build_percoin_argv(p);
+            check(!contains(argv, "--coin-rpc-auth") && !contains(argv, "--coin-rpc"),
+                  "DASH conf path with attach OFF emits neither --coin-rpc-auth nor --coin-rpc");
+        }
     }
 
     // 2) Embedded arm appears ONLY when explicitly opted in.
@@ -207,17 +255,20 @@ int main()
         }
     }
 
-    // 5) ★ F5 — DASH daemonless guard.
+    // 5) ★ Daemonless guard INVERTED — bare --run is the allowed default.
     {
         PerCoinParams p = dashDefault();
-        p.rpcHost = ""; p.rpcPort = 0;         // blank RPC arm
-        check(!validate_percoin(p).empty(),
-              "DASH blank RPC + embedded OFF ⇒ validate_percoin REFUSES");
-        p.embeddedMainnet = true;              // explicit embedded opt-in
+        p.rpcHost = ""; p.rpcPort = 0;              // blank RPC, attach OFF
         check(validate_percoin(p).empty(),
-              "DASH blank RPC + explicit embedded opt-in ⇒ allowed");
-        check(validate_percoin(dashDefault()).empty(),
-              "DASH with RPC arm ⇒ validate_percoin OK");
+              "DASH blank RPC + attach OFF ⇒ validate_percoin ALLOWS (daemonless)");
+        // Attach ticked but no endpoint ⇒ launchability refusal (not reward).
+        p.externalDaemonRpc = true;
+        check(!validate_percoin(p).empty(),
+              "DASH attach ON + blank RPC host ⇒ validate_percoin REFUSES (launchability)");
+        // Attach ticked WITH an endpoint ⇒ allowed.
+        p.rpcHost = "127.0.0.1"; p.rpcPort = 9998;
+        check(validate_percoin(p).empty(),
+              "DASH attach ON + RPC HOST:PORT ⇒ allowed");
     }
 
     // 6) BCH default: reward-safe AND carries none of the money/DASH flags it rejects.
@@ -237,6 +288,10 @@ int main()
         check(!contains(argv, "--addnode") && contains(argv, "--sharechain-addnode"),
               "BCH uses --sharechain-addnode (not DASH's --addnode)");
         check(contains(argv, "--http"), "BCH binds web via combined --http");
+        // A4: BCH has no endpoint/submit alias — an RPC host/port is silently
+        // dropped, so neither --coin-rpc nor the HOST:PORT may appear.
+        check(!contains(argv, "--coin-rpc") && !contains(argv, "127.0.0.1:8332"),
+              "BCH argv omits --coin-rpc and the RPC HOST:PORT (no endpoint alias)");
         checkEveryFlagInCatalog(Bin::BIN_BCH, argv, "BCH default: every flag is a catalog alias");
     }
 
@@ -264,6 +319,47 @@ int main()
         const auto argv = build_percoin_argv(p);
         check(contains(argv, "10.0.0.5:5023"),
               "DGB --http emits combined HOST:PORT when web host is non-default");
+    }
+
+    // 9) ★ E2 — legacy operation-mode flag resolves via the catalog. A "solo"
+    //    that emitted nothing silently ran an integrated PPLNS node; it MUST
+    //    emit --solo now. Each spelling must be a real BIN_LTC catalog alias.
+    {
+        check(legacy_mode_flag(LegacyMode::Solo) == "--solo",
+              "legacy_mode_flag(Solo) == --solo");
+        check(legacy_mode_flag(LegacyMode::Sharechain) == "--sharechain",
+              "legacy_mode_flag(Sharechain) == --sharechain");
+        check(legacy_mode_flag(LegacyMode::Integrated) == "--integrated",
+              "legacy_mode_flag(Integrated) == --integrated");
+        check(legacy_mode_flag(LegacyMode::Custodial) == "--custodial",
+              "legacy_mode_flag(Custodial) == --custodial");
+        check(legacy_mode_flag(LegacyMode::Standalone) == "--standalone",
+              "legacy_mode_flag(Standalone) == --standalone");
+        check(aliasInCatalog(Bin::BIN_LTC, "--solo")
+                  && aliasInCatalog(Bin::BIN_LTC, "--sharechain")
+                  && aliasInCatalog(Bin::BIN_LTC, "--integrated")
+                  && aliasInCatalog(Bin::BIN_LTC, "--custodial")
+                  && aliasInCatalog(Bin::BIN_LTC, "--standalone"),
+              "every legacy mode flag is a real BIN_LTC catalog alias");
+    }
+
+    // 10) ★ A4 — the catalog fact the BCH widget gating relies on: c2pool-bch
+    //     carries NO endpoint/submit/money/message alias, so those form fields
+    //     would silently drop and must be disabled.
+    {
+        using c2pool_qt::catview::spelling_for;
+        auto bchHas = [](const char* c) {
+            return spelling_for(Bin::BIN_BCH, c).has_value();
+        };
+        check(!bchHas("daemon_rpc.endpoint") && !bchHas("daemon_rpc.submit_endpoint"),
+              "BCH catalog has no RPC endpoint alias (host/port disabled)");
+        check(!bchHas("money.node_owner_address"),
+              "BCH catalog has no node_owner_address (payout field disabled)");
+        check(!bchHas("money.give_author_pct") && !bchHas("money.node_owner_fee_pct")
+                  && !bchHas("money.redistribute"),
+              "BCH catalog has no author-fee / owner-fee / redistribute surface");
+        check(!bchHas("global.message_blob_hex"),
+              "BCH catalog has no message-blob alias (message field disabled)");
     }
 
     std::printf(failures == 0 ? "ALL PASS\n" : "FAILURES: %d\n", failures);


### PR DESCRIPTION
## Summary

`ui/c2pool-qt` only. The panel now assembles argv to match the node's daemonless-default reality; **no node reward-code change** (`git diff --stat origin/master -- . ':!ui/c2pool-qt'` is empty), and the author-fee is never silently zeroed.

### E1 — DASH daemonless default; dashd RPC is an explicit opt-in
- The default DASH launch is a bare `--run` (daemonless cut mode). With no dashd arm the node keeps its good-citizen serving levers ON (embedded-mainnet included), so the panel does **not** emit `--embedded-mainnet` for that default.
- New `PerCoinParams::externalDaemonRpc` (default OFF) gates the whole `--coin-rpc` / `--coin-rpc-auth` arm on DASH. Because `--coin-rpc-auth` alone re-arms dashd (`main_dash.cpp:1191-1192`), auth is gated too — it can no longer leak out and silently leave daemonless mode. DGB/BCH keep their existing endpoint/auth emission.
- New "Attach external dashd" checkbox in the Parent Coin Daemon group (DASH-only, default OFF); the RPC host/port/conf fields enable only when it is ticked.
- `validate_percoin()` no longer refuses a daemonless DASH launch (the intended default) — it only refuses an *attach* opt-in with no RPC HOST:PORT. Dropped the "reward-UNSAFE" copy from the embedded controls (they are transport pinning / explicit gate-lift).

### E2 — legacy `solo` emits `--solo`
- The unified-binary mode combo now resolves its flag through the parameter catalog (new `LegacyMode` + `legacy_mode_flag`). A `solo` selection emits `--solo` — previously it emitted **nothing**, silently running an integrated PPLNS node. `custodial`/`standalone` added (custodial refuses a blank payout address, mirroring `main_ltc.cpp:5303-5306`). Persisted mode indices 0/1/2 stay valid.

### A4 — BCH money/RPC widgets disabled (DGB pattern extended)
- `c2pool-bch` carries no endpoint/submit/money/message alias, so those form values would be silently dropped. The catalog-driven gating now greys BCH's RPC host/port, payout-address and message-blob fields; legacy-only Python-p2pool widgets are disabled on every per-coin path.

## Reward-safety grep
- `git diff --stat origin/master -- . ':!ui/c2pool-qt'` → empty.
- `git diff` scan for `coinbase|subsidy|pplns|payee` → comment text / UI labels / legacy-widget enable calls only; no reward logic.
- author-fee stays the 0.1% binary default (omit `--give-author`); the explicit-zero ack path is unchanged.

## Tests — `test_reward_safe_launch` extended (Qt-free, catalog-driven)
Fresh clone of the pushed head on the build host, `-DC2POOL_QT_BUILD_TESTS=ON`, all three targets green:
```
1/3 reward_safe_launch ... Passed
2/3 address_validator .... Passed
3/3 embedded_leak ........ Passed
100% tests passed, 0 failed out of 3
```
New/changed coverage: DASH default is the daemonless golden `c2pool-dash --run --stratum 3333 --web-port 8080 --listen 9339` (no dashd/embedded/`--give-author`); dashd attach opt-in emits `--coin-rpc` and (with conf) `--coin-rpc-auth`, while auth-with-attach-OFF emits neither; the daemonless guard is inverted (blank RPC + attach OFF is allowed, attach ON + blank host refuses); `legacy_mode_flag` maps solo/sharechain/integrated/custodial/standalone to their catalog aliases; and the BCH catalog facts the widget gating relies on.
