### PR TITLE
dash(sharechain): DPI-resilient backfill — cap reply/ask size + socket keepalive/user-timeout

### DIFF
--- a/src/core/socket.cpp
+++ b/src/core/socket.cpp
@@ -4,6 +4,15 @@
 #include "log.hpp"
 #include <btclibs/util/strencodings.h>
 
+// Per-socket TCP liveness (keepalive + user-timeout). Linux-specific socket
+// options are guarded by __linux__; the portable boost::asio keep_alive option
+// is armed unconditionally. See Socket::init().
+#ifdef __linux__
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#endif
+
 namespace core
 {
 
@@ -76,6 +85,43 @@ void Socket::init()
     if (ec) { m_status = false; m_socket->close(); return; }
     m_addr_local = NetService(ep_local);
     m_addr       = NetService(ep_remote);
+
+    // ── Per-socket TCP liveness (pure transport; cannot corrupt protocol state).
+    // Motivation: a stateful ISP-side per-flow DPI blackhole (TSPU-class CGN on
+    // the hotel uplink) can silently wedge a flow both directions without ever
+    // sending FIN/RST. is_open() never falsifies for such a half-open drop, so
+    // a pending async_read/async_write can linger 15-30 min before anything
+    // notices — the sharechain sync stalls for that whole window.
+    //   * SO_KEEPALIVE (+ Linux 60/10/3 tuning) makes the kernel actively probe
+    //     an idle path and error the pending op when it has gone dead (~90 s).
+    //   * TCP_USER_TIMEOUT=30 s bounds how long UNACKED queued data may sit
+    //     before the kernel aborts the connection — this is the fast path for a
+    //     wedged (latched) flow: the write never ACKs, the socket errors in
+    //     ~30 s, the peer is dropped, and the download loop redials over a
+    //     FRESH connection (which gets a fresh DPI classifier budget).
+    // This runs for ALL lanes (core), which is safe: keepalive + user-timeout
+    // are liveness-only and never alter bytes on the wire. Best-effort — every
+    // option is ignore-on-unsupported so non-Linux / restricted hosts still run.
+    if (m_socket && m_socket->is_open()) {
+        boost::system::error_code kec;
+        m_socket->set_option(boost::asio::socket_base::keep_alive(true), kec); // portable (asio)
+        if (kec)
+            LOG_DEBUG_OTHER << "Socket::init: SO_KEEPALIVE set failed: " << kec.message();
+#ifdef __linux__
+        const int fd = m_socket->native_handle();
+        int idle  = 60;   // seconds idle before first keepalive probe
+        int intvl = 10;   // seconds between probes
+        int cnt   = 3;    // failed probes before the connection is dropped (~90 s)
+        ::setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,  &idle,  sizeof(idle));
+        ::setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+        ::setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,   &cnt,   sizeof(cnt));
+        // Abort a flow whose queued data stays unacknowledged for 30 s — the
+        // DPI-latch fast path. Ignore-on-unsupported (older kernels).
+        unsigned int usr_timeout_ms = 30000;
+        ::setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &usr_timeout_ms, sizeof(usr_timeout_ms));
+        LOG_TRACE << "Socket::init: TCP liveness armed (keepalive 60/10/3, user_timeout=30s)";
+#endif
+    }
 
     // start for reading socket data
     read();

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -250,6 +250,20 @@ NodeImpl::handle_get_share(std::vector<uint256> hashes, uint64_t parents,
     }
 
     parents = std::min(parents, (uint64_t)1000 / hashes.size());
+
+    // DPI-latch mitigation (DASH lane only). A stateful ISP-side per-flow DPI
+    // blackhole (TSPU-class CGN on the hotel uplink) silently drops ALL packets
+    // both directions once a single outbound-initiated TCP flow to the foreign
+    // hoster accumulates ~13-16 KB of payload that does not classify as a known
+    // protocol. c2pool's binary p2p sharereply is emitted as ONE async_write,
+    // so a large backfill (e.g. 109 shares ~= 103 KB) wedges at ~12 KB and no
+    // shares are ever parsed -> sync never advances. Capping parents at 8 keeps
+    // every message_sharereply at <= ~9 shares (~8.6 KB), safely under the
+    // latch budget, so even an un-updated requester peer receives a reply that
+    // fits. Per-coin isolation: this clamp is DASH-local; ltc/doge/btc/dgb/bch
+    // are untouched.
+    parents = std::min<uint64_t>(parents, pool::download::DASH_PARENTS_SERVE_CAP);
+
     std::vector<dash::ShareType> shares;
     for (const auto& handle_hash : hashes)
     {
@@ -857,9 +871,12 @@ void NodeImpl::download_shares(peer_ptr peer, const uint256& target_hash)
         peer = peer_it->second;
     }
 
