### PR TITLE
v37 Milestone A-BTC — live single-node Bitcoin-family daemon (v36-adapter-bound, W5 native coinbase, F1-correct) [experimental/regtest]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,6 +229,7 @@ jobs:
                     dgb_coin_node_seam_test dgb_block_broadcast_test dgb_won_block_dispatch_test dgb_forced_won_share_dualpath_test dgb_scrypt_pow_test dgb_nonce_grinder_test dgb_regrind_block_test dgb_won_block_finalize_test dgb_share_target_genesis_test dgb_share_target_retarget_test dgb_share_bits_oracle_pin_test dgb_pool_msg_wire_test dgb_get_shares_walk_test dgb_download_stops_test dgb_think_p1_walk_bounds_test dgb_think_p1_desired_emit_test dgb_think_p6_desired_cutoff_test dgb_think_p4_head_keys_test dgb_think_p3_best_head_test dgb_g1_oracle_byte_parity_test dgb_think_p2_walk_bounds_test dgb_expected_time_to_block_test dgb_tail_score_endpoints_test dgb_pool_attempts_per_second_test dgb_pool_efficiency_test dgb_think_p5_best_share_punish_test dgb_auto_ratchet_tail_guard_test dgb_auto_ratchet_sim_test dgb_binomial_conf_interval_test dgb_desired_version_tally_test dgb_min_protocol_ratchet_test dgb_get_height_and_last_endpoints_test dgb_chain_walk_window_test dgb_redistribute_delegate_ghal_test dgb_share_weight_decay_test dgb_naughty_propagation_test dgb_hash_format_parity_test dgb_emergency_decay_saturation_test dgb_arith256_muldiv_kat_test dgb_share_tx_relay_refs_test dgb_coin_peer_rearm_test v37_test v37_executor_test v37_scaffold_test v37_w2_ingestion_test v37_w4_prereq_test v37_w4_settlement_test v37_w5_coinbase_test v37_w3_relay_test v37_subthreshold_estimator_test v37_w6_persistence_test c2pool-v37-w6-leveldb-compile-check v37_w4_estimator_wiring_test v37_xmr_node_smoke \
                     v37_descriptor_xmr_test \
                     v37_xmr_canon_p1_kat \
+                    c2pool-v37-btc v37_btc_node_smoke v37_btc_digest_drift_kat f1_finalize_kat_btc \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke c2pool-v37-xmr \
                     xmr_randomx_verify_kat \
@@ -632,9 +633,12 @@ jobs:
                     v37_test v37_executor_test v37_scaffold_test v37_w2_ingestion_test v37_w4_prereq_test v37_w4_settlement_test v37_w5_coinbase_test v37_w3_relay_test v37_subthreshold_estimator_test v37_w6_persistence_test c2pool-v37-w6-leveldb-compile-check v37_w4_estimator_wiring_test v37_xmr_node_smoke \
                     v37_descriptor_xmr_test \
                     v37_xmr_canon_p1_kat \
+                    c2pool-v37-btc v37_btc_node_smoke v37_btc_digest_drift_kat f1_finalize_kat_btc \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
+                    xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat \
+            -j4 # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison
                  # (kManifest[i].upstream == &kP2pool). Fixed by replacing the

--- a/config/v37-btc/dash-regtest.yaml
+++ b/config/v37-btc/dash-regtest.yaml
@@ -1,0 +1,49 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# c2pool-v37  BITCOIN-FAMILY node — DASH REGTEST (Milestone A-BTC)
+#
+#   *** EXPERIMENTAL / PROTOTYPE — DO NOT RUN IN PRODUCTION ***
+#
+# The SHIPPED DEFAULT for the controlled mine-and-settle + reorg-drill demo.
+# regtest is REORG-INJECTABLE (invalidateblock / reconsiderblock), which the
+# controlled falsifier validation drives to exercise the F1 controlled-reorg path.
+# NEVER mainnet: --mainnet is refused by the daemon unless --i-understand-
+# experimental is also passed.
+#
+# CLI arguments always override values here. Maps to the main_v37_btc arg surface:
+#   --coin dash  --regtest  --rpc-host/-port/-user/-pass  --stratum-port
+#   --store  --d-conf  --slot-budget  --max-payout-bytes  --k-floor
+#   --subthreshold-estimator   (default OFF)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ─── Coin + network ─────────────────────────────────────────────────────────
+coin: dash
+network: regtest                 # DEFAULT; reorg-injectable for the falsifier drill
+                                 # (alternatives: devnet, testnet4[ltc]; NEVER mainnet)
+
+# ─── Coin daemon RPC endpoint (placeholder — point at your dashd regtest) ────
+rpc_host: 127.0.0.1
+rpc_port: 19998                  # dashd regtest RPC (placeholder; set to yours)
+rpc_user: "REPLACE_ME"           # dashd -rpcuser
+rpc_password: "REPLACE_ME"       # dashd -rpcpassword
+# In the shipped default build the daemon runs against a MOCK coin backend
+# (canned getblocktemplate/submitblock) so the lifecycle is host-safe; wire the
+# real embedded-SPV / daemon adapter with the CI FULL_LINK build.
+
+# ─── Stratum (miners connect here; payout address = stratum username) ────────
+stratum_port: 3333
+
+# ─── W6 settlement store (opened + RecoveryDriver run BEFORE start) ──────────
+store: "./v37btc-dash-regtest-store"
+
+# ─── v37 lane / settlement params ───────────────────────────────────────────
+lane_params:
+  d_conf: 6                      # coin finality depth before a found block settles
+  slot_budget_C: 2700            # K_fair coinbase output-count cap
+  max_payout_bytes: 0            # K_max payout byte budget (0 = unbounded)
+  k_floor: 1                     # byte-denominated h_min coefficient (h_min = k_floor*output_size)
+  subthreshold_estimator: false  # DEFAULT OFF — turning ON is a consensus change
+                                 # (RDWR-OQ2) NOT activated here.
+
+# ─── Payout descriptor canon (NATIVE ratified V37.0) ────────────────────────
+# BTC-family PayoutDescriptor kinds P2PKH/P2SH/P2WPKH/P2WSH/P2TR/RAW are the
+# native canon: NO P-1 activation, NO X6, NO RandomX. SHA-256d PoW is native.

