### PR TITLE
ci-required: gate parent cancel-in-progress on run_attempt == 1

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: ci-required-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # run_attempt == 1 so a RERUN of a superseded CI Required (attempt >= 2)
+  # does not cancel a live sibling run in the same ref group (e.g. B's coin
+  # matrix). Group stays keyed on github.ref. See ci-steward/leg-isolation (#1545).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == 1 }}
 
 jobs:
   param-catalog-tripwire:


### PR DESCRIPTION
## Problem
#1545 (leg-isolation, squash 0351bbb40, now on master) fixed the reusable-leg concurrency groups, but the CRIT-2 regression still reproduces at the **aggregate parent**: a rerun of a superseded `CI Required` run cancelled a live sibling run because both share `ci-required-${{ github.ref }}` with `cancel-in-progress` on every `pull_request` event. Demo evidence: runs A `34331422610` / B `34342446930` — B's coin-matrix was cancelled by a rerun of stale A.

## Fix
Gate the parent's `cancel-in-progress` on `github.run_attempt == 1`:

```yaml
concurrency:
  group: ci-required-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == 1 }}
```

Group stays keyed on `github.ref`. A genuine new push starts at attempt 1 and still cancels the prior in-flight run; a **rerun** of a stale run (attempt >= 2) no longer cancels a live sibling.

## Acceptance (demo, not CI-green)
B's 13 coin-matrix legs survive a rerun of stale A, run against a companion two-run demo PR (being recreated; #1546 was closed). If `github.run_attempt` does not resolve in the concurrency context at run start, that will be reported with both run ids and the rerun path switched to head-SHA keying.

No merge without push-approval.