### PR TITLE
v37/xmr X9 O-2: serve side — stratum listener, RandomX verify, live submit, finalize connect (DRAFT, do-not-merge)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,8 @@ jobs:
                     c2pool-v37-btc v37_btc_node_smoke v37_btc_digest_drift_kat f1_finalize_kat_btc c2pool-v37-btc-dash \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke c2pool-v37-xmr \
-                    xmr_randomx_verify_kat \
+                    v37_xmr_o2_live_submit_selfcheck v37_xmr_o2_finalize_connect_selfcheck \
+                    xmr_randomx_verify_kat v37_xmr_o2_randomx_kat \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -657,6 +658,7 @@ jobs:
                     v37_descriptor_xmr_test \
                     v37_xmr_canon_p1_kat \
                     c2pool-v37-btc v37_btc_node_smoke v37_btc_digest_drift_kat f1_finalize_kat_btc \
+                    v37_xmr_o2_live_submit_selfcheck v37_xmr_o2_finalize_connect_selfcheck \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.

--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -840,14 +840,24 @@ target_link_libraries(c2pool-v37-w6-leveldb-compile-check PRIVATE core Threads::
 # vendored ed25519 ge_* + keccak) + the P-1 / ed25519 point-check registrar
 # (v37_descriptor_xmr_point_check_ref10.cpp, guarded by V37_XMR_HAVE_MONERO_
 # CRYPTO — so the descriptor validator is LIVE and the daemon is not fail-closed).
-# NO RandomX / libzmq / async-HTTP is linked here: the live transport is the
-# dependency-free raw-socket RPC client with an RPC-poll ZMQ fallback (heavy
-# RandomX + real libzmq land in a later wave; see xmr/xmr_live_transport.hpp).
-# EXPERIMENTAL — prototype / stagenet only (see the file banner + README).
+# X9 O-2 (serve side): the X5 stratum front-end bodies (impl/xmr/stratum/
+# xmr_stratum.cpp — login/job/submit over the ITemplateSource / IPowVerifier /
+# IShareSink seams) are compiled INTO the daemon; the POSIX listener, the
+# monerod-template source, the live submit and the finalize-connect glue are
+# header-only under v37/xmr/. RandomX: linked ONLY when -DXMR_BUILD_RANDOMX=ON
+# (the non-sanitizer CI leg) — then V37_XMR_O2_WITH_RANDOMX puts the production
+# light verifier (impl/xmr/pow/randomx_verify.hpp) on the live submit path and
+# --randomx enables it. Without it the verifier is compiled out and the daemon
+# stays FAIL-CLOSED: every stratum submit is answered "Couldn't check PoW" and
+# no block is ever promoted/submitted. No libzmq / async-HTTP: the live
+# transport is the dependency-free raw-socket RPC client with an RPC-poll ZMQ
+# fallback (see xmr/xmr_live_transport.hpp).
+# EXPERIMENTAL — prototype / stagenet / regtest only (see the file banner).
 # Built on demand (like c2pool-v37); the non-san CI leg lists it for a compile
 # gate. The V37Engine/OwedLedger consensus stays header-only + untouched.
 add_executable(c2pool-v37-xmr
     v37/main_v37_xmr.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/xmr/stratum/xmr_stratum.cpp
     ${CMAKE_SOURCE_DIR}/src/sharechain/v37/v37_descriptor_xmr_point_check_ref10.cpp)
 c2pool_wire_version(c2pool-v37-xmr)
 target_include_directories(c2pool-v37-xmr PRIVATE
@@ -857,6 +867,12 @@ target_include_directories(c2pool-v37-xmr PRIVATE
 target_compile_definitions(c2pool-v37-xmr PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
 target_compile_features(c2pool-v37-xmr PRIVATE cxx_std_20)
 target_link_libraries(c2pool-v37-xmr PRIVATE xmr_node xmr_coin Threads::Threads)
+if (XMR_BUILD_RANDOMX AND TARGET randomx)
+    target_link_libraries(c2pool-v37-xmr PRIVATE randomx)
+    target_include_directories(c2pool-v37-xmr PRIVATE
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/third_party/randomx)
+    target_compile_definitions(c2pool-v37-xmr PRIVATE V37_XMR_O2_WITH_RANDOMX)
+endif()
 # ── Track A2 / Milestone A-BTC: the live BITCOIN-FAMILY single-node daemon ────
 # c2pool-v37-btc: the single-node DASH-regtest/devnet-capable (LTC testnet4
 # alternate) daemon (XbtcNode, src/c2pool/v37/btc/). It wires the MERGED v37

--- a/src/c2pool/v37/main_v37_xmr.cpp
+++ b/src/c2pool/v37/main_v37_xmr.cpp
@@ -8,25 +8,57 @@
 // ===========================================================================
 // src/c2pool/v37/main_v37_xmr.cpp   (Track A2 / Milestone A — the live daemon)
 //
-// c2pool-v37-xmr — the single-node, stagenet-capable Monero/RandomX (Family-B)
-// v37 daemon entrypoint. It stands up XmrNode (see xmr/xmr_node.hpp) against a
-// live monerod and runs the mine-and-settle path.
+// c2pool-v37-xmr — the single-node, stagenet/regtest-capable Monero/RandomX
+// (Family-B) v37 daemon entrypoint. It stands up XmrNode (see xmr/xmr_node.hpp)
+// against a live monerod and runs the mine-and-settle path.
 //
-// EXPERIMENTAL — PROTOTYPE / STAGENET ONLY. Do NOT run against mainnet value.
-// The default network is stagenet; mainnet requires --i-understand-mainnet and
-// is still fenced at the coinbase (FCMP/CARROT + mainnet acknowledgement).
+// EXPERIMENTAL — PROTOTYPE / STAGENET / REGTEST ONLY. Do NOT run against
+// mainnet value. The default network is stagenet; mainnet requires
+// --i-understand-mainnet and is still fenced at the coinbase (FCMP/CARROT +
+// mainnet acknowledgement).
 //
 // Modes:
 //   --mock-smoke    network-free CI smoke against a monerod STUB
-//                   (MockMonerodTransport); prints S1..S6 and exits.
+//                   (MockMonerodTransport); prints S1..S6 + FC1..FC16 and exits.
 //   (default)       connect to monerod at --rpc-host/--rpc-port (+ --zmq-port),
-//                   bring the node up, and run until SIGINT.
+//                   bring the node up, and run until SIGINT. With
+//                   --payout-address the X9 O-2 SERVE SIDE is up as well:
+//                   the stratum port is bound and miners are served.
+//
+// X9 O-2 — the SERVE side, assembled here in donor order (xmr/ headers):
+//   wire 1  xmr_stratum_listener.hpp   POSIX poll() listener = the X5 server's
+//                                      ITransport; login/job/submit/keepalived
+//                                      in the xmrig dialect; NEW-TEMPLATE PUSH.
+//   wire 2  xmr_o2_randomx_verify.hpp  IPowVerifier over the production light
+//                                      RandomX verifier (librandomx, under
+//                                      V37_XMR_O2_WITH_RANDOMX + --randomx);
+//                                      every submit is RE-HASHED here, and the
+//                                      EXACT 128-bit network rule gates submit.
+//   wire 3  xmr_live_submit.hpp        block blob = monerod template + nonce ->
+//                                      submit_block -> block_id resolved
+//                                      (monerod > local keccak > header).
+//   wire 4  xmr_o2_finalize_connect.hpp  FOUND -> XmrNode::on_network_block_won
+//                                      -> F1 driver; FINALIZE at D_conf burial;
+//                                      pending-FOUND sidecar across restarts.
+//   xmr_o2_template.hpp                monerod get_block_template provider +
+//                                      the ITemplateSource seam.
+// HONEST SCOPE (option A): the block bytes are monerod's own template (single
+// coinbase to --payout-address) with the winning nonce patched — a genuine,
+// monerod-validated block end to end, NOT yet the v37 K_fair settlement
+// coinbase (option B = XmrBlockTemplate + X6 over an implemented
+// xmr_coin_primitives seam; slots in behind the same two seams).
+//
+// THREADING: the listener thread owns sockets, sessions, the X5 server, the
+// RandomX verifier and the submit_block RPC; the main thread owns XmrNode /
+// MonerodAdapter / MainchainIndex / XmrFinalizeDriver / OwedLedger, the
+// template refresh and all stdout. The template snapshot (mutex) and the found
+// queues (mutex) are the only state that crosses.
 //
 // NOTE (single-node): real multi-node p2p carrier relay (src/pool p2p) is a
 // NOTED FOLLOW-ON. This cut runs single-node (its own carriers), enough for the
-// X9 stagenet mine-and-settle demo. RandomX verify + the X6 coinbase crypto are
-// linked only in the CI/stagenet build (V37_XMR_HAVE_MONERO_CRYPTO / RandomX);
-// the light build runs index + settlement + the F1 driver.
+// X9 mine-and-settle demo. The light build (no XMR_BUILD_RANDOMX) still runs
+// index + settlement + the F1 driver and can serve miners, but answers every
+// submit "Couldn't check PoW" and never promotes a block (fail-closed).
 // ===========================================================================
 
 #include <atomic>
@@ -36,6 +68,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 
@@ -43,8 +77,15 @@
 #include "xmr/xmr_node_config.hpp"
 #include "xmr/xmr_node_smoke.hpp"
 #include "xmr/xmr_live_transport.hpp"
+#include "xmr/xmr_o2_template.hpp"           // O-2: monerod template provider + ITemplateSource
+#include "xmr/xmr_o2_randomx_verify.hpp"     // O-2 wire 2: runtime RandomX IPowVerifier + exact gate
+#include "xmr/xmr_live_submit.hpp"           // O-2 wire 3: block-blob assembly + submit_block
+#include "xmr/xmr_stratum_listener.hpp"      // O-2 wire 1: POSIX stratum listener (ITransport)
+#include "xmr/xmr_o2_finalize_connect.hpp"   // O-2 wire 4: FOUND -> on_network_block_won -> F1
 
 using namespace c2pool::v37n::xmr;
+namespace strat = ::v37::xmr::stratum;
+namespace sub   = c2pool::v37n::xmr::submit;
 
 static std::atomic<bool> g_stop{false};
 static void on_sigint(int) { g_stop.store(true); }
@@ -52,6 +93,7 @@ static void on_sigint(int) { g_stop.store(true); }
 static MoneroNetwork parse_net(const std::string& s) {
     if (s == "mainnet")  return MoneroNetwork::Mainnet;
     if (s == "testnet")  return MoneroNetwork::Testnet;
+    if (s == "regtest")  return MoneroNetwork::Regtest;
     return MoneroNetwork::Stagenet;
 }
 
@@ -63,6 +105,11 @@ static int run_mock_smoke() {
     std::filesystem::create_directories(tmp);
 
     auto rep = smoke::run(tmp);
+    // O-2 wire 4: the finalize-connect self-check (network-free, RandomX-free)
+    // rides in the same report so `--mock-smoke` gates FOUND -> FINALIZE too.
+    auto fc = o2::finalize_connect_selfcheck(tmp / "fc");
+    for (const auto& c : fc.checks) rep.checks.push_back(c);
+
     std::printf("== c2pool-v37-xmr mock smoke ==\n");
     int fails = 0;
     for (const auto& c : rep.checks) {
@@ -75,6 +122,83 @@ static int run_mock_smoke() {
     std::filesystem::remove_all(tmp);
     return fails ? 1 : 0;
 }
+
+// ---------------------------------------------------------------------------
+// The EXACT network gate in front of the live submitter (listener thread).
+//
+// XmrStratumServer's own "network block" decision (top-64-bit word <= target,
+// xmr_stratum.cpp handle_submit) is a strict SUPERSET of Monero's rule — it can
+// pass a boundary hash monerod would reject. So the bytes the server just
+// hashed are re-checked here with O2RandomXVerifier::verify_network_block
+// (hash * difficulty < 2^256, 128-bit, reusing the memoised hash) and ONLY an
+// Accept reaches LiveSubmitShareSink -> submit_block. Fail-closed: with RandomX
+// compiled out / disabled / not initialised nothing is ever submitted.
+// ---------------------------------------------------------------------------
+class GatedShareSink final : public strat::IShareSink {
+public:
+    GatedShareSink(o2::O2RandomXVerifier& rx, const o2::MonerodTemplateProvider& provider,
+                   strat::ITemplateSource& source, sub::LiveSubmitShareSink& inner)
+        : m_rx(rx), m_provider(provider), m_source(source), m_inner(inner) {}
+
+    void on_accepted_share(const strat::AcceptedShare& s) override { m_inner.on_accepted_share(s); }
+
+    void submit_network_block(std::uint32_t template_id, std::uint32_t nonce,
+                              std::uint32_t extra_nonce) override {
+        m_calls.fetch_add(1, std::memory_order_relaxed);
+        strat::TemplateJob tj;
+        o2::MonerodTemplate t;
+        if (!m_source.rebuild_blob(template_id, extra_nonce, tj) ||
+            !m_provider.by_id(template_id, t) ||
+            tj.nonce_offset + strat::NONCE_SIZE > tj.blob.size()) {
+            m_stale.fetch_add(1, std::memory_order_relaxed);
+            set_last("template " + std::to_string(template_id) + " gone (stale)");
+            return;
+        }
+        for (std::size_t i = 0; i < strat::NONCE_SIZE; ++i)   // == the bytes the server hashed
+            tj.blob[tj.nonce_offset + i] = static_cast<std::uint8_t>(nonce >> (8 * i));
+        if (!m_rx.network_blocks_allowed()) {
+            m_refused.fetch_add(1, std::memory_order_relaxed);
+            set_last(std::string("refused: randomx ") + o2::O2RandomXVerifier::to_string(m_rx.mode()) +
+                     " (fail-closed, no submit)");
+            return;
+        }
+        o2::Hash32 pow{};
+        const o2::NetworkVerdict v = m_rx.verify_network_block(
+            tj.blob.data(), tj.blob.size(), tj.seed_hash,
+            o2::NetworkDifficulty{t.difficulty, t.difficulty_top64}, pow);
+        if (v != o2::NetworkVerdict::Accept) {
+            m_rejected.fetch_add(1, std::memory_order_relaxed);
+            set_last(std::string("exact network gate: ") + o2::to_string(v) + " (no submit)");
+            return;
+        }
+        m_accepted.fetch_add(1, std::memory_order_relaxed);
+        set_last("exact network gate: Accept pow=" + sub::to_hex(pow.data(), pow.size()));
+        m_inner.submit_network_block(template_id, nonce, extra_nonce);
+    }
+
+    std::uint64_t calls()    const { return m_calls.load(std::memory_order_relaxed); }
+    std::uint64_t accepted() const { return m_accepted.load(std::memory_order_relaxed); }
+    std::uint64_t rejected() const { return m_rejected.load(std::memory_order_relaxed); }
+    std::uint64_t refused()  const { return m_refused.load(std::memory_order_relaxed); }
+    std::uint64_t stale()    const { return m_stale.load(std::memory_order_relaxed); }
+    std::string last() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_last;
+    }
+
+private:
+    void set_last(std::string s) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_last = std::move(s);
+    }
+    o2::O2RandomXVerifier&              m_rx;
+    const o2::MonerodTemplateProvider&  m_provider;
+    strat::ITemplateSource&             m_source;
+    sub::LiveSubmitShareSink&           m_inner;
+    std::atomic<std::uint64_t> m_calls{0}, m_accepted{0}, m_rejected{0}, m_refused{0}, m_stale{0};
+    mutable std::mutex m_mtx;
+    std::string        m_last;
+};
 
 static int run_live(const XmrNodeConfig& cfg) {
     std::printf("c2pool-v37-xmr: EXPERIMENTAL prototype — network=%s monerod=%s:%u (zmq %u)\n",
@@ -95,21 +219,263 @@ static int run_live(const XmrNodeConfig& cfg) {
     }
     for (const auto& line : node.construction_log()) std::printf("  %s\n", line.c_str());
 
-    std::signal(SIGINT, on_sigint);
-    std::signal(SIGTERM, on_sigint);
-    std::printf("node up. Ctrl-C to stop. (ZMQ push drives the tip; RPC poll fallback every 5s)\n");
-
-    // Main loop: pump the RPC poll fallback (no-op under real ZMQ) so the
-    // MainchainIndex keeps tracking the tip + seed reach, and re-issue the
-    // adapter's ensure_seed_reach on each tick.
-    while (!g_stop.load()) {
-        transport.pump_poll();
-        node.adapter().ensure_seed_reach();
-        std::this_thread::sleep_for(std::chrono::seconds(5));
+    // ── wire 4: finalize connect (main thread) — BEFORE the listener and BEFORE
+    //    the first pump_poll, so a pending FOUND from the sidecar is re-driven
+    //    into the fresh driver before any Extend can step past its height.
+    o2::FoundBlockQueue found_q;
+    o2::FinalizeConnectOptions fo;
+    if (cfg.found_sidecar) fo.sidecar_path = cfg.resolved_settle_db_path() + "/pfound.tsv";
+    o2::FinalizeConnect fc(node, cfg, found_q, fo);
+    {
+        const auto boot = fc.reseed_after_bring_up();
+        std::printf("finalize-connect: sidecar=%s reseeded=%zu reregistered=%zu stale=%zu "
+                    "UNRECOVERABLE=%zu malformed=%zu (D_conf=%llu)\n",
+                    fo.sidecar_path.empty() ? "disabled" : (boot.sidecar_present ? "present" : "none"),
+                    boot.reseeded, boot.reregistered, boot.stale_dropped, boot.unrecoverable,
+                    boot.malformed, static_cast<unsigned long long>(cfg.d_conf));
     }
 
+    // ── payee identity key (the address boundary's OUTPUT) ───────────────────
+    std::optional<::v37::bytes32> payee_key;
+    if (!cfg.payee_spend_key_hex.empty() || !cfg.payee_view_key_hex.empty()) {
+        o2::PayeeKeys pk;
+        if (!o2::hash_from_hex(cfg.payee_spend_key_hex, pk.spend) ||
+            !o2::hash_from_hex(cfg.payee_view_key_hex, pk.view)) {
+            std::printf("REFUSED: --payee-spend-hex and --payee-view-hex must both be 64 hex chars\n");
+            node.stop();
+            return 2;
+        }
+        pk.subaddress = cfg.payee_subaddress;
+        payee_key = o2::payee_identity_key(pk);
+        if (!payee_key) {
+            std::printf("REFUSED: payee keys do not validate as an XMR payout descriptor "
+                        "(ed25519 point check) — no ledger key\n");
+            node.stop();
+            return 2;
+        }
+        std::printf("payee: identity_key=%s… (amount-honest FOUND/FINALIZE records)\n",
+                    hex_of(*payee_key).substr(0, 16).c_str());
+    } else {
+        std::printf("payee: no --payee-spend-hex/--payee-view-hex -> FOUND records are valueless "
+                    "{}/{} (the ledger still registers the block)\n");
+    }
+
+    // ── wire 2: RandomX runtime verify (init on main, BEFORE the listener) ───
+    o2::O2RandomXVerifier rx;
+    rx.init(o2::RandomXPolicy::from_config(cfg));
+    std::printf("  %s\n", rx.describe().c_str());
+    if (cfg.randomx_enabled && !rx.ready()) {
+        std::printf("REFUSED: --randomx requested but RandomX is %s "
+                    "(build with -DXMR_BUILD_RANDOMX=ON / check memory)\n",
+                    o2::O2RandomXVerifier::to_string(rx.mode()));
+        node.stop();
+        return 3;
+    }
+    if (!rx.ready())
+        std::printf("WARNING: RandomX verify %s — every stratum submit is answered "
+                    "\"Couldn't check PoW\"; network-block promotion is refused (fail-closed)\n",
+                    o2::O2RandomXVerifier::to_string(rx.mode()));
+
+    // ── the template + wire 3 (live submit) + wire 1 (listener) ─────────────
+    const bool serving = !cfg.payout_address.empty();
+    o2::MonerodTemplateProvider provider(transport, cfg.payout_address, cfg.template_reserve_size);
+    o2::MonerodStratumTemplateSource template_source(provider, cfg.stratum_share_diff);
+
+    sub::LiveBlockSubmitter submitter(transport);   // fresh socket per RPC: safe off-thread
+    sub::FoundBlockQueue    submit_q;
+    sub::LiveSubmitShareSink live_sink(
+        submitter, submit_q,
+        [&](std::uint32_t tid, std::uint32_t en, sub::BlockCandidate& out) {
+            o2::MonerodTemplate t;
+            if (!provider.by_id(tid, t)) return false;
+            strat::TemplateJob tj;
+            if (!template_source.rebuild_blob(tid, en, tj)) return false;
+            out.template_id     = tid;
+            out.height          = t.height;
+            out.full_blob       = t.full_blob;
+            out.hashing_blob    = tj.blob;          // the exact blob served for this job
+            out.nonce_offset    = t.nonce_offset;
+            out.major_version   = t.major_version;
+            out.prev_id         = t.prev_id;
+            out.expected_reward = t.expected_reward;
+            out.reserved_offset = 0;                // single template, extra_nonce not baked
+            out.reserved_size   = 0;
+            return true;
+        });
+    submitter.enable_network_submit(rx.network_blocks_allowed());   // fail-closed gate
+    GatedShareSink sink(rx, provider, template_source, live_sink);
+
+    o2::StratumListenerOptions lo;
+    lo.bind_host = cfg.stratum_bind_host;
+    lo.bind_port = cfg.stratum_bind_port;
+    o2::StratumListener listener(template_source, rx, sink, lo);
+    // Seed prefetch on the LISTENER thread, before jobs are pushed (Argon2d
+    // cache init never lands inside a miner's submit; the verifier is only ever
+    // touched from that thread once start() has run).
+    listener.set_template_hook([&](const strat::TemplateJob& peek) { rx.on_template(peek); });
+
+    std::uint32_t last_tid = 0;
+    if (serving) {
+        if (std::string e = listener.bind(); !e.empty()) {
+            std::printf("%s\n", e.c_str());
+            node.stop();
+            return 1;
+        }
+        // First template BEFORE start(): the dirty flag is latched and consumed
+        // on the loop's first pass, so the first logins are served immediately.
+        if (provider.refresh()) {
+            last_tid = provider.template_id();
+            listener.notify_new_template();
+            const o2::MonerodTemplate t = provider.current();
+            std::printf("template: id=%u height=%llu difficulty=%llu%s reward=%llu piconero "
+                        "major=%u nonce_offset=%zu hashing=%zuB full=%zuB%s%s\n",
+                        t.template_id, static_cast<unsigned long long>(t.height),
+                        static_cast<unsigned long long>(t.difficulty),
+                        t.difficulty_top64 ? " (+top64)" : "",
+                        static_cast<unsigned long long>(t.expected_reward),
+                        static_cast<unsigned>(t.major_version), t.nonce_offset,
+                        t.hashing_blob.size(), t.full_blob.size(),
+                        provider.offset_note().empty() ? "" : " ",
+                        provider.offset_note().c_str());
+        } else {
+            std::printf("template: first get_block_template FAILED: %s (miners are parked until "
+                        "it succeeds; is --payout-address a %s-format standard address?)\n",
+                        provider.last_error().c_str(), to_string(cfg.network));
+        }
+        listener.start();
+        std::printf("stratum: listening on %s:%u (share diff %s, network submit %s)\n",
+                    cfg.stratum_bind_host.c_str(), listener.bound_port(),
+                    cfg.stratum_share_diff ? std::to_string(cfg.stratum_share_diff).c_str() : "network",
+                    submitter.network_submit_enabled() ? "ENABLED" : "DISABLED (fail-closed)");
+    } else {
+        std::printf("stratum: NOT served (no --payout-address) — observe-side only\n");
+    }
+
+    std::signal(SIGINT, on_sigint);
+    std::signal(SIGTERM, on_sigint);
+    const std::uint32_t poll_ms = cfg.poll_ms ? cfg.poll_ms : 5000;
+    std::printf("node up. Ctrl-C to stop. (ZMQ push drives the tip; RPC poll fallback every %u ms)\n",
+                poll_ms);
+
+    // listener thread -> main thread: the accepted-block events (wire 3 -> wire 4).
+    auto bridge_found = [&]() {
+        sub::FoundBlockEvent s;
+        while (submit_q.pop(s)) {
+            std::printf("  [submit] %s\n", sub::describe(s).c_str());
+            o2::FoundBlockEvent e;
+            e.height          = s.height;
+            e.block_id_hex    = hex_of(s.block_id);   // monerod's own block hash (or its cross-checked equal)
+            e.prev_id_hex     = hex_of(s.prev_id);
+            e.reward_piconero = s.reward;
+            e.payee           = payee_key;
+            e.template_id     = s.template_id;
+            e.nonce           = s.nonce;
+            e.extra_nonce     = s.extra_nonce;
+            e.worker          = s.worker;
+            e.address         = s.address;
+            found_q.push(std::move(e));
+        }
+    };
+    auto drain_stratum_log = [&]() {
+        for (const auto& l : listener.drain_log()) std::printf("  [stratum] %s\n", l.c_str());
+    };
+    auto status = [&]() {
+        const auto ls = listener.stats();
+        const auto fs = fc.stats();
+        const o2::MonerodTemplate t = provider.current();
+        std::printf("status: hw=%llu cursor=%llu tip=%llu | template id=%u h=%llu diff=%llu "
+                    "refresh=%llu fail=%llu changes=%llu | stratum conn=%llu active=%llu logins=%llu "
+                    "submits=%llu shares=%llu net=%llu rejected=%llu pushes=%llu malformed=%llu | "
+                    "gate calls=%llu accept=%llu reject=%llu refused=%llu stale=%llu | "
+                    "submit calls=%zu ok=%zu rejected=%zu refused=%zu transport_err=%zu "
+                    "id_mismatch=%zu unattributable=%zu | found registered=%llu settled=%llu "
+                    "orphaned=%llu refused=%llu pending=%zu\n",
+                    static_cast<unsigned long long>(node.hw().hw_height),
+                    static_cast<unsigned long long>(node.finalize_driver().cursor_height()),
+                    static_cast<unsigned long long>(node.adapter().index().best_height()),
+                    t.template_id, static_cast<unsigned long long>(t.height),
+                    static_cast<unsigned long long>(t.difficulty),
+                    static_cast<unsigned long long>(provider.refreshes()),
+                    static_cast<unsigned long long>(provider.failures()),
+                    static_cast<unsigned long long>(provider.changes()),
+                    static_cast<unsigned long long>(ls.connections),
+                    static_cast<unsigned long long>(ls.active),
+                    static_cast<unsigned long long>(ls.logins),
+                    static_cast<unsigned long long>(ls.submits),
+                    static_cast<unsigned long long>(ls.accepted_shares),
+                    static_cast<unsigned long long>(ls.network_blocks),
+                    static_cast<unsigned long long>(ls.rejected_submits),
+                    static_cast<unsigned long long>(ls.job_pushes),
+                    static_cast<unsigned long long>(ls.malformed),
+                    static_cast<unsigned long long>(sink.calls()),
+                    static_cast<unsigned long long>(sink.accepted()),
+                    static_cast<unsigned long long>(sink.rejected()),
+                    static_cast<unsigned long long>(sink.refused()),
+                    static_cast<unsigned long long>(sink.stale()),
+                    submitter.calls(), submitter.ok(), submitter.rejected(), submitter.refused(),
+                    submitter.transport_errors(), submitter.id_mismatches(), submitter.unattributable(),
+                    static_cast<unsigned long long>(fs.registered),
+                    static_cast<unsigned long long>(fs.settled),
+                    static_cast<unsigned long long>(fs.orphaned),
+                    static_cast<unsigned long long>(fs.refused),
+                    fc.pending().size());
+        std::printf("  %s\n", rx.describe().c_str());
+        const std::string g = sink.last();
+        if (!g.empty()) std::printf("  gate: last=%s\n", g.c_str());
+        const std::string se = submitter.last_error();
+        if (!se.empty()) std::printf("  submit: last_error=%s\n", se.c_str());
+        std::fflush(stdout);
+    };
+
+    // Main loop (donor order per tick): drain wins -> register FOUND (durable)
+    // BEFORE the tip can advance past them; then pump the tip; then refresh the
+    // template and push it to miners ONLY when it changed.
+    auto last_status = std::chrono::steady_clock::now();
+    std::string last_template_err;
+    while (!g_stop.load()) {
+        bridge_found();
+        fc.tick();
+        transport.pump_poll();
+        node.adapter().ensure_seed_reach();
+        if (serving) {
+            if (provider.refresh()) {
+                const std::uint32_t tid = provider.template_id();
+                if (tid != last_tid) {
+                    last_tid = tid;
+                    listener.notify_new_template();   // -> listener: peek, seed prefetch, parked logins, broadcast_job
+                    const o2::MonerodTemplate t = provider.current();
+                    std::printf("template: id=%u height=%llu difficulty=%llu prev=%s… -> pushed to miners\n",
+                                t.template_id, static_cast<unsigned long long>(t.height),
+                                static_cast<unsigned long long>(t.difficulty),
+                                hex_of(t.prev_id).substr(0, 12).c_str());
+                }
+            } else {
+                const std::string e = provider.last_error();
+                if (e != last_template_err) {
+                    std::printf("template: refresh failed: %s\n", e.c_str());
+                    last_template_err = e;
+                }
+            }
+        }
+        drain_stratum_log();
+        if (cfg.status_every_s &&
+            std::chrono::steady_clock::now() - last_status >= std::chrono::seconds(cfg.status_every_s)) {
+            status();
+            last_status = std::chrono::steady_clock::now();
+        }
+        std::fflush(stdout);
+        std::this_thread::sleep_for(std::chrono::milliseconds(poll_ms));
+    }
+
+    // Teardown in donor order: network first (join the listener, so no submit is
+    // in flight), register any last-second win, THEN the node.
     std::printf("\nstopping…\n");
+    listener.stop();
+    drain_stratum_log();
+    bridge_found();
+    fc.drain_before_stop();
     node.stop();
+    status();
     std::printf("stopped. hw_height=%llu\n",
                 static_cast<unsigned long long>(node.hw().hw_height));
     return 0;
@@ -133,22 +499,44 @@ int main(int argc, char** argv) {
                      static_cast<std::uint16_t>(std::stoi(next("38083")));
         else if (a == "--stratum-port") cfg.stratum_bind_port =
                      static_cast<std::uint16_t>(std::stoi(next("3333")));
+        else if (a == "--stratum-bind-host") cfg.stratum_bind_host = next("127.0.0.1");
+        else if (a == "--payout-address") cfg.payout_address = next("");
+        else if (a == "--share-diff") cfg.stratum_share_diff = std::stoull(next("0"));
+        else if (a == "--template-reserve") cfg.template_reserve_size =
+                     static_cast<std::uint32_t>(std::stoul(next("0")));
+        else if (a == "--poll-ms") cfg.poll_ms = static_cast<std::uint32_t>(std::stoul(next("5000")));
+        else if (a == "--status-every") cfg.status_every_s =
+                     static_cast<std::uint32_t>(std::stoul(next("30")));
+        else if (a == "--no-found-sidecar") cfg.found_sidecar = false;
+        else if (a == "--payee-spend-hex") cfg.payee_spend_key_hex = next("");
+        else if (a == "--payee-view-hex")  cfg.payee_view_key_hex = next("");
+        else if (a == "--payee-subaddress") cfg.payee_subaddress = true;
         else if (a == "--lane-chain") cfg.lane_chain =
                      static_cast<::v37::ChainId>(std::stoul(next("0")));
         else if (a == "--d-conf") cfg.d_conf = std::stoull(next("60"));
         else if (a == "--data-dir") cfg.settle_db_path = next("");
         else if (a == "--i-understand-mainnet") cfg.i_understand_mainnet = true;
         else if (a == "--randomx") cfg.randomx_enabled = true;
+        else if (a == "--randomx-large-pages") cfg.randomx_large_pages = true;
         else if (a == "--help" || a == "-h") {
             std::printf(
                 "c2pool-v37-xmr (EXPERIMENTAL prototype; stagenet default)\n"
                 "  --mock-smoke                 network-free CI smoke (monerod stub), then exit\n"
-                "  --network <stagenet|testnet|mainnet>   default stagenet\n"
+                "  --network <stagenet|testnet|mainnet|regtest>   default stagenet\n"
                 "  --rpc-host <h>  --rpc-port <p>  --zmq-port <p>\n"
-                "  --stratum-port <p>  --lane-chain <id>  --d-conf <n>\n"
+                "  --lane-chain <id>  --d-conf <n>  --poll-ms <ms>  --status-every <s>\n"
                 "  --data-dir <path>            override the settlement store dir\n"
+                "  --no-found-sidecar           do not persist pending FOUNDs across restarts\n"
                 "  --i-understand-mainnet       required to settle a mainnet block\n"
-                "  --randomx                    enable heavy RandomX verify (CI/stagenet)\n");
+                "  --randomx                    enable heavy RandomX verify (needs XMR_BUILD_RANDOMX)\n"
+                "  --randomx-large-pages        RandomX cache in huge pages\n"
+                " serve side (X9 O-2; the stratum port is served only with a payout address):\n"
+                "  --payout-address <addr>      get_block_template wallet address (network-prefixed)\n"
+                "  --stratum-bind-host <ip>  --stratum-port <p>   default 127.0.0.1:3333\n"
+                "  --share-diff <n>             share (lane) difficulty; 0 = network (solo)\n"
+                "  --template-reserve <n>       get_block_template reserve_size (default 0)\n"
+                "  --payee-spend-hex <64hex> --payee-view-hex <64hex> [--payee-subaddress]\n"
+                "                               payout address keys -> amount-honest FOUND records\n");
             return 0;
         }
     }

--- a/src/c2pool/v37/test/CMakeLists.txt
+++ b/src/c2pool/v37/test/CMakeLists.txt
@@ -259,4 +259,53 @@ if (BUILD_TESTING)
     add_test(NAME v37_1_activation_test
              COMMAND v37_1_activation_test
              WORKING_DIRECTORY $<TARGET_FILE_DIR:v37_1_activation_test>)
+
+    # ── Track A2 / X9 O-2 — the XMR serve-side wiring gates (network-free) ────
+    # v37_xmr_o2_live_submit_selfcheck: the block-blob assembler + submit_block
+    # ack parser (incl. result.block_id) + LiveBlockSubmitter over the monerod
+    # STUB, pinned by a REAL golden (keccak256(varint(len)||hashing_blob) of the
+    # Monero mainnet genesis block == its published id), and the IShareSink ->
+    # FoundBlockQueue hand-off. Links xmr_node (RPC bodies/parsers) + xmr_coin
+    # (vendored keccak + varint). No RandomX, no sockets.
+    add_executable(v37_xmr_o2_live_submit_selfcheck v37_xmr_o2_live_submit_selfcheck.cpp)
+    target_compile_features(v37_xmr_o2_live_submit_selfcheck PRIVATE cxx_std_20)
+    target_include_directories(v37_xmr_o2_live_submit_selfcheck PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/vendor
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/compat)
+    target_link_libraries(v37_xmr_o2_live_submit_selfcheck PRIVATE xmr_node xmr_coin Threads::Threads)
+    add_test(NAME v37_xmr_o2_live_submit_selfcheck COMMAND v37_xmr_o2_live_submit_selfcheck)
+    # v37_xmr_o2_finalize_connect_selfcheck: queued win -> XmrNode::
+    # on_network_block_won (amount-honest FOUND) -> restart inside the D_conf
+    # window -> pending-FOUND sidecar re-drive -> FINALIZE at bin_height =
+    # H_b + D_conf -> finalW nets to 0; late-FOUND / malformed / all-zero bid
+    # refusals; orphan disposition. Same shape as v37_xmr_node_smoke (monerod
+    # STUB, injected test point-check backend). SAME HOLLOW-GREEN GUARD: both
+    # targets are listed in the build.yml --target lists (BOTH the Linux x86_64
+    # leg and the ASan+UBSan leg) so CI compiles + runs them.
+    add_executable(v37_xmr_o2_finalize_connect_selfcheck v37_xmr_o2_finalize_connect_selfcheck.cpp)
+    target_compile_features(v37_xmr_o2_finalize_connect_selfcheck PRIVATE cxx_std_20)
+    target_include_directories(v37_xmr_o2_finalize_connect_selfcheck PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(v37_xmr_o2_finalize_connect_selfcheck PRIVATE xmr_node Threads::Threads)
+    add_test(NAME v37_xmr_o2_finalize_connect_selfcheck COMMAND v37_xmr_o2_finalize_connect_selfcheck)
+    # v37_xmr_o2_randomx_kat: the runtime IPowVerifier (O2RandomXVerifier over
+    # the production LightVerifier + librandomx) reproducing the X8 KAT vector
+    # (mainnet block 3,000,000 PoW) through the MERGED XmrStratumServer's
+    # handle_login/handle_submit, plus the exact 128-bit network gate, the
+    # strict no-Argon2d-on-submit invariant, the seed mailbox and the
+    # fail-closed disabled/compiled-out modes. HEAVY (2 x 256 MiB caches) and
+    # JIT: like xmr_randomx_verify_kat it is built ONLY under XMR_BUILD_RANDOMX
+    # (the non-sanitizer CI leg) and is listed in that leg's --target list.
+    if (XMR_BUILD_RANDOMX AND TARGET randomx)
+        add_executable(v37_xmr_o2_randomx_kat
+            v37_xmr_o2_randomx_kat.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/xmr/stratum/xmr_stratum.cpp)
+        target_compile_features(v37_xmr_o2_randomx_kat PRIVATE cxx_std_20)
+        target_include_directories(v37_xmr_o2_randomx_kat PRIVATE
+            ${CMAKE_SOURCE_DIR}/src
+            ${CMAKE_SOURCE_DIR}/src/impl/xmr/third_party/randomx)
+        target_compile_definitions(v37_xmr_o2_randomx_kat PRIVATE V37_XMR_O2_WITH_RANDOMX)
+        target_link_libraries(v37_xmr_o2_randomx_kat PRIVATE xmr_coin randomx Threads::Threads)
+        add_test(NAME v37_xmr_o2_randomx_kat COMMAND v37_xmr_o2_randomx_kat)
+    endif()
 endif()

--- a/src/c2pool/v37/test/v37_xmr_o2_finalize_connect_selfcheck.cpp
+++ b/src/c2pool/v37/test/v37_xmr_o2_finalize_connect_selfcheck.cpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/test/v37_xmr_o2_finalize_connect_selfcheck.cpp  (X9 O-2, wire 4)
+//
+// Driver for o2::finalize_connect_selfcheck (xmr/xmr_o2_finalize_connect.hpp):
+// network-free, RandomX-free, against the monerod STUB with the injected test
+// point-check backend — the same shape as v37_xmr_node_smoke. Proves a queued
+// win -> XmrNode::on_network_block_won (amount-honest FOUND) -> restart inside
+// the D_conf window -> pending-FOUND sidecar re-drive -> FINALIZE at
+// bin_height = H_b + D_conf -> finalW nets to 0 -> sidecar retired; plus the
+// late-FOUND / malformed / all-zero-bid refusals, the valueless record,
+// idempotence per bid and the orphan disposition. Nonzero exit on any failure.
+// ===========================================================================
+#include <unistd.h>
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#include "c2pool/v37/xmr/xmr_o2_finalize_connect.hpp"
+
+int main() {
+    std::filesystem::path tmp =
+        std::filesystem::temp_directory_path() /
+        ("v37-xmr-o2-fc-" + std::to_string(::getpid()));
+    std::filesystem::remove_all(tmp);
+    std::filesystem::create_directories(tmp);
+
+    const auto rep = c2pool::v37n::xmr::o2::finalize_connect_selfcheck(tmp);
+    std::printf("== v37_xmr_o2_finalize_connect_selfcheck ==\n");
+    int fails = 0;
+    for (const auto& c : rep.checks) {
+        std::printf("  [%s] %s%s%s\n", c.pass ? "PASS" : "FAIL", c.name.c_str(),
+                    c.detail.empty() ? "" : "  -- ", c.detail.c_str());
+        if (!c.pass) ++fails;
+    }
+    std::printf("== %s (%d/%zu passed) ==\n", fails ? "FAIL" : "OK",
+                static_cast<int>(rep.checks.size()) - fails, rep.checks.size());
+    std::filesystem::remove_all(tmp);
+    return fails ? 1 : 0;
+}

--- a/src/c2pool/v37/test/v37_xmr_o2_live_submit_selfcheck.cpp
+++ b/src/c2pool/v37/test/v37_xmr_o2_live_submit_selfcheck.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/test/v37_xmr_o2_live_submit_selfcheck.cpp   (X9 O-2, wire 3)
+//
+// Network-free self-check of xmr/xmr_live_submit.hpp against the monerod STUB
+// (MockMonerodTransport): the block-blob assembler (nonce LE at nonce_offset,
+// extra_nonce at reserved_offset), the submit_block ack parser INCLUDING
+// result.block_id, LiveBlockSubmitter's fail-closed default + the three
+// block-id sources (monerod > local keccak > header) + their cross-checks, and
+// the IShareSink -> FoundBlockQueue hand-off in XmrStratumServer's call order.
+// REAL golden: keccak256(varint(len) || hashing_blob) of the Monero mainnet
+// genesis block reproduces its published id, pinning the object-hash framing.
+// ===========================================================================
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "c2pool/v37/xmr/xmr_live_submit.hpp"
+
+using namespace c2pool::v37n::xmr::submit;
+using ::c2pool::xmr::node::MockMonerodTransport;
+
+static int g_fail = 0, g_pass = 0;
+#define CHECK(cond, msg) do { if (cond) { ++g_pass; std::printf("  [PASS] %s\n", msg); } \
+                              else { ++g_fail; std::printf("  [FAIL] %s\n", msg); } } while (0)
+
+int main() {
+    // ---------------------------------------------------------------------
+    // G1: Monero MAINNET GENESIS block id pins keccak(varint(len) || hashing_blob).
+    //   header: varint(major=1) varint(minor=0) varint(ts=0) prev[32]=0 nonce=10000 LE
+    //   tree_root = v1 miner-tx hash = keccak256(GENESIS_TX blob)
+    //   hashing blob = header || tree_root || varint(1)
+    //   expected id  = 418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e3
+    // ---------------------------------------------------------------------
+    std::printf("== G1: genesis block id (object-hash framing) ==\n");
+    {
+        const std::string genesis_tx_hex =
+            "013c01ff0001ffffffffffff03029b2e4c0281c0b02e7c53291a94d1d0cbff8883f8024f5142ee494ffbbd08807121017767aafcde9be00dcfd098715ebcf7f410daebc582fda69d24a28e9d0bc890d1";
+        std::vector<std::uint8_t> tx;
+        CHECK(from_hex(genesis_tx_hex, tx), "genesis tx hex decodes");
+        const ::xmr::coin::Hash256 txh = ::xmr::coin::keccak256(tx.data(), tx.size());
+
+        std::vector<std::uint8_t> hb;
+        hb.push_back(0x01); hb.push_back(0x00); hb.push_back(0x00);   // major=1 minor=0 ts=0
+        hb.insert(hb.end(), 32, 0x00);                                // prev_id = null
+        const std::uint32_t nonce = 10000;                            // GENESIS_NONCE
+        for (int i = 0; i < 4; ++i) hb.push_back(static_cast<std::uint8_t>(nonce >> (8 * i)));
+        hb.insert(hb.end(), txh.data(), txh.data() + 32);             // tree_root (1 leaf)
+        hb.push_back(0x01);                                           // varint(n_tx = 1)
+        CHECK(hb.size() == 72, "genesis hashing blob is 72 bytes");
+
+        const Hash id = block_id_of_hashing_blob(hb);
+        const std::string got = mj::hash_to_hex(id);
+        std::printf("    computed genesis id = %s\n", got.c_str());
+        CHECK(got == "418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e3",
+              "block_id_of_hashing_blob == Monero mainnet genesis id (framing pinned)");
+
+        // Sanity: the same 72 bytes WITHOUT the varint framing must NOT match
+        // (proves the varint prefix is load-bearing, not accidental).
+        const ::xmr::coin::Hash256 raw = ::xmr::coin::keccak256(hb.data(), hb.size());
+        Hash rawh{}; std::memcpy(rawh.data(), raw.data(), 32);
+        CHECK(mj::hash_to_hex(rawh) != got, "unframed keccak differs (varint prefix is load-bearing)");
+
+        // And: the framing goes through BlockCandidate + hashing_blob_with_nonce.
+        BlockCandidate c;
+        c.height = 1; c.template_id = 7;
+        c.hashing_blob = hb; c.full_blob = hb;                 // header-identical stand-in
+        c.nonce_offset = 35;   // genesis-era header prefix is 3 bytes (varint 1,0,0), NOT the 7-byte v16 prefix
+        std::vector<std::uint8_t> zeroed = hb;                  // wipe the nonce, let the API patch it
+        for (int i = 0; i < 4; ++i) zeroed[35 + i] = 0;
+        c.hashing_blob = zeroed; c.full_blob = zeroed;
+        CHECK(validate_candidate(c).empty(), "candidate validates");
+        CHECK(mj::hash_to_hex(block_id_of_hashing_blob(hashing_blob_with_nonce(c, nonce))) == got,
+              "hashing_blob_with_nonce(cand, 10000) reproduces the genesis id");
+        // A WRONG nonce_offset (the v16 default 39 applied to a v1 header) must NOT reproduce it:
+        // the offset is the template layer's responsibility (survey: derive it from the
+        // hashing/full blob divergence point), and the id would silently differ.
+        BlockCandidate wrong = c; wrong.nonce_offset = 39;
+        CHECK(mj::hash_to_hex(block_id_of_hashing_blob(hashing_blob_with_nonce(wrong, nonce))) != got,
+              "a wrong nonce_offset yields a different id (offset is load-bearing)");
+    }
+
+    // ---------------------------------------------------------------------
+    // A1: assembly — nonce LE at nonce_offset, extra_nonce at reserved_offset.
+    // ---------------------------------------------------------------------
+    std::printf("== A1: assemble_block_blob ==\n");
+    {
+        BlockCandidate c;
+        c.height = 5; c.template_id = 1; c.nonce_offset = 39;
+        c.full_blob.assign(120, 0xAA);
+        c.hashing_blob.assign(76, 0xAA);
+        c.reserved_offset = 80; c.reserved_size = 8;
+        CHECK(validate_candidate(c).empty(), "candidate with reserve validates");
+        auto b = assemble_block_blob(c, 0x11223344u, 0xDEADBEEFu);
+        CHECK(b.size() == 120, "assembled size == full_blob size");
+        CHECK(b[39] == 0x44 && b[40] == 0x33 && b[41] == 0x22 && b[42] == 0x11, "nonce patched LE at 39");
+        CHECK(b[80] == 0xEF && b[81] == 0xBE && b[82] == 0xAD && b[83] == 0xDE, "extra_nonce patched LE at reserved_offset");
+        CHECK(b[84] == 0xAA && b[38] == 0xAA && b[43] == 0xAA, "bytes outside the two patches untouched");
+        CHECK(c.full_blob[39] == 0xAA, "candidate itself is not mutated");
+
+        BlockCandidate bad = c; bad.hashing_blob[3] = 0x00;
+        CHECK(!validate_candidate(bad).empty(), "header-prefix disagreement is refused");
+        BlockCandidate bad2 = c; bad2.nonce_offset = 118;
+        CHECK(!validate_candidate(bad2).empty(), "nonce_offset past end is refused");
+        BlockCandidate bad3 = c; bad3.reserved_offset = 40;
+        CHECK(!validate_candidate(bad3).empty(), "reserve overlapping the header is refused");
+        BlockCandidate bad4 = c; bad4.height = 0;
+        CHECK(!validate_candidate(bad4).empty(), "height 0 is refused");
+    }
+
+    // ---------------------------------------------------------------------
+    // P1: submit_block response parser incl. block_id.
+    // ---------------------------------------------------------------------
+    std::printf("== P1: parse_submit_block_ack ==\n");
+    {
+        const std::string ok = R"({"id":"0","jsonrpc":"2.0","result":{"block_id":"418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e3","status":"OK","untrusted":false}})";
+        auto a = parse_submit_block_ack(ok.data(), ok.size());
+        CHECK(a.accepted && a.status == "OK", "OK accepted");
+        CHECK(a.block_id.has_value() && mj::hash_to_hex(*a.block_id).rfind("418015bb", 0) == 0, "block_id parsed");
+        const std::string ok_old = R"({"id":"0","jsonrpc":"2.0","result":{"status":"OK"}})";
+        auto b = parse_submit_block_ack(ok_old.data(), ok_old.size());
+        CHECK(b.accepted && !b.block_id.has_value(), "older monerod (no block_id) still accepted");
+        const std::string rej = R"({"id":"0","jsonrpc":"2.0","error":{"code":-7,"message":"Block not accepted"}})";
+        auto r = parse_submit_block_ack(rej.data(), rej.size());
+        CHECK(!r.accepted && r.rpc_code == -7 && r.error.find("Block not accepted") != std::string::npos, "rpc error -7 surfaced");
+        const std::string garbage = "not json";
+        auto g = parse_submit_block_ack(garbage.data(), garbage.size());
+        CHECK(!g.accepted && !g.error.empty(), "garbage body rejected");
+    }
+
+    // ---------------------------------------------------------------------
+    // S1: LiveBlockSubmitter over MockMonerodTransport.
+    // ---------------------------------------------------------------------
+    std::printf("== S1: LiveBlockSubmitter ==\n");
+    {
+        // A candidate whose local id we can predict: reuse the genesis blob.
+        const std::string genesis_tx_hex =
+            "013c01ff0001ffffffffffff03029b2e4c0281c0b02e7c53291a94d1d0cbff8883f8024f5142ee494ffbbd08807121017767aafcde9be00dcfd098715ebcf7f410daebc582fda69d24a28e9d0bc890d1";
+        std::vector<std::uint8_t> tx; from_hex(genesis_tx_hex, tx);
+        const ::xmr::coin::Hash256 txh = ::xmr::coin::keccak256(tx.data(), tx.size());
+        std::vector<std::uint8_t> hb;
+        hb.push_back(0x01); hb.push_back(0x00); hb.push_back(0x00);
+        hb.insert(hb.end(), 32, 0x00);
+        hb.insert(hb.end(), 4, 0x00);                       // nonce left zero; API patches
+        hb.insert(hb.end(), txh.data(), txh.data() + 32);
+        hb.push_back(0x01);
+        std::vector<std::uint8_t> full = hb;                 // header-identical stand-in
+        full.insert(full.end(), tx.begin(), tx.end());       // "miner_tx" tail, whatever
+
+        BlockCandidate c;
+        c.height = 1; c.template_id = 42; c.nonce_offset = 35;   // genesis-era 3-byte header prefix
+        c.hashing_blob = hb; c.full_blob = full; c.expected_reward = 17'592'186'044'415ull;
+        const std::string GEN = "418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f4632e3";
+
+        MockMonerodTransport mock;
+        // (i) fail-closed default: nothing is posted.
+        {
+            LiveBlockSubmitter sub(mock);
+            auto o = sub.submit(c, 10000, 0);
+            CHECK(o.refused && !o.accepted, "default policy REFUSES (fail-closed)");
+            CHECK(mock.posted_bodies().empty(), "nothing posted to monerod when refused");
+            CHECK(sub.refused() == 1 && sub.calls() == 1, "refused counter");
+        }
+        // (ii) enabled; monerod returns OK + block_id; header confirms.
+        {
+            mock.set_method_body("submit_block",
+                R"({"id":"0","jsonrpc":"2.0","result":{"block_id":")" + GEN + R"(","status":"OK"}})");
+            mock.set_method_body("get_block_header_by_height",
+                R"({"id":"0","jsonrpc":"2.0","result":{"block_header":{"hash":")" + GEN +
+                R"(","prev_hash":"0000000000000000000000000000000000000000000000000000000000000000","height":1,"timestamp":0,"reward":17592186044415,"difficulty":1,"difficulty_top64":0}},"status":"OK"})");
+            SubmitPolicy p; p.network_submit_enabled = true;
+            LiveBlockSubmitter sub(mock, p);
+            auto o = sub.submit(c, 10000, 0);
+            CHECK(o.accepted && !o.refused, "accepted");
+            CHECK(o.id_source == IdSource::Monerod, "id source = monerod");
+            CHECK(o.block_id_hex() == GEN, "bid == monerod block_id");
+            CHECK(o.local_block_id && mj::hash_to_hex(*o.local_block_id) == GEN, "local id computed and equal");
+            CHECK(!o.id_mismatch, "no monerod/local mismatch");
+            CHECK(o.header_check == HeaderCheck::Confirmed, "header confirms");
+            CHECK(sub.ok() == 1 && sub.id_mismatches() == 0, "ok counter");
+            // the posted body is the KAT-pinned submit_block shape with the patched blob
+            const auto& posted = mock.posted_bodies();
+            CHECK(posted.size() == 2, "two RPCs posted (submit_block + header confirm)");
+            CHECK(posted[0].find("\"method\":\"submit_block\"") != std::string::npos, "first post is submit_block");
+            CHECK(posted[0].find("\"params\":[\"" + o.block_blob_hex + "\"]") != std::string::npos, "params carries the assembled blob hex");
+            CHECK(o.block_blob_hex.substr(35 * 2, 8) == "10270000", "posted blob has nonce 10000 LE at the header nonce offset (35 for this v1 header)");
+        }
+        // (iii) older monerod: no block_id -> local id used, header confirms it.
+        {
+            mock.set_method_body("submit_block", R"({"id":"0","jsonrpc":"2.0","result":{"status":"OK"}})");
+            SubmitPolicy p; p.network_submit_enabled = true;
+            LiveBlockSubmitter sub(mock, p);
+            auto o = sub.submit(c, 10000, 0);
+            CHECK(o.accepted && o.id_source == IdSource::Local && o.block_id_hex() == GEN, "no block_id -> local id");
+            CHECK(o.header_check == HeaderCheck::Confirmed, "header confirms the local id");
+        }
+        // (iv) no block_id, no hashing blob -> header (prev_id matched) supplies the id.
+        {
+            BlockCandidate c2 = c; c2.hashing_blob.clear();
+            SubmitPolicy p; p.network_submit_enabled = true;
+            LiveBlockSubmitter sub(mock, p);
+            auto o = sub.submit(c2, 10000, 0);
+            CHECK(o.accepted && o.id_source == IdSource::Header && o.block_id_hex() == GEN, "header fallback supplies the id");
+            // header at H with a DIFFERENT prev -> not ours -> unattributable
+            BlockCandidate c3 = c2; c3.prev_id[0] = 0x55;
+            auto o3 = sub.submit(c3, 10000, 0);
+            CHECK(o3.accepted && !o3.has_block_id() && o3.header_check == HeaderCheck::Mismatch,
+                  "prev mismatch -> no id adopted (unattributable, loud)");
+            CHECK(sub.unattributable() == 1, "unattributable counter");
+        }
+        // (v) monerod block_id != local -> monerod wins, mismatch flagged.
+        {
+            const std::string OTHER = "1111111111111111111111111111111111111111111111111111111111111111";
+            mock.set_method_body("submit_block",
+                R"({"id":"0","jsonrpc":"2.0","result":{"block_id":")" + OTHER + R"(","status":"OK"}})");
+            SubmitPolicy p; p.network_submit_enabled = true; p.confirm_with_header = false;
+            LiveBlockSubmitter sub(mock, p);
+            auto o = sub.submit(c, 10000, 0);
+            CHECK(o.accepted && o.id_mismatch && o.block_id_hex() == OTHER, "monerod id wins; mismatch flagged");
+            CHECK(o.header_check == HeaderCheck::NotRun, "header check skipped per policy");
+        }
+        // (vi) rejection + transport failure paths.
+        {
+            mock.set_method_body("submit_block", R"({"id":"0","jsonrpc":"2.0","error":{"code":-7,"message":"Block not accepted"}})");
+            SubmitPolicy p; p.network_submit_enabled = true;
+            LiveBlockSubmitter sub(mock, p);
+            auto o = sub.submit(c, 10000, 0);
+            CHECK(!o.accepted && !o.refused && o.rpc_code == -7, "rejection surfaced (-7)");
+            CHECK(sub.rejected() == 1, "rejected counter");
+            mock.fail_next(1);
+            auto o2 = sub.submit(c, 10000, 0);
+            CHECK(!o2.accepted && o2.error.rfind("transport:", 0) == 0, "transport failure surfaced");
+            CHECK(sub.transport_errors() == 1, "transport counter");
+            CHECK(sub.last_error() == o2.error, "last_error tracks");
+        }
+        // (vii) sink -> queue, with the handle_submit ordering (submit first, then on_accepted_share).
+        {
+            mock.set_method_body("submit_block",
+                R"({"id":"0","jsonrpc":"2.0","result":{"block_id":")" + GEN + R"(","status":"OK"}})");
+            SubmitPolicy p; p.network_submit_enabled = true;
+            LiveBlockSubmitter sub(mock, p);
+            FoundBlockQueue q;
+            LiveSubmitShareSink sink(sub, q, [&](std::uint32_t tid, std::uint32_t, BlockCandidate& out) {
+                if (tid != 42) return false;
+                out = c; return true;
+            });
+            sink.submit_network_block(42, 10000, 3);
+            CHECK(q.size() == 1 && q.pushed() == 1, "found event queued on OK");
+            strat::AcceptedShare sh; sh.template_id = 42; sh.nonce = 10000; sh.extra_nonce = 3;
+            sh.is_network_block = true; sh.worker = "rig1"; sh.address = "4AAAA";
+            sink.on_accepted_share(sh);
+            FoundBlockEvent ev;
+            CHECK(q.pop(ev), "event drained");
+            CHECK(ev.height == 1 && ev.block_id_hex() == GEN && ev.reward == c.expected_reward, "event carries height/bid/reward");
+            CHECK(ev.worker == "rig1" && ev.address == "4AAAA", "annotate() attached worker/address");
+            CHECK(!q.pop(ev), "queue empty after drain");
+            sink.submit_network_block(99, 1, 0);
+            CHECK(sink.stale_lookups() == 1 && q.size() == 0, "stale template -> nothing queued");
+            std::printf("    %s\n", describe(ev).c_str());
+            auto amt = single_key_amounts<std::map<std::array<std::uint8_t, 32>, long long>>(ev.block_id, ev.reward);
+            CHECK(amt.size() == 1 && amt.begin()->second == static_cast<long long>(c.expected_reward), "single_key_amounts");
+        }
+    }
+
+    std::printf("== %s (%d passed, %d failed) ==\n", g_fail ? "FAIL" : "OK", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/src/c2pool/v37/test/v37_xmr_o2_randomx_kat.cpp
+++ b/src/c2pool/v37/test/v37_xmr_o2_randomx_kat.cpp
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/test/v37_xmr_o2_randomx_kat.cpp   (X9 O-2, wire 2)
+//
+// The runtime RandomX IPowVerifier (xmr/xmr_o2_randomx_verify.hpp:
+// O2RandomXVerifier over the production LightVerifier + librandomx) against the
+// X8 KAT vector — Monero mainnet block 3,000,000 (seed = block id at 2,998,272,
+// difficulty 308739704685, PoW 309e84a7…) — in two suites:
+//   (A) the verifier alone: fail-closed disabled/compiled-out modes, JIT ->
+//       interpreter init, the STRICT no-Argon2d-on-submit invariant (I2), the
+//       main-thread -> listener seed mailbox, randomx_hash == the KAT PoW, the
+//       u64 seam rule, the EXACT 128-bit network gate (Accept / BelowTarget at
+//       8x / BelowTarget at 2^64 / Malformed) with the byte-identical hash memo,
+//       and the opt-in lazy policy;
+//   (B) the verifier plugged into the MERGED X5 XmrStratumServer through
+//       handle_login / handle_submit with fake template/sink/transport seams:
+//       "Couldn't check PoW" before the template hook, the O-2 flow (hook ->
+//       prefetch -> login -> winning submit -> submit_network_block -> exact
+//       gate Accept, 1 hash total), a wrong nonce = lane share only, and the
+//       disabled verifier never reaching the sink.
+// HEAVY: 2 x 256 MiB light caches per verifier instance (light mode only,
+// never the 2 GiB dataset). Built only under XMR_BUILD_RANDOMX (the
+// non-sanitizer CI leg). Nonzero exit on any failure.
+// ===========================================================================
+#include <cstdio>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "c2pool/v37/xmr/xmr_o2_randomx_verify.hpp"
+
+using namespace c2pool::v37n::xmr::o2;
+
+namespace {
+
+bool hex_to_bytes(const char* hex, std::vector<uint8_t>& out) {
+    out.clear();
+    const size_t n = std::strlen(hex);
+    if (n % 2) return false;
+    for (size_t i = 0; i < n; i += 2) {
+        uint8_t b;
+        if (!strat::StratumDialect::from_hex_byte(hex[i], hex[i + 1], b)) return false;
+        out.push_back(b);
+    }
+    return true;
+}
+
+int fails = 0;
+void check(bool ok, const char* what) {
+    std::printf("  [%s] %s\n", ok ? "PASS" : "FAIL", what);
+    if (!ok) ++fails;
+}
+
+// The X8 KAT suite-C vector (Monero mainnet block 3,000,000).
+const char* kSeedHex = "3c512c1a6e8210e985b47e855eaf93af952abb61b9bd032872a376910ba7d448";
+const char* kBlobHex =
+    "1010dea6caa906cc64d29f62794dbb5309732f74447d88389198cfbf86a499bd"
+    "5b4b5347bc43ae2b8000313cc88694451e92299e5283b2c51985e5c0d31b8d91"
+    "0f53d9a8b167a24e7bdf0626";
+const char* kPowHex = "309e84a7d1175490a14cf722f8f3862b3adda4fff904a5d72175ec0100000000";
+const uint64_t kDifficulty = 308739704685ULL;
+const uint64_t kHeight = 3000000;
+
+struct Vector {
+    std::vector<uint8_t> blob;
+    Seed32 seed{};
+    Hash32 want{};
+};
+
+bool load_vector(Vector& v) {
+    std::vector<uint8_t> seedv, powv;
+    if (!hex_to_bytes(kSeedHex, seedv) || !hex_to_bytes(kBlobHex, v.blob) || !hex_to_bytes(kPowHex, powv))
+        return false;
+    if (seedv.size() != 32 || powv.size() != 32) return false;
+    std::memcpy(v.seed.data(), seedv.data(), 32);
+    std::memcpy(v.want.data(), powv.data(), 32);
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Suite A — the verifier alone.
+// ---------------------------------------------------------------------------
+void suite_a(const Vector& kat) {
+    const std::vector<uint8_t>& blob = kat.blob;
+    const Seed32& seed = kat.seed;
+    const Hash32& want = kat.want;
+    const uint64_t difficulty = kDifficulty;
+    const uint64_t height = kHeight;
+
+    std::printf("== (A) O2RandomXVerifier ==\n");
+
+    // (0) disabled policy: fail-closed everywhere
+    {
+        O2RandomXVerifier v;
+        RandomXPolicy p; p.enabled = false;
+        const bool r = v.init(p);
+        Hash32 h{};
+        check(!r && !v.ready() && !v.network_blocks_allowed(), "disabled: init false, not ready, network blocks refused");
+        check(!v.randomx_hash(blob.data(), blob.size(), height, seed, h), "disabled: randomx_hash -> false (CouldNotCheck)");
+        const auto nv = v.verify_network_block(blob.data(), blob.size(), seed, NetworkDifficulty{difficulty, 0}, h);
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        check(nv == NetworkVerdict::VerifyUnavailable, "disabled: verify_network_block -> VerifyUnavailable");
+        check(v.mode() == O2RandomXVerifier::Mode::Disabled, "disabled: mode == Disabled");
+#else
+        check(nv == NetworkVerdict::VerifyUnavailable, "compiled-out: verify_network_block -> VerifyUnavailable");
+        check(v.mode() == O2RandomXVerifier::Mode::CompiledOut, "compiled-out: mode == CompiledOut");
+        check(!O2RandomXVerifier::meets_network_difficulty(want, NetworkDifficulty{1, 0}), "compiled-out: meets_network_difficulty fail-closed");
+#endif
+        std::printf("  %s\n", v.describe().c_str());
+    }
+
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+    // (1) enabled: init (JIT, interpreter fallback)
+    O2RandomXVerifier v;
+    RandomXPolicy p; p.enabled = true;
+    check(v.init(p), "enabled: init ok");
+    std::printf("  %s\n", v.describe().c_str());
+    check(v.ready() && v.network_blocks_allowed(), "enabled: ready + network blocks allowed");
+
+    // (2) strict I2: seed not resident -> refuse, no cache init
+    Hash32 h{};
+    check(!v.randomx_hash(blob.data(), blob.size(), height, seed, h), "I2 strict: non-resident seed -> false");
+    check(v.stats().seed_misses == 1 && v.stats().prefetches == 0, "I2 strict: seed_misses=1, prefetches=0");
+    check(v.verify_network_block(blob.data(), blob.size(), seed, NetworkDifficulty{difficulty, 0}, h) == NetworkVerdict::SeedNotResident,
+          "I2 strict: verify_network_block -> SeedNotResident");
+
+    // (3) main-thread post_seeds -> listener drain_pending (prefetch)
+    v.post_seeds(seed, std::nullopt);
+    check(v.drain_pending(), "mailbox: drain_pending applied a pair");
+    check(!v.drain_pending(), "mailbox: second drain is a no-op");
+    check(v.seed_resident(seed), "prefetch: seed resident");
+    check(v.stats().prefetches == 1, "prefetch: counted once");
+    check(v.ensure_seeds(seed, std::nullopt) && v.stats().prefetches == 1, "ensure_seeds: resident pair is a no-op (no re-key)");
+
+    // (4) IPowVerifier::randomx_hash reproduces the mainnet PoW
+    check(v.randomx_hash(blob.data(), blob.size(), height, seed, h), "randomx_hash: ok");
+    check(h == want, "randomx_hash: == block 3,000,000 PoW (X8 KAT vector)");
+    const uint64_t target = 0xFFFFFFFFFFFFFFFFULL / difficulty;
+    check(v.meets_target(h, target), "meets_target: block clears its own network target (u64 rule)");
+    check(!v.meets_target(h, target / 4), "meets_target: fails a 4x harder target");
+
+    // (5) exact network gate: memo reuse + meets_difficulty_128
+    Hash32 h2{};
+    auto nv = v.verify_network_block(blob.data(), blob.size(), seed, NetworkDifficulty{difficulty, 0}, h2);
+    check(nv == NetworkVerdict::Accept, "verify_network_block: Accept at the block's difficulty");
+    check(h2 == want, "verify_network_block: returns the PoW hash");
+    check(v.stats().memo_hits == 1 && v.stats().hashes == 1, "verify_network_block: reused the submit's hash (memo hit, no re-hash)");
+    nv = v.verify_network_block(blob.data(), blob.size(), seed, NetworkDifficulty{difficulty * 8, 0}, h2);
+    check(nv == NetworkVerdict::BelowTarget, "verify_network_block: BelowTarget at 8x difficulty");
+    nv = v.verify_network_block(blob.data(), blob.size(), seed, NetworkDifficulty{0, 1}, h2);
+    check(nv == NetworkVerdict::BelowTarget, "verify_network_block: BelowTarget at difficulty 2^64 (128-bit path)");
+    std::vector<uint8_t> blob2 = blob; blob2[39] ^= 0x01;
+    const auto before = v.stats();
+    nv = v.verify_network_block(blob2.data(), blob2.size(), seed, NetworkDifficulty{1, 0}, h2);
+    check(nv == NetworkVerdict::Accept, "verify_network_block: nonce+1 at difficulty 1 -> Accept (any hash meets diff 1)");
+    check(v.stats().hashes == before.hashes + 1 && v.stats().memo_hits == before.memo_hits, "verify_network_block: changed bytes re-hashed (no memo hit)");
+    check(h2 != want, "verify_network_block: changed bytes -> different PoW");
+    check(v.verify_network_block(blob.data(), blob.size(), seed, NetworkDifficulty{0, 0}, h2) == NetworkVerdict::Malformed, "verify_network_block: zero difficulty -> Malformed");
+    check(v.verify_network_block(nullptr, 0, seed, NetworkDifficulty{1, 0}, h2) == NetworkVerdict::Malformed, "verify_network_block: empty blob -> Malformed");
+    check(O2RandomXVerifier::meets_network_difficulty(want, NetworkDifficulty{difficulty, 0}), "meets_network_difficulty: exact rule on the KAT hash");
+
+    // (6) lazy policy: miss -> prefetch inside the submit
+    {
+        O2RandomXVerifier lz;
+        RandomXPolicy lp; lp.enabled = true; lp.lazy_prefetch_on_miss = true;
+        check(lz.init(lp), "lazy: init ok");
+        Hash32 lh{};
+        check(lz.randomx_hash(blob.data(), blob.size(), height, seed, lh) && lh == want, "lazy: non-resident seed prefetched inside randomx_hash, PoW matches");
+        check(lz.stats().prefetches == 1 && lz.stats().seed_misses == 0, "lazy: prefetches=1, seed_misses=0");
+    }
+    std::printf("  %s\n", v.describe().c_str());
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Suite B — the verifier through the MERGED XmrStratumServer.
+// ---------------------------------------------------------------------------
+struct FakeTemplates final : strat::ITemplateSource {
+    std::vector<uint8_t> blob;   // hashing blob with nonce ZEROED (served to miners)
+    Seed32 seed{};
+    uint64_t difficulty = 0;
+    bool get_job(uint32_t, strat::TemplateJob& out) override { return rebuild_blob(7, 0, out); }
+    bool rebuild_blob(uint32_t template_id, uint32_t, strat::TemplateJob& out) override {
+        if (template_id != 7) return false;
+        out.blob = blob; out.nonce_offset = 39; out.template_id = 7; out.height = kHeight;
+        out.mainchain_target = 0xFFFFFFFFFFFFFFFFULL / difficulty;
+        out.lane_target = 0xFFFFFFFFFFFFFFFFULL;           // lane diff 1
+        out.seed_hash = seed; out.next_seed_hash = std::nullopt; out.monero_major_version = 16;
+        return true;
+    }
+    uint32_t max_extra_nonces() const override { return 1; }
+};
+
+struct FakeSink final : strat::IShareSink {
+    O2RandomXVerifier& v; FakeTemplates& t;
+    int submits = 0, accepted = 0; bool last_net_flag = false;
+    NetworkVerdict verdict = NetworkVerdict::Malformed; Hash32 pow{};
+    FakeSink(O2RandomXVerifier& v_, FakeTemplates& t_) : v(v_), t(t_) {}
+    void on_accepted_share(const strat::AcceptedShare& s) override { ++accepted; last_net_flag = s.is_network_block; }
+    // The O-2 share-sink pattern: rebuild + patch nonce + EXACT gate.
+    void submit_network_block(uint32_t template_id, uint32_t nonce, uint32_t extra_nonce) override {
+        ++submits;
+        strat::TemplateJob tj;
+        if (!t.rebuild_blob(template_id, extra_nonce, tj)) { verdict = NetworkVerdict::Malformed; return; }
+        for (size_t i = 0; i < 4; ++i) tj.blob[tj.nonce_offset + i] = static_cast<uint8_t>(nonce >> (8 * i));
+        if (!v.network_blocks_allowed()) { verdict = NetworkVerdict::VerifyUnavailable; return; }
+        verdict = v.verify_network_block(tj.blob.data(), tj.blob.size(), tj.seed_hash,
+                                         NetworkDifficulty{t.difficulty, 0}, pow);
+        // only NetworkVerdict::Accept would patch the FULL blob and submit_block here
+    }
+};
+
+struct FakeTransport final : strat::ITransport {
+    std::vector<std::string> lines; int closed = 0;
+    bool send_line(uint64_t, std::string_view l) override { lines.emplace_back(l); return true; }
+    void close(uint64_t) override { ++closed; }
+};
+
+void suite_b(const Vector& kat) {
+    std::printf("== (B) O2RandomXVerifier x XmrStratumServer ==\n");
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+    const std::vector<uint8_t>& blob = kat.blob;
+    const Seed32& seed = kat.seed;
+    const Hash32& want = kat.want;
+    const std::string nonce_hex = strat::StratumDialect::to_hex(blob.data() + 39, 4);   // winning nonce, LE bytes verbatim
+
+    FakeTemplates t; t.blob = blob; t.seed = seed; t.difficulty = kDifficulty;
+    for (size_t i = 0; i < 4; ++i) t.blob[39 + i] = 0;    // served job carries a zero nonce
+
+    // strict I2 before any template hook: submit -> Couldn't check PoW
+    {
+        O2RandomXVerifier v; RandomXPolicy p; p.enabled = true; check(v.init(p), "init");
+        FakeSink sink(v, t); FakeTransport tr;
+        strat::XmrStratumServer srv(t, v, sink, tr);
+        strat::XmrStratumSession s(1);
+        check(srv.handle_login(s, 1, "4xxx.rig"), "login ok (no prefetch yet)");
+        strat::SubmitFields f{"", "1", nonce_hex, kPowHex};
+        check(srv.handle_submit(s, 2, f), "submit handled (connection kept)");
+        check(tr.lines.back().find("Couldn't check PoW") != std::string::npos, "no seed resident -> \"Couldn't check PoW\" (fail-closed, no cache init on submit)");
+        check(sink.submits == 0 && sink.accepted == 0, "no submit_network_block, no accepted share");
+        std::printf("  %s\n", v.describe().c_str());
+    }
+
+    // the O-2 flow: template hook -> prefetch -> login -> submit
+    {
+        O2RandomXVerifier v; RandomXPolicy p; p.enabled = true; check(v.init(p), "init");
+        FakeSink sink(v, t); FakeTransport tr;
+        strat::XmrStratumServer srv(t, v, sink, tr);
+
+        strat::TemplateJob tj; t.get_job(0, tj);
+        v.post_seeds(tj.seed_hash, tj.next_seed_hash);
+        check(v.drain_pending() && v.seed_resident(seed), "template hook: seeds prefetched on the listener side");
+
+        strat::XmrStratumSession s(2);
+        check(srv.handle_login(s, 1, "4xxx+1.rig"), "login ok");
+        check(tr.lines.back().find("\"algo\":\"rx/0\"") != std::string::npos, "login reply carries algo rx/0");
+
+        strat::SubmitFields f{"", "1", nonce_hex, kPowHex};
+        check(srv.handle_submit(s, 2, f), "submit handled");
+        check(tr.lines.back().find("\"status\":\"OK\"") != std::string::npos, "submit reply OK");
+        check(sink.submits == 1, "server called submit_network_block once");
+        check(sink.verdict == NetworkVerdict::Accept, "sink exact gate: Accept (hash*difficulty < 2^256)");
+        check(sink.pow == want, "sink saw the block 3,000,000 PoW");
+        check(sink.accepted == 1 && sink.last_net_flag, "accepted share flagged is_network_block");
+        check(v.stats().memo_hits == 1 && v.stats().hashes == 1, "exact gate reused the submit hash (1 hash total)");
+
+        // wrong nonce -> not a network block; lane diff 1 -> still an accepted share
+        std::string bad = nonce_hex; bad[0] = (bad[0] == '0') ? '1' : '0';
+        strat::SubmitFields g{"", "1", bad, kPowHex};
+        check(srv.handle_submit(s, 3, g), "submit(wrong nonce) handled");
+        check(sink.submits == 1, "wrong nonce: no network submit");
+        check(sink.accepted == 2 && !sink.last_net_flag, "wrong nonce: accepted as lane share (diff 1), not network");
+        check(tr.lines.back().find("\"status\":\"OK\"") != std::string::npos, "wrong nonce: reply OK (lane share)");
+        std::printf("  %s\n", v.describe().c_str());
+    }
+
+    // disabled verifier: every submit is CouldNotCheck, sink refuses
+    {
+        O2RandomXVerifier v; RandomXPolicy p; p.enabled = false; v.init(p);
+        FakeSink sink(v, t); FakeTransport tr;
+        strat::XmrStratumServer srv(t, v, sink, tr);
+        strat::XmrStratumSession s(3);
+        srv.handle_login(s, 1, "4xxx");
+        strat::SubmitFields f{"", "1", nonce_hex, kPowHex};
+        srv.handle_submit(s, 2, f);
+        check(tr.lines.back().find("Couldn't check PoW") != std::string::npos, "disabled: submit -> Couldn't check PoW");
+        check(sink.submits == 0, "disabled: never reaches submit_network_block");
+    }
+#else
+    (void)kat;
+    std::printf("  (skipped: RandomX compiled out)\n");
+#endif
+}
+
+} // namespace
+
+int main() {
+    Vector kat;
+    if (!load_vector(kat)) {
+        std::printf("bad KAT vector hex\n");
+        return 2;
+    }
+    std::printf("== v37_xmr_o2_randomx_kat (X8 vector: mainnet block %llu) ==\n",
+                static_cast<unsigned long long>(kHeight));
+    suite_a(kat);
+    suite_b(kat);
+    std::printf("== %s (%d failures) ==\n", fails ? "FAIL" : "OK", fails);
+    return fails ? 1 : 0;
+}

--- a/src/c2pool/v37/xmr/xmr_live_submit.hpp
+++ b/src/c2pool/v37/xmr/xmr_live_submit.hpp
@@ -1,0 +1,708 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_live_submit.hpp   (Track A2 / Milestone A — X9 O-2,
+//                                            wire (3): LIVE SUBMIT)
+//
+// THE LIVE-SUBMIT COMPONENT. Given a block candidate (the monerod block-template
+// bytes the stratum front-end served) and the winning header nonce, it
+//
+//   1. ASSEMBLES the full Monero block blob — the FULL blocktemplate_blob with
+//      the 4-byte little-endian nonce patched at the header nonce offset (and,
+//      when the template reserved tx_extra space, the per-client extra_nonce
+//      patched at reserved_offset);
+//   2. SUBMITS it to monerod over the X2 seam (IMonerodTransport::rpc_post with
+//      the KAT-pinned MoneroDaemonRpc::body_submit_block body);
+//   3. RETURNS ACCEPTANCE — monerod's status, plus the BLOCK ID the finalize
+//      driver must be handed. The id is resolved from three sources, in order:
+//        (a) result.block_id in monerod's submit_block response (authoritative;
+//            the tree's MoneroDaemonRpc::parse_submit_block does NOT read it, so
+//            this header carries its own parser — no existing file is edited);
+//        (b) a LOCAL computation keccak256(varint(len) ‖ hashing_blob_with_nonce)
+//            — the CryptoNote object-hash framing monerod applies to the hashing
+//            blob (get_block_hash == get_object_hash(get_block_hashing_blob)),
+//            over the vendored keccak in xmr_coin;
+//        (c) get_block_header_by_height(H) whose prev_hash matches the template's
+//            prev_id (a cross-check of (a)/(b) and the fallback for a monerod
+//            that returns no block_id).
+//      Any disagreement between the sources is recorded loudly (id_mismatch /
+//      HeaderCheck::Mismatch) but never silently papered over: the bid handed
+//      on is monerod's own when it gave one, because XmrNode's is_canonical
+//      predicate compares against index().by_height(H).id — monerod's view.
+//
+// HONEST SCOPE (option A, per the O-2 survey): the bytes submitted are monerod's
+// get_block_template block (single coinbase to the template wallet address)
+// with the nonce patched — a genuine, monerod-validated, accepted block end to
+// end, but NOT the v37 K_fair settlement coinbase. Option B (XmrBlockTemplate +
+// X6 executor over an implemented xmr_coin_primitives seam) slots in behind the
+// same BlockCandidate: full_blob := get_block_template_blob(...), hashing_blob
+// := get_hashing_blob(...). Nothing in this header depends on which option
+// produced the bytes.
+//
+// FAIL-CLOSED: SubmitPolicy::network_submit_enabled defaults to FALSE. The
+// assembler must set it from (RandomX compiled in && cfg.randomx_enabled &&
+// verifier ready). A stratum front-end that "structurally checks only" must
+// never reach monerod with an unverified block (xmr_node_config.hpp:104-107).
+//
+// THREADING (O-2 contract, survey §E): submit() runs on the STRATUM LISTENER
+// thread. It uses only the transport (LiveMonerodTransport opens a fresh socket
+// per call, so it is safe alongside the main loop's pump_poll) and its own
+// state. It NEVER touches MonerodAdapter / MainchainIndex / XmrFinalizeDriver.
+// A found block crosses to the main thread through FoundBlockQueue (mutex),
+// where the main loop calls XmrNode::on_network_block_won(). The transport
+// must complete rpc_post synchronously (LiveMonerodTransport and
+// MockMonerodTransport both do); an asynchronous transport is detected and
+// reported as an error rather than mis-read as a rejection.
+//
+// CONSUMER-TREE ONLY. Defines NO consensus digest. Uses ONLY: the X2 seam
+// (IMonerodTransport / RpcResponse / MoneroDaemonRpc body builders +
+// parse_block_header / ChainMainBlock / Hash), minijson, xmr_coin's BlobWriter
+// (monerod-identical varint) + keccak256, and the X5 IShareSink / AcceptedShare
+// seam. Header-only; the only link dependencies are xmr_node (monero_rpc.cpp)
+// and xmr_coin (vendored keccak), both already linked by c2pool-v37-xmr.
+// ===========================================================================
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/coin/xmr_blob.hpp"              // ::xmr::coin::BlobWriter (vendored varint)
+#include "impl/xmr/coin/xmr_keccak_midstate.hpp"   // ::xmr::coin::keccak256 (vendored cn_fast_hash)
+#include "impl/xmr/node/minijson.hpp"              // parse / hex_to_hash / hash_to_hex
+#include "impl/xmr/node/monero_rpc.hpp"            // MoneroDaemonRpc::body_* / parse_block_header
+#include "impl/xmr/node/monerod_transport.hpp"     // IMonerodTransport / RpcResponse
+#include "impl/xmr/node/xmr_node_types.hpp"        // Hash / ChainMainBlock / is_zero
+#include "impl/xmr/stratum/xmr_stratum.hpp"        // IShareSink / AcceptedShare / NONCE_SIZE
+
+namespace c2pool::v37n::xmr::submit {
+
+using Hash = ::c2pool::xmr::node::Hash;
+using ::c2pool::xmr::node::ChainMainBlock;
+using ::c2pool::xmr::node::IMonerodTransport;
+using ::c2pool::xmr::node::MoneroDaemonRpc;
+using ::c2pool::xmr::node::RpcResponse;
+namespace mj    = ::c2pool::xmr::node::minijson;
+namespace strat = ::v37::xmr::stratum;
+
+// ---------------------------------------------------------------------------
+// small byte helpers (local; no dependency on xmr_stratum.cpp's StratumDialect)
+// ---------------------------------------------------------------------------
+inline std::string to_hex(const std::uint8_t* p, std::size_t n) {
+    static const char* d = "0123456789abcdef";
+    std::string s;
+    s.reserve(n * 2);
+    for (std::size_t i = 0; i < n; ++i) {
+        s.push_back(d[p[i] >> 4]);
+        s.push_back(d[p[i] & 0xf]);
+    }
+    return s;
+}
+inline std::string to_hex(const std::vector<std::uint8_t>& v) { return to_hex(v.data(), v.size()); }
+
+inline bool from_hex(const std::string& hex, std::vector<std::uint8_t>& out) {
+    if (hex.size() % 2 != 0) return false;
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    out.clear();
+    out.reserve(hex.size() / 2);
+    for (std::size_t i = 0; i < hex.size(); i += 2) {
+        int hi = nib(hex[i]), lo = nib(hex[i + 1]);
+        if (hi < 0 || lo < 0) return false;
+        out.push_back(static_cast<std::uint8_t>((hi << 4) | lo));
+    }
+    return true;
+}
+
+// Overflow-safe "[off, off+4) lies inside blob".
+inline bool u32_fits(const std::vector<std::uint8_t>& blob, std::size_t off) noexcept {
+    return off <= blob.size() && blob.size() - off >= strat::NONCE_SIZE;
+}
+
+// Patch a 4-byte little-endian u32 at `off`. False if it does not fit.
+inline bool patch_u32_le(std::vector<std::uint8_t>& blob, std::size_t off, std::uint32_t v) noexcept {
+    if (!u32_fits(blob, off)) return false;
+    for (std::size_t i = 0; i < strat::NONCE_SIZE; ++i)
+        blob[off + i] = static_cast<std::uint8_t>(v >> (8 * i));
+    return true;
+}
+
+// ===========================================================================
+// BlockCandidate — what the template layer hands the submitter for ONE
+// (template_id, extra_nonce). Option A fills it straight from get_block_template
+// (+ the served hashing blob); option B from XmrBlockTemplate. The header bytes
+// [0, nonce_offset) of full_blob and hashing_blob MUST agree — both start with
+// the same block header (varint major ‖ varint minor ‖ varint ts ‖ prev[32]) —
+// and validate_candidate() enforces it, so a mismatched pair can never be
+// submitted under the wrong id.
+// ===========================================================================
+struct BlockCandidate {
+    std::uint32_t template_id = 0;
+    std::uint64_t height = 0;                 // Monero height of the block
+
+    // blocktemplate_blob: header ‖ miner_tx ‖ varint(n_tx_hashes) ‖ 32·n. This is
+    // what is SUBMITTED (with the nonce patched).
+    std::vector<std::uint8_t> full_blob;
+
+    // blockhashing_blob AS SERVED to the miner for (template_id, extra_nonce):
+    // header ‖ tree_root[32] ‖ varint(n_tx+1) — the exact RandomX input before
+    // the nonce. Optional (empty => no local block-id computation); when the
+    // template baked an extra_nonce into the miner_tx this must be the blob
+    // rebuilt for THAT extra_nonce (ITemplateSource::rebuild_blob's contract).
+    std::vector<std::uint8_t> hashing_blob;
+
+    std::size_t nonce_offset = strat::EXPECTED_NONCE_OFFSET_V16;   // 39 for v16 headers
+
+    // Optional extra_nonce splice inside the miner_tx of full_blob (monerod
+    // get_block_template reserve_size ≥ 4 → reserved_offset). 0/0 = not used;
+    // the single-template solo demo leaves this unset.
+    std::size_t reserved_offset = 0;
+    std::size_t reserved_size   = 0;
+
+    Hash          prev_id{};                  // template prev_hash (zero = unknown)
+    std::uint64_t expected_reward = 0;        // piconero (get_block_template.expected_reward)
+    std::uint8_t  major_version = 0;          // template major_version (diagnostic)
+};
+
+// Validate a candidate BEFORE any bytes are touched. Returns "" when sane.
+inline std::string validate_candidate(const BlockCandidate& c) {
+    if (c.height == 0) return "candidate: height is 0";
+    if (c.full_blob.empty()) return "candidate: empty full_blob";
+    if (!u32_fits(c.full_blob, c.nonce_offset))
+        return "candidate: nonce_offset " + std::to_string(c.nonce_offset) +
+               " past full_blob end (" + std::to_string(c.full_blob.size()) + ")";
+    if (!c.hashing_blob.empty()) {
+        if (!u32_fits(c.hashing_blob, c.nonce_offset))
+            return "candidate: nonce_offset past hashing_blob end";
+        // Both blobs share the header up to (and including) the nonce field.
+        if (std::memcmp(c.full_blob.data(), c.hashing_blob.data(), c.nonce_offset) != 0)
+            return "candidate: hashing_blob / full_blob header prefix disagree "
+                   "(wrong template pairing?)";
+    }
+    if (c.reserved_size != 0) {
+        if (c.reserved_size < strat::NONCE_SIZE)
+            return "candidate: reserved_size < 4 cannot carry an extra_nonce";
+        if (c.reserved_offset > c.full_blob.size() ||
+            c.full_blob.size() - c.reserved_offset < c.reserved_size)
+            return "candidate: reserved region past full_blob end";
+        if (c.reserved_offset < c.nonce_offset + strat::NONCE_SIZE)
+            return "candidate: reserved region overlaps the block header";
+    }
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// ASSEMBLY (pure). Precondition: validate_candidate(c).empty().
+// ---------------------------------------------------------------------------
+
+// The block blob to submit: full_blob with the winning nonce (and, when the
+// template reserved space, the extra_nonce) patched in little-endian.
+inline std::vector<std::uint8_t> assemble_block_blob(const BlockCandidate& c,
+                                                     std::uint32_t nonce,
+                                                     std::uint32_t extra_nonce) {
+    std::vector<std::uint8_t> blob = c.full_blob;
+    patch_u32_le(blob, c.nonce_offset, nonce);
+    if (c.reserved_size >= strat::NONCE_SIZE)
+        patch_u32_le(blob, c.reserved_offset, extra_nonce);
+    return blob;
+}
+
+// The exact RandomX input that won: served hashing blob with the nonce patched.
+inline std::vector<std::uint8_t> hashing_blob_with_nonce(const BlockCandidate& c,
+                                                         std::uint32_t nonce) {
+    std::vector<std::uint8_t> blob = c.hashing_blob;
+    patch_u32_le(blob, c.nonce_offset, nonce);
+    return blob;
+}
+
+// Monero block id of a hashing blob: keccak256(varint(len) ‖ hashing_blob).
+// monerod: get_block_hash(b) == get_object_hash(get_block_hashing_blob(b)), and
+// get_object_hash serialises the blobdata (varint length-prefixed) before
+// cn_fast_hash. The varint is xmr_coin's vendored tools::write_varint, so the
+// framing is byte-identical to monerod's. (Pinned by the O-2 self-check against
+// the Monero mainnet genesis block id.)
+inline Hash block_id_of_hashing_blob(const std::vector<std::uint8_t>& hashing_blob) {
+    ::xmr::coin::BlobWriter w;
+    w.put_varint(static_cast<std::uint64_t>(hashing_blob.size()));
+    w.put_bytes(hashing_blob.data(), hashing_blob.size());
+    const ::xmr::coin::Hash256 h = ::xmr::coin::keccak256(w.bytes());
+    Hash out{};
+    std::memcpy(out.data(), h.data(), out.size());
+    return out;
+}
+
+// ===========================================================================
+// submit_block response — parsed INCLUDING result.block_id (the tree's
+// MoneroDaemonRpc::parse_submit_block reads status only; monero_rpc.cpp:156-169).
+// Shapes handled:
+//   {"result":{"status":"OK","block_id":"<64 hex>",...}}        accepted
+//   {"result":{"status":"<anything else>"}}                      rejected
+//   {"error":{"code":-7,"message":"Block not accepted"}}         rejected (rpc)
+//   {"error":{"code":-6,"message":"Wrong block blob"}}           rejected (rpc)
+// ===========================================================================
+struct SubmitAck {
+    bool        accepted = false;
+    std::string status;          // result.status ("OK" on success)
+    std::string error;           // "rpc: <message>" / "json: ..." when not accepted
+    long        rpc_code = 0;    // error.code when an rpc error was returned
+    std::optional<Hash> block_id;  // result.block_id, when monerod supplied it
+};
+
+inline SubmitAck parse_submit_block_ack(const char* p, std::size_t n) {
+    SubmitAck out;
+    mj::Value root;
+    if (!mj::parse(p, n, root)) { out.error = "json: parse failed"; return out; }
+    const mj::Value& r = root["result"];
+    if (r.is_object()) {
+        out.status   = r["status"].as_string();
+        out.accepted = (out.status == "OK");
+        const std::string bid = r["block_id"].as_string();
+        Hash h{};
+        if (!bid.empty() && mj::hex_to_hash(bid, h)) out.block_id = h;
+        if (!out.accepted) out.error = "rpc: status " + (out.status.empty() ? "<empty>" : out.status);
+        return out;
+    }
+    const mj::Value& e = root["error"];
+    if (e.is_object()) {
+        out.error    = "rpc: " + e["message"].as_string();
+        out.rpc_code = std::strtol(e["code"].as_string().c_str(), nullptr, 10);
+    } else {
+        out.error = "json: no result";
+    }
+    return out;
+}
+inline SubmitAck parse_submit_block_ack(const std::vector<char>& body) {
+    return parse_submit_block_ack(body.data(), body.size());
+}
+
+// ===========================================================================
+// Outcome of one submit — everything the assembler / the log / the FOUND event
+// needs. `block_id` is the bid to hand to XmrNode::on_network_block_won (via
+// mj::hash_to_hex, lowercase — the same encoding XmrNode::hex_of produces).
+// ===========================================================================
+enum class IdSource : std::uint8_t { None = 0, Monerod = 1, Local = 2, Header = 3 };
+enum class HeaderCheck : std::uint8_t { NotRun = 0, Confirmed = 1, Mismatch = 2, Error = 3 };
+
+inline const char* to_string(IdSource s) {
+    switch (s) {
+        case IdSource::None:    return "none";
+        case IdSource::Monerod: return "monerod";
+        case IdSource::Local:   return "local";
+        case IdSource::Header:  return "header";
+    }
+    return "none";
+}
+inline const char* to_string(HeaderCheck c) {
+    switch (c) {
+        case HeaderCheck::NotRun:    return "not-run";
+        case HeaderCheck::Confirmed: return "confirmed";
+        case HeaderCheck::Mismatch:  return "MISMATCH";
+        case HeaderCheck::Error:     return "error";
+    }
+    return "not-run";
+}
+
+struct SubmitOutcome {
+    bool        accepted = false;       // monerod returned status "OK"
+    bool        refused  = false;       // never posted (policy / malformed candidate)
+    std::string status;                 // monerod result.status
+    std::string error;                  // refusal / transport / rpc text
+    long        rpc_code = 0;
+
+    std::uint64_t height = 0;
+    std::uint32_t template_id = 0;
+    std::uint32_t nonce = 0;
+    std::uint32_t extra_nonce = 0;
+
+    Hash        block_id{};             // the bid for the finalize driver (zero if unknown)
+    IdSource    id_source = IdSource::None;
+    std::optional<Hash> monerod_block_id;   // (a) result.block_id
+    std::optional<Hash> local_block_id;     // (b) keccak(varint ‖ hashing_blob)
+    std::optional<Hash> header_block_id;    // (c) get_block_header_by_height(H).hash
+    bool        id_mismatch = false;        // (a) and (b) both present and differ
+    HeaderCheck header_check = HeaderCheck::NotRun;
+
+    std::string block_blob_hex;         // exactly what was posted (diagnostic)
+    double      rpc_ms = 0.0;           // submit_block round-trip
+
+    std::string block_id_hex() const { return mj::hash_to_hex(block_id); }
+    bool has_block_id() const { return id_source != IdSource::None; }
+};
+
+// ===========================================================================
+// SubmitPolicy — fail-closed knobs. The assembler flips network_submit_enabled
+// ON only when the RandomX verifier is live (compiled in + --randomx + init ok).
+// ===========================================================================
+struct SubmitPolicy {
+    bool network_submit_enabled = false;   // FAIL-CLOSED default
+    bool compute_local_id       = true;    // (b) when a hashing blob is supplied
+    bool confirm_with_header    = true;    // (c) one get_block_header_by_height after OK
+};
+
+// ===========================================================================
+// LiveBlockSubmitter — assemble + submit + resolve the block id.
+// One instance; submit() is called from the listener thread. Counters are
+// atomics so the main loop can print them; last_error()/last_outcome() are
+// mutex-guarded copies.
+// ===========================================================================
+class LiveBlockSubmitter {
+public:
+    LiveBlockSubmitter(IMonerodTransport& transport, SubmitPolicy policy = {})
+        : m_tx(transport), m_policy(policy), m_enabled(policy.network_submit_enabled) {}
+
+    LiveBlockSubmitter(const LiveBlockSubmitter&) = delete;
+    LiveBlockSubmitter& operator=(const LiveBlockSubmitter&) = delete;
+
+    // Flip the fail-closed gate (main thread, before the listener starts, or
+    // any time — it is atomic).
+    void enable_network_submit(bool on) { m_enabled.store(on); }
+    bool network_submit_enabled() const { return m_enabled.load(); }
+    const SubmitPolicy& policy() const { return m_policy; }
+
+    // THE ENTRY POINT. Listener thread. Blocking for one (or two) RPC round
+    // trips on a fresh socket each.
+    SubmitOutcome submit(const BlockCandidate& c, std::uint32_t nonce, std::uint32_t extra_nonce) {
+        SubmitOutcome o;
+        o.height = c.height;
+        o.template_id = c.template_id;
+        o.nonce = nonce;
+        o.extra_nonce = extra_nonce;
+        m_calls.fetch_add(1);
+
+        // 0) fail-closed gate + candidate sanity, BEFORE any bytes are assembled.
+        if (!m_enabled.load()) {
+            o.refused = true;
+            o.error = "submit refused: network submit disabled (fail-closed — RandomX "
+                      "verify not live / --randomx not given)";
+            return finish(o, &m_refused);
+        }
+        if (std::string v = validate_candidate(c); !v.empty()) {
+            o.refused = true;
+            o.error = "submit refused: " + v;
+            return finish(o, &m_refused);
+        }
+
+        // 1) assemble the block bytes (+ the local id, if we can).
+        const std::vector<std::uint8_t> blob = assemble_block_blob(c, nonce, extra_nonce);
+        o.block_blob_hex = to_hex(blob);
+        if (m_policy.compute_local_id && !c.hashing_blob.empty())
+            o.local_block_id = block_id_of_hashing_blob(hashing_blob_with_nonce(c, nonce));
+
+        // 2) submit_block — the KAT-pinned body, over the X2 seam.
+        const auto t0 = std::chrono::steady_clock::now();
+        SubmitAck ack;
+        bool done = false;
+        m_tx.rpc_post(MoneroDaemonRpc::body_submit_block(o.block_blob_hex),
+                      [&](const RpcResponse& r) {
+                          done = true;
+                          if (!r.ok()) { ack.error = "transport: " + r.error; return; }
+                          ack = parse_submit_block_ack(r.body);
+                      });
+        o.rpc_ms = std::chrono::duration<double, std::milli>(
+                       std::chrono::steady_clock::now() - t0).count();
+        if (!done) {
+            o.error = "submit: transport did not complete synchronously "
+                      "(LiveBlockSubmitter requires a blocking IMonerodTransport)";
+            return finish(o, &m_transport_errors);
+        }
+        o.status   = ack.status;
+        o.rpc_code = ack.rpc_code;
+        if (!ack.accepted) {
+            o.error = ack.error.empty() ? "submit rejected" : ack.error;
+            return finish(o, ack.error.rfind("transport:", 0) == 0 ? &m_transport_errors : &m_rejected);
+        }
+
+        // 3) ACCEPTED. Resolve the block id: monerod > local > header.
+        o.accepted = true;
+        m_ok.fetch_add(1);
+        o.monerod_block_id = ack.block_id;
+        if (o.monerod_block_id) {
+            o.block_id = *o.monerod_block_id;
+            o.id_source = IdSource::Monerod;
+            if (o.local_block_id && *o.local_block_id != *o.monerod_block_id) {
+                o.id_mismatch = true;
+                m_id_mismatches.fetch_add(1);
+            }
+        } else if (o.local_block_id) {
+            o.block_id = *o.local_block_id;
+            o.id_source = IdSource::Local;
+        }
+
+        // 4) Cross-check / fallback via the settled header at H.
+        if (m_policy.confirm_with_header) confirm_with_header(c, o);
+
+        if (!o.has_block_id()) {
+            o.error = "accepted, but block id UNKNOWN (monerod gave no block_id, no "
+                      "hashing_blob for a local id, header lookup " +
+                      std::string(to_string(o.header_check)) + ")";
+            m_unattributable.fetch_add(1);
+        }
+        return finish(o, nullptr);
+    }
+
+    // --- diagnostics (never consensus) --------------------------------------
+    std::size_t calls()            const { return m_calls.load(); }
+    std::size_t ok()               const { return m_ok.load(); }
+    std::size_t rejected()         const { return m_rejected.load(); }
+    std::size_t refused()          const { return m_refused.load(); }
+    std::size_t transport_errors() const { return m_transport_errors.load(); }
+    std::size_t id_mismatches()    const { return m_id_mismatches.load(); }
+    std::size_t unattributable()   const { return m_unattributable.load(); }
+
+    std::string last_error() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_last.error;
+    }
+    SubmitOutcome last_outcome() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_last;
+    }
+
+private:
+    SubmitOutcome& finish(SubmitOutcome& o, std::atomic<std::size_t>* bump) {
+        if (bump) bump->fetch_add(1);
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_last = o;
+        return o;
+    }
+
+    // (c) get_block_header_by_height(H): confirm the id we hold, or adopt the
+    // header's id when we hold none and its prev_hash matches the template's
+    // prev_id (so a competing block at H cannot be mistaken for ours).
+    void confirm_with_header(const BlockCandidate& c, SubmitOutcome& o) {
+        std::optional<ChainMainBlock> hdr;
+        std::string err;
+        bool done = false;
+        m_tx.rpc_post(MoneroDaemonRpc::body_get_block_header_by_height(c.height),
+                      [&](const RpcResponse& r) {
+                          done = true;
+                          if (!r.ok()) { err = r.error; return; }
+                          hdr = MoneroDaemonRpc::parse_block_header(r.body);
+                          if (!hdr) err = "get_block_header_by_height: parse failed";
+                      });
+        if (!done || !hdr) { o.header_check = HeaderCheck::Error; return; }
+        o.header_block_id = hdr->id;
+        const bool prev_ok = ::c2pool::xmr::node::is_zero(c.prev_id) || hdr->prev_id == c.prev_id;
+        if (o.has_block_id()) {
+            o.header_check = (hdr->id == o.block_id) ? HeaderCheck::Confirmed : HeaderCheck::Mismatch;
+            if (o.header_check == HeaderCheck::Mismatch) m_id_mismatches.fetch_add(1);
+            return;
+        }
+        if (prev_ok) {
+            o.block_id = hdr->id;
+            o.id_source = IdSource::Header;
+            o.header_check = HeaderCheck::Confirmed;
+        } else {
+            o.header_check = HeaderCheck::Mismatch;   // another block sits at H
+        }
+    }
+
+    IMonerodTransport&        m_tx;
+    SubmitPolicy              m_policy;
+    std::atomic<bool>         m_enabled;
+    std::atomic<std::size_t>  m_calls{0}, m_ok{0}, m_rejected{0}, m_refused{0},
+                              m_transport_errors{0}, m_id_mismatches{0}, m_unattributable{0};
+    mutable std::mutex        m_mtx;
+    SubmitOutcome             m_last;
+};
+
+// ===========================================================================
+// FoundBlockEvent / FoundBlockQueue — the listener→main hand-off for an
+// ACCEPTED block. Carries everything wire (4) needs: height + block_id (for
+// XmrNode::on_network_block_won), reward (for the credit/payout amounts),
+// prev_id, and attribution for the log. Worker/address are filled in a beat
+// later by on_accepted_share (see LiveSubmitShareSink) via annotate().
+// ===========================================================================
+struct FoundBlockEvent {
+    std::uint64_t height = 0;
+    Hash          block_id{};
+    Hash          prev_id{};
+    std::uint64_t reward = 0;            // piconero (template expected_reward)
+    std::uint32_t template_id = 0;
+    std::uint32_t nonce = 0;
+    std::uint32_t extra_nonce = 0;
+    std::string   worker;                // from the login string (may be empty)
+    std::string   address;               // raw base58 login address (may be empty)
+    IdSource      id_source = IdSource::None;
+    bool          id_mismatch = false;
+    HeaderCheck   header_check = HeaderCheck::NotRun;
+    double        rpc_ms = 0.0;
+    std::chrono::steady_clock::time_point at{};
+
+    std::string block_id_hex() const { return mj::hash_to_hex(block_id); }
+};
+
+class FoundBlockQueue {
+public:
+    void push(FoundBlockEvent e) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_q.push_back(std::move(e));
+        m_pushed.fetch_add(1);
+    }
+    bool pop(FoundBlockEvent& out) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        if (m_q.empty()) return false;
+        out = std::move(m_q.front());
+        m_q.pop_front();
+        return true;
+    }
+    // Attach worker/address to a queued event (no-op if already drained —
+    // attribution is diagnostic only, never settlement-bearing).
+    void annotate(std::uint32_t template_id, std::uint32_t nonce, std::uint32_t extra_nonce,
+                  const std::string& worker, const std::string& address) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        for (auto it = m_q.rbegin(); it != m_q.rend(); ++it) {
+            if (it->template_id == template_id && it->nonce == nonce &&
+                it->extra_nonce == extra_nonce) {
+                it->worker = worker;
+                it->address = address;
+                return;
+            }
+        }
+    }
+    std::size_t size() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_q.size();
+    }
+    std::size_t pushed() const { return m_pushed.load(); }
+
+private:
+    mutable std::mutex         m_mtx;
+    std::deque<FoundBlockEvent> m_q;
+    std::atomic<std::size_t>   m_pushed{0};
+};
+
+// ===========================================================================
+// LiveSubmitShareSink — the X5 IShareSink that plugs LiveBlockSubmitter into
+// XmrStratumServer. handle_submit (xmr_stratum.cpp:402-406) calls
+// submit_network_block(template_id, nonce, extra_nonce) BEFORE the lane-target
+// check and BEFORE on_accepted_share (:426), so:
+//   * submit_network_block: look the candidate up (CandidateLookup — the
+//     assembler binds it to the template provider's full blob + the template
+//     source's rebuild_blob hashing blob), submit, and on OK push a
+//     FoundBlockEvent;
+//   * on_accepted_share (is_network_block): annotate that event with the
+//     worker/address (same triple, same thread, moments later).
+// ===========================================================================
+class LiveSubmitShareSink final : public strat::IShareSink {
+public:
+    // Fill `out` for (template_id, extra_nonce); false => template gone (stale).
+    using CandidateLookup =
+        std::function<bool(std::uint32_t template_id, std::uint32_t extra_nonce, BlockCandidate& out)>;
+
+    LiveSubmitShareSink(LiveBlockSubmitter& submitter, FoundBlockQueue& found, CandidateLookup lookup)
+        : m_submitter(submitter), m_found(found), m_lookup(std::move(lookup)) {}
+
+    void on_accepted_share(const strat::AcceptedShare& s) override {
+        m_accepted.fetch_add(1);
+        if (s.is_network_block)
+            m_found.annotate(s.template_id, s.nonce, s.extra_nonce, s.worker, s.address);
+    }
+
+    void submit_network_block(std::uint32_t template_id, std::uint32_t nonce,
+                              std::uint32_t extra_nonce) override {
+        BlockCandidate c;
+        if (!m_lookup || !m_lookup(template_id, extra_nonce, c)) {
+            m_stale.fetch_add(1);
+            set_error("submit: template " + std::to_string(template_id) + " gone (stale)");
+            return;
+        }
+        const SubmitOutcome o = m_submitter.submit(c, nonce, extra_nonce);
+        if (!o.accepted) { set_error(o.error); return; }
+        if (!o.has_block_id()) {
+            // Accepted by monerod but we cannot name it: NEVER hand a zero bid to
+            // the finalize driver (is_canonical would orphan it at maturity).
+            set_error(o.error);
+            return;
+        }
+        FoundBlockEvent ev;
+        ev.height       = o.height;
+        ev.block_id     = o.block_id;
+        ev.prev_id      = c.prev_id;
+        ev.reward       = c.expected_reward;
+        ev.template_id  = template_id;
+        ev.nonce        = nonce;
+        ev.extra_nonce  = extra_nonce;
+        ev.id_source    = o.id_source;
+        ev.id_mismatch  = o.id_mismatch;
+        ev.header_check = o.header_check;
+        ev.rpc_ms       = o.rpc_ms;
+        ev.at           = std::chrono::steady_clock::now();
+        m_found.push(std::move(ev));
+        set_error({});
+    }
+
+    // --- diagnostics ------------------------------------------------------
+    std::size_t accepted_shares() const { return m_accepted.load(); }
+    std::size_t stale_lookups()   const { return m_stale.load(); }
+    std::string last_error() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_last_error;
+    }
+
+private:
+    void set_error(std::string e) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_last_error = std::move(e);
+    }
+
+    LiveBlockSubmitter&      m_submitter;
+    FoundBlockQueue&         m_found;
+    CandidateLookup          m_lookup;
+    std::atomic<std::size_t> m_accepted{0}, m_stale{0};
+    mutable std::mutex       m_mtx;
+    std::string              m_last_error;
+};
+
+// ===========================================================================
+// Main-thread helper for wire (4): the credit/payout maps for an option-A
+// block. Recommended (survey §4): credit == payout == {identity_key : reward}
+// so finalW nets to 0 and the FOUND/FINALIZE trail is amount-honest. Templated
+// on the ledger's Amounts (std::map<::v37::bytes32, long long>; bytes32 ==
+// std::array<uint8_t,32>) so this header never pulls the engine. Pass
+// reward == 0 to get the degenerate {} (the ledger still registers the block).
+// ===========================================================================
+template <class AmountsT>
+AmountsT single_key_amounts(const std::array<std::uint8_t, 32>& identity_key,
+                            std::uint64_t reward_piconero) {
+    AmountsT a;
+    if (reward_piconero != 0)
+        a[identity_key] = static_cast<long long>(reward_piconero);
+    return a;
+}
+
+// One-line log rendering of a FOUND event (main thread).
+inline std::string describe(const FoundBlockEvent& e) {
+    std::string s = "FOUND h=" + std::to_string(e.height) + " bid=" + e.block_id_hex().substr(0, 16) +
+                    "… id-source=" + to_string(e.id_source) +
+                    " header=" + to_string(e.header_check) +
+                    (e.id_mismatch ? " ID-MISMATCH(monerod!=local)" : "") +
+                    " reward=" + std::to_string(e.reward) + "pico" +
+                    " tid=" + std::to_string(e.template_id) +
+                    " nonce=0x" + to_hex(reinterpret_cast<const std::uint8_t*>(&e.nonce), 4);
+    if (!e.worker.empty() || !e.address.empty())
+        s += " worker=" + (e.worker.empty() ? std::string("-") : e.worker) +
+             " addr=" + (e.address.size() > 12 ? e.address.substr(0, 12) + "…" : e.address);
+    return s;
+}
+
+} // namespace c2pool::v37n::xmr::submit

