### PR TITLE
ci: per-host disk semaphore (SLOTS=1) serializing the two 44G sanitizer legs

### DIFF
--- a/.github/actions/heavy-leg-lock/acquire.sh
+++ b/.github/actions/heavy-leg-lock/acquire.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Per-host heavy-leg semaphore (VM905: up to 8 runners on a 32-core/62 GB box).
+# History: a single slot (1 heavy leg per host) became the #1 CI failure mode --
+# 8 runners serialized behind one flock while ~2/3 of the box sat idle, and
+# waiters hard-failed at the -w budget (integrator measurement 2026-08-05). This
+# guard now offers HEAVY_LEG_SLOTS concurrent slots with first-free acquisition:
+# a leg takes the first free slot, so up to SLOTS heavy legs (ASan/UBSan build +
+# CodeQL c-cpp analyze) run concurrently on one host and the (SLOTS+1)th WAITS --
+# nothing is ever cancelled. 2 ASan/CodeQL legs fit 32c/62G comfortably; do NOT
+# raise SLOTS past 3 without first measuring an ASan leg's peak RSS.
+# Two holder invariants preserved from #1112:
+#  (1) the holder dies WITH the job -- it waits on the runner-worker PID and
+#      frees its slot the instant that worker dies; TTL is only a ceiling.
+#  (2) a stale holder from an already-dead job is REAPED at acquire, not blocked
+#      on: a recorded holder whose worker is gone, or a markerless PPID-1 legacy
+#      orphan, is by definition dead.
+# HEAVY_LEG_* env overrides exist ONLY for the honesty-gate test
+# (.github/actions/heavy-leg-lock/test.sh); production uses the defaults.
+LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-heavy-leg.lock}"
+HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}"
+WAIT="${HEAVY_LEG_WAIT:-5400}"
+TTL="${HEAVY_LEG_TTL:-14400}"
+SWEEP="${HEAVY_LEG_SWEEP:-1}"
+SLOTS="${HEAVY_LEG_SLOTS:-2}"
+ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
+
+# Slot files are ${LOCK}.1 .. ${LOCK}.SLOTS; each slot's live holder records a
+# ${HOLDERFILE}.<slot> marker ("holderpid workerpid"). Both are per-slot so two
+# concurrent holders never clobber each other's marker.
+
+# --- stale-holder sweep: reap the dead on each slot instead of blocking ---
+if [ "$SWEEP" = 1 ]; then
+  _s=1
+  while [ "$_s" -le "$SLOTS" ]; do
+    _mf="${HOLDERFILE}.${_s}"
+    if [ -f "$_mf" ]; then
+      read -r MH MW _ < "$_mf" 2>/dev/null || true
+      if [ -n "${MW:-}" ] && [ "${MW:-0}" != 0 ] && ! kill -0 "$MW" 2>/dev/null; then
+        echo "heavy-leg sweep: reaping holder pid ${MH:-?} on slot $_s (worker $MW dead)"
+        [ -n "${MH:-}" ] && kill "$MH" 2>/dev/null || true
+        rm -f "$_mf"
+      fi
+    fi
+    # Markerless PPID-1 orphan on this slot = a pre-guard `sleep` holder: our live
+    # holders always keep a marker, and a still-waiting new holder has a live
+    # parent, so PPID==1 + no marker is unambiguously dead.
+    if [ ! -f "$_mf" ] && command -v fuser >/dev/null 2>&1; then
+      for _q in $(fuser "${LOCK}.${_s}" 2>/dev/null | tr -d ' '); do
+        _qp="$(ps -o ppid= -p "$_q" 2>/dev/null | tr -d ' ' || true)"
+        if [ "${_qp:-0}" = 1 ]; then
+          echo "heavy-leg sweep: reaping markerless PPID-1 orphan pid $_q on slot $_s"
+          kill "$_q" 2>/dev/null || true
+        fi
+      done
+    fi
+    _s=$((_s+1))
+  done
+fi
+
+# --- find the runner-worker so the holder can die with the job ---
+WORKER=""
+_p=$$
+while [ "${_p:-1}" -gt 1 ]; do
+  case "$(ps -o comm= -p "$_p" 2>/dev/null || true)" in
+    Runner.Worker*) WORKER="$_p"; break ;;
+  esac
+  _p="$(ps -o ppid= -p "$_p" 2>/dev/null | tr -d ' ' || true)"
+  [ -z "${_p:-}" ] && break
+done
+
+# --- spawn the holder: first-free across SLOTS, holds its fd for the job's life ---
+# Each slot opens on fd (8+slot); slot 1 -> fd 9 (as before). The held fd is
+# closed (N>&-) in the sleep child so a kill of this bash frees the slot at once.
+# The holder exits when the runner-worker dies, or at TTL, whichever is first; if
+# the worker could not be found it falls back to a pure TTL ceiling.
+env LOCK="$LOCK" HOLDERFILE="$HOLDERFILE" ACQ="$ACQ" WAIT="$WAIT" TTL="$TTL" SLOTS="$SLOTS" WORKER="$WORKER" \
+bash -c '
+  _s=1
+  while [ "$_s" -le "$SLOTS" ]; do
+    _fd=$((8+_s))
+    eval "exec ${_fd}>\"\${LOCK}.\${_s}\"" || exit 1
+    _s=$((_s+1))
+  done
+  _held_fd=""
+  _deadline=$(( SECONDS + WAIT ))
+  while [ "$SECONDS" -lt "$_deadline" ]; do
+    _s=1
+    while [ "$_s" -le "$SLOTS" ]; do
+      _fd=$((8+_s))
+      if flock -n "$_fd"; then _held_fd="$_fd"; break; fi
+      _s=$((_s+1))
+    done
+    [ -n "$_held_fd" ] && break
+    sleep 3
+  done
+  [ -z "$_held_fd" ] && exit 1
+  _held_slot=$(( _held_fd - 8 ))
+  printf "%s %s\n" "$$" "${WORKER:-0}" > "${HOLDERFILE}.${_held_slot}"
+  echo "$_held_slot" > "$ACQ"
+  _end=$(( SECONDS + TTL ))
+  while [ "$SECONDS" -lt "$_end" ]; do
+    if [ -n "$WORKER" ] && ! kill -0 "$WORKER" 2>/dev/null; then break; fi
+    eval "sleep 15 ${_held_fd}>&-"
+  done
+  rm -f "${HOLDERFILE}.${_held_slot}"
+' </dev/null >/dev/null 2>&1 &
+HOLDER=$!
+disown "$HOLDER" 2>/dev/null || true
+echo "${HEAVY_LEG_HOLDER_ENV:-HEAVY_LEG_LOCK_HOLDER}=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
+
+# --- wait for the acquire handshake ---
+while kill -0 "$HOLDER" 2>/dev/null && [ ! -s "$ACQ" ]; do
+  sleep 2
+done
+if [ ! -s "$ACQ" ]; then
+  echo "::error::per-host heavy-leg lock: all $SLOTS slots busy for $((WAIT/60)) min on ${RUNNER_NAME:-?} -- blocked by live long holders, not this diff"
+  _s=1
+  while [ "$_s" -le "$SLOTS" ]; do
+    echo "  slot $_s (${LOCK}.${_s}):"
+    if command -v fuser >/dev/null 2>&1; then
+      for _q in $(fuser "${LOCK}.${_s}" 2>/dev/null | tr -d ' '); do
+        # pid ppid age(etimes,s) comm -- names the live holder blocking this slot
+        echo "    holder [pid ppid age_s comm]: $(ps -o pid=,ppid=,etimes=,comm= -p "$_q" 2>/dev/null | tr -s ' ')"
+      done
+    fi
+    if [ -f "${HOLDERFILE}.${_s}" ]; then
+      echo "    marker (holderpid workerpid): $(cat "${HOLDERFILE}.${_s}" 2>/dev/null)"
+    else
+      echo "    marker: (none)"
+    fi
+    _s=$((_s+1))
+  done
+  exit 1
+fi
+_got="$(cat "$ACQ" 2>/dev/null)"
+rm -f "$ACQ"
+echo "heavy-leg lock acquired on ${RUNNER_NAME:-?} slot ${_got:-?}/$SLOTS (holder pid $HOLDER, worker ${WORKER:-none})"

