### PR TITLE
DRAFT core: io_context-freeze guard — bound worker wait on producer dispatch

### DIFF
--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <mutex>
 #include <deque>
+#include <chrono>
 #include <future>
 #include <set>
 #include <map>
@@ -958,8 +959,19 @@ public:
         };
     }
 
-    /// Parameterized overload: dispatch-and-wait (used for delta, lookup, etc.)
-    /// These are called less frequently so blocking is acceptable.
+    /// Max time an io_context worker (e.g. the HTTP thread) may wait on the
+    /// producer io_context before giving up. Kept well under the 40s liveness
+    /// watchdog so a wedged/oversubscribed producer degrades to a 5xx instead
+    /// of freezing the worker into the io_context-freeze abort seen in prod.
+    static constexpr std::chrono::seconds PRODUCER_DISPATCH_TIMEOUT{10};
+
+    /// Parameterized overload: dispatch-and-wait (used for delta, lookup, etc.).
+    /// An io_context worker must NEVER block on the producer unboundedly, so we
+    /// (a) own the promise via shared_ptr — the posted task then stays valid
+    /// even after we stop waiting (the old [&]-capture would UAF a destroyed
+    /// promise if the wait was ever abandoned), and (b) bound the wait to
+    /// PRODUCER_DISPATCH_TIMEOUT, throwing a std::runtime_error the REST router
+    /// turns into a 5xx rather than hanging the HTTP thread past the watchdog.
     template<typename R, typename Arg0, typename... Args>
     std::function<R(Arg0, Args...)> thread_safe_wrap(std::function<R(Arg0, Args...)> fn) {
         if (!fn) return fn;
@@ -967,20 +979,27 @@ public:
             if (!m_context || std::this_thread::get_id() == m_main_thread_id) {
                 return fn(arg0, args...);
             }
-            std::promise<R> prom;
-            auto fut = prom.get_future();
-            boost::asio::post(*m_context, [&]() {
+            auto prom = std::make_shared<std::promise<R>>();
+            auto fut  = prom->get_future();
+            boost::asio::post(*m_context, [prom, fn, arg0, args...]() mutable {
                 try {
-                    prom.set_value(fn(arg0, args...));
+                    prom->set_value(fn(arg0, args...));
                 } catch (...) {
-                    prom.set_exception(std::current_exception());
+                    try { prom->set_exception(std::current_exception()); } catch (...) {}
                 }
             });
+            if (fut.wait_for(PRODUCER_DISPATCH_TIMEOUT) != std::future_status::ready) {
+                throw std::runtime_error(
+                    "thread_safe_wrap: producer io_context did not service dispatch "
+                    "within timeout (io_context-freeze guard)");
+            }
             return fut.get();
         };
     }
 
-    /// Void-returning overload (parameterized)
+    /// Void-returning overload (parameterized). Same io_context-freeze guard as
+    /// the value-returning overload above: shared_ptr-owned promise + bounded
+    /// wait, never an unbounded block on an io_context worker.
     template<typename... Args>
     std::function<void(Args...)> thread_safe_wrap(std::function<void(Args...)> fn) {
         if (!fn) return fn;
@@ -989,16 +1008,21 @@ public:
                 fn(args...);
                 return;
             }
-            std::promise<void> prom;
-            auto fut = prom.get_future();
-            boost::asio::post(*m_context, [&]() {
+            auto prom = std::make_shared<std::promise<void>>();
+            auto fut  = prom->get_future();
+            boost::asio::post(*m_context, [prom, fn, args...]() mutable {
                 try {
                     fn(args...);
-                    prom.set_value();
+                    prom->set_value();
                 } catch (...) {
-                    prom.set_exception(std::current_exception());
+                    try { prom->set_exception(std::current_exception()); } catch (...) {}
                 }
             });
+            if (fut.wait_for(PRODUCER_DISPATCH_TIMEOUT) != std::future_status::ready) {
+                throw std::runtime_error(
+                    "thread_safe_wrap: producer io_context did not service dispatch "
+                    "within timeout (io_context-freeze guard)");
+            }
             fut.get();
         };
     }


### PR DESCRIPTION
## DRAFT — io_context-freeze guard in `core::MiningInterface::thread_safe_wrap`

### Justification (this crash)
Production `main_ltc` aborted on the io_context-freeze watchdog (lambda#37 signature — distinct from the uint256 / cache_pplns / lambda#31 family). Backtrace / cores: an HTTP worker in `core::HttpSession::process_request` called a parameterized `thread_safe_wrap` provider, which `boost::asio::post`ed to the producer io_context and then blocked on `fut.get()` **with no bound**. The producer thread was itself wedged in a reorg-triggered PPLNS full-chain walk holding the share-tracker exclusive lock, so the posted task could not run; the HTTP worker stayed blocked past the 40s liveness watchdog → abort. The watchdog is correct — it is the only reason this was observable.

### What this PR changes (src/core only)
Two defects in the parameterized `thread_safe_wrap` overloads (`web_server.hpp`):
1. **UAF risk** — the posted task captured `[&]` to a stack `std::promise` and args. If the wait were ever abandoned, the task would write to a destroyed promise. State is now `shared_ptr`-owned and captured by value, valid independent of the caller's wait.
2. **Unbounded block** — `fut.get()` becomes `fut.wait_for(PRODUCER_DISPATCH_TIMEOUT = 10s)`. On timeout it throws a `std::runtime_error` the REST router turns into a 5xx, so an io_context worker can never freeze past the watchdog. 10s is deliberately well under the 40s watchdog.

Fast path (producer responsive) is behaviour-preserving. The 40s watchdog is **not** weakened (scope item 3).

### User-visible behaviour change (stated, not inferred)
When the producer io_context is wedged, a `/web/*` request that previously hung until the 40s watchdog aborted the process now returns a **5xx** after 10s (the process stays up). This is the intended trade — a bounded error response instead of a whole-process abort — but it IS a new user-visible response code on that path and is called out here explicitly.

### Scope conflict you need to arbitrate — items 1 done / 2 blocked / 3 done
- **(1) future::get() off the io_context worker** — DONE here (core-only).
- **(3) don't weaken the watchdog** — honoured.
- **(2) budget/bound the PPLNS precompute walk** — the actual full-chain walk under the exclusive lock lives in `src/impl/<coin>/share_tracker.hpp` (`:675-747`, all six coins). The shared-base rule on this PR is **"no src/impl/<coin> tree touched"** — so the true root fix (cooperative deadline / budget on the walk) **cannot ride this PR**. This core PR removes the *secondary* failure mode (the worker blocking on a wedged producer); the *primary* root — the unbounded lock-hold that freezes the producer — must be a **separate per-coin PR** (`ltc-doge/ioc-watchdog-boot-backfill-budget`, LTC+DOGE tree only). Flagging rather than silently splitting: a strict reading of scope-(2) and the shared-base constraint are mutually exclusive.

### Shared-base (EXCEPTIONAL) checklist
- [x] Justification paragraph (above: crash, cores, backtrace shape)
- [x] LTC + DOGE preservation verified — core compiles clean; four-coin build + ctest + gate smokes GREEN (see individual smokes below)
- [x] All four coin smokes green (ltc / doge / dgb / dash) — coin-matrix ltc/doge/dgb/dash smoke all pass on d765d8d7; LTC gate G3a + DOGE AuxPoW smoke also green
- [x] No `src/impl/<coin>` tree touched (diff: `src/core/web_server.hpp` only, 1 file)

### NOT in this PR / operator-gated
No restart, redeploy, binary bump, or sharechain/pplns state clear. The node stays read-only pending the operator's clear-state / wait-for-fix / stop-unit card. **#1533 alone does NOT stop the contabo abort loop** — it stops a worker blocking on a wedged producer, not the producer wedging; the abort-loop root is scope item (2), the separate per-coin budget PR.