--- a/src/c2pool/v37/xmr/xmr_node_config.hpp
+++ b/src/c2pool/v37/xmr/xmr_node_config.hpp
@@ -31,13 +31,20 @@ namespace c2pool::v37n::xmr {
 
 // The Monero network the daemon binds to. Stagenet is the shipped default —
 // a v37 XMR node is prototype-grade and must never default to real value.
-enum class MoneroNetwork : std::uint8_t { Stagenet = 0, Testnet = 1, Mainnet = 2 };
+//
+// Regtest (monerod --regtest) is FAKECHAIN: it runs the MAINNET config (mainnet
+// base58 prefixes, mainnet default ports) on a private chain with
+// --fixed-difficulty and in-daemon generateblocks. It carries no value, so it
+// does NOT trip the --i-understand-mainnet fence — but it must never be confused
+// with Mainnet either (its own settlement store dir, its own label).
+enum class MoneroNetwork : std::uint8_t { Stagenet = 0, Testnet = 1, Mainnet = 2, Regtest = 3 };
 
 inline const char* to_string(MoneroNetwork n) {
     switch (n) {
         case MoneroNetwork::Stagenet: return "stagenet";
         case MoneroNetwork::Testnet:  return "testnet";
         case MoneroNetwork::Mainnet:  return "mainnet";
+        case MoneroNetwork::Regtest:  return "regtest";
     }
     return "stagenet";
 }
@@ -57,6 +64,11 @@ inline c2pool::xmr::node::DaemonEndpoint default_endpoint(MoneroNetwork n) {
         case MoneroNetwork::Stagenet: e.rpc_port = 38081; e.zmq_port = 38083; break;
         case MoneroNetwork::Testnet:  e.rpc_port = 28081; e.zmq_port = 28083; break;
         case MoneroNetwork::Mainnet:  e.rpc_port = 18081; e.zmq_port = 18083; break;
+        // FAKECHAIN uses the mainnet defaults; a private regtest monerod should be
+        // started with explicit --rpc-bind-port / --zmq-pub and the daemon pointed
+        // at them (--rpc-port / --zmq-port) so it can never collide with a mainnet
+        // monerod on the same host.
+        case MoneroNetwork::Regtest:  e.rpc_port = 18081; e.zmq_port = 18083; break;
     }
     return e;
 }
