### PR TITLE
v37/xmr: flip XMR_BUILD_OPTION_B_KATS ON — run-coverage for the two option-B KATs (#1543)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,15 @@ jobs:
         # RandomX JIT/asm + intentional unaligned reads do not survive
         # -fsanitize, so the ASAN leg deliberately leaves it OFF. Light mode:
         # the KAT never allocates the 2 GiB dataset (256 MiB cache only).
-        run: cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON -DXMR_BUILD_RANDOMX=ON
+        #
+        # -DXMR_BUILD_OPTION_B_KATS=ON: register + build the two heavy X9
+        # option-B KATs (xmr_template_primitives_kat, xmr_block_assembly_kat)
+        # so they get RUN coverage on this non-sanitizer leg, not the
+        # compile-only coverage #1539 shipped. Both link xmr_template
+        # (block-template port + settle + ref10 point-check); they are logic/
+        # byte-identity KATs (no RandomX JIT), so the non-san leg is the right
+        # home and the ASan leg deliberately leaves this OFF. #1543.
+        run: cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON -DXMR_BUILD_RANDOMX=ON -DXMR_BUILD_OPTION_B_KATS=ON
 
       # Boost header-integrity + version gate: a torn/mixed Boost tree or apt-Boost
       # fallback fails HERE (fast, one TU), not deep in the coin build.
@@ -234,6 +242,7 @@ jobs:
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke c2pool-v37-xmr \
                     v37_xmr_o2_live_submit_selfcheck v37_xmr_o2_finalize_connect_selfcheck \
                     xmr_randomx_verify_kat v37_xmr_o2_randomx_kat \
+                    xmr_template_primitives_kat xmr_block_assembly_kat \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests

--- a/src/impl/xmr/test/CMakeLists.txt
+++ b/src/impl/xmr/test/CMakeLists.txt
@@ -306,18 +306,18 @@ if (BUILD_TESTING)
     # provided ONCE by the library and neither TU defines
     # XMR_BLOCK_ASSEMBLY_IMPLEMENT_PRIMITIVES (the ODR rule).
     #
-    # ci-allowlist-exempt: xmr_template_primitives_kat  -- heavy option-B leg (pulls the whole template port); NOT built in build.yml this wave, so it is guarded behind the OFF-by-default XMR_BUILD_OPTION_B_KATS option below. Library compile-coverage is still had at PR time via the c2pool-v37-xmr daemon target (which links xmr_template) on the non-san Linux leg; a later wave flips this option ON in build.yml.
-    # ci-allowlist-exempt: xmr_block_assembly_kat  -- heavy option-B leg (template + X6 settle + ref10 point-check); same gating as above.
-    #
-    # Both add_executable/add_test are gated behind XMR_BUILD_OPTION_B_KATS
-    # (default OFF, run locally with -DXMR_BUILD_OPTION_B_KATS=ON). Without this
-    # guard the add_test() below registers in every BUILD_TESTING build while the
-    # binaries are (deliberately) absent from build.yml's --target list, so ctest
-    # reports them ***Not Run and CTest exits 8 -- a red that is NOT a test
-    # failure. This mirrors the ltc_embedded_bootstrap_gate exempt idiom: exempt
-    # from the allowlist AND unregistered unless its own option is set.
+    # RUN-COVERAGE (#1543): both KATs are now built + registered on the
+    # non-sanitizer Linux leg, which configures with -DXMR_BUILD_OPTION_B_KATS=ON
+    # and lists xmr_template_primitives_kat + xmr_block_assembly_kat in its
+    # `cmake --build --target` allowlist (under the #1522 -j"${BUILD_J}" cap).
+    # They are therefore allowlisted, NOT ci-allowlist-exempt: the drift-guard
+    # sees them in build.yml. The option still defaults OFF so a minimal local
+    # build (or the ASan leg, which leaves it OFF) does not register the add_test
+    # while the binaries are absent -- that combination is what made ctest report
+    # ***Not Run and exit 8 on #1539 before the gate. CI passes the flag ON
+    # explicitly; only the non-san leg builds the targets it registers.
     option(XMR_BUILD_OPTION_B_KATS
-           "Build the heavy X9 option-B XMR KATs (local; not in the CI --target allowlist)" OFF)
+           "Build the heavy X9 option-B XMR KATs (CI non-san leg passes this ON; default OFF for minimal local builds)" OFF)
     if (XMR_BUILD_OPTION_B_KATS)
         # (1) primitive seam byte-identity + template in-situ (component 1 + the leg).
         add_executable(xmr_template_primitives_kat xmr_template_primitives_kat.cpp)