--- a/config/v37-btc/ltc-testnet4.yaml
+++ b/config/v37-btc/ltc-testnet4.yaml
@@ -1,0 +1,40 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# c2pool-v37  BITCOIN-FAMILY node — LTC TESTNET4 (Milestone A-BTC, ALTERNATE)
+#
+#   *** EXPERIMENTAL / PROTOTYPE — DO NOT RUN IN PRODUCTION ***
+#
+# The ALTERNATE backend to the DASH-regtest default: a public Scrypt testnet.
+# Same native BTC-family lane, same F1 finalize contract — only the coin backend
+# differs (litecoind testnet4 via the v36 embedded-SPV / daemon adapter). NEVER
+# mainnet.
+#
+# CLI: --coin ltc --testnet4 --rpc-* --stratum-port --store --d-conf ...
+# ═══════════════════════════════════════════════════════════════════════════
+
+# ─── Coin + network ─────────────────────────────────────────────────────────
+coin: ltc
+network: testnet4                # public Scrypt testnet (NEVER mainnet)
+
+# ─── Coin daemon RPC endpoint (placeholder — point at your litecoind testnet) ─
+rpc_host: 127.0.0.1
+rpc_port: 19332                  # litecoind testnet RPC (placeholder; set to yours)
+rpc_user: "REPLACE_ME"
+rpc_password: "REPLACE_ME"
+
+# ─── Stratum ────────────────────────────────────────────────────────────────
+stratum_port: 3334
+
+# ─── W6 settlement store ────────────────────────────────────────────────────
+store: "./v37btc-ltc-testnet4-store"
+
+# ─── v37 lane / settlement params ───────────────────────────────────────────
+lane_params:
+  d_conf: 12                     # LTC has faster blocks → deeper finality depth
+  slot_budget_C: 2700
+  max_payout_bytes: 0
+  k_floor: 1
+  subthreshold_estimator: false  # DEFAULT OFF (RDWR-OQ2 not activated)
+
+# ─── Payout descriptor canon (NATIVE ratified V37.0) ────────────────────────
+# P2PKH/P2SH/P2WPKH/P2WSH/P2TR/RAW native canon; Scrypt PoW is native — NO P-1,
+# NO RandomX.

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -857,6 +857,20 @@ target_include_directories(c2pool-v37-xmr PRIVATE
 target_compile_definitions(c2pool-v37-xmr PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
 target_compile_features(c2pool-v37-xmr PRIVATE cxx_std_20)
 target_link_libraries(c2pool-v37-xmr PRIVATE xmr_node xmr_coin Threads::Threads)
+# ── Track A2 / Milestone A-BTC: the live BITCOIN-FAMILY single-node daemon ────
+# c2pool-v37-btc: the single-node DASH-regtest/devnet-capable (LTC testnet4
+# alternate) daemon (XbtcNode, src/c2pool/v37/btc/). It wires the MERGED v37
+# lane (V37Engine / OwedLedger / W5 NATIVE coinbase) to the mature v36 coin
+# plumbing behind ICoinBackend + core::StratumServer; it defines NO consensus
+# digest. Like c2pool-v37 it links ONLY Threads — the lifecycle is header-only
+# and the local/CI compile gate runs against MockCoinBackend (HARD SAFETY 6: the
+# heavy DASH/LTC coin libs link on the follow-on that fills DashCoinBackend /
+# LtcCoinBackend). EXPERIMENTAL — prototype, DASH-regtest/devnet only (mainnet
+# refused without --i-understand-mainnet); see the file banner + btc/README.md.
+add_executable(c2pool-v37-btc v37/main_v37_btc.cpp)
+c2pool_wire_version(c2pool-v37-btc)
+target_include_directories(c2pool-v37-btc PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(c2pool-v37-btc Threads::Threads)
 
 # W0 HAND-WIRES its consumer-side test dir explicitly. Test wiring in this repo
 # is hand-listed add_subdirectory/add_test — there is no file(GLOB) over

--- a/src/c2pool/v37/btc/README.md
+++ b/src/c2pool/v37/btc/README.md
@@ -1,0 +1,68 @@
+# c2pool-v37-btc — the live single-node BITCOIN-FAMILY daemon (Milestone A-BTC)
+
+The sibling of Milestone A-XMR. It wires the coin-agnostic, MERGED v37 engine to
+the mature v36 Bitcoin-family coin plumbing to make a runnable, testnet-capable
+BTC-family node. EXPERIMENTAL / prototype — **DASH regtest/devnet default, do not
+run in production.** Mainnet is a loud opt-in (`--i-understand-mainnet`).
+
+## What is native here
+
+The BTC-family PayoutDescriptor canon (`src/sharechain/v37/v37_descriptor.hpp`:
+P2PKH/P2SH/P2WPKH/P2WSH/P2TR/RAW) is the **NATIVE ratified V37.0 canon** —
+SHA-256d/Scrypt/X11 PoW is native. **No P-1 activation, no X6, no RandomX.** The
+W5 coinbase (`w5_coinbase.hpp`) is the native BTC-family coinbase.
+
+| file | role |
+|------|------|
+| `btc_node_config.hpp` | config surface: coin (dash/ltc), network (regtest default), daemon RPC endpoint, stratum bind, lane params, D_conf |
+| `btc_coin_backend.hpp` | `ICoinBackend` — the v36 coin-adapter seam (mainchain view / canonicality / subsidy / submit); `MockCoinBackend` for the smoke; Dash/Ltc production bindings (GAP, CI leg) |
+| `btc_settle_store.hpp` | W6 `ISettleStore` seam + Mem/File store + `RecoveryDriver` (F2 fail-closed) |
+| `btc_finalize_driver.hpp` | the live **F1** driver the node runs (same contract, adds W6 write-ahead persistence) |
+| `btc_node.hpp` | `XbtcNode` lifecycle: `open()` → `start()` → `on_tip()`/`on_block_won()` → `stop()` |
+| `btc_node_smoke.hpp` | `run_btc_node_smoke()` — shared body |
+| `../settle_finalize_driver.hpp` | the coin-agnostic **F1** driver, **byte-for-byte the driver A-XMR runs** (`c2pool::v37n::settle::FinalizeDriver`); the node's `btc_finalize_driver.hpp` is the persistence-integrated wrapper of this same per-height contract (unifying the two is the noted follow-on) |
+| `../main_v37_btc.cpp` | the `c2pool-v37-btc` entrypoint |
+| `../test/v37_btc_node_smoke.cpp` | lifecycle smoke — CI gate (both build.yml legs) |
+| `../test/v37_btc_digest_drift_kat.cpp` | drift-guard (HARD SAFETY 1) |
+| `../test/f1_finalize_kat_btc.cpp` | **F1 falsifier KAT** over `settle_finalize_driver.hpp`: per-height/burst/restart catch-up == real-time, O5.5 shorter-branch refusal, and the jump-to-tip driver **forks** the owed_digest (7 checks) |
+
+## The construction / donor order (open before start)
+
+1. **`open()` — durable side, BEFORE the engine spins:** build the `ISettleStore`;
+   `RecoveryDriver::recover()` rebuilds the `OwedLedger` + `SettleHW` + finalize
+   cursor (F2: a torn store returns false → the daemon refuses to start);
+   construct the `BtcFinalizeDriver` seeded with the recovered cursor + event seq,
+   its `CanonicalFn` bound to the coin backend's `is_canonical()`.
+2. **`start()` — live side:** `V37Engine::start()`; `AddLane(lane_chain,
+   lane_params)` through the engine (so the lane digest is the executor's); bind
+   the v36 `core::StratumServer` to the stratum endpoint; run the height-watch
+   (`poll_tip()` → `BtcFinalizeDriver::advance_to_tip()`).
+3. **`stop()` — donor teardown:** network down first, then `V37Engine::stop()`
+   drains-and-joins.
+
+## The v36 seams reused (wired, not rewritten)
+
+- **Stratum front-end:** `core::stratum::IWorkSource` + `core::StratumServer`
+  (`src/core/stratum_work_source.hpp`); BTC impl `btc::stratum::BTCWorkSource`
+  (`src/impl/btc/stratum/work_source.hpp`), LTC impl `core::MiningInterface`.
+  `IWorkSource::mining_submit` classifies PoW ≤ block target → submit.
+- **DASH mainchain view (embedded-SPV, daemonless):** `dash::coin::chain_rpc`
+  getbestblockhash/getblockhash/getblockchaininfo from `HeaderChain`
+  (`src/impl/dash/coin/chain_rpc.hpp`, `header_chain.hpp`); reception feed
+  `dash::interfaces::TipAdvance`/`BlockConnected` (`node_interface.hpp`).
+- **DASH work/template:** `dash::coin::select_dash_work` / `build_embedded_workdata`
+  (`work_source.hpp`, `embedded_gbt.hpp`), bundle `dash::coin::NodeCoinState`.
+- **DASH block submit:** `dash::coin::reconstruct_won_block` →
+  `dash::coin::won_block_dispatch` (`won_block_dispatch.hpp`): ARM A
+  `CoinClient::submit_block_p2p_raw`, ARM B `NodeRPC::submit_block_hex`.
+- **Subsidy:** `dash::coin::subsidy` (creditPool-aware) / LTC `GetBlockSubsidy`.
+- **v37 engine types:** `c2pool::v37n::V37Engine` (`v37_engine.hpp`),
+  `c2pool::v37n::settle::OwedLedger` + `SettleHW` (`w4_settlement.hpp`),
+  `c2pool::v37n::coinbase::assemble` (`w5_coinbase.hpp`).
+
+## Run
+
+```
+c2pool-v37-btc --selftest   # network-free lifecycle invariants (CI-runnable)
+# live (CI/heavy leg): --coin dash --network regtest --daemon-rpc 127.0.0.1:19998 --stratum-bind 127.0.0.1:3032
+```

--- a/src/c2pool/v37/btc/btc_coin_backend.hpp
+++ b/src/c2pool/v37/btc/btc_coin_backend.hpp
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/btc/btc_coin_backend.hpp  (Track A2 / Milestone A-BTC — v36 seam)
+//
+// ICoinBackend — the SEAM between the v37 BTC-family node lifecycle and the
+// MATURE v36 coin plumbing. It names EXACTLY the four v36 operations the v37
+// node consumes, and NOTHING ELSE. We WIRE the v36 adapter; we do not rewrite
+// it (HARD SAFETY 5). Each pure-virtual documents the concrete v36 symbol its
+// production binding delegates to.
+//
+// THE FOUR OPERATIONS (and their v36 bindings) ------------------------------
+//   best_tip()      — the coin mainchain view: (height, block-hash) of the
+//                     best chain. DASH: dash::coin::chain_rpc getbestblockhash
+//                     + HeaderChain::tip()->{height,hash} (embedded-SPV,
+//                     daemonless, src/impl/dash/coin/chain_rpc.hpp +
+//                     header_chain.hpp). LTC testnet4: getbestblockhash /
+//                     getblockchaininfo RPC.
+//   is_canonical()  — the reorg predicate the F1 driver asks at maturity:
+//                     does the best chain still carry `bid` at `height`? DASH:
+//                     dash::coin::chain_rpc getblockhash <h> == bid
+//                     (HeaderChain::get_header_by_height). LTC: getblockhash RPC.
+//   block_reward()  — the subsidy at a height, for the W5 native coinbase's
+//                     block_reward argument. DASH: dash::coin::subsidy (the
+//                     creditPool-aware subsidy, src/impl/dash/coin/subsidy.hpp).
+//                     LTC: GetBlockSubsidy halving schedule.
+//   submit_block()  — hand an assembled full-block hex to the coin network.
+//                     DASH: the daemonless critical path is ARM A
+//                     CoinClient::submit_block_p2p_raw (embedded coin-P2P
+//                     relay) with ARM B NodeRPC::submit_block_hex (submitblock
+//                     RPC backup) — see dash::coin::won_block_dispatch
+//                     (won_block_dispatch.hpp) fed by
+//                     dash::coin::reconstruct_won_block. LTC: submitblock RPC.
+//
+// The STRATUM front-end is a SEPARATE v36 seam (core::stratum::IWorkSource +
+// core::StratumServer, src/core/stratum_work_source.hpp): the BTC-family node
+// hands the v36 BTCWorkSource / DASHWorkSource straight to a core::StratumServer
+// and lets IWorkSource::mining_submit classify PoW ≤ block target → submit. The
+// node's role is only to feed that work source the current template and to bind
+// its block-found callback to build the W5 coinbase + call submit_block() here.
+// So the WORK/TEMPLATE half is NOT in ICoinBackend — it lives in the v36 work
+// source; ICoinBackend carries the mainchain-view + subsidy + submit half the
+// F1 driver and the coinbase path need.
+//
+// Header-only, STL-only. The MockCoinBackend below is the LOCAL smoke backend
+// (HARD SAFETY 6: heavy/full DASH+LTC builds are CI-only; locally we smoke
+// against this mock). DashCoinBackend / LtcCoinBackend are the production
+// bindings — declared here as GAP stubs with their exact delegation cited, to
+// be filled in the follow-on that links the heavy v36 coin libraries under CI.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <sharechain/v37/v37_roundabout.hpp>   // ::v37::bytes32, ::v37::ChainId
+
+namespace c2pool::v37n::btc {
+
+// The coin mainchain view at one instant: best-chain height + block hash.
+struct CoinTip {
+    std::uint64_t  height = 0;
+    std::string    hash;      // display-hex block hash (the F1 driver's bid space)
+    ::v37::bytes32 id{};      // the 32-byte hash, for SettleHW::advance(best_id)
+};
+
+// The disposition of a submit_block(): whether the coin network accepted it.
+struct SubmitResult {
+    bool        accepted = false;   // accepted OR duplicate == success
+    bool        armed    = false;   // a submit sink was actually wired (fired)
+    std::string reason;             // loud cause on neither-accept (telemetry #987)
+};
+
+class ICoinBackend {
+public:
+    virtual ~ICoinBackend() = default;
+
+    // (1) mainchain view — best chain tip. Polled by the node's height-watch
+    //     loop; every advance feeds BtcFinalizeDriver::advance_to_tip().
+    virtual CoinTip best_tip() = 0;
+
+    // (2) reorg predicate — is `bid` still the canonical block at `height`?
+    //     Bound into BtcFinalizeDriver's CanonicalFn.
+    virtual bool is_canonical(std::uint64_t height, const std::string& bid) = 0;
+
+    // (3) subsidy — the block reward at `height`, for the W5 coinbase.
+    virtual std::uint64_t block_reward(std::uint64_t height) = 0;
+
+    // (4) submit — hand a full-block hex to the coin network (ARM A + ARM B).
+    virtual SubmitResult submit_block(const std::string& block_hex) = 0;
+
+    // Human tag for logs.
+    virtual const char* name() const = 0;
+};
+
+// ---------------------------------------------------------------------------
+// MockCoinBackend — the LOCAL smoke backend. A scripted, reorg-injectable coin
+// mainchain: append_block() extends the chain, reorg_to() rolls it back and
+// re-forges from a fork point (the controlled falsifier's reorg drill). No coin
+// daemon, no PoW, no network — everything the DASH-regtest demo needs to prove
+// the v37 lifecycle end to end without linking the heavy v36 coin libs.
+// ---------------------------------------------------------------------------
+class MockCoinBackend final : public ICoinBackend {
+public:
+    explicit MockCoinBackend(std::uint64_t fixed_reward = 5000000000ULL /*50.00*/)
+        : m_reward(fixed_reward) {}
+
+    // Extend the best chain by one block with the given hash. Returns its height.
+    std::uint64_t append_block(const std::string& hash) {
+        std::uint64_t h = m_chain.size();      // genesis at height 0 implied
+        m_chain.push_back(hash);
+        m_by_hash[hash] = h;
+        return h;
+    }
+
+    // Reorg: drop every block above `fork_height`, then append `new_tail` on top
+    // of the survivor. Blocks dropped here fail is_canonical() at their old
+    // height → the F1 driver orphans any found block among them.
+    void reorg_to(std::uint64_t fork_height, const std::vector<std::string>& new_tail) {
+        while (m_chain.size() > fork_height + 1) {
+            m_by_hash.erase(m_chain.back());
+            m_chain.pop_back();
+        }
+        for (const auto& h : new_tail) append_block(h);
+    }
+
+    CoinTip best_tip() override {
+        CoinTip t;
+        if (m_chain.empty()) return t;
+        t.height = m_chain.size() - 1;
+        t.hash   = m_chain.back();
+        t.id     = hash_to_id(t.hash);
+        return t;
+    }
+
+    bool is_canonical(std::uint64_t height, const std::string& bid) override {
+        if (height >= m_chain.size()) return false;
+        return m_chain[height] == bid;
+    }
+
+    std::uint64_t block_reward(std::uint64_t /*height*/) override { return m_reward; }
+
+    SubmitResult submit_block(const std::string& block_hex) override {
+        SubmitResult r;
+        r.armed = true;
+        r.accepted = !block_hex.empty();       // mock: any non-empty block "accepted"
+        m_submitted.push_back(block_hex);
+        if (!r.accepted) r.reason = "mock: empty block hex";
+        return r;
+    }
+
+    const char* name() const override { return "mock"; }
+
+    // smoke introspection
+    const std::vector<std::string>& submitted() const { return m_submitted; }
+
+private:
+    // A stable 32-byte id from the hash string (smoke only — the real backend
+    // carries the true block hash bytes).
+    static ::v37::bytes32 hash_to_id(const std::string& s) {
+        ::v37::bytes32 b{};
+        for (std::size_t i = 0; i < s.size() && i < 32; ++i)
+            b[i] = static_cast<std::uint8_t>(s[i]);
+        return b;
+    }
+    std::uint64_t            m_reward;
+    std::vector<std::string> m_chain;      // index == height
+    std::map<std::string, std::uint64_t> m_by_hash;
+    std::vector<std::string> m_submitted;
+};
+
+// ---------------------------------------------------------------------------
+// DashCoinBackend / LtcCoinBackend — PRODUCTION bindings (GAP: CI-only, links
+// the heavy v36 coin libs). Declared here with their exact delegation so the
+// follow-on is a fill-in, not a design. Kept out of the local smoke TU per HARD
+// SAFETY 6 (host OOM); see build.yml note — these compile on the CI leg that
+// already links src/impl/dash and src/impl/ltc.
+//
+//   class DashCoinBackend final : public ICoinBackend {
+//     // best_tip()     -> dash::coin::HeaderChain::tip() (embedded-SPV) with a
+//     //                   dash::coin::chain_rpc getbestblockhash cross-check.
+//     // is_canonical() -> dash::coin::HeaderChain::get_header_by_height(h)==bid
+//     //                   (chain_rpc getblockhash <h>).
+//     // block_reward() -> dash::coin::subsidy (creditPool-aware).
+//     // submit_block() -> dash::coin::won_block_dispatch: ARM A
+//     //                   CoinClient::submit_block_p2p_raw + ARM B
+//     //                   NodeRPC::submit_block_hex (submitblock backup).
+//     // (the full block hex comes from dash::coin::reconstruct_won_block fed the
+//     //  W5 coinbase this node built — see btc_node.hpp on_block_won.)
+//   };
+//   class LtcCoinBackend final : public ICoinBackend {
+//     // best_tip()/is_canonical()/block_reward() -> ltc daemon getblockchaininfo
+//     //   / getblockhash / GetBlockSubsidy; submit_block() -> submitblock RPC.
+//   };
+// ---------------------------------------------------------------------------
+
+} // namespace c2pool::v37n::btc

--- a/src/c2pool/v37/btc/btc_finalize_driver.hpp
+++ b/src/c2pool/v37/btc/btc_finalize_driver.hpp
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/btc/btc_finalize_driver.hpp  (Track A2 / Milestone A-BTC — F1)
+//
+// THE PRODUCTION SETTLEMENT FINALIZE DRIVER for the BITCOIN FAMILY — the piece
+// the F1 audit found had no live caller (OwedLedger::on_block_finalized was only
+// ever reached by the w4 test harness's reconcile()). This is the live driver,
+// written to the F1 CONTRACT verbatim:
+//
+//   on_block_finalized() is called ONCE PER COIN-HEIGHT STEP, IN ORDER, with
+//   bin_height = the best-chain HIGH-WATER AT THAT STEP — NEVER the live coin
+//   daemon tip. The stepping is driven off the coin adapter's mainchain height
+//   progression (dash::coin::chain_rpc / HeaderChain for DASH, the daemon RPC
+//   tip for LTC testnet4), one height at a time.
+//
+// COIN-AGNOSTIC BY CONSTRUCTION: this is BYTE-FOR-BYTE the same sequencing logic
+// as src/c2pool/v37/xmr/xmr_finalize_driver.hpp (Milestone A-XMR). The only
+// inputs are `bid` (a block-id string — a BTC-family block HASH hex here, a
+// Monero block id there), `height`, credit/payout Amounts, a ChainId, d_conf,
+// an ISettleStore and a caller-supplied canonicality predicate. It does NOT
+// name a coin. The XMR and BTC nodes feed it from different backends; the driver
+// is identical. (The two files could be one v37/finalize_driver.hpp; kept
+// parallel to let each milestone land independently.)
+//
+// WHY THIS SHAPE (the bug it avoids): OwedLedger::rearm_first_eligible(bin_height)
+// stamps first_eligible (the K_fair age clock) for every newly-owed key at
+// `bin_height`. If a node that has fallen behind finalized a backlog of matured
+// blocks all at the LIVE TIP height (the reconcile() shape), every key those
+// blocks newly owe would be stamped with a single, far-future age — over-aging
+// them relative to a node that stayed in sync, so the two nodes would compute
+// DIFFERENT K_fair orderings and DIFFERENT coinbases: a consensus split. The
+// contract removes that: a block mined at coin height H_b finalizes with
+// bin_height = H_b + D_conf (the high-water at the moment H_b became buried
+// D_conf deep), replayed in strict ascending order regardless of how far ahead
+// the live tip has run. Deterministic in the coin height progression alone.
+//
+// SCOPE: single lane (one BTC-family parent). Header-only, STL-only,
+// unit-testable with no coin adapter/engine (canonicality is a caller-supplied
+// predicate; the smoke feeds a scripted MockCoinBackend). Consensus-DIGEST-
+// NEUTRAL: it only SEQUENCES calls into the merged OwedLedger.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <c2pool/v37/w4_settlement.hpp>          // OwedLedger, SettleHW (merged)
+#include <c2pool/v37/btc/btc_settle_store.hpp>   // ISettleStore, SettleEvent, codec
+
+namespace c2pool::v37n::btc {
+
+// A settlement-carrying block WE found and broadcast, awaiting D_conf burial.
+struct FoundBlock {
+    std::string   bid;          // BTC-family block hash (hex) — the OwedLedger key
+    std::uint64_t height = 0;   // the coin height it was mined at
+    Amounts       credit;       // per-key entitlement E_b at b's burial-gated prefix
+    Amounts       payout;       // the coinbase outputs broadcast in b (K_fair)
+    bool          canonical = true;
+};
+
+// Result of one advance, for the smoke/KAT to assert the F1 discipline.
+struct FinalizeStep {
+    std::string   bid;
+    std::uint64_t coin_height = 0;   // H_b, the height the block was mined at
+    std::uint64_t bin_height  = 0;   // the high-water at the finalize step (== H_b + D_conf)
+};
+
+class BtcFinalizeDriver {
+public:
+    // `is_canonical(height, bid)` returns true iff the best chain still carries
+    // block `bid` at `height`. For DASH this is answered from the embedded-SPV
+    // HeaderChain (dash::coin::chain_rpc getblockhash <h> == bid); for LTC from
+    // the daemon getblockhash RPC. The MockCoinBackend answers it from its
+    // scripted chain (reorg-injectable).
+    using CanonicalFn = std::function<bool(std::uint64_t height, const std::string& bid)>;
+
+    BtcFinalizeDriver(OwedLedger& ledger, SettleHW& hw, ISettleStore& store,
+                      ::v37::ChainId chain, std::uint64_t d_conf,
+                      std::uint64_t recovered_cursor_height,
+                      std::uint64_t recovered_event_seq, CanonicalFn is_canonical)
+        : m_ledger(ledger), m_hw(hw), m_store(store), m_chain(chain),
+          m_d_conf(d_conf), m_cursor_h(recovered_cursor_height),
+          m_seq(recovered_event_seq), m_is_canonical(std::move(is_canonical)) {}
+
+    // Register a settlement-carrying block we just found. Write-ahead the FOUND
+    // event (durable BEFORE the block is announced, W6 §5.2), enter the merged
+    // ledger's pending set, and remember it for maturity. Idempotent per bid.
+    void on_block_found(const FoundBlock& b) {
+        if (m_found.count(b.bid)) return;
+        SettleEvent ev;
+        ev.kind = SettleEvKind::Found;
+        ev.bid = b.bid;
+        ev.credit = b.credit;
+        ev.payout = b.payout;
+        write_event(ev);
+        m_ledger.on_block_found(b.bid, b.credit, b.payout);
+        m_found.emplace(b.bid, b);
+        m_by_height[b.height].push_back(b.bid);
+    }
+
+    // A block left the best chain (an Orphan / a Reorg that dropped it). Dispose
+    // per the merged ledger's O3.5 rule (pre-SETTLED: pure removal; post-SETTLED:
+    // priced residual). Write-ahead the ORPHAN event.
+    void on_block_orphaned(const std::string& bid) {
+        auto it = m_found.find(bid);
+        Amounts payout = (it != m_found.end()) ? it->second.payout : Amounts{};
+        SettleEvent ev;
+        ev.kind = SettleEvKind::Orphan;
+        ev.bid = bid;
+        ev.payout = payout;
+        write_event(ev);
+        m_ledger.on_block_orphaned(bid, payout);
+        if (it != m_found.end()) it->second.canonical = false;
+    }
+
+    // ── THE F1 DRIVER ──────────────────────────────────────────────────────
+    // Advance settlement to reflect that the best chain now stands at
+    // (best_height, best_id). Steps the finalize cursor ONE coin-height at a
+    // time from cursor+1 up to the newly-buried frontier (best_height - D_conf),
+    // finalizing each matured found block IN ORDER with the per-step high-water.
+    // Returns the steps taken (for assertions); empty when nothing matured.
+    //
+    // O5.5: a candidate best_height BELOW the persisted high-water is REFUSED
+    // (settlement is never advanced or re-evaluated against a lower height); the
+    // driver returns empty without touching the ledger. A reorg that LOWERS the
+    // tip is handled by on_block_orphaned on the dropped blocks, not here.
+    std::vector<FinalizeStep> advance_to_tip(std::uint64_t best_height,
+                                             const ::v37::bytes32& best_id) {
+        std::vector<FinalizeStep> steps;
+
+        // O5.5 gate (MD-3 ruling A): refuse a shorter candidate outright.
+        if (!m_hw.admit_candidate_height(best_height)) {
+            persist_hw();                        // record the refusal count
+            return steps;
+        }
+        m_hw.advance(best_height, best_id);      // monotone high-water
+
+        // Newly-buried frontier. Guard unsigned underflow when the chain is
+        // shallower than D_conf (early regtest/devnet).
+        const std::uint64_t frontier =
+            (best_height >= m_d_conf) ? best_height - m_d_conf : 0;
+
+        // Step per coin-height, IN ORDER. For each height h that just crossed
+        // the D_conf burial threshold, the high-water at that step is h + D_conf
+        // (NOT best_height): that is the value the K_fair clock must see, so a
+        // node catching up replays the SAME per-height clock a synced node saw.
+        for (std::uint64_t h = m_cursor_h + 1; h <= frontier; ++h) {
+            const std::uint64_t bin_height = h + m_d_conf;   // high-water at this step
+
+            auto bit = m_by_height.find(h);
+            if (bit != m_by_height.end()) {
+                for (const std::string& bid : bit->second) {
+                    auto fit = m_found.find(bid);
+                    if (fit == m_found.end()) continue;
+                    if (!fit->second.canonical) continue;             // already orphaned
+                    if (m_is_canonical && !m_is_canonical(h, bid)) {  // orphaned at maturity
+                        on_block_orphaned(bid);
+                        continue;
+                    }
+                    if (!m_ledger.is_pending(bid)) continue;          // idempotent / already settled
+
+                    // FINALIZE — write-ahead THEN mutate the ledger (crash-safe
+                    // ordering), with the per-step bin_height. This is the sole
+                    // live caller of OwedLedger::on_block_finalized.
+                    SettleEvent ev;
+                    ev.kind = SettleEvKind::Finalize;
+                    ev.bid = bid;
+                    ev.bin_height = bin_height;
+                    write_event(ev);
+                    m_ledger.on_block_finalized(bid, bin_height);
+                    steps.push_back(FinalizeStep{bid, h, bin_height});
+                }
+            }
+            m_cursor_h = h;
+            persist_cursor();
+        }
+        persist_hw();
+        return steps;
+    }
+
+    std::uint64_t cursor_height() const { return m_cursor_h; }
+    std::uint64_t event_seq()     const { return m_seq; }
+
+private:
+    void write_event(const SettleEvent& ev) {
+        auto b = m_store.batch();
+        b->put(store_codec::k_evt(m_chain, ++m_seq), ev.serialize());
+        b->commit_sync();
+    }
+    void persist_cursor() {
+        std::string v;
+        store_codec::put_u64(v, m_cursor_h);
+        auto b = m_store.batch();
+        b->put(store_codec::k_cursor(m_chain), v);
+        b->commit_sync();
+    }
+    void persist_hw() {
+        m_hw.ledger_seq = m_ledger.ledger_seq();
+        auto b = m_store.batch();
+        b->put(store_codec::k_hw(m_chain), m_hw.serialize());
+        b->commit_sync();
+    }
+
+    OwedLedger&    m_ledger;
+    SettleHW&      m_hw;
+    ISettleStore&  m_store;
+    ::v37::ChainId m_chain;
+    std::uint64_t  m_d_conf;
+    std::uint64_t  m_cursor_h;   // highest coin height already processed for burial
+    std::uint64_t  m_seq;        // write-ahead event sequence
+    CanonicalFn    m_is_canonical;
+
+    std::map<std::string, FoundBlock>                 m_found;      // bid -> block
+    std::map<std::uint64_t, std::vector<std::string>> m_by_height;  // mined height -> bids
+};
+
+} // namespace c2pool::v37n::btc

--- a/src/c2pool/v37/btc/btc_node.hpp
+++ b/src/c2pool/v37/btc/btc_node.hpp
@@ -1,0 +1,275 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/btc/btc_node.hpp   (Track A2 / Milestone A-BTC — the lifecycle)
+//
+// XbtcNode — the live v37 node lifecycle for the BITCOIN FAMILY. It wires the
+// coin-agnostic, MERGED v37 engine (V37Engine, W4 OwedLedger, W5 native
+// coinbase) to the MATURE v36 coin plumbing (the coin adapter behind
+// ICoinBackend, and the v36 core::StratumServer / IWorkSource front-end).
+//
+// SIBLING of src/c2pool/v37/xmr/ (Milestone A-XMR): identical engine + F1 driver
+// + W6 shape; the coin backend differs (v36 Bitcoin/DASH adapter instead of
+// monerod, and the W5 NATIVE coinbase instead of the CARROT-fenced XMR one).
+//
+// ── THE CONSTRUCTION ORDER (donor lifecycle; open() then start()) ───────────
+//   1. open() — DURABLE side, BEFORE the engine spins:
+//        a. build the ISettleStore (File/LevelDB in prod, Mem in the smoke);
+//        b. RecoveryDriver::recover() rebuilds the OwedLedger + SettleHW +
+//           finalize cursor from the store — F2 fail-closed: a torn store
+//           returns false and the daemon REFUSES to start;
+//        c. construct the BtcFinalizeDriver seeded with the recovered cursor +
+//           event seq, its CanonicalFn bound to the coin backend's is_canonical.
+//   2. start() — LIVE side:
+//        d. V37Engine::start() (spawns the single executor thread);
+//        e. AddLane(lane_chain, lane_params) — the one BTC-family lane, seeded
+//           through the engine so its digest is the executor's, not ours;
+//        f. hand the v36 work source to a core::StratumServer bound to
+//           stratum_bind — miners connect; IWorkSource::mining_submit classifies
+//           PoW; a block-winning share fires on_block_won();
+//        g. run the height-watch: poll ICoinBackend::best_tip() and feed each
+//           advance to BtcFinalizeDriver::advance_to_tip() (the F1 contract).
+//   3. stop() — teardown in donor order: stop the stratum/network first, then
+//      V37Engine::stop() drains-and-joins (no callback can submit post-stop).
+//
+// ── HARD SAFETY MAPPING ─────────────────────────────────────────────────────
+//   (1) no consensus-DIGEST change — every digest comes from the merged
+//       V37Engine/OwedLedger/W5; XbtcNode only SEQUENCES calls. See the
+//       drift-guard KAT (btc_digest_drift_kat.cpp).
+//   (2) F1 — the finalize driver is the sole live caller of on_block_finalized,
+//       one coin-height step at a time, bin_height = high-water AT the step.
+//   (3) NATIVE canon — W5 assemble() is the native BTC-family coinbase; no
+//       XMR/P-1 code is reachable from here.
+//   (4) DASH-regtest DEFAULT; mainnet refused without i_understand_mainnet.
+//   (5) v36 reuse — the coin logic lives behind ICoinBackend / IWorkSource; we
+//       wire, never rewrite.
+//   (6) local smoke uses MockCoinBackend + MemSettleStore (no heavy libs).
+//
+// Header-only, STL-only. The stratum server object itself (Boost.Asio) is NOT
+// constructed here — XbtcNode exposes on_block_won() as the callback the v36
+// work source invokes on a block-winning share, so the lifecycle is unit-
+// testable with no network. main_v37_btc.cpp binds the real core::StratumServer.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <c2pool/v37/v37_engine.hpp>            // V37Engine (merged)
+#include <c2pool/v37/w4_settlement.hpp>         // OwedLedger, SettleHW (merged)
+#include <c2pool/v37/w5_coinbase.hpp>           // native BTC-family coinbase (merged)
+#include <c2pool/v37/btc/btc_node_config.hpp>
+#include <c2pool/v37/btc/btc_settle_store.hpp>
+#include <c2pool/v37/btc/btc_finalize_driver.hpp>
+#include <c2pool/v37/btc/btc_coin_backend.hpp>
+#include <sharechain/v37/v37_roundabout.hpp>    // ::v37::LaneRecord, LaneParams
+
+namespace c2pool::v37n::btc {
+
+namespace cb = ::c2pool::v37n::coinbase;
+
+// Resolve a canonical OWED key to its payout ScriptRef. In production this is
+// W4's OI-W4-1 identity view (SettlementView::identities); the smoke supplies a
+// P2PKH resolver. Injected so the lifecycle never bakes an identity policy.
+using PayOfFn = std::function<::v37::ScriptRef(const ::v37::bytes32& key)>;
+
+// The disposition of a block-winning share the v36 work source handed us.
+struct WonBlockOutcome {
+    bool                  emitted = false;   // W5 buried-gate decided to pay
+    std::size_t           outputs = 0;       // K_fair outputs assembled
+    ::v37::bytes32        state_root{};       // §13 root committed in the coinbase
+    SubmitResult          submit;            // coin-backend submit disposition
+    std::string           bid;               // the block hash we submitted under
+};
+
+class XbtcNode {
+public:
+    XbtcNode(BtcNodeConfig cfg, std::unique_ptr<ISettleStore> store,
+             std::shared_ptr<ICoinBackend> coin, PayOfFn pay_of)
+        : m_cfg(std::move(cfg)), m_store(std::move(store)),
+          m_coin(std::move(coin)), m_pay_of(std::move(pay_of)) {}
+
+    // ── STEP 1: open() — durable side, BEFORE the engine starts ──────────────
+    // Rebuild the OWED ledger from the store (F2 fail-closed). Returns false iff
+    // the store is torn (the daemon must then refuse to start). Also enforces
+    // the mainnet fence (HARD SAFETY 4).
+    bool open() {
+        if (m_cfg.network == BtcNetwork::Mainnet && !m_cfg.i_understand_mainnet)
+            return false;   // loud mainnet refusal
+
+        m_ledger = std::make_unique<OwedLedger>(m_cfg.lane_chain);
+
+        RecoveryDriver rec(*m_store, m_cfg.lane_chain);
+        bool ok = false;
+        RecoveredState st = rec.recover(*m_ledger, ok);
+        if (!ok) return false;                 // F2: torn store → refuse to start
+        m_hw = st.hw;
+
+        // The F1 driver, seeded with the recovered cursor + event seq, its
+        // canonicality predicate bound to the coin backend (the reorg oracle).
+        auto is_canon = [this](std::uint64_t h, const std::string& bid) {
+            return m_coin->is_canonical(h, bid);
+        };
+        m_fin = std::make_unique<BtcFinalizeDriver>(
+            *m_ledger, m_hw, *m_store, m_cfg.lane_chain, m_cfg.d_conf,
+            st.finalize_cursor_height, st.max_event_seq, is_canon);
+        m_opened = true;
+        return true;
+    }
+
+    // ── STEP 2: start() — live side ──────────────────────────────────────────
+    // Spin the engine and seed the single BTC-family lane THROUGH it (so its
+    // digest is the executor's). The stratum server + height-watch are driven
+    // externally (main binds core::StratumServer; a poll loop calls on_tip()).
+    bool start() {
+        if (!m_opened) return false;
+        m_engine = std::make_unique<V37Engine>();
+        m_engine->start();
+        ::v37::SubmitResult r =
+            m_engine->submit_tracked(
+                        ::v37::LaneRecord::add_lane(m_cfg.lane_chain, m_cfg.lane_params))
+                .get();
+        if (!r.applied()) return false;
+        m_started = true;
+        return true;
+    }
+
+    // ── STEP 2g: the F1 height-watch tick ───────────────────────────────────
+    // Called on every observed coin-tip advance (the main poll loop reads
+    // ICoinBackend::best_tip() and passes it here). Delegates to the F1 driver,
+    // which steps ONE coin-height at a time — never jumps to the tip.
+    std::vector<FinalizeStep> on_tip(const CoinTip& tip) {
+        if (!m_started) return {};
+        return m_fin->advance_to_tip(tip.height, tip.id);
+    }
+    // Convenience: read the backend's tip and tick.
+    std::vector<FinalizeStep> poll_tip() { return on_tip(m_coin->best_tip()); }
+
+    // ── STEP 2f: on_block_won() — a block-winning share arrived ──────────────
+    // The v36 work source's mining_submit found PoW ≤ block target. Build the
+    // W5 NATIVE coinbase from the finality-gated OWED ledger (oldest-owed-first
+    // K_fair, §13 state-root) under the buried gate, then submit the block to
+    // the coin network via the backend. `bid` is the winning block's hash; the
+    // real block hex is assembled by the v36 reconstructor from these outputs
+    // (dash::coin::reconstruct_won_block) — here we pass the coinbase summary
+    // through to the backend, which in production feeds the reconstructor.
+    //
+    // The buried gate here is the block's OWN-chain depth at win time (a fresh
+    // win is depth 0, so a live win emits nothing until it matures — exactly the
+    // W5/§4.7 rule); the STANDING settlement is what the F1 driver finalizes as
+    // blocks bury. So on_block_won primarily REGISTERS the found block with the
+    // F1 driver (write-ahead + pending) and assembles the coinbase the block
+    // will carry; emission of PRIOR owed balances rides the buried gate.
+    WonBlockOutcome on_block_won(const std::string& bid, std::uint64_t won_height,
+                                 std::uint64_t confirmations) {
+        WonBlockOutcome out;
+        out.bid = bid;
+        if (!m_started) return out;
+
+        const std::uint64_t reward = m_coin->block_reward(won_height);
+        cb::CoinbaseBudget budget;                 // ratified defaults (unbounded C/K_max here)
+        budget.k_floor = 0;
+
+        auto pay_of = [this](const ::v37::bytes32& k) { return m_pay_of(k); };
+
+        cb::BurialGate gate;
+        gate.d_conf        = m_cfg.d_conf;
+        gate.canonical     = m_coin->is_canonical(won_height, bid);
+        gate.confirmations = confirmations;
+
+        // W5 native coinbase from the OWED ledger, buried-gated (§13 state root).
+        cb::CoinbaseAssembly asm_ =
+            cb::assemble_if_buried(*m_ledger, reward, budget, gate, pay_of);
+        out.emitted    = asm_.emitted;
+        out.outputs    = asm_.outputs.size();
+        out.state_root = asm_.state_root;
+
+        // Register the found block with the F1 driver: write-ahead FOUND + enter
+        // the merged ledger's pending set, so as the block buries D_conf deep the
+        // height-watch finalizes it IN ORDER (the F1 contract). credit/payout are
+        // the per-key entitlement the block carries (from the assembly).
+        FoundBlock fb;
+        fb.bid    = bid;
+        fb.height = won_height;
+        for (const auto& o : asm_.outputs) {
+            fb.credit[o.key] = static_cast<long long>(o.amount);
+            fb.payout[o.key] = static_cast<long long>(o.amount);
+        }
+        m_fin->on_block_found(fb);
+
+        // Submit the block to the coin network (ARM A embedded P2P + ARM B
+        // submitblock RPC, behind the backend). block_hex is produced by the v36
+        // reconstructor in production; the smoke's MockCoinBackend accepts a
+        // non-empty placeholder. Fail-closed: if PoW verify is off, we never
+        // reach here (the work source rejected the share as a network block).
+        out.submit = m_coin->submit_block(reconstruct_block_hex(bid, asm_));
+        return out;
+    }
+
+    // A reorg dropped a block we found — dispose via the F1 driver (O3.5).
+    void on_block_orphaned(const std::string& bid) {
+        if (m_started) m_fin->on_block_orphaned(bid);
+    }
+
+    // ── STEP 3: stop() — donor teardown order ────────────────────────────────
+    void stop() {
+        if (m_engine) m_engine->stop();     // drain-and-join (network already down)
+        m_started = false;
+    }
+
+    // ── read seams (any thread) ──────────────────────────────────────────────
+    OwedLedger&       ledger()        { return *m_ledger; }
+    V37Engine&        engine()        { return *m_engine; }
+    BtcFinalizeDriver& finalizer()    { return *m_fin; }
+    const BtcNodeConfig& config() const { return m_cfg; }
+    std::shared_ptr<const ::v37::LaneSnapshot> lane_snapshot() const {
+        return m_engine ? m_engine->snapshot(m_cfg.lane_chain) : nullptr;
+    }
+
+private:
+    // Placeholder for the v36 reconstruct_won_block(share_hash, coinbase, ...)
+    // full-block-hex assembly. Kept out of the lifecycle proper (it needs the
+    // known-tx bodies + the coin's block header codec, which live in the v36
+    // coin lib). The DashCoinBackend fills this via reconstruct_won_block; the
+    // smoke returns a non-empty marker so submit() exercises the wire.
+    static std::string reconstruct_block_hex(const std::string& bid,
+                                             const cb::CoinbaseAssembly& a) {
+        // GAP: real path is dash::coin::reconstruct_won_block(...) -> .hex.
+        return "v37blk:" + bid + ":" + std::to_string(a.outputs.size());
+    }
+
+    BtcNodeConfig                  m_cfg;
+    std::unique_ptr<ISettleStore>  m_store;
+    std::shared_ptr<ICoinBackend>  m_coin;
+    PayOfFn                        m_pay_of;
+
+    std::unique_ptr<OwedLedger>        m_ledger;
+    SettleHW                           m_hw;
+    std::unique_ptr<BtcFinalizeDriver> m_fin;
+    std::unique_ptr<V37Engine>         m_engine;
+
+    bool m_opened = false;
+    bool m_started = false;
+};
+
+// ── a P2PKH pay_of for the smoke / any all-P2PKH deployment ─────────────────
+// Maps a canonical key's first 20 bytes to a P2PKH ScriptRef. Production wires
+// PayOfFn to the W4 OI-W4-1 identity view instead.
+inline PayOfFn p2pkh_pay_of() {
+    return [](const ::v37::bytes32& k) {
+        ::v37::ScriptRef r;
+        r.kind = ::v37::ScriptKind::P2PKH;
+        r.payload.assign(k.begin(), k.begin() + 20);
+        return r;
+    };
+}
+
+} // namespace c2pool::v37n::btc

--- a/src/c2pool/v37/btc/btc_node_config.hpp
+++ b/src/c2pool/v37/btc/btc_node_config.hpp
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/btc/btc_node_config.hpp   (Track A2 / Milestone A-BTC — node)
+//
+// The configuration surface for the single-node testnet-capable c2pool-v37
+// BITCOIN-FAMILY daemon (XbtcNode). CONSUMER-tree code: a pure value struct, no
+// consensus digest — every consensus knob it carries (LaneParams) is passed
+// THROUGH to the merged executor, never redefined here.
+//
+// EXPERIMENTAL / DEVNET-DEFAULT: `network` defaults to Regtest/Devnet and the
+// daemon README posture is do-not-run-in-production. Mainnet is a deliberate,
+// loud opt-in (XbtcNode refuses to build a mainnet coinbase / submit a mainnet
+// block without an explicit --i-understand-mainnet acknowledgement — HARD
+// SAFETY 4). DASH regtest/devnet is the DEFAULT so the controlled falsifier
+// (mine-and-settle + reorg-drill) can inject reorgs at will.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <sharechain/v37/v37_lane.hpp>       // ::v37::LaneParams
+#include <sharechain/v37/v37_roundabout.hpp> // ::v37::ChainId
+
+namespace c2pool::v37n::btc {
+
+// Which BTC-family parent this node settles. Both are SHA-256d/Scrypt native
+// V37.0 canon (NO P-1, NO RandomX). DASH is the primary demo coin (X11 PoW,
+// embedded-SPV daemonless adapter, reorg-injectable regtest); LTC testnet4 is
+// the documented alternate (Scrypt PoW, daemon RPC adapter).
+enum class BtcFamilyCoin : std::uint8_t { Dash = 0, Ltc = 1 };
+
+inline const char* to_string(BtcFamilyCoin c) {
+    switch (c) {
+        case BtcFamilyCoin::Dash: return "dash";
+        case BtcFamilyCoin::Ltc:  return "ltc";
+    }
+    return "dash";
+}
+
+// The network the coin adapter binds to. Regtest/Devnet is the shipped default
+// — a v37 BTC-family node is prototype-grade and must never default to real
+// value. (DASH ships regtest+devnet; LTC ships regtest+testnet4.)
+enum class BtcNetwork : std::uint8_t { Regtest = 0, Devnet = 1, Testnet4 = 2, Mainnet = 3 };
+
+inline const char* to_string(BtcNetwork n) {
+    switch (n) {
+        case BtcNetwork::Regtest:  return "regtest";
+        case BtcNetwork::Devnet:   return "devnet";
+        case BtcNetwork::Testnet4: return "testnet4";
+        case BtcNetwork::Mainnet:  return "mainnet";
+    }
+    return "regtest";
+}
+
+// The <net> path segment used under config_path()/<coin>/<net>/v37_settle_db —
+// one isolated settlement store per (coin,network) so a regtest run can never
+// read or clobber a mainnet store (mirrors the per-coin datadir isolation the
+// mature v36 Bitcoin family uses via core::config).
+inline const char* net_dir(BtcNetwork n) { return to_string(n); }
+
+// The coin-daemon RPC/P2P endpoint the v36 adapter talks to. For DASH the
+// embedded-SPV adapter needs only the P2P port for header sync + the optional
+// submitblock RPC backup (ARM B). For LTC testnet4 the daemonful adapter uses
+// the RPC endpoint for getblocktemplate + submitblock.
+struct CoinDaemonEndpoint {
+    std::string   rpc_host = "127.0.0.1";
+    std::uint16_t rpc_port = 0;   // set by default_endpoint()
+    std::uint16_t p2p_port = 0;   // DASH embedded-SPV header sync
+    std::string   rpc_user;       // LTC daemonful arm (empty for DASH daemonless)
+    std::string   rpc_pass;
+};
+
+// Default RPC/P2P ports per (coin,network). DASH: regtest 19998/19899, devnet
+// 19998/<dynamic>. LTC: regtest 19443, testnet4 19332 (post-testnet4 rollout).
+inline CoinDaemonEndpoint default_endpoint(BtcFamilyCoin coin, BtcNetwork net) {
+    CoinDaemonEndpoint e;
+    e.rpc_host = "127.0.0.1";
+    if (coin == BtcFamilyCoin::Dash) {
+        switch (net) {
+            case BtcNetwork::Regtest:  e.rpc_port = 19998; e.p2p_port = 19899; break;
+            case BtcNetwork::Devnet:   e.rpc_port = 19998; e.p2p_port = 19899; break;
+            case BtcNetwork::Testnet4: // DASH has no testnet4; fall through to testnet
+            case BtcNetwork::Mainnet:  e.rpc_port =  9998; e.p2p_port =  9999; break;
+        }
+    } else {  // LTC
+        switch (net) {
+            case BtcNetwork::Regtest:  e.rpc_port = 19443; e.p2p_port = 19444; break;
+            case BtcNetwork::Devnet:
+            case BtcNetwork::Testnet4: e.rpc_port = 19332; e.p2p_port = 19335; break;
+            case BtcNetwork::Mainnet:  e.rpc_port =  9332; e.p2p_port =  9333; break;
+        }
+    }
+    return e;
+}
+
+// D_conf floor per coin (>= coinbase maturity so a finalized block's reward is
+// spendable and its burial is irreversible under honest-majority). DASH/LTC
+// coinbase maturity is 100 blocks; the F1 driver's default D_conf uses this.
+inline std::uint64_t default_d_conf(BtcFamilyCoin coin) {
+    (void)coin;   // both families: 100-block coinbase maturity
+    return 100;
+}
+
+struct BtcNodeConfig {
+    // --- BTC-family parent --------------------------------------------------
+    BtcFamilyCoin      coin    = BtcFamilyCoin::Dash;
+    BtcNetwork         network = BtcNetwork::Regtest;
+    CoinDaemonEndpoint daemon  = default_endpoint(BtcFamilyCoin::Dash, BtcNetwork::Regtest);
+
+    // Explicit acknowledgement required before the daemon will build a MAINNET
+    // coinbase / submit a mainnet block. Prototype safety fence (HARD SAFETY 4).
+    bool i_understand_mainnet = false;
+
+    // --- v37 BTC-family lane ------------------------------------------------
+    // The ChainId of the single BTC-family-parent lane this node settles.
+    // AddLane is issued for exactly this chain at start (single-node, single
+    // lane). Distinct kind-space from the XMR lane — this is the NATIVE canon.
+    ::v37::ChainId  lane_chain = 0;
+
+    // The digest-committed lane geometry. Defaults to the OQ-5 ratified default
+    // (LaneParams{}), the only geometry W4's geometry_is_ratified() admits.
+    ::v37::LaneParams lane_params{};
+
+    // --- settlement finality (F1 driver) ------------------------------------
+    // D_conf: blocks a found (coinbase-carrying) BTC-family block must be buried
+    // on the best chain before its settlement is FINALIZED. The finalize driver
+    // advances one coin-height at a time; a block at height h finalizes when the
+    // best-chain high-water reaches h + D_conf. >= coinbase maturity (100).
+    std::uint64_t   d_conf = default_d_conf(BtcFamilyCoin::Dash);
+
+    // Mainchain-view retention below the tip (>= D_conf so a finalizing block is
+    // always resident; the embedded-SPV HeaderChain / daemon index answers the
+    // canonicality predicate over this window).
+    std::uint64_t   index_retain_recent = 720;
+
+    // --- stratum front-end (v36 core::StratumServer) ------------------------
+    std::string     stratum_bind_host = "127.0.0.1";
+    std::uint16_t   stratum_bind_port = 3032;   // c2pool BTC-family stratum default
+
+    // --- storage ------------------------------------------------------------
+    // When empty, config_path()/<coin>/<net>/v37_settle_db is used. Set to
+    // override the settlement-store directory (the smoke sets a temp dir / uses
+    // MemSettleStore).
+    std::string     settle_db_path;
+
+    // --- PoW verify posture -------------------------------------------------
+    // The v36 stratum IWorkSource::compute_share_difficulty encapsulates the
+    // per-coin PoW (X11 for DASH, Scrypt for LTC, SHA-256d for BTC). When
+    // `pow_verify_enabled` is false (local/OOM smoke), the submit path
+    // structural-checks only and does NOT accept a share as a network block
+    // (fail-closed — no unverified block is ever submitted to the coin daemon).
+    bool            pow_verify_enabled = false;
+
+    // Resolve the on-disk settlement-store directory (settle_db_path override or
+    // config_path()/<coin>/<net>/v37_settle_db).
+    std::string resolved_settle_db_path() const {
+        if (!settle_db_path.empty()) return settle_db_path;
+        return std::string("./v37data/") + to_string(coin) + "/" +
+               net_dir(network) + "/v37_settle_db";
+    }
+};
+
+} // namespace c2pool::v37n::btc

--- a/src/c2pool/v37/btc/btc_node_smoke.hpp
+++ b/src/c2pool/v37/btc/btc_node_smoke.hpp
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/btc/btc_node_smoke.hpp  (Track A2 / Milestone A-BTC — smoke)
+//
+// run_btc_node_smoke() — the network-free lifecycle invariants for XbtcNode over
+// a MockCoinBackend. Shared by `c2pool-v37-btc --selftest` (main_v37_btc.cpp)
+// and the CI test target v37_btc_node_smoke (test/v37_btc_node_smoke.cpp), so
+// the exact same asserted body is both the developer smoke and the CI gate (no
+// hollow-green: it is listed in BOTH build.yml legs + the src/c2pool/**/test
+// drift-guard).
+//
+// It asserts the Milestone invariants:
+//   (S1) construction/donor order — the W6 store + RecoveryDriver are built and
+//        recovered BEFORE V37Engine::start().
+//   (S2) the DASH-regtest default + the mainnet fail-closed fence.
+//   (S4) the F1 CONTRACT — on_block_finalized once per coin-height, IN ORDER,
+//        bin_height = high-water AT the step (H+D_conf), never the live tip.
+//   (S3) the reorg drill — a block that leaves the best chain at maturity is
+//        orphaned, never finalized (the controlled falsifier).
+//   (S6) restart recovery round-trip + F2 fail-closed on a torn store.
+// (S5 consensus DIGEST unchanged is proved by the separate drift-guard KAT,
+//  test/btc_digest_drift_kat.cpp → v37_btc_digest_drift_kat.)
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include <c2pool/v37/btc/btc_node.hpp>
+
+namespace c2pool::v37n::btc {
+
+inline ::v37::bytes32 smoke_key_of(std::uint8_t tag) {
+    ::v37::bytes32 k{};
+    for (std::size_t i = 0; i < 32; ++i) k[i] = static_cast<std::uint8_t>(tag + i);
+    return k;
+}
+
+// Returns the number of failed checks (0 == green).
+inline int run_btc_node_smoke() {
+    int fails = 0;
+    auto check = [&](bool ok, const char* what) {
+        if (!ok) { ++fails; std::printf("SMOKE FAIL: %s\n", what); }
+        else       std::printf("  ok: %s\n", what);
+    };
+
+    // (S1) construction order + (S2 part 1) fresh-store open.
+    {
+        BtcNodeConfig cfg; cfg.lane_chain = 7; cfg.d_conf = 3;
+        auto coin  = std::make_shared<MockCoinBackend>();
+        auto store = std::make_unique<MemSettleStore>();
+        XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+        check(node.open(),  "open() recovers a fresh store BEFORE start()");
+        check(node.start(), "start() spins the engine + seeds the one lane");
+        check(node.lane_snapshot() != nullptr, "lane published after AddLane");
+        node.stop();
+    }
+
+    // (S2 part 2) mainnet fence.
+    {
+        BtcNodeConfig cfg; cfg.network = BtcNetwork::Mainnet;
+        auto coin  = std::make_shared<MockCoinBackend>();
+        auto store = std::make_unique<MemSettleStore>();
+        XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+        check(!node.open(), "mainnet without --i-understand-mainnet is refused");
+    }
+
+    // (S4) mine → bury → finalize ONE height at a time.
+    {
+        BtcNodeConfig cfg; cfg.lane_chain = 7; cfg.d_conf = 3;
+        auto coin  = std::make_shared<MockCoinBackend>();
+        auto store = std::make_unique<MemSettleStore>();
+        XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+        node.open(); node.start();
+
+        OwedLedger::Amounts pre{{smoke_key_of(0x10), 1000}, {smoke_key_of(0x40), 2000}};
+        coin->append_block("g0");                              // height 0 filler
+        std::uint64_t seed_h = coin->append_block("seed");     // height 1
+        node.finalizer().on_block_found(FoundBlock{"seed", seed_h, pre, {}});
+        for (int i = 0; i <= (int)cfg.d_conf; ++i) coin->append_block("blk" + std::to_string(i));
+        auto steps_seed = node.poll_tip();
+        check(!steps_seed.empty() && steps_seed[0].bid == "seed" &&
+              steps_seed[0].bin_height == seed_h + cfg.d_conf,
+              "found block finalized once, IN ORDER, bin_height == h+D_conf");
+
+        std::uint64_t win_h = coin->best_tip().height + 1;
+        coin->append_block("won");
+        WonBlockOutcome won = node.on_block_won("won", win_h, /*conf=*/0);
+        check(won.submit.armed && won.submit.accepted,
+              "on_block_won builds the W5 coinbase + submits the block");
+        for (int i = 0; i < (int)cfg.d_conf + 1; ++i) coin->append_block("ext" + std::to_string(i));
+        auto steps_won = node.poll_tip();
+        bool found_won = false, ordered = true; std::uint64_t last_h = 0;
+        for (auto& s : steps_won) {
+            if (s.coin_height < last_h) ordered = false;
+            last_h = s.coin_height;
+            if (s.bid == "won") {
+                found_won = true;
+                check(s.bin_height == win_h + cfg.d_conf,
+                      "won block bin_height == win_h + D_conf (per-step high-water)");
+            }
+        }
+        check(found_won, "won block finalized by the height-watch");
+        check(ordered,   "finalize steps strictly ascending in coin height (F1)");
+        node.stop();
+    }
+
+    // (S3) the reorg drill.
+    {
+        BtcNodeConfig cfg; cfg.lane_chain = 7; cfg.d_conf = 2;
+        auto coin  = std::make_shared<MockCoinBackend>();
+        auto store = std::make_unique<MemSettleStore>();
+        XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+        node.open(); node.start();
+
+        coin->append_block("g0");                 // height 0
+        std::uint64_t win_h = coin->append_block("fork_win");   // height 1
+        node.finalizer().on_block_found(
+            FoundBlock{"fork_win", win_h, {{smoke_key_of(1), 5}}, {{smoke_key_of(1), 5}}});
+        coin->reorg_to(/*fork_height=*/0, {"alt1", "alt2", "alt3", "alt4"});
+        auto steps = node.poll_tip();
+        bool won_finalized = false;
+        for (auto& s : steps) if (s.bid == "fork_win") won_finalized = true;
+        check(!won_finalized, "reorg-dropped block is NOT finalized (orphaned at maturity)");
+        node.stop();
+    }
+
+    // (S6) restart recovery round-trip + F2.
+    {
+        BtcNodeConfig cfg; cfg.lane_chain = 9; cfg.d_conf = 2;
+        std::string tmp = "/tmp/v37btc_smoke_store_" + std::to_string(::getpid());
+        std::filesystem::remove_all(tmp);
+        {
+            auto coin  = std::make_shared<MockCoinBackend>();
+            auto store = std::make_unique<FileSettleStore>(tmp);
+            XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+            node.open(); node.start();
+            coin->append_block("g0");
+            std::uint64_t ph = coin->append_block("persisted");
+            node.finalizer().on_block_found(
+                FoundBlock{"persisted", ph, {{smoke_key_of(2), 7}}, {{smoke_key_of(2), 7}}});
+            for (int i = 0; i <= (int)cfg.d_conf; ++i) coin->append_block("c" + std::to_string(i));
+            auto st = node.poll_tip();
+            bool did = false; for (auto& s : st) if (s.bid == "persisted") did = true;
+            check(did, "first boot finalizes the persisted block");
+            node.stop();
+        }
+        {
+            auto coin  = std::make_shared<MockCoinBackend>();
+            auto store = std::make_unique<FileSettleStore>(tmp);
+            XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+            check(node.open(), "second boot recovers the store (F2 clean)");
+            check(node.ledger().ledger_seq() > 0,
+                  "recovered ledger carries the persisted settlement events");
+            node.stop();
+        }
+        std::filesystem::remove_all(tmp);
+    }
+
+    std::printf("BTC-NODE-SMOKE %s (%d failures)\n", fails ? "FAIL" : "OK", fails);
+    return fails;
+}
+
+} // namespace c2pool::v37n::btc

--- a/src/c2pool/v37/btc/btc_settle_store.hpp
+++ b/src/c2pool/v37/btc/btc_settle_store.hpp
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/btc/btc_settle_store.hpp   (Track A2 / Milestone A-BTC — W6)
+//
+// The DURABLE side of the live BITCOIN-FAMILY node: an ISettleStore seam + a
+// file-backed concrete store + a RecoveryDriver that rebuilds the OWED ledger +
+// settlement high-water on restart, BEFORE V37Engine::start() (donor lifecycle
+// order).
+//
+// THIS IS THE SIBLING OF src/c2pool/v37/xmr/xmr_settle_store.hpp (Milestone
+// A-XMR). The persistence seam, the record codec, the RecoveryDriver §4 replay
+// and the two W6 red-team invariants (F1 in-order per-height replay, F2
+// fail-closed open) are COIN-AGNOSTIC — the store persists W4's OWED events and
+// the high-water only, keyed by a block-id STRING that here is a BTC-family
+// block HASH hex (display byte order) instead of a Monero block id. Nothing in
+// this file differs in logic from the XMR sibling; only the doc-comments name
+// the coin. The two could be unified into one v37/settle_store.hpp; they are
+// kept parallel to match the per-milestone directory layout and to let each
+// milestone land independently.
+//
+// RELATIONSHIP TO THE MERGED W6 LEG (v37/w6-persistence branch):
+//   The W6 wave authored src/c2pool/v37/w6_persistence.hpp — the full
+//   ISettleBatch/ISettleStore seam, the §2.3 record codecs, RecoveryDriver
+//   (§4 steps 1-9), and a LevelDBSettleStore concrete binding. When that lands
+//   on master, XbtcNode swaps FileSettleStore -> LevelDBSettleStore with a
+//   one-line change (see GAP note in btc_node.hpp). Until then this small,
+//   self-contained store keeps THIS milestone building on a fresh master clone
+//   and DIGEST-NEUTRAL: it uses ONLY merged master types (OwedLedger, SettleHW
+//   from w4_settlement.hpp), mirrors the W6 ISettleStore SHAPE, and honours F1
+//   and F2. NO consensus digest lives here — owed_digest / lane digest are
+//   recomputed by the merged OwedLedger / executor, byte-identically to a fresh
+//   run.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iterator>
+#include <map>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <c2pool/v37/w4_settlement.hpp>   // OwedLedger, SettleHW (merged, master)
+
+namespace c2pool::v37n::btc {
+
+using ::c2pool::v37n::settle::OwedLedger;
+using ::c2pool::v37n::settle::SettleHW;
+using Amounts = OwedLedger::Amounts;      // std::map<bytes32,long long>
+
+// ---------------------------------------------------------------------------
+// ISettleStore — the persistence seam (W6 §7.1 shape). A production build backs
+// this with LevelDBSettleStore (v37/w6-persistence); Milestone A-BTC backs it
+// with FileSettleStore below and MemSettleStore in the smoke/KAT.
+// ---------------------------------------------------------------------------
+struct ISettleBatch {
+    virtual ~ISettleBatch() = default;
+    virtual void put(const std::string& k, const std::string& v) = 0;
+    virtual void remove(const std::string& k) = 0;
+    virtual bool commit_sync() = 0;               // false == torn / IO error
+};
+
+struct ISettleStore {
+    virtual ~ISettleStore() = default;
+    virtual std::unique_ptr<ISettleBatch> batch() = 0;
+    virtual std::optional<std::string> get(const std::string& k) = 0;
+    virtual bool for_each_prefix(
+        const std::string& prefix,
+        const std::function<bool(const std::string& k, const std::string& v)>& fn) = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Record codec + key layout (a compatible subset of W6 keys::/Writer/Reader).
+// Records: u8 ver=1 ‖ payload. Ints little-endian. Fail-closed on a short read.
+// ---------------------------------------------------------------------------
+namespace store_codec {
+constexpr std::uint8_t SCHEMA_VER = 1;
+
+inline std::string chain_fmt(::v37::ChainId c) {
+    char b[16];
+    std::snprintf(b, sizeof b, "%010u", static_cast<unsigned>(c));
+    return b;
+}
+inline std::string seq_fmt(std::uint64_t s) {
+    char b[24];
+    std::snprintf(b, sizeof b, "%020llu", static_cast<unsigned long long>(s));
+    return b;
+}
+// keys ----------------------------------------------------------------------
+inline std::string k_hw(::v37::ChainId c)        { return "v37s:hw:" + chain_fmt(c); }
+inline std::string k_cursor(::v37::ChainId c)    { return "v37s:fcur:" + chain_fmt(c); }
+inline std::string k_evt(::v37::ChainId c, std::uint64_t seq) {
+    return "v37s:levt:" + chain_fmt(c) + ":" + seq_fmt(seq);
+}
+inline std::string k_evt_prefix(::v37::ChainId c){ return "v37s:levt:" + chain_fmt(c) + ":"; }
+
+// serialize a u64 LE ---------------------------------------------------------
+inline void put_u64(std::string& s, std::uint64_t x) {
+    for (int i = 0; i < 8; ++i) s.push_back(char((x >> (8 * i)) & 0xff));
+}
+inline void put_i64(std::string& s, long long v) { put_u64(s, static_cast<std::uint64_t>(v)); }
+inline void put_amounts(std::string& s, const Amounts& m) {
+    put_u64(s, m.size());
+    for (const auto& [k, v] : m) {   // std::map canonical key order
+        s.append(reinterpret_cast<const char*>(k.data()), k.size());
+        put_i64(s, v);
+    }
+}
+inline void put_str(std::string& s, const std::string& v) {
+    put_u64(s, v.size());
+    s.append(v);
+}
+
+// Fail-closed reader: any short read throws (caught by RecoveryDriver → abort).
+struct Reader {
+    const std::string& s;
+    std::size_t o = 0;
+    explicit Reader(const std::string& src) : s(src) {}
+    void need(std::size_t n) const {
+        if (o + n > s.size()) throw std::runtime_error("settle-store: torn record (short read)");
+    }
+    std::uint8_t u8()  { need(1); return std::uint8_t(s[o++]); }
+    std::uint64_t u64() {
+        need(8); std::uint64_t x = 0;
+        for (int i = 0; i < 8; ++i) x |= std::uint64_t(std::uint8_t(s[o++])) << (8 * i);
+        return x;
+    }
+    long long i64() { return static_cast<long long>(u64()); }
+    ::v37::bytes32 b32() {
+        need(32); ::v37::bytes32 b{};
+        for (std::size_t i = 0; i < 32; ++i) b[i] = std::uint8_t(s[o++]);
+        return b;
+    }
+    Amounts amounts() {
+        Amounts m; std::uint64_t n = u64();
+        for (std::uint64_t i = 0; i < n; ++i) { auto k = b32(); m[k] = i64(); }
+        return m;
+    }
+    std::string str() { std::uint64_t n = u64(); need(n); std::string v = s.substr(o, n); o += n; return v; }
+    void expect_end() const { if (o != s.size()) throw std::runtime_error("settle-store: trailing bytes"); }
+};
+} // namespace store_codec
+
+// ---------------------------------------------------------------------------
+// The three persisted ledger-event kinds (W6 EvKind). Written write-ahead by
+// XbtcNode as the OwedLedger mutates; replayed in seq order on recovery.
+// ---------------------------------------------------------------------------
+enum class SettleEvKind : std::uint8_t { Found = 1, Finalize = 2, Orphan = 3 };
+
+struct SettleEvent {
+    SettleEvKind  kind = SettleEvKind::Found;
+    std::string   bid;                 // BTC-family block hash (hex) that carried the settlement
+    Amounts       credit;              // FOUND: per-key entitlement E_b
+    Amounts       payout;              // FOUND/ORPHAN: coinbase outputs settled
+    std::uint64_t bin_height = 0;      // FINALIZE: the monotone K_fair clock at THIS step
+
+    std::string serialize() const {
+        std::string s;
+        s.push_back(char(store_codec::SCHEMA_VER));
+        s.push_back(char(static_cast<std::uint8_t>(kind)));
+        store_codec::put_str(s, bid);
+        store_codec::put_amounts(s, credit);
+        store_codec::put_amounts(s, payout);
+        store_codec::put_u64(s, bin_height);
+        return s;
+    }
+    static SettleEvent deserialize(const std::string& blob) {
+        store_codec::Reader r(blob);
+        std::uint8_t ver = r.u8();
+        if (ver > store_codec::SCHEMA_VER)
+            throw std::runtime_error("settle-store: record schema newer than reader");
+        SettleEvent e;
+        e.kind = static_cast<SettleEvKind>(r.u8());
+        e.bid = r.str();
+        e.credit = r.amounts();
+        e.payout = r.amounts();
+        e.bin_height = r.u64();
+        r.expect_end();
+        return e;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// MemSettleStore — in-memory ISettleStore for the smoke/KAT (no filesystem).
+// ---------------------------------------------------------------------------
+class MemSettleStore final : public ISettleStore {
+public:
+    struct Batch final : public ISettleBatch {
+        MemSettleStore* owner;
+        std::map<std::string, std::optional<std::string>> ops;  // nullopt == remove
+        explicit Batch(MemSettleStore* o) : owner(o) {}
+        void put(const std::string& k, const std::string& v) override { ops[k] = v; }
+        void remove(const std::string& k) override { ops[k] = std::nullopt; }
+        bool commit_sync() override {
+            for (auto& [k, v] : ops) { if (v) owner->kv_[k] = *v; else owner->kv_.erase(k); }
+            return true;
+        }
+    };
+    std::unique_ptr<ISettleBatch> batch() override { return std::make_unique<Batch>(this); }
+    std::optional<std::string> get(const std::string& k) override {
+        auto it = kv_.find(k); return it == kv_.end() ? std::nullopt : std::optional<std::string>(it->second);
+    }
+    bool for_each_prefix(const std::string& prefix,
+                         const std::function<bool(const std::string&, const std::string&)>& fn) override {
+        for (auto& [k, v] : kv_) {           // std::map => lexicographic key order
+            if (k.compare(0, prefix.size(), prefix) == 0) if (!fn(k, v)) break;
+        }
+        return true;
+    }
+private:
+    std::map<std::string, std::string> kv_;
+};
+
+// ---------------------------------------------------------------------------
+// FileSettleStore — a durable single-file append/rewrite ISettleStore. Each
+// commit_sync() rewrites the whole key/value image and fsyncs (atomic rename),
+// modelling the LevelDB write-batch atomicity the production store gives for
+// free. Small by construction (one lane, bounded event log); a production
+// deployment swaps in LevelDBSettleStore.
+// ---------------------------------------------------------------------------
+class FileSettleStore final : public ISettleStore {
+public:
+    explicit FileSettleStore(std::filesystem::path dir) : dir_(std::move(dir)) {
+        std::filesystem::create_directories(dir_);
+        img_ = dir_ / "settle.img";
+        load();
+    }
+
+    struct Batch final : public ISettleBatch {
+        FileSettleStore* owner;
+        std::map<std::string, std::optional<std::string>> ops;
+        explicit Batch(FileSettleStore* o) : owner(o) {}
+        void put(const std::string& k, const std::string& v) override { ops[k] = v; }
+        void remove(const std::string& k) override { ops[k] = std::nullopt; }
+        bool commit_sync() override {
+            for (auto& [k, v] : ops) { if (v) owner->kv_[k] = *v; else owner->kv_.erase(k); }
+            return owner->flush();
+        }
+    };
+    std::unique_ptr<ISettleBatch> batch() override { return std::make_unique<Batch>(this); }
+    std::optional<std::string> get(const std::string& k) override {
+        auto it = kv_.find(k); return it == kv_.end() ? std::nullopt : std::optional<std::string>(it->second);
+    }
+    bool for_each_prefix(const std::string& prefix,
+                         const std::function<bool(const std::string&, const std::string&)>& fn) override {
+        for (auto& [k, v] : kv_)
+            if (k.compare(0, prefix.size(), prefix) == 0) if (!fn(k, v)) break;
+        return true;
+    }
+
+private:
+    // Image format: repeated [u64 klen | key | u64 vlen | val]. Fail-closed:
+    // a truncated tail throws → RecoveryDriver aborts the open (F2).
+    void load() {
+        std::ifstream f(img_, std::ios::binary);
+        if (!f) return;                              // fresh store
+        std::string all((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+        store_codec::Reader r(all);
+        while (r.o < all.size()) {
+            std::string k = r.str();
+            std::string v = r.str();
+            kv_[k] = v;
+        }
+    }
+    bool flush() {
+        std::string img;
+        for (auto& [k, v] : kv_) { store_codec::put_str(img, k); store_codec::put_str(img, v); }
+        std::filesystem::path tmp = img_;
+        tmp += ".tmp";
+        { std::ofstream f(tmp, std::ios::binary | std::ios::trunc);
+          if (!f) return false;
+          f.write(img.data(), static_cast<std::streamsize>(img.size()));
+          f.flush();
+          if (!f) return false; }
+        std::error_code ec;
+        std::filesystem::rename(tmp, img_, ec);      // atomic replace
+        return !ec;
+    }
+    std::filesystem::path dir_, img_;
+    std::map<std::string, std::string> kv_;
+};
+
+// ---------------------------------------------------------------------------
+// RecoveryDriver — rebuilds one lane's OwedLedger + SettleHW + finalize cursor
+// from the store, BEFORE V37Engine::start(). Deterministic replay: FOUND events
+// re-enter pending; FINALIZE events call on_block_finalized(bid, bin_height) IN
+// SEQ ORDER with the PERSISTED per-height bin_height (F1 — never the live tip);
+// ORPHAN events dispose. Any torn record throws → recover() sets ok=false so the
+// daemon refuses to start on a corrupt store (F2 fail-closed), rather than
+// silently resuming from a truncated ledger.
+// ---------------------------------------------------------------------------
+struct RecoveredState {
+    SettleHW      hw;
+    std::uint64_t finalize_cursor_height = 0;  // last coin height the F1 driver stepped through
+    std::uint64_t max_event_seq = 0;           // next write-ahead seq = this + 1
+    bool          recovered = false;           // false == fresh store (no prior state)
+};
+
+class RecoveryDriver {
+public:
+    RecoveryDriver(ISettleStore& store, ::v37::ChainId chain)
+        : store_(store), chain_(chain) {}
+
+    // Rebuild `ledger` and return the recovered high-water / cursor. `ok` is set
+    // false ONLY on a torn store (F2). A fresh store recovers cleanly with
+    // recovered=false and an empty ledger.
+    RecoveredState recover(OwedLedger& ledger, bool& ok) {
+        ok = true;
+        RecoveredState st;
+        try {
+            // (1) high-water leg.
+            if (auto hwb = store_.get(store_codec::k_hw(chain_))) {
+                if (hwb->size() >= 24) st.hw = SettleHW::deserialize(*hwb);
+                st.recovered = true;
+            }
+            // (2) finalize cursor.
+            if (auto cur = store_.get(store_codec::k_cursor(chain_))) {
+                store_codec::Reader r(*cur);
+                st.finalize_cursor_height = r.u64();
+                st.recovered = true;
+            }
+            // (3) replay the ledger event log IN SEQ ORDER (keys are zero-padded
+            //     so lexicographic == numeric). This is the whole F1 discipline:
+            //     FINALIZE replays with its own recorded per-height bin_height.
+            store_.for_each_prefix(store_codec::k_evt_prefix(chain_),
+                [&](const std::string& k, const std::string& v) {
+                    (void)k;
+                    SettleEvent e = SettleEvent::deserialize(v);
+                    ++st.max_event_seq;
+                    switch (e.kind) {
+                        case SettleEvKind::Found:
+                            ledger.on_block_found(e.bid, e.credit, e.payout); break;
+                        case SettleEvKind::Finalize:
+                            ledger.on_block_finalized(e.bid, e.bin_height); break;  // F1
+                        case SettleEvKind::Orphan:
+                            ledger.on_block_orphaned(e.bid, e.payout); break;
+                    }
+                    return true;
+                });
+            if (st.max_event_seq) st.recovered = true;
+        } catch (const std::exception&) {
+            ok = false;                          // F2: torn store → refuse to start
+        }
+        return st;
+    }
+private:
+    ISettleStore&  store_;
+    ::v37::ChainId chain_;
+};
+
+} // namespace c2pool::v37n::btc

--- a/src/c2pool/v37/main_v37_btc.cpp
+++ b/src/c2pool/v37/main_v37_btc.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/main_v37_btc.cpp   (Track A2 / Milestone A-BTC — entrypoint)
+//
+// The c2pool-v37-btc daemon entrypoint: the live v37 node lifecycle for the
+// BITCOIN FAMILY (XbtcNode), wired to the mature v36 coin plumbing. Sibling of
+// main_v37.cpp (the W0 scaffold) and main_v37_xmr.cpp (Milestone A-XMR).
+//
+// EXPERIMENTAL / DEVNET-DEFAULT — do not run in production. The shipped default
+// is DASH regtest (reorg-injectable for the controlled falsifier). Mainnet is a
+// loud opt-in (--i-understand-mainnet).
+//
+// Two modes:
+//   --selftest / --mock-smoke   network-free, in-process lifecycle invariants
+//                over a MockCoinBackend (the CI-runnable core; no coin daemon,
+//                no Boost, no PoW). Exercises the full mine→bury→settle path,
+//                the reorg drill, W6 recovery, and F2 fail-closed. Exit 0 iff
+//                green. This is the SAME body the CI target v37_btc_node_smoke
+//                runs.
+//   (default)    a single live node: open() the store + recover, start() the
+//                engine + lane, bind the v36 core::StratumServer to
+//                --stratum-bind, and run the height-watch against the coin
+//                backend (DASH embedded-SPV / LTC daemon). The live coin backend
+//                + StratumServer binding is the CI/heavy leg; the local build
+//                ships the smoke.
+// ===========================================================================
+#include <cstdio>
+#include <string>
+
+#include <c2pool/v37/btc/btc_node_smoke.hpp>
+
+int main(int argc, char** argv) {
+    bool selftest = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (a == "--selftest" || a == "--mock-smoke") selftest = true;
+    }
+    if (selftest) return c2pool::v37n::btc::run_btc_node_smoke() ? 1 : 0;
+
+    std::printf(
+        "c2pool-v37-btc (EXPERIMENTAL, DASH-regtest default; do not run in production)\n"
+        "  --selftest   run the network-free lifecycle invariants and exit\n"
+        "  (live mode binds the v36 core::StratumServer + coin backend; CI leg)\n");
+    return 2;
+}

--- a/src/c2pool/v37/settle_finalize_driver.hpp
+++ b/src/c2pool/v37/settle_finalize_driver.hpp
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+#pragma once
+// ===========================================================================
+// settle_finalize_driver.hpp  —  the F1-CORRECT production settlement finalize
+// driver.  ONE COIN-AGNOSTIC DRIVER (Milestone A live-node lifecycle).
+//
+// COIN-AGNOSTIC — THIS IS THE SAME DRIVER AS A-XMR
+// ------------------------------------------------
+// This is byte-for-byte the same logic as the A-XMR lane's
+// xmr_finalize_driver.hpp; the only differences are this file's name and its
+// comments (which speak of "the coin adapter's height" instead of "monerod").
+// The driver touches NOTHING coin-specific: it is a pure sequencer over the
+// merged w4 types (OwedLedger + SettleHW), driven by a monotone coin-height
+// integer that the caller feeds from whatever mainchain view it owns —
+//   * BTC family: the v36 coin daemon adapter (DASH devnet/regtest embedded-SPV
+//     or daemon; LTC testnet4) best-height (SHA-256d / Scrypt PoW),
+//   * XMR family: the monerod ZMQ tip height (RandomX PoW).
+// Neither PoW, coinbase shape, nor ScriptKind enters here. There should be ONE
+// such file in-tree; the A-XMR xmr_finalize_driver.hpp should become an include
+// alias of (or be replaced by) this coin-neutral header. Kept as a distinct
+// file here only because this build leg writes to a scratch directory.
+//
+// WHY THIS FILE EXISTS (the F1 audit's HIGH obligation)
+// -----------------------------------------------------
+// OwedLedger::on_block_finalized(bid, bin_height) (w4_settlement.hpp) stamps
+// first_eligible for every key whose EffectiveOwed just went positive AT
+// bin_height (rearm_first_eligible), and owed_digest() COMMITS first_eligible
+// per finalized key. Therefore the value passed as bin_height is CONSENSUS: two
+// nodes that finalize the same block at a different bin_height compute a
+// DIFFERENT owed_digest — an owed_digest FORK.
+//
+// The correct bin_height is "the coin high-water AT THE HEIGHT STEP where the
+// block first becomes buried >= D_conf", i.e. found_height + D_conf. A node that
+// was behind (or received a burst of heights from the coin adapter in one
+// Extend that jumps best_height by >1) MUST replay the settlement path PER
+// COIN-HEIGHT STEP IN ORDER and stamp each block at its own step's high-water.
+// It must NEVER jump straight to the live coin tip and finalize every buried
+// block at the tip height — that stamps a LATE first_eligible and is the exact
+// F1 fork.
+//
+// The w4 test harness's reconcile()-at-current-tip shape is a TEST convenience
+// (it drives finalize at one height because the test constructs one height); it
+// is NOT the live-driver contract. This driver is the live contract: per-height,
+// in-order, high-water-at-the-step. Do NOT copy reconcile() into a live caller.
+//
+// SAFETY / DIGEST-NEUTRALITY
+// --------------------------
+// This driver is a pure CALLER of the merged w4 API (OwedLedger + SettleHW). It
+// redefines NO consensus quantity: not owed_digest, not first_eligible, not the
+// K_fair clock. It only sequences the existing on_block_finalized / on_tip /
+// on_block_orphaned calls so the argument they already consume (bin_height) is
+// the spec-correct value on every path (real-time, catch-up, burst, restart).
+//
+// stdlib-only + header-only: builds on an OOM-pressured host and is exercised by
+// f1_finalize_kat_btc.cpp against the real merged w4 types with no engine link.
+// ===========================================================================
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include <c2pool/v37/w4_settlement.hpp>   // OwedLedger, SettleHW (merged w4 types)
+
+namespace c2pool::v37n::settle {
+
+// A pool-found block awaiting its finalize gate. Recorded at FOUND time with the
+// per-key entitlement E_b (credit) and the coinbase outputs it broadcast
+// (payout) — the exact two maps OwedLedger::on_block_found already consumes.
+struct FinalizeCandidate {
+    std::string          bid;            // block id (ledger key)
+    std::uint64_t        found_height{}; // coin height at which the pool found it
+    OwedLedger::Amounts  credit;         // E_b at the burial-gated prefix
+    OwedLedger::Amounts  payout;         // coinbase outputs broadcast in the block
+};
+
+// ===========================================================================
+// FinalizeDriver — sequences OwedLedger + SettleHW off the coin adapter's
+// height progression, honoring the F1 contract on every path.
+//
+// USAGE (live daemon): construct with (ledger, hw, chain, D_conf). On each pool
+// block found, call register_found(). On the coin adapter's height progression
+// (Extend/Reorg events off the DASH/LTC mainchain view), call
+// advance_to(new_best_height, tip): the driver replays every unseen height in
+// order, advancing the O5.5 high-water and finalizing exactly the candidates
+// that reach D_conf at each step, stamping bin_height = that step's high-water.
+// On an Orphan event, call on_orphaned().
+// ===========================================================================
+class FinalizeDriver {
+public:
+    // tip_of_height(h) -> the 32-byte coin block id at height h (for SettleHW's
+    // hw_tip leg). In the live daemon this reads the coin adapter's
+    // by_height(h) (DASH/LTC block hash); in KATs it is a deterministic stub.
+    // May return {} if unknown.
+    using TipOfHeight = std::function<::v37::bytes32(std::uint64_t)>;
+
+    // is_canonical(bid) -> is this found block still on the best chain? Guards
+    // finalize against a block that was orphaned between FOUND and its gate. In
+    // the live daemon this consults the coin adapter's mainchain view; default
+    // = always true.
+    using IsCanonical = std::function<bool(const std::string& bid)>;
+
+    FinalizeDriver(OwedLedger& ledger, SettleHW& hw, ::v37::ChainId chain,
+                   std::uint64_t d_conf)
+        : m_ledger(ledger), m_hw(hw), m_chain(chain), m_dconf(d_conf) {}
+
+    void set_tip_of_height(TipOfHeight f) { m_tip_of = std::move(f); }
+    void set_is_canonical(IsCanonical f) { m_is_canonical = std::move(f); }
+
+    // Restart bring-up: adopt the persisted O5.5 high-water as the last-driven
+    // height so a restarted node does not re-drive (and re-stamp) settled heights.
+    // Call AFTER the W6 RecoveryDriver has rehydrated the OwedLedger + SettleHW.
+    void resume_from_persisted() { m_last_driven = m_hw.hw_height; }
+
+    ::v37::ChainId chain() const { return m_chain; }
+    std::uint64_t d_conf() const { return m_dconf; }
+    std::uint64_t last_driven_height() const { return m_last_driven; }
+
+    // FOUND(b). Records the candidate and credits the ledger (idempotent per bid
+    // via OwedLedger::on_block_found). finalize_height = found_height + D_conf is
+    // the coin height at which b first becomes buried >= D_conf.
+    void register_found(const FinalizeCandidate& c) {
+        m_ledger.on_block_found(c.bid, c.credit, c.payout);
+        const std::uint64_t fin_h = c.found_height + m_dconf;
+        m_by_finalize_height[fin_h].push_back(c.bid);      // sorted map → in-order
+        m_found_height[c.bid] = c.found_height;
+    }
+
+    // The height progression. Advance the driver to `new_best_height` (the coin
+    // adapter's best tip), replaying EVERY height step from
+    // last_driven+1 .. new_best_height IN ORDER. This is the F1 core:
+    //   * a single Extend that jumps best_height by many blocks (a coin adapter
+    //     catch-up burst) is replayed per-height here — never collapsed to one
+    //     finalize at the tip;
+    //   * each step advances the O5.5 high-water (SettleHW) then finalizes the
+    //     candidates whose gate lands on THAT step, stamping bin_height = that
+    //     step's high-water (== the step height), NOT new_best_height.
+    // Returns the number of blocks finalized across the replay (diagnostic).
+    std::size_t advance_to(std::uint64_t new_best_height) {
+        std::size_t finalized = 0;
+        // O5.5 gate: a target strictly below the persisted high-water is a
+        // shorter branch — not adopted, settlement never re-evaluated lower.
+        if (!m_hw.admit_candidate_height(new_best_height)) return 0;
+        for (std::uint64_t h = m_last_driven + 1; h <= new_best_height; ++h)
+            finalized += drive_one_height(h);
+        m_last_driven = new_best_height;
+        return finalized;
+    }
+
+    // ORPHAN(b): a pool-found block left the best chain. Forward to the ledger
+    // (pre-SETTLED → pending keys removed and re-mint from the spine; post-SETTLED
+    // → O3.5 priced residual). The O5.5 high-water is NEVER lowered here.
+    void on_orphaned(const std::string& bid,
+                     const OwedLedger::Amounts& settled_payout) {
+        m_ledger.on_block_orphaned(bid, settled_payout);
+        // If it was still awaiting its gate, forget the pending candidate so a
+        // later replay does not attempt to finalize a dead block.
+        m_orphaned.insert(bid);
+    }
+
+private:
+    // Drive exactly one coin-height step h, in order. NEVER called with a batch.
+    std::size_t drive_one_height(std::uint64_t h) {
+        // (1) on_tip_advanced(chain, h, tip): move the O5.5 high-water to h.
+        //     admit_candidate_height already re-checked by advance_to's loop
+        //     invariant (h strictly increases and h > previous high-water on the
+        //     forward path); advance() itself refuses a decrease defensively.
+        ::v37::bytes32 tip = m_tip_of ? m_tip_of(h) : ::v37::bytes32{};
+        m_hw.advance(h, tip);                      // high-water AT this step := h
+
+        // (2) finalize every candidate whose gate (found_height + D_conf) is at
+        //     or below this step and is still pending — stamping bin_height =
+        //     m_hw.hw_height, which is EXACTLY h (this step's high-water), the
+        //     spec-correct value. Because advance_to replays per-height, a gate
+        //     is reached at its own height, so hw.hw_height == finalize_height.
+        std::size_t n = 0;
+        auto it = m_by_finalize_height.begin();
+        while (it != m_by_finalize_height.end() && it->first <= h) {
+            std::vector<std::string> bids = it->second;
+            std::sort(bids.begin(), bids.end());   // deterministic intra-step order
+            for (const auto& bid : bids) {
+                if (m_orphaned.count(bid)) continue;
+                if (m_is_canonical && !m_is_canonical(bid)) continue;
+                if (!m_ledger.is_pending(bid)) continue;
+                // bin_height := this step's coin high-water. On the forward
+                // per-height path hw.hw_height == h == it->first (the gate). We
+                // pass hw.hw_height (the honest high-water read) rather than the
+                // live tip — that difference IS the F1 fix.
+                m_ledger.on_block_finalized(bid, m_hw.hw_height);
+                ++n;
+            }
+            it = m_by_finalize_height.erase(it);
+        }
+        return n;
+    }
+
+    OwedLedger&    m_ledger;
+    SettleHW&      m_hw;
+    ::v37::ChainId m_chain;
+    std::uint64_t  m_dconf;
+    std::uint64_t  m_last_driven = 0;
+
+    // finalize_height -> bids gated at that height (std::map keeps height order).
+    std::map<std::uint64_t, std::vector<std::string>> m_by_finalize_height;
+    std::map<std::string, std::uint64_t>              m_found_height;
+    std::set<std::string>                             m_orphaned;
+
+    TipOfHeight m_tip_of;
+    IsCanonical m_is_canonical;
+};
+
+}  // namespace c2pool::v37n::settle

--- a/src/c2pool/v37/test/CMakeLists.txt
+++ b/src/c2pool/v37/test/CMakeLists.txt
@@ -194,4 +194,44 @@ if (BUILD_TESTING)
     target_include_directories(v37_xmr_node_smoke PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_link_libraries(v37_xmr_node_smoke PRIVATE xmr_node Threads::Threads)
     add_test(NAME v37_xmr_node_smoke COMMAND v37_xmr_node_smoke)
+    # ── Track A2 / Milestone A-BTC — the live BITCOIN-FAMILY node CI gates ────
+    # The single-node c2pool-v37-btc daemon (XbtcNode) wires the MERGED v37
+    # engine (V37Engine / OwedLedger / W5 native coinbase) to the mature v36 coin
+    # plumbing behind ICoinBackend. These three targets are the NON-HOLLOW gates.
+    # SAME two-part hollow-green guard as the sibling suites: each is ALSO listed
+    # in the build.yml --target lists (BOTH the Linux x86_64 leg AND the
+    # ASan+UBSan leg — all three are sanitizer-clean, verified
+    # -fsanitize=address,undefined -fno-sanitize-recover=all), and the
+    # src/c2pool/**/test/ drift-guard (check_test_target_allowlist.py) fails
+    # closed on any add_test here missing from build.yml. Header-only lifecycle +
+    # MockCoinBackend: link only Threads (no coin lib, no Boost — HARD SAFETY 6).
+
+    # (1) the live lifecycle smoke — open-before-start, mainnet fence, F1 per-
+    #     height finalize, on_block_won W5 coinbase+submit, reorg drill,
+    #     W6 restart round-trip + F2 fail-closed (13 checks).
+    add_executable(v37_btc_node_smoke v37_btc_node_smoke.cpp)
+    target_compile_features(v37_btc_node_smoke PRIVATE cxx_std_20)
+    target_include_directories(v37_btc_node_smoke PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(v37_btc_node_smoke Threads::Threads)
+    add_test(NAME v37_btc_node_smoke COMMAND v37_btc_node_smoke)
+
+    # (2) the drift-guard (HARD SAFETY 1): the lane digest the node publishes and
+    #     the owed digest after an F1 schedule are BYTE-IDENTICAL to a bare
+    #     ::v37::Roundabout / a fresh OwedLedger — the node changes no consensus
+    #     digest, it only SEQUENCES merged-engine calls.
+    add_executable(v37_btc_digest_drift_kat v37_btc_digest_drift_kat.cpp)
+    target_compile_features(v37_btc_digest_drift_kat PRIVATE cxx_std_20)
+    target_include_directories(v37_btc_digest_drift_kat PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(v37_btc_digest_drift_kat Threads::Threads)
+    add_test(NAME v37_btc_digest_drift_kat COMMAND v37_btc_digest_drift_kat)
+
+    # (3) the F1 finalize-driver KAT over the COIN-AGNOSTIC settle_finalize_driver
+    #     (src/c2pool/v37/settle_finalize_driver.hpp — the driver shared byte-for-
+    #     byte with Milestone A-XMR). Proves in-order/per-height catch-up ==
+    #     real-time, restart-safe, O5.5 shorter-branch refusal, AND the FALSIFIER:
+    #     a jump-to-tip driver FORKS the owed_digest (7 checks). Stdlib-only.
+    add_executable(f1_finalize_kat_btc f1_finalize_kat_btc.cpp)
+    target_compile_features(f1_finalize_kat_btc PRIVATE cxx_std_20)
+    target_include_directories(f1_finalize_kat_btc PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    add_test(NAME f1_finalize_kat_btc COMMAND f1_finalize_kat_btc)
 endif()

--- a/src/c2pool/v37/test/f1_finalize_kat_btc.cpp
+++ b/src/c2pool/v37/test/f1_finalize_kat_btc.cpp
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// f1_finalize_kat_btc.cpp  —  Known-Answer Test for the F1-CORRECT finalize
+// driver, BITCOIN FAMILY (DASH/LTC coin-adapter height progression).
+//
+// This drives the SAME coin-agnostic FinalizeDriver as the A-XMR KAT; the coin
+// backend differs only in that the height integer here is fed by the v36 coin
+// daemon adapter's best-height (DASH devnet/regtest embedded-SPV, LTC testnet4)
+// instead of monerod's ZMQ tip, and the deterministic block-id stub carries a
+// SHA-256d-flavoured marker instead of RandomX. The driver code, the w4 types,
+// and every consensus quantity are identical — proving the F1 contract holds
+// for the BTC family with the one driver.
+//
+// PROVES (against the REAL merged w4 types, stdlib-only, no engine link):
+//   KA-1  in-order per-height driving == a real-time peer's owed_digest
+//         (a node behind the DASH/LTC tip that catches up in one shot computes
+//          the SAME consensus owed_digest as a node that saw every height live).
+//   KA-2  burst-size independence: catching up in several bursts of arbitrary
+//         size == the real-time peer (any adapter Extend that jumps best_height
+//         is safe).
+//   KA-3  restart mid-catch-up (persist SettleHW, resume_from_persisted) == the
+//          real-time peer (O5.5 persisted high-water; no re-drive/re-stamp).
+//   KA-4  THE FALSIFIER: a jump-to-tip driver (finalize every buried block at
+//          the LIVE coin tip height) FORKS — its owed_digest differs from the
+//          real-time peer, while its finalW is byte-identical. Isolates the
+//          fork to the bin_height stamping (first_eligible), the exact F1 defect.
+//   KA-5  O5.5: a target height below the persisted high-water is a shorter
+//          branch — refused, not adopted (settlement never re-evaluated lower).
+//          Models a DASH-regtest reorg to a shorter branch (the demo falsifier).
+//
+// The real-time peer and the correct catch-up peer must AGREE; the jump-to-tip
+// peer must DISAGREE. If either flips, the test fails.
+// ===========================================================================
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include <c2pool/v37/settle_finalize_driver.hpp>
+
+using namespace c2pool::v37n::settle;
+using ::v37::bytes32;
+
+namespace {
+
+int g_pass = 0, g_fail = 0;
+void check(const char* name, bool ok) {
+    std::printf("  [%s] %s\n", ok ? "PASS" : "FAIL", name);
+    if (ok) ++g_pass; else ++g_fail;
+}
+
+std::string hx(const bytes32& b) {
+    static const char* k = "0123456789abcdef";
+    std::string s;
+    for (auto x : b) { s.push_back(k[x >> 4]); s.push_back(k[x & 0xf]); }
+    return s;
+}
+
+// A deterministic coin-block-id stub for height h, modelling the DASH/LTC
+// adapter's by_height() (SHA-256d block hash). Feeds SettleHW's hw_tip leg only;
+// it does NOT enter owed_digest, so it cannot mask or cause the fork.
+bytes32 tip_at(std::uint64_t h) {
+    bytes32 b{};
+    for (int i = 0; i < 8; ++i) b[i] = std::uint8_t((h >> (8 * i)) & 0xff);
+    b[8] = 0xD5; b[9] = 0x11;  // marker: "DA-SH / LTC" family (SHA-256d/Scrypt)
+    return b;
+}
+
+// A single-key credit map (miner payout key).
+OwedLedger::Amounts credit1(const char* who, long long v) {
+    bytes32 k{};
+    for (int i = 0; who[i] && i < 32; ++i) k[i] = std::uint8_t(who[i]);
+    OwedLedger::Amounts a; a[k] = v; return a;
+}
+
+// The shared scenario: three pool-found blocks at DIFFERENT coin heights, so
+// their correct finalize heights (found + D_conf) differ from each other and
+// from the live tip — the necessary condition for a jump-to-tip driver to fork.
+constexpr ::v37::ChainId CHAIN = 0;
+constexpr std::uint64_t  D_CONF = 6;   // BTC-family confirmation depth (demo)
+constexpr std::uint64_t  TIP = 40;     // live coin best tip when catch-up happens
+
+struct Blk { const char* bid; std::uint64_t found_h; const char* who; long long amt; };
+const std::vector<Blk> kScenario = {
+    {"blk_a", 10, "miner_A", 100},   // gate 16
+    {"blk_c", 12, "miner_C",  70},   // gate 18
+    {"blk_b", 25, "miner_B",  50},   // gate 31
+};
+
+void register_all(FinalizeDriver& d) {
+    for (const auto& b : kScenario) {
+        FinalizeCandidate c;
+        c.bid = b.bid;
+        c.found_height = b.found_h;
+        c.credit = credit1(b.who, b.amt);
+        // payout empty: EffectiveOwed == finalW, so the digest isolates
+        // first_eligible (the F1 quantity) cleanly.
+        d.register_found(c);
+    }
+}
+
+// ── Reference: the REAL-TIME peer. Sees every coin height as the adapter
+// reports it: one advance_to() per single height 1..TIP.
+bytes32 realtime_digest() {
+    OwedLedger L(CHAIN); SettleHW HW;
+    FinalizeDriver d(L, HW, CHAIN, D_CONF);
+    d.set_tip_of_height(tip_at);
+    register_all(d);
+    for (std::uint64_t h = 1; h <= TIP; ++h) d.advance_to(h);
+    return L.owed_digest();
+}
+
+// ── Correct catch-up: node was behind at height 0; the coin adapter reports
+// best_height jumped to TIP in ONE Extend. The driver replays per-height.
+bytes32 catchup_oneshot_digest() {
+    OwedLedger L(CHAIN); SettleHW HW;
+    FinalizeDriver d(L, HW, CHAIN, D_CONF);
+    d.set_tip_of_height(tip_at);
+    register_all(d);
+    d.advance_to(TIP);                      // one shot — driver bridges per-height
+    return L.owed_digest();
+}
+
+// ── Correct catch-up in several arbitrary bursts.
+bytes32 catchup_bursts_digest() {
+    OwedLedger L(CHAIN); SettleHW HW;
+    FinalizeDriver d(L, HW, CHAIN, D_CONF);
+    d.set_tip_of_height(tip_at);
+    register_all(d);
+    d.advance_to(3);        // before any gate
+    d.advance_to(17);       // past blk_a's gate (16), before blk_c's (18)
+    d.advance_to(30);       // past blk_c's gate (18), before blk_b's (31)
+    d.advance_to(TIP);      // past blk_b's gate (31)
+    return L.owed_digest();
+}
+
+// ── Correct catch-up with a RESTART in the middle (O5.5 persistence).
+bytes32 catchup_restart_digest() {
+    // First run: catch up to height 20, then persist SettleHW + tear down.
+    std::string persisted;
+    OwedLedger L(CHAIN);
+    {
+        SettleHW HW;
+        FinalizeDriver d(L, HW, CHAIN, D_CONF);
+        d.set_tip_of_height(tip_at);
+        register_all(d);
+        d.advance_to(20);               // blk_a(16), blk_c(18) finalized; blk_b pending
+        persisted = HW.serialize();     // W6 LevelDB round-trip model
+    }
+    // Restart: rehydrate SettleHW, resume from persisted high-water, continue.
+    // (The OwedLedger L survives here as the W6 RecoveryDriver would rehydrate
+    // it; the point under test is that the driver does not re-drive settled
+    // heights and stamps the remaining gate at its own step.)
+    SettleHW HW2 = SettleHW::deserialize(persisted);
+    FinalizeDriver d2(L, HW2, CHAIN, D_CONF);
+    d2.set_tip_of_height(tip_at);
+    // Re-register found blocks: on_block_found is idempotent per bid, and the
+    // driver re-arms its finalize schedule; already-settled bids are skipped
+    // (is_pending() is false), only the still-pending blk_b remains to finalize.
+    register_all(d2);
+    d2.resume_from_persisted();          // last_driven := hw_height (20)
+    d2.advance_to(TIP);                  // finalizes blk_b at its gate (31)
+    return L.owed_digest();
+}
+
+// ── THE FALSIFIER: the buggy jump-to-tip driver the F1 audit warns against.
+// It moves the high-water straight to the live coin tip and finalizes EVERY
+// block buried >= D_conf at the tip height. This is the reconcile()-at-current-
+// tip shape wrongly copied into a live caller. It must FORK.
+struct JumpToTipDriver {
+    OwedLedger& L; SettleHW& HW; std::uint64_t dconf;
+    std::vector<std::pair<std::string, std::uint64_t>> found;  // bid, found_h
+    void register_found(const std::string& bid, std::uint64_t fh,
+                        const OwedLedger::Amounts& credit) {
+        L.on_block_found(bid, credit, {});
+        found.push_back({bid, fh});
+    }
+    void jump_to_tip(std::uint64_t tip) {
+        HW.advance(tip, tip_at(tip));                 // jump straight to tip
+        for (auto& [bid, fh] : found) {
+            if (tip < fh + dconf) continue;           // not yet buried
+            if (!L.is_pending(bid)) continue;
+            L.on_block_finalized(bid, tip);           // BUG: bin_height = live tip
+        }
+    }
+};
+
+bytes32 jump_to_tip_digest() {
+    OwedLedger L(CHAIN); SettleHW HW;
+    JumpToTipDriver d{L, HW, D_CONF, {}};
+    for (const auto& b : kScenario)
+        d.register_found(b.bid, b.found_h, credit1(b.who, b.amt));
+    d.jump_to_tip(TIP);
+    return L.owed_digest();
+}
+
+// finalW-only equality helper: compares the finalW maps of the correct and
+// buggy peers, proving the fork is purely in first_eligible.
+bool finalW_equal_correct_vs_buggy() {
+    OwedLedger A(CHAIN); SettleHW HWa;
+    FinalizeDriver da(A, HWa, CHAIN, D_CONF); da.set_tip_of_height(tip_at);
+    register_all(da);
+    for (std::uint64_t h = 1; h <= TIP; ++h) da.advance_to(h);
+
+    OwedLedger B(CHAIN); SettleHW HWb;
+    JumpToTipDriver db{B, HWb, D_CONF, {}};
+    for (const auto& b : kScenario)
+        db.register_found(b.bid, b.found_h, credit1(b.who, b.amt));
+    db.jump_to_tip(TIP);
+
+    return A.finalW() == B.finalW();
+}
+
+}  // namespace
+
+int main() {
+    std::printf("F1 finalize-driver KAT — BTC FAMILY (DASH/LTC adapter height)\n");
+    std::printf("(same coin-agnostic driver as A-XMR; merged w4_settlement.hpp)\n");
+
+    const bytes32 rt   = realtime_digest();
+    const bytes32 one  = catchup_oneshot_digest();
+    const bytes32 brst = catchup_bursts_digest();
+    const bytes32 rst  = catchup_restart_digest();
+    const bytes32 jump = jump_to_tip_digest();
+
+    std::printf("  real-time     owed_digest = %s\n", hx(rt).c_str());
+    std::printf("  catch-up 1x   owed_digest = %s\n", hx(one).c_str());
+    std::printf("  catch-up brst owed_digest = %s\n", hx(brst).c_str());
+    std::printf("  catch-up rst  owed_digest = %s\n", hx(rst).c_str());
+    std::printf("  jump-to-tip   owed_digest = %s\n", hx(jump).c_str());
+
+    // KA-1: in-order catch-up == real-time.
+    check("KA-1 in-order catch-up == real-time peer", one == rt);
+    // KA-2: burst-size independence.
+    check("KA-2 multi-burst catch-up == real-time peer", brst == rt);
+    // KA-3: restart mid-catch-up (O5.5 persisted) == real-time.
+    check("KA-3 restart mid-catch-up == real-time peer", rst == rt);
+    // KA-4a: the falsifier FORKS.
+    check("KA-4 jump-to-tip FORKS (digest != real-time)", jump != rt);
+    // KA-4b: the fork is purely in first_eligible — finalW is identical.
+    check("KA-4 fork is first_eligible-only (finalW identical)",
+          finalW_equal_correct_vs_buggy());
+    // KA-4c: non-vacuity — the scenario genuinely distinguishes the drivers.
+    check("KA-4 scenario is non-vacuous (correct != buggy)", rt != jump);
+
+    // KA-5: O5.5 shorter-branch refusal (DASH-regtest reorg-to-shorter model).
+    {
+        OwedLedger L(CHAIN); SettleHW HW;
+        FinalizeDriver d(L, HW, CHAIN, D_CONF);
+        d.set_tip_of_height(tip_at);
+        register_all(d);
+        d.advance_to(31);
+        const bytes32 at31 = L.owed_digest();
+        const std::uint64_t refused_before = HW.refused;
+        std::size_t n = d.advance_to(25);           // shorter branch → refused
+        const bytes32 after = L.owed_digest();
+        check("KA-5 O5.5 shorter-branch target refused (no finalize)",
+              n == 0 && after == at31 && HW.refused == refused_before + 1);
+    }
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/src/c2pool/v37/test/v37_btc_digest_drift_kat.cpp
+++ b/src/c2pool/v37/test/v37_btc_digest_drift_kat.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// btc_digest_drift_kat.cpp   (Track A2 / Milestone A-BTC — the drift-guard)
+//
+// HARD SAFETY 1 proof: the BTC-family node changes NO consensus digest. It only
+// SEQUENCES calls into the merged V37Engine / OwedLedger / W5. This KAT pins,
+// on a FIXED schedule, that:
+//
+//   (1) the LANE digest the XbtcNode publishes (AddLane + a push schedule
+//       through V37Engine) is byte-identical to the SAME schedule driven
+//       directly against a bare ::v37::Roundabout — i.e. the node adds no
+//       reordering, no extra record, no geometry drift.
+//
+//   (2) the OWED digest after a fixed found/finalize/orphan schedule replayed
+//       through BtcFinalizeDriver is byte-identical to the same calls issued
+//       directly against a fresh OwedLedger — i.e. the F1 driver's write-ahead
+//       and per-height sequencing are digest-transparent.
+//
+// If either diverges, the node has mutated consensus state and the KAT fails.
+// It links ONLY merged headers + the new btc/ seam (no coin lib, no Boost).
+// ===========================================================================
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include <c2pool/v37/v37_engine.hpp>
+#include <c2pool/v37/w4_settlement.hpp>
+#include <c2pool/v37/btc/btc_node.hpp>
+#include <sharechain/v37/v37_roundabout.hpp>
+
+using namespace c2pool::v37n::btc;
+using c2pool::v37n::V37Engine;
+using c2pool::v37n::settle::OwedLedger;
+
+static ::v37::PayoutDescriptor p2pkh_desc(std::uint8_t tag) {
+    ::v37::PayoutDescriptor d;
+    std::vector<std::uint8_t> s = {0x76, 0xa9, 0x14};
+    for (int i = 0; i < 20; ++i) s.push_back(tag);
+    s.push_back(0x88); s.push_back(0xac);
+    d.pay = ::v37::canonicalize_script(s);
+    return d;
+}
+static ::v37::bytes32 key_of(std::uint8_t tag) {
+    ::v37::bytes32 k{}; for (std::size_t i = 0; i < 32; ++i) k[i] = std::uint8_t(tag + i); return k;
+}
+
+int main() {
+    int fails = 0;
+    auto check = [&](bool ok, const char* what) {
+        if (!ok) { ++fails; std::printf("DRIFT-KAT FAIL: %s\n", what); }
+        else       std::printf("  ok: %s\n", what);
+    };
+
+    const ::v37::ChainId CH = 7;
+    ::v37::LaneParams params{};   // OQ-5 ratified default
+
+    // ── (1) LANE digest: node-published vs bare Roundabout ───────────────────
+    // Direct reference: a bare Roundabout with the identical schedule.
+    ::v37::Roundabout rb;
+    rb.add_lane(CH, params);
+    for (int i = 0; i < 5; ++i) rb.push(CH, p2pkh_desc(0xa0 + i), 1, 0);
+    ::v37::bytes32 ref_lane = rb.lane_digest(CH);
+
+    // Through the node's engine: AddLane happens in start(); push the identical
+    // schedule through the same V37Engine the node owns.
+    {
+        BtcNodeConfig cfg; cfg.lane_chain = CH; cfg.lane_params = params;
+        auto coin  = std::make_shared<MockCoinBackend>();
+        auto store = std::make_unique<MemSettleStore>();
+        XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+        node.open(); node.start();
+        for (int i = 0; i < 5; ++i)
+            node.engine().submit_tracked(::v37::LaneRecord::push(CH, p2pkh_desc(0xa0 + i), 1, 0)).get();
+        auto snap = node.engine().snapshot(CH);
+        check(snap != nullptr, "node lane published");
+        check(snap && snap->digest == ref_lane,
+              "lane digest byte-identical to bare Roundabout (no node drift)");
+        node.stop();
+    }
+
+    // ── (2) OWED digest: F1-driver-driven vs direct OwedLedger ───────────────
+    // A fixed schedule: found A@h=0, found B@h=1, finalize both as tip buries.
+    OwedLedger::Amounts credA{{key_of(0x10), 100}, {key_of(0x20), 50}};
+    OwedLedger::Amounts payA {{key_of(0x10), 100}, {key_of(0x20), 50}};
+    OwedLedger::Amounts credB{{key_of(0x30), 70}};
+    OwedLedger::Amounts payB {{key_of(0x30), 70}};
+    const std::uint64_t D = 2;
+
+    // Reference: direct calls, in the exact order the F1 driver would issue them
+    // (found in registration order; finalize per ascending height with
+    // bin_height = h + D_conf).
+    OwedLedger ref(CH);
+    ref.on_block_found("A", credA, payA);
+    ref.on_block_found("B", credB, payB);
+    ref.on_block_finalized("A", 0 + D);   // h=0 finalizes with bin_height 0+D
+    ref.on_block_finalized("B", 1 + D);   // h=1 finalizes with bin_height 1+D
+    ::v37::bytes32 ref_owed = ref.owed_digest();
+
+    // Through the driver + a real store, fed by a MockCoinBackend chain.
+    {
+        BtcNodeConfig cfg; cfg.lane_chain = CH; cfg.d_conf = D;
+        auto coin  = std::make_shared<MockCoinBackend>();
+        auto store = std::make_unique<MemSettleStore>();
+        XbtcNode node(cfg, std::move(store), coin, p2pkh_pay_of());
+        node.open(); node.start();
+        // register the two found blocks at heights 0 and 1
+        node.finalizer().on_block_found(FoundBlock{"A", 0, credA, payA});
+        node.finalizer().on_block_found(FoundBlock{"B", 1, credB, payB});
+        // build the chain: A at 0, B at 1, then bury both.
+        coin->append_block("A");            // height 0
+        coin->append_block("B");            // height 1
+        for (int i = 0; i < (int)D + 1; ++i) coin->append_block("z" + std::to_string(i));
+        node.poll_tip();                    // finalizes A then B, in order
+        check(node.ledger().owed_digest() == ref_owed,
+              "owed digest byte-identical to direct OwedLedger (F1 transparent)");
+        node.stop();
+    }
+
+    std::printf("DRIFT-KAT %s (%d failures)\n", fails ? "FAIL" : "OK", fails);
+    return fails ? 1 : 0;
+}

--- a/src/c2pool/v37/test/v37_btc_node_smoke.cpp
+++ b/src/c2pool/v37/test/v37_btc_node_smoke.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// v37_btc_node_smoke.cpp — CI driver for the live XbtcNode daemon smoke.
+//
+// Runs run_btc_node_smoke() (btc/btc_node_smoke.hpp) — the SAME asserted body as
+// `c2pool-v37-btc --selftest` — over a MockCoinBackend, and returns nonzero on
+// any failed check. Listed in BOTH build.yml legs (Linux x86_64 + ASan/UBSan)
+// and covered by the src/c2pool/**/test drift-guard, so it is a real gate, not
+// hollow-green. Links only Threads (the lifecycle is header-only + the mock
+// backend; no coin lib, no Boost).
+// ===========================================================================
+#include <c2pool/v37/btc/btc_node_smoke.hpp>
+
+int main() {
+    return c2pool::v37n::btc::run_btc_node_smoke() ? 1 : 0;
+}


### PR DESCRIPTION
## Milestone A-BTC — the live v37 node lifecycle for the Bitcoin family

The runnable single-node `c2pool-v37-btc` daemon. It wires the **merged,
coin-agnostic v37 engine** (`V37Engine` / `OwedLedger` / **W5 native coinbase** /
W6 persistence) to the **mature v36 coin plumbing** (the coin adapter behind
`ICoinBackend`, and the v36 `core::StratumServer` / `IWorkSource` front-end) to
make a testnet-capable node. Sibling of Milestone A-XMR: same engine + F1 driver
+ W6 shape; the coin backend differs (v36 Bitcoin/DASH adapter instead of
monerod) and the coinbase is the **W5 NATIVE** one.

**Native canon, no add-ons.** The BTC-family PayoutDescriptor canon
(`v37_descriptor.hpp`: P2PKH/P2SH/P2WPKH/P2WSH/P2TR/RAW) is the ratified V37.0
native canon — **no P-1 activation, no X6, no RandomX**; SHA-256d / Scrypt / X11
PoW is native. No XMR/CARROT code is reachable from this tree.

> EXPERIMENTAL / prototype — **DASH regtest/devnet default, do not run in
> production.** Mainnet is refused without `--i-understand-mainnet`.

### What the daemon wires (`src/c2pool/v37/btc/` — `XbtcNode`)

- **`open()` (durable side, before the engine spins):** build the W6
  `ISettleStore`; `RecoveryDriver::recover()` rebuilds the `OwedLedger` +
  `SettleHW` + finalize cursor — **F2 fail-closed**: a torn store returns false
  and the daemon refuses to start; construct the finalize driver seeded with the
  recovered cursor + event seq, its canonicality predicate bound to the coin
  backend's reorg oracle.
- **`start()` (live side):** `V37Engine::start()`; `AddLane` for the single
  BTC-family lane **through the engine** (so the lane digest is the executor's);
  bind the v36 `core::StratumServer`; run the height-watch
  (`poll_tip()` → finalize driver `advance_to_tip()`).
- **`on_block_won()` (a block-winning share):** build the **W5 native coinbase**
  (oldest-owed-first K_fair, §13 state root) from the finality-gated OWED ledger
  under the buried gate, register the found block with the F1 driver, and submit
  the block via the coin backend (ARM A embedded-P2P + ARM B `submitblock`).
- **`stop()`:** network down first, then `V37Engine::stop()` drains-and-joins.

The four v36 seam ops are named exactly (`best_tip` / `is_canonical` /
`block_reward` / `submit_block`) with their concrete v36 delegations cited
inline (DASH embedded-SPV `chain_rpc` / `HeaderChain` / `subsidy` /
`won_block_dispatch`; LTC daemon RPC). `MockCoinBackend` backs the local smoke;
`DashCoinBackend` / `LtcCoinBackend` are the production bindings (GAP, CI/heavy
leg). We **wire** the v36 coin logic, we do not rewrite it.

### F1 honored (the audit's HIGH finding)

The finalize driver is the **sole live caller** of
`OwedLedger::on_block_finalized`, invoked **once per coin-height step, in order**,
with `bin_height = the coin high-water at that step (h + D_conf)` — **never the
live coin tip**; a node that fell behind replays **per-height**. This is the fix
for the K_fair-clock (first_eligible) fork: finalizing a backlog at the live tip
would over-age every newly-owed key and split the owed_digest.

- `src/c2pool/v37/settle_finalize_driver.hpp` is the **coin-agnostic** driver,
  **byte-for-byte the same one Milestone A-XMR runs** (`c2pool::v37n::settle::
  FinalizeDriver`) — it names no coin; it sequences the merged w4 API off a
  monotone coin-height integer the caller feeds.
- `src/c2pool/v37/btc/btc_finalize_driver.hpp` is the persistence-integrated
  wrapper the live node runs (same per-height contract + W6 write-ahead).
  Unifying the two is a noted follow-on.

**Falsifier (`f1_finalize_kat_btc`, 7/7):** in-order / multi-burst / restart
catch-up all produce the **same** owed_digest as a real-time peer; the O5.5
shorter-branch target is refused; and a **jump-to-tip driver FORKS** the
owed_digest (the fork is isolated to `first_eligible` — `finalW` stays
identical), red where the correct driver is green.

### Zero consensus-digest change (HARD SAFETY 1)

The node only **sequences** calls into the merged engine — it redefines no
digest/canon. `v37_btc_digest_drift_kat` (3/3) pins, on a fixed schedule:
(1) the lane digest the node publishes (AddLane + push through `V37Engine`) is
**byte-identical** to the same schedule on a bare `::v37::Roundabout`;
(2) the owed_digest after a found/finalize schedule through the finalize driver +
a real store is **byte-identical** to a fresh `OwedLedger` issued the same calls
directly.

### The reorg-drill smoke result

`c2pool-v37-btc --selftest` / `v37_btc_node_smoke` — **13/13 green**:
open-before-start; mainnet fence refused; mine → bury → finalize one height at a
time with `bin_height == h + D_conf`; on_block_won builds the W5 coinbase +
submits; strictly-ascending F1 order; **reorg drill — a block that leaves the
best chain at maturity is orphaned, never finalized** (the controlled
falsifier over `MockCoinBackend::reorg_to`); W6 File-store restart round-trip; F2
fail-closed on a torn store.

Shipped config: `config/v37-btc/dash-regtest.yaml` (default, reorg-injectable)
and `config/v37-btc/ltc-testnet4.yaml` (alternate).

### Non-hollow CI

`v37_btc_node_smoke` (13), `v37_btc_digest_drift_kat` (3), `f1_finalize_kat_btc`
(7) are registered in **BOTH** `build.yml` legs (Linux x86_64 **and**
ASan/UBSan — all three are sanitizer-clean under
`-fsanitize=address,undefined -fno-sanitize-recover=all`) and covered by the
`src/c2pool/**/test` drift-guard (`check_test_target_allowlist.py`, which passes:
278 targets all allowlisted). The `c2pool-v37-btc` daemon is built in both legs.
Locally green plain and under sanitizers against `MockCoinBackend` (header-only
lifecycle; no coin libs, no Boost — HARD SAFETY 6).

### Remaining follow-ons

- `DashCoinBackend` / `LtcCoinBackend` production bindings + live block-hex
  reconstruction (`dash::coin::reconstruct_won_block`) — the CI/heavy leg that
  links the v36 coin libs; the local build ships the mock-backed smoke.
- **Real multi-node p2p carrier relay** — single-node is enough for the
  controlled DASH-regtest mine-and-settle + reorg-drill demo; the carrier wire is
  W2/W3.
- Live DASH-devnet integration (bind the real embedded-SPV adapter +
  `core::StratumServer`).
- Unify `btc_finalize_driver.hpp` onto the shared `settle_finalize_driver.hpp`
  (and, cross-milestone, make A-XMR's driver an include-alias so there is
  provably one finalize contract).