@@ -94,6 +106,41 @@ struct XmrNodeConfig {
     // --- stratum front-end (X5) --------------------------------------------
     std::string     stratum_bind_host = "127.0.0.1";
     std::uint16_t   stratum_bind_port = 3333;   // XMRig default; single-node
+
+    // --- O-2 serve side (stratum listener + live submit) --------------------
+    // The wallet address monerod's get_block_template pays the block reward to
+    // (network-prefixed standard address; regtest = mainnet '4…' format). EMPTY
+    // = the stratum port is NOT served and the daemon runs observe-side only
+    // (index + settlement + F1 driver), exactly as the X9 bring-up did.
+    //
+    // HONEST SCOPE (option A): the block bytes served and submitted are
+    // monerod's own template — a single coinbase to this address — with the
+    // winning nonce patched. That is a genuine, monerod-validated block end to
+    // end, but NOT yet the v37 K_fair settlement coinbase (option B follow-on).
+    std::string     payout_address;
+    // get_block_template reserve_size (tx_extra nonce reservation). 0 = none:
+    // one blob for every worker (max_extra_nonces == 1). Per-client extra_nonce
+    // (>= 4) is a follow-on of the template source.
+    std::uint32_t   template_reserve_size = 0;
+    // Share (lane) difficulty served to miners. 0 = solo: the job target IS the
+    // network target, so every accepted share is a network block. A lower value
+    // (e.g. 1000 on regtest) makes miners report shares between blocks.
+    std::uint64_t   stratum_share_diff = 0;
+    // Main-loop cadence: tip poll fallback, template refresh, found-queue drain.
+    // 5 s suits stagenet; ~1000 ms for a regtest demo.
+    std::uint32_t   poll_ms = 5000;
+    // Pending-FOUND sidecar (pfound.tsv next to settle.img) so a restart inside
+    // the D_conf window does not lose a pending FOUND (D10). --no-found-sidecar.
+    bool            found_sidecar = true;
+    // Optional payee identity (the address boundary's OUTPUT): the raw public
+    // spend + view keys of the payout address, 64 hex each. When both are set,
+    // FOUND/FINALIZE records are amount-honest ({identity_key : reward}); when
+    // absent the block is recorded as a valueless {}/{} record.
+    std::string     payee_spend_key_hex;
+    std::string     payee_view_key_hex;
+    bool            payee_subaddress = false;
+    // Seconds between the main loop's one-line status reports (0 = never).
+    std::uint32_t   status_every_s = 30;
 
     // --- storage ------------------------------------------------------------
     // When empty, config_path()/<net>/v37_settle_db is used (see xmr_node.hpp).

--- a/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
@@ -1,0 +1,781 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp   (X9 / O-2 wire 4 —
+//                                                    FINALIZE CONNECT)
+//
+// FinalizeConnect — the MAIN-THREAD glue that routes an XMR network-block WIN
+// (the stratum share sink's submit_block "OK", produced on the listener thread)
+// into the F1 finalize driver through the ONE existing seam,
+//
+//     XmrNode::on_network_block_won(height, block_id, credit, payout)
+//                                                     (xmr_node.hpp:182-199)
+//
+// so that FOUND -> FINALIZE runs at D_conf burial off the adapter's
+// Extend/Reorg/Orphan stream (xmr_node.hpp:228-249 -> XmrFinalizeDriver::
+// advance_to_tip, xmr_finalize_driver.hpp:121-191). Nothing here touches the
+// driver, the ledger or the store directly: it only SEQUENCES calls into the
+// node (HARD SAFETY 1 — no consensus digest is defined or altered).
+//
+// WHAT IT ADDS ON TOP OF THE BARE HOOK
+//   (1) FoundBlockQueue — the single cross-thread object of the O-2 assembly
+//       for this wire: the listener thread pushes a FoundBlockEvent (height,
+//       monerod's block_id, reward, payee key, worker/address) right after
+//       submit_block returned "OK"; the main loop drains it in tick().
+//       Replaces the WIP FoundEvent/FoundQueue (xmr_o2_serve.hpp:338-358),
+//       which carried only a height.
+//   (2) Amount-honest credit/payout for the option-A (monerod-template) block:
+//       credit == payout == { identity_key(payout XMR_STD ref) : reward }, so
+//       finalW nets to 0 at FINALIZE and the FOUND/FINALIZE audit trail carries
+//       the real amount. Without a payee key the degenerate {}/{} record is
+//       used (the ledger still bumps; the block is recorded as valueless).
+//   (3) The LATE-FOUND guard: XmrFinalizeDriver::advance_to_tip steps only
+//       heights ABOVE its cursor (:155). A FOUND registered at a height the
+//       cursor already passed would sit pending FOREVER (its payout deducted
+//       from effective_owed for good). Such a win is REFUSED, loudly, instead
+//       of being poisoned into the ledger.
+//   (4) O-3 observability: XmrNode logs "win:" / "finalize: ... SETTLED at
+//       bin_height=" only into construction_log(), which main prints ONCE
+//       after bring_up. tick() echoes every new line to stdout and prints
+//       burial progress (h + D_conf - hw) for each pending FOUND.
+//   (5) A pending-FOUND SIDECAR (optional, one small text file next to
+//       settle.img) so a restart inside the D_conf window does not lose the
+//       pending FOUND — the same D10 defect the BTC side closed with
+//       block_event_driver.hpp:35-52. RecoveryDriver replays FOUND events into
+//       the OwedLedger but NOT into XmrFinalizeDriver::m_found/m_by_height
+//       (SettleEvent::Found carries no height), so without this the block is
+//       never finalized after a restart. The re-drive goes through the same
+//       on_network_block_won seam (no XmrFinalizeDriver::reseed_found seam
+//       exists yet): OwedLedger::on_block_found is idempotent per bid
+//       (w4_settlement.hpp:452), so the ledger and ledger_seq are untouched;
+//       ONE duplicate FOUND event lands in the write-ahead log. That duplicate
+//       is harmless on replay — it always precedes the bid's terminal
+//       FINALIZE/ORPHAN event, and the ledger ignores a FOUND for a bid it
+//       already holds pending. When the reseed_found seam lands (follow-on,
+//       consumer-tree edit), swap re_drive() to it and the duplicate goes away.
+//
+// KNOWN O-2 ORDERING DEVIATION (stated, not hidden): W6 §5.2 wants FOUND
+// durable BEFORE the block is announced. Under option A the announce IS
+// monerod's submit_block on the listener thread; the FOUND becomes durable on
+// the main thread's next tick. The crash window is [submit OK, next tick].
+// A block lost in that window still pays its payee on-chain (the template
+// coinbase pays the wallet directly) — only the v37 ledger record is missing.
+//
+// THREADING: FoundBlockQueue is thread-safe (one mutex). EVERYTHING ELSE in
+// this header is main-thread only — XmrNode, MonerodAdapter/MainchainIndex,
+// XmrFinalizeDriver and OwedLedger are single-threaded (no locks).
+//
+// Header-only, STL + POSIX file I/O (for the fsync'd sidecar). Includes only
+// consumer-tree headers already pulled in by main_v37_xmr.cpp.
+// ===========================================================================
+#pragma once
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <sharechain/v37/v37_descriptor_xmr.hpp>   // make_xmr_std/make_xmr_sub, xmr_identity_key, xmr_ref_valid
+#include <sharechain/v37/v37_hash.hpp>             // ::v37::bytes32
+
+#include "impl/xmr/node/xmr_node_types.hpp"        // c2pool::xmr::node::Hash
+#include "xmr_node.hpp"                            // XmrNode, hex_of, Amounts (via xmr_settle_store.hpp)
+#include "xmr_node_config.hpp"                     // XmrNodeConfig, MoneroNetwork
+
+namespace c2pool::v37n::xmr::o2 {
+
+// ── hex helpers (the inverse of hex_of, xmr_node.hpp:64) ────────────────────
+inline int fc_hex_nibble(char c) noexcept {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+// 64 hex chars (either case) -> 32 bytes. Works for c2pool::xmr::node::Hash and
+// ::v37::bytes32 alike (both are std::array<std::uint8_t, 32>).
+inline bool hash_from_hex(std::string_view hex, std::array<std::uint8_t, 32>& out) noexcept {
+    if (hex.size() != 64) return false;
+    for (std::size_t i = 0; i < 32; ++i) {
+        const int hi = fc_hex_nibble(hex[2 * i]);
+        const int lo = fc_hex_nibble(hex[2 * i + 1]);
+        if (hi < 0 || lo < 0) return false;
+        out[i] = static_cast<std::uint8_t>((hi << 4) | lo);
+    }
+    return true;
+}
+
+inline std::string lower_hex(std::string_view s) {
+    std::string o(s);
+    for (char& c : o) if (c >= 'A' && c <= 'F') c = static_cast<char>(c - 'A' + 'a');
+    return o;
+}
+
+// ── payee identity: the address boundary's OUTPUT, never an address string ──
+// The stratum listener (wire 1) decodes the miner's login address into raw
+// keys; this turns them into the ledger key the FOUND/FINALIZE record is
+// keyed by (sharechain/v37/v37_descriptor_xmr.hpp make_xmr_std :243 /
+// make_xmr_sub :252 / identity_key :289-302). Returns nullopt when the ref does
+// not validate under the installed ed25519 point-check backend — a key that
+// xmr_ref_valid() rejects must never become a ledger key (fail-closed).
+struct PayeeKeys {
+    std::array<std::uint8_t, 32> spend{};   // B (XMR_STD) or D_i (XMR_SUB)
+    std::array<std::uint8_t, 32> view{};    // A (main view key)
+    bool subaddress = false;                // false = XMR_STD, true = XMR_SUB
+};
+
+inline std::optional<::v37::bytes32> payee_identity_key(const PayeeKeys& k) {
+    ::v37::ScriptRef ref = k.subaddress ? ::v37::xmr::make_xmr_sub(k.spend, k.view)
+                                        : ::v37::xmr::make_xmr_std(k.spend, k.view);
+    if (!::v37::xmr::xmr_ref_valid(ref)) return std::nullopt;
+    return ::v37::xmr::xmr_identity_key(ref);
+}
+
+// ── the FOUND record crossing listener thread -> main thread ────────────────
+struct FoundBlockEvent {
+    std::uint64_t height = 0;             // H_b — the block's OWN height (template height); never 0
+    std::string   block_id_hex;           // monerod's block hash (submit_block result.block_id),
+                                          // 64 hex — REQUIRED: is_canonical (xmr_node.hpp:146-149)
+                                          // compares hex_of(index.by_height(H).id) == bid
+    std::string   prev_id_hex;            // template prev_hash (informational; cross-check only)
+    std::uint64_t reward_piconero = 0;    // get_block_template.expected_reward (or chain_main.reward)
+    std::optional<::v37::bytes32> payee;  // identity_key of the payout descriptor (payee_identity_key)
+    std::uint32_t template_id = 0;        // stratum bookkeeping (logged only)
+    std::uint32_t nonce = 0;
+    std::uint32_t extra_nonce = 0;
+    std::string   worker;                 // from the login string (logged only)
+    std::string   address;                // raw base58 (logged only — never a ledger key)
+    std::uint64_t found_unix_s = 0;       // 0 = stamp at push()
+};
+
+class FoundBlockQueue {
+public:
+    // Listener thread. Never blocks on anything but the mutex.
+    void push(FoundBlockEvent e) {
+        if (e.found_unix_s == 0)
+            e.found_unix_s = static_cast<std::uint64_t>(
+                std::chrono::duration_cast<std::chrono::seconds>(
+                    std::chrono::system_clock::now().time_since_epoch()).count());
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_q.push_back(std::move(e));
+        ++m_pushed;
+    }
+    // Main thread. Appends everything queued so far to `out`; returns the count.
+    std::size_t drain(std::vector<FoundBlockEvent>& out) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        const std::size_t n = m_q.size();
+        for (auto& e : m_q) out.push_back(std::move(e));
+        m_q.clear();
+        return n;
+    }
+    std::size_t size() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_q.size();
+    }
+    std::uint64_t pushed_total() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_pushed;
+    }
+private:
+    mutable std::mutex          m_mtx;
+    std::deque<FoundBlockEvent> m_q;
+    std::uint64_t               m_pushed = 0;
+};
+
+// ── options ─────────────────────────────────────────────────────────────────
+struct FinalizeConnectOptions {
+    // Pending-FOUND sidecar file. Empty = disabled (restart inside the D_conf
+    // window then loses the pending FOUND — the D10 defect). Recommended:
+    //   cfg.resolved_settle_db_path() + "/pfound.tsv"   (next to settle.img)
+    std::string sidecar_path;
+    bool        echo_node_log = true;   // print construction_log() deltas each tick (O-3)
+    bool        progress      = true;   // print burial progress whenever hw advances
+    std::FILE*  out           = stdout; // nullptr = silent (the self-check uses this)
+    std::string tag           = "[v37-xmr-fc]";
+};
+
+// ── the glue ────────────────────────────────────────────────────────────────
+class FinalizeConnect {
+public:
+    struct PendingRec {
+        std::uint64_t height = 0;
+        std::optional<::v37::bytes32> payee;
+        std::uint64_t reward = 0;
+        std::string   prev_id_hex;
+        std::uint64_t found_unix_s = 0;
+    };
+    struct RegisterResult {
+        bool        registered = false;
+        bool        duplicate  = false;   // already pending here (idempotent)
+        std::string reason;               // set when !registered
+    };
+    struct BootReport {
+        bool        sidecar_present = false;
+        std::size_t reseeded      = 0;   // ledger-pending bids re-driven into the fresh driver
+        std::size_t reregistered  = 0;   // sidecar without a FOUND event (crash in the window) -> registered now
+        std::size_t stale_dropped = 0;   // already SETTLED / already stepped past
+        std::size_t unrecoverable = 0;   // ledger-pending but height <= cursor: will never be stepped
+        std::size_t malformed     = 0;
+    };
+    struct TickReport {
+        std::size_t drained = 0, registered = 0, refused = 0, settled = 0, orphaned = 0;
+    };
+    struct Stats {
+        std::uint64_t registered = 0, refused = 0, late_refused = 0, settled = 0,
+                      orphaned = 0, sidecar_write_failures = 0;
+    };
+
+    // Construct AFTER node.bring_up() (the finalize driver exists) and AFTER
+    // main has printed construction_log() — the echo cursor starts at "now" so
+    // nothing is printed twice.
+    FinalizeConnect(XmrNode& node, const XmrNodeConfig& cfg, FoundBlockQueue& queue,
+                    FinalizeConnectOptions opts = {})
+        : m_node(node), m_cfg(cfg), m_q(queue), m_o(std::move(opts)),
+          m_log_cursor(node.construction_log().size()) {}
+
+    FinalizeConnect(const FinalizeConnect&) = delete;
+    FinalizeConnect& operator=(const FinalizeConnect&) = delete;
+
+    // ── boot: re-drive the sidecar's pending FOUNDs into the fresh driver.
+    //    Call BEFORE the stratum listener starts and BEFORE the first pump_poll
+    //    (so the driver's maps are rebuilt before any Extend can step past H_b).
+    BootReport reseed_after_bring_up() {
+        BootReport rep;
+        if (m_o.sidecar_path.empty()) return rep;
+
+        std::ifstream in(m_o.sidecar_path);
+        if (!in) {
+            say("boot: no pending-FOUND sidecar at " + m_o.sidecar_path + " (fresh)");
+            return rep;
+        }
+        rep.sidecar_present = true;
+
+        const std::uint64_t cursor = m_node.finalize_driver().cursor_height();
+        std::vector<std::pair<std::string, PendingRec>> recs;
+        std::string line;
+        while (std::getline(in, line)) {
+            if (line.empty()) continue;
+            std::string bid; PendingRec rec;
+            if (!parse_sidecar_line(line, bid, rec)) {
+                ++rep.malformed;
+                say("boot: MALFORMED sidecar line dropped: " + line);
+                continue;
+            }
+            recs.emplace_back(std::move(bid), std::move(rec));
+        }
+
+        for (auto& [bid, rec] : recs) {
+            c2pool::xmr::node::Hash id{};
+            (void)hash_from_hex(bid, id);   // validated by parse_sidecar_line
+            if (m_node.ledger().is_settled(bid)) {
+                ++rep.stale_dropped;
+                say("boot: dropped stale sidecar " + short_bid(bid) + " (already SETTLED)");
+                continue;
+            }
+            const bool pending = m_node.ledger().is_pending(bid);
+            if (rec.height <= cursor) {
+                if (pending) {
+                    // The driver's cursor is past H_b: advance_to_tip will never
+                    // step it. Keep it in the sidecar so this warning repeats at
+                    // every boot until an operator disposes of it.
+                    ++rep.unrecoverable;
+                    m_unrecoverable[bid] = rec;
+                    say("boot: UNRECOVERABLE PENDING " + bid + " h=" + std::to_string(rec.height) +
+                        " — the finalize cursor (" + std::to_string(cursor) + ") is already past its "
+                        "height (store written by a run without the sidecar?); it will never be "
+                        "stepped at maturity and its payout stays deducted from effective_owed: "
+                        "operator must dispose of it by hand");
+                } else {
+                    ++rep.stale_dropped;
+                    say("boot: dropped stale sidecar " + short_bid(bid) + " (not pending, cursor past h=" +
+                        std::to_string(rec.height) + ")");
+                }
+                continue;
+            }
+            // Re-drive through the one seam. `pending` == true: the ledger already
+            // holds it (RecoveryDriver replayed the FOUND) -> ledger no-op, driver
+            // maps rebuilt, one duplicate FOUND event (idempotent on replay).
+            // `pending` == false: the sidecar was written but the crash hit before
+            // the FOUND write-ahead -> this IS the registration (monerod had
+            // accepted the block before the sidecar was written).
+            Amounts credit = amounts_from(rec.payee, rec.reward, nullptr);
+            Amounts payout = credit;
+            const bool ok = m_node.on_network_block_won(rec.height, id, credit, payout);
+            if (!ok || !m_node.ledger().is_pending(bid)) {
+                ++rep.stale_dropped;
+                say("boot: sidecar " + short_bid(bid) + " not admitted by the node/ledger; dropped");
+                continue;
+            }
+            m_pending[bid] = rec;
+            if (pending) ++rep.reseeded; else ++rep.reregistered;
+            say(std::string("boot: ") + (pending ? "re-drove pending FOUND " : "RE-REGISTERED lost FOUND ") +
+                short_bid(bid) + " h=" + std::to_string(rec.height) +
+                " (finalizes when hw >= " + std::to_string(rec.height + m_cfg.d_conf) + ")");
+        }
+        (void)sidecar_flush();
+        echo_node_log();
+        return rep;
+    }
+
+    // ── the main-loop tick. Call it right BEFORE transport.pump_poll() so a win
+    //    queued during the sleep is registered before the tip can advance past
+    //    it (the late-FOUND guard below is the backstop, not the plan).
+    TickReport tick() {
+        TickReport t;
+        echo_node_log();                       // finalize: / win: lines since the last tick
+
+        std::vector<FoundBlockEvent> evs;
+        t.drained = m_q.drain(evs);
+        for (const auto& ev : evs) {
+            RegisterResult r = register_found(ev);
+            if (r.registered && !r.duplicate) ++t.registered;
+            else if (!r.registered)            ++t.refused;
+        }
+        reconcile(t);
+        echo_node_log();                       // the node's own "win: FOUND ..." lines
+        progress();
+        return t;
+    }
+
+    // ── shutdown: one last drain so a win that landed after the final tick has
+    //    its FOUND written before node.stop(). Order: listener.stop() ->
+    //    fc.drain_before_stop() -> node.stop().
+    TickReport drain_before_stop() { return tick(); }
+
+    // ── the FOUND path (also usable directly on the main thread, e.g. by a
+    //    --replay-found operator tool). Idempotent per bid. Never throws.
+    RegisterResult register_found(const FoundBlockEvent& ev) {
+        RegisterResult r;
+        const std::string bid = lower_hex(ev.block_id_hex);
+        c2pool::xmr::node::Hash id{};
+        if (!hash_from_hex(bid, id)) {
+            return refuse(r, bid, "malformed block id (need monerod's 64-hex block hash — "
+                                  "submit_block result.block_id)");
+        }
+        if (c2pool::xmr::node::is_zero(id))
+            return refuse(r, bid, "block id UNKNOWN (all-zero): is_canonical could never match it — "
+                                  "the submitter must supply monerod's block_id (or the local keccak / "
+                                  "get_block_header_by_height cross-check)");
+        if (ev.height == 0)
+            return refuse(r, bid, "refusing H_b == 0 (unknown height is not a height)");
+        if (m_pending.count(bid)) { r.registered = true; r.duplicate = true; return r; }
+        if (m_node.ledger().is_settled(bid))
+            return refuse(r, bid, "already SETTLED");
+        if (m_cfg.network == MoneroNetwork::Mainnet && !m_cfg.i_understand_mainnet)
+            return refuse(r, bid, "MAINNET block without --i-understand-mainnet (prototype fence)");
+
+        // LATE-FOUND guard: advance_to_tip steps only heights > cursor.
+        const std::uint64_t cursor = m_node.finalize_driver().cursor_height();
+        if (ev.height <= cursor) {
+            ++m_stats.late_refused;
+            return refuse(r, bid, "LATE FOUND: finalize cursor (" + std::to_string(cursor) +
+                                  ") is already past h=" + std::to_string(ev.height) +
+                                  " — the driver would never step it (pending forever); "
+                                  "drain the found queue BEFORE pump_poll / lower --poll-ms");
+        }
+
+        std::string why_valueless;
+        Amounts credit = amounts_from(ev.payee, ev.reward_piconero, &why_valueless);
+        Amounts payout = credit;
+
+        PendingRec rec;
+        rec.height = ev.height;
+        rec.payee = ev.payee;
+        rec.reward = ev.reward_piconero;
+        rec.prev_id_hex = lower_hex(ev.prev_id_hex);
+        rec.found_unix_s = ev.found_unix_s;
+
+        // write-ahead the sidecar, then the FOUND event (inside on_network_block_won)
+        m_pending[bid] = rec;
+        if (!sidecar_flush()) {
+            // The block is ALREADY on the chain (monerod accepted it): losing the
+            // FOUND registration is strictly worse than losing restart-hardening.
+            ++m_stats.sidecar_write_failures;
+            say("WARN: pending-FOUND sidecar write FAILED for " + short_bid(bid) +
+                " (" + std::string(std::strerror(errno)) + "); registering anyway — a restart "
+                "inside the D_conf window will lose this pending FOUND");
+        }
+        const bool ok = m_node.on_network_block_won(ev.height, id, credit, payout);
+        if (!ok) {
+            m_pending.erase(bid);
+            (void)sidecar_flush();
+            return refuse(r, bid, "node refused the win (mainnet fence)");
+        }
+        if (!m_node.ledger().is_pending(bid)) {
+            m_pending.erase(bid);
+            (void)sidecar_flush();
+            return refuse(r, bid, "ledger did not admit the FOUND (bid already known?)");
+        }
+        ++m_stats.registered;
+        say("FOUND registered " + short_bid(bid) + " h=" + std::to_string(ev.height) +
+            " reward=" + std::to_string(ev.reward_piconero) + " piconero payee=" +
+            (ev.payee ? hex_of(*ev.payee).substr(0, 12) + "…" : std::string("-")) +
+            (why_valueless.empty() ? "" : " [VALUELESS record: " + why_valueless + "]") +
+            (ev.worker.empty() ? "" : " worker=" + ev.worker) +
+            " tid=" + std::to_string(ev.template_id) + " nonce=" + std::to_string(ev.nonce) +
+            " -> finalizes when hw >= " + std::to_string(ev.height + m_cfg.d_conf) +
+            " (D_conf=" + std::to_string(m_cfg.d_conf) + ")");
+        r.registered = true;
+        return r;
+    }
+
+    // credit == payout == { payee : reward } (amount-honest, nets to 0 at
+    // FINALIZE); {} when no payee / zero reward (the degenerate valueless record).
+    static Amounts amounts_from(const std::optional<::v37::bytes32>& payee, std::uint64_t reward,
+                                std::string* why_valueless) {
+        Amounts a;
+        auto because = [&](const char* s) { if (why_valueless) *why_valueless = s; };
+        if (!payee)   { because("no payee identity key (address boundary not decoded)"); return a; }
+        if (reward == 0) { because("zero reward"); return a; }
+        if (reward > static_cast<std::uint64_t>(LLONG_MAX)) { because("reward exceeds long long"); return a; }
+        a[*payee] = static_cast<long long>(reward);
+        return a;
+    }
+
+    // ── read seams (main thread) ────────────────────────────────────────────
+    const std::map<std::string, PendingRec>& pending()       const { return m_pending; }
+    const std::map<std::string, PendingRec>& unrecoverable() const { return m_unrecoverable; }
+    const Stats& stats() const { return m_stats; }
+
+private:
+    RegisterResult& refuse(RegisterResult& r, const std::string& bid, std::string reason) {
+        ++m_stats.refused;
+        r.registered = false;
+        r.reason = std::move(reason);
+        say("REFUSED win " + short_bid(bid) + ": " + r.reason);
+        return r;
+    }
+
+    // Retire every pending bid the ledger no longer holds pending: SETTLED (the
+    // driver finalized it at bin_height = H_b + D_conf) or gone (orphaned —
+    // an Orphan event, or the canonical predicate at maturity).
+    void reconcile(TickReport& t) {
+        bool changed = false;
+        for (auto it = m_pending.begin(); it != m_pending.end();) {
+            const std::string& bid = it->first;
+            const PendingRec&  rec = it->second;
+            if (m_node.ledger().is_settled(bid)) {
+                ++t.settled; ++m_stats.settled;
+                say("FINALIZED " + short_bid(bid) + " h=" + std::to_string(rec.height) +
+                    " SETTLED at bin_height=" + std::to_string(rec.height + m_cfg.d_conf) +
+                    (rec.payee ? " effective_owed(payee)=" +
+                                 std::to_string(m_node.ledger().effective_owed(*rec.payee))
+                               : std::string("")) +
+                    " ledger_seq=" + std::to_string(m_node.ledger().ledger_seq()));
+                it = m_pending.erase(it); changed = true;
+            } else if (!m_node.ledger().is_pending(bid)) {
+                ++t.orphaned; ++m_stats.orphaned;
+                say("ORPHANED " + short_bid(bid) + " h=" + std::to_string(rec.height) +
+                    " left the pending set (pre-SETTLED removal, O3.5)");
+                it = m_pending.erase(it); changed = true;
+            } else {
+                ++it;
+            }
+        }
+        // an unrecoverable bid the ledger finally dropped (operator disposed of it)
+        for (auto it = m_unrecoverable.begin(); it != m_unrecoverable.end();) {
+            if (!m_node.ledger().is_pending(it->first)) { it = m_unrecoverable.erase(it); changed = true; }
+            else ++it;
+        }
+        if (changed) (void)sidecar_flush();
+    }
+
+    void progress() {
+        if (!m_o.progress || m_pending.empty()) return;
+        const std::uint64_t hw = m_node.hw().hw_height;
+        if (hw == m_last_hw_printed) return;
+        m_last_hw_printed = hw;
+        for (const auto& [bid, rec] : m_pending) {
+            const std::uint64_t need = rec.height + m_cfg.d_conf;
+            const std::uint64_t left = need > hw ? need - hw : 0;
+            say("pending " + short_bid(bid) + " h=" + std::to_string(rec.height) + " hw=" +
+                std::to_string(hw) + " — finalizes at hw>=" + std::to_string(need) + " (" +
+                std::to_string(left) + " to go)");
+        }
+    }
+
+    void echo_node_log() {
+        if (!m_o.echo_node_log) return;
+        const auto& L = m_node.construction_log();
+        for (; m_log_cursor < L.size(); ++m_log_cursor) say("node: " + L[m_log_cursor]);
+    }
+
+    void say(const std::string& s) const {
+        if (!m_o.out) return;
+        std::fprintf(m_o.out, "%s %s\n", m_o.tag.c_str(), s.c_str());
+        std::fflush(m_o.out);
+    }
+    static std::string short_bid(const std::string& bid) {
+        return bid.size() > 12 ? bid.substr(0, 12) + "…" : bid;
+    }
+
+    // ── sidecar codec: one record per line, space-separated, no escaping needed
+    //    (bids/keys are hex; '-' = absent):
+    //    1 <bid64> <height> <payee64|-> <reward> <prev64|-> <found_unix_s>
+    static std::string sidecar_line(const std::string& bid, const PendingRec& r) {
+        std::string s = "1 " + bid + " " + std::to_string(r.height) + " " +
+                        (r.payee ? hex_of(*r.payee) : std::string("-")) + " " +
+                        std::to_string(r.reward) + " " +
+                        (r.prev_id_hex.size() == 64 ? r.prev_id_hex : std::string("-")) + " " +
+                        std::to_string(r.found_unix_s) + "\n";
+        return s;
+    }
+    static bool parse_sidecar_line(const std::string& line, std::string& bid, PendingRec& r) {
+        std::istringstream is(line);
+        std::string ver, payee, prev;
+        unsigned long long h = 0, reward = 0, ts = 0;
+        if (!(is >> ver >> bid >> h >> payee >> reward >> prev >> ts)) return false;
+        if (ver != "1") return false;
+        std::array<std::uint8_t, 32> tmp{};
+        bid = lower_hex(bid);
+        if (!hash_from_hex(bid, tmp)) return false;
+        if (c2pool::xmr::node::is_zero(tmp)) return false;   // a zero bid can never finalize
+        if (h == 0) return false;
+        r.height = h;
+        r.reward = reward;
+        r.found_unix_s = ts;
+        if (payee != "-") {
+            ::v37::bytes32 k{};
+            if (!hash_from_hex(lower_hex(payee), k)) return false;
+            r.payee = k;
+        }
+        if (prev != "-") {
+            prev = lower_hex(prev);
+            if (!hash_from_hex(prev, tmp)) return false;
+            r.prev_id_hex = prev;
+        }
+        return true;
+    }
+
+    bool sidecar_flush() {
+        if (m_o.sidecar_path.empty()) return true;
+        std::string body;
+        for (const auto& [bid, rec] : m_pending)       body += sidecar_line(bid, rec);
+        for (const auto& [bid, rec] : m_unrecoverable) body += sidecar_line(bid, rec);
+        return atomic_write(m_o.sidecar_path, body);
+    }
+
+    // tmp -> fsync -> rename -> fsync(dir): the file is either the old or the new
+    // whole image, never a torn one.
+    static bool atomic_write(const std::string& path, const std::string& body) {
+        const std::string tmp = path + ".tmp";
+        int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+        if (fd < 0) return false;
+        std::size_t off = 0;
+        while (off < body.size()) {
+            const ssize_t n = ::write(fd, body.data() + off, body.size() - off);
+            if (n < 0) { if (errno == EINTR) continue; ::close(fd); return false; }
+            if (n == 0) { ::close(fd); return false; }
+            off += static_cast<std::size_t>(n);
+        }
+        if (::fsync(fd) != 0) { ::close(fd); return false; }
+        ::close(fd);
+        if (::rename(tmp.c_str(), path.c_str()) != 0) return false;
+        const std::string dir = std::filesystem::path(path).parent_path().string();
+        int dfd = ::open(dir.empty() ? "." : dir.c_str(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+        if (dfd >= 0) { (void)::fsync(dfd); ::close(dfd); }
+        return true;
+    }
+
+    XmrNode&               m_node;
+    const XmrNodeConfig&   m_cfg;
+    FoundBlockQueue&       m_q;
+    FinalizeConnectOptions m_o;
+
+    std::map<std::string, PendingRec> m_pending;        // bid -> rec, mirrors the sidecar
+    std::map<std::string, PendingRec> m_unrecoverable;  // kept in the sidecar so the boot warning repeats
+    Stats         m_stats;
+    std::size_t   m_log_cursor = 0;
+    std::uint64_t m_last_hw_printed = ~std::uint64_t{0};
+};
+
+} // namespace c2pool::v37n::xmr::o2
+
+// ===========================================================================
+// SELF-CHECK — network-free, RandomX-free, against the monerod STUB; the same
+// shape as xmr_node_smoke.hpp so it can run under `--mock-smoke` / the CI
+// smoke target. Proves: queued win -> FOUND (amount-honest) -> restart inside
+// the D_conf window -> sidecar re-drive -> FINALIZE at bin_height = H_b+D_conf
+// -> finalW nets to 0 -> sidecar retired; plus the late-FOUND and malformed
+// refusals, the valueless record, idempotence, and the orphan disposition.
+// ===========================================================================
+#include "xmr_node_smoke.hpp"   // smoke::Report, apply_row, blk_id, key_of, test_point_check
+#include "impl/xmr/node/monerod_transport.hpp"   // MockMonerodTransport
+
+namespace c2pool::v37n::xmr::o2 {
+
+inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp_root) {
+    using c2pool::xmr::node::MockMonerodTransport;
+    smoke::Report rep;
+    const ::v37::ChainId CHAIN = 7;
+    const std::uint64_t  D_CONF = 3;
+    const std::uint64_t  REWARD = 600000000000ull;   // 0.6 XMR in piconero
+
+    XmrNodeConfig cfg;
+    cfg.network = MoneroNetwork::Stagenet;
+    cfg.lane_chain = CHAIN;
+    cfg.d_conf = D_CONF;
+    cfg.settle_db_path = (tmp_root / "store").string();
+    std::filesystem::create_directories(cfg.settle_db_path);
+
+    FinalizeConnectOptions o;
+    o.sidecar_path = (std::filesystem::path(cfg.settle_db_path) / "pfound.tsv").string();
+    o.out = nullptr;   // silent
+
+    const ::v37::bytes32 payee = smoke::key_of(0xC3);
+    const std::string bid5 = hex_of(smoke::blk_id(5));
+    const std::string bid8 = hex_of(smoke::blk_id(8));
+    const std::string bid11 = hex_of(smoke::blk_id(11));
+    FoundBlockQueue q;
+
+    auto count_lines = [&](const std::string& p) {
+        std::ifstream f(p); std::string l; std::size_t n = 0;
+        while (std::getline(f, l)) if (!l.empty()) ++n;
+        return n;
+    };
+    auto chain = [&](XmrNode& node, std::uint64_t from, std::uint64_t to) {
+        for (std::uint64_t h = from; h <= to; ++h)
+            smoke::apply_row(node, h, smoke::blk_id(static_cast<std::uint8_t>(h)),
+                             smoke::blk_id(static_cast<std::uint8_t>(h - 1)));
+    };
+
+    // ── phase 1: node A — win at 5, buried 2 (< D_conf), then "crash" ────────
+    {
+        MockMonerodTransport mock;
+        XmrNode node(cfg, mock, &smoke::test_point_check);
+        try { node.bring_up(); } catch (const std::exception& e) {
+            rep.add("FC0 bring_up (node A)", false, e.what()); return rep;
+        }
+        chain(node, 1, 5);
+        FinalizeConnect fc(node, cfg, q, o);
+        auto boot = fc.reseed_after_bring_up();
+        rep.add("FC1 fresh boot: no sidecar, nothing reseeded",
+                !boot.sidecar_present && boot.reseeded == 0 && boot.reregistered == 0);
+
+        FoundBlockEvent ev;
+        ev.height = 5; ev.block_id_hex = bid5; ev.prev_id_hex = hex_of(smoke::blk_id(4));
+        ev.reward_piconero = REWARD; ev.payee = payee; ev.worker = "rig0"; ev.template_id = 42;
+        q.push(ev); q.push(ev);                       // duplicate push (idempotent per bid)
+        auto t = fc.tick();
+        rep.add("FC2 queued win -> on_network_block_won: ledger pending, idempotent per bid",
+                t.drained == 2 && t.registered == 1 && t.refused == 0 &&
+                fc.pending().size() == 1 && node.ledger().is_pending(bid5),
+                "drained=" + std::to_string(t.drained) + " registered=" + std::to_string(t.registered));
+        rep.add("FC3 amount-honest: effective_owed(payee) == -reward while pending",
+                node.ledger().effective_owed(payee) == -static_cast<long long>(REWARD));
+        rep.add("FC4 pending-FOUND sidecar written (write-ahead, 1 record)",
+                count_lines(o.sidecar_path) == 1);
+
+        chain(node, 6, 7);                            // hw=7 < 5+3
+        t = fc.tick();
+        rep.add("FC5 not yet buried D_conf (hw=7 < 8): still pending, no finalize",
+                t.settled == 0 && t.orphaned == 0 && fc.pending().size() == 1 &&
+                node.ledger().is_pending(bid5),
+                "cursor=" + std::to_string(node.finalize_driver().cursor_height()));
+
+        // late FOUND: cursor is 7-3=4, a win claimed at h=3 can never be stepped
+        FoundBlockEvent late = ev; late.height = 3; late.block_id_hex = hex_of(smoke::blk_id(3));
+        q.push(late);
+        t = fc.tick();
+        rep.add("FC6 late FOUND (height <= finalize cursor) refused, not poisoned into the ledger",
+                t.refused == 1 && fc.stats().late_refused == 1 &&
+                !node.ledger().is_pending(hex_of(smoke::blk_id(3))));
+
+        FoundBlockEvent bad = ev; bad.block_id_hex = "not-a-block-id";
+        q.push(bad);
+        t = fc.tick();
+        rep.add("FC7 malformed block id refused", t.refused == 1 && fc.pending().size() == 1);
+
+        FoundBlockEvent zero = ev; zero.block_id_hex = std::string(64, '0');
+        q.push(zero);
+        t = fc.tick();
+        rep.add("FC7b all-zero (unknown) block id refused — never a FOUND that cannot be canonical",
+                t.refused == 1 && fc.pending().size() == 1 &&
+                !node.ledger().is_pending(std::string(64, '0')));
+        // node A is destroyed here: a restart inside the D_conf window
+    }
+
+    // ── phase 2: node B on the same store — reseed, bury, FINALIZE ───────────
+    {
+        MockMonerodTransport mock;
+        XmrNode node(cfg, mock, &smoke::test_point_check);
+        try { node.bring_up(); } catch (const std::exception& e) {
+            rep.add("FC0 bring_up (node B)", false, e.what()); return rep;
+        }
+        const bool recovered_pending = node.ledger().is_pending(bid5);
+        FinalizeConnect fc(node, cfg, q, o);
+        auto boot = fc.reseed_after_bring_up();
+        rep.add("FC8 restart: sidecar re-drives the pending FOUND into the fresh driver",
+                recovered_pending && boot.sidecar_present && boot.reseeded == 1 &&
+                boot.reregistered == 0 && boot.unrecoverable == 0 && fc.pending().size() == 1,
+                "reseeded=" + std::to_string(boot.reseeded) + " unrec=" + std::to_string(boot.unrecoverable) +
+                " cursor=" + std::to_string(node.finalize_driver().cursor_height()));
+        const auto seq_before = node.ledger().ledger_seq();
+        rep.add("FC8b re-drive left the ledger untouched (ledger_seq unchanged, still pending)",
+                node.ledger().ledger_seq() == seq_before && node.ledger().is_pending(bid5));
+
+        chain(node, 5, 8);                            // index rebuilt from 5; hw -> 8 = 5+3
+        auto t = fc.tick();
+        rep.add("FC9 FOUND -> FINALIZE at D_conf burial after restart (bin_height = 5+3 = 8)",
+                t.settled == 1 && node.ledger().is_settled(bid5) && fc.pending().empty(),
+                "settled=" + std::to_string(t.settled));
+        rep.add("FC10 finalW nets to 0 for the payee (credit == payout)",
+                node.ledger().effective_owed(payee) == 0);
+        rep.add("FC11 sidecar retired after FINALIZE", count_lines(o.sidecar_path) == 0);
+        bool logged = false;
+        for (const auto& l : node.construction_log())
+            if (l.find("SETTLED at bin_height=8") != std::string::npos) logged = true;
+        rep.add("FC12 the node logged the FINALIZE step with the per-height bin_height (echoed by tick)", logged);
+
+        // valueless win (no payee decoded) still records the block
+        FoundBlockEvent v; v.height = 8; v.block_id_hex = bid8;
+        q.push(v);
+        t = fc.tick();
+        rep.add("FC13 valueless win (no payee) still registers (degenerate {}/{})",
+                t.registered == 1 && node.ledger().is_pending(bid8));
+        chain(node, 9, 11);
+        t = fc.tick();
+        rep.add("FC14 valueless win finalizes at 8+3=11", t.settled == 1 && node.ledger().is_settled(bid8));
+
+        // orphan disposition: win at 11, then a competing 11 wins the chain
+        FoundBlockEvent w; w.height = 11; w.block_id_hex = bid11; w.payee = payee; w.reward_piconero = REWARD;
+        q.push(w);
+        t = fc.tick();
+        const bool reg11 = t.registered == 1 && node.ledger().is_pending(bid11);
+        smoke::apply_row(node, 11, smoke::blk_id(99), smoke::blk_id(10));   // reorg at 11
+        chain(node, 12, 14);                          // bury the competitor: 11+3 = 14
+        t = fc.tick();
+        // the Orphan event or the canonical predicate at maturity disposed it
+        rep.add("FC15 orphaned win leaves the pending set (never SETTLED) and the sidecar",
+                reg11 && !node.ledger().is_pending(bid11) && !node.ledger().is_settled(bid11) &&
+                fc.pending().empty() && count_lines(o.sidecar_path) == 0 && fc.stats().orphaned == 1,
+                "orphaned=" + std::to_string(fc.stats().orphaned));
+        rep.add("FC16 orphan: payee's effective_owed back to 0 (pure pending removal)",
+                node.ledger().effective_owed(payee) == 0);
+        (void)fc.drain_before_stop();
+    }
+    return rep;
+}
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_o2_randomx_verify.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_randomx_verify.hpp
@@ -1,0 +1,477 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_o2_randomx_verify.hpp   (Track A2 / X9 O-2, piece 2)
+//
+// RUNTIME RandomX verify for the c2pool-v37-xmr daemon: the IPowVerifier seam
+// of the X5 stratum server (impl/xmr/stratum/xmr_stratum.hpp) implemented over
+// the production light-mode verifier (impl/xmr/pow/randomx_verify.hpp,
+// librandomx). X8 (#1512) proved that verifier against a REAL mainnet block in
+// CI; this component puts the same call sequence — init -> prefetch_epoch ->
+// hash()/verify() — on the daemon's LIVE submit path so that every share a
+// miner submits is re-hashed here, and a share is promoted to a network block
+// only under Monero's EXACT acceptance rule (hash * difficulty < 2^256).
+//
+// What it fixes versus the two earlier IPowVerifier adapters in the tree:
+//   * mbp_wiring.hpp LivePowVerifier never prefetches a seed, so every call
+//     returns SeedNotResident ("Couldn't check PoW"). Here the seeds of the
+//     current template (seed_hash + next_seed_hash) are prefetched by the
+//     new-template hook, OFF the submit path (invariant I2 of randomx_verify).
+//   * both adapters decide the NETWORK block with the top-64-bit-word <= target
+//     approximation. That test is a strict SUPERSET of Monero's rule (it can
+//     accept a boundary hash monerod rejects), so it is fine as the stratum
+//     server's cheap gate but must not be what triggers submit_block. This
+//     component exposes verify_network_block(), the exact 128-bit rule via
+//     c2pool::xmr::meets_difficulty_128 on the template's
+//     difficulty / difficulty_top64, for the share sink to call before it
+//     patches the nonce and submits.
+//
+// FAIL-CLOSED. When RandomX is compiled out (V37_XMR_O2_WITH_RANDOMX not
+// defined), disabled (cfg.randomx_enabled == false), or failed to initialise,
+// randomx_hash() returns false (=> SubmitError::CouldNotCheck for every share)
+// and verify_network_block() returns VerifyUnavailable, so no unverified block
+// can ever be submitted (xmr_node_config.hpp: "no unverified block is ever
+// submitted"). The daemon may still run observe-side in that state.
+//
+// THREADING (O-2 assembly contract, survey §E). LightVerifier is NOT
+// thread-safe, so this object is owned by the stratum LISTENER thread: init(),
+// drain_pending()/ensure_seeds(), randomx_hash(), verify_network_block() are
+// listener-thread calls. The ONLY cross-thread entry is post_seeds() — the main
+// thread's template refresher hands over the new template's seed pair through a
+// mutex-guarded mailbox, and the listener applies it (Argon2d cache init,
+// seconds on an epoch change, no-op otherwise) when it wakes for the
+// "template changed" signal, BEFORE it broadcast_job()s. Counters are atomics
+// so the main loop can print them (O-3 observability).
+//
+// CONSUMER-TREE ONLY: no consensus digest; calls the merged pow/ + stratum/
+// seams exactly as their headers document. Header-only, no new CMake target of
+// its own — the assemble step links `randomx` into c2pool-v37-xmr and defines
+// V37_XMR_O2_WITH_RANDOMX (see the O-2 integration notes).
+// ===========================================================================
+#pragma once
+
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/stratum/xmr_stratum.hpp"
+
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+#include "impl/xmr/pow/randomx_verify.hpp"   // LightVerifier, meets_difficulty_128
+#endif
+
+namespace c2pool::v37n::xmr::o2 {
+
+namespace strat = ::v37::xmr::stratum;
+
+// 32-byte RandomX seed (a Monero block id) / 32-byte PoW hash. Same shape as
+// strat::TemplateJob::seed_hash and c2pool::xmr::SeedHash (std::array<u8,32>),
+// so the stratum job's seed is passed through without conversion.
+using Seed32 = std::array<std::uint8_t, strat::HASH_SIZE>;
+using Hash32 = std::array<std::uint8_t, strat::HASH_SIZE>;
+
+// ---------------------------------------------------------------------------
+// Policy — the daemon's RandomX knobs (xmr_node_config.hpp:103-109 +
+// --randomx in main_v37_xmr.cpp). from_config() is a template so this header
+// stays free of the config/sharechain includes (any struct with the two
+// fields works, e.g. XmrNodeConfig).
+// ---------------------------------------------------------------------------
+struct RandomXPolicy {
+    bool enabled     = false;   // cfg.randomx_enabled   (--randomx)
+    bool large_pages = false;   // cfg.randomx_large_pages
+    bool secure_jit  = false;   // RANDOMX_FLAG_SECURE (W^X JIT pages); opt-in
+    // Invariant I2 of randomx_verify.hpp: never Argon2d-init a cache on the
+    // submit hot path. Default STRICT: a submit whose seed is not resident
+    // gets CouldNotCheck. Set true only for single-rig demos where a missed
+    // new-template hook is preferable to a rejected share (it then costs
+    // ~1-2 s once per epoch, on the listener thread, inside that submit).
+    bool lazy_prefetch_on_miss = false;
+
+    template <class Cfg>
+    static RandomXPolicy from_config(const Cfg& c) {
+        RandomXPolicy p;
+        p.enabled     = c.randomx_enabled;
+        p.large_pages = c.randomx_large_pages;
+        return p;
+    }
+};
+
+// Monero difficulty_type as returned by get_block_template / get_miner_data:
+// `difficulty` (low 64) and `difficulty_top64` (high 64). Regtest/stagenet
+// (and mainnet today) fit in `lo`; `hi` is carried so the rule stays exact.
+struct NetworkDifficulty {
+    std::uint64_t lo = 0;
+    std::uint64_t hi = 0;
+    bool is_zero() const noexcept { return lo == 0 && hi == 0; }
+};
+
+// Outcome of the exact network-block gate (verify_network_block).
+enum class NetworkVerdict : std::uint8_t {
+    Accept,             // re-hashed here; hash * difficulty < 2^256  -> submit it
+    BelowTarget,        // re-hashed here; does NOT meet the network difficulty
+    SeedNotResident,    // seed not prefetched (new-template hook missed)
+    VerifyUnavailable,  // RandomX compiled out / disabled / init failed (fail-closed)
+    Malformed,          // empty blob or zero difficulty — never a block
+};
+
+inline const char* to_string(NetworkVerdict v) noexcept {
+    switch (v) {
+        case NetworkVerdict::Accept:            return "Accept";
+        case NetworkVerdict::BelowTarget:       return "BelowTarget";
+        case NetworkVerdict::SeedNotResident:   return "SeedNotResident";
+        case NetworkVerdict::VerifyUnavailable: return "VerifyUnavailable";
+        case NetworkVerdict::Malformed:         return "Malformed";
+    }
+    return "?";
+}
+
+// Plain-value counters snapshot for the main loop's periodic status line.
+struct RandomXStats {
+    std::uint64_t hashes          = 0;  // randomx_hash() calls that produced a hash
+    std::uint64_t seed_misses     = 0;  // randomx_hash() refused: seed not resident
+    std::uint64_t unavailable     = 0;  // randomx_hash() refused: engine unavailable
+    std::uint64_t prefetches      = 0;  // ensure_seeds() calls that (re)keyed a cache
+    std::uint64_t network_accepts = 0;  // verify_network_block() -> Accept
+    std::uint64_t network_rejects = 0;  // verify_network_block() -> anything else
+    std::uint64_t memo_hits       = 0;  // network verify reused the submit's hash
+};
+
+// ---------------------------------------------------------------------------
+// O2RandomXVerifier — the runtime IPowVerifier + exact network gate.
+// ---------------------------------------------------------------------------
+class O2RandomXVerifier final : public strat::IPowVerifier {
+public:
+    enum class Mode : std::uint8_t {
+        CompiledOut,   // V37_XMR_O2_WITH_RANDOMX not defined (light build)
+        Disabled,      // policy.enabled == false (--randomx not given)
+        InitFailed,    // librandomx present but cache/VM alloc failed (OOM?)
+        Jit,           // ready: JIT-compiled light VM (fast path)
+        Interpreter,   // ready: portable interpreter (JIT refused, e.g. W^X)
+    };
+
+    static const char* to_string(Mode m) noexcept {
+        switch (m) {
+            case Mode::CompiledOut: return "compiled-out";
+            case Mode::Disabled:    return "disabled";
+            case Mode::InitFailed:  return "init-failed";
+            case Mode::Jit:         return "jit";
+            case Mode::Interpreter: return "interpreter";
+        }
+        return "?";
+    }
+
+    O2RandomXVerifier() = default;
+    O2RandomXVerifier(const O2RandomXVerifier&) = delete;
+    O2RandomXVerifier& operator=(const O2RandomXVerifier&) = delete;
+
+    // -----------------------------------------------------------------------
+    // init — allocate 2 x 256 MiB light caches + 1 light VM (never FULL_MEM).
+    // JIT first; if randomx_create_vm refuses JIT pages, retry with the
+    // portable interpreter (identical hashes; pattern of randomx_verify_kat
+    // suite C). Returns ready(). Call once, before the listener starts
+    // serving (from the listener thread, or from main BEFORE the listener
+    // thread is spawned — the object has no thread affinity, only a
+    // no-concurrent-use rule).
+    // -----------------------------------------------------------------------
+    bool init(const RandomXPolicy& policy) {
+        m_policy = policy;
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        if (!policy.enabled) { set_mode(Mode::Disabled); return false; }
+        ::c2pool::xmr::VerifierOptions opts;      // algo = RX_0 (RANDOMX_FLAG_V2 OFF)
+        opts.large_pages = policy.large_pages;
+        opts.secure_jit  = policy.secure_jit;
+        opts.use_jit     = true;
+        if (m_vm.init(opts)) { set_mode(Mode::Jit); return true; }
+        // init() is safe to re-run: a failed randomx_create_vm leaves vm_ null
+        // and the CacheSlots are move-reassigned (frees any cache already
+        // allocated) — see the KAT's suite-C comment.
+        opts.use_jit = false;
+        if (m_vm.init(opts)) { set_mode(Mode::Interpreter); return true; }
+        set_mode(Mode::InitFailed);
+        return false;
+#else
+        set_mode(Mode::CompiledOut);
+        return false;
+#endif
+    }
+
+    Mode mode() const noexcept { return static_cast<Mode>(m_mode.load(std::memory_order_acquire)); }
+    bool ready() const noexcept {
+        const Mode m = mode();
+        return m == Mode::Jit || m == Mode::Interpreter;
+    }
+    // The fail-closed switch the share sink must consult: a network block may
+    // be submitted only when this is true (and verify_network_block() said
+    // Accept for the exact bytes being submitted).
+    bool network_blocks_allowed() const noexcept { return ready(); }
+    const RandomXPolicy& policy() const noexcept { return m_policy; }
+
+    // -----------------------------------------------------------------------
+    // Seed handling (the LivePowVerifier defect fix).
+    //
+    // post_seeds   — ANY thread (the main loop's template refresher). Parks the
+    //                template's {seed_hash, next_seed_hash} in the mailbox.
+    // drain_pending — LISTENER thread. Applies a parked seed pair via
+    //                ensure_seeds(). Call it first thing when the listener
+    //                wakes for "template changed", before broadcast_job().
+    //                Returns true iff a pair was applied.
+    // ensure_seeds — LISTENER thread. prefetch_epoch(current, next): Argon2d
+    //                inits only the caches not already keyed (seconds on an
+    //                epoch change, no-op otherwise). Returns residency of
+    //                `current`.
+    // on_template  — convenience: ensure_seeds(job.seed_hash, job.next_seed_hash)
+    //                for any struct shaped like strat::TemplateJob.
+    // -----------------------------------------------------------------------
+    void post_seeds(const Seed32& current, const std::optional<Seed32>& next) {
+        std::lock_guard<std::mutex> lk(m_mail_mu);
+        m_mail_cur  = current;
+        m_mail_next = next;
+        m_mail_full = true;
+    }
+
+    bool drain_pending() {
+        Seed32 cur{};
+        std::optional<Seed32> next;
+        {
+            std::lock_guard<std::mutex> lk(m_mail_mu);
+            if (!m_mail_full) return false;
+            cur = m_mail_cur; next = m_mail_next;
+            m_mail_full = false;
+        }
+        ensure_seeds(cur, next);
+        return true;
+    }
+
+    bool ensure_seeds(const Seed32& current, const std::optional<Seed32>& next) {
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        if (!ready()) return false;
+        const bool cur_res  = m_vm.seed_resident(current);
+        const bool next_res = !next || m_vm.seed_resident(*next);
+        if (cur_res && next_res) return true;                    // nothing to do
+        if (!m_vm.prefetch_epoch(current, next)) return false;    // null cache (init not done)
+        m_stat_prefetches.fetch_add(1, std::memory_order_relaxed);
+        return m_vm.seed_resident(current);
+#else
+        (void)current; (void)next;
+        return false;
+#endif
+    }
+
+    template <class Job>
+    bool on_template(const Job& job) { return ensure_seeds(job.seed_hash, job.next_seed_hash); }
+
+    bool seed_resident(const Seed32& seed) const noexcept {
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        return ready() && m_vm.seed_resident(seed);
+#else
+        (void)seed;
+        return false;
+#endif
+    }
+
+    // -----------------------------------------------------------------------
+    // IPowVerifier — what XmrStratumServer::handle_submit calls
+    // (xmr_stratum.cpp:393 / :403 / :409). Listener thread.
+    // -----------------------------------------------------------------------
+
+    // Authoritative re-hash of the submitted share's blob (nonce already
+    // patched by the server). false => SubmitError::CouldNotCheck. Never
+    // trusts the client's `result`. Under invariant I2 a non-resident seed is
+    // a refusal, not a cache init — unless policy.lazy_prefetch_on_miss.
+    bool randomx_hash(const std::uint8_t* blob, std::size_t blob_size,
+                      std::uint64_t height,
+                      const Seed32& seed_hash,
+                      Hash32& out_hash,
+                      bool /*force_light: this verifier is light-only*/ = false) override {
+        (void)height;   // epoch selection is the template's seed_hash (monerod-supplied)
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        if (!ready() || !blob || blob_size == 0) {
+            m_stat_unavailable.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        if (!m_vm.seed_resident(seed_hash)) {
+            if (!m_policy.lazy_prefetch_on_miss ||
+                !m_vm.prefetch_epoch(seed_hash, std::nullopt) ||
+                !m_vm.seed_resident(seed_hash)) {
+                m_stat_seed_misses.fetch_add(1, std::memory_order_relaxed);
+                return false;
+            }
+            m_stat_prefetches.fetch_add(1, std::memory_order_relaxed);
+        }
+        if (!m_vm.hash(blob, blob_size, seed_hash, out_hash.data())) {
+            m_stat_seed_misses.fetch_add(1, std::memory_order_relaxed);
+            return false;
+        }
+        m_stat_hashes.fetch_add(1, std::memory_order_relaxed);
+        remember(blob, blob_size, seed_hash, out_hash);
+        return true;
+#else
+        (void)blob; (void)blob_size; (void)seed_hash; (void)out_hash;
+        m_stat_unavailable.fetch_add(1, std::memory_order_relaxed);
+        return false;
+#endif
+    }
+
+    // The u64-target test the seam documents (top 64-bit LE word <= target,
+    // target = 0xFFFF…/difficulty per xmr_stratum.cpp target_from_diff). It is
+    // exactly Monero's rule when the low 192 bits contribute no carry, and a
+    // SUPERSET of it otherwise — correct for the lane/share target, and safe
+    // as the server's cheap network pre-gate because it never misses a real
+    // block; the exact decision is verify_network_block() below.
+    bool meets_target(const Hash32& hash, std::uint64_t target) const override {
+        std::uint64_t top = 0;
+        for (int i = 0; i < 8; ++i)
+            top |= static_cast<std::uint64_t>(hash[strat::HASH_SIZE - 8 + i]) << (8 * i);
+        return top <= target;
+    }
+
+    // -----------------------------------------------------------------------
+    // EXACT network-block gate — for IShareSink::submit_network_block.
+    //
+    // `blob` = the hashing blob with the winning nonce patched (the same bytes
+    // the server just hashed); `seed` = the template's seed_hash; `diff` = the
+    // template's {difficulty, difficulty_top64}. Re-hashes (or reuses the
+    // byte-identical hash memoised by the preceding randomx_hash() call) and
+    // applies c2pool::xmr::meets_difficulty_128 — hash * difficulty < 2^256,
+    // the rule monerod's submit_block will apply. Only an Accept may lead to a
+    // submit_block; out_hash receives the PoW hash for logging.
+    // Listener thread.
+    // -----------------------------------------------------------------------
+    NetworkVerdict verify_network_block(const std::uint8_t* blob, std::size_t blob_size,
+                                        const Seed32& seed, NetworkDifficulty diff,
+                                        Hash32& out_hash) {
+        if (!blob || blob_size == 0 || diff.is_zero()) { count_reject(); return NetworkVerdict::Malformed; }
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        if (!ready()) { count_reject(); return NetworkVerdict::VerifyUnavailable; }
+        if (!m_vm.seed_resident(seed)) { count_reject(); return NetworkVerdict::SeedNotResident; }
+        if (recall(blob, blob_size, seed, out_hash)) {
+            m_stat_memo_hits.fetch_add(1, std::memory_order_relaxed);
+        } else if (!m_vm.hash(blob, blob_size, seed, out_hash.data())) {
+            count_reject(); return NetworkVerdict::SeedNotResident;
+        } else {
+            m_stat_hashes.fetch_add(1, std::memory_order_relaxed);
+            remember(blob, blob_size, seed, out_hash);
+        }
+        if (::c2pool::xmr::meets_difficulty_128(out_hash.data(), diff.lo, diff.hi)) {
+            m_stat_network_accepts.fetch_add(1, std::memory_order_relaxed);
+            return NetworkVerdict::Accept;
+        }
+        count_reject();
+        return NetworkVerdict::BelowTarget;
+#else
+        (void)seed; (void)out_hash;
+        count_reject();
+        return NetworkVerdict::VerifyUnavailable;
+#endif
+    }
+
+    // Exact rule on an already-computed hash (no residency needed). Fail-closed
+    // when RandomX is compiled out: without the engine nothing here has been
+    // verified, so nothing may be promoted.
+    static bool meets_network_difficulty(const Hash32& hash, NetworkDifficulty diff) noexcept {
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+        if (diff.is_zero()) return false;
+        return ::c2pool::xmr::meets_difficulty_128(hash.data(), diff.lo, diff.hi);
+#else
+        (void)hash; (void)diff;
+        return false;
+#endif
+    }
+
+    // -----------------------------------------------------------------------
+    // Observability (any thread).
+    // -----------------------------------------------------------------------
+    RandomXStats stats() const noexcept {
+        RandomXStats s;
+        s.hashes          = m_stat_hashes.load(std::memory_order_relaxed);
+        s.seed_misses     = m_stat_seed_misses.load(std::memory_order_relaxed);
+        s.unavailable     = m_stat_unavailable.load(std::memory_order_relaxed);
+        s.prefetches      = m_stat_prefetches.load(std::memory_order_relaxed);
+        s.network_accepts = m_stat_network_accepts.load(std::memory_order_relaxed);
+        s.network_rejects = m_stat_network_rejects.load(std::memory_order_relaxed);
+        s.memo_hits       = m_stat_memo_hits.load(std::memory_order_relaxed);
+        return s;
+    }
+
+    // One status line for stdout, e.g.
+    //   "randomx: mode=jit enabled=1 large_pages=0 hashes=17 seed_misses=0
+    //    unavailable=0 prefetches=1 net_accept=1 net_reject=0 memo_hits=1"
+    std::string describe() const {
+        const RandomXStats s = stats();
+        std::string o = "randomx: mode=";
+        o += to_string(mode());
+        o += " enabled=";     o += m_policy.enabled ? '1' : '0';
+        o += " large_pages="; o += m_policy.large_pages ? '1' : '0';
+        o += " lazy=";        o += m_policy.lazy_prefetch_on_miss ? '1' : '0';
+        o += " hashes=";      o += std::to_string(s.hashes);
+        o += " seed_misses="; o += std::to_string(s.seed_misses);
+        o += " unavailable="; o += std::to_string(s.unavailable);
+        o += " prefetches=";  o += std::to_string(s.prefetches);
+        o += " net_accept=";  o += std::to_string(s.network_accepts);
+        o += " net_reject=";  o += std::to_string(s.network_rejects);
+        o += " memo_hits=";   o += std::to_string(s.memo_hits);
+        return o;
+    }
+
+private:
+    void set_mode(Mode m) noexcept { m_mode.store(static_cast<std::uint8_t>(m), std::memory_order_release); }
+    void count_reject() noexcept { m_stat_network_rejects.fetch_add(1, std::memory_order_relaxed); }
+
+    // Single-entry memo of the last hash computed: handle_submit calls
+    // randomx_hash() and then, on the same thread, the sink calls
+    // verify_network_block() on the SAME bytes. Reuse only on byte-identical
+    // blob AND seed; anything else recomputes. Listener thread only.
+    void remember(const std::uint8_t* blob, std::size_t n, const Seed32& seed, const Hash32& hash) {
+        m_memo_blob.assign(blob, blob + n);
+        m_memo_seed  = seed;
+        m_memo_hash  = hash;
+        m_memo_valid = true;
+    }
+    bool recall(const std::uint8_t* blob, std::size_t n, const Seed32& seed, Hash32& hash) const {
+        if (!m_memo_valid || m_memo_blob.size() != n || m_memo_seed != seed) return false;
+        if (n && std::memcmp(m_memo_blob.data(), blob, n) != 0) return false;
+        hash = m_memo_hash;
+        return true;
+    }
+
+    RandomXPolicy              m_policy{};
+    std::atomic<std::uint8_t>  m_mode{static_cast<std::uint8_t>(Mode::CompiledOut)};
+
+#if defined(V37_XMR_O2_WITH_RANDOMX)
+    ::c2pool::xmr::LightVerifier m_vm;           // listener thread only
+#endif
+
+    // seed mailbox (main thread -> listener thread)
+    std::mutex             m_mail_mu;
+    Seed32                 m_mail_cur{};
+    std::optional<Seed32>  m_mail_next;
+    bool                   m_mail_full = false;
+
+    // last-hash memo (listener thread only)
+    std::vector<std::uint8_t> m_memo_blob;
+    Seed32                    m_memo_seed{};
+    Hash32                    m_memo_hash{};
+    bool                      m_memo_valid = false;
+
+    // counters (relaxed atomics; read by the main loop for status lines)
+    std::atomic<std::uint64_t> m_stat_hashes{0};
+    std::atomic<std::uint64_t> m_stat_seed_misses{0};
+    std::atomic<std::uint64_t> m_stat_unavailable{0};
+    std::atomic<std::uint64_t> m_stat_prefetches{0};
+    std::atomic<std::uint64_t> m_stat_network_accepts{0};
+    std::atomic<std::uint64_t> m_stat_network_rejects{0};
+    std::atomic<std::uint64_t> m_stat_memo_hits{0};
+};
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_o2_template.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_template.hpp
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_o2_template.hpp   (Track A2 / X9 O-2 — the template)
+//
+// THE MONEROD TEMPLATE for the O-2 serve side: the block bytes the stratum
+// listener serves to miners and the live submitter hands back to monerod.
+//
+//   MonerodTemplateProvider — pulls monerod's get_block_template (blocking, over
+//       the shared LiveMonerodTransport — a fresh socket per call, so the MAIN
+//       thread's refresh() never collides with the listener thread's reads) and
+//       keeps ONE mutex-guarded snapshot: the hashing blob (what the miner
+//       grinds), the FULL blocktemplate_blob (what is submitted), the height,
+//       the 128-bit network difficulty, prev_hash, expected_reward and the
+//       RandomX seed pair. Keyed by a template_id that changes ONLY when the
+//       template really changed (height / prev / bytes), so in-flight jobs stay
+//       resolvable across identical refreshes.
+//   MonerodStratumTemplateSource — the X5 ITemplateSource over that snapshot:
+//       one blob for every worker (max_extra_nonces == 1; the extra_nonce is not
+//       baked), the job (lane) target from cfg.stratum_share_diff or, when 0,
+//       the network target (solo: every accepted share is a network block).
+//
+// HONEST SCOPE (option A, see main_v37_xmr.cpp): the bytes are monerod's own
+// single-coinbase template paid to cfg.payout_address, nonce patched at submit.
+// The v37 K_fair settlement coinbase (XmrBlockTemplate + X6, option B) slots in
+// behind the same two seams once impl/xmr/template/xmr_coin_primitives has
+// bodies. Nothing here defines a consensus digest (consumer tree only).
+//
+// THREADING: refresh() = main thread; current()/by_id()/template_id()/get_job()/
+// rebuild_blob() = any thread (mutex snapshot copy / atomic).
+// ===========================================================================
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/node/minijson.hpp"
+#include "impl/xmr/node/monerod_transport.hpp"
+#include "impl/xmr/node/xmr_node_types.hpp"
+#include "impl/xmr/stratum/xmr_stratum.hpp"
+
+namespace c2pool::v37n::xmr::o2 {
+
+namespace strat = ::v37::xmr::stratum;
+namespace mj    = ::c2pool::xmr::node::minijson;
+
+// One get_block_template snapshot (everything the serve + submit side needs).
+struct MonerodTemplate {
+    std::uint32_t template_id = 0;
+    std::vector<std::uint8_t> hashing_blob;    // blockhashing_blob (miner grinds this)
+    std::vector<std::uint8_t> full_blob;       // blocktemplate_blob (submitted, nonce patched)
+    std::uint64_t height = 0;
+    std::uint64_t difficulty = 0;              // network difficulty, low 64 bits
+    std::uint64_t difficulty_top64 = 0;        // high 64 bits (0 on regtest/stagenet/mainnet today)
+    std::size_t   nonce_offset = strat::EXPECTED_NONCE_OFFSET_V16;   // header nonce, v16 == 39
+    std::uint64_t reserved_offset = 0;         // tx_extra nonce reservation (0 = none)
+    std::uint64_t expected_reward = 0;         // piconero
+    ::c2pool::xmr::node::Hash prev_id{};       // result.prev_hash
+    std::array<std::uint8_t, strat::HASH_SIZE> seed_hash{};
+    std::optional<std::array<std::uint8_t, strat::HASH_SIZE>> next_seed_hash;
+    std::uint8_t  major_version = 0;
+    bool          valid = false;
+};
+
+class MonerodTemplateProvider {
+public:
+    MonerodTemplateProvider(::c2pool::xmr::node::IMonerodTransport& transport,
+                            std::string payout_address, std::uint32_t reserve_size = 0)
+        : m_transport(transport), m_addr(std::move(payout_address)), m_reserve(reserve_size) {}
+
+    // Refresh the cached template from monerod (main thread). Returns true when
+    // a valid template is now cached (new or unchanged); the error is kept in
+    // last_error() otherwise.
+    bool refresh() {
+        const std::string body =
+            R"({"jsonrpc":"2.0","id":"0","method":"get_block_template","params":{)"
+            R"("wallet_address":")" + m_addr + R"(","reserve_size":)" +
+            std::to_string(m_reserve) + "}}";
+        bool got = false;
+        m_transport.rpc_post(body, [&](const ::c2pool::xmr::node::RpcResponse& r) {
+            if (!r.ok()) { set_error(r.error); return; }
+            got = parse_into(r.body);
+        });
+        if (got) m_refreshes.fetch_add(1, std::memory_order_relaxed);
+        else     m_failures.fetch_add(1, std::memory_order_relaxed);
+        return got;
+    }
+
+    // Snapshot of the current template (copy; any thread).
+    MonerodTemplate current() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_cur;
+    }
+    // Look a template up by id. Only the CURRENT template is retained; an older
+    // id is gone (=> "Stale share" in the submit path).
+    bool by_id(std::uint32_t id, MonerodTemplate& out) const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        if (m_cur.valid && m_cur.template_id == id) { out = m_cur; return true; }
+        return false;
+    }
+    // The current template id (0 = none yet). Any thread. The main loop compares
+    // it across refreshes and signals the listener ONLY on a change.
+    std::uint32_t template_id() const { return m_tid.load(std::memory_order_acquire); }
+
+    std::string last_error() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_last_error;
+    }
+    std::string offset_note() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_offset_note;
+    }
+    std::uint64_t refreshes() const { return m_refreshes.load(std::memory_order_relaxed); }
+    std::uint64_t failures()  const { return m_failures.load(std::memory_order_relaxed); }
+    std::uint64_t changes()   const { return m_changes.load(std::memory_order_relaxed); }
+
+    static bool from_hex(const std::string& hex, std::vector<std::uint8_t>& out) {
+        if (hex.size() % 2 != 0) return false;
+        out.clear();
+        out.reserve(hex.size() / 2);
+        auto nib = [](char c) -> int {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            return -1;
+        };
+        for (std::size_t i = 0; i < hex.size(); i += 2) {
+            const int hi = nib(hex[i]), lo = nib(hex[i + 1]);
+            if (hi < 0 || lo < 0) return false;
+            out.push_back(static_cast<std::uint8_t>((hi << 4) | lo));
+        }
+        return true;
+    }
+
+private:
+    void set_error(std::string e) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_last_error = std::move(e);
+    }
+
+    // monerod emits difficulty as a JSON number here, but the X9 bring-up found
+    // get_miner_data emitting a "0x…" hex STRING (v0.18); accept both, and read
+    // wide_difficulty (hex string, 128-bit) when present so the top64 is exact.
+    static void read_difficulty(const mj::Value& res, std::uint64_t& lo, std::uint64_t& hi) {
+        lo = 0; hi = 0;
+        const mj::Value& wide = res["wide_difficulty"];
+        if (wide.is_string() && !wide.as_string().empty()) {
+            std::uint64_t h = 0, l = 0;
+            if (mj::hex_to_u128(wide.as_string(), h, l)) { lo = l; hi = h; return; }
+        }
+        const mj::Value& d = res["difficulty"];
+        if (d.is_number()) {
+            lo = d.as_u64();
+            hi = res["difficulty_top64"].as_u64();
+            return;
+        }
+        if (d.is_string()) {
+            std::uint64_t h = 0, l = 0;
+            if (mj::hex_to_u128(d.as_string(), h, l)) { lo = l; hi = h; }
+        }
+    }
+
+    bool parse_into(const std::vector<char>& body) {
+        mj::Value root;
+        if (!mj::parse(body.data(), body.size(), root)) { set_error("template: JSON parse failed"); return false; }
+        const mj::Value& res = root["result"];
+        if (!res.is_object()) {
+            set_error("template: no result (" + root["error"]["message"].as_string() + ")");
+            return false;
+        }
+        if (res["status"].as_string() != "OK") {
+            set_error("template: status " + res["status"].as_string());
+            return false;
+        }
+        MonerodTemplate t;
+        if (!from_hex(res["blocktemplate_blob"].as_string(), t.full_blob) || t.full_blob.empty()) {
+            set_error("template: bad blocktemplate_blob"); return false;
+        }
+        if (!from_hex(res["blockhashing_blob"].as_string(), t.hashing_blob) || t.hashing_blob.empty()) {
+            set_error("template: bad blockhashing_blob"); return false;
+        }
+        t.height          = res["height"].as_u64();
+        t.reserved_offset = res["reserved_offset"].as_u64();
+        t.expected_reward = res["expected_reward"].as_u64();
+        t.major_version   = t.full_blob[0];
+        read_difficulty(res, t.difficulty, t.difficulty_top64);
+        if (t.height == 0 || (t.difficulty == 0 && t.difficulty_top64 == 0)) {
+            set_error("template: height/difficulty missing"); return false;
+        }
+        std::array<std::uint8_t, 32> h{};
+        if (mj::hex_to_hash(res["prev_hash"].as_string(), h)) t.prev_id = h;
+        if (mj::hex_to_hash(res["seed_hash"].as_string(), h)) t.seed_hash = h;
+        if (mj::hex_to_hash(res["next_seed_hash"].as_string(), h)) t.next_seed_hash = h;
+
+        // Header nonce offset: v16 headers put the 4-byte nonce at 39. Cross-check
+        // against where the hashing blob and the full blob first diverge (they
+        // share the whole header incl. the nonce, then diverge — hashing blob has
+        // the tree root, the full blob has the miner_tx): divergence == offset+4.
+        // The derived offset is load-bearing (a wrong one yields a wrong block id
+        // and a share hashed at the wrong bytes), so trust it over the constant.
+        t.nonce_offset = strat::EXPECTED_NONCE_OFFSET_V16;
+        std::string note;
+        {
+            std::size_t div = 0;
+            const std::size_t n = std::min(t.hashing_blob.size(), t.full_blob.size());
+            while (div < n && t.hashing_blob[div] == t.full_blob[div]) ++div;
+            if (div >= strat::NONCE_SIZE && div - strat::NONCE_SIZE != t.nonce_offset) {
+                note = "nonce_offset derived=" + std::to_string(div - strat::NONCE_SIZE) +
+                       " (v16 default 39)";
+                t.nonce_offset = div - strat::NONCE_SIZE;
+            }
+        }
+        if (t.nonce_offset + strat::NONCE_SIZE > t.hashing_blob.size() ||
+            t.nonce_offset + strat::NONCE_SIZE > t.full_blob.size()) {
+            set_error("template: nonce offset past blob end"); return false;
+        }
+        t.valid = true;
+
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_offset_note = note;
+        m_last_error.clear();
+        // Bump the id only when the template actually changed (new height, new
+        // parent or new bytes), so in-flight jobs stay resolvable otherwise.
+        if (!m_cur.valid || m_cur.height != t.height || m_cur.prev_id != t.prev_id ||
+            m_cur.full_blob != t.full_blob) {
+            t.template_id = ++m_id_counter;
+            m_changes.fetch_add(1, std::memory_order_relaxed);
+        } else {
+            t.template_id = m_cur.template_id;
+        }
+        m_cur = std::move(t);
+        m_tid.store(m_cur.template_id, std::memory_order_release);
+        return true;
+    }
+
+    ::c2pool::xmr::node::IMonerodTransport& m_transport;
+    std::string   m_addr;
+    std::uint32_t m_reserve;
+    mutable std::mutex m_mtx;
+    MonerodTemplate m_cur;
+    std::uint32_t m_id_counter = 0;
+    std::string   m_last_error;
+    std::string   m_offset_note;
+    std::atomic<std::uint32_t> m_tid{0};
+    std::atomic<std::uint64_t> m_refreshes{0}, m_failures{0}, m_changes{0};
+};
+
+// ---------------------------------------------------------------------------
+// ITemplateSource — serve the cached monerod hashing blob to miners.
+// ---------------------------------------------------------------------------
+class MonerodStratumTemplateSource final : public strat::ITemplateSource {
+public:
+    // share_diff 0 => the job target is the network target (solo).
+    MonerodStratumTemplateSource(const MonerodTemplateProvider& provider, std::uint64_t share_diff)
+        : m_provider(provider), m_share_diff(share_diff) {}
+
+    bool get_job(std::uint32_t /*extra_nonce*/, strat::TemplateJob& out) override {
+        MonerodTemplate t = m_provider.current();
+        if (!t.valid) return false;
+        fill_from(t, out);
+        return true;
+    }
+    bool rebuild_blob(std::uint32_t template_id, std::uint32_t /*extra_nonce*/,
+                      strat::TemplateJob& out) override {
+        MonerodTemplate t;
+        if (!m_provider.by_id(template_id, t)) return false;   // -> Stale
+        fill_from(t, out);
+        return true;
+    }
+    std::uint32_t max_extra_nonces() const override { return 1; }
+
+    // 64-bit target from a difficulty (xmr_stratum.cpp target_from_diff rule).
+    static std::uint64_t target_from_diff(std::uint64_t diff) {
+        return diff ? (0xFFFFFFFFFFFFFFFFULL / diff) : 0xFFFFFFFFFFFFFFFFULL;
+    }
+    // The u64 network target of a 128-bit difficulty: a top64 > 0 means the
+    // difficulty exceeds 2^64 and no u64 target can express it — serve the
+    // hardest target (1) so nothing is mistaken for a block; the sink applies
+    // the exact 128-bit rule anyway.
+    static std::uint64_t network_target(std::uint64_t lo, std::uint64_t hi) {
+        if (hi) return 1;
+        return target_from_diff(lo);
+    }
+
+private:
+    void fill_from(const MonerodTemplate& t, strat::TemplateJob& out) const {
+        out.blob                 = t.hashing_blob;
+        out.nonce_offset         = t.nonce_offset;
+        out.template_id          = t.template_id;
+        out.height               = t.height;
+        out.mainchain_target     = network_target(t.difficulty, t.difficulty_top64);
+        // lane target = the EASIER of {share diff, network}; 0 => network (solo)
+        out.lane_target          = m_share_diff
+                                       ? std::max(target_from_diff(m_share_diff), out.mainchain_target)
+                                       : out.mainchain_target;
+        out.seed_hash            = t.seed_hash;
+        out.next_seed_hash       = t.next_seed_hash;
+        out.monero_major_version = t.major_version;
+    }
+
+    const MonerodTemplateProvider& m_provider;
+    std::uint64_t m_share_diff;
+};
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_stratum_listener.hpp
+++ b/src/c2pool/v37/xmr/xmr_stratum_listener.hpp
@@ -1,0 +1,817 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_stratum_listener.hpp   (Track A2 / X9 O-2 — wire 1)
+//
+// STRATUM LISTENER — the host / TCP layer that the X5 stratum front-end
+// (impl/xmr/stratum/xmr_stratum.hpp, PR #1507) deliberately left to the host:
+// it BINDS the XMR stratum port, ACCEPTS RandomX miners (xmrig), newline-frames
+// and tokenises their CryptoNote/xmrig JSON dialect, and DRIVES the merged
+// XmrStratumServer (login / job / submit). It IS the server's ITransport seam.
+//
+// What it owns:
+//   * one POSIX poll() event loop on ONE background thread ("the listener
+//     thread"): listen fd + a self-pipe wake fd + every client fd;
+//   * one XmrStratumSession per connection (the X5 4-deep job ring);
+//   * the XmrStratumServer itself, constructed over the three X5 seams the
+//     assembler passes in (ITemplateSource / IPowVerifier / IShareSink) and
+//     over `*this` as the transport;
+//   * per-client read/write buffers (non-blocking sockets; a slow reader is
+//     buffered up to max_write_backlog, then dropped — never blocks the loop).
+//
+// What it delivers:
+//   * RandomX WORK: the first job in the login reply (X5 handle_login) and a
+//     `job` push to EVERY logged-in session whenever the main loop signals a
+//     new template via notify_new_template() — the NEW-TEMPLATE PUSH that X5's
+//     broadcast_job() existed for but nothing called. Before the push it runs
+//     the assembler's TemplateHook on the listener thread with a peek of the
+//     new template, which is where the RandomX seed epoch gets prefetched (so
+//     the ~seconds Argon2d cache init never lands inside a miner's submit and
+//     the verifier — not thread-safe — is only ever touched from this thread).
+//   * SHARES: every "submit" is handed to XmrStratumServer::handle_submit,
+//     which rebuilds the blob, re-hashes it with the IPowVerifier, and calls
+//     the assembler's IShareSink (on_accepted_share / submit_network_block) —
+//     ON THE LISTENER THREAD. The sink must do its own submit and hand results
+//     to the main thread through a queue (nothing here touches XmrNode).
+//   * OBSERVABILITY: counters (stats()) and a bounded log the main loop drains
+//     (drain_log()) — the listener never prints; all stdout stays on main.
+//
+// Startup race handled: a miner that logs in BEFORE the daemon has its first
+// template is PARKED (no reply) and answered with a real login_ok the moment
+// notify_new_template() delivers one (bounded by parked_login_ttl_ms, then it
+// gets "No job available" and xmrig's own retry takes over).
+//
+// THREADING CONTRACT (see the O-2 survey §E):
+//   listener thread: sockets, sessions, XmrStratumServer, ITemplateSource reads
+//                    (get_job/rebuild_blob — the source must be safe for a
+//                    concurrent reader), IPowVerifier, IShareSink callbacks.
+//   any thread:      notify_new_template(), request_stop(), stats(),
+//                    drain_log(), bound_port().
+//   main thread:     bind(), start(), stop() (joins), destructor.
+//
+// CONSUMER-TREE ONLY: defines no consensus digest; calls only the merged X5
+// front-end. Linux/POSIX sockets (the daemon is Linux-only; CI = ubuntu).
+// ===========================================================================
+#pragma once
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/node/minijson.hpp"          // xmrig JSON tokeniser (header-only)
+#include "impl/xmr/stratum/xmr_stratum.hpp"    // X5 seams + XmrStratumServer
+
+namespace c2pool::v37n::xmr::o2 {
+
+namespace strat = ::v37::xmr::stratum;
+namespace mj    = ::c2pool::xmr::node::minijson;
+
+// ---------------------------------------------------------------------------
+// Tunables. Defaults suit a single-rig regtest/stagenet demo.
+// ---------------------------------------------------------------------------
+struct StratumListenerOptions {
+    std::string   bind_host = "127.0.0.1";   // cfg.stratum_bind_host (dotted quad or resolvable name)
+    std::uint16_t bind_port = 3333;          // cfg.stratum_bind_port (0 = ephemeral; see bound_port())
+    int           backlog = 16;
+    std::size_t   max_clients = 256;         // beyond this, accept() + close immediately
+    std::size_t   max_line_bytes = 64 * 1024;      // one JSON request line
+    std::size_t   max_write_backlog = 1u << 20;    // pending bytes per slow client before drop
+    int           poll_timeout_ms = 250;     // idle tick (parked-login expiry granularity)
+    int           parked_login_ttl_ms = 15000;     // xmrig's login response timeout is 20 s
+    int           max_json_depth = 8;        // login/submit are depth-3 objects; guards the recursive parser
+    std::size_t   max_log_lines = 2048;      // bounded log (oldest dropped)
+};
+
+// Point-in-time counters (all monotone since start(), except `active`).
+struct StratumListenerStats {
+    std::uint64_t connections = 0;       // accepted
+    std::uint64_t active = 0;            // open right now
+    std::uint64_t closed = 0;            // closed for any reason (peer or server)
+    std::uint64_t logins = 0;            // successful (session logged in)
+    std::uint64_t parked_logins = 0;     // logins that waited for the first template
+    std::uint64_t submits = 0;           // "submit" requests seen
+    std::uint64_t accepted_shares = 0;   // IShareSink::on_accepted_share calls
+    std::uint64_t network_blocks = 0;    // IShareSink::submit_network_block calls
+    std::uint64_t rejected_submits = 0;  // submit answered with an error (stale/low-diff/…)
+    std::uint64_t job_pushes = 0;        // `job` notifications pushed (broadcast)
+    std::uint64_t template_signals = 0;  // notify_new_template() calls
+    std::uint64_t malformed = 0;         // unparseable / too-deep request lines
+};
+
+// ---------------------------------------------------------------------------
+// StratumListener
+// ---------------------------------------------------------------------------
+class StratumListener final : public strat::ITransport {
+public:
+    // Runs on the listener thread, BEFORE jobs are pushed, with a peek of the
+    // current template (extra_nonce 0). Use it to prefetch the RandomX seed
+    // epoch: verifier.prefetch(peek.seed_hash, peek.next_seed_hash).
+    using TemplateHook = std::function<void(const strat::TemplateJob& peek)>;
+
+    StratumListener(strat::ITemplateSource& templates,
+                    strat::IPowVerifier& verifier,
+                    strat::IShareSink& sink,
+                    StratumListenerOptions opts = {})
+        : m_opts(std::move(opts)),
+          m_templates(templates),
+          m_tap(*this, sink),
+          m_server(templates, verifier, m_tap, *this) {}
+
+    ~StratumListener() override { stop(); }
+
+    StratumListener(const StratumListener&) = delete;
+    StratumListener& operator=(const StratumListener&) = delete;
+
+    // Install the seed-prefetch hook. Call before start().
+    void set_template_hook(TemplateHook h) { m_hook = std::move(h); }
+
+    // Create the wake pipe, resolve + bind + listen. Returns "" on success,
+    // else a human-readable reason (port busy, bad host, …). Does NOT spawn
+    // the thread — so a bind failure is reported synchronously to main.
+    std::string bind() {
+        if (m_listen_fd >= 0) return "";
+        if (m_wake[0] < 0) {
+            int p[2];
+            if (::pipe(p) != 0)
+                return std::string("stratum: pipe() failed: ") + std::strerror(errno);
+            set_nonblock_cloexec(p[0]);
+            set_nonblock_cloexec(p[1]);
+            m_wake[0] = p[0];
+            m_wake[1] = p[1];
+        }
+        sockaddr_in a{};
+        a.sin_family = AF_INET;
+        a.sin_port   = ::htons(m_opts.bind_port);
+        if (!resolve_ipv4(m_opts.bind_host, a.sin_addr))
+            return "stratum: cannot resolve bind host '" + m_opts.bind_host + "'";
+
+        int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (fd < 0) return std::string("stratum: socket() failed: ") + std::strerror(errno);
+        int on = 1;
+        ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+        if (::bind(fd, reinterpret_cast<sockaddr*>(&a), sizeof(a)) < 0) {
+            std::string e = "stratum: bind " + m_opts.bind_host + ":" +
+                            std::to_string(m_opts.bind_port) + " failed: " + std::strerror(errno);
+            ::close(fd);
+            return e;
+        }
+        if (::listen(fd, m_opts.backlog) < 0) {
+            std::string e = std::string("stratum: listen() failed: ") + std::strerror(errno);
+            ::close(fd);
+            return e;
+        }
+        set_nonblock_cloexec(fd);
+        sockaddr_in got{};
+        socklen_t gl = sizeof(got);
+        if (::getsockname(fd, reinterpret_cast<sockaddr*>(&got), &gl) == 0)
+            m_bound_port.store(::ntohs(got.sin_port), std::memory_order_release);
+        else
+            m_bound_port.store(m_opts.bind_port, std::memory_order_release);
+        m_listen_fd = fd;
+        log("listening on " + m_opts.bind_host + ":" + std::to_string(bound_port()));
+        return "";
+    }
+
+    // Spawn the listener thread. Requires a successful bind(). False if not
+    // bound or already running.
+    bool start() {
+        if (m_listen_fd < 0 || m_thread.joinable()) return false;
+        m_stop.store(false, std::memory_order_release);
+        m_running.store(true, std::memory_order_release);
+        m_thread = std::thread([this] {
+            loop();
+            m_running.store(false, std::memory_order_release);
+        });
+        return true;
+    }
+
+    // Ask the loop to exit (non-blocking; any thread).
+    void request_stop() {
+        m_stop.store(true, std::memory_order_release);
+        wake();
+    }
+
+    // Stop + join, then close every socket. Safe to call repeatedly and when
+    // never started. Call BEFORE XmrNode::stop() (donor order: network first).
+    void stop() {
+        request_stop();
+        if (m_thread.joinable()) m_thread.join();
+        // Single-threaded from here.
+        for (auto& [cid, c] : m_clients) {
+            (void)cid;
+            if (c.fd >= 0) ::close(c.fd);
+            c.fd = -1;
+        }
+        m_clients.clear();
+        m_stats.active.store(0, std::memory_order_relaxed);
+        if (m_listen_fd >= 0) { ::close(m_listen_fd); m_listen_fd = -1; }
+        if (m_wake[0] >= 0)   { ::close(m_wake[0]);   m_wake[0] = -1; }
+        if (m_wake[1] >= 0)   { ::close(m_wake[1]);   m_wake[1] = -1; }
+    }
+
+    bool running() const { return m_running.load(std::memory_order_acquire); }
+
+    // The port actually bound (differs from options only when 0 was asked for).
+    std::uint16_t bound_port() const { return m_bound_port.load(std::memory_order_acquire); }
+    const StratumListenerOptions& options() const { return m_opts; }
+
+    // NEW-TEMPLATE PUSH (any thread; the main loop calls this whenever the
+    // template source's template_id changed). On the listener thread this
+    // runs: peek template -> TemplateHook (seed prefetch) -> answer parked
+    // logins -> broadcast_job() to every already-logged-in session.
+    void notify_new_template() {
+        m_stats.template_signals.fetch_add(1, std::memory_order_relaxed);
+        m_template_dirty.store(true, std::memory_order_release);
+        wake();
+    }
+
+    StratumListenerStats stats() const {
+        StratumListenerStats s;
+        s.connections      = m_stats.connections.load(std::memory_order_relaxed);
+        s.active           = m_stats.active.load(std::memory_order_relaxed);
+        s.closed           = m_stats.closed.load(std::memory_order_relaxed);
+        s.logins           = m_stats.logins.load(std::memory_order_relaxed);
+        s.parked_logins    = m_stats.parked_logins.load(std::memory_order_relaxed);
+        s.submits          = m_stats.submits.load(std::memory_order_relaxed);
+        s.accepted_shares  = m_stats.accepted_shares.load(std::memory_order_relaxed);
+        s.network_blocks   = m_stats.network_blocks.load(std::memory_order_relaxed);
+        s.rejected_submits = m_stats.rejected_submits.load(std::memory_order_relaxed);
+        s.job_pushes       = m_stats.job_pushes.load(std::memory_order_relaxed);
+        s.template_signals = m_stats.template_signals.load(std::memory_order_relaxed);
+        s.malformed        = m_stats.malformed.load(std::memory_order_relaxed);
+        return s;
+    }
+
+    // Take every pending log line (oldest first). Any thread. The main loop
+    // prints these (prefix them as it likes); the listener itself never prints.
+    std::vector<std::string> drain_log() {
+        std::vector<std::string> out;
+        std::lock_guard<std::mutex> lk(m_log_mtx);
+        out.assign(m_log.begin(), m_log.end());
+        m_log.clear();
+        return out;
+    }
+
+    // ── ITransport (called by XmrStratumServer on the listener thread) ─────
+    bool send_line(std::uint64_t client_id, std::string_view line) override {
+        Client* c = live(client_id);
+        if (!c) return false;
+        classify_reply(*c, line);
+        if (c->wbuf.empty()) {
+            // Fast path: write straight to the socket; buffer only the rest.
+            for (;;) {
+                const ssize_t n = ::send(c->fd, line.data(), line.size(), MSG_NOSIGNAL);
+                if (n >= 0) {
+                    line.remove_prefix(static_cast<std::size_t>(n));
+                    break;
+                }
+                if (errno == EINTR) continue;
+                if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+                close_client(client_id, std::string("send failed: ") + std::strerror(errno));
+                return false;
+            }
+            if (line.empty()) return true;
+        }
+        if (c->wbuf.size() + line.size() > m_opts.max_write_backlog) {
+            close_client(client_id, "write backlog exceeded (slow reader)");
+            return false;
+        }
+        c->wbuf.append(line.data(), line.size());
+        return true;
+    }
+
+    void close(std::uint64_t client_id) override {
+        close_client(client_id, "closed by server");
+    }
+
+private:
+    // ── per-connection state ───────────────────────────────────────────────
+    struct ParkedLogin {
+        std::uint32_t req_id = 0;
+        std::string   login;
+        std::string   agent;
+        std::chrono::steady_clock::time_point since;
+    };
+
+    struct Client {
+        int         fd = -1;
+        bool        dead = false;          // fd closed; erased by reap() after the current pass
+        std::string peer;                  // "ip:port" for the log
+        std::string rbuf;                  // unframed inbound bytes
+        std::string wbuf;                  // unsent outbound bytes (slow reader)
+        std::optional<ParkedLogin> parked; // login waiting for the first template
+        std::unique_ptr<strat::XmrStratumSession> session;
+        bool        last_reply_error = false;
+        std::string last_reply_msg;
+    };
+
+    struct AtomicStats {
+        std::atomic<std::uint64_t> connections{0}, active{0}, closed{0}, logins{0},
+            parked_logins{0}, submits{0}, accepted_shares{0}, network_blocks{0},
+            rejected_submits{0}, job_pushes{0}, template_signals{0}, malformed{0};
+    };
+
+    // Forwarding IShareSink: counts + logs, then hands everything to the
+    // assembler's sink unchanged (same thread, same order as X5 calls them:
+    // submit_network_block BEFORE on_accepted_share).
+    class SinkTap final : public strat::IShareSink {
+    public:
+        SinkTap(StratumListener& owner, strat::IShareSink& inner)
+            : m_owner(owner), m_inner(inner) {}
+        void on_accepted_share(const strat::AcceptedShare& s) override {
+            m_owner.m_stats.accepted_shares.fetch_add(1, std::memory_order_relaxed);
+            m_owner.log("share ACCEPTED height=" + std::to_string(s.height) +
+                        " template=" + std::to_string(s.template_id) +
+                        " nonce=" + hex_u32(s.nonce) +
+                        " worker='" + s.worker + "'" +
+                        (s.is_network_block ? " NETWORK-BLOCK" : ""));
+            m_inner.on_accepted_share(s);
+        }
+        void submit_network_block(std::uint32_t template_id, std::uint32_t nonce,
+                                  std::uint32_t extra_nonce) override {
+            m_owner.m_stats.network_blocks.fetch_add(1, std::memory_order_relaxed);
+            m_owner.log("NETWORK BLOCK candidate: template=" + std::to_string(template_id) +
+                        " nonce=" + hex_u32(nonce) + " extra_nonce=" + std::to_string(extra_nonce) +
+                        " -> sink.submit_network_block");
+            m_inner.submit_network_block(template_id, nonce, extra_nonce);
+        }
+    private:
+        StratumListener&  m_owner;
+        strat::IShareSink& m_inner;
+    };
+
+    // ── small helpers ──────────────────────────────────────────────────────
+    static void set_nonblock_cloexec(int fd) {
+        int fl = ::fcntl(fd, F_GETFL, 0);
+        if (fl >= 0) ::fcntl(fd, F_SETFL, fl | O_NONBLOCK);
+        int fd_fl = ::fcntl(fd, F_GETFD, 0);
+        if (fd_fl >= 0) ::fcntl(fd, F_SETFD, fd_fl | FD_CLOEXEC);
+    }
+
+    static bool resolve_ipv4(const std::string& host, in_addr& out) {
+        if (host.empty()) { out.s_addr = ::htonl(INADDR_LOOPBACK); return true; }
+        if (::inet_pton(AF_INET, host.c_str(), &out) == 1) return true;
+        addrinfo hints{};
+        hints.ai_family   = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        addrinfo* res = nullptr;
+        if (::getaddrinfo(host.c_str(), nullptr, &hints, &res) != 0 || !res) return false;
+        bool ok = false;
+        for (addrinfo* p = res; p; p = p->ai_next) {
+            if (p->ai_family == AF_INET && p->ai_addrlen >= sizeof(sockaddr_in)) {
+                out = reinterpret_cast<sockaddr_in*>(p->ai_addr)->sin_addr;
+                ok = true;
+                break;
+            }
+        }
+        ::freeaddrinfo(res);
+        return ok;
+    }
+
+    static std::string peer_string(const sockaddr_in& sa) {
+        char buf[INET_ADDRSTRLEN] = {0};
+        if (!::inet_ntop(AF_INET, &sa.sin_addr, buf, sizeof(buf))) return "?";
+        return std::string(buf) + ":" + std::to_string(::ntohs(sa.sin_port));
+    }
+
+    static std::string hex_u32(std::uint32_t v) {
+        char b[16];
+        std::snprintf(b, sizeof(b), "0x%08x", static_cast<unsigned>(v));
+        return b;
+    }
+
+    // Request id: xmrig sends a JSON number; tolerate a numeric string.
+    static std::uint32_t req_id_of(const mj::Value& v) {
+        if (v.is_number()) return v.as_u32();
+        if (v.is_string()) return static_cast<std::uint32_t>(std::strtoul(v.text.c_str(), nullptr, 10));
+        return 0;
+    }
+
+    // Reject pathologically nested input before it reaches the recursive
+    // minijson parser (which is KAT-grade, not adversarial-hardened).
+    static bool depth_ok(std::string_view s, int max_depth) {
+        int depth = 0;
+        bool in_str = false, esc = false;
+        for (char c : s) {
+            if (in_str) {
+                if (esc) esc = false;
+                else if (c == '\\') esc = true;
+                else if (c == '"') in_str = false;
+                continue;
+            }
+            if (c == '"') in_str = true;
+            else if (c == '{' || c == '[') { if (++depth > max_depth) return false; }
+            else if (c == '}' || c == ']') { if (depth > 0) --depth; }
+        }
+        return true;
+    }
+
+    // Remember whether the line we are about to send is a dialect error reply
+    // ({"id":N,"jsonrpc":"2.0","error":{"message":"…"}}) so a submit can be
+    // logged as rejected without wrapping the server.
+    static void classify_reply(Client& c, std::string_view line) {
+        static constexpr std::string_view kErr = "\"error\":{";
+        static constexpr std::string_view kMsg = "\"message\":\"";
+        const std::size_t e = line.find(kErr);
+        c.last_reply_error = (e != std::string_view::npos);
+        c.last_reply_msg.clear();
+        if (!c.last_reply_error) return;
+        const std::size_t m = line.find(kMsg, e);
+        if (m == std::string_view::npos) return;
+        const std::size_t b = m + kMsg.size();
+        const std::size_t q = line.find('"', b);
+        c.last_reply_msg.assign(line.substr(b, q == std::string_view::npos ? std::string_view::npos : q - b));
+    }
+
+    void log(std::string line) {
+        std::lock_guard<std::mutex> lk(m_log_mtx);
+        if (m_log.size() >= m_opts.max_log_lines) m_log.pop_front();
+        m_log.push_back(std::move(line));
+    }
+
+    void wake() {
+        const int fd = m_wake[1];
+        if (fd < 0) return;
+        const char b = 1;
+        (void)!::write(fd, &b, 1);   // EAGAIN == a wake is already pending; fine
+    }
+
+    void drain_wake() {
+        char buf[64];
+        while (::read(m_wake[0], buf, sizeof(buf)) > 0) {}
+    }
+
+    Client* live(std::uint64_t cid) {
+        auto it = m_clients.find(cid);
+        if (it == m_clients.end() || it->second.dead || it->second.fd < 0) return nullptr;
+        return &it->second;
+    }
+
+    // Deferred close: shut the fd now, erase the entry in reap() so callers
+    // iterating m_clients (broadcast, expiry) never see an invalidated iterator.
+    void close_client(std::uint64_t cid, const std::string& why) {
+        auto it = m_clients.find(cid);
+        if (it == m_clients.end() || it->second.dead) return;
+        Client& c = it->second;
+        if (c.fd >= 0) { ::close(c.fd); c.fd = -1; }
+        c.dead = true;
+        c.parked.reset();
+        m_stats.active.fetch_sub(1, std::memory_order_relaxed);
+        m_stats.closed.fetch_add(1, std::memory_order_relaxed);
+        log("client " + std::to_string(cid) + " (" + c.peer + ") closed: " + why);
+    }
+
+    void reap() {
+        for (auto it = m_clients.begin(); it != m_clients.end();) {
+            if (it->second.dead) it = m_clients.erase(it);
+            else ++it;
+        }
+    }
+
+    // ── the event loop (listener thread) ───────────────────────────────────
+    void loop() {
+        std::vector<pollfd> pfds;
+        std::vector<std::uint64_t> ids;
+        while (!m_stop.load(std::memory_order_acquire)) {
+            if (m_template_dirty.exchange(false, std::memory_order_acq_rel))
+                on_template_changed();
+
+            pfds.clear();
+            ids.clear();
+            pfds.push_back(pollfd{m_listen_fd, POLLIN, 0});
+            pfds.push_back(pollfd{m_wake[0], POLLIN, 0});
+            for (auto& [cid, c] : m_clients) {
+                if (c.dead || c.fd < 0) continue;
+                short ev = POLLIN;
+                if (!c.wbuf.empty()) ev |= POLLOUT;
+                pfds.push_back(pollfd{c.fd, ev, 0});
+                ids.push_back(cid);
+            }
+
+            const int rc = ::poll(pfds.data(), pfds.size(), m_opts.poll_timeout_ms);
+            if (rc < 0) {
+                if (errno == EINTR) continue;
+                log(std::string("poll() failed, listener exiting: ") + std::strerror(errno));
+                break;
+            }
+            if (rc > 0) {
+                if (pfds[1].revents & POLLIN) drain_wake();
+                if (pfds[0].revents & POLLIN) do_accept();
+                for (std::size_t i = 2; i < pfds.size(); ++i) {
+                    const short re = pfds[i].revents;
+                    if (!re) continue;
+                    const std::uint64_t cid = ids[i - 2];
+                    if (re & POLLOUT) flush(cid);
+                    if (re & (POLLIN | POLLHUP | POLLERR | POLLNVAL)) do_read(cid);
+                }
+            }
+            expire_parked();
+            reap();
+        }
+    }
+
+    void do_accept() {
+        for (;;) {
+            sockaddr_in sa{};
+            socklen_t sl = sizeof(sa);
+            const int fd = ::accept(m_listen_fd, reinterpret_cast<sockaddr*>(&sa), &sl);
+            if (fd < 0) {
+                if (errno == EINTR) continue;
+                if (errno != EAGAIN && errno != EWOULDBLOCK)
+                    log(std::string("accept() failed: ") + std::strerror(errno));
+                break;
+            }
+            set_nonblock_cloexec(fd);
+            int one = 1;
+            ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+            const std::string peer = peer_string(sa);
+            if (m_stats.active.load(std::memory_order_relaxed) >= m_opts.max_clients) {
+                log("refused " + peer + ": client cap (" + std::to_string(m_opts.max_clients) + ")");
+                ::close(fd);
+                continue;
+            }
+            const std::uint64_t cid = ++m_next_cid;
+            Client c;
+            c.fd = fd;
+            c.peer = peer;
+            c.session = std::make_unique<strat::XmrStratumSession>(cid);
+            m_clients.emplace(cid, std::move(c));
+            m_stats.connections.fetch_add(1, std::memory_order_relaxed);
+            m_stats.active.fetch_add(1, std::memory_order_relaxed);
+            log("client " + std::to_string(cid) + " connected from " + peer);
+        }
+    }
+
+    void flush(std::uint64_t cid) {
+        Client* c = live(cid);
+        if (!c || c->wbuf.empty()) return;
+        for (;;) {
+            const ssize_t n = ::send(c->fd, c->wbuf.data(), c->wbuf.size(), MSG_NOSIGNAL);
+            if (n >= 0) { c->wbuf.erase(0, static_cast<std::size_t>(n)); return; }
+            if (errno == EINTR) continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return;
+            close_client(cid, std::string("send failed: ") + std::strerror(errno));
+            return;
+        }
+    }
+
+    void do_read(std::uint64_t cid) {
+        Client* c = live(cid);
+        if (!c) return;
+        char buf[8192];
+        for (;;) {
+            const ssize_t n = ::recv(c->fd, buf, sizeof(buf), 0);
+            if (n > 0) {
+                c->rbuf.append(buf, static_cast<std::size_t>(n));
+                if (c->rbuf.size() > 4 * m_opts.max_line_bytes) {
+                    close_client(cid, "inbound backlog too large");
+                    return;
+                }
+                continue;
+            }
+            if (n == 0) { close_client(cid, "peer closed"); return; }
+            if (errno == EINTR) continue;
+            if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+            close_client(cid, std::string("recv failed: ") + std::strerror(errno));
+            return;
+        }
+        // Drain complete newline-framed requests.
+        for (;;) {
+            c = live(cid);
+            if (!c) return;                          // dispatch closed us
+            const std::size_t nl = c->rbuf.find('\n');
+            if (nl == std::string::npos) {
+                if (c->rbuf.size() > m_opts.max_line_bytes)
+                    close_client(cid, "request line too long");
+                break;
+            }
+            std::string line = c->rbuf.substr(0, nl);
+            c->rbuf.erase(0, nl + 1);
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            if (line.empty()) continue;
+            dispatch(cid, line);
+        }
+    }
+
+    // ── the xmrig dialect → X5 server ─────────────────────────────────────
+    void dispatch(std::uint64_t cid, const std::string& line) {
+        Client* c = live(cid);
+        if (!c) return;
+        if (!depth_ok(line, m_opts.max_json_depth)) {
+            m_stats.malformed.fetch_add(1, std::memory_order_relaxed);
+            close_client(cid, "request nested too deep");
+            return;
+        }
+        mj::Value req;
+        if (!mj::parse(line, req) || !req.is_object()) {
+            m_stats.malformed.fetch_add(1, std::memory_order_relaxed);
+            send_line(cid, strat::StratumDialect::build_error(0, "Malformed request"));
+            close_client(cid, "malformed JSON");
+            return;
+        }
+        const std::uint32_t req_id = req_id_of(req["id"]);
+        const std::string   method = req["method"].as_string();
+        const mj::Value&    params = req["params"];
+        strat::XmrStratumSession& s = *c->session;
+
+        if (method == "login") {
+            const std::string login = params["login"].as_string();
+            const std::string agent = params["agent"].as_string();
+            if (s.logged_in()) { close_client(cid, "duplicate login"); return; }   // p2pool semantics
+            if (c->parked)     { close_client(cid, "login while a login is pending"); return; }
+            if (login.empty()) {
+                send_line(cid, strat::StratumDialect::build_error(req_id, "Missing login"));
+                close_client(cid, "empty login");
+                return;
+            }
+            strat::TemplateJob peek;
+            if (!m_templates.get_job(0, peek)) {
+                // No template yet: park, answer when notify_new_template() lands.
+                c->parked = ParkedLogin{req_id, login, agent, std::chrono::steady_clock::now()};
+                m_stats.parked_logins.fetch_add(1, std::memory_order_relaxed);
+                log("client " + std::to_string(cid) + " login PARKED (no template yet) agent='" +
+                    agent + "'");
+                return;
+            }
+            do_login(cid, req_id, login, agent);
+            return;
+        }
+
+        if (method == "submit") {
+            m_stats.submits.fetch_add(1, std::memory_order_relaxed);
+            if (!s.logged_in()) {
+                send_line(cid, strat::StratumDialect::build_error(req_id, "Unauthenticated"));
+                return;
+            }
+            strat::SubmitFields f;
+            f.rpc_id = params["id"].as_string();
+            f.job_id = params["job_id"].as_string();
+            f.nonce  = params["nonce"].as_string();
+            f.result = params["result"].as_string();
+            c->last_reply_error = false;
+            c->last_reply_msg.clear();
+            if (!m_server.handle_submit(s, req_id, f)) {
+                close_client(cid, "submit rejected at parse level (malformed fields)");
+                return;
+            }
+            c = live(cid);
+            if (c && c->last_reply_error) {
+                m_stats.rejected_submits.fetch_add(1, std::memory_order_relaxed);
+                log("client " + std::to_string(cid) + " submit REJECTED: " + c->last_reply_msg +
+                    " (job_id=" + f.job_id + " nonce=" + f.nonce + ")");
+            }
+            return;
+        }
+
+        if (method == "keepalived") {
+            send_line(cid, strat::StratumDialect::build_status_ok(req_id));
+            return;
+        }
+
+        if (method == "getjob") {
+            // Legacy CryptoNote-stratum request: acknowledge, then push a job.
+            if (!s.logged_in()) {
+                send_line(cid, strat::StratumDialect::build_error(req_id, "Unauthenticated"));
+                return;
+            }
+            send_line(cid, strat::StratumDialect::build_status_ok(req_id));
+            m_server.broadcast_job(s);
+            m_stats.job_pushes.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
+
+        send_line(cid, strat::StratumDialect::build_error(req_id, "Unknown method"));
+    }
+
+    void do_login(std::uint64_t cid, std::uint32_t req_id, const std::string& login,
+                  const std::string& agent) {
+        Client* c = live(cid);
+        if (!c) return;
+        strat::XmrStratumSession& s = *c->session;
+        if (!m_server.handle_login(s, req_id, login)) {
+            close_client(cid, "login refused by server");
+            return;
+        }
+        if (s.logged_in()) {
+            m_stats.logins.fetch_add(1, std::memory_order_relaxed);
+            const strat::LoginString& ls = s.login();
+            log("client " + std::to_string(cid) + " LOGIN OK address=" + ls.address +
+                " worker='" + ls.worker + "'" +
+                (ls.custom_diff ? " custom_diff=" + std::to_string(*ls.custom_diff) : "") +
+                " agent='" + agent + "' -> first job sent");
+        } else {
+            // Race: template vanished between the peek and handle_login; the
+            // server already answered "No job available" and xmrig will retry.
+            log("client " + std::to_string(cid) + " login answered 'No job available'");
+        }
+    }
+
+    // Answer every parked login now that a template exists.
+    void flush_parked() {
+        std::vector<std::tuple<std::uint64_t, std::uint32_t, std::string, std::string>> todo;
+        for (auto& [cid, c] : m_clients) {
+            if (c.dead || !c.parked) continue;
+            todo.emplace_back(cid, c.parked->req_id, c.parked->login, c.parked->agent);
+            c.parked.reset();
+        }
+        for (auto& [cid, rid, login, agent] : todo) do_login(cid, rid, login, agent);
+    }
+
+    void expire_parked() {
+        const auto now = std::chrono::steady_clock::now();
+        const auto ttl = std::chrono::milliseconds(m_opts.parked_login_ttl_ms);
+        for (auto& [cid, c] : m_clients) {
+            if (c.dead || !c.parked) continue;
+            if (now - c.parked->since < ttl) continue;
+            const std::uint32_t rid = c.parked->req_id;
+            c.parked.reset();
+            send_line(cid, strat::StratumDialect::build_error(rid, "No job available"));
+            log("client " + std::to_string(cid) + " parked login EXPIRED (no template within " +
+                std::to_string(m_opts.parked_login_ttl_ms) + " ms)");
+        }
+    }
+
+    // The NEW-TEMPLATE PUSH, on the listener thread.
+    void on_template_changed() {
+        strat::TemplateJob peek;
+        if (!m_templates.get_job(0, peek)) {
+            log("template signal received but the template source has no job");
+            return;
+        }
+        if (m_hook) m_hook(peek);   // seed prefetch (may take seconds; miners idle meanwhile)
+
+        // Sessions already logged in get a `job` push; parked logins get their
+        // login_ok (which carries the new job) — never both.
+        std::vector<std::uint64_t> already;
+        for (auto& [cid, c] : m_clients)
+            if (!c.dead && c.session && c.session->logged_in()) already.push_back(cid);
+
+        flush_parked();
+
+        std::size_t pushed = 0;
+        for (std::uint64_t cid : already) {
+            Client* c = live(cid);
+            if (!c) continue;
+            m_server.broadcast_job(*c->session);
+            ++pushed;
+        }
+        m_stats.job_pushes.fetch_add(pushed, std::memory_order_relaxed);
+        log("template " + std::to_string(peek.template_id) + " height=" + std::to_string(peek.height) +
+            " -> job pushed to " + std::to_string(pushed) + " session(s)");
+    }
+
+    // ── members (declaration order == construction order; m_tap before m_server)
+    StratumListenerOptions   m_opts;
+    strat::ITemplateSource&  m_templates;
+    SinkTap                  m_tap;
+    strat::XmrStratumServer  m_server;
+    TemplateHook             m_hook;
+
+    int                      m_listen_fd = -1;
+    int                      m_wake[2] = {-1, -1};
+    std::atomic<std::uint16_t> m_bound_port{0};
+    std::atomic<bool>        m_stop{false};
+    std::atomic<bool>        m_running{false};
+    std::atomic<bool>        m_template_dirty{false};
+    std::thread              m_thread;
+
+    std::map<std::uint64_t, Client> m_clients;   // listener thread only
+    std::uint64_t            m_next_cid = 0;
+
+    AtomicStats              m_stats;
+    mutable std::mutex       m_log_mtx;
+    std::deque<std::string>  m_log;
+};
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/impl/xmr/CMakeLists.txt
+++ b/src/impl/xmr/CMakeLists.txt
@@ -34,6 +34,20 @@ add_subdirectory(coin)
 # X2 node KAT in test/, or later W3 wire / W5 coinbase legs) is built.
 add_subdirectory(node)
 
+# X8 / O-2: librandomx from the VENDORED tevador/RandomX tree (consensus pin
+# 12f2c2ff, third_party/randomx). OFF by default — 2 x 256 MiB light caches +
+# a JIT are OOM-hostile on a laptop and do not survive -fsanitize — and turned
+# ON by the non-sanitizer CI leg (-DXMR_BUILD_RANDOMX=ON). Declared HERE (not
+# only in test/) so the c2pool-v37-xmr daemon can link `randomx` for its
+# runtime submit-path verify without BUILD_TESTING; test/ re-declares the same
+# option (idempotent) and guards its own add_subdirectory with NOT TARGET.
+option(XMR_BUILD_RANDOMX
+    "Build librandomx (tevador/RandomX pin 12f2c2ff) for the runtime verify + KAT" OFF)
+if (XMR_BUILD_RANDOMX AND NOT TARGET randomx
+    AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/randomx/CMakeLists.txt)
+    add_subdirectory(third_party/randomx ${CMAKE_CURRENT_BINARY_DIR}/randomx_build)
+endif()
+
 if (BUILD_TESTING)
     add_subdirectory(test)
 endif()

--- a/src/impl/xmr/test/CMakeLists.txt
+++ b/src/impl/xmr/test/CMakeLists.txt
@@ -272,16 +272,20 @@ if (BUILD_TESTING)
         # Primary: full tevador/RandomX source vendored/submoduled under
         # ../third_party/randomx (later wave); fall back to FetchContent at the
         # foundation's consensus pin. Either path defines the `randomx` lib.
-        if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/randomx/CMakeLists.txt)
-            add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../third_party/randomx
-                             ${CMAKE_CURRENT_BINARY_DIR}/randomx_build)
-        else()
-            include(FetchContent)
-            FetchContent_Declare(randomx
-                GIT_REPOSITORY https://github.com/tevador/RandomX.git
-                GIT_TAG        12f2c2ff  # consensus pin (see third_party/randomx/PROVENANCE.txt)
-            )
-            FetchContent_MakeAvailable(randomx)
+        # O-2: ../CMakeLists.txt now defines the target first (so the daemon can
+        # link it without BUILD_TESTING); only define it here if that did not.
+        if (NOT TARGET randomx)
+            if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/randomx/CMakeLists.txt)
+                add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../third_party/randomx
+                                 ${CMAKE_CURRENT_BINARY_DIR}/randomx_build)
+            else()
+                include(FetchContent)
+                FetchContent_Declare(randomx
+                    GIT_REPOSITORY https://github.com/tevador/RandomX.git
+                    GIT_TAG        12f2c2ff  # consensus pin (see third_party/randomx/PROVENANCE.txt)
+                )
+                FetchContent_MakeAvailable(randomx)
+            endif()
         endif()
         add_executable(xmr_randomx_verify_kat
             ${CMAKE_CURRENT_SOURCE_DIR}/../pow/randomx_verify_kat.cpp)


