### PR TITLE
ci: isolate reusable-leg concurrency groups so a stale rerun cannot cancel the live coin matrix

### DIFF
--- a/.github/workflows/btc-embedded-standalone-smoke.yml
+++ b/.github/workflows/btc-embedded-standalone-smoke.yml
@@ -33,7 +33,11 @@ on:
       - '.github/workflows/btc-embedded-standalone-smoke.yml'
 
 concurrency:
-  group: btc-standalone-smoke-${{ github.workflow }}-${{ github.ref }}
+  # See coin-matrix.yml: github.workflow is the CALLER name when reused, so
+  # scope the reused-path group to the run instance to stop a rerun of a
+  # superseded CI Required run from cancelling the live leg; direct triggers
+  # keep a stable per-ref group.
+  group: btc-standalone-smoke-${{ github.ref }}-${{ github.workflow == 'BTC embedded-standalone daemonless smoke' && 'direct' || github.run_id }}
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -24,7 +24,16 @@ on:
 # oversubscription root cause, not just queue depth). Per-ref group so
 # distinct PRs/branches never cancel each other.
 concurrency:
-  group: coin-matrix-${{ github.workflow }}-${{ github.ref }}
+  # github.workflow resolves to the CALLER name ("CI Required") when this
+  # workflow is reused, so as a leg it is a constant that cannot discriminate
+  # run instances: a re-run of a SUPERSEDED CI Required run then shares this
+  # group with the live run and cancels its coin matrix (a red CI Required
+  # unrelated to the diff). Scope the reused-path group to the run instance
+  # (github.run_id) so a rerun never collides with the live run; new-push
+  # superseding is handled by the parent ci-required-<ref> group. Direct
+  # triggers keep a stable per-ref group so back-to-back runs still auto-cancel
+  # and protect the shared self-hosted pool.
+  group: coin-matrix-${{ github.ref }}-${{ github.workflow == 'Coin matrix' && 'direct' || github.run_id }}
   cancel-in-progress: true
 
 


### PR DESCRIPTION
## Defect
On a multi-coin PR each reusable leg of CI Required builds its concurrency group from `${{ github.workflow }}`, which inside a reused workflow resolves to the **caller** name ("CI Required") — a constant across every run of the PR. So `coin-matrix` (and `btc-embedded-standalone-smoke`) share one group across run instances. Re-running a **superseded** CI Required run re-enters that group and, via `cancel-in-progress`, cancels the **live** runs coin matrix → a red CI Required unrelated to the diff.

## Fix (2 files, groups only)
- Drop the collapsing `${{ github.workflow }}` token; use a hardcoded per-workflow literal so legs have **distinct** group literals and can never cancel each other.
- On the **reused** path, scope the group to the run instance (`github.run_id`) so a rerun of a stale run cannot collide with the live run. New-push superseding is delegated to the parent `ci-required-${{ github.ref }}` group, which already cancels the whole stale run.
- On **direct** triggers (`github.workflow` == the workflows own name) the group stays a stable per-ref literal, so back-to-back runs still auto-cancel and self-hosted pool protection is unchanged.

## Acceptance mapping
1. Distinct literals per (workflow, leg): `coin-matrix-…` vs `btc-standalone-smoke-…` — see diff.
2. Rerun of one leg no longer cancels siblings **or** the live same-leg run (run-instance scoped) — two-run green demonstration to follow once CI runs.
3. Per-coin source-presence guards (#47) untouched — only the `concurrency.group` lines change.
4. Fresh branch off todays master (`2013555e`), not a rebase of the stale branch.

## Note for review
The reused/direct split relies on comparing `github.workflow` to each workflows literal name. Trade-off surfaced: keeps direct-trigger load-shed intact rather than making the group unconditionally unique. Signed commit; no merge without push-approval.