### PR TITLE
ci: hard-floor heavy-disk-guard stale-hours at 3h

### DIFF
--- a/.github/actions/heavy-disk-guard/action.yml
+++ b/.github/actions/heavy-disk-guard/action.yml
@@ -20,7 +20,11 @@ inputs:
     description: >
       Age in hours above which a sibling build tree is treated as orphaned by a
       host-reaped job and reaped. A heavy build+test finishes in ~25 min, so the
-      default of 6h can only ever match a dead job's leftovers.
+      default of 6h can only ever match a dead job's leftovers. Hard-clamped to a
+      3h floor by guard.sh: the sweep's only protection for a LIVE co-resident
+      tree is its mtime being younger than this window, so a value near job
+      runtime would reap live trees mid-build. Values below 3h are raised to 3h
+      with a warning, never honored.
     default: "6"
 
 runs:

--- a/.github/actions/heavy-disk-guard/guard.sh
+++ b/.github/actions/heavy-disk-guard/guard.sh
@@ -18,6 +18,26 @@ set -uo pipefail
 FLOOR_GB="${HEAVY_DISK_FLOOR_GB:-64}"
 CCACHE_MAX="${HEAVY_DISK_CCACHE_MAX:-15G}"
 STALE_HOURS="${HEAVY_DISK_STALE_HOURS:-6}"
+# Hard floor on STALE_HOURS. The ONLY thing that keeps the mtime sweep below from
+# reaping a LIVE co-resident build tree is that the tree is younger than
+# STALE_HOURS -- and `find -mmin` reads the TOP-LEVEL build dir's own mtime, which
+# stops advancing once configure finishes creating it. So the real liveness margin
+# is STALE_HOURS minus (job time after configure), not STALE_HOURS. At the ~25min
+# heavy-leg runtime the 6h default is a huge margin, but anyone lowering this near
+# job runtime would start reaping live sibling trees mid-build -- turning a green
+# sibling into a red. Refuse to go below 3h (still >> job runtime); clamp with a
+# loud warning rather than fail, so a config typo can never itself cause a red.
+STALE_HOURS_FLOOR=3
+case "$STALE_HOURS" in
+  ''|*[!0-9]*)
+    echo "::warning::heavy-disk-guard: non-integer stale-hours '$STALE_HOURS' -- clamped to ${STALE_HOURS_FLOOR}h floor to protect live co-resident build trees"
+    STALE_HOURS=$STALE_HOURS_FLOOR ;;
+  *)
+    if [ "$STALE_HOURS" -lt "$STALE_HOURS_FLOOR" ]; then
+      echo "::warning::heavy-disk-guard: stale-hours ${STALE_HOURS}h is below the ${STALE_HOURS_FLOOR}h floor (heavy-leg runtime ~25min) -- clamped to ${STALE_HOURS_FLOOR}h to protect live co-resident build trees"
+      STALE_HOURS=$STALE_HOURS_FLOOR
+    fi ;;
+esac
 BUILD_VOLUME="${HEAVY_DISK_BUILD_VOLUME:-${GITHUB_WORKSPACE:-$PWD}}"
 # Runner-home roots to sweep for orphaned build trees. Default: every
 # actions-runner* home of the current user -- the co-resident heavy runners

--- a/.github/actions/heavy-disk-guard/test.sh
+++ b/.github/actions/heavy-disk-guard/test.sh
@@ -6,6 +6,10 @@
 #   B. the guard FAILS FAST (exit 1) with the infra error when the floor is
 #      unreachable -- i.e. the guard actually blocks, it is not a silent no-op;
 #   C. the guard PASSES (exit 0) when the floor is met.
+#   D. the STALE_HOURS clamp is real -- a sub-floor stale-hours is raised to the
+#      3h floor, so a tree younger than 3h is SPARED (not reaped) even though the
+#      requested 1h would have reaped it. Guards the "someone lowers STALE_HOURS
+#      near job runtime and starts reaping live sibling trees" foot-gun.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -31,12 +35,14 @@ plant () {
   echo "$d"
 }
 