### PR DESCRIPTION
## X9 O-2 — the XMR serve side: FOUND → FINALIZE, live

**DRAFT / do-not-merge.** Turns the X9 observe-side `c2pool-v37-xmr` daemon into one that serves RandomX miners and settles the blocks they find. Consumer/impl tree only — **no consensus digest is defined or altered; `src/sharechain/v37` is untouched.**

### What is wired (the four pieces X9 left disconnected)
| wire | file | what it does |
|---|---|---|
| 1 stratum listener | `xmr_stratum_listener.hpp` | POSIX `poll()` TCP server that **is** the X5 server's `ITransport`; binds the stratum port, accepts xmrig, tokenises login/submit/keepalived, drives `XmrStratumServer`, and calls the previously-uncalled `broadcast_job()` on a **new-template push** (seed prefetch on the listener thread, off the submit path) |
| 2 RandomX verify | `xmr_o2_randomx_verify.hpp` | `IPowVerifier` over the production light verifier (librandomx). Every submit is **re-hashed** (client `result` never trusted); the network decision uses the **exact 128-bit rule** `hash·difficulty < 2^256`, not the u64 approximation. **Fail-closed** when RandomX is compiled out / disabled / uninitialised |
| 3 live submit | `xmr_live_submit.hpp` | assembles the monerod template blob + winning nonce → `submit_block`; resolves the block id from **monerod `result.block_id` > local `keccak256(varint(len)‖hashing_blob)` > `get_block_header_by_height` cross-check**; fail-closed by default |
| 4 finalize connect | `xmr_o2_finalize_connect.hpp` | routes an accepted block into `XmrNode::on_network_block_won` so **FOUND → FINALIZE** runs at `D_conf` burial off the existing Extend/Reorg stream; amount-honest credit/payout; late-FOUND guard; **pending-FOUND sidecar** that survives a restart inside the `D_conf` window (the D10 defect the BTC side closed) |
| template | `xmr_o2_template.hpp` | monerod `get_block_template` provider + the X5 `ITemplateSource` seam |