--- a/src/impl/xmr/test/xmr_template_primitives_kat.cpp
+++ b/src/impl/xmr/test/xmr_template_primitives_kat.cpp
@@ -127,7 +127,7 @@ void kat_varint() {
     struct V { uint64_t v; const char* hexv; } canon[] = {
         {0, "00"}, {1, "01"}, {127, "7f"}, {128, "8001"}, {255, "ff01"}, {300, "ac02"},
         {16383, "ff7f"}, {16384, "808001"}, {0xFFFFFFFFULL, "ffffffff0f"},
-        {600000000000ULL, "80a094a58b11"},                       // 0.6 XMR tail reward
+        {600000000000ULL, "80e0a596bb11"},                       // 0.6 XMR tail reward
         {(1ULL << 56) - 1, "ffffffffffffff7f"},                   // MAX_OUTPUT_VALUE
         {UINT64_MAX, "ffffffffffffffffff01"},
     };


### PR DESCRIPTION
## What

Closes #1543. Flip `XMR_BUILD_OPTION_B_KATS` **ON** in CI so the two X9 option-B KATs get **run-coverage**, not the compile-only coverage #1539 shipped.

- `xmr_template_primitives_kat`
- `xmr_block_assembly_kat`

## How (deliberately tight)

1. **Configure** the non-sanitizer Linux leg with `-DXMR_BUILD_OPTION_B_KATS=ON` (added to the existing `Configure` step alongside `-DXMR_BUILD_RANDOMX=ON`).
2. **Build** both targets by appending them to that leg's `cmake --build --target` list. That step already runs under `-j"${BUILD_J:-8}"`, so the **#1522 per-runner `BUILD_J` cap is honored automatically** — no new `-jN` is introduced. These are logic / byte-identity KATs (no RandomX JIT), so the non-san leg is the right home; the ASan leg deliberately leaves the option OFF.
3. **Allowlist**: drop the two `# ci-allowlist-exempt:` lines in `src/impl/xmr/test/CMakeLists.txt`. The targets are now in the build.yml `--target` allowlist, so the drift-guard sees them registered (no longer exempt). Guard passes: `297 test target(s) across 11 test tree(s) all present`.

## Finding — run-coverage caught a wrong test golden (test-only fix)

The moment the primitives KAT actually ran it RED'd on a hardcoded oracle:

```
[FAIL] varint(600000000000) = 80e0a596bb11 (canon 80a094a58b11)
```

The hardcoded `"80a094a58b11"` decodes to `587146268672` — **not** 0.6 XMR. The library's four independent varint implementations (`writeVarint` vector + byte-sink, `tools::get_varint_data`, `BlobWriter`) all agree on `"80e0a596bb11"`, which decodes back to exactly `600000000000`. The block-assembly KAT's byte-identical monerod-shaped coinbase prefix independently confirms the **product** varint is correct. Fix is the **test literal only** — no product or consensus bytes change. Compile-only coverage had masked this latent wrong-golden; this is exactly what the run-coverage flip is for.

## Evidence — both KATs registered + passing (local ctest)

```
Test project /tmp/c2pool-1543/build_ci
    Start 1507: xmr_template_primitives_kat
1/2 Test #1507: xmr_template_primitives_kat ......   Passed    0.02 sec
    Start 1508: xmr_block_assembly_kat
2/2 Test #1508: xmr_block_assembly_kat ...........   Passed    0.03 sec

100% tests passed, 0 tests failed out of 2
```

Internal self-check counts: `xmr_block_assembly_kat` **192 passed / 0 failed** (K0..K6); `xmr_template_primitives_kat` **122 passed / 0 failed**.

## Consensus posture

Build/test-plumbing + one wrong test-golden fix. No consensus digest defined or altered; `src/sharechain/v37` canon untouched; `src/core` untouched. Single XMR test tree + CI config.

## Landing

Feature-branch off `v37-dev`, PR **into `v37-dev`**. Signed commit (frstrtr), attribution-clean. Kept **DRAFT** until the full CI rollup is green with the flag ON — will cite the head SHA + the CI ctest line and request the merge tap then.
