### PR TITLE
[DO NOT MERGE] crit2 two-run demo — run_attempt gate acceptance for #1547

### DIFF
--- a/.ci-scratch/crit2-demo.txt
+++ b/.ci-scratch/crit2-demo.txt
@@ -1,3 +1,5 @@
 CRIT-2 two-run demo for #1547 run_attempt gate.
 DO NOT MERGE. Scratch PR to prove B coin-matrix survives rerun of stale A.
 run-A armed: 2026-09-09T16:38:33Z
+Run B scratch — 2026-09-09T18:40:42Z
+do-not-merge; arms Run B for #1547 run_attempt cancel-gate demo

--- a/.ci-scratch/crit2-demo.txt
+++ b/.ci-scratch/crit2-demo.txt
@@ -1,0 +1,3 @@
+CRIT-2 two-run demo for #1547 run_attempt gate.
+DO NOT MERGE. Scratch PR to prove B coin-matrix survives rerun of stale A.
+run-A armed: 2026-09-09T16:38:33Z

--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: ci-required-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # run_attempt == 1 so a RERUN of a superseded CI Required (attempt >= 2)
+  # does not cancel a live sibling run in the same ref group (e.g. B's coin
+  # matrix). Group stays keyed on github.ref. See ci-steward/leg-isolation (#1545).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == 1 }}
 
 jobs:
   param-catalog-tripwire:


### PR DESCRIPTION
**DO NOT MERGE — scratch PR.** Acceptance vehicle for #1547 (run_attempt gate on the ci-required parent group).

Branched off `ci-steward/concurrency-run-attempt-gate` so this PR's `CI Required` runs use the gated `cancel-in-progress: ${{ github.event_name == 'pull_request' && github.run_attempt == 1 }}`. (The prior demo #1546 was off bare master and so falsified — it never carried the gate.)

Two-run demo protocol:
1. This commit = **Run A** armed.
2. Push a second scratch commit = **Run B** (live coin-matrix).
3. Rerun the now-superseded **Run A**.
4. Expect: B's 13 coin-matrix legs SURVIVE — the rerun is run_attempt >= 2, so it does not cancel B.

Falsification path: if `github.run_attempt` does not resolve in the concurrency context at run start, both run ids will be reported and the rerun path switched to head-SHA keying.