`main_v37_xmr.cpp` assembles them in donor order behind `--payout-address` (the stratum port is served only when one is given; otherwise the daemon stays observe-side). New flags: `--network regtest`, `--stratum-bind-host`, `--payout-address`, `--share-diff`, `--poll-ms`, `--payee-spend-hex/--payee-view-hex`, `--status-every`, `--no-found-sidecar`. `MoneroNetwork::Regtest` is FAKECHAIN — mainnet config, but it does **not** trip the `--i-understand-mainnet` fence.

### Honest scope (option A)
The block bytes submitted are **monerod's own single-coinbase template** with the winning nonce patched — a genuine, monerod-validated block end to end, but **not yet the v37 K_fair settlement coinbase**. Option B (`XmrBlockTemplate` + X6 over an implemented `xmr_coin_primitives` seam) is a follow-on behind the same two seams.

### Build / CI
`XMR_BUILD_RANDOMX` is hoisted from `test/` into `src/impl/xmr/CMakeLists.txt` so `c2pool-v37-xmr` links librandomx (`V37_XMR_O2_WITH_RANDOMX`) on the non-sanitizer CI leg that already passes `-DXMR_BUILD_RANDOMX=ON`; the X5 stratum bodies compile into the daemon. Three new gates are listed in both build.yml target legs (drift-guard green):
- `v37_xmr_o2_live_submit_selfcheck` — **55/55**, incl. a real golden: `keccak256(varint(len)‖hashing_blob)` of the Monero mainnet genesis reproduces its published id;
- `v37_xmr_o2_finalize_connect_selfcheck` — **18/18**, FOUND → restart-in-window → sidecar re-drive → FINALIZE at `bin_height = H_b + D_conf` → finalW nets to 0;
- `v37_xmr_o2_randomx_kat` — RandomX-leg only, the X8 block-3,000,000 PoW driven through the merged `XmrStratumServer`.