--- a/.github/actions/heavy-leg-lock/action.yml
+++ b/.github/actions/heavy-leg-lock/action.yml
@@ -1,0 +1,38 @@
+name: heavy-leg-lock
+description: >-
+  Acquire a per-host slotted flock semaphore (reap-guard) governing a RAM- or
+  disk-heavy CI leg. Holds a disowned slot that auto-frees when the runner-worker
+  dies at job end; stale holders from dead jobs are reaped at acquire. Same proven
+  logic as the inline pre-checkout RAM lock in build.yml (which cannot use this
+  action because it must run before checkout).
+inputs:
+  lock-file:
+    description: Base path of the per-slot lock files.
+    default: /tmp/c2pool-heavy-leg.lock
+  holder-file:
+    description: Base path of the per-slot holder markers.
+    default: /tmp/c2pool-heavy-leg.holder
+  slots:
+    description: Number of concurrent slots on the host.
+    default: "2"
+  wait:
+    description: Max seconds to wait for a free slot before failing.
+    default: "5400"
+  ttl:
+    description: Holder ceiling in seconds (worker-death frees earlier).
+    default: "14400"
+  holder-env:
+    description: Name of the env var to export the holder pid into (for release).
+    default: HEAVY_LEG_LOCK_HOLDER
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        HEAVY_LEG_LOCK: ${{ inputs.lock-file }}
+        HEAVY_LEG_HOLDERFILE: ${{ inputs.holder-file }}
+        HEAVY_LEG_SLOTS: ${{ inputs.slots }}
+        HEAVY_LEG_WAIT: ${{ inputs.wait }}
+        HEAVY_LEG_TTL: ${{ inputs.ttl }}
+        HEAVY_LEG_HOLDER_ENV: ${{ inputs.holder-env }}
+      run: bash "$GITHUB_ACTION_PATH/acquire.sh"