-ORPHAN="$(plant actions-runner-heavy-9 build_asan '3 hours ago')"
+# Ages are well clear of the 3h STALE_HOURS floor so CASE A's stale-hours=3 is
+# used verbatim (not clamped): 4h orphan is reaped, a fresh live tree is spared.
+ORPHAN="$(plant actions-runner-heavy-9 build_asan '4 hours ago')"
 LIVE="$(plant   actions-runner-heavy-8 build_asan 'now')"
-NONBUILD="$(plant actions-runner-heavy-7 srcdir   '3 hours ago')"
+NONBUILD="$(plant actions-runner-heavy-7 srcdir   '4 hours ago')"
 
 # ---- CASE A: sweep reaps the orphan, spares the live + non-build -----------
-HEAVY_DISK_FLOOR_GB=0 HEAVY_DISK_STALE_HOURS=1 \
+HEAVY_DISK_FLOOR_GB=0 HEAVY_DISK_STALE_HOURS=3 \
   HEAVY_DISK_SWEEP_ROOTS="$SBX/actions-runner*" \
   bash "$GUARD" >"$SBX/a.log" 2>&1
 rcA=$?
@@ -61,6 +67,18 @@ HEAVY_DISK_FLOOR_GB=1 HEAVY_DISK_STALE_HOURS=6 \
 rcC=$?
 [ $rcC -eq 0 ] && ok "C: guard passes on reachable floor" || bad "C: expected exit 0, got $rcC"
 grep -q "heavy-disk-guard: OK" "$SBX/c.log" && ok "C: prints OK line" || bad "C: missing OK line"
+
+# ---- CASE D: STALE_HOURS clamp protects a near-runtime tree ----------------
+# A 2h-old tree is younger than the 3h floor. A requested stale-hours=1 asks to
+# reap it, but the clamp raises the threshold to 3h -- so it MUST be spared.
+NEAR="$(plant actions-runner-heavy-6 build_asan '2 hours ago')"
+HEAVY_DISK_FLOOR_GB=0 HEAVY_DISK_STALE_HOURS=1 \
+  HEAVY_DISK_SWEEP_ROOTS="$SBX/actions-runner*" \
+  bash "$GUARD" >"$SBX/d.log" 2>&1
+rcD=$?
+[ $rcD -eq 0 ]     && ok "D: guard exit 0 with clamped stale-hours"        || bad "D: expected exit 0, got $rcD"
+grep -qi "clamped to 3h" "$SBX/d.log" && ok "D: emits clamp warning"       || bad "D: missing clamp warning"
+[ -d "$NEAR" ]     && ok "D: 2h tree spared by clamp (would die at 1h)"    || bad "D: clamp failed -- 2h tree reaped: $NEAR"
 
 echo "-----"
 if [ "$fails" -eq 0 ]; then


### PR DESCRIPTION
Follow-up (2) to #1510. Guards the `stale-hours` input of the heavy-disk-guard.

## Why
The guard.sh mtime sweep reaps sibling build trees older than `STALE_HOURS`. The ONLY thing protecting a LIVE co-resident build tree from being reaped is that a tree mid-build has a fresh mtime — but `find -mmin` reads the top-level build dir's own mtime, which stops advancing once configure finishes creating it. So the effective liveness margin is `STALE_HOURS - (post-configure job time)`, not `STALE_HOURS`.

Safe today (6h default >> ~25min heavy-leg runtime), but dangerous the moment anyone lowers `stale-hours` near job runtime: the sweep would reap a live sibling tree mid-build and turn a green sibling into a code-shaped red.

## Change
- guard.sh clamps any `STALE_HOURS` below **3h** up to 3h, with a loud `::warning::` — non-integer or empty values clamp too. Clamp, not fail: a config typo must never itself cause a red.
- action.yml documents the 3h floor on the `stale-hours` input.
- Honesty gate gains **CASE D**: a 2h-old tree survives a requested `stale-hours=1` because the clamp raises the window to 3h. CASE A retimed to 4h / stale-hours=3 so it still exercises the sweep above the floor.

## Verification
`bash .github/actions/heavy-disk-guard/test.sh` — all 12 assertions PASS (A–D) locally.

No behavior change at the 6h default; only sub-3h inputs are affected.
