### PR TITLE
v37/xmr X9 option B: v37 K_fair settlement coinbase (assemble + submit; regtest FOUND->FINALIZE)

### DIFF
--- a/src/c2pool/CMakeLists.txt
+++ b/src/c2pool/CMakeLists.txt
@@ -855,9 +855,15 @@ target_link_libraries(c2pool-v37-w6-leveldb-compile-check PRIVATE core Threads::
 # EXPERIMENTAL — prototype / stagenet / regtest only (see the file banner).
 # Built on demand (like c2pool-v37); the non-san CI leg lists it for a compile
 # gate. The V37Engine/OwedLedger consensus stays header-only + untouched.
+# X9 OPTION B (--coinbase v37): the v37 K_fair SETTLEMENT coinbase. main_v37_xmr
+# includes the settlement provider/fixture (header-only, src/c2pool/v37/xmr/),
+# which drive the X6 executor (settle/xmr_coinbase.cpp, compiled in here) and the
+# whole-block template builder (xmr_template, linked below). No consensus digest
+# is defined; src/sharechain/v37 is untouched. Option A stays the default.
 add_executable(c2pool-v37-xmr
     v37/main_v37_xmr.cpp
     ${CMAKE_SOURCE_DIR}/src/impl/xmr/stratum/xmr_stratum.cpp
+    ${CMAKE_SOURCE_DIR}/src/impl/xmr/settle/xmr_coinbase.cpp
     ${CMAKE_SOURCE_DIR}/src/sharechain/v37/v37_descriptor_xmr_point_check_ref10.cpp)
 c2pool_wire_version(c2pool-v37-xmr)
 target_include_directories(c2pool-v37-xmr PRIVATE
@@ -866,7 +872,10 @@ target_include_directories(c2pool-v37-xmr PRIVATE
     ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/compat)
 target_compile_definitions(c2pool-v37-xmr PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
 target_compile_features(c2pool-v37-xmr PRIVATE cxx_std_20)
-target_link_libraries(c2pool-v37-xmr PRIVATE xmr_node xmr_coin Threads::Threads)
+# xmr_template carries the p2pool block-template port + the authored primitive
+# seam bodies (xmr_coin_primitives.cpp). Link it EXACTLY ONCE and NEVER define
+# XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES here (that ODR path is KAT-only).
+target_link_libraries(c2pool-v37-xmr PRIVATE xmr_template xmr_node xmr_coin Threads::Threads)
 if (XMR_BUILD_RANDOMX AND TARGET randomx)
     target_link_libraries(c2pool-v37-xmr PRIVATE randomx)
     target_include_directories(c2pool-v37-xmr PRIVATE

--- a/src/c2pool/v37/main_v37_xmr.cpp
+++ b/src/c2pool/v37/main_v37_xmr.cpp
@@ -77,11 +77,13 @@
 #include "xmr/xmr_node_config.hpp"
 #include "xmr/xmr_node_smoke.hpp"
 #include "xmr/xmr_live_transport.hpp"
-#include "xmr/xmr_o2_template.hpp"           // O-2: monerod template provider + ITemplateSource
+#include "xmr/xmr_o2_template.hpp"           // O-2: monerod template provider + ITemplateSource (option A)
 #include "xmr/xmr_o2_randomx_verify.hpp"     // O-2 wire 2: runtime RandomX IPowVerifier + exact gate
 #include "xmr/xmr_live_submit.hpp"           // O-2 wire 3: block-blob assembly + submit_block
 #include "xmr/xmr_stratum_listener.hpp"      // O-2 wire 1: POSIX stratum listener (ITransport)
 #include "xmr/xmr_o2_finalize_connect.hpp"   // O-2 wire 4: FOUND -> on_network_block_won -> F1
+#include "xmr/xmr_o2_settlement_fixture.hpp"  // O-2 option B: XmrSettlementConfig + XmrOwedFixture (proof ledger)
+#include "xmr/xmr_o2_settlement_provider.hpp" // O-2 option B: v37 K_fair settlement template provider + source
 
 using namespace c2pool::v37n::xmr;
 namespace strat = ::v37::xmr::stratum;
@@ -134,10 +136,16 @@ static int run_mock_smoke() {
 // Accept reaches LiveSubmitShareSink -> submit_block. Fail-closed: with RandomX
 // compiled out / disabled / not initialised nothing is ever submitted.
 // ---------------------------------------------------------------------------
-class GatedShareSink final : public strat::IShareSink {
+// Templated on the template PROVIDER + its SNAPSHOT type so BOTH the option-A
+// monerod provider (MonerodTemplateProvider / MonerodTemplate) and the option-B
+// v37 settlement provider (XmrSettlementTemplateProvider / SettlementSnapshot)
+// drive the identical exact 128-bit gate. Snapshot needs only .difficulty and
+// .difficulty_top64; Provider needs by_id(id, Snapshot&).
+template <class Provider, class Snapshot>
+class GatedShareSinkT final : public strat::IShareSink {
 public:
-    GatedShareSink(o2::O2RandomXVerifier& rx, const o2::MonerodTemplateProvider& provider,
-                   strat::ITemplateSource& source, sub::LiveSubmitShareSink& inner)
+    GatedShareSinkT(o2::O2RandomXVerifier& rx, const Provider& provider,
+                    strat::ITemplateSource& source, sub::LiveSubmitShareSink& inner)
         : m_rx(rx), m_provider(provider), m_source(source), m_inner(inner) {}
 
     void on_accepted_share(const strat::AcceptedShare& s) override { m_inner.on_accepted_share(s); }
@@ -146,7 +154,7 @@ public:
                               std::uint32_t extra_nonce) override {
         m_calls.fetch_add(1, std::memory_order_relaxed);
         strat::TemplateJob tj;
-        o2::MonerodTemplate t;
+        Snapshot t;
         if (!m_source.rebuild_blob(template_id, extra_nonce, tj) ||
             !m_provider.by_id(template_id, t) ||
             tj.nonce_offset + strat::NONCE_SIZE > tj.blob.size()) {
@@ -192,13 +200,222 @@ private:
         m_last = std::move(s);
     }
     o2::O2RandomXVerifier&              m_rx;
-    const o2::MonerodTemplateProvider&  m_provider;
+    const Provider&                     m_provider;
     strat::ITemplateSource&             m_source;
     sub::LiveSubmitShareSink&           m_inner;
     std::atomic<std::uint64_t> m_calls{0}, m_accepted{0}, m_rejected{0}, m_refused{0}, m_stale{0};
     mutable std::mutex m_mtx;
     std::string        m_last;
 };
+
+// The reward a snapshot's coinbase pays, and a one-line kind-specific tail for
+// the template log. Overloaded so serve_and_run() stays provider-agnostic.
+static inline std::uint64_t snap_reward(const o2::MonerodTemplate& t)    { return t.expected_reward; }
+static inline std::uint64_t snap_reward(const o2::SettlementSnapshot& t) { return t.reward; }
+static inline std::string   snap_extra(const o2::MonerodTemplate& t) {
+    return "hashing=" + std::to_string(t.hashing_blob.size()) + "B full=" + std::to_string(t.full_blob.size()) + "B";
+}
+static inline std::string   snap_extra(const o2::SettlementSnapshot& t) {
+    return "outputs=" + std::to_string(t.n_outputs) + " n_tx=" + std::to_string(t.n_tx) +
+           " (v37 K_fair settlement coinbase)";
+}
+
+// ---------------------------------------------------------------------------
+// serve_and_run — the serve side + main loop + teardown, generic over the
+// template PROVIDER / SNAPSHOT / SOURCE so option A (monerod template) and
+// option B (v37 settlement coinbase) share ONE body. Provider must expose
+// refresh()/template_id()/current()->Snapshot/by_id(id,Snapshot&)/last_error()/
+// offset_note()/refreshes()/failures()/changes(); Snapshot must expose
+// template_id/height/difficulty/difficulty_top64/major_version/nonce_offset/
+// prev_id (+ the reward/extra via snap_reward()/snap_extra()); Source is a
+// strat::ITemplateSource. `candidate_lookup` maps (template_id, extra_nonce) to
+// a submit::BlockCandidate for the live submitter (mode-specific).
+// ---------------------------------------------------------------------------
+template <class Provider, class Source>
+static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transport,
+                         XmrNode& node, o2::FinalizeConnect& fc, o2::FoundBlockQueue& found_q,
+                         const std::optional<::v37::bytes32>& payee_key, o2::O2RandomXVerifier& rx,
+                         bool serving, const char* not_served_reason,
+                         Provider& provider, Source& template_source,
+                         sub::LiveSubmitShareSink::CandidateLookup candidate_lookup) {
+    using Snapshot = std::decay_t<decltype(provider.current())>;
+
+    sub::LiveBlockSubmitter submitter(transport);   // fresh socket per RPC: safe off-thread
+    sub::FoundBlockQueue    submit_q;
+    sub::LiveSubmitShareSink live_sink(submitter, submit_q, std::move(candidate_lookup));
+    submitter.enable_network_submit(rx.network_blocks_allowed());   // fail-closed gate
+    GatedShareSinkT<Provider, Snapshot> sink(rx, provider, template_source, live_sink);
+
+    o2::StratumListenerOptions lo;
+    lo.bind_host = cfg.stratum_bind_host;
+    lo.bind_port = cfg.stratum_bind_port;
+    o2::StratumListener listener(template_source, rx, sink, lo);
+    // Seed prefetch on the LISTENER thread, before jobs are pushed (Argon2d
+    // cache init never lands inside a miner's submit).
+    listener.set_template_hook([&](const strat::TemplateJob& peek) { rx.on_template(peek); });
+
+    std::uint32_t last_tid = 0;
+    if (serving) {
+        if (std::string e = listener.bind(); !e.empty()) {
+            std::printf("%s\n", e.c_str());
+            node.stop();
+            return 1;
+        }
+        // First template BEFORE start(): the dirty flag is latched and consumed
+        // on the loop's first pass, so the first logins are served immediately.
+        if (provider.refresh()) {
+            last_tid = provider.template_id();
+            listener.notify_new_template();
+            const Snapshot t = provider.current();
+            std::printf("template: id=%u height=%llu difficulty=%llu%s reward=%llu piconero "
+                        "major=%u nonce_offset=%zu %s%s%s\n",
+                        t.template_id, static_cast<unsigned long long>(t.height),
+                        static_cast<unsigned long long>(t.difficulty),
+                        t.difficulty_top64 ? " (+top64)" : "",
+                        static_cast<unsigned long long>(snap_reward(t)),
+                        static_cast<unsigned>(t.major_version), t.nonce_offset,
+                        snap_extra(t).c_str(),
+                        provider.offset_note().empty() ? "" : " ",
+                        provider.offset_note().c_str());
+        } else {
+            std::printf("template: first build FAILED: %s (miners are parked until it "
+                        "succeeds; %s coinbase)\n",
+                        provider.last_error().c_str(), to_string(cfg.coinbase));
+        }
+        listener.start();
+        std::printf("stratum: listening on %s:%u (%s coinbase, share diff %s, network submit %s)\n",
+                    cfg.stratum_bind_host.c_str(), listener.bound_port(), to_string(cfg.coinbase),
+                    cfg.stratum_share_diff ? std::to_string(cfg.stratum_share_diff).c_str() : "network",
+                    submitter.network_submit_enabled() ? "ENABLED" : "DISABLED (fail-closed)");
+    } else {
+        std::printf("stratum: NOT served (%s) — observe-side only\n", not_served_reason);
+    }
+
+    std::signal(SIGINT, on_sigint);
+    std::signal(SIGTERM, on_sigint);
+    const std::uint32_t poll_ms = cfg.poll_ms ? cfg.poll_ms : 5000;
+    std::printf("node up. Ctrl-C to stop. (ZMQ push drives the tip; RPC poll fallback every %u ms)\n",
+                poll_ms);
+
+    auto bridge_found = [&]() {
+        sub::FoundBlockEvent s;
+        while (submit_q.pop(s)) {
+            std::printf("  [submit] %s\n", sub::describe(s).c_str());
+            o2::FoundBlockEvent e;
+            e.height          = s.height;
+            e.block_id_hex    = hex_of(s.block_id);
+            e.prev_id_hex     = hex_of(s.prev_id);
+            e.reward_piconero = s.reward;
+            e.payee           = payee_key;
+            e.template_id     = s.template_id;
+            e.nonce           = s.nonce;
+            e.extra_nonce     = s.extra_nonce;
+            e.worker          = s.worker;
+            e.address         = s.address;
+            found_q.push(std::move(e));
+        }
+    };
+    auto drain_stratum_log = [&]() {
+        for (const auto& l : listener.drain_log()) std::printf("  [stratum] %s\n", l.c_str());
+    };
+    auto status = [&]() {
+        const auto ls = listener.stats();
+        const auto fs = fc.stats();
+        const Snapshot t = provider.current();
+        std::printf("status: hw=%llu cursor=%llu tip=%llu | template id=%u h=%llu diff=%llu "
+                    "refresh=%llu fail=%llu changes=%llu | stratum conn=%llu active=%llu logins=%llu "
+                    "submits=%llu shares=%llu net=%llu rejected=%llu pushes=%llu malformed=%llu | "
+                    "gate calls=%llu accept=%llu reject=%llu refused=%llu stale=%llu | "
+                    "submit calls=%zu ok=%zu rejected=%zu refused=%zu transport_err=%zu "
+                    "id_mismatch=%zu unattributable=%zu | found registered=%llu settled=%llu "
+                    "orphaned=%llu refused=%llu pending=%zu\n",
+                    static_cast<unsigned long long>(node.hw().hw_height),
+                    static_cast<unsigned long long>(node.finalize_driver().cursor_height()),
+                    static_cast<unsigned long long>(node.adapter().index().best_height()),
+                    t.template_id, static_cast<unsigned long long>(t.height),
+                    static_cast<unsigned long long>(t.difficulty),
+                    static_cast<unsigned long long>(provider.refreshes()),
+                    static_cast<unsigned long long>(provider.failures()),
+                    static_cast<unsigned long long>(provider.changes()),
+                    static_cast<unsigned long long>(ls.connections),
+                    static_cast<unsigned long long>(ls.active),
+                    static_cast<unsigned long long>(ls.logins),
+                    static_cast<unsigned long long>(ls.submits),
+                    static_cast<unsigned long long>(ls.accepted_shares),
+                    static_cast<unsigned long long>(ls.network_blocks),
+                    static_cast<unsigned long long>(ls.rejected_submits),
+                    static_cast<unsigned long long>(ls.job_pushes),
+                    static_cast<unsigned long long>(ls.malformed),
+                    static_cast<unsigned long long>(sink.calls()),
+                    static_cast<unsigned long long>(sink.accepted()),
+                    static_cast<unsigned long long>(sink.rejected()),
+                    static_cast<unsigned long long>(sink.refused()),
+                    static_cast<unsigned long long>(sink.stale()),
+                    submitter.calls(), submitter.ok(), submitter.rejected(), submitter.refused(),
+                    submitter.transport_errors(), submitter.id_mismatches(), submitter.unattributable(),
+                    static_cast<unsigned long long>(fs.registered),
+                    static_cast<unsigned long long>(fs.settled),
+                    static_cast<unsigned long long>(fs.orphaned),
+                    static_cast<unsigned long long>(fs.refused),
+                    fc.pending().size());
+        std::printf("  %s\n", rx.describe().c_str());
+        const std::string g = sink.last();
+        if (!g.empty()) std::printf("  gate: last=%s\n", g.c_str());
+        const std::string se = submitter.last_error();
+        if (!se.empty()) std::printf("  submit: last_error=%s\n", se.c_str());
+        std::fflush(stdout);
+    };
+
+    auto last_status = std::chrono::steady_clock::now();
+    std::string last_template_err;
+    while (!g_stop.load()) {
+        bridge_found();
+        fc.tick();
+        transport.pump_poll();
+        node.adapter().ensure_seed_reach();
+        if (serving) {
+            if (provider.refresh()) {
+                const std::uint32_t tid = provider.template_id();
+                if (tid != last_tid) {
+                    last_tid = tid;
+                    listener.notify_new_template();
+                    const Snapshot t = provider.current();
+                    std::printf("template: id=%u height=%llu difficulty=%llu prev=%s… reward=%llu -> "
+                                "pushed to miners\n",
+                                t.template_id, static_cast<unsigned long long>(t.height),
+                                static_cast<unsigned long long>(t.difficulty),
+                                hex_of(t.prev_id).substr(0, 12).c_str(),
+                                static_cast<unsigned long long>(snap_reward(t)));
+                }
+            } else {
+                const std::string e = provider.last_error();
+                if (e != last_template_err) {
+                    std::printf("template: refresh failed: %s\n", e.c_str());
+                    last_template_err = e;
+                }
+            }
+        }
+        drain_stratum_log();
+        if (cfg.status_every_s &&
+            std::chrono::steady_clock::now() - last_status >= std::chrono::seconds(cfg.status_every_s)) {
+            status();
+            last_status = std::chrono::steady_clock::now();
+        }
+        std::fflush(stdout);
+        std::this_thread::sleep_for(std::chrono::milliseconds(poll_ms));
+    }
+
+    std::printf("\nstopping…\n");
+    listener.stop();
+    drain_stratum_log();
+    bridge_found();
+    fc.drain_before_stop();
+    node.stop();
+    status();
+    std::printf("stopped. hw_height=%llu\n",
+                static_cast<unsigned long long>(node.hw().hw_height));
+    return 0;
+}
 
 static int run_live(const XmrNodeConfig& cfg) {
     std::printf("c2pool-v37-xmr: EXPERIMENTAL prototype — network=%s monerod=%s:%u (zmq %u)\n",
@@ -277,208 +494,83 @@ static int run_live(const XmrNodeConfig& cfg) {
                     o2::O2RandomXVerifier::to_string(rx.mode()));
 
     // ── the template + wire 3 (live submit) + wire 1 (listener) ─────────────
+    // Branch on the coinbase mode. Option A (monerod template) is byte-identical
+    // to PR #1534; option B (v37 settlement coinbase) drives the SAME listener /
+    // RandomX gate / live submitter / finalize-connect through serve_and_run.
+    if (cfg.coinbase == CoinbaseMode::V37Settlement) {
+        // fail-closed: v37 mode serves only with a torsion-valid residual sink.
+        const bool serving =
+            !cfg.residual_sink_spend_hex.empty() && !cfg.residual_sink_view_hex.empty();
+
+        o2::XmrSettlementConfig scfg;
+        scfg.chain_id   = cfg.lane_chain;
+        scfg.h_min      = cfg.settle_h_min;
+        scfg.output_cap = cfg.settle_output_cap;
+        std::array<std::uint8_t, 32> sink_B{}, sink_A{};
+        if (serving) {
+            if (!o2::hex32(cfg.residual_sink_spend_hex, sink_B) ||
+                !o2::hex32(cfg.residual_sink_view_hex, sink_A) ||
+                !scfg.set_residual_sink_hex(cfg.residual_sink_spend_hex, cfg.residual_sink_view_hex,
+                                            cfg.residual_sink_subaddress)) {
+                std::printf("REFUSED: --residual-sink-spend-hex/--residual-sink-view-hex must both be "
+                            "64 hex chars (the XMR wallet the exact-sum residual is paid to)\n");
+                node.stop();
+                return 2;
+            }
+        }
+
+        // The proof ledger (no live S-1 emission yet). Empty => the whole reward
+        // flows to the residual sink (one v37 output). --owed-demo-amount seeds a
+        // distinct K_fair OWED payee (the sink material with spend/view swapped —
+        // still two valid ed25519 points, a different identity) so the assembled
+        // coinbase carries an OWED output alongside the sink (multi-output proof).
+        o2::XmrOwedFixture ledger(cfg.lane_chain);
+        if (serving && cfg.owed_demo_amount) {
+            ledger.seed_owed_std(sink_A, sink_B, cfg.owed_demo_amount);
+            std::printf("owed-demo: seeded %llu piconero owed to a distinct K_fair payee "
+                        "(coinbase will carry OWED + residual sink)\n",
+                        static_cast<unsigned long long>(cfg.owed_demo_amount));
+        }
+
+        o2::XmrSettlementTemplateProvider provider(transport, ledger, scfg, cfg.stratum_share_diff);
+        o2::SettlementStratumTemplateSource template_source(provider);
+        std::printf("coinbase: %s (lane_chain=%u, residual sink %s)\n",
+                    to_string(cfg.coinbase), static_cast<unsigned>(cfg.lane_chain),
+                    serving ? "SET (torsion-checked at build)" : "UNSET (observe-side only)");
+
+        auto candidate = [&provider](std::uint32_t tid, std::uint32_t en, sub::BlockCandidate& out) {
+            std::string w;
+            return provider.candidate_by_id(tid, en, out, &w);
+        };
+        return serve_and_run(cfg, transport, node, fc, found_q, payee_key, rx, serving,
+                             "no --residual-sink-spend-hex/--residual-sink-view-hex",
+                             provider, template_source, candidate);
+    }
+
+    // ── option A (default): monerod's own get_block_template ────────────────
     const bool serving = !cfg.payout_address.empty();
     o2::MonerodTemplateProvider provider(transport, cfg.payout_address, cfg.template_reserve_size);
     o2::MonerodStratumTemplateSource template_source(provider, cfg.stratum_share_diff);
-
-    sub::LiveBlockSubmitter submitter(transport);   // fresh socket per RPC: safe off-thread
-    sub::FoundBlockQueue    submit_q;
-    sub::LiveSubmitShareSink live_sink(
-        submitter, submit_q,
-        [&](std::uint32_t tid, std::uint32_t en, sub::BlockCandidate& out) {
-            o2::MonerodTemplate t;
-            if (!provider.by_id(tid, t)) return false;
-            strat::TemplateJob tj;
-            if (!template_source.rebuild_blob(tid, en, tj)) return false;
-            out.template_id     = tid;
-            out.height          = t.height;
-            out.full_blob       = t.full_blob;
-            out.hashing_blob    = tj.blob;          // the exact blob served for this job
-            out.nonce_offset    = t.nonce_offset;
-            out.major_version   = t.major_version;
-            out.prev_id         = t.prev_id;
-            out.expected_reward = t.expected_reward;
-            out.reserved_offset = 0;                // single template, extra_nonce not baked
-            out.reserved_size   = 0;
-            return true;
-        });
-    submitter.enable_network_submit(rx.network_blocks_allowed());   // fail-closed gate
-    GatedShareSink sink(rx, provider, template_source, live_sink);
-
-    o2::StratumListenerOptions lo;
-    lo.bind_host = cfg.stratum_bind_host;
-    lo.bind_port = cfg.stratum_bind_port;
-    o2::StratumListener listener(template_source, rx, sink, lo);
-    // Seed prefetch on the LISTENER thread, before jobs are pushed (Argon2d
-    // cache init never lands inside a miner's submit; the verifier is only ever
-    // touched from that thread once start() has run).
-    listener.set_template_hook([&](const strat::TemplateJob& peek) { rx.on_template(peek); });
-
-    std::uint32_t last_tid = 0;
-    if (serving) {
-        if (std::string e = listener.bind(); !e.empty()) {
-            std::printf("%s\n", e.c_str());
-            node.stop();
-            return 1;
-        }
-        // First template BEFORE start(): the dirty flag is latched and consumed
-        // on the loop's first pass, so the first logins are served immediately.
-        if (provider.refresh()) {
-            last_tid = provider.template_id();
-            listener.notify_new_template();
-            const o2::MonerodTemplate t = provider.current();
-            std::printf("template: id=%u height=%llu difficulty=%llu%s reward=%llu piconero "
-                        "major=%u nonce_offset=%zu hashing=%zuB full=%zuB%s%s\n",
-                        t.template_id, static_cast<unsigned long long>(t.height),
-                        static_cast<unsigned long long>(t.difficulty),
-                        t.difficulty_top64 ? " (+top64)" : "",
-                        static_cast<unsigned long long>(t.expected_reward),
-                        static_cast<unsigned>(t.major_version), t.nonce_offset,
-                        t.hashing_blob.size(), t.full_blob.size(),
-                        provider.offset_note().empty() ? "" : " ",
-                        provider.offset_note().c_str());
-        } else {
-            std::printf("template: first get_block_template FAILED: %s (miners are parked until "
-                        "it succeeds; is --payout-address a %s-format standard address?)\n",
-                        provider.last_error().c_str(), to_string(cfg.network));
-        }
-        listener.start();
-        std::printf("stratum: listening on %s:%u (share diff %s, network submit %s)\n",
-                    cfg.stratum_bind_host.c_str(), listener.bound_port(),
-                    cfg.stratum_share_diff ? std::to_string(cfg.stratum_share_diff).c_str() : "network",
-                    submitter.network_submit_enabled() ? "ENABLED" : "DISABLED (fail-closed)");
-    } else {
-        std::printf("stratum: NOT served (no --payout-address) — observe-side only\n");
-    }
-
-    std::signal(SIGINT, on_sigint);
-    std::signal(SIGTERM, on_sigint);
-    const std::uint32_t poll_ms = cfg.poll_ms ? cfg.poll_ms : 5000;
-    std::printf("node up. Ctrl-C to stop. (ZMQ push drives the tip; RPC poll fallback every %u ms)\n",
-                poll_ms);
-
-    // listener thread -> main thread: the accepted-block events (wire 3 -> wire 4).
-    auto bridge_found = [&]() {
-        sub::FoundBlockEvent s;
-        while (submit_q.pop(s)) {
-            std::printf("  [submit] %s\n", sub::describe(s).c_str());
-            o2::FoundBlockEvent e;
-            e.height          = s.height;
-            e.block_id_hex    = hex_of(s.block_id);   // monerod's own block hash (or its cross-checked equal)
-            e.prev_id_hex     = hex_of(s.prev_id);
-            e.reward_piconero = s.reward;
-            e.payee           = payee_key;
-            e.template_id     = s.template_id;
-            e.nonce           = s.nonce;
-            e.extra_nonce     = s.extra_nonce;
-            e.worker          = s.worker;
-            e.address         = s.address;
-            found_q.push(std::move(e));
-        }
+    auto candidate = [&provider, &template_source](std::uint32_t tid, std::uint32_t en,
+                                                   sub::BlockCandidate& out) {
+        o2::MonerodTemplate t;
+        if (!provider.by_id(tid, t)) return false;
+        strat::TemplateJob tj;
+        if (!template_source.rebuild_blob(tid, en, tj)) return false;
+        out.template_id     = tid;
+        out.height          = t.height;
+        out.full_blob       = t.full_blob;
+        out.hashing_blob    = tj.blob;          // the exact blob served for this job
+        out.nonce_offset    = t.nonce_offset;
+        out.major_version   = t.major_version;
+        out.prev_id         = t.prev_id;
+        out.expected_reward = t.expected_reward;
+        out.reserved_offset = 0;                // single template, extra_nonce not baked
+        out.reserved_size   = 0;
+        return true;
     };
-    auto drain_stratum_log = [&]() {
-        for (const auto& l : listener.drain_log()) std::printf("  [stratum] %s\n", l.c_str());
-    };
-    auto status = [&]() {
-        const auto ls = listener.stats();
-        const auto fs = fc.stats();
-        const o2::MonerodTemplate t = provider.current();
-        std::printf("status: hw=%llu cursor=%llu tip=%llu | template id=%u h=%llu diff=%llu "
-                    "refresh=%llu fail=%llu changes=%llu | stratum conn=%llu active=%llu logins=%llu "
-                    "submits=%llu shares=%llu net=%llu rejected=%llu pushes=%llu malformed=%llu | "
-                    "gate calls=%llu accept=%llu reject=%llu refused=%llu stale=%llu | "
-                    "submit calls=%zu ok=%zu rejected=%zu refused=%zu transport_err=%zu "
-                    "id_mismatch=%zu unattributable=%zu | found registered=%llu settled=%llu "
-                    "orphaned=%llu refused=%llu pending=%zu\n",
-                    static_cast<unsigned long long>(node.hw().hw_height),
-                    static_cast<unsigned long long>(node.finalize_driver().cursor_height()),
-                    static_cast<unsigned long long>(node.adapter().index().best_height()),
-                    t.template_id, static_cast<unsigned long long>(t.height),
-                    static_cast<unsigned long long>(t.difficulty),
-                    static_cast<unsigned long long>(provider.refreshes()),
-                    static_cast<unsigned long long>(provider.failures()),
-                    static_cast<unsigned long long>(provider.changes()),
-                    static_cast<unsigned long long>(ls.connections),
-                    static_cast<unsigned long long>(ls.active),
-                    static_cast<unsigned long long>(ls.logins),
-                    static_cast<unsigned long long>(ls.submits),
-                    static_cast<unsigned long long>(ls.accepted_shares),
-                    static_cast<unsigned long long>(ls.network_blocks),
-                    static_cast<unsigned long long>(ls.rejected_submits),
-                    static_cast<unsigned long long>(ls.job_pushes),
-                    static_cast<unsigned long long>(ls.malformed),
-                    static_cast<unsigned long long>(sink.calls()),
-                    static_cast<unsigned long long>(sink.accepted()),
-                    static_cast<unsigned long long>(sink.rejected()),
-                    static_cast<unsigned long long>(sink.refused()),
-                    static_cast<unsigned long long>(sink.stale()),
-                    submitter.calls(), submitter.ok(), submitter.rejected(), submitter.refused(),
-                    submitter.transport_errors(), submitter.id_mismatches(), submitter.unattributable(),
-                    static_cast<unsigned long long>(fs.registered),
-                    static_cast<unsigned long long>(fs.settled),
-                    static_cast<unsigned long long>(fs.orphaned),
-                    static_cast<unsigned long long>(fs.refused),
-                    fc.pending().size());
-        std::printf("  %s\n", rx.describe().c_str());
-        const std::string g = sink.last();
-        if (!g.empty()) std::printf("  gate: last=%s\n", g.c_str());
-        const std::string se = submitter.last_error();
-        if (!se.empty()) std::printf("  submit: last_error=%s\n", se.c_str());
-        std::fflush(stdout);
-    };
-
-    // Main loop (donor order per tick): drain wins -> register FOUND (durable)
-    // BEFORE the tip can advance past them; then pump the tip; then refresh the
-    // template and push it to miners ONLY when it changed.
-    auto last_status = std::chrono::steady_clock::now();
-    std::string last_template_err;
-    while (!g_stop.load()) {
-        bridge_found();
-        fc.tick();
-        transport.pump_poll();
-        node.adapter().ensure_seed_reach();
-        if (serving) {
-            if (provider.refresh()) {
-                const std::uint32_t tid = provider.template_id();
-                if (tid != last_tid) {
-                    last_tid = tid;
-                    listener.notify_new_template();   // -> listener: peek, seed prefetch, parked logins, broadcast_job
-                    const o2::MonerodTemplate t = provider.current();
-                    std::printf("template: id=%u height=%llu difficulty=%llu prev=%s… -> pushed to miners\n",
-                                t.template_id, static_cast<unsigned long long>(t.height),
-                                static_cast<unsigned long long>(t.difficulty),
-                                hex_of(t.prev_id).substr(0, 12).c_str());
-                }
-            } else {
-                const std::string e = provider.last_error();
-                if (e != last_template_err) {
-                    std::printf("template: refresh failed: %s\n", e.c_str());
-                    last_template_err = e;
-                }
-            }
-        }
-        drain_stratum_log();
-        if (cfg.status_every_s &&
-            std::chrono::steady_clock::now() - last_status >= std::chrono::seconds(cfg.status_every_s)) {
-            status();
-            last_status = std::chrono::steady_clock::now();
-        }
-        std::fflush(stdout);
-        std::this_thread::sleep_for(std::chrono::milliseconds(poll_ms));
-    }
-
-    // Teardown in donor order: network first (join the listener, so no submit is
-    // in flight), register any last-second win, THEN the node.
-    std::printf("\nstopping…\n");
-    listener.stop();
-    drain_stratum_log();
-    bridge_found();
-    fc.drain_before_stop();
-    node.stop();
-    status();
-    std::printf("stopped. hw_height=%llu\n",
-                static_cast<unsigned long long>(node.hw().hw_height));
-    return 0;
+    return serve_and_run(cfg, transport, node, fc, found_q, payee_key, rx, serving,
+                         "no --payout-address", provider, template_source, candidate);
 }
 
 int main(int argc, char** argv) {
@@ -511,6 +603,18 @@ int main(int argc, char** argv) {
         else if (a == "--payee-spend-hex") cfg.payee_spend_key_hex = next("");
         else if (a == "--payee-view-hex")  cfg.payee_view_key_hex = next("");
         else if (a == "--payee-subaddress") cfg.payee_subaddress = true;
+        else if (a == "--coinbase") {
+            const std::string m = next("monerod");
+            cfg.coinbase = (m == "v37" || m == "settlement" || m == "v37-settlement")
+                               ? CoinbaseMode::V37Settlement : CoinbaseMode::MonerodTemplate;
+        }
+        else if (a == "--residual-sink-spend-hex") cfg.residual_sink_spend_hex = next("");
+        else if (a == "--residual-sink-view-hex")  cfg.residual_sink_view_hex = next("");
+        else if (a == "--residual-sink-subaddress") cfg.residual_sink_subaddress = true;
+        else if (a == "--settle-h-min") cfg.settle_h_min = std::stoull(next("0"));
+        else if (a == "--settle-output-cap") cfg.settle_output_cap =
+                     static_cast<std::uint32_t>(std::stoul(next("0")));
+        else if (a == "--owed-demo-amount") cfg.owed_demo_amount = std::stoull(next("0"));
         else if (a == "--lane-chain") cfg.lane_chain =
                      static_cast<::v37::ChainId>(std::stoul(next("0")));
         else if (a == "--d-conf") cfg.d_conf = std::stoull(next("60"));
@@ -536,7 +640,17 @@ int main(int argc, char** argv) {
                 "  --share-diff <n>             share (lane) difficulty; 0 = network (solo)\n"
                 "  --template-reserve <n>       get_block_template reserve_size (default 0)\n"
                 "  --payee-spend-hex <64hex> --payee-view-hex <64hex> [--payee-subaddress]\n"
-                "                               payout address keys -> amount-honest FOUND records\n");
+                "                               payout address keys -> amount-honest FOUND records\n"
+                " option B (X9): the v37 K_fair SETTLEMENT coinbase (not monerod's template):\n"
+                "  --coinbase <monerod|v37>     monerod (default, option A) | v37 (option B)\n"
+                "  --residual-sink-spend-hex <64hex> --residual-sink-view-hex <64hex>\n"
+                "                               REQUIRED for v37 mode: the XMR wallet the exact-sum\n"
+                "                               residual is paid to (torsion-checked at build)\n"
+                "  --residual-sink-subaddress   the sink keys are a subaddress (D_i, A_main)\n"
+                "  --settle-h-min <pico>        owed-output floor (0 on XMR)\n"
+                "  --settle-output-cap <n>      TOTAL outputs cap (0 = weight-aware default)\n"
+                "  --owed-demo-amount <pico>    seed one K_fair OWED payee into the proof ledger\n"
+                "                               (coinbase carries OWED + residual sink)\n");
             return 0;
         }
     }

--- a/src/c2pool/v37/xmr/xmr_node_config.hpp
+++ b/src/c2pool/v37/xmr/xmr_node_config.hpp
@@ -55,6 +55,26 @@ inline const char* to_string(MoneroNetwork n) {
 // family uses via core::config).
 inline const char* net_dir(MoneroNetwork n) { return to_string(n); }
 
+// Which coinbase the serve side builds, serves and submits.
+//   MonerodTemplate (option A, default, PR #1534): monerod's own get_block_template
+//     block — a single coinbase to --payout-address, nonce patched. A genuine,
+//     monerod-validated block, but NOT the v37 settlement coinbase.
+//   V37Settlement (option B): a v37-BUILT Monero block whose miner_tx is the
+//     K_fair settlement coinbase (oldest-owed-first EffectiveOwed payees ++
+//     mandated fixed outputs ++ exact-sum residual sink), assembled from
+//     get_miner_data over the W4 OwedLedger. Requires a torsion-valid residual
+//     sink (--residual-sink-spend-hex/--residual-sink-view-hex). Fail-closed:
+//     without a valid sink the daemon refuses to serve.
+enum class CoinbaseMode : std::uint8_t { MonerodTemplate = 0, V37Settlement = 1 };
+
+inline const char* to_string(CoinbaseMode m) {
+    switch (m) {
+        case CoinbaseMode::MonerodTemplate: return "monerod-template (option A)";
+        case CoinbaseMode::V37Settlement:   return "v37-settlement (option B)";
+    }
+    return "monerod-template (option A)";
+}
+
 // Default monerod RPC/ZMQ ports per network (monerod >= v0.18.0.0). The X2
 // adapter needs get_miner_data + the three ZMQ topics, all >= v0.18.
 inline c2pool::xmr::node::DaemonEndpoint default_endpoint(MoneroNetwork n) {
@@ -141,6 +161,30 @@ struct XmrNodeConfig {
     bool            payee_subaddress = false;
     // Seconds between the main loop's one-line status reports (0 = never).
     std::uint32_t   status_every_s = 30;
+
+    // --- O-2 OPTION B: the v37 K_fair settlement coinbase -------------------
+    // --coinbase monerod (option A, default) | v37 (option B). In v37 mode the
+    // block the pool assembles + submits is the settlement coinbase, not
+    // monerod's get_block_template — so --payout-address is not consulted for
+    // the coinbase bytes (it may stay empty; the serve port opens when the
+    // residual sink is set, mirroring option A's payout_address gate).
+    CoinbaseMode    coinbase = CoinbaseMode::MonerodTemplate;
+    // The mandated residual sink (REQUIRED for v37 mode): the raw public spend
+    // (B) + view (A) keys, 64 hex each, of the XMR wallet the exact-sum residual
+    // is paid to. Torsion-checked at build; the daemon REFUSES v37 mode without
+    // a valid sink. --residual-sink-subaddress builds an XMR_SUB (D_i, A_main).
+    std::string     residual_sink_spend_hex;
+    std::string     residual_sink_view_hex;
+    bool            residual_sink_subaddress = false;
+    // The v37 lane parameters (consensus once multi-node; explicit here).
+    std::uint64_t   settle_h_min      = 0;      // piconero floor per owed output (0 on XMR)
+    std::uint32_t   settle_output_cap = 0;      // TOTAL outputs cap; 0 => weight-aware default
+    // Optional demo owed entry seeded into the (otherwise empty) proof ledger so
+    // the assembled coinbase carries a real K_fair OWED payee alongside the sink
+    // (a multi-output settlement coinbase). 0 => empty ledger (sink-only).
+    // The owed payee is a distinct torsion-valid payee derived from the sink
+    // material with spend/view swapped (see main). Proof-only; no live ledger yet.
+    std::uint64_t   owed_demo_amount = 0;
 
     // --- storage ------------------------------------------------------------
     // When empty, config_path()/<net>/v37_settle_db is used (see xmr_node.hpp).

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
+//                        (Track A2 / X9 option B — the settlement SOURCE, the
+//                         construction layer that FEEDS XmrOwedSettlementSource)
+//
+// XmrOwedSettlementSource (xmr_o2_settlement_source.hpp) is the IXmrSettlement-
+// Source VALUE that the whole-block template calls into. This header is the
+// piece that BUILDS it deterministically and fail-closed for the FOUND->
+// FINALIZE proof: it owns the Option-B *config surface*, the hand-built
+// XmrCoinbaseContext, and the fixture OwedLedger — the three things the survey
+// (item E, "the settlement source feeding it") lists as still unwritten because
+// the observe-side X9 daemon has no live XMR OwedLedger yet (Track A2 S-1
+// emission, task #27).
+//
+// WHY A SEPARATE HEADER (not an edit to xmr_node_config.hpp / the source):
+//   * xmr_node_config.hpp today carries only the Option-A payout_address knob.
+//     Option B needs a residual-sink descriptor, h_min, output_cap, chain_id,
+//     the KFairSource ruling and the lane_commitment source knob. Those are a
+//     COHESIVE, fail-closed value struct (XmrSettlementConfig) — kept here so
+//     the assemble step wires it into XmrNodeConfig with a one-line
+//     `std::optional<XmrSettlementConfig> settlement;` add, rather than this
+//     component editing the shared config header.
+//   * XmrOwedSettlementSource::build() already does every byte of the seam
+//     projection + X6 crypto. This header does NOT reimplement it — it produces
+//     the XmrCoinbaseContext + the ledger it consumes, then forwards to it.
+//
+// WHAT THIS FEEDS (the consumer graph, all in src/impl/xmr + src/c2pool/v37/xmr):
+//
+//     XmrSettlementConfig + XmrParentContext + OwedLedger
+//                 |  make_xmr_coinbase_context()      (fail-closed, no crypto)
+//                 v
+//           XmrCoinbaseContext ---- XmrOwedSettlementSource::build() ----> src
+//                                        (r, R, P_i, view tags, MM leaf, order)
+//                 |                              |
+//                 |  assembly_settle_inputs(src) |  src->seam()
+//                 v                              v
+//        AssemblyInputs.settle  ------> XmrBlockAssembler::build() -> AssembledTemplate
+//        (the K_fair owed set +          (reward/payee-set fixpoint; the assembler
+//         lane params: the coinbase       re-runs X6 over these owed entries and
+//         OUTPUTS the block pays)         emits the whole Monero block)
+//
+// So the miner_tx the pool assembles pays the v37 K_fair payees (oldest-owed-
+// first EffectiveOwed ++ fixed ++ exact-sum residual sink), NOT a single miner
+// output. On an EMPTY ledger the whole reward flows to the residual sink — the
+// cleanest FOUND->FINALIZE proof shape (one coinbase output, no owed tail).
+//
+// CONSENSUS GATE (unchanged from the source header): this defines NO v37
+// consensus digest. It only READS OwedLedger::owed_digest() and serialises it
+// into the Monero coinbase's tx_extra 0x03; the Monero block is validated by
+// monerod (RandomX + HF13 exact-sum), not by any v37 rule. The single-pool
+// proof needs no operator tap. Two knobs become LANE consensus the moment
+// Option B goes multi-node and each must then ship as an operator-tap DRAFT
+// (never a silent flip): `kfair` (W4Propose vs X6Allocate) and `lc_source`
+// (which digest r and the MM root bind). They are EXPLICIT flags here until
+// tapped — the whole point of surfacing them in the config value.
+//
+// FAIL-CLOSED (defence in depth over XmrOwedSettlementSource::build's own):
+//   * residual_sink MUST be a well-formed XMR ref (kind XMR_STD/XMR_SUB, 64-B
+//     payload) here, AND torsion-valid under the installed ed25519 point-check
+//     backend at build() — no backend => build() refuses (BadSinkDescriptor).
+//   * output_cap must leave room for fixed + the sink (>= fixed.size() + 1).
+//   * ctx.chain_id must equal ledger.chain(); CARROT fence major_version <= 16.
+//   * every fixed output must be a well-formed XMR ref.
+//   None of these throw: every entry point returns std::nullopt / nullptr with
+//   a human-readable *why, exactly as the rest of the O-2 consumer tree does.
+// ===========================================================================
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/coin/xmr_crypto_types.hpp"        // Hash256, Bytes32
+#include "impl/xmr/settle/xmr_coinbase.hpp"          // x6::FixedOutput, CoinbaseInputs
+#include "impl/xmr/template/xmr_block_template.hpp"   // XmrMinerData (parent-context bridge)
+#include "xmr_o2_settlement_source.hpp"              // XmrOwedSettlementSource, XmrCoinbaseContext, KFairSource
+
+namespace c2pool::v37n::xmr::o2 {
+
+// x6, OwedLedger, PayOfFn, AgeOfFn, KFairSource, XmrCoinbaseContext,
+// XmrOwedSettlementSource, lane_commitment_from_owed_digest all come in from
+// xmr_o2_settlement_source.hpp (same namespace).
+
+// ---------------------------------------------------------------------------
+// Which digest r and the MM root bind. A consensus ruling the moment Option B
+// is multi-node (survey gate flag (2)); explicit here until tapped.
+// ---------------------------------------------------------------------------
+enum class LaneCommitmentSource : std::uint8_t {
+    OwedDigest = 0,   // ledger.owed_digest() — the §4.5 OWED commitment (recommended)
+    Explicit   = 1,   // an operator-supplied bytes32 (lane digest / SettlementView::digest)
+};
+
+inline const char* to_string(LaneCommitmentSource s) {
+    switch (s) {
+        case LaneCommitmentSource::OwedDigest: return "owed-digest";
+        case LaneCommitmentSource::Explicit:   return "explicit";
+    }
+    return "?";
+}
+
+// ---------------------------------------------------------------------------
+// hex helpers (64-hex -> 32 bytes). Boundary-only; the canon never holds a
+// printable string. Returns false on any non-hex char or a length != 64.
+// ---------------------------------------------------------------------------
+inline bool hex32(const std::string& s, std::array<std::uint8_t, 32>& out) {
+    if (s.size() != 64) return false;
+    auto nib = [](char c, int& v) -> bool {
+        if (c >= '0' && c <= '9') { v = c - '0';        return true; }
+        if (c >= 'a' && c <= 'f') { v = c - 'a' + 10;   return true; }
+        if (c >= 'A' && c <= 'F') { v = c - 'A' + 10;   return true; }
+        return false;
+    };
+    for (std::size_t i = 0; i < 32; ++i) {
+        int hi = 0, lo = 0;
+        if (!nib(s[2 * i], hi) || !nib(s[2 * i + 1], lo)) return false;
+        out[i] = static_cast<std::uint8_t>((hi << 4) | lo);
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// XmrSettlementConfig — the Option-B lane-parameter surface (consumer-tree).
+// Every field is either a lane parameter (consensus once tapped) or a fence.
+// Defaults are the safe pre-CARROT, XMR-dust-0 shape; the sink is REQUIRED.
+// ---------------------------------------------------------------------------
+struct XmrSettlementConfig {
+    // --- lane identity + fence ---
+    ::v37::ChainId chain_id = 0;                    // == OwedLedger::chain()
+    std::uint8_t   monero_major_version =           // pre-CARROT fence (<= 16)
+        ::v37::xmr::XMR_PRECARROT_MAX_MAJOR_VERSION;
+
+    // --- owed-emission policy ---
+    std::uint64_t  h_min      = ::v37::xmr::XMR_DUST;  // piconero floor per owed output (0 on XMR)
+    std::uint32_t  output_cap = 0;                     // TOTAL outputs cap C. 0 => output_cap_ceiling
+    std::uint32_t  output_cap_ceiling = 2700;          // used when output_cap == 0 (wire cap analogue)
+
+    // --- the mandated residual sink (REQUIRED; torsion-checked at build) ---
+    ::v37::ScriptRef residual_sink;                    // XMR_STD/XMR_SUB, 64-B payload
+    ::v37::bytes32   residual_sink_identity{};         // its ledger identity_key (payout-map key)
+
+    // --- mandated fixed outputs (dev / donation / finder), usually empty ---
+    std::vector<x6::FixedOutput> fixed;
+
+    // --- rulings (operator-tap DRAFT once multi-node; explicit flags here) ---
+    KFairSource          kfair     = KFairSource::W4Propose;
+    LaneCommitmentSource lc_source = LaneCommitmentSource::OwedDigest;
+    ::v37::bytes32       lane_commitment_explicit{};   // used iff lc_source == Explicit
+
+    // ---- sink constructors (payout-target bytes, never address strings) ----
+    // Set the sink from raw 32-byte key material; also fills residual_sink_identity.
+    void set_residual_sink_std(const std::array<std::uint8_t, 32>& spend_B,
+                               const std::array<std::uint8_t, 32>& view_A) {
+        residual_sink          = ::v37::xmr::make_xmr_std(spend_B, view_A);
+        residual_sink_identity = ::v37::xmr::xmr_identity_key(residual_sink);
+    }
+    void set_residual_sink_sub(const std::array<std::uint8_t, 32>& sub_spend_D,
+                               const std::array<std::uint8_t, 32>& main_view_A) {
+        residual_sink          = ::v37::xmr::make_xmr_sub(sub_spend_D, main_view_A);
+        residual_sink_identity = ::v37::xmr::xmr_identity_key(residual_sink);
+    }
+    // Set the sink from 64-hex spend + view keys (the operator test-wallet ref).
+    // sub == true builds an XMR_SUB ref (sub-spend D_i, main view A). Returns
+    // false (leaving the sink untouched) on any malformed hex.
+    bool set_residual_sink_hex(const std::string& spend_hex,
+                               const std::string& view_hex, bool sub = false) {
+        std::array<std::uint8_t, 32> p0{}, p1{};
+        if (!hex32(spend_hex, p0) || !hex32(view_hex, p1)) return false;
+        if (sub) set_residual_sink_sub(p0, p1);
+        else     set_residual_sink_std(p0, p1);
+        return true;
+    }
+
+    // Concrete TOTAL-outputs cap to hand XmrOwedSettlementSource::build (which,
+    // unlike XmrBlockAssembler, requires a concrete cap, not the 0 sentinel).
+    std::uint32_t resolved_output_cap() const {
+        return output_cap != 0 ? output_cap : output_cap_ceiling;
+    }
+
+    // Structural, backend-free validity (torsion is enforced at build()).
+    // Returns false and fills *why on any refusal.
+    bool validate_structural(std::string* why = nullptr) const {
+        auto no = [&](const std::string& m) { if (why) *why = m; return false; };
+        if (!::v37::xmr::xmr_precarrot_ok(monero_major_version))
+            return no("XmrSettlementConfig: monero_major_version > pre-CARROT max (16)");
+        if (!::v37::xmr::xmr_ref_well_formed(residual_sink))
+            return no("XmrSettlementConfig: residual_sink is not a well-formed XMR ref "
+                      "(need an XMR_STD/XMR_SUB 64-B payload — set --residual-sink-*)");
+        for (const auto& f : fixed)
+            if (!::v37::xmr::xmr_ref_well_formed(f.pay))
+                return no("XmrSettlementConfig: a fixed output is not a well-formed XMR ref");
+        const std::uint32_t cap = resolved_output_cap();
+        if (cap < fixed.size() + 1)
+            return no("XmrSettlementConfig: output_cap leaves no room for fixed + sink "
+                      "(need >= fixed.size() + 1)");
+        if (lc_source == LaneCommitmentSource::Explicit &&
+            lane_commitment_explicit == ::v37::bytes32{})
+            return no("XmrSettlementConfig: lc_source == Explicit but lane_commitment_explicit is zero");
+        if (why) why->clear();
+        return true;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// XmrParentContext — the mainchain-tip scalars the coinbase binds. In
+// production these come from the node's get_miner_data / get_block_template;
+// for the proof they are the regtest tip. base_reward is the consensus subsidy
+// (get_base_reward(already_generated_coins)); fees is Σ selected tx fees. When
+// this context also feeds XmrBlockAssembler, major/height/prev_id MUST equal
+// AssemblyInputs.miner's (the assembler overwrites them and re-derives r from
+// the miner values, so a mismatch would desync r).
+// ---------------------------------------------------------------------------
+struct XmrParentContext {
+    std::uint8_t         monero_major_version = ::v37::xmr::XMR_PRECARROT_MAX_MAJOR_VERSION;
+    std::uint64_t        height = 0;             // unlock = height + 60
+    ::xmr::coin::Hash256 prev_id{};              // parent block id (bin origin)
+    std::uint64_t        base_reward = 0;        // consensus subsidy, piconero
+    std::uint64_t        fees = 0;               // Σ selected tx fees, piconero
+
+    std::uint64_t budget() const { return base_reward + fees; }
+
+    // prev_id from a 64-hex Monero block id.
+    bool set_prev_id_hex(const std::string& hex) {
+        std::array<std::uint8_t, 32> b{};
+        if (!hex32(hex, b)) return false;
+        std::copy(b.begin(), b.end(), prev_id.data());
+        return true;
+    }
+
+    // Bridge from the template leg's XmrMinerData (major/height/prev_id). The
+    // subsidy is NOT in XmrMinerData (it carries already_generated_coins), so
+    // base_reward + fees are supplied by the caller (the provider computes the
+    // subsidy with the template leg's xmr_base_reward()).
+    static XmrParentContext from_miner(const ::c2pool::xmr::XmrMinerData& m,
+                                       std::uint64_t base_reward,
+                                       std::uint64_t fees) {
+        XmrParentContext p;
+        p.monero_major_version = m.major_version;
+        p.height               = m.height;
+        std::memcpy(p.prev_id.data(), m.prev_id.h, 32);
+        p.base_reward          = base_reward;
+        p.fees                 = fees;
+        return p;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Resolve the lane commitment r and the MM root bind, per the config's ruling.
+// ---------------------------------------------------------------------------
+inline ::v37::bytes32 resolve_lane_commitment(const XmrSettlementConfig& cfg,
+                                              const OwedLedger& ledger) {
+    switch (cfg.lc_source) {
+        case LaneCommitmentSource::OwedDigest: return lane_commitment_from_owed_digest(ledger);
+        case LaneCommitmentSource::Explicit:   return cfg.lane_commitment_explicit;
+    }
+    return lane_commitment_from_owed_digest(ledger);
+}
+
+// ---------------------------------------------------------------------------
+// Assemble the XmrCoinbaseContext from config + tip + ledger. Structural,
+// backend-free (torsion is enforced by XmrOwedSettlementSource::build). Returns
+// std::nullopt + *why on any structural refusal or a chain-id mismatch.
+// ---------------------------------------------------------------------------
+inline std::optional<XmrCoinbaseContext>
+make_xmr_coinbase_context(const XmrSettlementConfig& cfg,
+                          const XmrParentContext& parent,
+                          const OwedLedger& ledger,
+                          std::string* why = nullptr) {
+    auto no = [&](const std::string& m) -> std::optional<XmrCoinbaseContext> {
+        if (why) *why = m; return std::nullopt;
+    };
+    if (!cfg.validate_structural(why)) return std::nullopt;
+    if (cfg.chain_id != ledger.chain())
+        return no("make_xmr_coinbase_context: cfg.chain_id != ledger.chain()");
+    if (cfg.monero_major_version != parent.monero_major_version)
+        return no("make_xmr_coinbase_context: cfg.monero_major_version != parent tip major_version "
+                  "(r would desync from the assembler's miner-derived r)");
+
+    XmrCoinbaseContext ctx;
+    ctx.monero_major_version   = parent.monero_major_version;
+    ctx.height                 = parent.height;
+    ctx.prev_id                = parent.prev_id;
+    ctx.base_reward            = parent.base_reward;
+    ctx.fees                   = parent.fees;
+    ctx.chain_id               = cfg.chain_id;
+    ctx.lane_commitment        = resolve_lane_commitment(cfg, ledger);
+    ctx.residual_sink          = cfg.residual_sink;
+    ctx.residual_sink_identity = cfg.residual_sink_identity;
+    ctx.fixed                  = cfg.fixed;
+    ctx.h_min                  = cfg.h_min;
+    ctx.output_cap             = cfg.resolved_output_cap();
+    if (why) why->clear();
+    return ctx;
+}
+
+// ---------------------------------------------------------------------------
+// Build the settlement source for a template: make the context, then forward
+// to XmrOwedSettlementSource::build (which projects the K_fair owed set, runs
+// X6 once — r, R, P_i, view tags, MM leaf, canonical order — and fails closed
+// on the CARROT fence / bad sink / cap / chain mismatch / derivation).
+//
+//   reward_hint : the exact-sum budget the owed set is chosen at. 0 =>
+//                 parent.budget() (base_reward + fees) — the assembler's own
+//                 first sizing-pass reward, so the snapshot matches pass 1.
+//   age_of      : REQUIRED for KFairSource::X6Allocate, ignored for W4Propose.
+//
+// Returns nullptr + *why on refusal. The returned source is heap-owned (stable
+// address, immutable after build) — the exact ownership the template's raw
+// seam pointer needs.
+// ---------------------------------------------------------------------------
+inline std::unique_ptr<XmrOwedSettlementSource>
+build_settlement_source(const XmrSettlementConfig& cfg,
+                        const XmrParentContext& parent,
+                        const OwedLedger& ledger,
+                        const PayOfFn& pay_of,
+                        std::uint64_t reward_hint,
+                        std::string* why,
+                        const AgeOfFn& age_of = {}) {
+    std::optional<XmrCoinbaseContext> ctx = make_xmr_coinbase_context(cfg, parent, ledger, why);
+    if (!ctx) return nullptr;
+    const std::uint64_t hint = reward_hint != 0 ? reward_hint : parent.budget();
+    return XmrOwedSettlementSource::build(ledger, pay_of, *ctx, hint, why, cfg.kfair, age_of);
+}
+
+// ---------------------------------------------------------------------------
+// The x6::CoinbaseInputs to drop into AssemblyInputs.settle. `src->inputs()`
+// carries the K_fair owed set + lane params (reward/extra_nonce NOT applied —
+// the assembler overwrites them from AssemblyInputs.miner and the template's
+// final reward, and iterates the count-invariance fixpoint over these owed
+// entries). weight_aware_cap == true zeroes output_cap so the assembler
+// resolves the weight-aware cap itself (recommended for real multi-payee
+// blocks); false keeps the config's concrete cap.
+// ---------------------------------------------------------------------------
+inline x6::CoinbaseInputs assembly_settle_inputs(const XmrOwedSettlementSource& src,
+                                                 bool weight_aware_cap = true) {
+    x6::CoinbaseInputs in = src.inputs();
+    if (weight_aware_cap) in.output_cap = 0;   // 0 => XmrBlockAssembler weight-aware default
+    return in;
+}
+
+// ===========================================================================
+// XmrOwedFixture — the deterministic proof ledger (survey item E). The X9
+// observe-side daemon has no live XMR OwedLedger yet, so the FOUND->FINALIZE
+// proof is driven from a hand-built one:
+//
+//   * EMPTY (no seed)  => propose_coinbase returns no owed outs => the whole
+//                         reward flows to the residual sink: a one-output
+//                         coinbase, the cleanest proof shape.
+//   * seed_owed(ref,a) => credits + FINALIZES `a` piconero to `ref`, so
+//                         EffectiveOwed(ref) == a and it is armed: the coinbase
+//                         then pays that payee (K_fair) with the sink absorbing
+//                         the exact-sum residual — a real multi-payee proof.
+//
+// It also carries the payout resolver (identity_key -> ScriptRef) the source's
+// pay_of needs. Everything is deterministic in the seeds' insertion order.
+// ===========================================================================
+class XmrOwedFixture {
+public:
+    explicit XmrOwedFixture(::v37::ChainId chain) : m_ledger(chain) {}
+
+    // Credit + finalize `amount` piconero owed to XMR ref `pay`. Its ledger key
+    // is the canon identity_key(pay); the resolver learns pay for that key.
+    // bin_height auto-increments so each seed arms at a distinct (older-first)
+    // age — matching the K_fair oldest-owed-first order. Returns the key.
+    ::v37::bytes32 seed_owed(const ::v37::ScriptRef& pay, std::uint64_t amount) {
+        ::v37::bytes32 key = ::v37::xmr::xmr_identity_key(pay);
+        m_paymap[key] = pay;
+        const std::string bid = "fixture-seed-" + std::to_string(m_next_bid++);
+        OwedLedger::Amounts credit; credit[key] = static_cast<long long>(amount);
+        m_ledger.on_block_found(bid, credit, /*payout=*/{});
+        m_ledger.on_block_finalized(bid, /*bin_height=*/m_next_age++);
+        return key;
+    }
+
+    // Convenience: seed from raw key material.
+    ::v37::bytes32 seed_owed_std(const std::array<std::uint8_t, 32>& spend_B,
+                                 const std::array<std::uint8_t, 32>& view_A,
+                                 std::uint64_t amount) {
+        return seed_owed(::v37::xmr::make_xmr_std(spend_B, view_A), amount);
+    }
+
+    // The pay_of resolver bound to this fixture. A key with no learned ref maps
+    // to a RAW sentinel — never paid, CARRIED by W4's canon rule (deterministic).
+    PayOfFn pay_of() const {
+        return [this](const ::v37::bytes32& k) -> ::v37::ScriptRef {
+            auto it = m_paymap.find(k);
+            if (it != m_paymap.end()) return it->second;
+            ::v37::ScriptRef raw; raw.kind = ::v37::ScriptKind::RAW; raw.payload.clear();
+            return raw;
+        };
+    }
+
+    const OwedLedger& ledger() const { return m_ledger; }
+    OwedLedger&       ledger()       { return m_ledger; }
+    std::size_t       seeded() const { return m_paymap.size(); }
+
+private:
+    OwedLedger                            m_ledger;
+    std::map<::v37::bytes32, ::v37::ScriptRef> m_paymap;
+    std::uint64_t                         m_next_bid = 0;
+    std::uint64_t                         m_next_age = 1;   // 0 reserved / unarmed
+};
+
+// ===========================================================================
+// Structural self-check (no crypto backend needed). A KAT TU can call
+// selftest::run() to prove the config/context plumbing holds; the crypto path
+// (build_settlement_source succeeding) is exercised by the template KATs where
+// the ref10 point-check backend is installed.
+// ===========================================================================
+namespace selftest {
+
+// A structurally well-formed (but NOT torsion-valid) XMR ref: two ed25519
+// basepoint encodings. Passes xmr_ref_well_formed; passes xmr_ref_valid ONLY
+// with the ref10 backend installed. Good enough for the backend-free checks.
+inline ::v37::ScriptRef sample_wellformed_ref() {
+    std::array<std::uint8_t, 32> bp = ::v37::xmr::kat::TORSION_PASS_BASEPOINT;
+    return ::v37::xmr::make_xmr_std(bp, bp);
+}
+
+inline bool run(std::string* why = nullptr) {
+    auto fail = [&](const std::string& m) { if (why) *why = m; return false; };
+
+    // (S1) A config with no sink is refused structurally.
+    {
+        XmrSettlementConfig cfg;
+        cfg.chain_id = 7;
+        std::string w;
+        if (cfg.validate_structural(&w)) return fail("S1: empty-sink config accepted");
+    }
+    // (S2) A well-formed sink + room for it validates; a cap of 0 with a fixed
+    //      output plus sink that overflows the ceiling is refused.
+    XmrSettlementConfig cfg;
+    cfg.chain_id           = 7;
+    cfg.residual_sink      = sample_wellformed_ref();
+    cfg.residual_sink_identity = ::v37::xmr::xmr_identity_key(cfg.residual_sink);
+    {
+        std::string w;
+        if (!cfg.validate_structural(&w)) return fail("S2: well-formed sink config refused: " + w);
+    }
+    {
+        XmrSettlementConfig bad = cfg;
+        bad.output_cap = 1;                       // room for exactly 1 = the sink
+        bad.fixed.push_back(x6::FixedOutput{sample_wellformed_ref(), 1, {}});
+        std::string w;
+        if (bad.validate_structural(&w)) return fail("S3: cap-too-small (fixed+sink) accepted");
+    }
+    // (S4) make_xmr_coinbase_context copies every field through and defaults the
+    //      lane commitment to the empty ledger's owed_digest.
+    {
+        XmrOwedFixture fx(7);
+        XmrParentContext parent;
+        parent.height = 100; parent.base_reward = 600000000000ULL; parent.fees = 0;
+        std::string w;
+        auto ctx = make_xmr_coinbase_context(cfg, parent, fx.ledger(), &w);
+        if (!ctx) return fail("S4: context build refused: " + w);
+        if (ctx->chain_id != 7)                       return fail("S4: chain_id not copied");
+        if (ctx->output_cap != cfg.resolved_output_cap()) return fail("S4: output_cap not resolved");
+        if (!(ctx->lane_commitment == fx.ledger().owed_digest()))
+            return fail("S4: lane_commitment != owed_digest (default source)");
+        if (!(ctx->residual_sink == cfg.residual_sink)) return fail("S4: sink not copied");
+    }
+    // (S5) chain-id mismatch between config and ledger is refused.
+    {
+        XmrOwedFixture fx(9);                         // ledger chain 9 != cfg.chain_id 7
+        XmrParentContext parent; parent.height = 1;
+        std::string w;
+        if (make_xmr_coinbase_context(cfg, parent, fx.ledger(), &w))
+            return fail("S5: chain-id mismatch accepted");
+    }
+    // (S6) fixture seeding: EffectiveOwed and the resolver track the seed set.
+    {
+        XmrOwedFixture fx(7);
+        std::array<std::uint8_t, 32> b = ::v37::xmr::kat::STD_KAT.p0;
+        std::array<std::uint8_t, 32> a = ::v37::xmr::kat::STD_KAT.p1;
+        ::v37::bytes32 key = fx.seed_owed_std(b, a, 12345);
+        if (fx.ledger().effective_owed(key) != 12345) return fail("S6: seeded EffectiveOwed wrong");
+        PayOfFn po = fx.pay_of();
+        if (!::v37::xmr::is_xmr_kind(po(key).kind))    return fail("S6: resolver lost the seeded ref");
+        ::v37::bytes32 miss{}; miss[0] = 0xEE;
+        if (::v37::xmr::is_xmr_kind(po(miss).kind))    return fail("S6: resolver invented a ref (must be RAW/carry)");
+    }
+    if (why) why->clear();
+    return true;
+}
+
+} // namespace selftest
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_provider.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_provider.hpp
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_o2_settlement_provider.hpp   (Track A2 / X9 OPTION B)
+//
+// THE OPTION-B TEMPLATE PROVIDER — the serve-side analogue of
+// MonerodTemplateProvider (xmr_o2_template.hpp, option A), but the block bytes
+// it serves and submits are the v37 K_fair SETTLEMENT coinbase, not monerod's
+// single-output get_block_template.
+//
+// Flow, once per refresh (main thread):
+//   monerod get_miner_data  ->  node::MinerData (major/height/prev_id/seed/
+//                               difficulty/median_weight/already_generated_coins)
+//        |                       + an (empty on regtest) tx backlog
+//        v
+//   build_settlement_source(scfg, XmrParentContext, OwedLedger, pay_of, hint)
+//        |  (xmr_o2_settlement_fixture.hpp -> XmrOwedSettlementSource: projects
+//        |   the W4 K_fair owed set into x6::CoinbaseInputs, fail-closed)
+//        v
+//   XmrBlockAssembler::build(AssemblyInputs{from_miner_data, backlog, settle})
+//        |  (xmr_block_assembly.hpp: reward/payee-set fixpoint, weight-aware cap)
+//        v
+//   AssembledTemplate  ->  hashing_blob(en) served to miners
+//                          materialize(en) -> BlockBytes -> submit_block payload
+//
+// The three consumer seams the O-2 serve path already speaks to option A are
+// re-implemented over the AssembledTemplate so main_v37_xmr.cpp branches with a
+// few lines and reuses the listener / RandomX gate / LiveBlockSubmitter /
+// finalize-connect UNCHANGED:
+//   * XmrSettlementTemplateProvider   — mirrors MonerodTemplateProvider's
+//       refresh()/template_id()/current()/by_id()/last_error()/counters, plus
+//       difficulty_by_id() for the exact 128-bit network gate and
+//       candidate_by_id() for the submit path.
+//   * SettlementStratumTemplateSource — strat::ITemplateSource over the snapshot
+//       (get_job/rebuild_blob/max_extra_nonces). extra_nonce IS baked into the
+//       miner_tx 0x02 tag, so distinct extra_nonce => distinct blob (real
+//       per-worker search spaces, unlike option A's single blob).
+//
+// CONSENSUS STATUS: defines NO v37 consensus digest. It READS OwedLedger::
+// owed_digest() (through the settlement source) and serialises it into the
+// Monero coinbase tx_extra 0x03; the Monero block is validated by monerod
+// (RandomX + HF13 exact-sum), not by any v37 rule. Single-pool FOUND->FINALIZE
+// is safe pool-local. The two multi-node lane-consensus rulings (KFairSource,
+// lane_commitment source + the canonical_coinbase_matches ACCEPT gate on peers)
+// are surfaced as EXPLICIT config in XmrSettlementConfig and are NOT wired here
+// as a peer-reject gate — that seam is handed to the operator.
+//
+// THREADING: refresh() = main thread (reads the ledger, calls get_miner_data).
+// current()/by_id()/difficulty_by_id()/candidate_by_id()/template_id() and the
+// ITemplateSource methods are any-thread (mutex snapshot copy / shared_ptr to an
+// immutable AssembledTemplate). A retained snapshot outlives every in-flight job
+// that can still name its template_id.
+// ===========================================================================
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/node/monero_rpc.hpp"             // MoneroDaemonRpc::body_get_miner_data / parse_miner_data
+#include "impl/xmr/node/monerod_transport.hpp"      // IMonerodTransport / RpcResponse
+#include "impl/xmr/node/xmr_node_types.hpp"         // node::MinerData / TxBacklogEntry / Hash / Difficulty128
+#include "impl/xmr/stratum/xmr_stratum.hpp"         // ITemplateSource / TemplateJob
+#include "impl/xmr/template/xmr_block_assembly.hpp" // XmrBlockAssembler / AssembledTemplate / from_miner_data / from_backlog / BlockBytes
+#include "xmr_o2_settlement_fixture.hpp"            // XmrSettlementConfig / XmrParentContext / XmrOwedFixture / build_settlement_source / assembly_settle_inputs
+#include "xmr_live_submit.hpp"                       // submit::BlockCandidate
+
+namespace c2pool::v37n::xmr::o2 {
+
+namespace strat = ::v37::xmr::stratum;
+namespace asm_  = ::c2pool::xmr::assembly;
+namespace node  = ::c2pool::xmr::node;
+
+// One immutable, refcounted settlement template snapshot the serve + submit side
+// share. The AssembledTemplate is heap-owned and immutable after build(), so a
+// listener thread may materialize()/hashing_blob() while the main thread builds
+// the next one.
+struct SettlementSnapshot {
+    std::uint32_t                            template_id = 0;
+    std::shared_ptr<const asm_::AssembledTemplate> tpl;   // the v37 whole-block builder result
+    std::uint64_t                            height = 0;
+    std::uint64_t                            difficulty = 0;       // network difficulty lo64
+    std::uint64_t                            difficulty_top64 = 0; // hi64
+    std::uint64_t                            reward = 0;           // Σ coinbase outputs (piconero)
+    std::uint8_t                             major_version = 0;
+    std::size_t                              nonce_offset = 0;
+    node::Hash                               prev_id{};
+    std::array<std::uint8_t, strat::HASH_SIZE> seed_hash{};
+    std::size_t                              n_outputs = 0;
+    std::size_t                              n_tx = 0;
+    bool                                     valid = false;
+};
+
+// ---------------------------------------------------------------------------
+// XmrSettlementTemplateProvider — the option-B provider.
+// ---------------------------------------------------------------------------
+class XmrSettlementTemplateProvider {
+public:
+    // `ledger_owner` supplies the (possibly seeded, possibly empty) OwedLedger +
+    // its pay_of resolver. `scfg` is the fail-closed lane-parameter surface
+    // (residual sink REQUIRED + torsion-checked at build). `share_diff` mirrors
+    // option A (0 => solo/network target).
+    XmrSettlementTemplateProvider(node::IMonerodTransport& transport,
+                                  XmrOwedFixture& ledger_owner,
+                                  XmrSettlementConfig scfg,
+                                  std::uint64_t share_diff)
+        : m_tx(transport), m_ledger(ledger_owner), m_scfg(std::move(scfg)),
+          m_share_diff(share_diff) {}
+
+    XmrSettlementTemplateProvider(const XmrSettlementTemplateProvider&) = delete;
+    XmrSettlementTemplateProvider& operator=(const XmrSettlementTemplateProvider&) = delete;
+
+    // MAIN THREAD. get_miner_data -> assemble a fresh v37 settlement template.
+    // Returns true when a valid template is cached (new or unchanged); the human
+    // reason for a failure is kept in last_error().
+    bool refresh() {
+        node::MinerData md;
+        std::string rpc_err;
+        bool got = false;
+        m_tx.rpc_post(node::MoneroDaemonRpc::body_get_miner_data(),
+                      [&](const node::RpcResponse& r) {
+                          if (!r.ok()) { rpc_err = "transport: " + r.error; return; }
+                          if (auto p = node::MoneroDaemonRpc::parse_miner_data(r.body)) { md = *p; got = true; }
+                          else rpc_err = "get_miner_data: parse/validate failed";
+                      });
+        if (!got) { set_error(rpc_err.empty() ? "get_miner_data: no response" : rpc_err);
+                    m_failures.fetch_add(1); return false; }
+        if (!md.valid()) { set_error("get_miner_data: invalid miner_data"); m_failures.fetch_add(1); return false; }
+
+        node::Hash md_prev = md.prev_id;
+        // Tip UNCHANGED => keep the existing template BYTE-FOR-BYTE. This is
+        // load-bearing: XmrBlockAssembler stamps a fresh header timestamp on each
+        // build, so re-assembling under the same id would change the bytes a
+        // miner is already grinding (its shares would then miss on the daemon's
+        // re-hash — "Low diff"). Only reassemble when the parent tip moves.
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            if (m_cur.valid && m_cur.height == md.height && m_cur.prev_id == md_prev) {
+                m_last_error.clear();
+                m_refreshes.fetch_add(1);
+                return true;
+            }
+        }
+
+        std::string why;
+        SettlementSnapshot snap;
+        if (!assemble(md, snap, why)) { set_error(why); m_failures.fetch_add(1); return false; }
+
+        m_refreshes.fetch_add(1);
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_last_error.clear();
+        snap.template_id = ++m_id_counter;   // a real tip change => a fresh template + job
+        m_changes.fetch_add(1);
+        retain(snap);
+        m_cur = std::move(snap);
+        m_tid.store(m_cur.template_id, std::memory_order_release);
+        return true;
+    }
+
+    // --- MonerodTemplateProvider-shaped surface (any thread) ----------------
+    SettlementSnapshot current() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_cur;
+    }
+    bool by_id(std::uint32_t id, SettlementSnapshot& out) const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        auto it = m_ring.find(id);
+        if (it == m_ring.end() || !it->second.valid) return false;
+        out = it->second;
+        return true;
+    }
+    std::uint32_t template_id() const { return m_tid.load(std::memory_order_acquire); }
+    std::string   last_error() const { std::lock_guard<std::mutex> lk(m_mtx); return m_last_error; }
+    std::string   offset_note() const { return {}; }   // no derived-offset surprise: we own the layout
+    std::uint64_t refreshes() const { return m_refreshes.load(); }
+    std::uint64_t failures()  const { return m_failures.load(); }
+    std::uint64_t changes()   const { return m_changes.load(); }
+
+    // 128-bit network difficulty for a retained template — the exact gate input.
+    bool difficulty_by_id(std::uint32_t id, std::uint64_t& lo, std::uint64_t& hi) const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        auto it = m_ring.find(id);
+        if (it == m_ring.end() || !it->second.valid) return false;
+        lo = it->second.difficulty; hi = it->second.difficulty_top64;
+        return true;
+    }
+
+    // The submit-path candidate for (template_id, extra_nonce). Materialises the
+    // full block blob + the exact served hashing blob (both from the SAME
+    // AssembledTemplate), plus every offset the submitter patches. false =>
+    // template gone (stale) or a layout invariant failed.
+    bool candidate_by_id(std::uint32_t id, std::uint32_t extra_nonce,
+                         submit::BlockCandidate& out, std::string* why = nullptr) const {
+        SettlementSnapshot snap;
+        if (!by_id(id, snap) || !snap.tpl) { if (why) *why = "settlement template gone (stale)"; return false; }
+        asm_::BlockBytes b;
+        std::string me;
+        if (!snap.tpl->materialize(extra_nonce, b, &me)) { if (why) *why = "materialize: " + me; return false; }
+        out.template_id     = id;
+        out.height          = snap.height;
+        out.full_blob       = b.full_blob;
+        out.hashing_blob    = b.hashing_blob;
+        out.nonce_offset    = b.nonce_offset;
+        out.reserved_offset = 0;                 // extra_nonce is BAKED into the miner_tx, not spliced
+        out.reserved_size   = 0;
+        out.prev_id         = snap.prev_id;
+        out.expected_reward = snap.reward;
+        out.major_version   = snap.major_version;
+        return true;
+    }
+
+    // Fill a stratum job blob for (template_id, extra_nonce). Shared by get_job
+    // (current id) and rebuild_blob (a specific id).
+    bool fill_job(std::uint32_t id, std::uint32_t extra_nonce, strat::TemplateJob& out) const {
+        SettlementSnapshot snap;
+        if (!by_id(id, snap) || !snap.tpl) return false;
+        out.blob                 = snap.tpl->hashing_blob(extra_nonce);
+        out.nonce_offset         = snap.nonce_offset;
+        out.template_id          = id;
+        out.height               = snap.height;
+        out.mainchain_target     = network_target(snap.difficulty, snap.difficulty_top64);
+        out.lane_target          = m_share_diff
+                                       ? std::max(target_from_diff(m_share_diff), out.mainchain_target)
+                                       : out.mainchain_target;
+        out.seed_hash            = snap.seed_hash;
+        out.next_seed_hash       = std::nullopt;
+        out.monero_major_version = snap.major_version;
+        return !out.blob.empty();
+    }
+
+    std::uint32_t current_id() const { return m_tid.load(std::memory_order_acquire); }
+
+    // 64-bit target helpers (identical rule to MonerodStratumTemplateSource).
+    static std::uint64_t target_from_diff(std::uint64_t diff) {
+        return diff ? (0xFFFFFFFFFFFFFFFFULL / diff) : 0xFFFFFFFFFFFFFFFFULL;
+    }
+    static std::uint64_t network_target(std::uint64_t lo, std::uint64_t hi) {
+        if (hi) return 1;                       // a >2^64 difficulty: hardest u64 target; exact gate re-checks
+        return target_from_diff(lo);
+    }
+
+private:
+    static constexpr std::size_t RING = 6;      // retain a few templates so in-flight jobs resolve
+
+    void set_error(std::string e) { std::lock_guard<std::mutex> lk(m_mtx); m_last_error = std::move(e); }
+
+    // Add a new snapshot to the retain ring, evicting the oldest id beyond RING.
+    void retain(const SettlementSnapshot& snap) {   // caller holds m_mtx
+        m_ring[snap.template_id] = snap;
+        m_order.push_back(snap.template_id);
+        while (m_order.size() > RING) {
+            const std::uint32_t old = m_order.front();
+            m_order.pop_front();
+            if (old != snap.template_id) m_ring.erase(old);
+        }
+    }
+
+    // Turn one MinerData into a v37 settlement AssembledTemplate.
+    bool assemble(const node::MinerData& md, SettlementSnapshot& snap, std::string& why) {
+        // lane parameters that track the tip: major_version (CARROT fence key)
+        // and chain_id (== ledger.chain()). Everything else is operator config.
+        XmrSettlementConfig scfg = m_scfg;
+        scfg.monero_major_version = md.major_version;
+        scfg.chain_id             = m_ledger.ledger().chain();
+
+        // The XMR miner-data view the assembler consumes. lane_target is stored
+        // only (not used in block bytes); carry the network difficulty for tidiness.
+        ::c2pool::xmr::difficulty_type lane_t; lane_t.lo = md.difficulty.lo; lane_t.hi = md.difficulty.hi;
+        ::c2pool::xmr::XmrMinerData xmr_md = asm_::from_miner_data(md, lane_t);
+
+        const std::uint64_t base_reward = asm_::xmr_base_reward(md.already_generated_coins);
+        std::uint64_t fees = 0;
+        for (const auto& t : md.tx_backlog) fees += t.fee;
+
+        XmrParentContext parent = XmrParentContext::from_miner(xmr_md, base_reward, fees);
+
+        std::string ss_why;
+        std::unique_ptr<XmrOwedSettlementSource> src = build_settlement_source(
+            scfg, parent, m_ledger.ledger(), m_ledger.pay_of(),
+            /*reward_hint=*/base_reward + fees, &ss_why);
+        if (!src) { why = "settlement source refused: " + ss_why; return false; }
+
+        asm_::AssemblyInputs a;
+        a.miner   = xmr_md;
+        a.mempool = asm_::from_backlog(md.tx_backlog);       // empty on regtest => n_tx == 0
+        a.settle  = assembly_settle_inputs(*src, /*weight_aware_cap=*/true);
+
+        std::string as_why;
+        std::unique_ptr<asm_::AssembledTemplate> tpl = asm_::XmrBlockAssembler::build(a, &as_why);
+        if (!tpl) { why = "assembler refused: " + as_why; return false; }
+
+        // A probe materialisation locks in the layout (nonce offset, blob sizes).
+        asm_::BlockBytes probe;
+        std::string pe;
+        if (!tpl->materialize(0, probe, &pe)) { why = "probe materialize: " + pe; return false; }
+
+        snap.tpl              = std::shared_ptr<const asm_::AssembledTemplate>(tpl.release());
+        snap.height           = snap.tpl->height();
+        snap.difficulty       = md.difficulty.lo;
+        snap.difficulty_top64 = md.difficulty.hi;
+        snap.reward           = snap.tpl->reward();
+        snap.major_version    = snap.tpl->major_version();
+        snap.nonce_offset     = probe.nonce_offset;
+        std::memcpy(snap.prev_id.data(), snap.tpl->prev_id().data(), 32);
+        std::memcpy(snap.seed_hash.data(), md.seed_hash.data(), strat::HASH_SIZE);
+        snap.n_outputs        = snap.tpl->outputs().size();
+        snap.n_tx             = snap.tpl->n_tx();
+        snap.valid            = true;
+        why.clear();
+        return true;
+    }
+
+    node::IMonerodTransport& m_tx;
+    XmrOwedFixture&          m_ledger;
+    XmrSettlementConfig      m_scfg;
+    std::uint64_t            m_share_diff;
+
+    mutable std::mutex m_mtx;
+    SettlementSnapshot m_cur;
+    std::map<std::uint32_t, SettlementSnapshot> m_ring;   // retained by id
+    std::deque<std::uint32_t> m_order;
+    std::uint32_t m_id_counter = 0;
+    std::string   m_last_error;
+    std::atomic<std::uint32_t> m_tid{0};
+    std::atomic<std::uint64_t> m_refreshes{0}, m_failures{0}, m_changes{0};
+};
+
+// ---------------------------------------------------------------------------
+// SettlementStratumTemplateSource — strat::ITemplateSource over the provider.
+// Serves the v37 settlement hashing blob per (template_id, extra_nonce).
+// ---------------------------------------------------------------------------
+class SettlementStratumTemplateSource final : public strat::ITemplateSource {
+public:
+    explicit SettlementStratumTemplateSource(const XmrSettlementTemplateProvider& provider)
+        : m_provider(provider) {}
+
+    bool get_job(std::uint32_t extra_nonce, strat::TemplateJob& out) override {
+        const std::uint32_t id = m_provider.current_id();
+        if (id == 0) return false;
+        return m_provider.fill_job(id, extra_nonce, out);
+    }
+    bool rebuild_blob(std::uint32_t template_id, std::uint32_t extra_nonce,
+                      strat::TemplateJob& out) override {
+        return m_provider.fill_job(template_id, extra_nonce, out);   // false => Stale
+    }
+    // The miner_tx bakes a per-worker extra_nonce (distinct blob per worker),
+    // unlike option A's single blob. Bound a broadcast batch generously.
+    std::uint32_t max_extra_nonces() const override { return 65536; }
+
+private:
+    const XmrSettlementTemplateProvider& m_provider;
+};
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_source.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_source.hpp
@@ -1,0 +1,532 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_o2_settlement_source.hpp
+//                        (Track A2 / X9 option B — the settlement seam impl)
+//
+// XmrOwedSettlementSource: the ONLY IXmrSettlementSource in the tree. It is
+// the value that XmrBlockTemplate (impl/xmr/template, the p2pool block_template
+// port) calls into so that the miner_tx the pool assembles is the v37 K_fair
+// SETTLEMENT coinbase — outputs = oldest-owed-first EffectiveOwed payees from
+// the W4 OwedLedger ++ mandated fixed outputs ++ the exact-sum residual sink —
+// instead of monerod's single --payout-address output (option A, PR #1534).
+//
+// It is a PER-TEMPLATE VALUE SNAPSHOT, built on the main thread from
+//   (OwedLedger, pay_of, XmrCoinbaseContext, reward_hint)
+// with the X6 executor (impl/xmr/settle/xmr_coinbase) doing every byte of
+// crypto/serialization. Nothing here defines a consensus digest; the header
+// only CALLS OwedLedger::propose_coinbase / owed_digest and the X6 builder.
+// It never touches src/sharechain/v37 (its descriptor_xmr header is a
+// read-only value consumer, exactly as X6 uses it).
+//
+// WHERE THE K_FAIR SET COMES FROM (the survey's gate flag, ruling owed):
+//   * KFairSource::W4Propose (DEFAULT, recommended): the owed output set and
+//     order are OwedLedger::propose_coinbase (w4_settlement.hpp:565 — the
+//     canonical (first_eligible ASC, key ASC) walk with take = min(owed,
+//     budget) and CARRY on take < h_min). X6 is then a pure crypto/serialize
+//     executor: it is fed owed := take_i, first_eligible := i (the proposal
+//     index), h_min := 0, so allocate_exact_sum reproduces the proposal
+//     byte-for-byte and appends the residual sink. This is the BTC W5 shape
+//     ("the order is W4's and cannot drift", w5_coinbase.hpp:299-322).
+//   * KFairSource::X6Allocate (alternative, needs AgeOf): owed := every
+//     EffectiveOwed > 0 with first_eligible := age_of(key) and h_min := ctx.h_min;
+//     X6's own sort + skip/break rule decides (mbp_wiring.hpp OwedCoinbaseBridge
+//     shape). Kept ONLY so the operator ruling is a one-line flip.
+//   The two can emit different output sets from the same ledger (X6 skips
+//   owed < h_min and BREAKS on a sub-h_min final partial; W4 carries and
+//   CONTINUES). Whichever is ruled becomes lane canon; the enum pins the choice
+//   in the provider, not in this header's defaults alone.
+//
+// WHAT IS PRE-COMPUTED (and why it is safe to snapshot):
+//   r = H_s(domain || major || chain_id || lane_commitment || prev_id || height)
+//   depends on NEITHER the reward NOR the extra_nonce, so r, R = rG, every
+//   one-time key P_i = H_s(8rA_i || i)G + B_i and view tag, and the MM leaf
+//   keccak(MM_LEAF_DOMAIN || chain_id_le32 || lane_commitment) are fixed for
+//   the template's lifetime. Only the AMOUNTS vary with the reward the template
+//   settles on, and those are re-allocated deterministically in split_reward().
+//
+// COUNT INVARIANCE (survey must_implement 3a — NOT solved here, by design):
+//   XmrBlockTemplate::update() calls split_reward twice (dry run at
+//   base + Σfees, then at the penalty-adjusted final reward) and assumes the
+//   payee COUNT is reward-independent. X6's set is budget-dependent (the sink
+//   exists iff residual > 0; a lower budget truncates the tail). This seam
+//   keeps payees() FIXED at the reward_hint allocation and makes split_reward
+//   return false whenever the allocation at `reward` has a different shape —
+//   fail-closed (the template falls back to use_old_template(), which the
+//   provider MUST detect via template_id/height). The fixpoint (re-allocate at
+//   the final reward and iterate) belongs to the template-side patch / the
+//   provider ring, which rebuilds THIS snapshot at reward_hint := final reward.
+//   Do NOT "fix" it here by forcing the sink to always exist: that would alter
+//   X6's allocation canon.
+//
+// PER-TEMPLATE SEAM CAPTURE (survey 3b): XmrBlockTemplate stores a raw
+//   IXmrSettlementSource* and RE-QUERIES it at job/submit time, and its
+//   OLD_TEMPLATES copies share that pointer. So this object is heap-owned
+//   (build() returns a unique_ptr — stable address), immutable after build,
+//   and the provider ring owns one per template_id for as long as that id can
+//   be submitted. Never point a template at a snapshot that may be destroyed
+//   or rebuilt underneath it.
+//
+// FAIL-CLOSED RULES:
+//   * the residual sink (and every fixed output) MUST pass xmr_ref_valid —
+//     torsion check under the installed ed25519 point-check backend. No backend
+//     => nothing validates => build() refuses (BadSinkDescriptor). This is the
+//     "REFUSE to serve B without --residual-sink-*" rule.
+//   * a ledger key whose pay_of() ref is not a valid XMR ref is never paid and
+//     never dropped ad hoc: it is CARRIED by W4's own rule (h_min_of ->
+//     UINT64_MAX, the canon CARRY branch), so every node with the same ledger +
+//     backend produces the same set. The count is surfaced for diagnostics.
+//   * CARROT fence: major_version > 16 refuses (X6 CarrotFence), and
+//     derive_output_key() refuses an hf_major that differs from the one r was
+//     derived under.
+//   * ctx.chain_id must equal ledger.chain(); mismatch refuses.
+//
+// THREADING: build() = main thread (reads the ledger). Every other method is
+// const, touches no shared state, and is safe from the listener thread through
+// the template's seam pointer.
+// ===========================================================================
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <c2pool/v37/w4_settlement.hpp>            // OwedLedger (merged; propose_coinbase, owed_digest)
+#include <sharechain/v37/v37_descriptor.hpp>        // ScriptRef, ScriptKind (read-only canon)
+#include <sharechain/v37/v37_descriptor_xmr.hpp>    // xmr_ref_valid, is_xmr_kind, xmr_precarrot_ok
+#include <sharechain/v37/v37_hash.hpp>              // bytes32
+
+#include "impl/xmr/coin/xmr_crypto_types.hpp"       // Bytes32, PublicKey, SecretKey, Hash256
+#include "impl/xmr/settle/xmr_coinbase.hpp"         // X6: CoinbaseInputs, build_coinbase, allocate_exact_sum, ...
+#include "impl/xmr/template/xmr_block_template.hpp" // IXmrSettlementSource, XmrPayee, c2pool::xmr::hash
+
+namespace c2pool::v37n::xmr::o2 {
+
+namespace x6 = ::v37::xmr::settle;
+
+using OwedLedger = ::c2pool::v37n::settle::OwedLedger;
+using Amounts    = OwedLedger::Amounts;                    // std::map<bytes32, long long>
+using TplHash    = ::c2pool::xmr::hash;                    // the template's 32-byte hash POD
+
+// Resolve a canonical OWED key to its payout ScriptRef (the fold's identity
+// view in production; a fixed resolver in the smoke). Same shape as
+// btc_node.hpp:82 PayOfFn and mbp_wiring.hpp:96 PayOf.
+using PayOfFn = std::function<::v37::ScriptRef(const ::v37::bytes32& key)>;
+// K_fair age of a key (first_eligible). ONLY the X6Allocate path needs it;
+// OwedLedger keeps m_first_eligible private, so the W4Propose path never asks.
+using AgeOfFn = std::function<std::uint64_t(const ::v37::bytes32& key)>;
+
+// ---------------------------------------------------------------------------
+// 32-byte shims between the three hash spellings that meet at this seam:
+//   c2pool::xmr::hash (template, uint8_t h[32])  <->  xmr::coin::Bytes32 (X6)
+//   <->  ::v37::bytes32 (ledger keys / digests, std::array<uint8_t,32>).
+// Plain memcpy; every one of them is a bare 32-byte little-endian string.
+// ---------------------------------------------------------------------------
+inline TplHash tpl_hash_from(const ::xmr::coin::Bytes32& b) {
+    TplHash h; std::memcpy(h.h, b.data(), 32); return h;
+}
+inline TplHash tpl_hash_from(const ::v37::bytes32& b) {
+    TplHash h; std::memcpy(h.h, b.data(), 32); return h;
+}
+inline ::xmr::coin::Hash256 hash256_from(const TplHash& h) {
+    ::xmr::coin::Hash256 o{}; std::memcpy(o.data(), h.h, 32); return o;
+}
+inline ::xmr::coin::Hash256 hash256_from(const ::v37::bytes32& b) {
+    ::xmr::coin::Hash256 o{}; std::memcpy(o.data(), b.data(), 32); return o;
+}
+inline ::v37::bytes32 bytes32_from(const ::xmr::coin::Bytes32& b) {
+    ::v37::bytes32 o{}; std::memcpy(o.data(), b.data(), 32); return o;
+}
+inline ::v37::bytes32 bytes32_from(const TplHash& h) {
+    ::v37::bytes32 o{}; std::memcpy(o.data(), h.h, 32); return o;
+}
+
+// ---------------------------------------------------------------------------
+// Which implementation of "K_fair" picks the owed output set. See banner.
+// ---------------------------------------------------------------------------
+enum class KFairSource : std::uint8_t {
+    W4Propose  = 0,   // OwedLedger::propose_coinbase decides; X6 executes (default)
+    X6Allocate = 1,   // X6 allocate_exact_sum decides over effective_owed_all (needs AgeOf)
+};
+
+inline const char* to_string(KFairSource s) {
+    switch (s) {
+        case KFairSource::W4Propose:  return "w4-propose";
+        case KFairSource::X6Allocate: return "x6-allocate";
+    }
+    return "?";
+}
+
+// ---------------------------------------------------------------------------
+// The consensus-derived context for ONE template (mirrors mbp_wiring.hpp:78-91
+// CoinbaseContext field-for-field, minus the per-WORKER extra_nonce, which the
+// template patches itself). Every field is a pure function of the mainchain
+// tip + lane state / lane parameters, so the coinbase is byte-reproducible.
+// ---------------------------------------------------------------------------
+struct XmrCoinbaseContext {
+    // --- CARROT fence key + Monero parent ---
+    std::uint8_t          monero_major_version = 16;
+    std::uint64_t         height = 0;                 // block height; unlock = height + 60
+    ::xmr::coin::Hash256  prev_id{};                  // parent block id (bin origin)
+    std::uint64_t         base_reward = 0;            // get_base_reward(already_generated_coins)
+    std::uint64_t         fees = 0;                   // Σ selected tx fees (informational split)
+
+    // --- lane context ---
+    std::uint32_t         chain_id = 0;               // v37 ChainId of the XMR lane (== ledger.chain())
+    ::v37::bytes32        lane_commitment{};          // r-seed + MM leaf (recommended: owed_digest())
+
+    // --- lane parameters (consensus once tapped; explicit flags until then) ---
+    ::v37::ScriptRef      residual_sink;              // mandated absorber, XMR ref (REQUIRED, torsion-checked)
+    ::v37::bytes32        residual_sink_identity{};   // its ledger identity_key (payout-map key)
+    std::vector<x6::FixedOutput> fixed;               // mandated dev/donation/finder outputs (optional)
+    std::uint64_t         h_min = 0;                  // piconero floor per owed output (dust = 0 on XMR)
+    std::uint32_t         output_cap = 0;             // TOTAL outputs cap C (weight_aware_output_cap(...))
+
+    std::uint64_t budget() const { return base_reward + fees; }
+};
+
+// The lane_commitment source the survey recommends: the §4.5 OWED commitment
+// over the finalized partition (public, const, deterministic). Whether this or
+// the lane digest / SettlementView::digest goes into r and the MM root is a
+// consensus ruling; the provider picks EXPLICITLY and passes it in ctx.
+inline ::v37::bytes32 lane_commitment_from_owed_digest(const OwedLedger& ledger) {
+    return ledger.owed_digest();
+}
+
+// ===========================================================================
+// XmrOwedSettlementSource
+// ===========================================================================
+class XmrOwedSettlementSource final : public ::c2pool::xmr::IXmrSettlementSource {
+public:
+    // Build the per-template snapshot. Returns nullptr and fills *why on any
+    // refusal (fence, bad sink, cap, budget, derivation, chain mismatch).
+    //   reward_hint : the exact-sum budget the owed set is chosen at (the
+    //                 template's final reward once the fixpoint converges; the
+    //                 provider's first guess is base_reward + Σ selected fees).
+    //                 0 => ctx.budget().
+    //   age_of      : REQUIRED for KFairSource::X6Allocate, ignored otherwise.
+    static std::unique_ptr<XmrOwedSettlementSource>
+    build(const OwedLedger& ledger, const PayOfFn& pay_of, const XmrCoinbaseContext& ctx,
+          std::uint64_t reward_hint, std::string* why,
+          KFairSource source = KFairSource::W4Propose, const AgeOfFn& age_of = {})
+    {
+        auto refuse = [&](const std::string& msg) -> std::unique_ptr<XmrOwedSettlementSource> {
+            if (why) *why = msg;
+            return nullptr;
+        };
+        if (reward_hint == 0) reward_hint = ctx.budget();
+
+        // ---- fences / lane-parameter validity (fail-closed) ----
+        if (!::v37::xmr::xmr_precarrot_ok(ctx.monero_major_version))
+            return refuse(std::string("refused: ") + x6::to_string(x6::BuildError::CarrotFence));
+        if (ctx.chain_id != ledger.chain())
+            return refuse("refused: ctx.chain_id != ledger.chain()");
+        if (!::v37::xmr::xmr_ref_valid(ctx.residual_sink))
+            return refuse(std::string("refused: ") + x6::to_string(x6::BuildError::BadSinkDescriptor) +
+                          " (need --residual-sink-* XMR ref AND the ed25519 point-check backend)");
+        for (const auto& f : ctx.fixed) {
+            if (!::v37::xmr::xmr_ref_valid(f.pay))
+                return refuse("refused: a fixed output is not a valid XMR ref");
+        }
+        if (ctx.output_cap < ctx.fixed.size() + 1)
+            return refuse(std::string("refused: ") + x6::to_string(x6::BuildError::CapTooSmall));
+        if (reward_hint == 0)
+            return refuse(std::string("refused: ") + x6::to_string(x6::BuildError::ZeroBudget));
+        std::uint64_t fixed_sum = 0;
+        for (const auto& f : ctx.fixed) {
+            if (f.amount > reward_hint - fixed_sum)
+                return refuse(std::string("refused: ") + x6::to_string(x6::BuildError::FixedExceedsBudget));
+            fixed_sum += f.amount;
+        }
+        if (source == KFairSource::X6Allocate && !age_of)
+            return refuse("refused: KFairSource::X6Allocate needs an AgeOf resolver");
+
+        std::unique_ptr<XmrOwedSettlementSource> s(new XmrOwedSettlementSource());
+        s->m_ctx         = ctx;
+        s->m_source      = source;
+        s->m_reward_hint = reward_hint;
+        s->m_ledger_seq  = ledger.ledger_seq();
+        s->m_owed_digest = ledger.owed_digest();
+
+        // ---- the fixed part of the X6 inputs (reward / extra_nonce applied per query) ----
+        x6::CoinbaseInputs& in = s->m_inputs;
+        in.monero_major_version   = ctx.monero_major_version;
+        in.height                 = ctx.height;
+        in.prev_id                = ctx.prev_id;
+        in.chain_id               = ctx.chain_id;
+        in.lane_commitment        = ctx.lane_commitment;
+        in.fixed                  = ctx.fixed;
+        in.residual_sink          = ctx.residual_sink;
+        in.residual_sink_identity = ctx.residual_sink_identity;
+        in.output_cap             = ctx.output_cap;
+        in.extra_nonce.clear();
+
+        // A key whose ref is not a payable XMR ref is downgraded to a RAW
+        // sentinel; W4's h_min_of(RAW) = UINT64_MAX then CARRIES it (canon
+        // branch, deterministic across nodes with the same backend).
+        std::size_t unpayable = 0;
+        auto payable_ref = [&](const ::v37::bytes32& k) -> ::v37::ScriptRef {
+            ::v37::ScriptRef r = pay_of(k);
+            if (!::v37::xmr::xmr_ref_valid(r)) {
+                ++unpayable;
+                ::v37::ScriptRef raw; raw.kind = ::v37::ScriptKind::RAW; raw.payload.clear();
+                return raw;
+            }
+            return r;
+        };
+
+        const unsigned cap_owed = static_cast<unsigned>(
+            std::min<std::size_t>(ctx.output_cap - ctx.fixed.size() - 1,
+                                  std::numeric_limits<unsigned>::max()));
+
+        if (source == KFairSource::W4Propose) {
+            // W4 canon picks the set over budget - Σfixed with C = cap - fixed - sink.
+            const std::uint64_t owed_budget = reward_hint - fixed_sum;
+            auto h_min_of = [&](::v37::ScriptKind k) -> std::uint64_t {
+                return ::v37::xmr::is_xmr_kind(k) ? ctx.h_min
+                                                  : std::numeric_limits<std::uint64_t>::max();
+            };
+            OwedLedger::Proposal prop = ledger.propose_coinbase(owed_budget, cap_owed,
+                                                                payable_ref, h_min_of);
+            in.owed.reserve(prop.outs.size());
+            for (std::size_t i = 0; i < prop.outs.size(); ++i) {
+                x6::OwedEntry e;
+                e.pay            = prop.outs[i].pay;
+                e.owed           = prop.outs[i].amount;   // exactly the proposed take
+                e.first_eligible = i;                     // proposal index == canonical order
+                e.identity       = prop.outs[i].key;
+                in.owed.push_back(std::move(e));
+            }
+            in.h_min = 0;                                 // W4 already applied the floor
+        }
+        else {
+            // X6 decides: every EffectiveOwed > 0 with its real age; X6 sorts
+            // (first_eligible ASC, identity ASC) and applies its own h_min rule.
+            for (const auto& [k, owed] : ledger.effective_owed_all()) {
+                if (owed <= 0) continue;
+                ::v37::ScriptRef r = payable_ref(k);
+                if (!::v37::xmr::is_xmr_kind(r.kind)) continue;   // unpayable => carry
+                x6::OwedEntry e;
+                e.pay            = r;
+                e.owed           = static_cast<std::uint64_t>(owed);
+                e.first_eligible = age_of(k);
+                e.identity       = k;
+                in.owed.push_back(std::move(e));
+            }
+            in.h_min = ctx.h_min;
+        }
+        s->m_unpayable = unpayable;
+
+        // ---- run X6 once at reward_hint: fixes r, R, keys, view tags, MM leaf, ORDER ----
+        s->m_built = x6::build_coinbase(s->inputs_at(reward_hint, {}));
+        if (!s->m_built.ok)
+            return refuse(std::string("refused: X6 build_coinbase: ") + s->m_built.detail);
+
+        s->m_payees.reserve(s->m_built.outputs.size());
+        for (const auto& o : s->m_built.outputs) {
+            ::c2pool::xmr::XmrPayee p;
+            std::memcpy(p.spend_public_key.h, o.pay.payload.data(),      32);   // B (or D_i)
+            std::memcpy(p.view_public_key.h,  o.pay.payload.data() + 32, 32);   // A
+            s->m_payees.push_back(p);
+        }
+        s->m_r    = tpl_hash_from(s->m_built.r);
+        s->m_R    = tpl_hash_from(s->m_built.R);
+        s->m_leaf = tpl_hash_from(s->m_built.mm_root);   // == mm_commitment_root(chain_id, lane_commitment)
+        if (why) why->clear();
+        return s;
+    }
+
+    // Non-copyable / non-movable on purpose: the template keeps a raw pointer.
+    XmrOwedSettlementSource(const XmrOwedSettlementSource&) = delete;
+    XmrOwedSettlementSource& operator=(const XmrOwedSettlementSource&) = delete;
+    ~XmrOwedSettlementSource() override = default;
+
+    // =====================================================================
+    // IXmrSettlementSource (the template seam) — all pure, all const.
+    // =====================================================================
+
+    // X6 canonical order: [K_fair owed] ++ [fixed] ++ [sink?], fixed at reward_hint.
+    [[nodiscard]] const std::vector<::c2pool::xmr::XmrPayee>& payees() const override {
+        return m_payees;
+    }
+
+    [[nodiscard]] const TplHash& tx_secret_key() const override { return m_r; }
+    [[nodiscard]] const TplHash& tx_public_key() const override { return m_R; }
+
+    // P_i / view_tag_i were derived under r for the SAME major version; refuse
+    // any other fork (fence) and any index outside the snapshot.
+    [[nodiscard]] bool derive_output_key(std::size_t i, std::uint8_t hf_major,
+                                         TplHash& out_eph_pubkey,
+                                         std::uint8_t& out_view_tag) const override {
+        if (!::v37::xmr::xmr_precarrot_ok(hf_major)) return false;        // CARROT fence
+        if (hf_major != m_ctx.monero_major_version) return false;          // r was seeded with ctx.major
+        if (i >= m_built.outputs.size()) return false;
+        const x6::CoinbaseOutput& o = m_built.outputs[i];
+        out_eph_pubkey = tpl_hash_from(o.one_time_key);
+        out_view_tag   = o.view_tag.tag;
+        return true;
+    }
+
+    // Exact-sum split at `reward` over the snapshot's owed/fixed/sink set.
+    // true  => rewards[i] is the piconero amount of payees()[i], Σ == reward.
+    // false => the allocation at `reward` has a different SHAPE (count / payee
+    //          order) than payees() — fail closed; see the banner (3a).
+    [[nodiscard]] bool split_reward(std::uint64_t reward,
+                                    std::vector<std::uint64_t>& rewards) const override {
+        x6::BuildError err = x6::BuildError::None;
+        const std::vector<x6::CoinbaseOutput> outs = x6::allocate_exact_sum(inputs_at(reward, {}), &err);
+        if (outs.empty() || err != x6::BuildError::None) return false;
+        if (!same_shape(outs)) return false;
+        rewards.resize(outs.size());
+        std::uint64_t sum = 0;
+        for (std::size_t i = 0; i < outs.size(); ++i) { rewards[i] = outs[i].amount; sum += outs[i].amount; }
+        return sum == reward;   // X6 invariant; belt-and-braces
+    }
+
+    // Single v37 MM-tree leaf: keccak(MM_LEAF_DOMAIN || chain_id_le32 || lane_commitment).
+    // extra_nonce-INDEPENDENT (the commitment binds the ledger, not the worker),
+    // so a stale template_id can never patch a different root than was hashed.
+    [[nodiscard]] TplHash commitment_leaf(std::uint32_t /*extra_nonce*/) const override {
+        return m_leaf;
+    }
+
+    // depth 0 => the template emits [0x03][1+32][varint(0)][root], byte-equal
+    // to X6 assemble_tx_extra's { varint(33) || 0x00 || root }.
+    [[nodiscard]] std::uint64_t merkle_tree_data() const override { return 0; }
+
+    // =====================================================================
+    // Value accessors (provider ring / FOUND record / KATs / ACCEPT check)
+    // =====================================================================
+
+    // The seam pointer the template takes. Address is stable for this object's life.
+    ::c2pool::xmr::IXmrSettlementSource* seam() { return this; }
+
+    const XmrCoinbaseContext& context()      const { return m_ctx; }
+    KFairSource               kfair_source() const { return m_source; }
+    std::uint64_t             reward_hint()  const { return m_reward_hint; }
+    // Ledger state this snapshot was cut at — part of the provider's REBUILD
+    // KEY (prev_id, height, backlog, ledger_seq/owed_digest), since r and the
+    // MM leaf depend on lane_commitment and the owed set on the ledger.
+    std::uint64_t             ledger_seq()   const { return m_ledger_seq; }
+    const ::v37::bytes32&     owed_digest()  const { return m_owed_digest; }
+    // Ledger keys with EffectiveOwed > 0 that were CARRIED as unpayable.
+    std::size_t               carried_unpayable() const { return m_unpayable; }
+
+    // The full X6 result at reward_hint (empty extra_nonce => no 0x02 tag; use
+    // build_at() for the template-equal tx_extra).
+    const x6::BuiltCoinbase&  built() const { return m_built; }
+    const x6::CoinbaseInputs& inputs() const { return m_inputs; }   // reward/extra_nonce NOT applied
+
+    // X6 inputs at a given exact-sum budget and 0x02 extra-nonce payload.
+    // X6 consumes only budget(); the (base_reward, fees) split is kept where
+    // it is representable so audit trails keep the subsidy/fees distinction.
+    x6::CoinbaseInputs inputs_at(std::uint64_t reward,
+                                 const std::vector<unsigned char>& extra_nonce) const {
+        x6::CoinbaseInputs in = m_inputs;
+        if (reward >= m_ctx.base_reward) { in.base_reward = m_ctx.base_reward; in.fees = reward - m_ctx.base_reward; }
+        else                             { in.base_reward = reward;            in.fees = 0; }
+        in.extra_nonce = extra_nonce;
+        return in;
+    }
+
+    // The 0x02 payload exactly as XmrBlockTemplate lays it out for extra_nonce
+    // e: LE32(e) followed by zero padding up to the template's corrected size
+    // (EXTRA_NONCE_SIZE + max_reward_amounts_weight - reward_amounts_weight).
+    static std::vector<unsigned char> extra_nonce_bytes(std::uint32_t e, std::size_t padded_len) {
+        std::vector<unsigned char> b(std::max<std::size_t>(padded_len, 4), 0);
+        b[0] = static_cast<unsigned char>(e);       b[1] = static_cast<unsigned char>(e >> 8);
+        b[2] = static_cast<unsigned char>(e >> 16); b[3] = static_cast<unsigned char>(e >> 24);
+        return b;
+    }
+
+    // Full X6 rebuild at (reward, extra_nonce): the bytes a KAT compares against
+    // the template's miner_tx slice, and what a peer's ACCEPT check (W3,
+    // canonical_coinbase_matches) recomputes.
+    x6::BuiltCoinbase build_at(std::uint64_t reward,
+                               const std::vector<unsigned char>& extra_nonce) const {
+        return x6::build_coinbase(inputs_at(reward, extra_nonce));
+    }
+
+    // Allocation at `reward` (amount / pay / identity / role), with the
+    // snapshot's one-time keys + view tags attached when the shape matches.
+    // Empty on an X6 allocation error.
+    std::vector<x6::CoinbaseOutput> outputs_at(std::uint64_t reward, bool* shape_ok = nullptr) const {
+        x6::BuildError err = x6::BuildError::None;
+        std::vector<x6::CoinbaseOutput> outs = x6::allocate_exact_sum(inputs_at(reward, {}), &err);
+        const bool ok = !outs.empty() && err == x6::BuildError::None && same_shape(outs);
+        if (ok) {
+            for (std::size_t i = 0; i < outs.size(); ++i) {
+                outs[i].one_time_key = m_built.outputs[i].one_time_key;
+                outs[i].view_tag     = m_built.outputs[i].view_tag;
+            }
+        }
+        if (shape_ok) *shape_ok = ok;
+        return outs;
+    }
+    bool shape_matches_at(std::uint64_t reward) const {
+        bool ok = false; (void)outputs_at(reward, &ok); return ok;
+    }
+    std::size_t output_count_at(std::uint64_t reward) const {
+        return outputs_at(reward).size();
+    }
+
+    // FOUND-record `payout`: { identity_key : piconero } over EVERY output the
+    // coinbase actually pays (owed keys, fixed identities, the sink identity),
+    // at the reward the template settled on (XmrBlockTemplate::get_reward()).
+    // Duplicate identities (e.g. a sink that is also an owed key) SUM. Empty
+    // when the allocation at `reward` fails or its shape does not match.
+    Amounts payout_map_at(std::uint64_t reward) const {
+        Amounts m;
+        bool ok = false;
+        const std::vector<x6::CoinbaseOutput> outs = outputs_at(reward, &ok);
+        if (!ok) return m;
+        for (const auto& o : outs) m[o.identity] += static_cast<long long>(o.amount);
+        return m;
+    }
+    Amounts payout_map() const { return payout_map_at(m_reward_hint); }
+
+private:
+    XmrOwedSettlementSource() = default;
+
+    // Same count, same payee (pay + identity + role) at every index as the
+    // snapshot's canonical order. Amounts are allowed to differ (that is the
+    // whole point of re-splitting); nothing else is.
+    bool same_shape(const std::vector<x6::CoinbaseOutput>& outs) const {
+        if (outs.size() != m_built.outputs.size()) return false;
+        for (std::size_t i = 0; i < outs.size(); ++i) {
+            const x6::CoinbaseOutput& a = outs[i];
+            const x6::CoinbaseOutput& b = m_built.outputs[i];
+            if (a.role != b.role || a.identity != b.identity || !(a.pay == b.pay)) return false;
+        }
+        return true;
+    }
+
+    XmrCoinbaseContext   m_ctx;
+    KFairSource          m_source = KFairSource::W4Propose;
+    std::uint64_t        m_reward_hint = 0;
+    std::uint64_t        m_ledger_seq = 0;
+    ::v37::bytes32       m_owed_digest{};
+    std::size_t          m_unpayable = 0;
+
+    x6::CoinbaseInputs   m_inputs;     // fixed part; reward + extra_nonce applied per query
+    x6::BuiltCoinbase    m_built;      // X6 at reward_hint: r, R, keys, view tags, mm_root, order
+
+    std::vector<::c2pool::xmr::XmrPayee> m_payees;
+    TplHash              m_r;
+    TplHash              m_R;
+    TplHash              m_leaf;
+};
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/impl/xmr/CMakeLists.txt
+++ b/src/impl/xmr/CMakeLists.txt
@@ -34,6 +34,13 @@ add_subdirectory(coin)
 # X2 node KAT in test/, or later W3 wire / W5 coinbase legs) is built.
 add_subdirectory(node)
 
+# X9 OPTION B: the whole-block template builder library (xmr_template =
+# xmr_block_template.cpp p2pool port + the authored xmr_coin_primitives.cpp seam
+# bodies over xmr_coin). Unconditional like coin/node — its TUs compile only when
+# a dependent target links it (the c2pool-v37-xmr daemon behind --coinbase v37,
+# and the assembly KAT in test/). See template/CMakeLists.txt.
+add_subdirectory(template)
+
 # X8 / O-2: librandomx from the VENDORED tevador/RandomX tree (consensus pin
 # 12f2c2ff, third_party/randomx). OFF by default — 2 x 256 MiB light caches +
 # a JIT are OOM-hostile on a laptop and do not survive -fsanitize — and turned

--- a/src/impl/xmr/template/CMakeLists.txt
+++ b/src/impl/xmr/template/CMakeLists.txt
@@ -1,0 +1,38 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Family B (XMR / RandomX lane) — whole-block template builder library (X9 opt-B)
+#
+# `xmr_template` = the p2pool-derived XmrBlockTemplate TU (GPL-3.0-only source,
+# combined under AGPLv3 §13; see the PROVENANCE block atop
+# xmr_block_template.cpp and xmr_provenance.hpp) + the AUTHORED bodies for the
+# consumer-side primitive seam it consumes (xmr_coin_primitives.cpp, AGPL-3),
+# which forward to the X1 `xmr_coin` library (vendored monero-project keccak.c,
+# vendored tools::write_varint) so the template's varints / Keccak / midstate
+# are the SAME bytes xmr_blob.hpp emits.
+#
+# Until this wave the template TU was compiled by NO target. Like xmr_coin it
+# costs a plain `--target c2pool` build nothing: its TUs compile only when a
+# target links it (the xmr_template_primitives_kat in ../test, and — behind the
+# --settlement-coinbase opt-in — c2pool-v37-xmr once the option-B provider is
+# wired in src/c2pool/CMakeLists.txt).
+#
+# Hook (one line, in ../CMakeLists.txt next to add_subdirectory(coin)/(node)):
+#     add_subdirectory(template)
+# No add_executable here, so the tools/ci/check_test_target_allowlist.py
+# drift-guard (which audits test/ trees) is unaffected.
+# ─────────────────────────────────────────────────────────────────────────────
+
+if (NOT TARGET Threads::Threads)
+    find_package(Threads REQUIRED)
+endif()
+
+add_library(xmr_template STATIC
+    xmr_block_template.cpp        # p2pool block_template.cpp port (GPL-3, AGPLv3 §13)
+    xmr_coin_primitives.cpp       # authored seam bodies over xmr_coin (AGPL-3)
+)
+
+# Consumers include "xmr_block_template.hpp" / "xmr_coin_primitives.hpp" /
+# "xmr_coin_adapters.hpp" relative to this dir; xmr_coin's PUBLIC include dirs
+# (coin/, coin/vendor, coin/compat) propagate through the PUBLIC link below.
+target_include_directories(xmr_template PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(xmr_template PUBLIC xmr_coin Threads::Threads)
+target_compile_features(xmr_template PUBLIC cxx_std_20)

--- a/src/impl/xmr/template/xmr_block_assembly.hpp
+++ b/src/impl/xmr/template/xmr_block_assembly.hpp
@@ -1,0 +1,991 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/template/xmr_block_assembly.hpp  --  X9 option B:
+//                                                   WHOLE-BLOCK ASSEMBLY
+//
+// AUTHORED for c2pool (AGPL-3.0). NOT a port. This file is the glue that turns
+// the two disconnected legs already in the tree into one producer of a FULL,
+// SUBMITTABLE Monero block:
+//
+//   * the p2pool-derived whole-block template builder
+//       XmrBlockTemplate  (xmr_block_template.{hpp,cpp}, GPL-3 via AGPLv3 s13)
+//     which serialises  header || miner_tx || varint(n_tx) || 32*n tx hashes,
+//     does the penalty-aware tx selection, the Keccak-midstate per-extra-nonce
+//     coinbase re-hash, the tree_hash main branch and the 76..128 B RandomX
+//     hashing blob -- but consumes its coinbase through the abstract seam
+//       IXmrSettlementSource   (payees / r / R / P_i / split / MM leaf)
+//     and its primitives through xmr_coin_primitives.hpp, which DECLARES
+//     writeVarint / keccak / keccak_step / keccak_finish / umul128 / udiv128 /
+//     parallel_run / seconds_since_epoch with NO bodies; and
+//
+//   * the X6 W5-XMR settlement executor
+//       build_coinbase / allocate_exact_sum / derive_output / mm_commitment_root
+//       (settle/xmr_coinbase.{hpp,cpp}, AGPL-3, KAT-pinned)
+//     which is the CANON for what the coinbase pays (K_fair oldest-owed-first
+//     EffectiveOwed payees ++ mandated fixed outputs ++ exact-sum residual sink,
+//     HF13 no-burn), the deterministic tx key r and the 0x03 MM commitment.
+//
+// What this header adds (three seams, all impl-side; nothing under
+// src/sharechain/v37 is touched and no consumer-tree header is included):
+//
+//   1. PRIMITIVE BODIES for xmr_coin_primitives.hpp, over the vendored
+//      monero-project keccak.c / varint.h (BSD-3) -- compiled into exactly ONE
+//      translation unit that defines XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES
+//      before including this header (see the bottom of the file).
+//
+//   2. X6SettlementSource : IXmrSettlementSource -- a per-template VALUE
+//      snapshot built from X6 CoinbaseInputs. payees()/r/R/P_i/view tags/the
+//      MM root are X6's own outputs, so "the X6 coinbase IS the block's
+//      coinbase" holds by construction and is byte-proven by the self-check.
+//      It also solves the p2pool COUNT-INVARIANCE assumption (the upstream
+//      flow calls split_reward twice -- a sizing pass at base+sum(fees) and a
+//      final pass at the penalty-adjusted reward -- and requires the same
+//      miner_tx size): X6's payee SET varies with the budget, so the seam
+//      accepts a reward only if X6's allocate_exact_sum at that reward yields
+//      the SAME payee set (then adopts those canonical amounts, exact-sum for
+//      that reward) and otherwise records the wanted reward and refuses, which
+//      makes XmrBlockTemplate::update() fall back to its empty old template;
+//      the assembler (3) then rebuilds the snapshot at the wanted reward and
+//      iterates to a fixpoint. This keeps X6's allocation canon untouched (no
+//      "sink always present" hack) and needs NO edit to the ported TU.
+//
+//   3. XmrBlockAssembler / AssembledTemplate -- the fixpoint driver + the
+//      immutable per-build record. Every build owns its OWN seam snapshot and
+//      its OWN XmrBlockTemplate (so the seam pointer the template stores can
+//      never be re-queried for a stale template id after the ledger moved --
+//      the OLD_TEMPLATES double-buffer sharing problem of the ported class is
+//      side-stepped rather than patched), and exposes for one extra_nonce:
+//         full_blob     = get_block_template_blob  (extra nonce + MM root
+//                         patched, header nonce zero: the submit_block payload)
+//         hashing_blob  = get_hashing_blob          (the RandomX input)
+//      plus the X6 output list with FINAL amounts (the FOUND payout map) and
+//      the final CoinbaseInputs (what a peer feeds canonical_coinbase_matches).
+//
+// Thread-safety: an AssembledTemplate is immutable after build(); all reads
+// are const and touch no shared mutable state, so a listener thread may call
+// materialize()/hashing_blob() concurrently while the main thread builds the
+// next record. The provider (consumer tree) swaps records under its own lock.
+//
+// Consensus status: see the survey's gate flag. This header activates NO
+// consensus rule by itself; lane parameters (residual sink, h_min, output cap,
+// chain_id, the lane_commitment definition) arrive in CoinbaseInputs from the
+// consumer and are REQUIRED (build fails closed without a valid sink).
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/template/xmr_block_template.hpp"   // XmrBlockTemplate, IXmrSettlementSource, XmrMinerData, XmrTxMempoolData
+#include "impl/xmr/settle/xmr_coinbase.hpp"           // X6: CoinbaseInputs, build_coinbase, allocate_exact_sum, ...
+#include "impl/xmr/coin/xmr_blob.hpp"                 // BlobWriter, tx_prefix_hash, coinbase_tx_hash, tree_root, branches
+#include "impl/xmr/coin/xmr_keccak_midstate.hpp"      // keccak256 (+ vendor/keccak.h under extern "C")
+#include "impl/xmr/node/xmr_node_types.hpp"           // node::MinerData / TxBacklogEntry / Hash / Difficulty128
+
+namespace c2pool::xmr::assembly {
+
+using ::v37::xmr::settle::BuildError;
+using ::v37::xmr::settle::BuiltCoinbase;
+using ::v37::xmr::settle::CoinbaseInputs;
+using ::v37::xmr::settle::CoinbaseOutput;
+using ::v37::xmr::settle::ReceivedCoinbase;
+
+// ===========================================================================
+// Type shims: c2pool::xmr::hash (uint8_t[32], the p2pool-shaped template type)
+// <-> xmr::coin::Bytes32 family (X1/X6) <-> node::Hash (std::array, X2 wire).
+// All three are the same 32 little-endian bytes; memcpy is the whole adapter.
+// ===========================================================================
+inline hash to_hash(const ::xmr::coin::Bytes32& b) { hash h; std::memcpy(h.h, b.data(), HASH_SIZE); return h; }
+inline hash to_hash(const node::Hash& a)            { hash h; std::memcpy(h.h, a.data(), HASH_SIZE); return h; }
+inline ::xmr::coin::Hash256 to_hash256(const hash& h) { ::xmr::coin::Hash256 o; std::memcpy(o.data(), h.h, HASH_SIZE); return o; }
+inline ::xmr::coin::Hash256 to_hash256(const node::Hash& a) { ::xmr::coin::Hash256 o; std::memcpy(o.data(), a.data(), HASH_SIZE); return o; }
+inline node::Hash to_node_hash(const hash& h) { node::Hash a{}; std::memcpy(a.data(), h.h, HASH_SIZE); return a; }
+inline node::Hash to_node_hash(const ::xmr::coin::Bytes32& b) { node::Hash a{}; std::memcpy(a.data(), b.data(), HASH_SIZE); return a; }
+inline difficulty_type to_difficulty(const node::Difficulty128& d) { difficulty_type t; t.lo = d.lo; t.hi = d.hi; return t; }
+
+// Monero base (subsidy) reward for the block AFTER `already_generated_coins`
+// (cryptonote get_block_reward: (2^64-1 - A) >> 19, floored at the 0.6 XMR
+// tail). Byte-for-byte the static helper inside xmr_block_template.cpp; it is
+// re-stated here because the assembler must size the X6 budget BEFORE the
+// template runs, and the self-check pins the two against each other via
+// XmrBlockTemplate::get_reward().
+inline std::uint64_t xmr_base_reward(std::uint64_t already_generated_coins) {
+    const std::uint64_t r = ~already_generated_coins >> 19;
+    return (r < BASE_BLOCK_REWARD) ? BASE_BLOCK_REWARD : r;
+}
+
+// Split a total coinbase budget back into X6's (base_reward, fees) pair given
+// the consensus subsidy. Only the SUM feeds allocation and r-derivation, so the
+// split is presentational: under a block-weight penalty the budget can drop
+// below the subsidy, in which case base_reward := budget and fees := 0.
+inline void set_budget(CoinbaseInputs& in, std::uint64_t subsidy, std::uint64_t budget) {
+    if (budget >= subsidy) { in.base_reward = subsidy; in.fees = budget - subsidy; }
+    else                   { in.base_reward = budget;  in.fees = 0; }
+}
+
+// --- X2 adapter values -> template inputs ------------------------------------
+inline XmrMinerData from_miner_data(const node::MinerData& md, difficulty_type lane_target) {
+    XmrMinerData d;
+    d.major_version           = md.major_version;
+    d.height                  = md.height;
+    d.prev_id                 = to_hash(md.prev_id);
+    d.already_generated_coins = md.already_generated_coins;
+    d.median_weight           = md.median_weight;
+    d.median_timestamp        = md.median_timestamp;
+    d.difficulty              = to_difficulty(md.difficulty);
+    d.seed_hash               = to_hash(md.seed_hash);
+    d.lane_target             = lane_target;
+    return d;
+}
+inline std::vector<XmrTxMempoolData> from_backlog(const std::vector<node::TxBacklogEntry>& backlog) {
+    std::vector<XmrTxMempoolData> out;
+    out.reserve(backlog.size());
+    for (const auto& e : backlog) {
+        XmrTxMempoolData t;
+        t.id            = to_hash(e.id);
+        t.weight        = e.weight ? e.weight : e.blob_size;
+        t.fee           = e.fee;
+        t.time_received = e.time_received;   // 0 from get_miner_data => passes the 5-s age gate
+        out.push_back(t);
+    }
+    return out;
+}
+
+// LE32 extra nonce padded to `size` bytes -- the exact bytes the template
+// writes into the 0x02 tag (EXTRA_NONCE_SIZE..EXTRA_NONCE_MAX_SIZE).
+inline std::vector<unsigned char> extra_nonce_bytes(std::uint32_t extra_nonce, std::size_t size) {
+    std::vector<unsigned char> v(size, 0);
+    for (std::size_t i = 0; i < 4 && i < size; ++i) v[i] = static_cast<unsigned char>(extra_nonce >> (8 * i));
+    return v;
+}
+
+// ===========================================================================
+// X6SettlementSource -- the IXmrSettlementSource VALUE snapshot over X6.
+//
+// One instance per template build. Built from a complete CoinbaseInputs whose
+// budget() is the reward HINT; build() runs X6 build_coinbase once, so the
+// payee list, r, R, every P_i / view tag and the MM root are fixed for the life
+// of the snapshot. split_reward() may ADOPT a different budget (see the header
+// banner) but never a different payee set -- the keys do not depend on the
+// amounts, which is why re-deriving is unnecessary and the template's two-pass
+// flow stays sound.
+//
+// Call protocol with XmrBlockTemplate::update() (upstream order, pinned to the
+// p2pool commit named in xmr_block_template.hpp):
+//   payees() ... merkle_tree_data() ... split_reward(base + sum(fees))   [1]
+//   create_miner_tx(dry_run)  -> derive_output_key not called
+//   [tx selection]            split_reward(final_reward)                 [2]
+//   create_miner_tx(final)    -> derive_output_key(i) for every payee,
+//                                tx_public_key()
+//   calc_miner_tx_hash(0)     -> commitment_leaf(0)
+//   (-3 path only: split_reward(r2) [3], dry-run, split_reward(final') [4])
+// begin_update() resets the call counter; call [1] is the SIZING pass and
+// returns the snapshot's canonical amounts (the sizing amounts only bound the
+// amount-varint weight; p2pool's padded extra nonce absorbs any difference).
+// Every later call is a REAL reward and goes through the same-set rule.
+// ===========================================================================
+class X6SettlementSource final : public IXmrSettlementSource {
+public:
+    // Build the snapshot. `in.budget()` is the reward hint. Returns nullptr and
+    // fills *why (if given) when X6 refuses (CARROT fence, bad sink/payee ref,
+    // fixed > budget, cap too small, derivation failure) -- fail closed.
+    static std::unique_ptr<X6SettlementSource> build(const CoinbaseInputs& in,
+                                                     std::uint64_t subsidy,
+                                                     std::string* why) {
+        std::unique_ptr<X6SettlementSource> s(new X6SettlementSource());
+        s->m_in = in;
+        s->m_in.extra_nonce = extra_nonce_bytes(0, EXTRA_NONCE_SIZE); // keys/amounts are nonce-independent
+        s->m_subsidy = subsidy;
+        s->m_cb = ::v37::xmr::settle::build_coinbase(s->m_in);
+        if (!s->m_cb.ok) {
+            if (why) *why = std::string("X6 build_coinbase refused: ") + s->m_cb.detail;
+            return nullptr;
+        }
+        s->m_payees.clear();
+        s->m_payees.reserve(s->m_cb.outputs.size());
+        for (const auto& o : s->m_cb.outputs) {
+            XmrPayee p;
+            std::memcpy(p.spend_public_key.h, o.pay.payload.data(), HASH_SIZE);      // B (or D_i)
+            std::memcpy(p.view_public_key.h,  o.pay.payload.data() + HASH_SIZE, HASH_SIZE); // A
+            s->m_payees.push_back(p);
+        }
+        s->m_r    = to_hash(s->m_cb.r);
+        s->m_R    = to_hash(s->m_cb.R);
+        s->m_leaf = to_hash(s->m_cb.mm_root);
+        return s;
+    }
+
+    // ---- IXmrSettlementSource ---------------------------------------------
+    [[nodiscard]] const std::vector<XmrPayee>& payees() const override { return m_payees; }
+    [[nodiscard]] const hash& tx_secret_key() const override { return m_r; }
+    [[nodiscard]] const hash& tx_public_key() const override { return m_R; }
+
+    [[nodiscard]] bool derive_output_key(std::size_t i, std::uint8_t hf_major,
+                                         hash& out_eph_pubkey, std::uint8_t& out_view_tag) const override {
+        // CARROT/FCMP++ fence: the template's fork must be the fork r was
+        // derived under, and pre-CARROT. Otherwise the template refuses.
+        if (!::v37::xmr::xmr_precarrot_ok(hf_major)) return false;
+        if (hf_major != m_in.monero_major_version) return false;
+        if (i >= m_cb.outputs.size()) return false;
+        out_eph_pubkey = to_hash(m_cb.outputs[i].one_time_key);
+        out_view_tag   = m_cb.outputs[i].view_tag.tag;
+        return true;
+    }
+
+    [[nodiscard]] bool split_reward(std::uint64_t reward, std::vector<std::uint64_t>& rewards) const override {
+        ++m_split_calls;
+        if (m_split_calls == 1) {
+            // sizing pass (upstream call [1]); amounts only bound varint weight
+            fill_amounts(rewards);
+            return true;
+        }
+        if (reward == m_in.budget()) { fill_amounts(rewards); return true; }
+
+        // A different real reward: accept iff X6's canonical allocation at that
+        // reward pays the SAME ordered payee set; then adopt its amounts.
+        CoinbaseInputs probe = m_in;
+        set_budget(probe, m_subsidy, reward);
+        BuildError err = BuildError::None;
+        std::vector<CoinbaseOutput> alt = ::v37::xmr::settle::allocate_exact_sum(probe, &err);
+        if (alt.empty() || !same_set(alt)) {
+            m_wanted = reward;
+            return false;   // template falls back; the assembler rebuilds at `reward`
+        }
+        for (std::size_t i = 0; i < alt.size(); ++i) m_cb.outputs[i].amount = alt[i].amount;
+        set_budget(m_in, m_subsidy, reward);
+        m_cb.budget = reward;
+        fill_amounts(rewards);
+        return true;
+    }
+
+    // Single MM-tree leaf: root == leaf == X6 mm_commitment_root(chain_id,
+    // lane_commitment); extra-nonce independent (the nonce lives in 0x02).
+    [[nodiscard]] hash commitment_leaf(std::uint32_t /*extra_nonce*/) const override { return m_leaf; }
+    // depth 0 => the template's 0x03 tag is  03 | 0x21 | 0x00 | root[32],
+    // byte-identical to X6 assemble_tx_extra.
+    [[nodiscard]] std::uint64_t merkle_tree_data() const override { return 0; }
+
+    // ---- assembler protocol / read-back ------------------------------------
+    void begin_update() const { m_split_calls = 0; m_wanted.reset(); }
+    [[nodiscard]] std::uint64_t budget() const { return m_in.budget(); }
+    [[nodiscard]] std::optional<std::uint64_t> wanted_reward() const { return m_wanted; }
+    [[nodiscard]] unsigned split_calls() const { return m_split_calls; }
+
+    // The FINAL inputs (budget adopted) and outputs (amounts adopted): what a
+    // peer's canonical_coinbase_matches() must be fed, and the FOUND payout
+    // map {identity : amount} over ALL outputs (owed / fixed / sink).
+    [[nodiscard]] const CoinbaseInputs& inputs() const { return m_in; }
+    [[nodiscard]] const std::vector<CoinbaseOutput>& outputs() const { return m_cb.outputs; }
+    [[nodiscard]] const BuiltCoinbase& built() const { return m_cb; }
+    [[nodiscard]] std::uint64_t subsidy() const { return m_subsidy; }
+
+private:
+    X6SettlementSource() = default;
+
+    void fill_amounts(std::vector<std::uint64_t>& rewards) const {
+        rewards.resize(m_cb.outputs.size());
+        for (std::size_t i = 0; i < rewards.size(); ++i) rewards[i] = m_cb.outputs[i].amount;
+    }
+    bool same_set(const std::vector<CoinbaseOutput>& alt) const {
+        if (alt.size() != m_cb.outputs.size()) return false;
+        for (std::size_t i = 0; i < alt.size(); ++i) {
+            const CoinbaseOutput& a = alt[i];
+            const CoinbaseOutput& b = m_cb.outputs[i];
+            if (a.role != b.role || !(a.pay == b.pay) || a.identity != b.identity) return false;
+            if (a.amount == 0) return false;   // never emit a zero-amount output
+        }
+        return true;
+    }
+
+    mutable CoinbaseInputs m_in;
+    mutable BuiltCoinbase  m_cb;
+    std::uint64_t          m_subsidy = 0;
+    std::vector<XmrPayee>  m_payees;
+    hash m_r, m_R, m_leaf;
+    mutable unsigned                     m_split_calls = 0;
+    mutable std::optional<std::uint64_t> m_wanted;
+};
+
+// ===========================================================================
+// One materialised (template, extra_nonce) pair: the two blobs the submit path
+// needs plus every offset a submitter or verifier patches / inspects.
+// ===========================================================================
+struct BlockBytes {
+    std::uint32_t extra_nonce = 0;
+    std::vector<std::uint8_t> full_blob;     // header(nonce=0) || miner_tx || varint(n_tx) || 32*n   -> submit_block (patch nonce first)
+    std::vector<std::uint8_t> hashing_blob;  // header(nonce=0) || tree_root[32] || varint(n_tx+1)      -> RandomX input
+    std::size_t nonce_offset = 0;            // 4-B header nonce, same offset in BOTH blobs (39 for v16 / 5-B timestamp varint)
+    std::size_t miner_tx_offset = 0;         // == header size
+    std::size_t extra_nonce_offset = 0;      // in full_blob: first byte of the 0x02 payload
+    std::size_t extra_nonce_size = 0;        // 4..14 (padded)
+    std::size_t merkle_root_offset = 0;      // in full_blob: the 32-B root inside the 0x03 tag
+    std::size_t miner_tx_size = 0;           // incl. trailing rct_type byte
+    ::xmr::coin::Hash256 merkle_root{};      // MM commitment root patched at merkle_root_offset (== X6 mm_root)
+    ::xmr::coin::Hash256 tree_root{};        // tx tree root inside hashing_blob
+    std::vector<::xmr::coin::Hash256> tx_hashes; // non-coinbase tx ids in the template's order (leaf 1..n)
+
+    // The miner_tx PREFIX (everything but the rct_type byte): what X6
+    // build_coinbase(...).prefix must equal for this extra_nonce.
+    [[nodiscard]] std::vector<unsigned char> coinbase_prefix() const {
+        return std::vector<unsigned char>(full_blob.begin() + static_cast<std::ptrdiff_t>(miner_tx_offset),
+                                          full_blob.begin() + static_cast<std::ptrdiff_t>(miner_tx_offset + miner_tx_size - 1));
+    }
+};
+
+// Monero block id = keccak256( varint(len(hashing_blob)) || hashing_blob ), with
+// the nonce already patched into the blob (get_block_hash over the hashing blob).
+inline ::xmr::coin::Hash256 block_id_of(const std::vector<std::uint8_t>& hashing_blob_with_nonce) {
+    ::xmr::coin::BlobWriter w;
+    w.put_varint(hashing_blob_with_nonce.size());
+    w.put_bytes(hashing_blob_with_nonce.data(), hashing_blob_with_nonce.size());
+    return ::xmr::coin::keccak256(w.bytes());
+}
+
+// Parse a serialised coinbase PREFIX (version .. tx_extra) into X6's
+// ReceivedCoinbase for canonical_coinbase_matches(). Accepts the miner_tx as
+// found in a block blob (the rct_type byte after the prefix is ignored). Returns
+// false on any structural error. *consumed = prefix length on success.
+inline bool parse_coinbase_prefix(const std::uint8_t* p, std::size_t n,
+                                  ReceivedCoinbase& out, std::uint64_t* height_out = nullptr,
+                                  std::size_t* consumed = nullptr) {
+    const std::uint8_t* it = p;
+    const std::uint8_t* end = p + n;
+    auto rd = [&](std::uint64_t& v) -> bool { return tools::read_varint(it, end, v) > 0; };
+    std::uint64_t version = 0, unlock = 0, vin = 0, height = 0, nout = 0, xlen = 0;
+    if (!rd(version) || version != TX_VERSION) return false;
+    if (!rd(unlock)) return false;
+    if (!rd(vin) || vin != 1) return false;
+    if (it >= end || *it++ != TXIN_GEN) return false;
+    if (!rd(height)) return false;
+    if (unlock != height + MINER_REWARD_UNLOCK_TIME) return false;
+    if (!rd(nout)) return false;
+    out.amounts.clear(); out.keys.clear(); out.view_tags.clear();
+    for (std::uint64_t i = 0; i < nout; ++i) {
+        std::uint64_t amt = 0;
+        if (!rd(amt)) return false;
+        if (it >= end || *it++ != TXOUT_TO_TAGGED_KEY) return false;
+        if (static_cast<std::size_t>(end - it) < HASH_SIZE + 1) return false;
+        ::xmr::coin::PublicKey k; std::memcpy(k.data(), it, HASH_SIZE); it += HASH_SIZE;
+        ::xmr::coin::ViewTag vt; vt.tag = *it++;
+        out.amounts.push_back(amt); out.keys.push_back(k); out.view_tags.push_back(vt);
+    }
+    if (!rd(xlen) || static_cast<std::size_t>(end - it) < xlen) return false;
+    out.tx_extra.assign(it, it + xlen);
+    it += xlen;
+    // tx pubkey: tag 0x01 must be the first extra field (X6 layout)
+    if (out.tx_extra.size() < 1 + HASH_SIZE || out.tx_extra[0] != TX_EXTRA_TAG_PUBKEY) return false;
+    std::memcpy(out.R.data(), out.tx_extra.data() + 1, HASH_SIZE);
+    if (height_out) *height_out = height;
+    if (consumed) *consumed = static_cast<std::size_t>(it - p);
+    return true;
+}
+
+// ===========================================================================
+// AssembledTemplate -- the immutable per-build record (one ledger snapshot, one
+// prev_id, one payee set, one XmrBlockTemplate). Owns the seam it was built
+// over; the seam is declared FIRST so it outlives the template that points to it.
+// ===========================================================================
+class AssembledTemplate {
+public:
+    [[nodiscard]] std::uint64_t height() const { return m_tpl->get_height(); }
+    [[nodiscard]] std::uint64_t reward() const { return m_tpl->get_reward(); }   // == seam().budget() == sum(outputs)
+    [[nodiscard]] std::uint8_t  major_version() const { return m_major; }
+    [[nodiscard]] const ::xmr::coin::Hash256& prev_id() const { return m_prev_id; }
+    [[nodiscard]] const ::xmr::coin::Hash256& seed_hash() const { return m_seed_hash; }
+    [[nodiscard]] difficulty_type lane_target() const { return m_tpl->get_lane_target(); }
+    [[nodiscard]] std::size_t nonce_offset() const { return m_nonce_offset; }
+    [[nodiscard]] std::size_t n_tx() const { return m_n_tx; }
+    [[nodiscard]] int passes() const { return m_passes; }                        // fixpoint passes taken
+    [[nodiscard]] std::uint64_t built_at() const { return m_tpl->last_updated(); }
+    [[nodiscard]] const X6SettlementSource& seam() const { return *m_seam; }
+    [[nodiscard]] const XmrBlockTemplate& tpl() const { return *m_tpl; }
+
+    // FOUND record material: what the coinbase actually pays, by identity.
+    [[nodiscard]] const std::vector<CoinbaseOutput>& outputs() const { return m_seam->outputs(); }
+    [[nodiscard]] const CoinbaseInputs& coinbase_inputs() const { return m_seam->inputs(); }
+
+    // RandomX hashing blob for one extra nonce (76..128 B). Header nonce zero.
+    [[nodiscard]] std::vector<std::uint8_t> hashing_blob(std::uint32_t extra_nonce,
+                                                         std::size_t* nonce_offset = nullptr) const {
+        std::uint8_t buf[HASHING_BLOB_MAX_SIZE];
+        std::uint64_t h = 0; difficulty_type t; hash seed; std::size_t no = 0; std::uint32_t tid = 0;
+        const std::uint32_t n = m_tpl->get_hashing_blob(extra_nonce, buf, h, t, seed, no, tid);
+        if (nonce_offset) *nonce_offset = no;
+        return std::vector<std::uint8_t>(buf, buf + n);
+    }
+
+    // Both blobs + offsets for one extra nonce. Returns false only if the
+    // template's own invariants fail (header prefix disagreement / layout).
+    [[nodiscard]] bool materialize(std::uint32_t extra_nonce, BlockBytes& out, std::string* why = nullptr) const {
+        out = BlockBytes{};
+        out.extra_nonce = extra_nonce;
+        hash root;
+        out.full_blob = m_tpl->get_block_template_blob(m_internal_tid, extra_nonce,
+                                                       out.nonce_offset, out.extra_nonce_offset,
+                                                       out.merkle_root_offset, root);
+        out.merkle_root = to_hash256(root);
+        out.miner_tx_offset = out.nonce_offset + NONCE_SIZE;
+        out.miner_tx_size   = m_miner_tx_size;
+        out.extra_nonce_size = m_extra_nonce_size;
+        out.tx_hashes = m_tx_hashes;
+
+        std::size_t no2 = 0;
+        out.hashing_blob = hashing_blob(extra_nonce, &no2);
+        if (no2 != out.nonce_offset || out.hashing_blob.size() < HASHING_BLOB_MIN_SIZE ||
+            out.hashing_blob.size() > HASHING_BLOB_MAX_SIZE) {
+            if (why) *why = "assembled hashing blob out of range / nonce offset mismatch";
+            return false;
+        }
+        // validate_candidate() invariant: both blobs share the header through the nonce.
+        if (out.full_blob.size() < out.miner_tx_offset ||
+            std::memcmp(out.full_blob.data(), out.hashing_blob.data(), out.miner_tx_offset) != 0) {
+            if (why) *why = "full_blob / hashing_blob header prefix disagree";
+            return false;
+        }
+        if (out.merkle_root_offset + HASH_SIZE + 1 != out.miner_tx_offset + out.miner_tx_size) {
+            if (why) *why = "miner_tx layout: MM root is not the last prefix field";
+            return false;
+        }
+        std::memcpy(out.tree_root.data(), out.hashing_blob.data() + out.miner_tx_offset, HASH_SIZE);
+        return true;
+    }
+
+private:
+    friend class XmrBlockAssembler;
+    AssembledTemplate() = default;
+
+    std::unique_ptr<X6SettlementSource> m_seam;   // FIRST: must outlive m_tpl
+    std::unique_ptr<XmrBlockTemplate>   m_tpl;
+    std::uint32_t m_internal_tid = 0;             // the template's own id (1 for a fresh object)
+    std::uint8_t  m_major = 0;
+    ::xmr::coin::Hash256 m_prev_id{};
+    ::xmr::coin::Hash256 m_seed_hash{};
+    std::size_t m_nonce_offset = 0;
+    std::size_t m_miner_tx_size = 0;
+    std::size_t m_extra_nonce_size = 0;
+    std::size_t m_n_tx = 0;
+    std::vector<::xmr::coin::Hash256> m_tx_hashes;
+    int m_passes = 0;
+};
+
+// ===========================================================================
+// XmrBlockAssembler -- build one AssembledTemplate from miner data + backlog +
+// the lane's X6 context, iterating the reward/payee-set fixpoint.
+// ===========================================================================
+struct AssemblyInputs {
+    XmrMinerData                  miner;      // from_miner_data()
+    std::vector<XmrTxMempoolData> mempool;    // from_backlog()
+    // Lane context: owed / fixed / residual_sink(+identity) / chain_id /
+    // lane_commitment / h_min / output_cap. monero_major_version, height,
+    // prev_id, base_reward, fees and extra_nonce are OVERWRITTEN from `miner`
+    // and the template's final reward. output_cap == 0 => weight-aware default.
+    CoinbaseInputs                settle;
+    std::uint32_t                 wire_cap = 2700;   // output cap ceiling when output_cap == 0
+    int                           max_passes = 6;    // fixpoint bound (fail closed beyond)
+};
+
+class XmrBlockAssembler {
+public:
+    static std::unique_ptr<AssembledTemplate> build(const AssemblyInputs& a, std::string* why) {
+        auto fail = [&](const std::string& s) -> std::unique_ptr<AssembledTemplate> { if (why) *why = s; return nullptr; };
+
+        if (a.miner.height == 0) return fail("miner data: height 0");
+        // CARROT fence FIRST: the v37 lane's governing pre-CARROT rule
+        // (output-key derivation is pre-CARROT). It is checked before the
+        // template's own HARDFORK_SUPPORTED_VERSION pin so the refusal names the
+        // lane fence that actually governs (both are pinned at 16 today).
+        if (!::v37::xmr::xmr_precarrot_ok(a.miner.major_version))
+            return fail("CARROT_FENCE: major_version " + std::to_string(a.miner.major_version) +
+                        " > pre-CARROT max " + std::to_string(::v37::xmr::XMR_PRECARROT_MAX_MAJOR_VERSION));
+        if (a.miner.major_version > HARDFORK_SUPPORTED_VERSION)
+            return fail("template refuses major_version " + std::to_string(a.miner.major_version) +
+                        " > HARDFORK_SUPPORTED_VERSION " + std::to_string(HARDFORK_SUPPORTED_VERSION));
+
+        const std::uint64_t subsidy = xmr_base_reward(a.miner.already_generated_coins);
+        std::uint64_t fees_all = 0, weight_all = 0;
+        for (const auto& t : a.mempool) { fees_all += t.fee; weight_all += t.weight; }
+
+        CoinbaseInputs base = a.settle;
+        base.monero_major_version = a.miner.major_version;
+        base.height  = a.miner.height;
+        base.prev_id = to_hash256(a.miner.prev_id);
+        if (base.output_cap == 0)
+            base.output_cap = ::v37::xmr::settle::weight_aware_output_cap(a.miner.median_weight, weight_all, a.wire_cap);
+
+        std::uint64_t hint = subsidy + fees_all;   // == the template's sizing-pass reward
+        std::vector<std::uint64_t> tried;
+        std::string sub;
+
+        for (int pass = 1; pass <= a.max_passes; ++pass) {
+            CoinbaseInputs in = base;
+            set_budget(in, subsidy, hint);
+
+            std::unique_ptr<X6SettlementSource> seam = X6SettlementSource::build(in, subsidy, &sub);
+            if (!seam) return fail("pass " + std::to_string(pass) + ": " + sub);
+
+            std::unique_ptr<XmrBlockTemplate> tpl(new XmrBlockTemplate(seam.get()));
+            seam->begin_update();
+            tpl->update(a.miner, a.mempool);
+
+            const bool ok = tpl->last_updated() != 0 && tpl->get_height() == a.miner.height && tpl->get_reward() != 0;
+            if (ok) {
+                if (tpl->get_reward() != seam->budget())
+                    return fail("internal: template reward " + std::to_string(tpl->get_reward()) +
+                                " != adopted budget " + std::to_string(seam->budget()));
+                std::uint64_t sum = 0;
+                for (const auto& o : seam->outputs()) sum += o.amount;
+                if (sum != tpl->get_reward())
+                    return fail("internal: sum(outputs) != reward (exact-sum violated)");
+
+                std::unique_ptr<AssembledTemplate> rec(new AssembledTemplate());
+                rec->m_seam = std::move(seam);
+                rec->m_tpl  = std::move(tpl);
+                rec->m_major = a.miner.major_version;
+                rec->m_prev_id = to_hash256(a.miner.prev_id);
+                rec->m_seed_hash = to_hash256(a.miner.seed_hash);
+                rec->m_passes = pass;
+                if (!finish_layout(*rec, why)) return nullptr;
+                return rec;
+            }
+
+            const std::optional<std::uint64_t> w = seam->wanted_reward();
+            if (!w) return fail("pass " + std::to_string(pass) + ": template refused (no reward requested; "
+                                "split calls=" + std::to_string(seam->split_calls()) + ")");
+            tried.push_back(hint);
+            if (std::find(tried.begin(), tried.end(), *w) != tried.end())
+                return fail("pass " + std::to_string(pass) + ": reward/payee-set fixpoint cycle at " + std::to_string(*w));
+            hint = *w;
+        }
+        return fail("no reward/payee-set fixpoint within " + std::to_string(a.max_passes) + " passes");
+    }
+
+private:
+    // Derive the layout constants from a probe materialisation at extra_nonce 0
+    // and parse the tx-hash list off the template blob.
+    static bool finish_layout(AssembledTemplate& rec, std::string* why) {
+        // internal template id: read it back rather than assume 1
+        {
+            std::uint8_t buf[HASHING_BLOB_MAX_SIZE];
+            std::uint64_t h = 0; difficulty_type t; hash seed; std::size_t no = 0; std::uint32_t tid = 0;
+            const std::uint32_t n = rec.m_tpl->get_hashing_blob(0, buf, h, t, seed, no, tid);
+            if (tid == 0 || n < HASHING_BLOB_MIN_SIZE || n > HASHING_BLOB_MAX_SIZE) {
+                if (why) *why = "internal: probe hashing blob invalid";
+                return false;
+            }
+            rec.m_internal_tid = tid;
+            rec.m_nonce_offset = no;
+            // trailing varint = n_tx + 1
+            const std::uint8_t* it = buf + no + NONCE_SIZE + HASH_SIZE;
+            const std::uint8_t* bend = buf + n;   // named lvalue: read_varint deduces one InputIt for both ends
+            std::uint64_t cnt = 0;
+            if (tools::read_varint(it, bend, cnt) <= 0 || cnt == 0 || it != bend) {
+                if (why) *why = "internal: probe hashing blob tx count varint";
+                return false;
+            }
+            rec.m_n_tx = static_cast<std::size_t>(cnt - 1);
+        }
+        std::size_t no = 0, eo = 0, ro = 0; hash root;
+        const std::vector<std::uint8_t> full = rec.m_tpl->get_block_template_blob(rec.m_internal_tid, 0, no, eo, ro, root);
+        const std::size_t header = no + NONCE_SIZE;
+        // 0x02 tag layout: 02 | varint(len) | payload ; len < 0x80 so one byte
+        if (eo < 2 || eo > full.size() || full[eo - 2] != TX_EXTRA_NONCE) {
+            if (why) *why = "internal: extra-nonce tag layout";
+            return false;
+        }
+        rec.m_extra_nonce_size = full[eo - 1];
+        if (rec.m_extra_nonce_size < EXTRA_NONCE_SIZE || rec.m_extra_nonce_size > EXTRA_NONCE_MAX_SIZE) {
+            if (why) *why = "internal: extra-nonce size out of range";
+            return false;
+        }
+        // miner_tx ends right after the MM root + the rct_type byte
+        const std::size_t tx_end = ro + HASH_SIZE + 1;
+        if (tx_end > full.size() || full[tx_end - 1] != 0) {
+            if (why) *why = "internal: rct_type byte";
+            return false;
+        }
+        rec.m_miner_tx_size = tx_end - header;
+        // varint(n_tx) || 32*n
+        const std::uint8_t* it = full.data() + tx_end;
+        const std::uint8_t* fend = full.data() + full.size();   // named lvalue for read_varint deduction
+        std::uint64_t n = 0;
+        if (tools::read_varint(it, fend, n) <= 0 || n != rec.m_n_tx ||
+            static_cast<std::size_t>(fend - it) != n * HASH_SIZE) {
+            if (why) *why = "internal: tx-hash list layout";
+            return false;
+        }
+        rec.m_tx_hashes.resize(static_cast<std::size_t>(n));
+        for (std::size_t i = 0; i < n; ++i) std::memcpy(rec.m_tx_hashes[i].data(), it + i * HASH_SIZE, HASH_SIZE);
+        return true;
+    }
+};
+
+// ===========================================================================
+// SELF-CHECK (the KATs that prove "X6's coinbase IS the block's coinbase").
+// Header-only so a KAT executable is a 3-line TU; returns true iff every check
+// passes, appending a line per check to `log`.
+// ===========================================================================
+namespace kat {
+
+inline void hex_into(std::string& s, const void* p, std::size_t n) {
+    static const char* d = "0123456789abcdef";
+    const auto* b = static_cast<const unsigned char*>(p);
+    for (std::size_t i = 0; i < n; ++i) { s.push_back(d[b[i] >> 4]); s.push_back(d[b[i] & 0xf]); }
+}
+inline std::array<std::uint8_t, 32> unhex32(const char* h) {
+    std::array<std::uint8_t, 32> o{};
+    auto nib = [](char c) -> int { return (c >= '0' && c <= '9') ? c - '0' : (c >= 'a' && c <= 'f') ? c - 'a' + 10 : (c >= 'A' && c <= 'F') ? c - 'A' + 10 : 0; };
+    for (std::size_t i = 0; i < 32; ++i) o[i] = static_cast<std::uint8_t>((nib(h[2 * i]) << 4) | nib(h[2 * i + 1]));
+    return o;
+}
+
+struct Checker {
+    std::string& log; int pass = 0, fail = 0;
+    explicit Checker(std::string& l) : log(l) {}
+    bool operator()(bool ok, const std::string& what) {
+        log += ok ? "  [PASS] " : "  [FAIL] "; log += what; log += '\n';
+        if (ok) ++pass; else ++fail;
+        return ok;
+    }
+};
+
+// Real ed25519 points from the OFFICIAL monero-project tests/crypto/tests.txt
+// vectors (same ones xmr_coinbase_kat.cpp uses): B = derive_public_key base,
+// A = generate_key_derivation pub. Canonical on-curve points => ECDH works.
+inline ::v37::ScriptRef std_ref() {
+    return ::v37::xmr::make_xmr_std(unhex32("6d9dd2068b9d6d643b407e360dfc5eb7a1f628fe2de8112a9e5731e8b3680c39"),
+                                    unhex32("fdfd97d2ea9f1c25df773ff2c973d885653a3ee643157eb0ae2b6dd98f0b6984"));
+}
+inline ::v37::bytes32 id_of(unsigned char seed) {
+    ::v37::bytes32 b{}; for (int i = 0; i < 32; ++i) b[static_cast<std::size_t>(i)] = static_cast<std::uint8_t>(seed + i); return b;
+}
+inline hash hash_of(unsigned char seed) { hash h; for (std::size_t i = 0; i < HASH_SIZE; ++i) h.h[i] = static_cast<std::uint8_t>(seed * 7 + i); return h; }
+
+inline CoinbaseInputs lane_ctx() {
+    CoinbaseInputs in;
+    in.chain_id = 0x0000ABCD;
+    in.lane_commitment = id_of(0x11);
+    in.residual_sink = std_ref();
+    in.residual_sink_identity = id_of(0x99);
+    in.h_min = 0;
+    in.output_cap = 2700;
+    return in;
+}
+inline XmrMinerData miner(std::uint64_t height, std::uint64_t median_weight, std::uint64_t agc, std::uint8_t major = 16) {
+    XmrMinerData d;
+    d.major_version = major; d.height = height; d.prev_id = hash_of(0x31);
+    d.already_generated_coins = agc; d.median_weight = median_weight; d.median_timestamp = 1700000000;
+    d.difficulty.lo = 1000; d.seed_hash = hash_of(0x53); d.lane_target.lo = 0xFFFFFFFFFFFFFFFFull;
+    return d;
+}
+inline std::vector<XmrTxMempoolData> txs(std::size_t n, std::uint64_t weight, std::uint64_t fee) {
+    std::vector<XmrTxMempoolData> v;
+    for (std::size_t i = 0; i < n; ++i) { XmrTxMempoolData t; t.id = hash_of(static_cast<unsigned char>(0x80 + i)); t.weight = weight; t.fee = fee; v.push_back(t); }
+    return v;
+}
+
+// (a)+(b)+(c)+(d) for one template and one extra nonce.
+inline bool check_template(Checker& C, const AssembledTemplate& t, std::uint32_t en, const std::string& tag) {
+    BlockBytes b; std::string why;
+    if (!C(t.materialize(en, b, &why), tag + " materialize(en=" + std::to_string(en) + ") " + why)) return false;
+
+    // (a) miner_tx prefix == X6 build_coinbase(final inputs, extra_nonce padded).prefix
+    CoinbaseInputs ref = t.coinbase_inputs();
+    ref.extra_nonce = extra_nonce_bytes(en, b.extra_nonce_size);
+    const BuiltCoinbase cb = ::v37::xmr::settle::build_coinbase(ref);
+    const std::vector<unsigned char> got = b.coinbase_prefix();
+    bool ok = C(cb.ok && got == cb.prefix, tag + " (a) template miner_tx prefix == X6 build_coinbase().prefix");
+    ok &= C(b.merkle_root == cb.mm_root, tag + " (a') patched MM root == X6 mm_root");
+    ok &= C(std::memcmp(got.data() + (got.size() - HASH_SIZE), cb.mm_root.data(), HASH_SIZE) == 0, tag + " (a'') MM root is the last prefix field");
+    std::uint64_t sum = 0; for (const auto& o : t.outputs()) sum += o.amount;
+    ok &= C(sum == t.reward() && sum == cb.budget, tag + " exact-sum: sum(outputs) == template reward == X6 budget");
+
+    // (b)+(c) tree root == tree_root([X6 coinbase_tx_hash] ++ template tx ids); branch verifies
+    std::vector<::xmr::coin::Hash256> leaves; leaves.push_back(cb.coinbase_tx_hash);
+    for (const auto& h : b.tx_hashes) leaves.push_back(h);
+    const ::xmr::coin::Hash256 root = ::xmr::coin::tree_root(leaves);
+    ok &= C(root == b.tree_root, tag + " (b)(c) hashing-blob tree root == tree_root([X6 leaf0] ++ tx ids), n_tx=" + std::to_string(b.tx_hashes.size()));
+    ::xmr::coin::TreeBranch br;
+    ok &= C(::xmr::coin::make_coinbase_branch(leaves, br) && ::xmr::coin::verify_branch(cb.coinbase_tx_hash, br, b.tree_root),
+            tag + " (c') coinbase branch verifies against the served root");
+
+    // (d) both blobs share the header; block id computes; extra nonce bytes patched
+    ok &= C(b.nonce_offset == 39 || b.nonce_offset == 38 || b.nonce_offset == 40, tag + " (d) nonce offset " + std::to_string(b.nonce_offset));
+    ok &= C(std::memcmp(b.full_blob.data(), b.hashing_blob.data(), b.nonce_offset + NONCE_SIZE) == 0, tag + " (d') header prefix agrees (validate_candidate invariant)");
+    ok &= C(std::memcmp(b.full_blob.data() + b.extra_nonce_offset, ref.extra_nonce.data(), b.extra_nonce_size) == 0, tag + " (d'') extra nonce bytes patched at extra_nonce_offset");
+    ok &= C(b.hashing_blob.size() >= HASHING_BLOB_MIN_SIZE && b.hashing_blob.size() <= HASHING_BLOB_MAX_SIZE, tag + " hashing blob size " + std::to_string(b.hashing_blob.size()));
+    std::vector<std::uint8_t> hb = b.hashing_blob; hb[b.nonce_offset] = 0x2A;
+    const ::xmr::coin::Hash256 bid = block_id_of(hb);
+    ok &= C(!(bid == ::xmr::coin::Hash256{}), tag + " block id computes");
+
+    // (e) the served prefix re-parses and canonical_coinbase_matches() == true (the W3 ACCEPT check)
+    ReceivedCoinbase rc; std::uint64_t h = 0; std::size_t used = 0;
+    ok &= C(parse_coinbase_prefix(b.full_blob.data() + b.miner_tx_offset, b.miner_tx_size, rc, &h, &used) && used == got.size() && h == t.height(),
+            tag + " (e) miner_tx prefix parses (height " + std::to_string(h) + ")");
+    const auto m = ::v37::xmr::settle::canonical_coinbase_matches(ref, rc);
+    ok &= C(m.matches, tag + " (e') canonical_coinbase_matches(final inputs, parsed) == true " + m.reason);
+    // negative control: a different lane_commitment must NOT match (R and the MM root move)
+    CoinbaseInputs bad = ref; bad.lane_commitment = id_of(0x22);
+    ok &= C(!::v37::xmr::settle::canonical_coinbase_matches(bad, rc).matches, tag + " (e'') negative: other lane_commitment does not match");
+    return ok;
+}
+
+inline bool selfcheck(std::string& log) {
+    Checker C(log);
+
+    // ---- K0: primitive bodies vs the vendored reference ----------------------
+    {
+        for (std::uint64_t v : {0ull, 1ull, 127ull, 128ull, 300ull, 16383ull, 16384ull, 600000000000ull, 35184372088831ull, 0xFFFFFFFFFFFFFFFFull}) {
+            std::vector<std::uint8_t> a; writeVarint(v, a);
+            ::xmr::coin::BlobWriter w; w.put_varint(v);
+            C(a == w.bytes(), "K0 writeVarint(" + std::to_string(v) + ") == tools::write_varint");
+        }
+        std::vector<std::uint8_t> buf(300);
+        for (std::size_t i = 0; i < buf.size(); ++i) buf[i] = static_cast<std::uint8_t>((i * 131 + 7) & 0xff);
+        hash md; keccak(buf.data(), buf.size(), md.h);
+        C(to_hash256(md) == ::xmr::coin::keccak256(buf), "K0 keccak() one-shot == cn_fast_hash");
+        bool all = true; int n_fast = 0;
+        for (std::size_t len = 0; len <= buf.size(); ++len) {
+            const ::xmr::coin::Hash256 want = ::xmr::coin::keccak256(buf.data(), len);
+            for (std::size_t N = 0; N <= len; N += KeccakParams::HASH_DATA_AREA) {   // every block-aligned midstate split
+                std::array<std::uint64_t, 25> st{};
+                keccak_step(buf.data(), static_cast<int>(N), st);
+                keccak_finish(buf.data() + N, static_cast<int>(len - N), st);
+                ::xmr::coin::Hash256 got; std::memcpy(got.data(), st.data(), HASH_SIZE);
+                if (!(got == want)) all = false; else ++n_fast;
+            }
+        }
+        C(all, "K0 keccak_step/keccak_finish raw-state midstate == cn_fast_hash for every (len, split), " + std::to_string(n_fast) + " cases");
+        std::uint64_t hi = 0;
+        const std::uint64_t lo = umul128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull, &hi);
+        C(lo == 1 && hi == 0xFFFFFFFFFFFFFFFEull, "K0 umul128(2^64-1, 2^64-1)");
+        std::uint64_t rem = 0;
+        const std::uint64_t q = udiv128(0x0000000000000001ull, 0x0000000000000005ull, 7, &rem);   // (2^64+5)/7
+        C(q == 2635249153387078803ull && rem == 0, "K0 udiv128((2^64+5), 7)");
+        C(xmr_base_reward(0) == 35184372088831ull, "K0 base reward at agc=0 == 2^45-1 pn (regtest first blocks)");
+        C(xmr_base_reward(~0ull) == BASE_BLOCK_REWARD, "K0 base reward floor == 0.6 XMR tail");
+        C(seconds_since_epoch() > 1600000000ull, "K0 seconds_since_epoch");
+    }
+
+    // ---- K1: regtest-like: empty mempool, nothing owed -> sink-only coinbase --
+    {
+        AssemblyInputs a; a.miner = miner(1, 300000, 0); a.settle = lane_ctx();
+        std::string why;
+        auto t = XmrBlockAssembler::build(a, &why);
+        if (C(t != nullptr, "K1 build (sink-only) " + why)) {
+            C(t->passes() == 1, "K1 converged in 1 pass");
+            C(t->reward() == 35184372088831ull, "K1 reward == monerod expected_reward at agc=0 (" + std::to_string(t->reward()) + ")");
+            C(t->outputs().size() == 1 && t->outputs()[0].role == CoinbaseOutput::Role::Sink, "K1 single sink output");
+            C(t->n_tx() == 0, "K1 n_tx == 0");
+            for (std::uint32_t en : {0u, 1u, 0xFFFFFFFFu}) check_template(C, *t, en, "K1");
+            // per-extra-nonce distinctness: distinct coinbase => distinct tree root
+            BlockBytes b0, b1; std::string w;
+            C(t->materialize(0, b0, &w) && t->materialize(1, b1, &w) && !(b0.tree_root == b1.tree_root) && b0.full_blob.size() == b1.full_blob.size(),
+              "K1 extra_nonce 0 vs 1 => different tree root, same blob size");
+            // get_hashing_blobs (parallel_run) matches get_hashing_blob
+            std::vector<std::uint8_t> blobs; std::uint64_t h; difficulty_type dt; hash sh; std::size_t no; std::uint32_t tid;
+            const std::uint32_t bs = t->tpl().get_hashing_blobs(5, 4, blobs, h, dt, sh, no, tid);
+            bool same = bs >= HASHING_BLOB_MIN_SIZE && blobs.size() == static_cast<std::size_t>(bs) * 4;
+            for (std::uint32_t i = 0; same && i < 4; ++i) {
+                const std::vector<std::uint8_t> one = t->hashing_blob(5 + i);
+                same = one.size() == bs && std::memcmp(one.data(), blobs.data() + static_cast<std::size_t>(i) * bs, bs) == 0;
+            }
+            C(same, "K1 get_hashing_blobs(5,4) via parallel_run == 4x get_hashing_blob");
+        }
+    }
+
+    // ---- K2: 6 owed + 1 fixed + sink, 5 txs below median (fast midstate path) --
+    {
+        AssemblyInputs a; a.miner = miner(3000000, 300000, 18000000000000000000ull); a.settle = lane_ctx();
+        a.mempool = txs(5, 2000, 30000000);
+        for (unsigned char i = 0; i < 6; ++i) {
+            ::v37::xmr::settle::OwedEntry e; e.pay = std_ref(); e.owed = 1000000000ull * (i + 1); e.first_eligible = 100 + (5 - i); e.identity = id_of(static_cast<unsigned char>(0x40 + i));
+            a.settle.owed.push_back(e);
+        }
+        ::v37::xmr::settle::FixedOutput f; f.pay = std_ref(); f.amount = 5000000ull; f.identity = id_of(0x77); a.settle.fixed.push_back(f);
+        std::string why;
+        auto t = XmrBlockAssembler::build(a, &why);
+        if (C(t != nullptr, "K2 build (6 owed + fixed + sink, 5 txs) " + why)) {
+            C(t->passes() == 1, "K2 converged in 1 pass (below median: final == sizing reward)");
+            C(t->reward() == xmr_base_reward(a.miner.already_generated_coins) + 5 * 30000000ull, "K2 reward == subsidy + all fees");
+            C(t->outputs().size() == 8, "K2 8 outputs (6 owed + fixed + sink), extra-nonce offset past one Keccak block => midstate fast path");
+            C(t->n_tx() == 5, "K2 n_tx == 5");
+            // K_fair order: oldest first_eligible first => identity 0x45 (fe=100) ... 0x40 (fe=105)
+            C(t->outputs()[0].identity == id_of(0x45) && t->outputs()[5].identity == id_of(0x40), "K2 K_fair oldest-owed-first order preserved through the template");
+            for (std::uint32_t en : {0u, 1u, 0xFFFFFFFFu}) check_template(C, *t, en, "K2");
+        }
+    }
+
+    // ---- K3: penalty zone, payee set CHANGES with the final reward -> fixpoint --
+    {
+        // median 2000, 10 txs of 500 B / 1e9 fee: the greedy keeps 3 (penalty-free),
+        // sizing reward = subsidy + 10e9, final = subsidy + 3e9.
+        AssemblyInputs a; a.miner = miner(3000000, 2000, 18000000000000000000ull); a.settle = lane_ctx();
+        a.mempool = txs(10, 500, 1000000000ull);
+        const std::uint64_t subsidy = xmr_base_reward(a.miner.already_generated_coins);
+        ::v37::xmr::settle::OwedEntry A; A.pay = std_ref(); A.owed = subsidy + 5000000000ull; A.first_eligible = 1; A.identity = id_of(0x41);
+        ::v37::xmr::settle::OwedEntry B; B.pay = std_ref(); B.owed = 100000000000ull;         B.first_eligible = 2; B.identity = id_of(0x42);
+        a.settle.owed = {A, B};
+        std::string why;
+        auto t = XmrBlockAssembler::build(a, &why);
+        if (C(t != nullptr, "K3 build (penalty zone, set changes) " + why)) {
+            C(t->passes() == 2, "K3 converged in 2 passes (rebuilt at the wanted reward), passes=" + std::to_string(t->passes()));
+            C(t->reward() == subsidy + 3000000000ull, "K3 final reward == subsidy + 3 fees (" + std::to_string(t->reward()) + ")");
+            C(t->outputs().size() == 1 && t->outputs()[0].identity == id_of(0x41) && t->outputs()[0].amount == t->reward(),
+              "K3 coinbase pays only A (B and the sink vanished at the final reward)");
+            C(t->n_tx() == 3, "K3 3 txs selected");
+            for (std::uint32_t en : {0u, 7u}) check_template(C, *t, en, "K3");
+        }
+    }
+
+    // ---- K4: penalty zone, SAME set at the final reward -> adopted in pass 1 --
+    {
+        AssemblyInputs a; a.miner = miner(3000000, 2000, 18000000000000000000ull); a.settle = lane_ctx();
+        a.mempool = txs(10, 500, 1000000000ull);
+        const std::uint64_t subsidy = xmr_base_reward(a.miner.already_generated_coins);
+        ::v37::xmr::settle::OwedEntry A; A.pay = std_ref(); A.owed = 1000000000ull; A.first_eligible = 1; A.identity = id_of(0x41);
+        a.settle.owed = {A};
+        std::string why;
+        auto t = XmrBlockAssembler::build(a, &why);
+        if (C(t != nullptr, "K4 build (penalty zone, same set) " + why)) {
+            C(t->passes() == 1, "K4 adopted the final reward in pass 1 (same payee set)");
+            C(t->reward() == subsidy + 3000000000ull && t->reward() < subsidy + 10000000000ull, "K4 final reward below the sizing reward");
+            C(t->outputs().size() == 2 && t->outputs()[1].role == CoinbaseOutput::Role::Sink &&
+              t->outputs()[0].amount + t->outputs()[1].amount == t->reward(), "K4 owed + sink, exact-sum at the ADOPTED reward");
+            for (std::uint32_t en : {0u, 0xFFFFFFFFu}) check_template(C, *t, en, "K4");
+        }
+    }
+
+    // ---- K5/K6: fail-closed ---------------------------------------------------
+    {
+        AssemblyInputs a; a.miner = miner(1, 300000, 0, 17); a.settle = lane_ctx();
+        std::string why;
+        C(XmrBlockAssembler::build(a, &why) == nullptr && why.find("CARROT") != std::string::npos, "K5 major_version 17 refused (CARROT fence): " + why);
+        AssemblyInputs b; b.miner = miner(1, 300000, 0); b.settle = lane_ctx(); b.settle.residual_sink = ::v37::ScriptRef{};
+        C(XmrBlockAssembler::build(b, &why) == nullptr && why.find("residual_sink") != std::string::npos, "K6 missing residual sink refused: " + why);
+        AssemblyInputs c; c.miner = miner(1, 300000, 0); c.settle = lane_ctx(); c.settle.output_cap = 1;
+        ::v37::xmr::settle::FixedOutput f; f.pay = std_ref(); f.amount = 1; f.identity = id_of(0x77); c.settle.fixed.push_back(f);
+        C(XmrBlockAssembler::build(c, &why) == nullptr, "K6' output_cap too small for fixed + sink refused: " + why);
+    }
+
+    log += "summary: " + std::to_string(C.pass) + " passed, " + std::to_string(C.fail) + " failed\n";
+    return C.fail == 0;
+}
+
+} // namespace kat
+} // namespace c2pool::xmr::assembly
+
+// ===========================================================================
+// PRIMITIVE BODIES for xmr_coin_primitives.hpp  --  compile in EXACTLY ONE TU:
+//
+//     #define XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES
+//     #include "impl/xmr/template/xmr_block_assembly.hpp"
+//
+// Byte-identity with monero-project keccak.c (vendored, BSD-3): the one-shot
+// keccak() IS the vendored function; keccak_step/keccak_finish are the raw
+// 25-lane state form of keccak_update/keccak_finish (same 136-B rate, same
+// 0x01 ... 0x80 Keccak padding -- NOT SHA3's 0x06 -- same keccakf(24)), which
+// the ported template needs because it caches std::array<uint64_t,25> and
+// patches the tail in place. The self-check (K0) pins them against
+// cn_fast_hash for every (length, split) pair. The digest is the first 4 lanes
+// in host order; the template memcpy's them, as p2pool does (LE hosts).
+// ===========================================================================
+#ifdef XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES
+namespace c2pool::xmr {
+
+void writeVarint(std::uint64_t value, std::vector<std::uint8_t>& out) {
+    ::xmr::coin::BlobWriter w;                       // tools::write_varint (vendored varint.h)
+    w.put_varint(value);
+    out.insert(out.end(), w.bytes().begin(), w.bytes().end());
+}
+
+void keccak(const std::uint8_t* in, std::size_t inlen, std::uint8_t* md, int mdlen) {
+    ::keccak(in, inlen, md, mdlen);                  // vendor/keccak.c (extern "C")
+}
+
+namespace {
+inline std::uint64_t load_le64(const std::uint8_t* p) {
+    std::uint64_t v = 0;
+    for (int i = 0; i < 8; ++i) v |= static_cast<std::uint64_t>(p[i]) << (8 * i);
+    return v;
+}
+inline void absorb_block(const std::uint8_t* block, std::array<std::uint64_t, 25>& st) {
+    for (int i = 0; i < KeccakParams::HASH_DATA_AREA / 8; ++i) st[static_cast<std::size_t>(i)] ^= load_le64(block + 8 * i);
+    ::keccakf(st.data(), KECCAK_ROUNDS);
+}
+} // namespace
+
+void keccak_step(const std::uint8_t* in, int inlen, std::array<std::uint64_t, 25>& state) {
+    for (; inlen >= KeccakParams::HASH_DATA_AREA; inlen -= KeccakParams::HASH_DATA_AREA, in += KeccakParams::HASH_DATA_AREA)
+        absorb_block(in, state);
+    // a non-multiple is a caller error (the template always steps whole blocks)
+}
+
+void keccak_finish(const std::uint8_t* in, int inlen, std::array<std::uint64_t, 25>& state) {
+    for (; inlen >= KeccakParams::HASH_DATA_AREA; inlen -= KeccakParams::HASH_DATA_AREA, in += KeccakParams::HASH_DATA_AREA)
+        absorb_block(in, state);
+    std::uint8_t temp[KeccakParams::HASH_DATA_AREA];
+    std::memset(temp, 0, sizeof(temp));
+    if (inlen > 0) std::memcpy(temp, in, static_cast<std::size_t>(inlen));
+    temp[inlen] = 1;                                  // Keccak (pre-SHA3) padding start
+    temp[KeccakParams::HASH_DATA_AREA - 1] |= 0x80;   // final bit
+    absorb_block(temp, state);
+    // digest = state[0..3] (little-endian lanes); the caller memcpy's 32 bytes
+}
+
+std::uint64_t umul128(std::uint64_t a, std::uint64_t b, std::uint64_t* hi) {
+    const unsigned __int128 p = static_cast<unsigned __int128>(a) * b;
+    *hi = static_cast<std::uint64_t>(p >> 64);
+    return static_cast<std::uint64_t>(p);
+}
+
+std::uint64_t udiv128(std::uint64_t numhi, std::uint64_t numlo, std::uint64_t den, std::uint64_t* rem) {
+    const unsigned __int128 n = (static_cast<unsigned __int128>(numhi) << 64) | numlo;
+    const unsigned __int128 q = n / den;                 // caller guarantees numhi < den (quotient fits)
+    *rem = static_cast<std::uint64_t>(n % den);
+    return static_cast<std::uint64_t>(q);
+}
+
+// Serial fan-out: the template's only user (get_hashing_blobs) shares an atomic
+// counter and loops until it is exhausted, so one synchronous call covers every
+// blob. A thread-pool variant can replace this body without touching callers.
+void parallel_run(const std::function<void()>& f, bool /*wait*/) { f(); }
+
+std::uint64_t seconds_since_epoch() {
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+} // namespace c2pool::xmr
+#endif // XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES
+
+// ===========================================================================
+// KAT driver: define XMR_BLOCK_ASSEMBLY_SELFCHECK_MAIN in a TU that also
+// compiles xmr_block_template.cpp, settle/xmr_coinbase.cpp, the primitives TU
+// and links xmr_coin. Nonzero exit on any failure (build.yml test lane shape).
+// ===========================================================================
+#ifdef XMR_BLOCK_ASSEMBLY_SELFCHECK_MAIN
+#include <cstdio>
+int main() {
+    std::string log;
+    const bool ok = c2pool::xmr::assembly::kat::selfcheck(log);
+    std::fputs("xmr_block_assembly_kat (X9 option B: whole-block assembly over X6)\n", stdout);
+    std::fputs(log.c_str(), stdout);
+    std::fputs(ok ? "RESULT: GREEN\n" : "RESULT: RED\n", stdout);
+    return ok ? 0 : 1;
+}
+#endif

--- a/src/impl/xmr/template/xmr_coin_adapters.hpp
+++ b/src/impl/xmr/template/xmr_coin_adapters.hpp
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/template/xmr_coin_adapters.hpp
+//
+// AUTHORED. memcpy shims between the three 32-byte hash spellings that meet at
+// the template seam, and the two {lo,hi} 128-bit difficulty spellings:
+//
+//   c2pool::xmr::hash            { uint8_t h[32] }          (template / p2pool port)
+//   xmr::coin::Bytes32 & kin     { std::array<uchar,32> }   (Hash256, PublicKey, SecretKey)
+//   c2pool::xmr::node::Hash      std::array<uint8_t,32>     (monerod adapter)
+//
+//   c2pool::xmr::difficulty_type { lo, hi }                 (template)
+//   c2pool::xmr::node::Difficulty128 { lo, hi }             (adapter)
+//
+// Deliberately generic (any trivially-copyable 32-byte type / any {lo,hi}
+// aggregate) so this header pulls in NEITHER coin/ NOR node/ headers -- the
+// template tree stays include-light and the consumer picks the concrete types.
+// All layouts are the same little-endian byte string Monero puts on the wire;
+// the shims are pure copies, never a byte-order change.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#include "xmr_coin_primitives.hpp"
+
+namespace c2pool::xmr {
+
+template <class T>
+concept Bytes32Like = std::is_trivially_copyable_v<T> && (sizeof(T) == HASH_SIZE);
+
+template <class D>
+concept DifficultyLike = requires(D d) {
+    { d.lo } -> std::convertible_to<uint64_t>;
+    { d.hi } -> std::convertible_to<uint64_t>;
+};
+
+// ---- 32-byte hashes -----------------------------------------------------------
+template <Bytes32Like B>
+inline hash to_hash(const B& b) noexcept {
+    hash h;
+    std::memcpy(h.h, &b, HASH_SIZE);
+    return h;
+}
+
+inline hash to_hash(const uint8_t* p) noexcept {
+    hash h;
+    std::memcpy(h.h, p, HASH_SIZE);
+    return h;
+}
+
+template <Bytes32Like B>
+inline B from_hash(const hash& h) noexcept {
+    B b{};
+    std::memcpy(&b, h.h, HASH_SIZE);
+    return b;
+}
+
+template <Bytes32Like B>
+inline void copy_hash(const hash& h, B& out) noexcept {
+    std::memcpy(&out, h.h, HASH_SIZE);
+}
+
+// ---- 128-bit difficulty / target ---------------------------------------------
+template <DifficultyLike D>
+inline difficulty_type to_difficulty(const D& d) noexcept {
+    difficulty_type t;
+    t.lo = static_cast<uint64_t>(d.lo);
+    t.hi = static_cast<uint64_t>(d.hi);
+    return t;
+}
+
+inline difficulty_type to_difficulty(uint64_t lo, uint64_t hi = 0) noexcept {
+    difficulty_type t;
+    t.lo = lo;
+    t.hi = hi;
+    return t;
+}
+
+template <DifficultyLike D>
+inline D from_difficulty(const difficulty_type& t) noexcept {
+    D d{};
+    d.lo = t.lo;
+    d.hi = t.hi;
+    return d;
+}
+
+} // namespace c2pool::xmr

--- a/src/impl/xmr/template/xmr_coin_primitives.cpp
+++ b/src/impl/xmr/template/xmr_coin_primitives.cpp
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/template/xmr_coin_primitives.cpp
+//
+// AUTHORED for c2pool (not ported). Bodies for the consumer-side seam declared
+// in xmr_coin_primitives.hpp -- the surface the p2pool-derived whole-block
+// template builder (xmr_block_template.cpp) consumes -- layered over the X1
+// `xmr_coin` library so the template emits bytes that are IDENTICAL to the
+// lane's authored serializer (xmr_blob.hpp) and to monerod:
+//
+//   writeVarint      -> the VENDORED tools::write_varint (vendor/varint.h, BSD-3),
+//                       exactly what BlobWriter::put_varint uses. Same codec,
+//                       same bytes, for both serializers.
+//   keccak           -> the VENDORED monero-project keccak() (vendor/keccak.c,
+//                       Saarinen baseline). Identical signature; a plain forward.
+//   keccak_step /    -> AUTHORED over the vendored keccakf(st, 24): the raw
+//   keccak_finish       25-lane sponge form the template caches per miner-tx
+//                       prefix (m_minerTxKeccakState). Absorbs whole 136-B
+//                       blocks as little-endian u64 lanes; finish pads with the
+//                       ORIGINAL Keccak rule monerod uses (0x01 ... | 0x80),
+//                       NOT the SHA-3 0x06 domain byte. For every split point:
+//                         step(head); finish(tail)  ==  keccak(head || tail)
+//                       and the digest is lanes 0..3 of the state (the template
+//                       memcpy()s state.data(); LE host asserted below).
+//   umul128/udiv128  -> unsigned __int128 (same semantics as x86-64 mul/divq
+//                       that p2pool uses; vendor/int-util.h mul128 agrees).
+//   parallel_run     -> std::thread fan-out (the "thread pool in the real tree").
+//   seconds_since_epoch -> std::chrono system_clock.
+//
+// Nothing here touches consensus digests; it is byte plumbing under the seam.
+// The XMR-lane KAT (test/xmr_template_primitives_kat.cpp) pins every body
+// against the vendored one-shot oracle across all split points and then drives
+// the real XmrBlockTemplate through BOTH Keccak paths (keccak_custom slow path
+// and the keccak_step/keccak_finish midstate fast path), recomputing the
+// coinbase hash + tree root independently through xmr::coin.
+// ---------------------------------------------------------------------------
+
+#include "xmr_coin_primitives.hpp"
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <chrono>
+#include <cstring>
+#include <exception>
+#include <thread>
+#include <vector>
+
+extern "C" {
+#include "vendor/keccak.h"   // ::keccak(in, inlen, md, mdlen), ::keccakf(st, rounds), KECCAK_ROUNDS
+}
+#include "vendor/varint.h"   // tools::write_varint (BSD-3, vendored)
+
+// The template reads the digest with memcpy(dst, state.data(), 32), i.e. it
+// takes lanes 0..3 in HOST byte order. That equals memcpy_swap64le() (what the
+// vendored keccak() emits) only on a little-endian host. p2pool has the same
+// assumption; make it explicit instead of silent.
+static_assert(std::endian::native == std::endian::little,
+              "xmr_coin_primitives: keccak_step/keccak_finish state export assumes a little-endian host");
+
+namespace c2pool::xmr {
+
+namespace {
+
+constexpr int kRate      = KeccakParams::HASH_DATA_AREA;   // 136 B for Keccak-256
+constexpr int kRateWords = kRate / 8;                        // 17 lanes
+static_assert(kRate == 136 && kRateWords == 17, "Keccak-256 rate must be 136 bytes");
+
+inline uint64_t load_le64(const uint8_t* p) noexcept {
+    uint64_t v;
+    std::memcpy(&v, p, sizeof(v));   // LE host (asserted above) => this IS the LE lane
+    return v;
+}
+
+// XOR one full rate-sized block into the sponge and permute. Mirrors the block
+// loop of the vendored keccak() / KECCAK_PROCESS_BLOCK byte-for-byte.
+inline void absorb_block(const uint8_t* block, std::array<uint64_t, 25>& st) noexcept {
+    for (int i = 0; i < kRateWords; ++i) {
+        st[static_cast<size_t>(i)] ^= load_le64(block + 8 * i);
+    }
+    ::keccakf(st.data(), KECCAK_ROUNDS);
+}
+
+} // namespace
+
+// ---- CryptoNote varint --------------------------------------------------------
+// Same codec object BlobWriter::put_varint drives (tools::write_varint over a
+// char* cursor), so the template's varints and xmr_blob's are the same bytes.
+void writeVarint(uint64_t value, std::vector<uint8_t>& out)
+{
+    char tmp[(sizeof(uint64_t) * 8 + 6) / 7];   // max 10 bytes for a u64
+    char* end = tmp;
+    tools::write_varint(end, value);
+    out.insert(out.end(), reinterpret_cast<const uint8_t*>(tmp),
+               reinterpret_cast<const uint8_t*>(end));
+}
+
+// ---- Keccak-256 one-shot (vendored) ------------------------------------------
+void keccak(const uint8_t* in, size_t inlen, uint8_t* md, int mdlen)
+{
+    ::keccak(in, inlen, md, mdlen);   // monero-project keccak.c, unmodified
+}
+
+// ---- Keccak midstate: raw 25-lane state form ---------------------------------
+// Contract (header): `inlen` is a whole multiple of HASH_DATA_AREA. Trailing
+// bytes short of a block are NOT absorbed (they belong to keccak_finish); the
+// template always passes (offset / 136) * 136, so the assert documents the
+// contract rather than guarding a live path.
+void keccak_step(const uint8_t* in, int inlen, std::array<uint64_t, 25>& state)
+{
+    assert(inlen >= 0 && (inlen % kRate) == 0 && "keccak_step: inlen must be a multiple of 136");
+    for (; inlen >= kRate; inlen -= kRate, in += kRate) {
+        absorb_block(in, state);
+    }
+}
+
+// Absorb the tail into an already-stepped state, pad, permute. The tail may be
+// LONGER than one block: the template's fast path hands up to sizeof(tx_buf)
+// (288 B) here (calc_miner_tx_hash), so any whole blocks are absorbed first,
+// exactly as the one-shot loop would have. Padding is the original-Keccak
+// 0x01 ... 0x80 rule of monerod's keccak.c (the two bytes coincide into 0x81
+// when the tail is 135 B). The 32-byte digest is state[0..3].
+void keccak_finish(const uint8_t* in, int inlen, std::array<uint64_t, 25>& state)
+{
+    assert(inlen >= 0 && "keccak_finish: negative length");
+    for (; inlen >= kRate; inlen -= kRate, in += kRate) {
+        absorb_block(in, state);
+    }
+
+    uint8_t temp[kRate];
+    std::memset(temp, 0, sizeof(temp));
+    if (inlen > 0) std::memcpy(temp, in, static_cast<size_t>(inlen));
+    temp[inlen]     = 0x01;   // Keccak (pre-SHA3) domain/padding start
+    temp[kRate - 1] |= 0x80;  // final bit of the rate block
+    absorb_block(temp, state);
+}
+
+// ---- 128-bit multiply / divide ------------------------------------------------
+uint64_t umul128(uint64_t a, uint64_t b, uint64_t* hi)
+{
+    const unsigned __int128 p = static_cast<unsigned __int128>(a) * b;
+    *hi = static_cast<uint64_t>(p >> 64);
+    return static_cast<uint64_t>(p);
+}
+
+// Precondition (as with x86-64 `divq`, which p2pool emits inline): den != 0 and
+// numhi < den so the quotient fits 64 bits. The template's only caller
+// (get_block_reward) satisfies both: den = median^2 > 0 and the numerator is
+// base_reward * (2m - w) * w <= base_reward * m^2. A zero divisor is turned
+// into a saturated quotient instead of a SIGFPE so a malformed miner_data
+// cannot take the daemon down; the reward it yields is nonsense that monerod
+// rejects, never a consensus value.
+uint64_t udiv128(uint64_t numhi, uint64_t numlo, uint64_t den, uint64_t* rem)
+{
+    assert(den != 0 && "udiv128: zero divisor");
+    if (den == 0) {
+        if (rem) *rem = numlo;
+        return ~0ULL;
+    }
+    const unsigned __int128 n = (static_cast<unsigned __int128>(numhi) << 64) | numlo;
+    assert(numhi < den && "udiv128: quotient does not fit 64 bits");
+    if (rem) *rem = static_cast<uint64_t>(n % den);
+    return static_cast<uint64_t>(n / den);   // truncates like divq's overflow would NOT: caller's precondition
+}
+
+// ---- fan-out helper ------------------------------------------------------------
+// Runs `f` on hardware_concurrency() threads (the calling thread takes one
+// share when waiting). Copies of `f` divide the work themselves (the template
+// uses a shared atomic counter). If a thread cannot be spawned the remaining
+// work is simply run on the calling thread -- correct, only slower.
+void parallel_run(const std::function<void()>& f, bool wait)
+{
+    unsigned n = std::thread::hardware_concurrency();
+    if (n == 0) n = 1;
+    n = std::min<unsigned>(n, 64);
+
+    if (!wait) {
+        for (unsigned i = 0; i < n; ++i) {
+            try { std::thread(f).detach(); }
+            catch (const std::exception&) { f(); }
+        }
+        return;
+    }
+
+    std::vector<std::thread> pool;
+    pool.reserve(n > 1 ? n - 1 : 0);
+    for (unsigned i = 1; i < n; ++i) {
+        try { pool.emplace_back(f); }
+        catch (const std::exception&) { break; }   // fall back: this thread finishes the rest
+    }
+    f();
+    for (std::thread& t : pool) t.join();
+}
+
+// ---- wall clock ---------------------------------------------------------------
+uint64_t seconds_since_epoch()
+{
+    using namespace std::chrono;
+    return static_cast<uint64_t>(
+        duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
+}
+
+} // namespace c2pool::xmr

--- a/src/impl/xmr/test/CMakeLists.txt
+++ b/src/impl/xmr/test/CMakeLists.txt
@@ -298,4 +298,37 @@ if (BUILD_TESTING)
         # end-to-end verify; suite (B) arithmetic runs always.
         add_test(NAME xmr_randomx_verify_kat COMMAND xmr_randomx_verify_kat --engine)
     endif()
+
+    # =========================================================================
+    # X9 OPTION B — whole-block settlement coinbase (consumer-tree; no consensus
+    # digest). Both link xmr_template (the p2pool block-template port + the
+    # authored xmr_coin_primitives.cpp seam bodies), so the primitive bodies are
+    # provided ONCE by the library and neither TU defines
+    # XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES (the ODR rule).
+    #
+    # ci-allowlist-exempt: xmr_template_primitives_kat  -- heavy option-B leg (pulls the whole template port); compilation is gated at PR time by the c2pool-v37-xmr daemon target (which links xmr_template) on the non-san Linux leg, not by BUILD_TESTING; a later wave folds it into build.yml.
+    # ci-allowlist-exempt: xmr_block_assembly_kat  -- heavy option-B leg (template + X6 settle + ref10 point-check); same gating as above.
+
+    # (1) primitive seam byte-identity + template in-situ (component 1 + the leg).
+    add_executable(xmr_template_primitives_kat xmr_template_primitives_kat.cpp)
+    target_link_libraries(xmr_template_primitives_kat PRIVATE xmr_template)
+    target_compile_features(xmr_template_primitives_kat PRIVATE cxx_std_20)
+    add_test(NAME xmr_template_primitives_kat COMMAND xmr_template_primitives_kat)
+
+    # (2) whole-block assembly self-check K0..K6 ("the X6 K_fair coinbase IS the
+    #     block's coinbase"): xmr_block_assembly.hpp over the X6 executor
+    #     (settle/xmr_coinbase.cpp) + the ed25519 point-check registrar
+    #     (v37_descriptor_xmr_point_check_ref10.cpp, V37_XMR_HAVE_MONERO_CRYPTO).
+    add_executable(xmr_block_assembly_kat
+        xmr_block_assembly_selfcheck.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../settle/xmr_coinbase.cpp
+        ${CMAKE_SOURCE_DIR}/src/sharechain/v37/v37_descriptor_xmr_point_check_ref10.cpp)
+    target_link_libraries(xmr_block_assembly_kat PRIVATE xmr_template)
+    target_include_directories(xmr_block_assembly_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/../coin/vendor
+        ${CMAKE_CURRENT_SOURCE_DIR}/../coin/compat)
+    target_compile_definitions(xmr_block_assembly_kat PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
+    target_compile_features(xmr_block_assembly_kat PRIVATE cxx_std_20)
+    add_test(NAME xmr_block_assembly_kat COMMAND xmr_block_assembly_kat)
 endif()

--- a/src/impl/xmr/test/CMakeLists.txt
+++ b/src/impl/xmr/test/CMakeLists.txt
@@ -306,29 +306,40 @@ if (BUILD_TESTING)
     # provided ONCE by the library and neither TU defines
     # XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES (the ODR rule).
     #
-    # ci-allowlist-exempt: xmr_template_primitives_kat  -- heavy option-B leg (pulls the whole template port); compilation is gated at PR time by the c2pool-v37-xmr daemon target (which links xmr_template) on the non-san Linux leg, not by BUILD_TESTING; a later wave folds it into build.yml.
+    # ci-allowlist-exempt: xmr_template_primitives_kat  -- heavy option-B leg (pulls the whole template port); NOT built in build.yml this wave, so it is guarded behind the OFF-by-default XMR_BUILD_OPTION_B_KATS option below. Library compile-coverage is still had at PR time via the c2pool-v37-xmr daemon target (which links xmr_template) on the non-san Linux leg; a later wave flips this option ON in build.yml.
     # ci-allowlist-exempt: xmr_block_assembly_kat  -- heavy option-B leg (template + X6 settle + ref10 point-check); same gating as above.
+    #
+    # Both add_executable/add_test are gated behind XMR_BUILD_OPTION_B_KATS
+    # (default OFF, run locally with -DXMR_BUILD_OPTION_B_KATS=ON). Without this
+    # guard the add_test() below registers in every BUILD_TESTING build while the
+    # binaries are (deliberately) absent from build.yml's --target list, so ctest
+    # reports them ***Not Run and CTest exits 8 -- a red that is NOT a test
+    # failure. This mirrors the ltc_embedded_bootstrap_gate exempt idiom: exempt
+    # from the allowlist AND unregistered unless its own option is set.
+    option(XMR_BUILD_OPTION_B_KATS
+           "Build the heavy X9 option-B XMR KATs (local; not in the CI --target allowlist)" OFF)
+    if (XMR_BUILD_OPTION_B_KATS)
+        # (1) primitive seam byte-identity + template in-situ (component 1 + the leg).
+        add_executable(xmr_template_primitives_kat xmr_template_primitives_kat.cpp)
+        target_link_libraries(xmr_template_primitives_kat PRIVATE xmr_template)
+        target_compile_features(xmr_template_primitives_kat PRIVATE cxx_std_20)
+        add_test(NAME xmr_template_primitives_kat COMMAND xmr_template_primitives_kat)
 
-    # (1) primitive seam byte-identity + template in-situ (component 1 + the leg).
-    add_executable(xmr_template_primitives_kat xmr_template_primitives_kat.cpp)
-    target_link_libraries(xmr_template_primitives_kat PRIVATE xmr_template)
-    target_compile_features(xmr_template_primitives_kat PRIVATE cxx_std_20)
-    add_test(NAME xmr_template_primitives_kat COMMAND xmr_template_primitives_kat)
-
-    # (2) whole-block assembly self-check K0..K6 ("the X6 K_fair coinbase IS the
-    #     block's coinbase"): xmr_block_assembly.hpp over the X6 executor
-    #     (settle/xmr_coinbase.cpp) + the ed25519 point-check registrar
-    #     (v37_descriptor_xmr_point_check_ref10.cpp, V37_XMR_HAVE_MONERO_CRYPTO).
-    add_executable(xmr_block_assembly_kat
-        xmr_block_assembly_selfcheck.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../settle/xmr_coinbase.cpp
-        ${CMAKE_SOURCE_DIR}/src/sharechain/v37/v37_descriptor_xmr_point_check_ref10.cpp)
-    target_link_libraries(xmr_block_assembly_kat PRIVATE xmr_template)
-    target_include_directories(xmr_block_assembly_kat PRIVATE
-        ${CMAKE_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_SOURCE_DIR}/../coin/vendor
-        ${CMAKE_CURRENT_SOURCE_DIR}/../coin/compat)
-    target_compile_definitions(xmr_block_assembly_kat PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
-    target_compile_features(xmr_block_assembly_kat PRIVATE cxx_std_20)
-    add_test(NAME xmr_block_assembly_kat COMMAND xmr_block_assembly_kat)
+        # (2) whole-block assembly self-check K0..K6 ("the X6 K_fair coinbase IS the
+        #     block's coinbase"): xmr_block_assembly.hpp over the X6 executor
+        #     (settle/xmr_coinbase.cpp) + the ed25519 point-check registrar
+        #     (v37_descriptor_xmr_point_check_ref10.cpp, V37_XMR_HAVE_MONERO_CRYPTO).
+        add_executable(xmr_block_assembly_kat
+            xmr_block_assembly_selfcheck.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/../settle/xmr_coinbase.cpp
+            ${CMAKE_SOURCE_DIR}/src/sharechain/v37/v37_descriptor_xmr_point_check_ref10.cpp)
+        target_link_libraries(xmr_block_assembly_kat PRIVATE xmr_template)
+        target_include_directories(xmr_block_assembly_kat PRIVATE
+            ${CMAKE_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_SOURCE_DIR}/../coin/vendor
+            ${CMAKE_CURRENT_SOURCE_DIR}/../coin/compat)
+        target_compile_definitions(xmr_block_assembly_kat PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
+        target_compile_features(xmr_block_assembly_kat PRIVATE cxx_std_20)
+        add_test(NAME xmr_block_assembly_kat COMMAND xmr_block_assembly_kat)
+    endif()
 endif()

--- a/src/impl/xmr/test/xmr_block_assembly_selfcheck.cpp
+++ b/src/impl/xmr/test/xmr_block_assembly_selfcheck.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/test/xmr_block_assembly_selfcheck.cpp   (X9 option B)
+//
+// 3-line driver for the whole-block-assembly self-check (K0..K6 in
+// xmr_block_assembly.hpp::kat::selfcheck): proves the X9 option-B components
+// integrate and are byte-correct WITHOUT monerod or RandomX —
+//   K0  primitive bodies (varint / Keccak one-shot + midstate / mul-div-128)
+//       byte-identical to the vendored oracle for every split;
+//   K1  regtest-shape sink-only coinbase (empty ledger, whole reward -> sink);
+//   K2  6 owed + fixed + sink, K_fair oldest-owed-first order preserved;
+//   K3  penalty-zone reward/payee-set fixpoint (rebuild at the wanted reward);
+//   K4  same set at the final reward (adopted in pass 1);
+//   K5/K6 fail-closed (CARROT fence, missing residual sink, cap too small);
+//   and for each template + extra_nonce: (a) the template miner_tx prefix ==
+//   X6 build_coinbase().prefix, (b/c) the hashing-blob tree root == tree_root
+//   ([X6 coinbase leaf] ++ tx ids) with a verifying branch, (d) both blobs
+//   share the header and the block id computes, (e) the served prefix re-parses
+//   and canonical_coinbase_matches() == true (the W3 ACCEPT re-derivation), with
+//   a negative control. i.e. "the X6 K_fair coinbase IS the block's coinbase."
+//
+// The primitive bodies come from linking xmr_template (xmr_coin_primitives.o);
+// this TU does NOT define XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES (the ODR rule).
+// ---------------------------------------------------------------------------
+#define XMR_BLOCK_ASSEMBLY_SELFCHECK_MAIN
+#include "impl/xmr/template/xmr_block_assembly.hpp"

--- a/src/impl/xmr/test/xmr_template_primitives_kat.cpp
+++ b/src/impl/xmr/test/xmr_template_primitives_kat.cpp
@@ -1,0 +1,625 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/test/xmr_template_primitives_kat.cpp  --  X9 option-B KAT:
+// the whole-block template's primitive seam (xmr_coin_primitives.cpp)
+//
+// Pins every body behind template/xmr_coin_primitives.hpp against an
+// INDEPENDENT oracle, then drives the real XmrBlockTemplate (the p2pool port
+// that no target compiled until this wave) and recomputes what it emitted
+// through the lane's OWN serializer/hash path (xmr::coin, X1):
+//
+//   1. writeVarint(vector)  == header byte_sink form == tools::get_varint_data
+//                           == BlobWriter::put_varint   (canonical LEB128 vectors)
+//   2. keccak (one-shot)    == xmr::coin::keccak256 (cn_fast_hash) incl. the
+//                              published Keccak("") constant and the REAL Monero
+//                              block-3,000,000 miner-tx-hash triple
+//   3. keccak_step+finish   == keccak(head||tail) for EVERY block-aligned split
+//                              and tails {0,1,135,136,137,271,272,288} bytes
+//                              (the template's fast path hands tails up to 288 B),
+//                              and == the KECCAK_CTX KeccakMidstate path
+//   4. keccak_custom        == keccak over a patched byte stream (template use)
+//   5. umul128              == vendored int-util.h mul128 (independent schoolbook)
+//      udiv128              == hand-computed reward-math vector + reconstruction
+//   6. parallel_run(wait)   partitions a counter-driven job and joins
+//   7. seconds_since_epoch  agrees with std::chrono
+//   8. adapters             round-trip hash/Bytes32/std::array and difficulty
+//   9. IN-SITU: XmrBlockTemplate with a stub IXmrSettlementSource for payee
+//      counts that exercise the keccak_custom SLOW path (extra-nonce offset <
+//      136) and the keccak_step/keccak_finish midstate FAST path (offset >= 136,
+//      incl. a >136-B tail): for extra_nonce in {0, 1, 0xFFFFFFFF}
+//        (a) the miner_tx prefix sliced out of get_block_template_blob() is
+//            byte-identical to xmr::coin::write_coinbase_prefix_head + tx_extra
+//            (the two serializers agree),
+//        (b) tree_root([coinbase_tx_hash(tx_prefix_hash(prefix))] ++ backlog ids)
+//            recomputed through xmr::coin == the 32-B root inside get_hashing_blob(),
+//        (c) block id keccak(varint(len)||hashing_blob) agrees on both paths,
+//        (d) get_hashing_blobs (parallel_run in situ) == per-blob get_hashing_blob,
+//        (e) an old template_id keeps resolving after a further update().
+//
+// Own harness (nonzero exit on any failure), STL + xmr_template + xmr_coin
+// only: NO RandomX, monerod, libsodium or boost. Runs on both build.yml legs.
+// ---------------------------------------------------------------------------
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "xmr_coin_primitives.hpp"
+#include "xmr_coin_adapters.hpp"
+#include "xmr_block_template.hpp"
+
+#include "xmr_crypto_types.hpp"      // Hash256 / PublicKey / ViewTag
+#include "xmr_keccak_midstate.hpp"   // keccak256() == cn_fast_hash, KeccakMidstate
+#include "xmr_blob.hpp"              // BlobWriter, write_coinbase_prefix_head, tx hashes, tree_root
+#include "vendor/varint.h"           // tools::get_varint_data
+
+extern "C" {
+#include "vendor/int-util.h"         // mul128 (independent schoolbook oracle)
+}
+
+namespace cx = c2pool::xmr;
+using xmr::coin::Hash256;
+
+namespace {
+
+int g_fail = 0;
+#define CHECK(cond, ...) do { \
+    bool _ok = (cond); \
+    std::printf("  [%s] ", _ok ? "PASS" : "FAIL"); \
+    std::printf(__VA_ARGS__); std::printf("\n"); \
+    if (!_ok) ++g_fail; \
+} while (0)
+
+std::string hex(const uint8_t* b, size_t n) {
+    static const char* d = "0123456789abcdef";
+    std::string s; s.reserve(n * 2);
+    for (size_t i = 0; i < n; ++i) { s.push_back(d[b[i] >> 4]); s.push_back(d[b[i] & 0xf]); }
+    return s;
+}
+std::string hex(const std::vector<uint8_t>& v) { return hex(v.data(), v.size()); }
+std::string hx(const cx::hash& h) { return hex(h.h, 32); }
+std::string hx(const Hash256& h) { return hex(h.data(), 32); }
+
+std::vector<uint8_t> unhex(const std::string& h) {
+    std::vector<uint8_t> o;
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        return -1;
+    };
+    for (size_t i = 0; i + 1 < h.size(); i += 2)
+        o.push_back(static_cast<uint8_t>((nib(h[i]) << 4) | nib(h[i + 1])));
+    return o;
+}
+
+// deterministic pseudo-random bytes (xorshift64*), no <random> dependency
+struct Prng {
+    uint64_t s;
+    explicit Prng(uint64_t seed) : s(seed ? seed : 0x9E3779B97F4A7C15ULL) {}
+    uint64_t next() { s ^= s >> 12; s ^= s << 25; s ^= s >> 27; return s * 0x2545F4914F6CDD1DULL; }
+    void fill(std::vector<uint8_t>& v) { for (auto& b : v) b = static_cast<uint8_t>(next() >> 56); }
+};
+
+cx::hash keccak_str(const std::string& tag, uint64_t i = 0) {
+    std::vector<uint8_t> in(tag.begin(), tag.end());
+    for (int k = 0; k < 8; ++k) in.push_back(static_cast<uint8_t>(i >> (8 * k)));
+    cx::hash h;
+    cx::keccak(in.data(), in.size(), h.h, 32);
+    return h;
+}
+
+bool eq32(const uint8_t* a, const uint8_t* b) { return std::memcmp(a, b, 32) == 0; }
+
+// =====================================================================
+void kat_varint() {
+    std::printf("== 1. writeVarint (vector) == byte_sink form == tools::write_varint == BlobWriter ==\n");
+
+    struct V { uint64_t v; const char* hexv; } canon[] = {
+        {0, "00"}, {1, "01"}, {127, "7f"}, {128, "8001"}, {255, "ff01"}, {300, "ac02"},
+        {16383, "ff7f"}, {16384, "808001"}, {0xFFFFFFFFULL, "ffffffff0f"},
+        {600000000000ULL, "80a094a58b11"},                       // 0.6 XMR tail reward
+        {(1ULL << 56) - 1, "ffffffffffffff7f"},                   // MAX_OUTPUT_VALUE
+        {UINT64_MAX, "ffffffffffffffffff01"},
+    };
+    for (const V& c : canon) {
+        std::vector<uint8_t> a; cx::writeVarint(c.v, a);
+        std::vector<uint8_t> b; cx::writeVarint(c.v, [&b](uint8_t x) { b.push_back(x); });
+        std::string t = tools::get_varint_data(c.v);
+        xmr::coin::BlobWriter w; w.put_varint(c.v);
+        const bool ok = hex(a) == c.hexv && a == b &&
+                        std::vector<uint8_t>(t.begin(), t.end()) == a && w.bytes() == a;
+        CHECK(ok, "varint(%llu) = %s (canon %s)", static_cast<unsigned long long>(c.v), hex(a).c_str(), c.hexv);
+    }
+
+    // sweep: every 7-bit boundary +-1 and a pseudo-random set
+    Prng rng(1);
+    bool sweep_ok = true;
+    std::vector<uint64_t> vals;
+    for (int s = 0; s < 64; s += 7) { vals.push_back(1ULL << s); vals.push_back((1ULL << s) - 1); vals.push_back((1ULL << s) + 1); }
+    for (int i = 0; i < 2000; ++i) vals.push_back(rng.next() >> (rng.next() % 64));
+    for (uint64_t v : vals) {
+        std::vector<uint8_t> a; cx::writeVarint(v, a);
+        std::vector<uint8_t> b; cx::writeVarint(v, [&b](uint8_t x) { b.push_back(x); });
+        xmr::coin::BlobWriter w; w.put_varint(v);
+        if (a != b || w.bytes() != a || a.size() != tools::get_varint_byte_size(v)) { sweep_ok = false; break; }
+    }
+    CHECK(sweep_ok, "varint sweep (%zu values): vector == byte_sink == BlobWriter, size == get_varint_byte_size", vals.size());
+}
+
+// =====================================================================
+void kat_keccak_oneshot() {
+    std::printf("== 2. keccak (one-shot) == xmr::coin::keccak256 / cn_fast_hash ==\n");
+
+    cx::hash e; cx::keccak(nullptr, 0, e.h, 32);
+    CHECK(hx(e) == "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470",
+          "keccak(\"\") = %s (published original-Keccak-256 constant)", hx(e).c_str());
+
+    // REAL Monero mainnet block 3,000,000: miner_tx_hash == keccak(H_prefix||H_rct_base||H_prunable)
+    std::vector<uint8_t> triple;
+    for (const char* p : {"18b7efb2ab347082fc161ff480b0554dbf94de87251e676d8b67d7f5d9173b24",
+                          "bc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a",
+                          "0000000000000000000000000000000000000000000000000000000000000000"}) {
+        auto v = unhex(p); triple.insert(triple.end(), v.begin(), v.end());
+    }
+    cx::hash th; cx::keccak(triple.data(), triple.size(), th.h, 32);
+    CHECK(hx(th) == "7f88a52afdab303ddb9d444cb5b53adb5a12c63a82e898a9d2db9f76dd1127f6",
+          "keccak(96-B triple) = %s (real blk 3,000,000 miner_tx_hash)", hx(th).c_str());
+
+    // H(rct_base = 0x00) is the constant the template hard-codes (known_second_hash)
+    uint8_t zero = 0; cx::hash rb; cx::keccak(&zero, 1, rb.h, 32);
+    static const uint8_t known_second_hash[32] = {188,54,120,158,122,30,40,20,54,70,66,41,130,143,129,125,
+                                                  102,18,247,180,119,214,101,145,255,150,169,224,100,188,201,138};
+    CHECK(eq32(rb.h, known_second_hash), "keccak(0x00) == template known_second_hash (RCTTypeNull base)");
+
+    Prng rng(2);
+    bool ok = true;
+    for (size_t len : {size_t(1), size_t(55), size_t(135), size_t(136), size_t(137), size_t(271), size_t(272), size_t(273), size_t(1000), size_t(4096)}) {
+        std::vector<uint8_t> m(len); rng.fill(m);
+        cx::hash a; cx::keccak(m.data(), m.size(), a.h, 32);
+        Hash256 b = xmr::coin::keccak256(m.data(), m.size());
+        if (!eq32(a.h, b.data())) { ok = false; std::printf("    mismatch at len %zu\n", len); }
+    }
+    CHECK(ok, "keccak == keccak256 for lengths {1,55,135,136,137,271,272,273,1000,4096}");
+}
+
+// =====================================================================
+void kat_keccak_midstate() {
+    std::printf("== 3. keccak_step + keccak_finish == keccak(head||tail), every split ==\n");
+
+    constexpr int R = cx::KeccakParams::HASH_DATA_AREA;
+    Prng rng(3);
+    std::vector<uint8_t> msg(6 * R + 300); rng.fill(msg);
+
+    const int tails[] = {0, 1, 7, 8, 9, 63, 64, 65, 134, 135, 136, 137, 200, 271, 272, 273, 287, 288};
+    size_t cases = 0; bool ok = true;
+    for (int N = 0; N + 288 <= static_cast<int>(msg.size()); N += R) {
+        for (int tl : tails) {
+            const int L = N + tl;
+            // oracle: vendored one-shot
+            cx::hash want; cx::keccak(msg.data(), static_cast<size_t>(L), want.h, 32);
+            // raw-state path (what the template caches / resumes)
+            std::array<uint64_t, 25> st{};
+            cx::keccak_step(msg.data(), N, st);
+            cx::keccak_finish(msg.data() + N, tl, st);
+            uint8_t got[32]; std::memcpy(got, st.data(), 32);
+            // KECCAK_CTX path (xmr_keccak_midstate.hpp) -- same split
+            xmr::coin::KeccakMidstate ms;
+            ms.absorb(msg.data(), static_cast<size_t>(N));
+            ms.absorb(msg.data() + N, static_cast<size_t>(tl));
+            Hash256 ctx = ms.finalize_copy();
+            ++cases;
+            if (!eq32(got, want.h) || !eq32(ctx.data(), want.h)) {
+                ok = false;
+                std::printf("    mismatch N=%d tail=%d: raw=%s ctx=%s want=%s\n", N, tl,
+                            hex(got, 32).c_str(), hx(ctx).c_str(), hx(want).c_str());
+            }
+        }
+    }
+    CHECK(ok, "raw-state step/finish == one-shot == KECCAK_CTX for %zu (split, tail) cases", cases);
+
+    // step with inlen=0 is a no-op; finish on an untouched state == keccak(tail)
+    {
+        std::array<uint64_t, 25> st{};
+        cx::keccak_step(msg.data(), 0, st);
+        bool zero = true; for (uint64_t w : st) zero = zero && (w == 0);
+        cx::keccak_finish(msg.data(), 100, st);
+        cx::hash want; cx::keccak(msg.data(), 100, want.h, 32);
+        CHECK(zero && eq32(reinterpret_cast<const uint8_t*>(st.data()), want.h),
+              "keccak_step(0 bytes) is a no-op; keccak_finish alone == keccak(tail)");
+    }
+
+    // resume-many-tails from ONE stepped state (the template copies the cached
+    // state per extra_nonce and finishes each copy independently)
+    {
+        std::array<uint64_t, 25> base{};
+        cx::keccak_step(msg.data(), 2 * R, base);
+        bool ok2 = true;
+        for (uint32_t en = 0; en < 16; ++en) {
+            std::vector<uint8_t> tail(msg.begin() + 2 * R, msg.begin() + 2 * R + 150);
+            std::memcpy(tail.data() + 40, &en, 4);          // "patch the extra nonce"
+            std::vector<uint8_t> full(msg.begin(), msg.begin() + 2 * R);
+            full.insert(full.end(), tail.begin(), tail.end());
+            cx::hash want; cx::keccak(full.data(), full.size(), want.h, 32);
+            std::array<uint64_t, 25> st = base;
+            cx::keccak_finish(tail.data(), static_cast<int>(tail.size()), st);
+            if (!eq32(reinterpret_cast<const uint8_t*>(st.data()), want.h)) ok2 = false;
+        }
+        CHECK(ok2, "one cached midstate resumed for 16 patched tails (per-extra-nonce pattern)");
+    }
+}
+
+// =====================================================================
+void kat_keccak_custom() {
+    std::printf("== 4. keccak_custom (byte_at stream, patched regions) == keccak ==\n");
+    Prng rng(4);
+    std::vector<uint8_t> data(300); rng.fill(data);
+    const size_t en_off = 120, root_off = 160;
+    const uint8_t en[4] = {0xde, 0xad, 0xbe, 0xef};
+    cx::hash root = keccak_str("root");
+    std::vector<uint8_t> patched = data;
+    std::memcpy(patched.data() + en_off, en, 4);
+    std::memcpy(patched.data() + root_off, root.h, 32);
+    cx::hash want; cx::keccak(patched.data(), patched.size(), want.h, 32);
+    cx::hash got;
+    cx::keccak_custom([&](int off) -> uint8_t {
+        uint32_t k = static_cast<uint32_t>(off - static_cast<int>(en_off));
+        if (k < 4) return en[k];
+        k = static_cast<uint32_t>(off - static_cast<int>(root_off));
+        if (k < 32) return root.h[k];
+        return data[static_cast<size_t>(off)];
+    }, static_cast<int>(data.size()), got.h, 32);
+    CHECK(eq32(got.h, want.h), "keccak_custom over patched stream == keccak(patched bytes)");
+}
+
+// =====================================================================
+void kat_mul_div_128() {
+    std::printf("== 5. umul128 / udiv128 ==\n");
+
+    struct M { uint64_t a, b, lo, hi; } mv[] = {
+        {0, 0, 0, 0}, {1, 1, 1, 0}, {UINT64_MAX, 1, UINT64_MAX, 0},
+        {1ULL << 32, 1ULL << 32, 0, 1},
+        {UINT64_MAX, UINT64_MAX, 1, UINT64_MAX - 1},
+        {600000000000ULL, 87500000000ULL, 0x07dc231427d00000ULL, 0xb1eULL},   // reward-math numerator
+    };
+    for (const M& m : mv) {
+        uint64_t hi = 0; const uint64_t lo = cx::umul128(m.a, m.b, &hi);
+        uint64_t vhi = 0; const uint64_t vlo = mul128(m.a, m.b, &vhi);   // vendored int-util.h
+        CHECK(lo == m.lo && hi == m.hi && vlo == lo && vhi == hi,
+              "umul128(%llu, %llu) = (hi %llx, lo %llx) == vendored mul128",
+              static_cast<unsigned long long>(m.a), static_cast<unsigned long long>(m.b),
+              static_cast<unsigned long long>(hi), static_cast<unsigned long long>(lo));
+    }
+    Prng rng(5); bool ok = true;
+    for (int i = 0; i < 20000 && ok; ++i) {
+        const uint64_t a = rng.next(), b = rng.next();
+        uint64_t hi, vhi; const uint64_t lo = cx::umul128(a, b, &hi); const uint64_t vlo = mul128(a, b, &vhi);
+        ok = (lo == vlo && hi == vhi);
+    }
+    CHECK(ok, "umul128 == vendored mul128 on 20000 pseudo-random pairs");
+
+    // get_block_reward vector: base 0.6 XMR, median 300000, weight 350000
+    //   reward = base*(2m-w)*w / m^2 = 5.25e22 / 9e10 = 583333333333 rem 30000000000
+    {
+        uint64_t rem = 0;
+        const uint64_t q = cx::udiv128(0xb1eULL, 0x07dc231427d00000ULL, 90000000000ULL, &rem);
+        CHECK(q == 583333333333ULL && rem == 30000000000ULL,
+              "udiv128(reward numerator, median^2) = %llu rem %llu (hand-computed 583333333333 r 30000000000)",
+              static_cast<unsigned long long>(q), static_cast<unsigned long long>(rem));
+    }
+    {
+        uint64_t rem = 0;
+        const uint64_t q = cx::udiv128(1, 0, 1ULL << 32, &rem);
+        CHECK(q == (1ULL << 32) && rem == 0, "udiv128(2^64, 2^32) = 2^32 rem 0");
+        const uint64_t q2 = cx::udiv128(0, 100, 7, &rem);
+        CHECK(q2 == 14 && rem == 2, "udiv128(100, 7) = 14 rem 2");
+    }
+    // reconstruction sweep with numhi < den (the divq precondition)
+    bool rok = true;
+    for (int i = 0; i < 20000 && rok; ++i) {
+        const uint64_t den = rng.next() | 1;
+        const uint64_t hi = rng.next() % den;
+        const uint64_t lo = rng.next();
+        uint64_t rem = 0;
+        const uint64_t q = cx::udiv128(hi, lo, den, &rem);
+        uint64_t phi = 0; const uint64_t plo = cx::umul128(q, den, &phi);
+        // (q*den) + rem must equal (hi:lo) with rem < den
+        const uint64_t slo = plo + rem;
+        const uint64_t shi = phi + (slo < plo ? 1 : 0);
+        rok = (rem < den) && (slo == lo) && (shi == hi);
+    }
+    CHECK(rok, "udiv128 reconstruction q*den+rem == (hi:lo), rem < den, on 20000 pseudo-random triples");
+}
+
+// =====================================================================
+void kat_parallel_run_and_clock() {
+    std::printf("== 6/7. parallel_run(wait=true) partitions work; seconds_since_epoch ==\n");
+    constexpr uint32_t N = 100000;
+    std::atomic<uint32_t> counter{0};
+    std::atomic<uint64_t> sum{0};
+    std::atomic<int> copies{0};
+    cx::parallel_run([&]() {
+        ++copies;
+        uint64_t local = 0;
+        for (;;) {
+            const uint32_t i = counter.fetch_add(1);
+            if (i >= N) break;
+            local += i;
+        }
+        sum += local;
+    }, true);
+    const uint64_t want = static_cast<uint64_t>(N) * (N - 1) / 2;
+    CHECK(sum.load() == want && copies.load() >= 1,
+          "counter-partitioned sum over %d copies = %llu (want %llu); returned after join",
+          copies.load(), static_cast<unsigned long long>(sum.load()), static_cast<unsigned long long>(want));
+
+    const uint64_t s = cx::seconds_since_epoch();
+    const auto now = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+    CHECK(s > 1700000000ULL && (now >= static_cast<long long>(s)) && (now - static_cast<long long>(s)) <= 2,
+          "seconds_since_epoch = %llu (chrono %lld)", static_cast<unsigned long long>(s), static_cast<long long>(now));
+}
+
+// =====================================================================
+void kat_adapters() {
+    std::printf("== 8. type adapters ==\n");
+    cx::hash h = keccak_str("adapter");
+    Hash256 h256 = cx::from_hash<Hash256>(h);
+    xmr::coin::PublicKey pk = cx::from_hash<xmr::coin::PublicKey>(h);
+    std::array<uint8_t, 32> arr = cx::from_hash<std::array<uint8_t, 32>>(h);
+    CHECK(eq32(h256.data(), h.h) && eq32(pk.data(), h.h) && eq32(arr.data(), h.h),
+          "from_hash -> Hash256 / PublicKey / std::array<uint8_t,32> byte-identical");
+    CHECK(cx::to_hash(h256) == h && cx::to_hash(pk) == h && cx::to_hash(arr) == h && cx::to_hash(h.h) == h,
+          "to_hash round-trips all three spellings");
+    struct D128 { uint64_t lo = 0, hi = 0; } d{0x1234, 0x5678};
+    cx::difficulty_type t = cx::to_difficulty(d);
+    D128 back = cx::from_difficulty<D128>(t);
+    CHECK(t.lo == 0x1234 && t.hi == 0x5678 && back.lo == d.lo && back.hi == d.hi &&
+          cx::to_difficulty(7).lo == 7 && cx::to_difficulty(7).hi == 0,
+          "difficulty {lo,hi} round-trips");
+}
+
+// =====================================================================
+// 9. IN-SITU: the real XmrBlockTemplate over a stub settlement seam.
+// =====================================================================
+struct StubSeam final : cx::IXmrSettlementSource {
+    std::vector<cx::XmrPayee> ps;
+    cx::hash r, R;
+    explicit StubSeam(size_t n) {
+        for (size_t i = 0; i < n; ++i) {
+            cx::XmrPayee p;
+            p.spend_public_key = keccak_str("B", i);
+            p.view_public_key  = keccak_str("A", i);
+            ps.push_back(p);
+        }
+        r = keccak_str("r"); R = keccak_str("R");
+    }
+    const std::vector<cx::XmrPayee>& payees() const override { return ps; }
+    const cx::hash& tx_secret_key() const override { return r; }
+    const cx::hash& tx_public_key() const override { return R; }
+    bool derive_output_key(size_t i, uint8_t hf, cx::hash& out, uint8_t& vt) const override {
+        if (hf > cx::HARDFORK_SUPPORTED_VERSION) return false;   // CARROT fence shape
+        out = keccak_str("P", i);
+        vt = static_cast<uint8_t>(i * 7 + 1);
+        return true;
+    }
+    bool split_reward(uint64_t reward, std::vector<uint64_t>& rewards) const override {
+        const size_t n = ps.size();
+        if (n == 0) return false;
+        rewards.assign(n, reward / n);
+        rewards[n - 1] += reward - (reward / n) * n;            // exact sum
+        return true;
+    }
+    cx::hash commitment_leaf(uint32_t en) const override { return keccak_str("leaf", en); }
+    uint64_t merkle_tree_data() const override { return 0; }
+};
+
+// parse a CryptoNote varint at p (bounded)
+uint64_t read_varint(const std::vector<uint8_t>& b, size_t& pos) {
+    uint64_t v = 0; int shift = 0;
+    while (pos < b.size()) {
+        const uint8_t x = b[pos++];
+        v |= static_cast<uint64_t>(x & 0x7f) << shift;
+        if (!(x & 0x80)) break;
+        shift += 7;
+    }
+    return v;
+}
+
+void kat_template_in_situ(size_t n_payees, size_t n_backlog) {
+    std::printf("== 9. XmrBlockTemplate in situ: %zu payees, %zu backlog txs ==\n", n_payees, n_backlog);
+
+    StubSeam seam(n_payees);
+    cx::XmrBlockTemplate t(&seam);
+
+    cx::XmrMinerData md;
+    md.major_version = cx::HARDFORK_SUPPORTED_VERSION;
+    md.height = 3000000;
+    md.prev_id = keccak_str("prev", n_payees);
+    md.already_generated_coins = UINT64_MAX - 1000;   // ~agc >> 19 == 0 -> tail emission 0.6 XMR
+    md.median_weight = 300000;
+    md.median_timestamp = 1700000000;
+    md.difficulty.lo = 1000; md.difficulty.hi = 0;
+    md.seed_hash = keccak_str("seed");
+    md.lane_target.lo = 1ULL << 40; md.lane_target.hi = 0;
+
+    std::vector<cx::XmrTxMempoolData> pool;
+    uint64_t fees = 0;
+    for (size_t i = 0; i < n_backlog; ++i) {
+        cx::XmrTxMempoolData tx;
+        tx.id = keccak_str("txid", i);
+        tx.weight = 1500 + i;
+        tx.fee = 30000000 + i;         // 0.00003 XMR-ish, < HIGH_FEE_VALUE
+        tx.time_received = 0;          // passes the 5-s age gate
+        pool.push_back(tx);
+        fees += tx.fee;
+    }
+
+    t.update(md, pool);
+
+    const uint64_t reward = t.get_reward();
+    CHECK(t.get_height() == md.height && reward == cx::BASE_BLOCK_REWARD + fees,
+          "update(): height %llu, reward %llu == base 0.6 XMR + fees %llu (below-median, all txs taken)",
+          static_cast<unsigned long long>(t.get_height()), static_cast<unsigned long long>(reward),
+          static_cast<unsigned long long>(fees));
+
+    std::vector<uint64_t> amounts;
+    CHECK(seam.split_reward(reward, amounts) && amounts.size() == n_payees, "stub split_reward at final reward");
+
+    uint8_t hb[cx::HASHING_BLOB_MAX_SIZE];
+    uint64_t h = 0; cx::difficulty_type lt; cx::hash seed; size_t nonce_off = 0; uint32_t tid = 0;
+    const uint32_t hb_len = t.get_hashing_blob(0, hb, h, lt, seed, nonce_off, tid);
+    CHECK(hb_len == 76 && nonce_off == 39 && tid == 1 && h == md.height && lt.lo == md.lane_target.lo && seed == md.seed_hash,
+          "get_hashing_blob(0): %u B, nonce_offset %zu, template_id %u", hb_len, nonce_off, tid);
+
+    const size_t header_len = nonce_off + cx::NONCE_SIZE;   // 43 for v16 + 5-B timestamp
+
+    for (uint32_t en : {0u, 1u, 0xFFFFFFFFu}) {
+        size_t no = 0, eno = 0, mro = 0; cx::hash mroot;
+        std::vector<uint8_t> blob = t.get_block_template_blob(tid, en, no, eno, mro, mroot);
+
+        // ---- carve the block: header || miner_tx(prefix || rct_type) || varint(n_tx) || ids ----
+        const size_t prefix_end = mro + 32;                    // MM tag is the last tx_extra field
+        bool layout_ok = no == nonce_off && blob.size() > prefix_end + 1 &&
+                         std::memcmp(blob.data(), hb, header_len) == 0 &&
+                         blob[prefix_end] == 0 /* rct_type RCTTypeNull */;
+        const std::vector<uint8_t> prefix(blob.begin() + header_len, blob.begin() + prefix_end);
+        size_t pos = prefix_end + 1;
+        const uint64_t n_tx = read_varint(blob, pos);
+        std::vector<Hash256> leaves(1);
+        for (uint64_t i = 0; i < n_tx && pos + 32 <= blob.size(); ++i, pos += 32) {
+            Hash256 id; std::memcpy(id.data(), blob.data() + pos, 32);
+            leaves.push_back(id);
+        }
+        layout_ok = layout_ok && (n_tx == n_backlog) && (pos == blob.size());
+        CHECK(layout_ok, "en=%08x: blob %zu B = header(%zu) || miner_tx || varint(%llu) || ids; offsets nonce %zu extra %zu root %zu",
+              en, blob.size(), header_len, static_cast<unsigned long long>(n_tx), no, eno, mro);
+
+        // ---- (a) two serializers agree: rebuild the prefix through xmr::coin ----
+        {
+            std::vector<xmr::coin::PublicKey> keys(n_payees);
+            std::vector<xmr::coin::ViewTag> vts(n_payees);
+            for (size_t i = 0; i < n_payees; ++i) {
+                cx::hash P; uint8_t vt = 0;
+                (void)seam.derive_output_key(i, md.major_version, P, vt);
+                keys[i] = cx::from_hash<xmr::coin::PublicKey>(P);
+                vts[i].tag = vt;
+            }
+            std::vector<uint8_t> want = xmr::coin::write_coinbase_prefix_head(
+                md.height, amounts.data(), keys.data(), vts.data(), n_payees);
+            // tx_extra exactly as X6 assemble_tx_extra / the template emit it:
+            //   0x01 R[32] | 0x02 varint(len) nonce[len] | 0x03 (1+32) varint(0) root[32]
+            const size_t en_len = blob[eno - 1];               // the template's corrected size (<= 14, 1-byte varint)
+            xmr::coin::BlobWriter x;
+            x.put_byte(xmr::coin::TX_EXTRA_TAG_PUBKEY);
+            x.put_bytes(seam.R.h, 32);
+            x.put_byte(xmr::coin::TX_EXTRA_TAG_NONCE);
+            x.put_varint(en_len);
+            x.put_u32_le(en);
+            for (size_t i = 4; i < en_len; ++i) x.put_byte(0);
+            x.put_byte(xmr::coin::TX_EXTRA_TAG_MERGE_MINING);
+            x.put_byte(static_cast<uint8_t>(1 + 32));
+            x.put_varint(0);                                   // merkle_tree_data() == 0
+            const cx::hash leaf = seam.commitment_leaf(en);
+            x.put_bytes(leaf.h, 32);
+            xmr::coin::BlobWriter w;
+            w.put_bytes(want.data(), want.size());
+            w.put_varint(x.size());
+            w.put_bytes(x.bytes().data(), x.size());
+            CHECK(w.bytes() == prefix && mroot == leaf && en_len == cx::EXTRA_NONCE_SIZE,
+                  "en=%08x: (a) template miner_tx prefix (%zu B) == xmr::coin write_coinbase_prefix_head + tx_extra; extra_nonce len %zu",
+                  en, prefix.size(), en_len);
+        }
+
+        // ---- (b) coinbase hash + tree root recomputed through xmr::coin == root in the hashing blob ----
+        {
+            leaves[0] = xmr::coin::coinbase_tx_hash(xmr::coin::tx_prefix_hash(prefix));
+            const Hash256 root = xmr::coin::tree_root(leaves);
+            uint8_t hbe[cx::HASHING_BLOB_MAX_SIZE];
+            uint64_t h2; cx::difficulty_type lt2; cx::hash s2; size_t no2; uint32_t tid2;
+            const uint32_t len2 = t.get_hashing_blob(en, hbe, h2, lt2, s2, no2, tid2);
+            const bool root_ok = len2 == hb_len && eq32(hbe + header_len, root.data()) &&
+                                 std::memcmp(hbe, blob.data(), header_len) == 0 &&
+                                 hbe[header_len + 32] == static_cast<uint8_t>(n_backlog + 1);
+            // which Keccak path did calc_miner_tx_hash take for this layout?
+            const size_t en_off_in_tx = eno - header_len;
+            const size_t N = (en_off_in_tx / 136) * 136;
+            const size_t tail = prefix.size() - N;
+            CHECK(root_ok, "en=%08x: (b) tree_root([coinbase_tx_hash(prefix)] ++ %zu ids) == hashing-blob root %s  [%s path: midstate N=%zu, tail=%zu B]",
+                  en, leaves.size() - 1, hx(root).c_str(),
+                  N ? "keccak_step/finish FAST" : "keccak_custom SLOW", N, tail);
+
+            // (c) block id = keccak(varint(len) || hashing_blob): primitives vs xmr::coin agree
+            std::vector<uint8_t> pre; cx::writeVarint(len2, pre); pre.insert(pre.end(), hbe, hbe + len2);
+            cx::hash bid; cx::keccak(pre.data(), pre.size(), bid.h, 32);
+            Hash256 bid2 = xmr::coin::keccak256(pre.data(), pre.size());
+            CHECK(eq32(bid.h, bid2.data()), "en=%08x: (c) block id keccak(varint(%u)||blob) = %s on both paths", en, len2, hx(bid).c_str());
+        }
+    }
+
+    // ---- (d) get_hashing_blobs (parallel_run in situ) == per-blob get_hashing_blob ----
+    {
+        std::vector<uint8_t> blobs;
+        uint64_t h3; cx::difficulty_type lt3; cx::hash s3; size_t no3; uint32_t tid3;
+        const uint32_t sz = t.get_hashing_blobs(1000, 64, blobs, h3, lt3, s3, no3, tid3);
+        bool ok = (sz == hb_len) && (blobs.size() == static_cast<size_t>(sz) * 64);
+        for (uint32_t i = 0; ok && i < 64; ++i) {
+            uint8_t one[cx::HASHING_BLOB_MAX_SIZE];
+            uint64_t hh; cx::difficulty_type ll; cx::hash ss; size_t nn; uint32_t tt;
+            const uint32_t l1 = t.get_hashing_blob(1000 + i, one, hh, ll, ss, nn, tt);
+            ok = (l1 == sz) && std::memcmp(one, blobs.data() + static_cast<size_t>(i) * sz, sz) == 0;
+        }
+        // distinct extra nonces => distinct roots (disjoint search spaces)
+        bool distinct = ok && std::memcmp(blobs.data() + header_len, blobs.data() + sz + header_len, 32) != 0;
+        CHECK(ok && distinct, "(d) get_hashing_blobs(1000, 64) == 64 x get_hashing_blob; roots differ per extra_nonce");
+    }
+
+    // ---- (e) old template id keeps resolving after a further update() ----
+    {
+        cx::XmrMinerData md2 = md;
+        md2.height = md.height + 1;
+        md2.prev_id = keccak_str("prev2", n_payees);
+        t.update(md2, pool);
+        size_t a, b, c; cx::hash m1, m2;
+        std::vector<uint8_t> old_blob = t.get_block_template_blob(tid, 5, a, b, c, m1);
+        std::vector<uint8_t> new_blob = t.get_block_template_blob(tid + 1, 5, a, b, c, m2);
+        const bool ok = old_blob.size() > 39 && new_blob.size() > 39 &&
+                        std::memcmp(old_blob.data() + 7, md.prev_id.h, 32) == 0 &&
+                        std::memcmp(new_blob.data() + 7, md2.prev_id.h, 32) == 0 &&
+                        t.get_height() == md2.height;
+        CHECK(ok, "(e) template_id %u still resolves (prev %s...) after update() to id %u", tid, hx(md.prev_id).substr(0, 16).c_str(), tid + 1);
+    }
+}
+
+} // namespace
+
+int main() {
+    std::printf("xmr_template_primitives_kat: X9 option-B coin-primitives seam\n");
+    kat_varint();
+    kat_keccak_oneshot();
+    kat_keccak_midstate();
+    kat_keccak_custom();
+    kat_mul_div_128();
+    kat_parallel_run_and_clock();
+    kat_adapters();
+    // payee counts chosen so calc_miner_tx_hash takes: 1,2 -> SLOW (keccak_custom);
+    // 4 -> FAST (N=136, tail < 136); 9 -> FAST with a >136-B tail (whole block
+    // absorbed inside keccak_finish); 12 -> FAST N=272. 0/3 backlog txs cover a
+    // single-leaf tree and a 4-leaf tree_hash main branch.
+    kat_template_in_situ(1, 0);
+    kat_template_in_situ(2, 3);
+    kat_template_in_situ(4, 3);
+    kat_template_in_situ(9, 3);
+    kat_template_in_situ(12, 7);
+    std::printf("\n%s (%d failure%s)\n", g_fail ? "FAILED" : "ALL PASS", g_fail, g_fail == 1 ? "" : "s");
+    return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
## X9 option B — the v37 K_fair settlement coinbase (ready; merge is integrator's tap)

Follow-on to the option-A serve/submit path (#1534). **Option A** serves and submits monerod's own `get_block_template` block (a single coinbase to `--payout-address`, nonce patched). **Option B** (this PR) has the pool assemble its **own** Monero block whose `miner_tx` is the v37 **K_fair settlement coinbase** — oldest-owed-first `EffectiveOwed` payees ++ mandated fixed outputs ++ the exact-sum residual sink (HF13 no-burn) — submits **that** block to monerod, and drives FOUND → FINALIZE.

Selected by `--coinbase v37`; monerod-template (option A) stays the default and is byte-unchanged.

### Scope / consensus posture
Consumer + impl tree only. **No consensus digest is defined or altered; `src/sharechain/v37` is untouched.** The Monero block is validated by monerod itself (RandomX PoW + exact-sum coinbase), not by any v37 rule; `OwedLedger::owed_digest()` is only **read** and serialised into the coinbase `tx_extra` `0x03` merge-mining tag. The single-pool FOUND → FINALIZE proof is a pool-local build/submit and needs **no operator tap**.

### What landed
Components (`src/impl/xmr/template`, `src/c2pool/v37/xmr`):
- `xmr_coin_primitives.cpp` — authored bodies for the consumer-side seam (varint / Keccak one-shot + 25-lane midstate / 128-bit mul-div / thread fan-out / wall clock) over the vendored monero-project `keccak.c` and `tools::write_varint`, so the template's bytes equal `xmr_blob`'s and monerod's.
- `xmr_block_assembly.hpp` — `XmrBlockAssembler` / `AssembledTemplate` / `X6SettlementSource`: glues the p2pool-derived `XmrBlockTemplate` to the X6 W5-XMR coinbase executor over `IXmrSettlementSource`, resolves the p2pool `split_reward` count-invariance assumption with a reward/payee-set fixpoint, and emits the submittable full block blob + the RandomX hashing blob + every offset a submitter/verifier patches.
- `xmr_o2_settlement_fixture.hpp` — the fail-closed config surface (`XmrSettlementConfig`: residual sink REQUIRED + torsion-checked, `h_min`, `output_cap`, `chain_id`, `KFairSource` + lane-commitment-source knobs) + the hand-built `XmrCoinbaseContext` + a deterministic proof `OwedLedger`.
- `xmr_o2_settlement_provider.hpp` — the serve-side provider: `get_miner_data` → `XmrBlockAssembler` → `AssembledTemplate`, mirroring the option-A provider's API so the stratum listener / runtime RandomX gate / live submitter / finalize-connect are reused unchanged. Reassembles only on a real tip change so a served template stays byte-stable for in-flight jobs.

`main_v37_xmr.cpp`: a `--coinbase monerod|v37` branch; the serve loop and the exact 128-bit network gate are templated over the provider so both options share one body. New flags: `--residual-sink-spend-hex` / `--residual-sink-view-hex` [`/ --residual-sink-subaddress`], `--settle-h-min`, `--settle-output-cap`, `--owed-demo-amount`.

CMake: `add_subdirectory(template)` builds `xmr_template` (the block-template port + the primitive seam bodies); `c2pool-v37-xmr` links it and compiles `settle/xmr_coinbase.cpp` behind the same target; two CI-exempt option-B KATs.

### Build
Built off `workstation-191` with `g++-15` (15.2.0), `-DXMR_BUILD_RANDOMX=ON`, Release. Daemon links clean (0 errors). The whole-block-assembly self-check `xmr_block_assembly_kat` (K0..K6) is **GREEN, 192/192** — pins primitive byte-identity, the K_fair oldest-owed-first order through the template, the reward/payee-set fixpoint, fail-closed refusals, and "the X6 K_fair coinbase IS the block's coinbase" (miner_tx prefix byte-equality, hashing-blob tree root + verifying branch, `canonical_coinbase_matches` with a negative control).

### Proof — isolated private regtest (FOUND → FINALIZE)
Isolated `monerod --regtest --fixed-difficulty 20000 --offline` (own datadir, private RPC/P2P/ZMQ ports) + real `xmrig` rx/0 → the `--coinbase v37` daemon. The live stagenet node and other protected jobs were not touched.

```
status: ... net=7 | gate calls=7 accept=7 reject=0 refused=0 | submit calls=7 ok=7 rejected=0
        | found registered=7 settled=5 orphaned=2 pending=3
[submit] FOUND h=61 bid=eeaf483104ab11aa... id-source=monerod header=confirmed reward=35180312232951pico
[v37-xmr-fc] FINALIZED 2c8a43265261... h=64 SETTLED at bin_height=67 effective_owed(payee)=-105539930186014 ledger_seq=117
```

v37 K_fair blocks assembled → RandomX-gated (exact 128-bit rule) → `submit_block`-ACCEPTED by monerod (block id from monerod, header cross-check confirmed) → FOUND → FINALIZE at D_conf burial. Zero low-diff shares.

Decode of an accepted, FINALIZED coinbase (block `2c8a4326...`, height 64) — the v37 payout outputs, not monerod's single output:

```
miner_tx version=2 unlock_time=124 (=64+60) vin=gen{height:64}
n_outputs: 2
  out[0] amount=1000000000000     (1.000000 XMR)  txout_to_tagged_key P=2e2d918e... view_tag=e6   # K_fair OWED payee
  out[1] amount=34180110929974    (34.180111 XMR) txout_to_tagged_key P=d0818c74... view_tag=e9   # exact-sum residual sink
sum(outputs)=35180110929974 == block_reward   (HF13 exact-sum, no burn)
tx_extra: 0x01 R=4b7cabe6...                  # deterministic tx public key r*G
          0x02 extra_nonce=03000000
          0x03 merge-mining tag depth=0 root=ac8a67a7...   # mm_commitment_root(chain_id=7, owed_digest)
```

Each output is a distinct one-time key derived under the deterministic `r`; `r` and the keys vary per height (verified across blocks) while the lane-commitment MM root is stable for the fixed demo ledger.

### Honest gaps
- **Multi-node lane consensus is NOT wired (operator tap).** Two rulings become v37 lane consensus the moment option B goes multi-node and each must ship as its own operator-tapped change, never a silent flip: (1) `KFairSource` (W4Propose vs X6Allocate); (2) the `lane_commitment` definition that `r` and the MM root bind, **and** wiring `canonical_coinbase_matches` (already implemented + KAT-proven) as a REJECTION gate on peers' found-block announcements. Both are surfaced as explicit `XmrSettlementConfig` flags and left un-wired.
- **No live XMR OwedLedger yet** (Track A2 S-1 emission in progress): the proof ledger is a deterministic fixture (`--owed-demo-amount` seeds one K_fair payee; empty ledger => sink-only). Real owed emission is the follow-on.
- Single-node cut (own carriers); real p2p carrier relay is a noted follow-on, as in option A.
- **Option-B KATs are compile-coverage only.** `xmr_block_assembly_kat` and `xmr_template_primitives_kat` are heavy (pull the whole template + settle + ref10). Their `add_test` registration stays **gated OFF behind `XMR_BUILD_OPTION_B_KATS` (default OFF)** — this is the fix on head `5e1eead9`: previously the tests were registered but the binaries were CI-allowlist-exempt/not built, so ctest reported them `***Not Run` and the leg exited 8 on both hosts. With the option gated OFF, the two KATs get **compile coverage** via the `c2pool-v37-xmr` daemon target on the non-sanitizer Linux leg but no run coverage. **Run-coverage is deferred** to the standalone `XMR_BUILD_OPTION_B_KATS` flip PR (with the #1522 `BUILD_J` cap), which folds them into `build.yml` — tracked separately.

