### PR TITLE
v37 XMR: fix hex-string difficulty parse (live stagenet blocker) + O-1 finalize-cursor seed

### DIFF
--- a/src/c2pool/v37/xmr/xmr_finalize_driver.hpp
+++ b/src/c2pool/v37/xmr/xmr_finalize_driver.hpp
@@ -138,8 +138,23 @@ public:
         // the D_conf burial threshold, the high-water at that step is h + D_conf
         // (NOT best_height): that is the value the K_fair clock must see, so a
         // node catching up replays the SAME per-height clock a synced node saw.
+        //
+        // CURSOR PERSISTENCE (O-1, X9 stagenet bring-up): the cursor is written
+        // once after the walk, plus immediately after any height that actually
+        // finalized / orphaned a found block (so a crash between such steps
+        // never re-plays a step whose write-ahead is already durable). It used
+        // to be written on EVERY height: on a fresh store against live stagenet
+        // (tip ~2.2M) that is ~2.2M whole-image rewrites of settle.img inside
+        // bring_up() -- minutes of silence and heavy I/O -- for heights that
+        // carry no found block at all. The F1 contract is untouched: the per-
+        // height bin_height, the in-order stepping and the write-ahead-then-
+        // mutate ordering are exactly as before; only the cursor checkpoint
+        // cadence changed, and the walk is idempotent on replay (is_pending /
+        // canonical guards) so a stale cursor after a crash is harmless.
+        const std::uint64_t cursor_before = m_cursor_h;
         for (std::uint64_t h = m_cursor_h + 1; h <= frontier; ++h) {
             const std::uint64_t bin_height = h + m_d_conf;   // high-water at this step
+            bool touched = false;                            // a found block was disposed at h
 
             auto bit = m_by_height.find(h);
             if (bit != m_by_height.end()) {
@@ -149,6 +164,7 @@ public:
                     if (!fit->second.canonical) continue;             // already orphaned
                     if (m_is_canonical && !m_is_canonical(h, bid)) {  // orphaned at maturity
                         on_block_orphaned(bid);
+                        touched = true;
                         continue;
                     }
                     if (!m_ledger.is_pending(bid)) continue;          // idempotent / already settled
@@ -163,11 +179,13 @@ public:
                     write_event(ev);
                     m_ledger.on_block_finalized(bid, bin_height);
                     steps.push_back(FinalizeStep{bid, h, bin_height});
+                    touched = true;
                 }
             }
             m_cursor_h = h;
-            persist_cursor();
+            if (touched) persist_cursor();
         }
+        if (m_cursor_h != cursor_before) persist_cursor();
         persist_hw();
         return steps;
     }

--- a/src/impl/xmr/node/minijson.hpp
+++ b/src/impl/xmr/node/minijson.hpp
@@ -247,4 +247,30 @@ inline std::string hash_to_hex(const std::array<std::uint8_t, 32>& h) {
     return out;
 }
 
+// monerod >= v0.18 emits get_miner_data.difficulty (and block_header
+// .wide_difficulty) as a "0x..." hex STRING of up to 32 nibbles -- a 128-bit
+// cryptonote::difficulty_type -- not as a JSON number. Parses it into (hi, lo).
+// Returns false on an empty, non-hex, or > 128-bit string (caller keeps zero).
+inline bool hex_to_u128(const std::string& hex, std::uint64_t& hi, std::uint64_t& lo) {
+    std::size_t p = 0;
+    if (hex.size() >= 2 && hex[0] == '0' && (hex[1] == 'x' || hex[1] == 'X')) p = 2;
+    if (p >= hex.size() || hex.size() - p > 32) return false;
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    std::uint64_t h = 0, l = 0;
+    for (; p < hex.size(); ++p) {
+        int n = nib(hex[p]);
+        if (n < 0) return false;
+        h = (h << 4) | (l >> 60);
+        l = (l << 4) | static_cast<std::uint64_t>(n);
+    }
+    hi = h;
+    lo = l;
+    return true;
+}
+
 } // namespace c2pool::xmr::node::minijson