-    // p2pool: parents=random.randrange(500)
+    // p2pool: parents=random.randrange(500). DASH lane uses a SMALL range
+    // (DASH_PARENTS_RANGE=12) instead of the shared PARENTS_RANGE=500 so every
+    // ask stays under the ISP DPI-latch budget (see share_download.hpp). This
+    // is DASH-local — ltc/doge/btc/dgb keep PARENTS_RANGE (per-coin isolation).
     const uint64_t parents =
-        core::random::random_uint256().GetLow64() % pool::download::PARENTS_RANGE;
+        core::random::random_uint256().GetLow64() % pool::download::DASH_PARENTS_RANGE;
 
     // stops need a tracker read — try_to_lock per the architectural rule (the
     // IO thread NEVER blocks on m_tracker_mutex). If think() holds it, skip;

--- a/src/impl/dash/node.cpp
+++ b/src/impl/dash/node.cpp
@@ -230,8 +230,24 @@ NodeImpl::handle_get_share(std::vector<uint256> hashes, uint64_t parents,
         return {};
     }
 
+    // ENTRY observability (#1039 "name every decline" pattern): one
+    // rate-limited log proves the serve handler was actually REACHED for an
+    // incoming sharereq. Without it, "never entered" (a parse-drop in
+    // handle_message that returns before ever calling this) is field-
+    // indistinguishable from "entered but produced no shares" (decode skew /
+    // empty hashes / all-misses) — the single missing datum when a fresh peer
+    // cannot download an established chain.
+    static uint64_t serve_entry_log = 0;
+    if (serve_entry_log++ % 50 == 0)
+        LOG_INFO << "[handle_get_share] serving req from " << peer_addr.to_string()
+                 << " hashes=" << hashes.size() << " parents=" << parents;
+
     if (hashes.empty())
+    {
+        LOG_WARNING << "[handle_get_share] EMPTY hashes from " << peer_addr.to_string()
+                    << " (decode skew or malformed sharereq)";
         return {};
+    }
 
     parents = std::min(parents, (uint64_t)1000 / hashes.size());
     std::vector<dash::ShareType> shares;
@@ -734,12 +750,24 @@ void NodeImpl::run_think()
             drain_peer_best_adverts();
             if (!result.desired.empty() && !m_peers.empty()) {
                 for (const auto& [peer_addr, hash] : result.desired) {
-                    (void)peer_addr;  // oracle: random peer, not the reporter
-                    auto peer_it = m_peers.begin();
-                    if (m_peers.size() > 1)
-                        std::advance(peer_it,
-                            core::random::random_uint256().GetLow64() % m_peers.size());
-                    download_shares(peer_it->second, hash);
+                    // Prefer the peer that REPORTED this hash (think()'s paired
+                    // peer_addr — oracle node.py download_shares carries the
+                    // (peer_addr, share_hash) pair). Discarding it and asking a
+                    // RANDOM peer is p2pool-faithful for a large mesh, but in a
+                    // small/hub topology it scatters sharereqs at chain-empty
+                    // peers; with per-target MAX_EMPTY_RETRIES abandonment that
+                    // starves the pull of the one node that actually holds the
+                    // chain (the fresh-sharechain no-sync symptom). Resolve the
+                    // reporter to its live connection; download_shares() falls
+                    // back to a random peer when it is absent/disconnected, so
+                    // liveness is preserved. Mirrors the advert-driven path
+                    // (drain_peer_best_adverts), which already targets the
+                    // advertiser.
+                    peer_ptr target;
+                    auto conn_it = m_connections.find(peer_addr);
+                    if (conn_it != m_connections.end())
+                        target = conn_it->second;
+                    download_shares(target, hash);
                 }
             }
 

