### PR TITLE
dash(sharechain): prefer the reporting peer on share download + serve-path observability

### DIFF
--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -230,8 +230,24 @@ NodeImpl::handle_get_share(std::vector<uint256> hashes, uint64_t parents,
         return {};
     }
 
+    // ENTRY observability (#1039 "name every decline" pattern): one
+    // rate-limited log proves the serve handler was actually REACHED for an
+    // incoming sharereq. Without it, "never entered" (a parse-drop in
+    // handle_message that returns before ever calling this) is field-
+    // indistinguishable from "entered but produced no shares" (decode skew /
+    // empty hashes / all-misses) — the single missing datum when a fresh peer
+    // cannot download an established chain.
+    static uint64_t serve_entry_log = 0;
+    if (serve_entry_log++ % 50 == 0)
+        LOG_INFO << "[handle_get_share] serving req from " << peer_addr.to_string()
+                 << " hashes=" << hashes.size() << " parents=" << parents;
+
     if (hashes.empty())
+    {
+        LOG_WARNING << "[handle_get_share] EMPTY hashes from " << peer_addr.to_string()
+                    << " (decode skew or malformed sharereq)";
         return {};
+    }
 
     parents = std::min(parents, (uint64_t)1000 / hashes.size());
     std::vector<dash::ShareType> shares;
@@ -734,12 +750,24 @@ void NodeImpl::run_think()
             drain_peer_best_adverts();
             if (!result.desired.empty() && !m_peers.empty()) {
                 for (const auto& [peer_addr, hash] : result.desired) {
-                    (void)peer_addr;  // oracle: random peer, not the reporter
-                    auto peer_it = m_peers.begin();
-                    if (m_peers.size() > 1)
-                        std::advance(peer_it,
-                            core::random::random_uint256().GetLow64() % m_peers.size());
-                    download_shares(peer_it->second, hash);
+                    // Prefer the peer that REPORTED this hash (think()'s paired
+                    // peer_addr — oracle node.py download_shares carries the
+                    // (peer_addr, share_hash) pair). Discarding it and asking a
+                    // RANDOM peer is p2pool-faithful for a large mesh, but in a
+                    // small/hub topology it scatters sharereqs at chain-empty
+                    // peers; with per-target MAX_EMPTY_RETRIES abandonment that
+                    // starves the pull of the one node that actually holds the
+                    // chain (the fresh-sharechain no-sync symptom). Resolve the
+                    // reporter to its live connection; download_shares() falls
+                    // back to a random peer when it is absent/disconnected, so
+                    // liveness is preserved. Mirrors the advert-driven path
+                    // (drain_peer_best_adverts), which already targets the
+                    // advertiser.
+                    peer_ptr target;
+                    auto conn_it = m_connections.find(peer_addr);
+                    if (conn_it != m_connections.end())
+                        target = conn_it->second;
+                    download_shares(target, hash);
                 }
             }
 


### PR DESCRIPTION
Re-land of the stale branch dash/fresh-sharechain-sync-fix (was ahead 1 / behind 305, never a PR), cherry-picked onto today master and **scoped DASH-only**.

## What / why
A fresh c2pool-dash node joining an established sharechain in a small/hub topology never downloaded the chain: run_think() paired each desired missing-parent hash with the peer that reported it, but the download leg discarded that peer and asked a RANDOM peer. With few peers (one holds the chain, rest empty), sharereqs scatter at chain-empty peers and per-target MAX_EMPTY_RETRIES starves the pull of the one node that has the chain.

**Fix (dash only):** run_think() resolves each desired hash reporting peer_addr to its live m_connections entry and passes it to download_shares(), which already prefers a supplied live peer and random-falls-back when it is absent/disconnected (dash node.cpp download_shares ~:851) — liveness preserved. Plus a rate-limited handle_get_share ENTRY log so a parse-drop is field-distinguishable from entered-but-empty.

## Scope note
btc/ltc are intentionally untouched: master already prefers the reporter there via the kr1z1s convergence hotfix #25(C) (ltc download_shares advertiser-prefer; btc serve-from-storage). The original cross-coin commit is superseded on those two coins, so this stays a single-file DASH change (no cross-bucket bundling).

No consensus/reward logic changes: only which peer is asked and what is logged. Awaiting integrator verify (oracle + full Linux x86_64 CI).