`c2pool-v37-xmr --mock-smoke` now runs **29/29** (S1..S6 + the finalize-connect suite).

### Build result (workstation-191, gcc/g++-15, `-DXMR_BUILD_RANDOMX=ON`)
`c2pool-v37-xmr` links `randomx` with `V37_XMR_O2_WITH_RANDOMX`; build rc=0. Test binaries green:
`v37_xmr_node_smoke 11/11`, `v37_xmr_o2_live_submit_selfcheck 55/55`, `v37_xmr_o2_finalize_connect_selfcheck 18/18`, `v37_xmr_o2_randomx_kat` (mode=jit) 0 failures, `xmr_randomx_verify_kat --engine` (real block 3,000,000) 0 failures, `xmr_stratum_selftest 347/347`, `xmr_x2_node_kat` PASS.

### Live regtest proof (FOUND → FINALIZE)
Isolated private monerod (`--regtest --fixed-difficulty 20000 --offline`, own datadir + ports 18089/18088/18090 — the live stagenet node was never touched). xmrig → the daemon's stratum port:

```
[stratum] NETWORK BLOCK candidate: template=85 nonce=0x00008215 -> sink.submit_network_block
gate: last=exact network gate: Accept pow=d993d5508c3a46aaf8abaa5f8e10afac...
[submit] FOUND h=21 bid=40d2c6d31fa955e3… id-source=monerod header=confirmed reward=35182996382719pico
[v37-xmr-fc] FOUND registered 40d2c6d31fa9… h=21 -> finalizes when hw >= 24 (D_conf=3)
[v37-xmr-fc] FINALIZED 40d2c6d31fa9… h=21 SETTLED at bin_height=24 ledger_seq=28
```