--- a/src/pool/share_download.hpp
+++ b/src/pool/share_download.hpp
@@ -30,8 +30,25 @@ namespace pool::download
 {
 
 // oracle node.py download loop: parents=random.randrange(500) — a RANDOM chunk
-// size per request, NOT a fixed 500 (mirrors ltc node.cpp:1010).
+// size per request, NOT a fixed 500 (mirrors ltc node.cpp:1010). Shared default
+// for ltc/doge/btc/dgb/bch — do NOT retune (per-coin isolation invariant).
 inline constexpr uint64_t PARENTS_RANGE = 500;
+
+// DPI-latch mitigation — DASH lane ONLY (do NOT apply to PARENTS_RANGE above).
+// A stateful ISP-side per-flow DPI blackhole (TSPU-class CGN on the hotel
+// uplink) silently blackholes a single outbound TCP flow once it accumulates
+// ~13-16 KB of payload that does not classify as a known protocol; c2pool
+// sends a whole backfill reply in ONE async_write, so a large reply wedges and
+// no shares are parsed. Two DASH-local caps keep every reply under the latch:
+//   * SERVE cap  — the server clamps its reply to <= this many parents so even
+//     an un-updated requester gets a reply that fits (<= ~8.6 KB at 8 shares).
+//   * PARENTS_RANGE (requester) — our own asks draw parents from [0, 12), so a
+//     freshly-updated requester keeps each round-trip small.
+// The DPI budget is CUMULATIVE per flow, so the connection is recycled every
+// ~1-2 replies; that is EXPECTED and by design (each fresh handshake gets a
+// fresh classifier budget). ltc/doge/btc/dgb/bch keep PARENTS_RANGE=500.
+inline constexpr uint64_t DASH_PARENTS_SERVE_CAP = 8;
+inline constexpr uint64_t DASH_PARENTS_RANGE     = 12;
 
 // oracle: stops list truncated [:100] (node.py download loop; ltc:1035-1039).
 inline constexpr std::size_t STOPS_CAP = 100;


### PR DESCRIPTION
**Landing order (explicit):**
1. Merge #1535 (dash/fresh-sharechain-sync-fix-redo) FIRST — it is this PR base.
2. Then retarget/rebase this PR (#1536) onto master so it gets REAL CI (coin matrix + gates), not the current hollow attribution-only green.
3. Merge #1536 after it is green on master.

Re-land of the stale branch dash/dpi-resilient-backfill (was ahead 2 / behind 305, never a PR), cherry-picked onto today master. **Stacked on #1535** (its first commit is #1535); this PR adds only the DPI commit. Retargets to master automatically once #1535 lands.

## Problem
A stateful ISP-side per-flow DPI blackhole (TSPU-class CGN on the hotel uplink) silently drops all packets both directions once one outbound TCP flow accumulates ~13-16 KB of unclassified payload. c2pool emits a whole sharechain backfill reply as ONE async_write, so a large reply (~109 shares ~103 KB) wedges at ~12 KB, nothing is parsed, and sync never advances; with no socket keepalive/timeout the zombie flow lingers 15-30 min.

## Three coordinated changes
1. **DASH serve cap** — handle_get_share clamps parents to DASH_PARENTS_SERVE_CAP=8 (<= ~8.6 KB reply), protecting even an un-updated requester.
2. **DASH requester range** — DASH download loop draws parents from [0,12) (DASH_PARENTS_RANGE) instead of shared PARENTS_RANGE=500. **Per-coin isolation:** ltc/doge/btc/dgb/bch keep PARENTS_RANGE=500.
3. **Core socket liveness** — Socket::init arms SO_KEEPALIVE (Linux 60/10/3) + TCP_USER_TIMEOUT=30s so a latched flow errors in ~30s (not 15-30min), dropping the peer and redialing over a fresh connection (fresh DPI budget). Core change but pure-liveness (never alters wire bytes), best-effort/ignore-on-unsupported.

Awaiting integrator verify (oracle + full Linux x86_64 CI). No consensus/reward changes.
