### PR TITLE
ci: fix base ASan leg — remove duplicated orphan xmr target lines (xmr_crypto_kats: command not found)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -637,8 +637,6 @@ jobs:
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
-                    xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat \
-            -j4 # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison
                  # (kManifest[i].upstream == &kP2pool). Fixed by replacing the


### PR DESCRIPTION
The base **Linux x86_64 (AsAN+UBSan)** step has a bad-merge duplicate in build.yml: after the correct target list ending `xmr_miner_block_path_smoke` + `-j4`, a truncated copy `xmr_crypto_kats … xmr_e2e_kat` + a second `-j4` follow. The first `-j4` closes the `cmake --build`, so the orphan lines execute as a shell command → `xmr_crypto_kats: command not found` (exit 127). This reddens the base ASan leg on **master and every open PR** (byte-identical), blocking the merge queue. Fix removes the two orphan lines only; the retained target-list line is complete and unchanged. COIN_BCH ASan block was checked and is clean.