Final status: 143 submits, **19 network blocks — submit_block accepted 19/19**, gate accept 19/19, **15 SETTLED**, 1 competing same-height block correctly flagged `id_mismatch` and orphaned, 3 pending. Every FINALIZED bid equals monerod's own canonical hash at that height:

```
h=20 monerod get_block_header_by_height.hash = 78f5bf0d8ef9786e...  daemon FINALIZED 78f5bf0d8ef9  ✓
h=21 monerod get_block_header_by_height.hash = 40d2c6d31fa955e3...  daemon FINALIZED 40d2c6d31fa9  ✓
h=22 monerod get_block_header_by_height.hash = b514f9804f93c611...  daemon FINALIZED b514f9804f93  ✓
h=23 monerod get_block_header_by_height.hash = 28df1901e2b701df...  daemon FINALIZED 28df1901e2b7  ✓
h=24 monerod get_block_header_by_height.hash = 587fecc70e947f8b...  daemon FINALIZED 587fecc70e94  ✓
h=25 monerod get_block_header_by_height.hash = 67a4ccec9623d864...  daemon FINALIZED 67a4ccec9623  ✓
```

Restart drill: a SIGINT mid-window then restart re-drove the 3 pending FOUNDs from the sidecar (`reseeded=3`) and resumed `hw_height=28 cursor=25 (resumed)`.

### Notes for review
- Threading: the listener thread owns sockets/sessions/X5 server/RandomX verifier/`submit_block`; the main thread owns `XmrNode`/adapter/index/finalize driver/ledger and all stdout. Only the template snapshot and the found queues cross (both mutex-guarded).
- The one observed `id_mismatch` is two blocks winning the same height in quick succession: the daemon trusts monerod's `block_id`, logs the header mismatch loudly, and orphans the non-canonical one at maturity — the designed behaviour, exercised for real here.
