### PR TITLE
ltc: chunk parent-share request drain in run_think IO-phase (half-2 of #1542 boot io-freeze fix)

### DIFF
--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -1425,11 +1425,43 @@ void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
             if (!oldest_parent.IsNull() && !m_chain->contains(oldest_parent))
             {
                 auto locked = weak_peer.lock();
-                if (locked)
-                    download_shares(locked, oldest_parent);
+                if (locked) {
+                    // half-2: route the recursive re-request through the budgeted
+                    // drain so backward chain-walk fan-out stays bounded on the io
+                    // thread (same guard as the IO-phase desired drain).
+                    m_pending_desired.emplace_back(locked->addr(), oldest_parent);
+                    drain_pending_desired();
+                }
             }
         }
     );
+}
+
+void NodeImpl::drain_pending_desired()
+{
+    // IO thread only. Process up to DESIRED_REQUEST_BUDGET queued desired-share
+    // requests per pass, then repost the remainder so the io_context pulse can
+    // fire between chunks (half-2 of the boot io-freeze fix). Mirrors the
+    // m_think_needs_continue chunk-yield-repost pattern already used by run_think.
+    if (m_peers.empty()) {
+        // No peers to ask; desired is recomputed next think(). Drop the queue
+        // (matches the old `!m_peers.empty()` guard that skipped requesting).
+        m_pending_desired.clear();
+        return;
+    }
+    std::size_t processed = 0;
+    while (!m_pending_desired.empty() && processed < DESIRED_REQUEST_BUDGET) {
+        auto entry = m_pending_desired.front();
+        m_pending_desired.pop_front();
+        peer_ptr advertiser;
+        for (auto& [nonce, p] : m_peers) {
+            if (p && p->addr() == entry.first) { advertiser = p; break; }
+        }
+        download_shares(advertiser, entry.second);
+        ++processed;
+    }
+    if (!m_pending_desired.empty())
+        boost::asio::post(*m_context, [this]() { drain_pending_desired(); });
 }
 
 void NodeImpl::load_persisted_shares()
@@ -2088,14 +2120,17 @@ void NodeImpl::run_think()
             // Request desired shares. #25(C): pass the ADVERTISER (the peer whose
             // desired entry named the hash) so download_shares prefers it and fails
             // over to other peers instead of picking a fully random one.