--- a/.github/actions/heavy-leg-lock/test.sh
+++ b/.github/actions/heavy-leg-lock/test.sh
@@ -119,6 +119,51 @@ else
 fi
 reap "$L2" "$H2"
 
+echo; echo "### acquire.sh (composite-action body used by the SLOTS=1 disk semaphore)"
+# The disk semaphore reuses the SAME reap-guard logic via .github/actions/heavy-leg-lock.
+# Gate it at SLOTS=1 (its production slot count) so a hollow sweep there is caught too,
+# and prove the holder-env override lands the pid under the requested var name.
+ACQ2="$ROOT/.github/actions/heavy-leg-lock/acquire.sh"
+[ -s "$ACQ2" ] || { echo "FATAL: missing $ACQ2"; exit 2; }
+run_disk() {  # $1 sweep(0/1)  $2 wait(s)  $3 lock-base  $4 marker-base
+  HEAVY_LEG_LOCK="$3" HEAVY_LEG_HOLDERFILE="$4" \
+  HEAVY_LEG_WAIT="$2" HEAVY_LEG_TTL=3 HEAVY_LEG_SWEEP="$1" HEAVY_LEG_SLOTS=1 \
+  HEAVY_LEG_HOLDER_ENV=HEAVY_DISK_LOCK_HOLDER \
+  RUNNER_NAME="honesty-test-disk" GITHUB_ENV="$TMP/genv-disk" \
+  bash "$ACQ2"
+}
+disk_reap() {  # $1 marker  $2 lock
+  [ -f "$1" ] && awk {print } "$1" | xargs -r kill 2>/dev/null || true
+  fuser -k "$2" 2>/dev/null || true
+  sleep 0.3 || true
+}
+
+echo; echo "### CASE 3  DISK FIXED (sweep on, SLOTS=1): sole slot saturated -> reaped -> GREEN"
+L3="$TMP/case3.lock"; H3="$TMP/case3.holder"
+SLOTS=1 plant_orphan "$L3.1" "$H3.1" || exit 1
+rm -f "$TMP/genv-disk"
+if run_disk 1 20 "$L3" "$H3"; then
+  echo "-> PASS: disk semaphore reaped the stale holder and acquired slot 1"
+  if grep -q ^HEAVY_DISK_LOCK_HOLDER= "$TMP/genv-disk" 2>/dev/null; then
+    echo "-> PASS: holder pid exported under HEAVY_DISK_LOCK_HOLDER"
+  else
+    echo "-> FAIL: holder-env override did not export HEAVY_DISK_LOCK_HOLDER"; fail=1
+  fi
+else
+  echo "-> FAIL: disk semaphore did NOT recover from a reapable orphan on its sole slot"; fail=1
+fi
+disk_reap "$H3.1" "$L3.1"
+
+echo; echo "### CASE 4  DISK LEAKED (sweep off, SLOTS=1): saturation must block -> RED"
+L4="$TMP/case4.lock"; H4="$TMP/case4.holder"
+SLOTS=1 plant_orphan "$L4.1" "$H4.1" || exit 1
+if run_disk 0 5 "$L4" "$H4"; then
+  echo "-> FAIL: disk semaphore acquired despite a live orphan on its sole slot -- hollow sweep"; fail=1
+else
+  echo "-> PASS: orphan blocked the sole slot and acquire failed red without the sweep"
+fi
+disk_reap "$H4.1" "$L4.1"
+
 echo
 if [ "$fail" = 0 ]; then
   echo "HONESTY GATE PASSED: perturb -> reaped -> green ; restore leak -> red"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -600,6 +600,26 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr"
 
