### PR TITLE
ci: static BUILD_J compile-parallelism knob from runner .env (default 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
       # fallback fails HERE (fast, one TU), not deep in the coin build.
       - name: Boost sentinel
         run: |
-          cmake --build build_ci --target boost_sentinel -j8
+          cmake --build build_ci --target boost_sentinel -j"${BUILD_J:-8}"
           # --no-tests=error: the sentinel must actually RUN; if the target
           # ever fails to register, an empty selection cannot pass as green.
           ctest --test-dir build_ci -R '^boost_sentinel$' --output-on-failure --no-tests=error
@@ -200,7 +200,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/ci-logs"
-          cmake --build build_ci --target c2pool -j8 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build.log"
+          cmake --build build_ci --target c2pool -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build.log"
 
       - name: Build tests
         shell: bash          # pipefail: see the Build step note above
@@ -233,7 +233,7 @@ jobs:
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke c2pool-v37-xmr \
                     xmr_randomx_verify_kat \
-            -j8 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
+            -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
         working-directory: build_ci
@@ -810,7 +810,7 @@ jobs:
         run: cmake -S . -B build_bch -DCMAKE_TOOLCHAIN_FILE=build_bch/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_BCH=ON
 
       - name: Build c2pool-bch binary
-        run: cmake --build build_bch --target c2pool-bch -j8
+        run: cmake --build build_bch --target c2pool-bch -j"${BUILD_J:-8}"
 
       - name: Build BCH test targets
         run: |
@@ -847,7 +847,7 @@ jobs:
                     bch_g2_block_assembly_roundtrip_test \
                     bch_dashboard_pplns_current_test \
                     bch_coin_peer_manager_kat_test \
-            -j8
+            -j"${BUILD_J:-8}"
 
       - name: Run BCH tests
         working-directory: build_bch
@@ -1278,7 +1278,7 @@ jobs:
         run: cmake -S ui/c2pool-qt -B build-qt -DC2POOL_QT_BUILD_TESTS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: Build leak harness
-        run: cmake --build build-qt --target c2pool-qt_test_embedded_leak -j8
+        run: cmake --build build-qt --target c2pool-qt_test_embedded_leak -j"${BUILD_J:-8}"
 
       # ── Reward-safety + address-registry gates (Qt-free / Qt-Core; no display) ─
       # These prove the per-coin argv is reward-safe (no silent embedded arm, no
@@ -1288,7 +1288,7 @@ jobs:
       - name: Build + run reward-safe launch and address-validator gates
         run: |
           cmake --build build-qt \
-            --target c2pool-qt_test_reward_safe_launch c2pool-qt_test_address_validator -j8
+            --target c2pool-qt_test_reward_safe_launch c2pool-qt_test_address_validator -j"${BUILD_J:-8}"
           ./build-qt/c2pool-qt_test_reward_safe_launch
           ./build-qt/c2pool-qt_test_address_validator
 
@@ -1758,7 +1758,7 @@ jobs:
         run: cmake -S . -B build_dgb_auxdoge -DCMAKE_TOOLCHAIN_FILE=build_dgb_auxdoge/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON -DAUX_DOGE=ON
 
       - name: Build c2pool-dgb binary (AUX_DOGE seam ON)
-        run: cmake --build build_dgb_auxdoge --target c2pool-dgb -j8
+        run: cmake --build build_dgb_auxdoge --target c2pool-dgb -j"${BUILD_J:-8}"
 
       # Link-level companion to the compile-time aux_doge_isolation_guard.hpp:
       # fail the build if the DGB parent (AUX_DOGE seam ON) ODR-uses any LTC
@@ -1896,7 +1896,7 @@ jobs:
                      test_dash_bls_verify test_dash_quorum_members \
                      test_dash_quorum_member_source test_dash_govvote_bls \
                      test_dash_chainlock_verify test_dash_isdlock test_dash_dstx \
-            -j8
+            -j"${BUILD_J:-8}"
 
       # LEG 2: the artefact itself carries the dashbls backend.
       - name: BLS link guard (binary carries dashbls)


### PR DESCRIPTION
## What
Self-hosted Linux legs in build.yml hardcoded `-j8` on every `cmake --build` compile step. This wires those compile steps to read a **static** `BUILD_J` from the environment: `-j"${BUILD_J:-8}"`. Set `BUILD_J` once in each self-hosted runner .env (sourced into every job by the Actions runner). No live free-mem formula — the value is fixed per host, not computed at build time.

## Why / sizing
.198 host: 31G RAM, **zero swap**, 3 concurrent Runner.Listeners. Three simultaneous `-j8`+ compiles overcommit cc1plus RSS and OOM the shared cgroup. **Recommended BUILD_J=6** (3x6 = 18 jobs, ~1.5G/job headroom on 31G). Set it in each runner .env; activation is a runner-config step, not this PR.

## Scope (deliberately tight)
- Changed: the 9 `cmake --build` **compile** steps (main c2pool, boost_sentinel, build-tests, BCH, Qt leak/gates, DGB-auxdoge, DASH).
- **Unchanged**: ASan/UBSan legs keep their explicit `-j4` RSS cap; `ctest -j8` kept (test procs are light, not the OOM source); Windows `%NUMBER_OF_PROCESSORS%`.
- `:-8` default preserves current behavior on any runner without BUILD_J set (incl. github-hosted).

## Disk note (separate PR — do NOT bundle)
/ on .198 is at **82% (42G free)** — the heavy-3 link ENOSPC has no headroom margin. A runner _diag/workdir prune is a follow-up PR.

Signed commit; no auto-generated trailers.