-            if (!result.desired.empty() && !m_peers.empty()) {
-                for (auto& [peer_addr, hash] : result.desired) {
-                    peer_ptr advertiser;
-                    for (auto& [nonce, p] : m_peers) {
-                        if (p && p->addr() == peer_addr) { advertiser = p; break; }
-                    }
-                    download_shares(advertiser, hash);
-                }
+            // half-2 boot io-freeze fix: queue the desired requests and drain
+            // them in bounded passes instead of synchronously here. A large
+            // persisted sharechain yields a huge result.desired; draining it all
+            // in one go monopolizes the io thread and starves the io_context
+            // pulse (main_ltc.cpp watchdog) -> abort during boot. result.desired
+            // is recomputed authoritatively each think(), so replace the queue.
+            m_pending_desired.clear();
+            if (!result.desired.empty()) {
+                for (auto& [peer_addr, hash] : result.desired)
+                    m_pending_desired.emplace_back(peer_addr, hash);
+                drain_pending_desired();
             }
 
             // Work refresh on IO thread — NO lock held. Takes 1-5s but doesn't

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -574,6 +574,12 @@ public:
     /// Recursively fetches parents until the chain is connected or CHAIN_LENGTH reached.
     void download_shares(peer_ptr peer, const uint256& target_hash);
 
+    /// Drain up to DESIRED_REQUEST_BUDGET queued desired-share requests
+    /// (m_pending_desired) per pass, reposting the remainder to the io_context
+    /// so its watchdog pulse fires between chunks (half-2 boot io-freeze fix).
+    /// IO thread only.
+    void drain_pending_desired();
+
     /// Return the hash of our tallest chain head, or uint256::ZERO if empty.
     uint256 best_share_hash();
 
@@ -803,6 +809,17 @@ protected:
     std::atomic<uint64_t> m_broadcast_acquired{0};
     std::atomic<uint64_t> m_broadcast_reached_send{0};
     std::set<uint256> m_downloading_shares;   // hashes currently being fetched
+
+    // ---- half-2 boot io-freeze fix: budgeted parent-share request drain ----
+    // A large persisted sharechain makes run_think's IO-phase produce a huge
+    // result.desired. Draining it all synchronously monopolizes the io thread
+    // and starves the io_context pulse (main_ltc.cpp watchdog: 5s pulse / 30s
+    // freeze) -> abort during boot. Queue the desired requests here and drain
+    // them in bounded passes, reposting the remainder so the pulse fires
+    // between chunks. IO-THREAD CONFINED, same discipline as m_downloading_shares
+    // above -- never touch off the io thread. Mirrors m_think_needs_continue.
+    static constexpr std::size_t DESIRED_REQUEST_BUDGET = 50;
+    std::deque<std::pair<NetService, uint256>> m_pending_desired;
 
     // v36-0.24 kr1z1s convergence hotfix #25(C): per-(hash,peer) parent-fetch
     // failure memory. Replaces the old peer-BLIND per-hash counter


### PR DESCRIPTION
## Half-2 of the LTC boot io-freeze fix (follow-up to #1542)

#1542 (merged as 610ab05ac) budgeted `think()`'s boot backfill in
`share_tracker.hpp` — half-1. This is the second, independent half: the boot
`:8080` crash-loop also has an io-thread monopolizer in `run_think`'s IO-phase.

### Problem
On a large persisted sharechain, `run_think`'s IO-phase drained the ENTIRE
`result.desired` set synchronously (`node.cpp:2091`), issuing hundreds of
`download_shares()` back-to-back. That starves the io_context pulse (external
watchdog in `main_ltc.cpp`: 5s pulse / 30s freeze) → `abort()` → `:8080` 503.
The tracker exclusive lock is already released before this loop
(`node.cpp:2028`), so this is pure io-thread starvation, not a lock stall.

### Fix (chunk-and-yield; LTC-only, no `src/core`)
- Queue `result.desired` into an io-thread-confined `m_pending_desired` and
  drain it in bounded passes (`DESIRED_REQUEST_BUDGET = 50`), reposting the
  remainder to the io_context so the pulse fires between chunks — the same
  chunk-yield-repost shape as `m_think_needs_continue` (half-1).
- The recursive parent re-request (`node.cpp:1429`) routes through the same
  budgeted queue so backward chain-walk fan-out stays bounded.
- **Nothing is moved off the io thread.** `m_pending_desired` and
  `download_shares`' state (`m_downloading_shares` / `m_pending_share_reqs` /
  `m_peers`) stay io-thread-confined by design (`node.hpp:63-70`); relocating
  would be a real race. The SET of requests issued is unchanged — only their
  scheduling is chunked — so convergence behaviour is preserved.
- Parent-share servicing (`handle_get_share`) and the `create_share_fn`
  ancestor walk are untouched: both already self-guard via
  `try_to_lock` / drop-on-busy.

### Test
- Build: `c2pool-ltc` + `share_test`, exit 0, no errors.
- `share_test` 132/132 passed.
- `LtcRestartReorgSupersede` 9/9 (reorg / boot-backfill / supersede),
  `LtcKr1z1sDropTailGuard` pass.
- Reviewer note: two ctest entries can show "failed — Not Run, Unable to find
  executable" (`test_web_honesty_regression`, a dash dashboard test). Those are
  unbuilt cross-coin targets in the LTC build dir, not regressions.

Files: `src/impl/ltc/node.cpp`, `src/impl/ltc/node.hpp` (+62/-10). Commit
GPG-signed (EDDSA `99556F8DE6AD66057A1A10EC50AB1379285EFE76`).