+      # Per-host DISK semaphore (SLOTS=1): serializes the two ~44G sanitizer
+      # build trees (build_asan + build_bch_asan) so they never co-admit on one
+      # host and exhaust the disk -- the concurrent-admission ENOSPC class
+      # (run 34006115987 / #1506) that the stale-hours clamp (#1517) and a floor
+      # bump cannot gate. DISTINCT from the RAM heavy-leg lock (SLOTS=2, linux-asan
+      # + CodeQL), which stays 2-up: this governs ONLY {linux-asan, coin-bch-asan}
+      # at SLOTS=1. Per-host (/tmp flock), so heavy pairs on DIFFERENT hosts still
+      # run in parallel. The disowned holder auto-frees when the runner-worker dies
+      # at job end -- i.e. AFTER Prune runner workspace has dropped the 44G tree,
+      # which is exactly when the disk pressure clears (an earlier release would
+      # free the slot while the tree is still on disk). Reap-guard identical to the
+      # RAM lock; honesty-gated at SLOTS=1 in heavy-leg-lock/test.sh.
+      - name: Acquire per-host heavy-disk semaphore
+        if: runner.environment != 'github-hosted'
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-heavy-disk.lock
+          holder-file: /tmp/c2pool-heavy-disk.holder
+          slots: "1"
+          holder-env: HEAVY_DISK_LOCK_HOLDER
       - name: Heavy-leg disk headroom guard (+ bounded prune)
         if: runner.environment != 'github-hosted'
         uses: ./.github/actions/heavy-disk-guard
@@ -944,6 +964,26 @@ jobs:
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr"
 