--- a/src/impl/xmr/node/monero_rpc.cpp
+++ b/src/impl/xmr/node/monero_rpc.cpp
@@ -92,7 +92,17 @@ bool root_result(const std::vector<char>& body, mj::Value& root, const mj::Value
 
 Difficulty128 read_difficulty(const mj::Value& obj) {
     Difficulty128 d;
-    d.lo = obj["difficulty"].as_u64();
+    const mj::Value& v = obj["difficulty"];
+    if (v.is_string()) {
+        // monerod >= v0.18.0.0 get_miner_data emits "difficulty" as a "0x..."
+        // hex STRING (128-bit), NOT a number (verified on the v0.18.5.1 stagenet
+        // wire: "difficulty": "0x36de33"). Reading it as a number yielded 0, so
+        // MinerData::valid() rejected every frame and the live daemon never
+        // applied a tip. Block headers keep the numeric lo64 / top64 pair below.
+        if (!mj::hex_to_u128(v.as_string(), d.hi, d.lo)) d = Difficulty128{};
+        return d;
+    }
+    d.lo = v.as_u64();
     d.hi = obj["difficulty_top64"].as_u64(); // absent => 0 (fits u64 today)
     return d;
 }

--- a/src/impl/xmr/node/monero_zmq.cpp
+++ b/src/impl/xmr/node/monero_zmq.cpp
@@ -28,7 +28,16 @@ namespace {
 
 Difficulty128 read_difficulty(const mj::Value& obj) {
     Difficulty128 d;
-    d.lo = obj["difficulty"].as_u64();
+    const mj::Value& v = obj["difficulty"];
+    if (v.is_string()) {
+        // monerod >= v0.18 emits miner_data "difficulty" as a "0x..." hex STRING
+        // (128-bit) on both the RPC and the json-full-miner_data feeds; the
+        // RPC-poll fallback (xmr_live_transport.hpp) forwards that same body
+        // here. See monero_rpc.cpp read_difficulty for the live-wire evidence.
+        if (!mj::hex_to_u128(v.as_string(), d.hi, d.lo)) d = Difficulty128{};
+        return d;
+    }
+    d.lo = v.as_u64();
     d.hi = obj["difficulty_top64"].as_u64();
     return d;
 }

--- a/src/impl/xmr/test/x2_adapter_kat.cpp
+++ b/src/impl/xmr/test/x2_adapter_kat.cpp
@@ -338,6 +338,91 @@ int main() {
               "submit_block posted the blob hex through the seam");
     }
 
+    // ======================================================================
+    std::printf("== [7] live-wire regression: monerod v0.18 hex-string difficulty ==\n");
+    {
+        // VERBATIM get_miner_data response body captured from monerod v0.18.5.1
+        // (stagenet, 2026-09-07, height 2202216), CRLF pretty-print included.
+        // "difficulty" is a "0x..." hex STRING, not a number: before this vector
+        // the parsers read it as 0, MinerData::valid() rejected every frame and
+        // the live c2pool-v37-xmr daemon never applied a tip (hw_height stayed 0).
+        static const char* kWire =
+            "{\r\n  \"id\": \"0\",\r\n  \"jsonrpc\": \"2.0\",\r\n  \"result\": {\r\n"
+            "    \"already_generated_coins\": 18162842501536847281,\r\n"
+            "    \"difficulty\": \"0x36de33\",\r\n"
+            "    \"height\": 2202216,\r\n"
+            "    \"major_version\": 16,\r\n"
+            "    \"median_weight\": 300000,\r\n"
+            "    \"prev_id\": \"914d16a7fb163667e7837ea728ed326d7fbf483d8f364388c00814294559d2a5\",\r\n"
+            "    \"seed_hash\": \"9bde15898b36a6b811fa85bb4fb403aed61006318a7762b33b87a0be333976dc\",\r\n"
+            "    \"status\": \"OK\",\r\n"
+            "    \"tx_backlog\": [{\r\n"
+            "      \"fee\": 121920000,\r\n"
+            "      \"id\": \"80f854da409ddb7b49b792a91c48f87f541b271128228a7abdf0442a535b2fa7\",\r\n"
+            "      \"weight\": 1524\r\n"
+            "    }],\r\n"
+            "    \"untrusted\": false\r\n"
+            "  }\r\n}";
+
+        // (a) the hex_to_u128 primitive.
+        std::uint64_t hi = 1, lo = 1;
+        CHECK(mj::hex_to_u128("0x36de33", hi, lo) && hi == 0 && lo == 0x36de33ull,
+              "hex_to_u128(\"0x36de33\") == (0, 0x36de33)");
+        CHECK(mj::hex_to_u128("0x1ffffffffffffffff", hi, lo) && hi == 1 && lo == 0xffffffffffffffffull,
+              "hex_to_u128 crosses the 64-bit boundary into hi");
+        CHECK(mj::hex_to_u128("36DE33", hi, lo) && hi == 0 && lo == 0x36de33ull,
+              "hex_to_u128 accepts no-prefix upper-case hex");
+        CHECK(!mj::hex_to_u128("0x", hi, lo) && !mj::hex_to_u128("", hi, lo) &&
+              !mj::hex_to_u128("0xzz", hi, lo) &&
+              !mj::hex_to_u128("0x123456789012345678901234567890123", hi, lo),
+              "hex_to_u128 rejects empty / non-hex / > 128-bit");
+
+        // (b) RPC path: MoneroDaemonRpc::get_miner_data through the seam.
+        MockMonerodTransport mock;
+        mock.set_method_body("get_miner_data", kWire);
+        MoneroDaemonRpc rpc(mock);
+        std::optional<MinerData> got;
+        rpc.get_miner_data([&](std::optional<MinerData> md, const std::string&){ got = md; });
+        CHECK(got.has_value(), "RPC: live stagenet get_miner_data body parses");
+        CHECK(got && got->difficulty.lo == 0x36de33ull && got->difficulty.hi == 0,
+              "RPC: hex-string difficulty == 0x36de33");
+        CHECK(got && got->valid() && got->height == 2202216 && got->major_version == 16,
+              "RPC: MinerData::valid() holds on the live body");
+        CHECK(got && got->tx_backlog.size() == 1 && got->tx_backlog[0].fee == 121920000ull &&
+              got->tx_backlog[0].weight == 1524,
+              "RPC: live tx_backlog entry decoded");
+        CHECK(got && got->already_generated_coins == 18162842501536847281ull,
+              "RPC: already_generated_coins > 2^63 preserved");
+
+        // (c) poll-fallback path: the live transport (xmr_live_transport.hpp
+        //     pump_poll) forwards this SAME result-wrapped body as a
+        //     json-full-miner_data frame; the ZMQ decoder must accept it too.
+        std::vector<char> payload(kWire, kWire + std::strlen(kWire));
+        auto md2 = ZmqSubscriber::parse_miner_data_payload(payload);
+        CHECK(md2.has_value() && md2->valid() && md2->difficulty.lo == 0x36de33ull,
+              "ZMQ/poll: result-wrapped live body parses with hex difficulty");
+
+        // (d) numeric difficulty (mock / older wire shape) still parses.
+        const Hash prev = H(3000000), seed = H(2998272);
+        MockMonerodTransport mock_num;
+        mock_num.set_method_body("get_miner_data", miner_data_rpc(3000001, prev, seed, 123456789ull));
+        MoneroDaemonRpc rpc_num(mock_num);
+        std::optional<MinerData> got_num;
+        rpc_num.get_miner_data([&](std::optional<MinerData> md, const std::string&){ got_num = md; });
+        CHECK(got_num && got_num->difficulty.lo == 123456789ull && got_num->difficulty.hi == 0,
+              "RPC: numeric difficulty + difficulty_top64 still parse");
+
+        // (e) end-to-end: the adapter applies the live tip from the wire body.
+        MonerodAdapter adapter(mock);
+        adapter.start();
+        adapter.initial_sync();
+        CHECK(adapter.index().best_height() == 2202215, "adapter: live body drives tip == 2202215");
+        Hash want_tip;
+        CHECK(mj::hex_to_hash("914d16a7fb163667e7837ea728ed326d7fbf483d8f364388c00814294559d2a5", want_tip) &&
+              adapter.index().best_id() == want_tip,
+              "adapter: tip id == live prev_id");
+    }
+
     std::printf("\n%s (%d failure%s)\n", g_fail ? "RESULT: FAIL" : "RESULT: PASS",
                 g_fail, g_fail == 1 ? "" : "s");
     return g_fail ? 1 : 0;


### PR DESCRIPTION
Two fixes found by the X9 stagenet bring-up of the `c2pool-v37-xmr` daemon (Milestone A-XMR #1520) on a live synced monerod v0.18.5.1 (stagenet, height ~2.2M). Consumer/impl tree only — **no `src/sharechain/v37` canon, no owed_digest fold; digest-neutral.**

**`83128c4f` — the live blocker (parse layer, X2).** monerod v0.18 returns `get_miner_data.difficulty` as a hex STRING (e.g. `"0x36de33"`), but both `read_difficulty()` helpers (`src/impl/xmr/node/monero_rpc.cpp`, `monero_zmq.cpp`) called `as_u64()` → 0 → `MinerData::valid()` false → **every miner_data frame dropped**. On unmodified master the daemon polls forever and never tracks a tip (`hw_height=0`, no `settle.img`), despite 200-OK bodies arriving. Fix: `minijson::hex_to_u128` + a string branch; `x2_adapter_kat.cpp` section [7] pins the verbatim stagenet wire body (RPC path, poll-fallback, adapter end-to-end).

**`0de9b9c8` — O-1 finalize-cursor seed.** `xmr_finalize_driver.hpp` persisted the cursor once per height walked; on a fresh store against a ~2.2M-height chain that is ~5.8 min of whole-image commits (159 µs each on ZFS) inside `bring_up()`. Persist once per walk + after any height touching a found block instead. F1 contract untouched; `v37_xmr_node_smoke` S6 (cursor 17/17) still passes.

**Bring-up result (observe-side, proven on .40 against live stagenet):** P-1 active (`point-check installed; XMR descriptors validate`); `hw_height` tracked real network blocks 2202218→2202220 with persisted `hw_tip` == monerod's block hash at each height; SIGINT→restart resumed (`recovery: hw_height=… (resumed)`, no re-walk), monotone, refused=0.

**Verification:** `xmr_x2_node_kat` PASS (0 failures); `v37_xmr_node_smoke` 11/11; `--mock-smoke` 11/11 on both the build host and .40. Binary built on the CI plain-leg recipe with `-static-libstdc++ -static-libgcc` for glibc portability.

**Not in this PR (follow-on, O-2):** the full FOUND→FINALIZE wiring — TCP `ITransport` stratum host, network-keyed base58 boundary (+regtest), `ITemplateSource` from the monerod adapter, `LightVerifier` with vendored librandomx, the full block-blob assembler, and `XmrFinalizeDriver` as sole store writer. Also seen live: O-3 (no live-loop observability), O-5 (spurious `Reorg{depth=0}` per poll; `flush()` has no fsync), O-4 (CARROT fence pinned at 255).