+      # Per-host DISK semaphore (SLOTS=1): serializes the two ~44G sanitizer
+      # build trees (build_asan + build_bch_asan) so they never co-admit on one
+      # host and exhaust the disk -- the concurrent-admission ENOSPC class
+      # (run 34006115987 / #1506) that the stale-hours clamp (#1517) and a floor
+      # bump cannot gate. DISTINCT from the RAM heavy-leg lock (SLOTS=2, linux-asan
+      # + CodeQL), which stays 2-up: this governs ONLY {linux-asan, coin-bch-asan}
+      # at SLOTS=1. Per-host (/tmp flock), so heavy pairs on DIFFERENT hosts still
+      # run in parallel. The disowned holder auto-frees when the runner-worker dies
+      # at job end -- i.e. AFTER Prune runner workspace has dropped the 44G tree,
+      # which is exactly when the disk pressure clears (an earlier release would
+      # free the slot while the tree is still on disk). Reap-guard identical to the
+      # RAM lock; honesty-gated at SLOTS=1 in heavy-leg-lock/test.sh.
+      - name: Acquire per-host heavy-disk semaphore
+        if: runner.environment != 'github-hosted'
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-heavy-disk.lock
+          holder-file: /tmp/c2pool-heavy-disk.holder
+          slots: "1"
+          holder-env: HEAVY_DISK_LOCK_HOLDER
       - name: Heavy-leg disk headroom guard (+ bounded prune)
         if: runner.environment != 'github-hosted'
         uses: ./.github/actions/heavy-disk-guard

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,6 +340,9 @@ jobs:
     #     PMTU. See the note in codeql-analysis.yml; it is revisitable, but
     #     flock separation would still keep these two on different hosts.
     # Do not consolidate these two onto one label.
+    # The per-coin ASan mirrors (COIN_BCH AsAN+UBSan, etc.) follow this SAME rule: they run on
+    # c2pool-heavy too (not c2pool-build, whose 232G volume floors out at the 50G disk guard), and
+    # are serialized against this leg on a shared heavy host by the per-host disk semaphore (SLOTS=1).
     runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     continue-on-error: true
     steps:
@@ -865,7 +868,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   coin-bch-asan:
     name: COIN_BCH Linux x86_64 (AsAN+UBSan)
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-heavy"]') || 'ubuntu-24.04' }}
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -599,7 +599,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCOIN_DGB=ON \
             -DC2POOL_GOLDEN_RESOLVED_CONFIG_GATE=OFF \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g1" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr"
 
@@ -963,7 +963,7 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_BUILD_TYPE=Release \
             -DCOIN_BCH=ON \
-            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g1" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr"
 


### PR DESCRIPTION
## Problem
The concurrent-admission ENOSPC class (run 34006115987 / #1506) is still open on master. The stale-hours clamp (#1517) and a heavy-disk-guard floor bump **cannot** gate it: the RAM heavy-leg lock runs `linux-asan` at SLOTS=2 (shared with CodeQL) and `coin-bch-asan` takes **no** lock, so both ~44G sanitizer build trees (`build_asan` + `build_bch_asan`) can admit on one host simultaneously and exhaust the disk. (This is the hinge verdict I gave integrator on 09-06: the lock does not serialize the two 44G legs.)

## Fix
A **distinct per-host DISK semaphore at SLOTS=1** governing exactly `{linux-asan, coin-bch-asan}`.
- Per-host (`/tmp` flock) ⇒ heavy pairs on **different** hosts still run 2-up; on the **same** host the second 44G leg WAITS.
- The RAM lock (SLOTS=2, linux-asan + CodeQL) is **untouched** and stays 2-up.
- Held via a disowned holder that **auto-frees when the runner-worker dies at job end** — i.e. *after* `Prune runner workspace` drops the 44G tree, which is exactly when disk pressure clears. An earlier explicit release would free the slot while the tree is still on disk (88G peak), so job-end auto-free is the correct disk semantics; no explicit release step is added.

## Shape
Shipped as a composite action `.github/actions/heavy-leg-lock` reusing the **proven reap-guard/sweep script verbatim**, parameterized by lock-file / holder-file / slots / holder-env. The RAM lock keeps its inline copy because it must acquire **before checkout** (the action file is not on disk yet); the disk lock acquires post-checkout, right before the heavy-disk-guard/Build.

## Verification (honesty gate)
`heavy-leg-lock/test.sh` extended — CASE 3/4 drive `acquire.sh` at SLOTS=1:
- CASE 3 (sweep on): sole slot saturated with a dead-owner orphan → reaped → GREEN; holder pid exported under `HEAVY_DISK_LOCK_HOLDER`.
- CASE 4 (sweep off): same saturation must block → RED (proves the sweep is load-bearing on the sole slot, not hollow).
All 6 checks pass locally (RAM CASE 1/2 + disk CASE 3/4).

Draft until CI is green on 80b7904f. Merge on operator push-approval.