### PR TITLE
[DRAFT] v37/xmr option B: canonical K_fair payees (W4Propose) + section-13 state-root commitment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
         # RandomX JIT/asm + intentional unaligned reads do not survive
         # -fsanitize, so the ASAN leg deliberately leaves it OFF. Light mode:
         # the KAT never allocates the 2 GiB dataset (256 MiB cache only).
-        run: cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON -DXMR_BUILD_RANDOMX=ON
+        run: cmake -S . -B build_ci -DCMAKE_TOOLCHAIN_FILE=build_ci/conan_toolchain.cmake -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCOIN_DGB=ON -DXMR_BUILD_RANDOMX=ON -DXMR_BUILD_OPTION_B_KATS=ON
 
       # Boost header-integrity + version gate: a torn/mixed Boost tree or apt-Boost
       # fallback fails HERE (fast, one TU), not deep in the coin build.
@@ -234,6 +234,7 @@ jobs:
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke c2pool-v37-xmr \
                     v37_xmr_o2_live_submit_selfcheck v37_xmr_o2_finalize_connect_selfcheck \
                     xmr_randomx_verify_kat v37_xmr_o2_randomx_kat \
+                    xmr_template_primitives_kat xmr_block_assembly_kat v37_xmr_o2_settlement_kat \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -601,6 +602,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCOIN_DGB=ON \
             -DC2POOL_GOLDEN_RESOLVED_CONFIG_GATE=OFF \
+            -DXMR_BUILD_OPTION_B_KATS=ON \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr -fno-omit-frame-pointer -fno-sanitize-recover=undefined -g1" \
             -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr" \
             -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined -fno-sanitize=vptr"
@@ -659,6 +661,7 @@ jobs:
                     v37_xmr_canon_p1_kat \
                     c2pool-v37-btc v37_btc_node_smoke v37_btc_digest_drift_kat f1_finalize_kat_btc \
                     v37_xmr_o2_live_submit_selfcheck v37_xmr_o2_finalize_connect_selfcheck \
+                    xmr_template_primitives_kat xmr_block_assembly_kat v37_xmr_o2_settlement_kat \
                     xmr_primitives_selfcheck xmr_x2_node_kat xmr_receipt_kat xmr_torsion_kat xmr_wire_dos_check xmr_stratum_selftest xmr_provenance_gate \
                     xmr_crypto_kats xmr_ed25519_derivation_kat xmr_difficulty_kat xmr_coinbase_kat xmr_goldens_kat xmr_e2e_kat xmr_miner_block_path_smoke \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.

--- a/src/c2pool/v37/main_v37_xmr.cpp
+++ b/src/c2pool/v37/main_v37_xmr.cpp
@@ -306,7 +306,15 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
             e.block_id_hex    = hex_of(s.block_id);
             e.prev_id_hex     = hex_of(s.prev_id);
             e.reward_piconero = s.reward;
-            e.payee           = payee_key;
+            e.payee           = payee_key;   // informational since R-7 (never booked)
+            // R-7 (2026-09-10): the FOUND record books what the COINBASE PAID —
+            // the emitted Role::Owed set, captured at the SUBMIT seam from the
+            // very snapshot whose bytes went to monerod (never re-looked-up here:
+            // the provider ring can evict a template between submit and tick).
+            // Empty under option A (monerod's template pays no v37 owed) and for
+            // a sink-only option-B block. `credit` (E_b) stays empty until Track
+            // A2 S-1 emission exists.
+            e.coinbase_owed.insert(s.coinbase_owed.begin(), s.coinbase_owed.end());
             e.template_id     = s.template_id;
             e.nonce           = s.nonce;
             e.extra_nonce     = s.extra_nonce;
@@ -358,6 +366,15 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
                     static_cast<unsigned long long>(fs.orphaned),
                     static_cast<unsigned long long>(fs.refused),
                     fc.pending().size());
+        // R-7 acceptance probe, printed every status tick: the ledger-wide
+        // minimum EffectiveOwed. It must be 0 (i.e. no negative row) for the
+        // whole run, INCLUDING while blocks are pending. The pre-R-7 split-ledger
+        // wiring drove this to -reward per pending FOUND.
+        std::printf("  owed: min_effective_owed=%lld booked=%lld ledger_seq=%llu "
+                    "split_brain_refused=%llu\n",
+                    fc.min_effective_owed(), fc.stats().owed_booked,
+                    static_cast<unsigned long long>(node.ledger().ledger_seq()),
+                    static_cast<unsigned long long>(fc.stats().split_brain_refused));
         std::printf("  %s\n", rx.describe().c_str());
         const std::string g = sink.last();
         if (!g.empty()) std::printf("  gate: last=%s\n", g.c_str());
@@ -470,11 +487,12 @@ static int run_live(const XmrNodeConfig& cfg) {
             node.stop();
             return 2;
         }
-        std::printf("payee: identity_key=%s… (amount-honest FOUND/FINALIZE records)\n",
+        std::printf("payee: identity_key=%s… (INFORMATIONAL since R-7: this key is logged with "
+                    "each FOUND but is NEVER booked into the ledger — the FOUND payout is the "
+                    "coinbase's own emitted K_fair owed set)\n",
                     hex_of(*payee_key).substr(0, 16).c_str());
     } else {
-        std::printf("payee: no --payee-spend-hex/--payee-view-hex -> FOUND records are valueless "
-                    "{}/{} (the ledger still registers the block)\n");
+        std::printf("payee: no --payee-spend-hex/--payee-view-hex (informational only since R-7)\n");
     }
 
     // ── wire 2: RandomX runtime verify (init on main, BEFORE the listener) ───
@@ -506,6 +524,14 @@ static int run_live(const XmrNodeConfig& cfg) {
         scfg.chain_id   = cfg.lane_chain;
         scfg.h_min      = cfg.settle_h_min;
         scfg.output_cap = cfg.settle_output_cap;
+        scfg.allow_nonruled_local_only = cfg.lane_commitment_local_only;
+        if (!o2::parse_lane_commitment_source(cfg.lane_commitment_source, scfg.lc_source)) {
+            std::printf("REFUSED: --lane-commitment must be one of "
+                        "state-root (RULED) | owed-digest | explicit; got \"%s\"\n",
+                        cfg.lane_commitment_source.c_str());
+            node.stop();
+            return 2;
+        }
         std::array<std::uint8_t, 32> sink_B{}, sink_A{};
         if (serving) {
             if (!o2::hex32(cfg.residual_sink_spend_hex, sink_B) ||
@@ -519,12 +545,32 @@ static int run_live(const XmrNodeConfig& cfg) {
             }
         }
 
-        // The proof ledger (no live S-1 emission yet). Empty => the whole reward
-        // flows to the residual sink (one v37 output). --owed-demo-amount seeds a
-        // distinct K_fair OWED payee (the sink material with spend/view swapped —
-        // still two valid ed25519 points, a different identity) so the assembled
-        // coinbase carries an OWED output alongside the sink (multi-output proof).
-        o2::XmrOwedFixture ledger(cfg.lane_chain);
+        // ── R-7 (2026-09-10): ONE LEDGER ────────────────────────────────────
+        // The coinbase MUST be built against the SAME OwedLedger the finalize
+        // driver writes — the node's: store-backed, RecoveryDriver-replayed,
+        // XmrFinalizeDriver-driven. Before this fix the daemon held TWO disjoint
+        // OwedLedger objects (a settlement one the coinbase paid from, a node one
+        // FINALIZE booked into). The settlement one was never decremented, so
+        // propose_coinbase re-proposed the SAME owed row at its full
+        // EffectiveOwed on EVERY block (a no-double-pay violation of whitepaper
+        // section 9 / OI-W4-5) while the node one went negative by one full
+        // reward per concurrent pending FOUND.
+        // With one ledger, block N+1's proposal already sees block N's pending
+        // payout deducted (effective_owed = finalW - SUM_pending payout), so a
+        // row that is already in flight cannot be re-proposed.
+        // `node` outlives `ledger`, the provider and every retained template.
+        //
+        // --owed-demo-amount seeds a distinct K_fair OWED payee (the sink
+        // material with spend/view swapped — still two valid ed25519 points, a
+        // different identity) so the assembled coinbase carries an OWED output
+        // alongside the sink (multi-output proof). With no seed and an empty
+        // ledger the whole reward flows to the residual sink (one v37 output).
+        // NOTE (honest scope): the demo seed is written straight into the
+        // in-memory ledger, NOT through the settle-store write-ahead log, so it
+        // does not survive a restart and IS re-applied on every boot that passes
+        // the flag. It is a proof knob, not lane state; real owed arrives with
+        // Track A2 S-1 emission.
+        o2::XmrOwedFixture ledger(node.ledger());
         if (serving && cfg.owed_demo_amount) {
             ledger.seed_owed_std(sink_A, sink_B, cfg.owed_demo_amount);
             std::printf("owed-demo: seeded %llu piconero owed to a distinct K_fair payee "
@@ -534,9 +580,20 @@ static int run_live(const XmrNodeConfig& cfg) {
 
         o2::XmrSettlementTemplateProvider provider(transport, ledger, scfg, cfg.stratum_share_diff);
         o2::SettlementStratumTemplateSource template_source(provider);
-        std::printf("coinbase: %s (lane_chain=%u, residual sink %s)\n",
-                    to_string(cfg.coinbase), static_cast<unsigned>(cfg.lane_chain),
-                    serving ? "SET (torsion-checked at build)" : "UNSET (observe-side only)");
+        // Serve banner: name the two RULED consensus choices and print the
+        // resolved 32-byte lane commitment, so a node's committed value is
+        // auditable straight from the log (RULED 2026-09-10).
+        {
+            const ::v37::bytes32 lc = o2::resolve_lane_commitment(scfg, ledger.ledger());
+            char lc_hex[65];
+            for (int i = 0; i < 32; ++i) std::snprintf(lc_hex + 2 * i, 3, "%02x", lc[static_cast<std::size_t>(i)]);
+            std::printf("coinbase: %s (lane_chain=%u, residual sink %s, k_fair=%s, "
+                        "lane_commitment=%s%s %s)\n",
+                        to_string(cfg.coinbase), static_cast<unsigned>(cfg.lane_chain),
+                        serving ? "SET (torsion-checked at build)" : "UNSET (observe-side only)",
+                        o2::to_string(scfg.kfair), o2::to_string(scfg.lc_source),
+                        cfg.lane_commitment_local_only ? " LOCAL-ONLY-OVERRIDE" : "", lc_hex);
+        }
 
         auto candidate = [&provider](std::uint32_t tid, std::uint32_t en, sub::BlockCandidate& out) {
             std::string w;
@@ -615,6 +672,8 @@ int main(int argc, char** argv) {
         else if (a == "--settle-output-cap") cfg.settle_output_cap =
                      static_cast<std::uint32_t>(std::stoul(next("0")));
         else if (a == "--owed-demo-amount") cfg.owed_demo_amount = std::stoull(next("0"));
+        else if (a == "--lane-commitment") cfg.lane_commitment_source = next("state-root");
+        else if (a == "--lane-commitment-local-only") cfg.lane_commitment_local_only = true;
         else if (a == "--lane-chain") cfg.lane_chain =
                      static_cast<::v37::ChainId>(std::stoul(next("0")));
         else if (a == "--d-conf") cfg.d_conf = std::stoull(next("60"));
@@ -650,7 +709,14 @@ int main(int argc, char** argv) {
                 "  --settle-h-min <pico>        owed-output floor (0 on XMR)\n"
                 "  --settle-output-cap <n>      TOTAL outputs cap (0 = weight-aware default)\n"
                 "  --owed-demo-amount <pico>    seed one K_fair OWED payee into the proof ledger\n"
-                "                               (coinbase carries OWED + residual sink)\n");
+                "                               (coinbase carries OWED + residual sink)\n"
+                "  --lane-commitment <state-root|owed-digest|explicit>\n"
+                "                               what the tx_extra 0x03 MM root binds and what seeds\n"
+                "                               the tx secret key r. RULED 2026-09-10: state-root =\n"
+                "                               the whitepaper section 13 StateCommitment root\n"
+                "                               (default; strictly subsumes owed-digest)\n"
+                "  --lane-commitment-local-only accept a non-ruled --lane-commitment for a\n"
+                "                               SINGLE-POOL experiment (never for a lane with peers)\n");
             return 0;
         }
     }

--- a/src/c2pool/v37/main_v37_xmr.cpp
+++ b/src/c2pool/v37/main_v37_xmr.cpp
@@ -565,17 +565,93 @@ static int run_live(const XmrNodeConfig& cfg) {
         // different identity) so the assembled coinbase carries an OWED output
         // alongside the sink (multi-output proof). With no seed and an empty
         // ledger the whole reward flows to the residual sink (one v37 output).
-        // NOTE (honest scope): the demo seed is written straight into the
-        // in-memory ledger, NOT through the settle-store write-ahead log, so it
-        // does not survive a restart and IS re-applied on every boot that passes
-        // the flag. It is a proof knob, not lane state; real owed arrives with
+        //
+        // ── F-1 (2026-09-10): THE SEED IS DURABLE AND RESTART-IDEMPOTENT ─────
+        // It used to be written STRAIGHT into the ledger, bypassing the settle-
+        // store write-ahead log. Since R-7 made that ledger the node's — durable
+        // and RecoveryDriver-replayed — the credit leg was in-memory while the
+        // PAYOUT that drew on it went through XmrFinalizeDriver's WAL and WAS
+        // persisted. So a restart against the same data-dir replayed the payout
+        // with no matching credit: finalW landed at -(amount paid), a NEGATIVE
+        // effective_owed row surviving the restart (§9 no-double-pay /
+        // OI-W4-5), and re-passing the flag credited it AGAIN on top of the
+        // recovered ledger — once per boot instead of once ever.
+        // Now the seed goes through XmrFinalizeDriver::seed_owed_durable() as
+        // two ordinary write-ahead events (FOUND(credit)/FINALIZE) under the
+        // stable bid kOwedDemoSeedBid. RecoveryDriver replays it exactly like
+        // any other event, and because the replay leaves that bid in the
+        // ledger's SETTLED (terminal) set, this call is a no-op on every later
+        // boot: applied EXACTLY ONCE for the life of the data-dir.
+        // It remains a proof knob, not lane state; real owed arrives with
         // Track A2 S-1 emission.
-        o2::XmrOwedFixture ledger(node.ledger());
-        if (serving && cfg.owed_demo_amount) {
-            ledger.seed_owed_std(sink_A, sink_B, cfg.owed_demo_amount);
-            std::printf("owed-demo: seeded %llu piconero owed to a distinct K_fair payee "
-                        "(coinbase will carry OWED + residual sink)\n",
-                        static_cast<unsigned long long>(cfg.owed_demo_amount));
+        o2::XmrOwedFixture ledger(node.ledger(), o2::XmrOwedFixture::DurableLedger{});
+        if (serving) {
+            // Resolver-only, and UNCONDITIONAL on the flag: the owed ROW is
+            // durable but this key->ScriptRef map is in-memory and must be
+            // rebuilt every boot. Without it a recovered demo row would resolve
+            // to the RAW sentinel and be CARRIED forever instead of paid — the
+            // flag must not have to be re-passed just to keep the row payable.
+            const ::v37::bytes32 demo_key = ledger.learn_pay_std(sink_A, sink_B);
+
+            if (cfg.owed_demo_amount) {
+                OwedLedger::Amounts seed;
+                seed[demo_key] = static_cast<long long>(cfg.owed_demo_amount);
+                const auto sr = node.finalize_driver().seed_owed_durable(
+                    kOwedDemoSeedBid, seed, kOwedDemoSeedBinHeight);
+                switch (sr) {
+                    case SeedOwedResult::Applied:
+                        std::printf("owed-demo: seeded %llu piconero owed to a distinct K_fair payee "
+                                    "through the settle-store write-ahead log (bid=%s, bin_height=%llu) "
+                                    "— durable, replayed on restart, applied exactly once\n",
+                                    static_cast<unsigned long long>(cfg.owed_demo_amount),
+                                    kOwedDemoSeedBid,
+                                    static_cast<unsigned long long>(kOwedDemoSeedBinHeight));
+                        break;
+                    case SeedOwedResult::AlreadyDurable:
+                        std::printf("owed-demo: --owed-demo-amount IGNORED — this data-dir already "
+                                    "carries the durable seed (bid=%s), replayed from the settle "
+                                    "store on this boot. One demo seed per data-dir, ever; "
+                                    "re-crediting it would be the double-apply F-1 closed. "
+                                    "effective_owed(demo payee)=%lld\n",
+                                    kOwedDemoSeedBid, node.ledger().effective_owed(demo_key));
+                        break;
+                    case SeedOwedResult::Refused:
+                        std::printf("owed-demo: REFUSED — malformed seed (amount must be > 0)\n");
+                        break;
+                }
+            }
+        }
+
+        // ── F-1 acceptance probe at BOOT (not only after a fresh start) ──────
+        // INV-1 for this lane is effective_owed(k) >= 0 at every step. Print the
+        // post-recovery minimum on EVERY boot so a restart-negative is visible in
+        // the log the moment it happens, instead of surfacing later as a coinbase
+        // that quietly pays nothing.
+        // REQUIRED-OPERATOR-RULING (F-1-R1): the paper is silent on what a node
+        // must DO with a negative row it recovers. §4.4 explicitly permits a
+        // negative EffectiveOwed as over-credit netted FORWARD (never a
+        // clawback), so refusing to serve would contradict canon; but serving a
+        // K_fair coinbase off a ledger carrying an unexplained negative row is
+        // the §9 hazard this defect produced. This ships the NON-committal side
+        // — warn loudly, keep serving — and does NOT self-pick. The operator
+        // rules whether a recovered negative must be fail-closed (refuse to
+        // serve) or netted forward per §4.4.
+        {
+            long long min_eo = 0;
+            for (const auto& [k, v] : node.ledger().effective_owed_all()) {
+                (void)k;
+                if (v < min_eo) min_eo = v;
+            }
+            if (min_eo < 0)
+                std::printf("owed: *** INV-1 WARNING *** the ledger recovered from %s carries a "
+                            "NEGATIVE effective_owed row (min=%lld). Under whitepaper 4.4 that is a "
+                            "forward-repair net, never a clawback, so serving continues — but an "
+                            "unexplained negative after a restart is the F-1 signature (a credit "
+                            "leg that never reached the write-ahead log). "
+                            "REQUIRED-OPERATOR-RULING F-1-R1: fail-closed or net forward?\n",
+                            cfg.resolved_settle_db_path().c_str(), min_eo);
+            else
+                std::printf("owed: post-recovery min_effective_owed=%lld (INV-1 holds)\n", min_eo);
         }
 
         o2::XmrSettlementTemplateProvider provider(transport, ledger, scfg, cfg.stratum_share_diff);
@@ -708,7 +784,10 @@ int main(int argc, char** argv) {
                 "  --residual-sink-subaddress   the sink keys are a subaddress (D_i, A_main)\n"
                 "  --settle-h-min <pico>        owed-output floor (0 on XMR)\n"
                 "  --settle-output-cap <n>      TOTAL outputs cap (0 = weight-aware default)\n"
-                "  --owed-demo-amount <pico>    seed one K_fair OWED payee into the proof ledger\n"
+                "  --owed-demo-amount <pico>    seed one K_fair OWED payee into the proof ledger,\n"
+                "                               DURABLY (settle-store write-ahead log) and exactly\n"
+                "                               ONCE per data-dir: a restart replays the seed and\n"
+                "                               ignores the flag rather than re-crediting it\n"
                 "                               (coinbase carries OWED + residual sink)\n"
                 "  --lane-commitment <state-root|owed-digest|explicit>\n"
                 "                               what the tx_extra 0x03 MM root binds and what seeds\n"

--- a/src/c2pool/v37/test/CMakeLists.txt
+++ b/src/c2pool/v37/test/CMakeLists.txt
@@ -292,11 +292,18 @@ if (BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/compat)
     target_link_libraries(v37_xmr_o2_live_submit_selfcheck PRIVATE xmr_node xmr_coin Threads::Threads)
     add_test(NAME v37_xmr_o2_live_submit_selfcheck COMMAND v37_xmr_o2_live_submit_selfcheck)
-    # v37_xmr_o2_finalize_connect_selfcheck: queued win -> XmrNode::
-    # on_network_block_won (amount-honest FOUND) -> restart inside the D_conf
-    # window -> pending-FOUND sidecar re-drive -> FINALIZE at bin_height =
-    # H_b + D_conf -> finalW nets to 0; late-FOUND / malformed / all-zero bid
-    # refusals; orphan disposition. Same shape as v37_xmr_node_smoke (monerod
+    # v37_xmr_o2_finalize_connect_selfcheck: an S-1-shaped credit block ARMS owed
+    # -> a settlement win whose coinbase pays part of it -> queued win ->
+    # XmrNode::on_network_block_won booking the EMITTED Role::Owed set (R-7) ->
+    # restart inside the D_conf window -> the schema-v2 pending-FOUND sidecar
+    # re-drives the SAME payout map -> FINALIZE at bin_height = H_b + D_conf
+    # extinguishes that owed EXACTLY ONCE. Pins R-7's two invariants: INV-1
+    # effective_owed >= 0 at every step (it used to go to -reward per pending
+    # FOUND) and INV-2 a FINALIZE moves effective_owed by exactly +credit
+    # (OI-W4-5). Plus the split-brain precheck, the option-A degenerate {}/{}
+    # record, the v1 legacy sidecar path, the sidecar codec round trip, and the
+    # late-FOUND / malformed / all-zero bid refusals + orphan disposition.
+    # Same shape as v37_xmr_node_smoke (monerod
     # STUB, injected test point-check backend). SAME HOLLOW-GREEN GUARD: both
     # targets are listed in the build.yml --target lists (BOTH the Linux x86_64
     # leg and the ASan+UBSan leg) so CI compiles + runs them.
@@ -324,6 +331,46 @@ if (BUILD_TESTING)
         target_compile_definitions(v37_xmr_o2_randomx_kat PRIVATE V37_XMR_O2_WITH_RANDOMX)
         target_link_libraries(v37_xmr_o2_randomx_kat PRIVATE xmr_coin randomx Threads::Threads)
         add_test(NAME v37_xmr_o2_randomx_kat COMMAND v37_xmr_o2_randomx_kat)
+    endif()
+
+    # v37_xmr_o2_settlement_kat: the MULTI-NODE settlement KATs for option B —
+    # the first test executable over the CONSUMER option-B settlement path
+    # (XmrOwedSettlementSource / xmr_o2_settlement_fixture / the assembler's
+    # per-reward re-projection hook). Pins the two operator rulings of
+    # 2026-09-10:
+    #   (KW) the payee set IS OwedLedger::propose_coinbase output AT THE REWARD
+    #        THE BLOCK PAYS, proven against an INDEPENDENT K_fair reference walk
+    #        written in the KAT; non-W4Propose sources are refused at both gates.
+    #   (KS) the coinbase's MM-root leaf commits the whitepaper section-13
+    #        StateCommitment root; a verifier holding the same ledger recovers
+    #        it; the section-13 O(log n) balance proof verifies against exactly
+    #        that root.
+    #   (KC) the reward/payee-set fixpoint stays fail-closed when re-projection
+    #        changes the set SIZE, and an EMPTY hook is byte-identical to before.
+    # Same recipe as impl/xmr/test's xmr_block_assembly_kat (it drives the same
+    # template port + X6 executor and needs the real ed25519 point-check
+    # backend), plus the consumer W4/W5 headers. Gated behind the SAME
+    # XMR_BUILD_OPTION_B_KATS option so ctest never registers a NOT_BUILT
+    # sentinel in a build whose --target list omits it; build.yml's Linux
+    # x86_64 leg sets the option AND lists the target.
+    # ci-allowlist-exempt: v37_xmr_o2_settlement_kat -- heavy option-B leg (template port + X6 settle + ref10 point-check), gated behind XMR_BUILD_OPTION_B_KATS exactly like its impl-side sibling.
+    # Idempotent re-declaration: option() never overwrites an existing cache
+    # entry, so this only matters if src/impl/xmr/test was not configured.
+    option(XMR_BUILD_OPTION_B_KATS
+           "Build the heavy X9 option-B XMR KATs (local; not in the CI --target allowlist)" OFF)
+    if (XMR_BUILD_OPTION_B_KATS AND TARGET xmr_template)
+        add_executable(v37_xmr_o2_settlement_kat
+            v37_xmr_o2_settlement_kat.cpp
+            ${CMAKE_SOURCE_DIR}/src/impl/xmr/settle/xmr_coinbase.cpp
+            ${CMAKE_SOURCE_DIR}/src/sharechain/v37/v37_descriptor_xmr_point_check_ref10.cpp)
+        target_link_libraries(v37_xmr_o2_settlement_kat PRIVATE xmr_template)
+        target_include_directories(v37_xmr_o2_settlement_kat PRIVATE
+            ${CMAKE_SOURCE_DIR}/src
+            ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/vendor
+            ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/compat)
+        target_compile_definitions(v37_xmr_o2_settlement_kat PRIVATE V37_XMR_HAVE_MONERO_CRYPTO)
+        target_compile_features(v37_xmr_o2_settlement_kat PRIVATE cxx_std_20)
+        add_test(NAME v37_xmr_o2_settlement_kat COMMAND v37_xmr_o2_settlement_kat)
     endif()
 
     # Track A2 CONSUMER half — multi-node carrier accounting over a REAL socket.

--- a/src/c2pool/v37/test/v37_xmr_o2_settlement_kat.cpp
+++ b/src/c2pool/v37/test/v37_xmr_o2_settlement_kat.cpp
@@ -1,0 +1,1126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// v37_xmr_o2_settlement_kat.cpp
+//   The multi-node settlement KATs for the X9 option-B coinbase, pinning the
+//   two operator rulings of 2026-09-10 and the count-invariance fixpoint that
+//   has to survive them.
+//
+//   RULED (1) K_fair source == W4Propose. The XMR coinbase selects payees by
+//     the ONE ratified K_fair rule: OwedLedger::propose_coinbase — oldest-owed-
+//     first, (first_eligible ASC, identity ASC), take = min(EffectiveOwed,
+//     remaining), CARRY a sub-h_min take, count-capped at C (whitepaper
+//     erratum E-1). Every node derives the SAME set from the same ledger.
+//   RULED (2) lane_commitment == the whitepaper §13 StateCommitment Merkle
+//     root. The MM-root leaf in the coinbase tx_extra 0x03 commits that root
+//     (via keccak(MM_LEAF_DOMAIN || chain_id_le32 || root)), not the narrower
+//     owed_digest. Strict subsumption: the §13 summary leaf CONTAINS
+//     owed_digest.
+//
+//   There was no test executable over the consumer option-B settlement path
+//   before this file; the impl-side self-check (xmr_block_assembly_kat) covers
+//   only the halves that need no OwedLedger.
+//
+//   Group KW: the payee set IS the canonical K_fair proposal at the reward the
+//             block PAYS, proven against an INDEPENDENT reference walk written
+//             in this file (never by calling the code under test).
+//   Group KS: the §13 root is what the block commits, and a verifier holding
+//             the same ledger recovers it; a one-piconero ledger difference
+//             moves it; the §13 O(log n) balance proof verifies against exactly
+//             the committed root.
+//   Group KC: the reward/payee-set fixpoint stays fail-closed under a
+//             re-projected set that may CHANGE SIZE with the reward, and the
+//             cap_owed == 0 CONVENTION COLLISION between W4 (0 == unbounded)
+//             and X6 (0 == no room) is translated, never forwarded (KC-5..7).
+//   Group KF: R-7 (2026-09-10) — ONE ledger, and the ledger decrement is
+//             EXACTLY the coinbase-paid Role::Owed set. effective_owed stays
+//             non-negative (INV-1) and a FINALIZE moves it by exactly +credit
+//             (INV-2, OI-W4-5); an owed row in flight cannot be re-proposed
+//             (no-double-pay, whitepaper section 9). Each carries a REGRESSION
+//             PIN that reproduces the shipped split-ledger defect side by side.
+// ===========================================================================
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <c2pool/v37/w5_coinbase.hpp>
+#include <c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp>
+#include <c2pool/v37/xmr/xmr_o2_settlement_source.hpp>
+
+#include "impl/xmr/settle/xmr_coinbase.hpp"
+#include "impl/xmr/template/xmr_block_assembly.hpp"
+
+namespace o2   = ::c2pool::v37n::xmr::o2;
+namespace asm_ = ::c2pool::xmr::assembly;
+namespace x6   = ::v37::xmr::settle;
+namespace cb37 = ::c2pool::v37n::coinbase;
+
+using Out = x6::CoinbaseOutput;
+
+// ---------------------------------------------------------------------------
+// tiny check harness (same shape as the impl-side self-check)
+// ---------------------------------------------------------------------------
+namespace {
+
+int g_pass = 0, g_fail = 0;
+
+bool CHECK(bool ok, const std::string& what) {
+    std::printf("  [%s] %s\n", ok ? "PASS" : "FAIL", what.c_str());
+    if (ok) ++g_pass; else ++g_fail;
+    return ok;
+}
+
+std::string hex(const void* p, std::size_t n) {
+    static const char* d = "0123456789abcdef";
+    const auto* b = static_cast<const unsigned char*>(p);
+    std::string s;
+    for (std::size_t i = 0; i < n; ++i) { s.push_back(d[b[i] >> 4]); s.push_back(d[b[i] & 0xf]); }
+    return s;
+}
+std::string hex(const ::v37::bytes32& b) { return hex(b.data(), 32); }
+
+std::array<std::uint8_t, 32> unhex32(const char* h) {
+    std::array<std::uint8_t, 32> o{};
+    auto nib = [](char c) -> int {
+        return (c >= '0' && c <= '9') ? c - '0'
+             : (c >= 'a' && c <= 'f') ? c - 'a' + 10
+             : (c >= 'A' && c <= 'F') ? c - 'A' + 10 : 0;
+    };
+    for (std::size_t i = 0; i < 32; ++i) o[i] = static_cast<std::uint8_t>((nib(h[2 * i]) << 4) | nib(h[2 * i + 1]));
+    return o;
+}
+
+// THREE distinct, TORSION-VALID ed25519 points. This matters: the canonical
+// K_fair projection downgrades a key whose ScriptRef fails xmr_ref_valid() to a
+// RAW sentinel and CARRIES it, so a payee built on a torsion-failing point is
+// silently never paid. (The vectors in monero-project tests/crypto/tests.txt
+// that the impl-side xmr_block_assembly_kat uses do NOT pass this check — X6
+// only requires well-formedness of an owed ref, the consumer projection
+// requires validity. Use the canon's own KAT identities plus the regtest
+// wallet keys the FOUND->FINALIZE proof pays.)
+const std::array<std::uint8_t, 32> SINK_B = unhex32("a03ab8e2191c928bffa5c875c42834f793a356c12cd6d319310619055bcc7005");
+const std::array<std::uint8_t, 32> SINK_A = unhex32("099b5b60c9a497e55985b3843c3fda8da741814c39f0cda7fab35c0c4c1c023d");
+
+::v37::ScriptRef ref_a() {                                           // payee A
+    return ::v37::xmr::make_xmr_std(::v37::xmr::kat::STD_KAT.p0, ::v37::xmr::kat::STD_KAT.p1);
+}
+::v37::ScriptRef ref_b() {                                           // payee B (distinct identity)
+    return ::v37::xmr::make_xmr_std(::v37::xmr::kat::SUB_KAT.p0, ::v37::xmr::kat::STD_KAT.p1);
+}
+::v37::ScriptRef ref_sink() { return ::v37::xmr::make_xmr_std(SINK_B, SINK_A); }
+
+// ---------------------------------------------------------------------------
+// THE INDEPENDENT K_fair REFERENCE. Written from the whitepaper rule, NOT by
+// calling OwedLedger::propose_coinbase / project_w4_owed / allocate_exact_sum.
+//   order  : (first_eligible ASC, identity_key ASC)
+//   take   : min(owed, remaining)
+//   floor  : take < h_min  =>  CARRY (skip and CONTINUE — never break, never
+//                              emit a sub-floor owed output)
+//   cap    : at most C owed entries (C = total_output_cap - n_fixed - 1)
+//   sink   : the exact-sum residual, iff residual > 0, LAST.
+// ---------------------------------------------------------------------------
+struct RefRow {
+    std::uint64_t  first_eligible;
+    ::v37::bytes32 key;
+    std::uint64_t  owed;
+};
+struct RefOut {
+    ::v37::bytes32 key;
+    std::uint64_t  amount;
+    bool           is_sink;
+};
+
+std::vector<RefOut> kfair_reference(std::vector<RefRow> rows, std::uint64_t reward,
+                                    std::uint64_t fixed_sum, std::size_t n_fixed,
+                                    std::uint32_t total_output_cap, std::uint64_t h_min,
+                                    const ::v37::bytes32& sink_identity) {
+    std::sort(rows.begin(), rows.end(), [](const RefRow& a, const RefRow& b) {
+        if (a.first_eligible != b.first_eligible) return a.first_eligible < b.first_eligible;
+        return a.key < b.key;
+    });
+    const std::size_t cap = static_cast<std::size_t>(total_output_cap) - n_fixed - 1;
+    std::vector<RefOut> out;
+    std::uint64_t remaining = reward - fixed_sum;
+    for (const RefRow& r : rows) {
+        if (out.size() >= cap) break;
+        if (remaining == 0) break;
+        const std::uint64_t take = std::min<std::uint64_t>(r.owed, remaining);
+        if (take < h_min) continue;                       // CARRY, keep walking
+        out.push_back(RefOut{r.key, take, false});
+        remaining -= take;
+    }
+    // (this KAT never configures fixed outputs; they would slot in here)
+    if (remaining > 0) out.push_back(RefOut{sink_identity, remaining, true});
+    return out;
+}
+
+std::string describe(const std::vector<Out>& outs) {
+    std::string s;
+    for (const auto& o : outs) {
+        s += (o.role == Out::Role::Owed ? "owed:" : o.role == Out::Role::Fixed ? "fixed:" : "sink:");
+        s += hex(o.identity).substr(0, 8);
+        s += "=" + std::to_string(o.amount) + " ";
+    }
+    return s;
+}
+
+bool same_as_reference(const std::vector<Out>& got, const std::vector<RefOut>& want) {
+    if (got.size() != want.size()) return false;
+    for (std::size_t i = 0; i < got.size(); ++i) {
+        if (got[i].amount != want[i].amount) return false;
+        if (!(got[i].identity == want[i].key)) return false;
+        const bool is_sink = got[i].role == Out::Role::Sink;
+        if (is_sink != want[i].is_sink) return false;
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// One assembled option-B template, wired EXACTLY as the daemon provider wires
+// it (build_settlement_source -> assembly_settle_inputs -> make_reproject_owed
+// -> XmrBlockAssembler::build).
+// ---------------------------------------------------------------------------
+struct Lane {
+    o2::XmrSettlementConfig cfg;
+    o2::XmrOwedFixture      fx;
+    std::vector<RefRow>     seeded;      // the KAT's OWN model of the ledger
+    std::uint64_t           next_age = 1;
+
+    // OWNING form: the lane holds its own ledger.
+    explicit Lane(::v37::ChainId chain, std::uint64_t h_min = 0) : fx(chain) {
+        init(chain, h_min);
+    }
+    // NON-OWNING form (R-7 one-ledger wiring): the lane's coinbase is built
+    // against an EXTERNAL OwedLedger — in the daemon, XmrNode::ledger(), the
+    // one the finalize driver writes.
+    explicit Lane(o2::OwedLedger& external, std::uint64_t h_min = 0) : fx(external) {
+        init(external.chain(), h_min);
+    }
+
+    void init(::v37::ChainId chain, std::uint64_t h_min) {
+        cfg.chain_id   = chain;
+        cfg.h_min      = h_min;
+        cfg.output_cap = 0;              // 0 => the ceiling; the assembler resolves weight-aware
+        cfg.residual_sink          = ref_sink();
+        cfg.residual_sink_identity = ::v37::xmr::xmr_identity_key(cfg.residual_sink);
+    }
+
+    ::v37::bytes32 seed(const ::v37::ScriptRef& pay, std::uint64_t amount) {
+        const ::v37::bytes32 k = fx.seed_owed(pay, amount);
+        seeded.push_back(RefRow{next_age++, k, amount});   // fixture arms at bin_height 1,2,...
+        return k;
+    }
+};
+
+std::unique_ptr<asm_::AssembledTemplate>
+assemble(Lane& lane, const ::c2pool::xmr::XmrMinerData& md,
+         const std::vector<::c2pool::xmr::XmrTxMempoolData>& mempool,
+         std::uint32_t wire_cap, std::string& why, bool wire_reprojection = true) {
+    o2::XmrSettlementConfig scfg = lane.cfg;
+    scfg.monero_major_version = md.major_version;
+
+    std::uint64_t fees = 0, weight_all = 0;
+    for (const auto& t : mempool) { fees += t.fee; weight_all += t.weight; }
+    const std::uint64_t subsidy = asm_::xmr_base_reward(md.already_generated_coins);
+
+    o2::XmrParentContext parent = o2::XmrParentContext::from_miner(md, subsidy, fees);
+
+    std::unique_ptr<o2::XmrOwedSettlementSource> src = o2::build_settlement_source(
+        scfg, parent, lane.fx.ledger(), lane.fx.pay_of(), subsidy + fees, &why);
+    if (!src) return nullptr;
+
+    asm_::AssemblyInputs a;
+    a.miner    = md;
+    a.mempool  = mempool;
+    a.settle   = o2::assembly_settle_inputs(*src, /*weight_aware_cap=*/true);
+    a.wire_cap = wire_cap;
+    if (wire_reprojection) a.reproject_owed = o2::make_reproject_owed(scfg, lane.fx);
+    return asm_::XmrBlockAssembler::build(a, &why);
+}
+
+::c2pool::xmr::XmrMinerData miner(std::uint64_t height, std::uint64_t median_weight,
+                                  std::uint64_t agc, std::uint8_t major = 16) {
+    ::c2pool::xmr::XmrMinerData d;
+    d.major_version = major;
+    d.height        = height;
+    for (std::size_t i = 0; i < 32; ++i) d.prev_id.h[i] = static_cast<std::uint8_t>(0x31 * 7 + i);
+    d.already_generated_coins = agc;
+    d.median_weight   = median_weight;
+    d.median_timestamp = 1700000000;
+    d.difficulty.lo = 1000;
+    for (std::size_t i = 0; i < 32; ++i) d.seed_hash.h[i] = static_cast<std::uint8_t>(0x53 * 7 + i);
+    d.lane_target.lo = 0xFFFFFFFFFFFFFFFFull;
+    return d;
+}
+
+std::vector<::c2pool::xmr::XmrTxMempoolData> txs(std::size_t n, std::uint64_t weight, std::uint64_t fee) {
+    std::vector<::c2pool::xmr::XmrTxMempoolData> v;
+    for (std::size_t i = 0; i < n; ++i) {
+        ::c2pool::xmr::XmrTxMempoolData t;
+        for (std::size_t j = 0; j < 32; ++j) t.id.h[j] = static_cast<std::uint8_t>((0x80 + i) * 7 + j);
+        t.weight = weight; t.fee = fee;
+        v.push_back(t);
+    }
+    return v;
+}
+
+// The TOTAL output cap the assembler actually resolved for this template — the
+// value the canonical proposal must have been cut at (RULED; it is the
+// weight-aware cap, not the config ceiling).
+std::uint32_t resolved_cap(const asm_::AssembledTemplate& t) {
+    return t.coinbase_inputs().output_cap;
+}
+
+// =========================================================================
+// GROUP KW — the payee set IS the canonical K_fair proposal
+// =========================================================================
+
+// KW-1 / KC-1: a PENALTY-ZONE template where the canonical set at the FINAL
+// reward is strictly different from the set at the sizing reward, because the
+// tail payee's take falls BELOW h_min and W4 therefore CARRIES it whole. The
+// pre-ruling assembler froze the sizing-pass rows and let X6 pay that payee a
+// sub-floor dust output; the ruled assembler re-projects and pays the sink.
+void kw1_kc1() {
+    std::printf("KW-1 / KC-1: payee set == canonical K_fair reference at the FINAL reward\n");
+
+    const std::uint64_t H_MIN = 5000000000ull;                 // 5e9 piconero owed floor
+    Lane lane(7, H_MIN);
+    const std::uint64_t subsidy = asm_::xmr_base_reward(18000000000000000000ull);
+    const ::v37::bytes32 kA = lane.seed(ref_a(), subsidy);      // oldest (first_eligible 1)
+    const ::v37::bytes32 kB = lane.seed(ref_b(), 100000000000ull);
+    (void)kB;
+
+    // median 2000 with 10 txs of 500 B / 1e9 fee: the greedy keeps 3, so the
+    // FINAL reward is subsidy + 3e9 while the SIZING reward is subsidy + 10e9.
+    auto md = miner(3000000, 2000, 18000000000000000000ull);
+    auto mp = txs(10, 500, 1000000000ull);
+
+    std::string why;
+    auto t = assemble(lane, md, mp, 2700, why);
+    if (!CHECK(t != nullptr, "KW-1 assemble: " + why)) return;
+
+    const std::uint64_t final_reward = t->reward();
+    CHECK(final_reward == subsidy + 3000000000ull,
+          "KW-1 final reward == subsidy + 3 fees (" + std::to_string(final_reward) + ")");
+    CHECK(final_reward < subsidy + 10000000000ull, "KW-1 penalty zone: final reward < sizing reward");
+
+    const std::vector<RefOut> want = kfair_reference(lane.seeded, final_reward, 0, 0,
+                                                     resolved_cap(*t), H_MIN,
+                                                     lane.cfg.residual_sink_identity);
+    CHECK(same_as_reference(t->outputs(), want),
+          "KW-1 outputs == INDEPENDENT canonical K_fair walk at the final reward and resolved cap "
+          "[got " + describe(t->outputs()) + "]");
+    // The discriminating detail: B's take at the final reward is 3e9 < h_min, so
+    // the canonical rule CARRIES B whole and the residual goes to the SINK.
+    CHECK(t->outputs().size() == 2 &&
+          t->outputs()[0].role == Out::Role::Owed && t->outputs()[0].identity == kA &&
+          t->outputs()[0].amount == subsidy &&
+          t->outputs()[1].role == Out::Role::Sink && t->outputs()[1].amount == 3000000000ull,
+          "KW-1 the sub-floor tail payee is CARRIED (sink absorbs 3e9), not paid dust");
+    CHECK(t->passes() == 2, "KC-1 re-projection changed the set => fixpoint took 2 passes, passes=" +
+                            std::to_string(t->passes()));
+    std::uint64_t sum = 0;
+    for (const auto& o : t->outputs()) sum += o.amount;
+    CHECK(sum == final_reward, "KC-1 exact-sum: sum(outputs) == template reward");
+
+    // Regression pin: with the re-projection hook UNWIRED (the pre-ruling
+    // assembler) the very same lane emits a DIFFERENT set — the dust output the
+    // canonical rule forbids. This is what the ruling closes.
+    std::string why2;
+    auto old = assemble(lane, md, mp, 2700, why2, /*wire_reprojection=*/false);
+    if (CHECK(old != nullptr, "KW-1 control: unwired assemble: " + why2)) {
+        CHECK(!same_as_reference(old->outputs(), want),
+              "KW-1 control: WITHOUT re-projection the set is NOT the canonical proposal "
+              "[got " + describe(old->outputs()) + "]");
+    }
+}
+
+// KW-2: the non-ruled K_fair source is refused at BOTH gates, and the refusal
+// names the ruling.
+void kw2() {
+    std::printf("KW-2: KFairSource::X6Allocate is refused, config-level and build-level\n");
+
+    Lane lane(7);
+    o2::XmrSettlementConfig bad = lane.cfg;
+    bad.kfair = o2::KFairSource::X6Allocate;
+    std::string w;
+    CHECK(!bad.validate_structural(&w) && w.find("RULED") != std::string::npos,
+          "KW-2 config gate refuses X6Allocate: " + w);
+
+    o2::XmrParentContext parent;
+    parent.height = 100; parent.base_reward = 600000000000ull; parent.fees = 0;
+    auto ctx = o2::make_xmr_coinbase_context(lane.cfg, parent, lane.fx.ledger(), &w);
+    if (!CHECK(ctx.has_value(), "KW-2 the RULED config still builds a context: " + w)) return;
+
+    auto src = o2::XmrOwedSettlementSource::build(lane.fx.ledger(), lane.fx.pay_of(), *ctx,
+                                                  parent.budget(), &w, o2::KFairSource::X6Allocate);
+    CHECK(src == nullptr && w.find("RULED") != std::string::npos,
+          "KW-2 build gate refuses X6Allocate: " + w);
+
+    auto ok = o2::XmrOwedSettlementSource::build(lane.fx.ledger(), lane.fx.pay_of(), *ctx,
+                                                 parent.budget(), &w, o2::KFairSource::W4Propose);
+    CHECK(ok != nullptr && ok->kfair_source() == o2::KFairSource::W4Propose,
+          "KW-2 W4Propose (the ruled source) builds: " + w);
+}
+
+// KW-3: canonical ORDER survives the whole template — proposal order first,
+// then fixed, then the sink LAST, with the configured sink identity.
+// KW-4: payout_map_at(final reward) is honest.
+void kw3_kw4() {
+    std::printf("KW-3 / KW-4: canonical order through the template + payout-map honesty\n");
+
+    Lane lane(7);
+    const ::v37::bytes32 kA = lane.seed(ref_a(), 1000000000ull);      // older
+    const ::v37::bytes32 kB = lane.seed(ref_b(), 2000000000ull);      // younger
+
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+    std::string why;
+    auto t = assemble(lane, md, {}, 2700, why);
+    if (!CHECK(t != nullptr, "KW-3 assemble: " + why)) return;
+
+    const auto& outs = t->outputs();
+    CHECK(outs.size() == 3, "KW-3 2 owed + sink");
+    CHECK(outs.size() == 3 && outs[0].identity == kA && outs[1].identity == kB,
+          "KW-3 oldest-owed-first order (A before B) preserved through the block template");
+    CHECK(outs.size() == 3 && outs[0].role == Out::Role::Owed && outs[1].role == Out::Role::Owed &&
+          outs[2].role == Out::Role::Sink,
+          "KW-3 roles: owed ++ fixed ++ sink, sink LAST");
+    CHECK(!outs.empty() && outs.back().identity == lane.cfg.residual_sink_identity,
+          "KW-3 the last output pays the CONFIGURED residual_sink_identity");
+
+    const std::vector<RefOut> want = kfair_reference(lane.seeded, t->reward(), 0, 0,
+                                                     resolved_cap(*t), lane.cfg.h_min,
+                                                     lane.cfg.residual_sink_identity);
+    CHECK(same_as_reference(outs, want), "KW-3 outputs == canonical reference [" + describe(outs) + "]");
+
+    // KW-4: the FOUND-record payout map sums to the block reward and its owed
+    // part is exactly the proposal's takes.
+    std::map<::v37::bytes32, long long> pm;
+    for (const auto& o : outs) pm[o.identity] += static_cast<long long>(o.amount);
+    long long total = 0;
+    for (const auto& [k, v] : pm) { (void)k; total += v; }
+    CHECK(static_cast<std::uint64_t>(total) == t->reward(),
+          "KW-4 payout map sums to the block reward");
+    CHECK(pm[kA] == 1000000000ll && pm[kB] == 2000000000ll,
+          "KW-4 the owed part of the payout map == the proposal takes");
+}
+
+// =========================================================================
+// GROUP KS — the §13 state root is what the block commits
+// =========================================================================
+
+void ks1_ks2_ks3_ks4() {
+    std::printf("KS: the whitepaper section-13 StateCommitment root is committed and recoverable\n");
+
+    Lane lane(7);
+    const ::v37::bytes32 kA = lane.seed(ref_a(), 1000000000ull);
+    lane.seed(ref_b(), 2000000000ull);
+
+    const ::v37::bytes32 root = cb37::StateCommitment(lane.fx.ledger(), lane.fx.ledger().chain()).root();
+    CHECK(!(root == ::v37::bytes32{}), "KS-1 the section-13 root is non-zero (" + hex(root).substr(0, 16) + "...)");
+    CHECK(o2::resolve_lane_commitment(lane.cfg, lane.fx.ledger()) == root,
+          "KS-1 the RULED default lane_commitment IS StateCommitment::root()");
+
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+    std::string why;
+    auto t = assemble(lane, md, {}, 2700, why);
+    if (!CHECK(t != nullptr, "KS-1 assemble: " + why)) return;
+
+    CHECK(t->coinbase_inputs().lane_commitment == root,
+          "KS-1 the coinbase's lane_commitment is the section-13 root");
+
+    // KS-1: the 32 bytes patched inside the tx_extra 0x03 tag are
+    // mm_commitment_root(chain_id, state_root).
+    asm_::BlockBytes b;
+    std::string me;
+    if (!CHECK(t->materialize(0, b, &me), "KS-1 materialize: " + me)) return;
+    const ::xmr::coin::Hash256 want_leaf = x6::mm_commitment_root(lane.cfg.chain_id, root);
+    CHECK(b.merkle_root == want_leaf,
+          "KS-1 tx_extra 0x03 root == mm_commitment_root(chain_id, section-13 root)");
+    CHECK(std::memcmp(b.full_blob.data() + b.merkle_root_offset, want_leaf.data(), 32) == 0,
+          "KS-1 the patched bytes at merkle_root_offset are that value");
+
+    // KS-2: an INDEPENDENT verifier that holds the same ledger parses the served
+    // miner_tx prefix and recomputes root -> leaf -> compare.
+    x6::ReceivedCoinbase rc;
+    std::uint64_t h = 0; std::size_t used = 0;
+    const bool parsed = asm_::parse_coinbase_prefix(b.full_blob.data() + b.miner_tx_offset,
+                                                    b.miner_tx_size, rc, &h, &used);
+    if (CHECK(parsed && h == t->height(), "KS-2 the served miner_tx prefix parses")) {
+        // the 0x03 tag is the LAST prefix field: [03][varint(33)][00][root32]
+        const bool tail_ok = rc.tx_extra.size() >= 32 &&
+            std::memcmp(rc.tx_extra.data() + rc.tx_extra.size() - 32, want_leaf.data(), 32) == 0;
+        CHECK(tail_ok, "KS-2 a verifier recomputes the leaf from its own ledger copy and it MATCHES "
+                       "the served tx_extra");
+    }
+    // KS-2 negative control: a ledger differing by ONE piconero on one balance
+    // yields a DIFFERENT section-13 root, hence a different MM leaf.
+    {
+        Lane other(7);
+        other.seed(ref_a(), 1000000000ull);
+        other.seed(ref_b(), 2000000001ull);              // one piconero apart
+        const ::v37::bytes32 r2 = cb37::StateCommitment(other.fx.ledger(), other.fx.ledger().chain()).root();
+        CHECK(!(r2 == root), "KS-2 negative: a 1-piconero ledger difference moves the section-13 root");
+        CHECK(!(x6::mm_commitment_root(lane.cfg.chain_id, r2) == want_leaf),
+              "KS-2 negative: and therefore moves the MM leaf the block commits");
+    }
+
+    // KS-3: the whitepaper section-13 O(log n) balance proof verifies against
+    // EXACTLY the root the block commits.
+    {
+        cb37::StateCommitment sc(lane.fx.ledger(), lane.fx.ledger().chain());
+        ::v37::bytes32 leaf{};
+        ::v37::Lane::MerkleProof proof;
+        const bool have = sc.prove(kA, leaf, proof);
+        CHECK(have, "KS-3 a balance proof exists for a finalized payee key");
+        CHECK(have && ::v37::Lane::verify_proof(root, leaf, proof),
+              "KS-3 Lane::verify_proof(leaf, proof, committed root) accepts");
+        if (have) {
+            ::v37::bytes32 tampered = leaf; tampered[0] ^= 0x01;
+            CHECK(!::v37::Lane::verify_proof(root, tampered, proof),
+                  "KS-3 negative: a tampered leaf is rejected against the committed root");
+        }
+    }
+
+    // KS-4: an EMPTY ledger still has a summary-leaf-only root (non-zero) and a
+    // sink-only coinbase still builds against it.
+    {
+        Lane empty(7);
+        const ::v37::bytes32 er = cb37::StateCommitment(empty.fx.ledger(), empty.fx.ledger().chain()).root();
+        CHECK(!(er == ::v37::bytes32{}), "KS-4 empty ledger: summary-leaf-only root is non-zero");
+        CHECK(cb37::StateCommitment(empty.fx.ledger(), empty.fx.ledger().chain()).leaf_count() == 1,
+              "KS-4 empty ledger: exactly one leaf (the V37S summary)");
+        std::string w2;
+        auto et = assemble(empty, miner(1, 300000, 0), {}, 2700, w2);
+        if (CHECK(et != nullptr, "KS-4 sink-only coinbase builds on an empty ledger: " + w2)) {
+            CHECK(et->outputs().size() == 1 && et->outputs()[0].role == Out::Role::Sink,
+                  "KS-4 the whole reward flows to the residual sink");
+            CHECK(et->coinbase_inputs().lane_commitment == er,
+                  "KS-4 and it commits the empty ledger's section-13 root");
+        }
+    }
+}
+
+// KS-5: the same lane under owed-digest vs state-root gives a different tx
+// secret key r, a different R, different one-time keys and different block
+// bytes — the reason every pinned option-B byte golden was regenerated.
+void ks5() {
+    std::printf("KS-5: switching the lane commitment moves r / R / P_i and the block bytes\n");
+
+    Lane lane(7);
+    lane.seed(ref_a(), 1000000000ull);
+
+    o2::XmrSettlementConfig old_cfg = lane.cfg;
+    old_cfg.lc_source = o2::LaneCommitmentSource::OwedDigest;
+    old_cfg.allow_nonruled_local_only = true;                 // single-pool escape hatch
+
+    o2::XmrParentContext parent;
+    parent.height = 100; parent.base_reward = 600000000000ull; parent.fees = 0;
+
+    std::string w;
+    auto ruled = o2::build_settlement_source(lane.cfg, parent, lane.fx.ledger(), lane.fx.pay_of(),
+                                             parent.budget(), &w);
+    if (!CHECK(ruled != nullptr, "KS-5 ruled (state-root) source builds: " + w)) return;
+    auto legacy = o2::build_settlement_source(old_cfg, parent, lane.fx.ledger(), lane.fx.pay_of(),
+                                              parent.budget(), &w);
+    if (!CHECK(legacy != nullptr, "KS-5 legacy (owed-digest) source builds: " + w)) return;
+
+    CHECK(std::memcmp(ruled->tx_secret_key().h, legacy->tx_secret_key().h, 32) != 0,
+          "KS-5 tx secret key r differs");
+    CHECK(std::memcmp(ruled->tx_public_key().h, legacy->tx_public_key().h, 32) != 0,
+          "KS-5 tx public key R differs");
+    CHECK(std::memcmp(ruled->commitment_leaf(0).h, legacy->commitment_leaf(0).h, 32) != 0,
+          "KS-5 the MM commitment leaf differs");
+    CHECK(ruled->built().prefix != legacy->built().prefix,
+          "KS-5 the whole miner_tx prefix differs (golden regeneration is EXPECTED, not a regression)");
+    CHECK(ruled->payees().size() == legacy->payees().size(),
+          "KS-5 the PAYEE SET is unchanged by the commitment switch (only the keys move)");
+}
+
+// =========================================================================
+// GROUP KC — the fixpoint stays fail-closed
+// =========================================================================
+
+// KC-2: the proposal is cut at the RESOLVED (weight-aware) cap, so the W4 tail
+// is CARRIED rather than truncated by X6 — the two caps agree by construction.
+void kc2() {
+    std::printf("KC-2: the canonical proposal is cut at the RESOLVED weight-aware cap\n");
+
+    Lane lane(7);
+    for (int i = 0; i < 6; ++i)
+        lane.seed(i % 2 ? ref_b() : ref_a(), 1000000000ull * static_cast<std::uint64_t>(i + 1));
+    // NOTE: ref_a()/ref_b() alternate, so only 2 distinct identity keys exist —
+    // seeding the same ref twice ACCUMULATES on one ledger key. That is exactly
+    // what we want here: 2 real payees, and a wire cap that leaves room for
+    // fewer owed slots than the config ceiling would.
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    std::string why;
+    auto t = assemble(lane, md, {}, /*wire_cap=*/2, why);      // total cap 2 => 1 owed slot + sink
+    if (!CHECK(t != nullptr, "KC-2 assemble at wire_cap 2: " + why)) return;
+
+    CHECK(resolved_cap(*t) == 2, "KC-2 the assembler resolved the weight-aware cap to 2 (not the 2700 ceiling)");
+    CHECK(t->coinbase_inputs().owed.size() <= 1,
+          "KC-2 the proposal handed to X6 holds at most cap-1 owed rows (the tail was CARRIED, "
+          "not truncated after the fact); rows=" + std::to_string(t->coinbase_inputs().owed.size()));
+    CHECK(t->outputs().size() == 2 && t->outputs()[0].role == Out::Role::Owed &&
+          t->outputs()[1].role == Out::Role::Sink,
+          "KC-2 one owed output + sink [" + describe(t->outputs()) + "]");
+
+    // Build the reference over the KAT's own accumulated model of the ledger.
+    std::map<::v37::bytes32, RefRow> acc;
+    for (const RefRow& r : lane.seeded) {
+        auto it = acc.find(r.key);
+        if (it == acc.end()) acc.emplace(r.key, r);           // oldest arming wins (first_eligible)
+        else it->second.owed += r.owed;
+    }
+    std::vector<RefRow> rows;
+    for (const auto& [k, r] : acc) { (void)k; rows.push_back(r); }
+    const std::vector<RefOut> want = kfair_reference(rows, t->reward(), 0, 0, resolved_cap(*t),
+                                                     lane.cfg.h_min, lane.cfg.residual_sink_identity);
+    CHECK(same_as_reference(t->outputs(), want),
+          "KC-2 outputs == canonical reference AT THE RESOLVED CAP [" + describe(t->outputs()) + "]");
+}
+
+// KC-3: fail-closed. A re-projection callback that refuses must abort the whole
+// assembly with a NAMED reason — never a silently different payee set.
+void kc3() {
+    std::printf("KC-3: a refusing re-projection callback fails the assembly closed\n");
+
+    Lane lane(7);
+    lane.seed(ref_a(), 1000000000ull);
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    o2::XmrSettlementConfig scfg = lane.cfg;
+    scfg.monero_major_version = md.major_version;
+    const std::uint64_t subsidy = asm_::xmr_base_reward(md.already_generated_coins);
+    o2::XmrParentContext parent = o2::XmrParentContext::from_miner(md, subsidy, 0);
+
+    std::string why;
+    auto src = o2::build_settlement_source(scfg, parent, lane.fx.ledger(), lane.fx.pay_of(),
+                                           subsidy, &why);
+    if (!CHECK(src != nullptr, "KC-3 source builds: " + why)) return;
+
+    asm_::AssemblyInputs a;
+    a.miner   = md;
+    a.settle  = o2::assembly_settle_inputs(*src, true);
+    a.reproject_owed = [](std::uint64_t, std::uint32_t, std::vector<x6::OwedEntry>&, std::string* w) {
+        if (w) *w = "synthetic ledger read failure";
+        return false;
+    };
+    std::string w2;
+    auto t = asm_::XmrBlockAssembler::build(a, &w2);
+    CHECK(t == nullptr, "KC-3 the assembler refuses to serve a template");
+    CHECK(w2.find("reproject_owed refused") != std::string::npos &&
+          w2.find("synthetic ledger read failure") != std::string::npos,
+          "KC-3 and names the cause: " + w2);
+
+    // The other two fail-closed exits are unchanged and still reachable: the
+    // CARROT fence and a missing residual sink.
+    asm_::AssemblyInputs f;
+    f.miner  = miner(1, 300000, 0, 17);
+    f.settle = o2::assembly_settle_inputs(*src, true);
+    f.reproject_owed = o2::make_reproject_owed(scfg, lane.fx);
+    std::string w3;
+    const bool fenced = asm_::XmrBlockAssembler::build(f, &w3) == nullptr;
+    CHECK(fenced && w3.find("CARROT") != std::string::npos,
+          "KC-3 CARROT fence still refuses under the ruled wiring: " + w3);
+}
+
+// KC-4: with reproject_owed EMPTY the impl-only assembler is byte-identical to
+// master — the pre-ruling behaviour is preserved for every caller that does not
+// opt in (this is what keeps xmr_block_assembly_kat K0..K6 green unchanged).
+void kc4() {
+    std::printf("KC-4: back-compat — an empty reproject_owed keeps the old assembler behaviour\n");
+
+    Lane lane(7);
+    lane.seed(ref_a(), 1000000000ull);
+    lane.seed(ref_b(), 2000000000ull);
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    std::string w1, w2;
+    auto wired   = assemble(lane, md, {}, 2700, w1, /*wire_reprojection=*/true);
+    auto unwired = assemble(lane, md, {}, 2700, w2, /*wire_reprojection=*/false);
+    if (!CHECK(wired != nullptr && unwired != nullptr, "KC-4 both assemble: " + w1 + " / " + w2)) return;
+
+    // In the NON-penalty case the sizing reward IS the final reward, so the
+    // re-projection is a no-op and the two must agree BYTE for byte.
+    asm_::BlockBytes bw, bu;
+    std::string me;
+    if (!CHECK(wired->materialize(0, bw, &me) && unwired->materialize(0, bu, &me),
+               "KC-4 materialize: " + me)) return;
+    CHECK(bw.full_blob == bu.full_blob,
+          "KC-4 identical block bytes when the reward never moves (re-projection is a no-op)");
+    CHECK(wired->passes() == unwired->passes() && wired->passes() == 1, "KC-4 both converge in 1 pass");
+}
+
+// =========================================================================
+// GROUP KF — R-7: effective_owed non-negative + finality-invariant, and the
+// ledger decrement is EXACTLY the coinbase-paid owed set.
+//
+// The defect these pin: the daemon used to hold TWO disjoint OwedLedger objects
+// — a settlement one the coinbase was built from and a node one FINALIZE booked
+// into — and booked a FICTIONAL payout ({ operator --payee-* : FULL block
+// reward }) into the second. Consequences, both empirically confirmed on the
+// PR's own regtest run: effective_owed went NEGATIVE by one reward per pending
+// FOUND, and the settlement ledger, never decremented, re-proposed the SAME
+// owed row at its full EffectiveOwed on EVERY block (no-double-pay violation of
+// whitepaper section 9 / OI-W4-5).
+// =========================================================================
+
+// { identity : amount } over the EMITTED Role::Owed outputs of an assembled
+// template — the ONLY legal FOUND payout map. Written here independently of the
+// provider's owed_payout_of() so the KAT does not test the code by calling it.
+o2::Amounts emitted_owed(const asm_::AssembledTemplate& t) {
+    o2::Amounts m;
+    for (const auto& o : t.outputs())
+        if (o.role == Out::Role::Owed) m[o.identity] += static_cast<long long>(o.amount);
+    return m;
+}
+o2::Amounts emitted_by_role(const asm_::AssembledTemplate& t, Out::Role want) {
+    o2::Amounts m;
+    for (const auto& o : t.outputs())
+        if (o.role == want) m[o.identity] += static_cast<long long>(o.amount);
+    return m;
+}
+bool all_nonnegative(const o2::OwedLedger& led) {
+    for (const auto& [k, v] : led.effective_owed_all()) { (void)k; if (v < 0) return false; }
+    return true;
+}
+long long min_effective_owed(const o2::OwedLedger& led) {
+    long long m = 0;
+    for (const auto& [k, v] : led.effective_owed_all()) { (void)k; if (v < m) m = v; }
+    return m;
+}
+
+// KF-1: ONE-LEDGER INVARIANTS with THREE CONCURRENT pending FOUNDs — the exact
+// shape that produced the reported divergence ("found registered=30 settled=25
+// orphaned=2 refused=0 pending=3").
+void kf1() {
+    std::printf("KF-1: R-7 one-ledger invariants over 3 concurrent pending FOUNDs\n");
+
+    o2::OwedLedger led(7);                       // THE ledger (the node's, in the daemon)
+    Lane lane(led);
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    const std::uint64_t ARM[3] = {1000000000ull, 700000000ull, 250000000ull};
+    std::vector<o2::Amounts> booked;
+    bool inv1 = true;
+
+    for (int i = 0; i < 3; ++i) {
+        lane.seed(ref_a(), ARM[i]);              // a fresh E_b credit arms more owed
+        std::string why;
+        auto t = assemble(lane, md, {}, 2700, why);
+        if (!CHECK(t != nullptr, "KF-1 assemble block " + std::to_string(i) + ": " + why)) return;
+
+        const o2::Amounts owed = emitted_owed(*t);
+        if (!CHECK(owed.size() == 1 && owed.begin()->second == static_cast<long long>(ARM[i]),
+                   "KF-1 block " + std::to_string(i) + " pays exactly the newly armed owed"))
+            return;
+        // This is what FinalizeConnect books: credit == {} (no S-1 fold yet),
+        // payout == the EMITTED Role::Owed set, into the SAME ledger.
+        led.on_block_found("kf1-blk-" + std::to_string(i), /*credit=*/{}, owed);
+        booked.push_back(owed);
+        inv1 = inv1 && all_nonnegative(led);
+    }
+    CHECK(inv1, "KF-1 INV-1: effective_owed >= 0 after EVERY on_block_found (3 pending), min=" +
+                std::to_string(min_effective_owed(led)));
+    CHECK(led.effective_owed(::v37::xmr::xmr_identity_key(ref_a())) == 0,
+          "KF-1 with all three in flight the payee's effective_owed is exactly 0 (fully committed, "
+          "never negative)");
+
+    // INV-2 (OI-W4-5): a FINALIZE moves effective_owed by EXACTLY +credit[k].
+    // credit == {} here, so it is INVARIANT. Do NOT assert monotonicity across
+    // the FOUND transition — effective_owed legitimately drops there; that IS
+    // the pending-payout deduction the coinbase drew on.
+    bool inv2 = true;
+    for (int i = 0; i < 3; ++i) {
+        const o2::Amounts before = led.effective_owed_all();
+        led.on_block_finalized("kf1-blk-" + std::to_string(i), 100 + static_cast<std::uint64_t>(i));
+        const o2::Amounts after = led.effective_owed_all();
+        for (const auto& [k, v] : after) {
+            const auto it = before.find(k);
+            const long long b = it == before.end() ? 0 : it->second;
+            if (v != b) inv2 = false;            // credit == {} => exactly unchanged
+        }
+        inv1 = inv1 && all_nonnegative(led);
+    }
+    CHECK(inv2, "KF-1 INV-2: each FINALIZE changed effective_owed by EXACTLY +credit[k] "
+                "(credit == {} => unchanged, never decreased)");
+    CHECK(inv1 && min_effective_owed(led) == 0,
+          "KF-1 INV-1 holds through FINALIZE too: no negative row anywhere in the run");
+
+    // ── REGRESSION PIN: the SHIPPED split-ledger wiring goes NEGATIVE ────────
+    // Same three blocks, but the payout is booked into a SECOND ledger the
+    // coinbase never read (and, as shipped, the payout was the full reward).
+    {
+        o2::OwedLedger settle_led(7);            // the coinbase's ledger
+        o2::OwedLedger node_led(7);              // the finalize driver's ledger
+        Lane split(settle_led);
+        split.seed(ref_a(), 1000000000ull);
+        std::string why;
+        auto t = assemble(split, md, {}, 2700, why);
+        if (CHECK(t != nullptr, "KF-1 split-arm assemble: " + why)) {
+            const ::v37::bytes32 payee = ::v37::xmr::xmr_identity_key(ref_a());
+            for (int i = 0; i < 3; ++i) {
+                o2::Amounts fictional;           // the pre-R-7 record: payee -> FULL reward
+                fictional[payee] = static_cast<long long>(t->reward());
+                node_led.on_block_found("split-" + std::to_string(i), fictional, fictional);
+            }
+            CHECK(node_led.effective_owed(payee) ==
+                      -3ll * static_cast<long long>(t->reward()),
+                  "KF-1 REGRESSION PIN: the shipped split-ledger + full-reward record drives "
+                  "effective_owed to -3*reward with 3 pending (" +
+                  std::to_string(node_led.effective_owed(payee)) + ") — the class that must "
+                  "never come back");
+            CHECK(min_effective_owed(node_led) < 0,
+                  "KF-1 REGRESSION PIN: and the ledger-wide minimum is negative");
+        }
+    }
+}
+
+// KF-2: the COINBASE-PAID SET is EXACTLY what the ledger decrements — no fixed
+// key, no sink key, no extra key; and the sink/fixed identities are never
+// touched by the ledger at all.
+void kf2() {
+    std::printf("KF-2: ledger decrement == the emitted Role::Owed set (fixed + sink EXCLUDED)\n");
+
+    o2::OwedLedger led(7);
+    Lane lane(led);
+    // One mandated fixed output, so the template carries all three roles.
+    ::v37::ScriptRef fixed_pay = ref_b();
+    const ::v37::bytes32 fixed_id = ::v37::xmr::xmr_identity_key(fixed_pay);
+    lane.cfg.fixed.push_back(x6::FixedOutput{fixed_pay, 250000000ull, fixed_id});
+
+    const ::v37::bytes32 kA = lane.seed(ref_a(), 1000000000ull);
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    std::string why;
+    auto t = assemble(lane, md, {}, 2700, why);
+    if (!CHECK(t != nullptr, "KF-2 assemble: " + why)) return;
+
+    const o2::Amounts owed  = emitted_owed(*t);
+    const o2::Amounts fixed = emitted_by_role(*t, Out::Role::Fixed);
+    const o2::Amounts sink  = emitted_by_role(*t, Out::Role::Sink);
+    CHECK(owed.size() == 1 && owed.count(kA) == 1 && fixed.size() == 1 && sink.size() == 1,
+          "KF-2 the template carries owed + fixed + sink [" + describe(t->outputs()) + "]");
+
+    // (a) exactly the Role::Owed keys — no fixed, no sink, nothing extra.
+    CHECK(owed.count(fixed_id) == 0 && owed.count(lane.cfg.residual_sink_identity) == 0,
+          "KF-2(a) the payout map holds NO fixed and NO sink identity");
+    // (b) amounts are the emitted ones, and strictly less than the block reward.
+    long long owed_sum = 0;
+    for (const auto& [k, v] : owed) { (void)k; owed_sum += v; }
+    CHECK(owed.at(kA) == 1000000000ll && static_cast<std::uint64_t>(owed_sum) < t->reward(),
+          "KF-2(b) amounts == the emitted owed amounts and sum < reward (a sink exists)");
+
+    // (c) the ledger decrement is exactly that, and the fixed/sink identities are
+    //     never created as ledger keys.
+    const long long eo_before = led.effective_owed(kA);
+    led.on_block_found("kf2", /*credit=*/{}, owed);
+    CHECK(led.effective_owed(kA) == eo_before - owed.at(kA) && led.effective_owed(kA) >= 0,
+          "KF-2(c) FOUND decremented effective_owed by EXACTLY the coinbase-paid owed");
+    led.on_block_finalized("kf2", 42);
+    const o2::Amounts all = led.effective_owed_all();
+    CHECK(all.count(fixed_id) == 0 && all.count(lane.cfg.residual_sink_identity) == 0,
+          "KF-2(c) the fixed and sink identities are NOT ledger keys (they were never credited, "
+          "so booking them would drive their finalW permanently negative)");
+    CHECK(led.effective_owed(kA) == eo_before - owed.at(kA) && min_effective_owed(led) == 0,
+          "KF-2(c) after FINALIZE the balance is unchanged (credit == {}) and nothing is negative");
+
+    // (d) WHY the emitted set — not the W4 proposal — is the load-bearing read.
+    //     Today they cannot diverge, because the projection forces h_min := 0
+    //     into X6 (xmr_o2_settlement_source.hpp) after W4 has applied the floor.
+    //     PIN that, then show at the X6 level that a NON-zero X6 h_min WOULD make
+    //     allocate_exact_sum emit a strict PREFIX of the proposal (X6 BREAKs on a
+    //     budget-truncated sub-floor partial; W4 CARRYs and keeps scanning), i.e.
+    //     booking the proposal would decrement owed the sink actually swallowed.
+    CHECK(t->coinbase_inputs().h_min == 0,
+          "KF-2(d) the X6 h_min the block was built with is 0 — LOAD-BEARING: it is what makes "
+          "the emitted set equal the W4 proposal today");
+    {
+        x6::CoinbaseInputs in = t->coinbase_inputs();
+        in.owed.clear();
+        // two rows; the second's take will be budget-truncated below the floor
+        x6::OwedEntry e0; e0.pay = ref_a(); e0.identity = kA; e0.owed = 1000000000ull; e0.first_eligible = 0;
+        x6::OwedEntry e1; e1.pay = ref_b(); e1.identity = fixed_id; e1.owed = 1000000000ull; e1.first_eligible = 1;
+        in.owed = {e0, e1};
+        in.fixed.clear();
+        in.base_reward = 1000000100ull; in.fees = 0;   // room for row 0 + 100 piconero
+        in.h_min = 1000ull;                            // a NON-zero X6 floor
+        x6::BuildError err = x6::BuildError::None;
+        const std::vector<Out> outs = x6::allocate_exact_sum(in, &err);
+        std::size_t n_owed = 0;
+        for (const auto& o : outs) if (o.role == Out::Role::Owed) ++n_owed;
+        CHECK(err == x6::BuildError::None && n_owed == 1,
+              "KF-2(d) with a non-zero X6 h_min the executor emits a STRICT PREFIX (1 of 2 rows) "
+              "and the sink absorbs the rest — proof that the FOUND map must be read from the "
+              "EMITTED outputs, never from a re-run of the W4 projection");
+    }
+}
+
+// KF-3: NO-DOUBLE-PAY across consecutive blocks. This is the harder half of the
+// defect and the one the PR's own offline verifier saw on all 28 blocks ("the
+// owed payee first at its full EffectiveOwed").
+void kf3() {
+    std::printf("KF-3: an owed row already in flight cannot be re-proposed by the next block\n");
+
+    o2::OwedLedger led(7);
+    Lane lane(led);
+    const ::v37::bytes32 kA = lane.seed(ref_a(), 1000000000ull);
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    std::string why;
+    auto b1 = assemble(lane, md, {}, 2700, why);
+    if (!CHECK(b1 != nullptr, "KF-3 assemble block 1: " + why)) return;
+    const o2::Amounts paid1 = emitted_owed(*b1);
+    CHECK(paid1.size() == 1 && paid1.at(kA) == 1000000000ll, "KF-3 block 1 pays the whole owed row");
+
+    led.on_block_found("kf3-b1", /*credit=*/{}, paid1);      // FOUND, NOT yet finalized
+    CHECK(led.effective_owed(kA) == 0,
+          "KF-3 the pending payout is already deducted from EffectiveOwed");
+
+    auto b2 = assemble(lane, md, {}, 2700, why);
+    if (!CHECK(b2 != nullptr, "KF-3 assemble block 2: " + why)) return;
+    CHECK(emitted_owed(*b2).empty(),
+          "KF-3 block 2 emits NO owed output — the row in flight cannot be paid twice [" +
+          describe(b2->outputs()) + "]");
+    CHECK(b2->outputs().size() == 1 && b2->outputs()[0].role == Out::Role::Sink,
+          "KF-3 block 2 is sink-only");
+
+    led.on_block_finalized("kf3-b1", 7);
+    CHECK(led.effective_owed(kA) == 0 && min_effective_owed(led) == 0,
+          "KF-3 after FINALIZE the row is extinguished EXACTLY ONCE and nothing is negative");
+
+    // REGRESSION PIN: under the shipped split-ledger wiring the settlement ledger
+    // is never decremented, so block 2 re-emits the SAME row at the SAME amount.
+    {
+        o2::OwedLedger settle_led(7);
+        o2::OwedLedger node_led(7);
+        Lane split(settle_led);
+        const ::v37::bytes32 sk = split.seed(ref_a(), 1000000000ull);
+        std::string w;
+        auto s1 = assemble(split, md, {}, 2700, w);
+        if (!CHECK(s1 != nullptr, "KF-3 split-arm block 1: " + w)) return;
+        node_led.on_block_found("split-b1", /*credit=*/{}, emitted_owed(*s1));   // wrong ledger
+        auto s2 = assemble(split, md, {}, 2700, w);
+        if (!CHECK(s2 != nullptr, "KF-3 split-arm block 2: " + w)) return;
+        const o2::Amounts again = emitted_owed(*s2);
+        CHECK(again.size() == 1 && again.count(sk) == 1 && again.at(sk) == 1000000000ll,
+              "KF-3 REGRESSION PIN: with the ledgers SPLIT, block 2 re-pays the identical owed "
+              "row at its full EffectiveOwed — 28 payments of a balance the paper extinguishes "
+              "once. Never again.");
+    }
+}
+
+// =========================================================================
+// GROUP KC (continued) — the count-invariance convention collision
+// =========================================================================
+
+// KC-5: cap_owed == 0 must emit ZERO owed rows. Canon reads slot_budget_C == 0
+// as UNBOUNDED; X6 reads its own cap_owed == 0 as "no room". The projection MUST
+// translate, never forward.
+void kc5() {
+    std::printf("KC-5: cap_owed == 0 (total cap == n_fixed + 1) emits ZERO owed rows\n");
+
+    // ---- n_fixed == 0, resolved total cap 1 --------------------------------
+    {
+        o2::OwedLedger led(7);
+        Lane lane(led);
+        const ::v37::bytes32 kA = lane.seed(ref_a(), 1000000000ull);
+        const ::v37::bytes32 kB = lane.seed(ref_b(), 2000000000ull);
+        auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+        // (a) the projection itself, at total_output_cap == 1.
+        std::vector<x6::OwedEntry> out;
+        std::string why;
+        const bool ok = o2::project_w4_owed(led, lane.fx.pay_of(), /*h_min=*/0, /*n_fixed=*/0,
+                                            /*fixed_sum=*/0, /*reward=*/600000000000ull,
+                                            /*total_output_cap=*/1, out, nullptr, &why);
+        CHECK(ok, "KC-5(a) project_w4_owed SUCCEEDS at cap_owed == 0 (clear-and-succeed, not a "
+                  "refusal: a refusal is permanently fatal, never a retry signal): " + why);
+        CHECK(out.empty(), "KC-5(a) and it emits ZERO owed rows over a 2-eligible ledger "
+                           "(canon's 0 == UNBOUNDED is NEVER forwarded); rows=" +
+                           std::to_string(out.size()));
+
+        // (b) the assembled block at wire_cap 1: exactly the residual sink.
+        auto t = assemble(lane, md, {}, /*wire_cap=*/1, why);
+        if (CHECK(t != nullptr, "KC-5(b) the template still BUILDS at cap 1 (fail-closed, not "
+                                "fail-stopped): " + why)) {
+            CHECK(resolved_cap(*t) == 1, "KC-5(b) resolved total cap == 1");
+            CHECK(t->outputs().size() == 1 && t->outputs()[0].role == Out::Role::Sink &&
+                  t->outputs()[0].identity == lane.cfg.residual_sink_identity &&
+                  t->outputs()[0].amount == t->reward(),
+                  "KC-5(b) exactly n_fixed + 1 == 1 output: the whole owed budget in the sink [" +
+                  describe(t->outputs()) + "]");
+            CHECK(emitted_owed(*t).empty(),
+                  "KC-5(b) and therefore the FOUND payout map is EMPTY — nothing is decremented "
+                  "for money the sink took");
+        }
+
+        // (c) every carried key keeps its age: the very next block at a normal
+        //     cap pays them in the SAME canonical order, at their FULL owed.
+        auto t2 = assemble(lane, md, {}, 2700, why);
+        if (CHECK(t2 != nullptr, "KC-5(c) next block at a normal cap: " + why)) {
+            const std::vector<RefOut> want = kfair_reference(lane.seeded, t2->reward(), 0, 0,
+                                                             resolved_cap(*t2), 0,
+                                                             lane.cfg.residual_sink_identity);
+            CHECK(same_as_reference(t2->outputs(), want),
+                  "KC-5(c) the CARRIED keys keep their first_eligible ages — same disposition as "
+                  "W4's sub-h_min CARRY, no starvation damage [" + describe(t2->outputs()) + "]");
+            const o2::Amounts owed2 = emitted_owed(*t2);
+            CHECK(owed2.size() == 2 && owed2.at(kA) == 1000000000ll && owed2.at(kB) == 2000000000ll,
+                  "KC-5(c) and both are paid in full by the next block with cap room");
+        }
+    }
+
+    // ---- n_fixed == 2, resolved total cap 3 --------------------------------
+    {
+        o2::OwedLedger led(7);
+        Lane lane(led);
+        lane.cfg.fixed.push_back(x6::FixedOutput{ref_a(), 1000000ull, ::v37::xmr::xmr_identity_key(ref_a())});
+        lane.cfg.fixed.push_back(x6::FixedOutput{ref_b(), 2000000ull, ::v37::xmr::xmr_identity_key(ref_b())});
+        lane.seed(ref_a(), 1000000000ull);
+        lane.seed(ref_b(), 2000000000ull);
+
+        std::vector<x6::OwedEntry> out;
+        std::string why;
+        const bool ok = o2::project_w4_owed(led, lane.fx.pay_of(), 0, /*n_fixed=*/2,
+                                            /*fixed_sum=*/3000000ull, 600000000000ull,
+                                            /*total_output_cap=*/3, out, nullptr, &why);
+        CHECK(ok && out.empty(),
+              "KC-5 n_fixed == 2, total cap 3 => cap_owed == 0 => ZERO owed rows; rows=" +
+              std::to_string(out.size()) + " " + why);
+
+        auto md = miner(3000000, 300000, 18000000000000000000ull);
+        auto t = assemble(lane, md, {}, /*wire_cap=*/3, why);
+        if (CHECK(t != nullptr, "KC-5 n_fixed == 2 template builds at cap 3: " + why)) {
+            CHECK(t->outputs().size() == 3 && emitted_owed(*t).empty(),
+                  "KC-5 exactly n_fixed + 1 == 3 outputs (2 fixed + sink), no owed [" +
+                  describe(t->outputs()) + "]");
+        }
+    }
+}
+
+// KC-6: REACHABILITY + the CONVENTION COLLISION, asserted side by side so a
+// future "simplification" of the new guard fails loudly.
+void kc6() {
+    std::printf("KC-6: cap_owed == 0 is reachable on an ordinary FULL block; the two 0-conventions\n");
+
+    // (a) an ordinary full block resolves the weight-aware cap to 1.
+    CHECK(x6::weight_aware_output_cap(300000, 299900, 2700) == 1,
+          "KC-6(a) weight_aware_output_cap(median 300000, reserved 299900, wire 2700) == 1 — "
+          "cap_owed == 0 arises when the chain is BUSIEST, not from a synthetic config");
+    CHECK(x6::weight_aware_output_cap(300000, 0, 2700) > 1,
+          "KC-6(a) control: an empty block leaves plenty of owed slots");
+
+    // (b) the two conventions, in the same check.
+    o2::OwedLedger led(7);
+    Lane lane(led);
+    lane.seed(ref_a(), 1000000000ull);
+    lane.seed(ref_b(), 2000000000ull);
+
+    auto h_min_0 = [](::v37::ScriptKind) -> std::uint64_t { return 0; };
+    o2::PayOfFn pay = lane.fx.pay_of();
+    const o2::OwedLedger::Proposal p =
+        led.propose_coinbase(600000000000ull, /*slot_budget_C=*/0, pay, h_min_0);
+    CHECK(!p.outs.empty(),
+          "KC-6(b) CANON: OwedLedger::propose_coinbase(slot_budget_C = 0) is UNBOUNDED — it "
+          "proposes " + std::to_string(p.outs.size()) + " rows");
+
+    x6::CoinbaseInputs in;
+    in.monero_major_version = 16;
+    in.height      = 100;
+    in.base_reward = 600000000000ull;
+    in.chain_id    = 7;
+    in.residual_sink          = ref_sink();
+    in.residual_sink_identity = lane.cfg.residual_sink_identity;
+    in.output_cap  = 1;                       // == fixed.size() + 1: LEGAL for X6
+    for (const auto& po : p.outs) {
+        x6::OwedEntry e;
+        e.pay = po.pay; e.identity = po.key; e.owed = po.amount; e.first_eligible = in.owed.size();
+        in.owed.push_back(e);
+    }
+    x6::BuildError err = x6::BuildError::None;
+    const std::vector<Out> outs = x6::allocate_exact_sum(in, &err);
+    std::size_t n_owed = 0;
+    for (const auto& o : outs) if (o.role == Out::Role::Owed) ++n_owed;
+    CHECK(err == x6::BuildError::None && n_owed == 0 && outs.size() == 1,
+          "KC-6(b) X6: allocate_exact_sum with output_cap == fixed.size() + 1 is LEGAL (not "
+          "CapTooSmall) and emits ZERO owed outputs");
+    CHECK(!p.outs.empty() && n_owed == 0,
+          "KC-6(b) THEREFORE the projection MUST TRANSLATE the cap, never forward the 0 — this is "
+          "the guard against 'simplifying' the cap_owed == 0 early return away");
+}
+
+// KC-7: BACK-COMPAT — the new guard is unreachable on the default path, so an
+// empty reproject_owed stays byte-identical to the pre-ruling assembler.
+void kc7() {
+    std::printf("KC-7: the cap_owed == 0 guard is unreachable at the default cap\n");
+
+    o2::OwedLedger led(7);
+    Lane lane(led);
+    lane.seed(ref_a(), 1000000000ull);
+    auto md = miner(3000000, 300000, 18000000000000000000ull);
+
+    std::string why;
+    auto t = assemble(lane, md, {}, 2700, why);
+    if (!CHECK(t != nullptr, "KC-7 assemble: " + why)) return;
+    CHECK(resolved_cap(*t) > 1,
+          "KC-7 the resolved cap on an EMPTY block leaves owed slots (cap=" +
+          std::to_string(resolved_cap(*t)) + "), so the guard never fires");
+    CHECK(!emitted_owed(*t).empty(),
+          "KC-7 and the owed row IS paid — the guard did not swallow it");
+
+    std::vector<x6::OwedEntry> out;
+    const bool ok = o2::project_w4_owed(led, lane.fx.pay_of(), 0, 0, 0, t->reward(),
+                                        resolved_cap(*t), out, nullptr, &why);
+    CHECK(ok && out.size() == 1,
+          "KC-7 project_w4_owed at the resolved cap is unchanged by the guard; rows=" +
+          std::to_string(out.size()));
+}
+
+// The backend-free config/context self-check (S1..S8), including the two RULED
+// refusals and the state-root resolver.
+void fixture_selftest() {
+    std::printf("S: fixture config/context self-check (S1..S8)\n");
+    std::string why;
+    CHECK(o2::selftest::run(&why), "S1..S8 fixture selftest: " + why);
+}
+
+} // namespace
+
+int main() {
+    std::printf("v37_xmr_o2_settlement_kat "
+                "(multi-node option B: W4Propose K_fair + section-13 state-root commitment)\n");
+    CHECK(::v37::xmr::point_check_backend() != nullptr,
+          "prelude: an ed25519 point-check backend is installed (ref10)");
+
+    fixture_selftest();
+    kw1_kc1();
+    kw2();
+    kw3_kw4();
+    ks1_ks2_ks3_ks4();
+    ks5();
+    kc2();
+    kc3();
+    kc4();
+    kf1();
+    kf2();
+    kf3();
+    kc5();
+    kc6();
+    kc7();
+
+    std::printf("summary: %d passed, %d failed\n", g_pass, g_fail);
+    std::printf("RESULT: %s\n", g_fail == 0 ? "GREEN" : "RED");
+    return g_fail == 0 ? 0 : 1;
+}

--- a/src/c2pool/v37/xmr/xmr_finalize_driver.hpp
+++ b/src/c2pool/v37/xmr/xmr_finalize_driver.hpp
@@ -39,6 +39,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -55,6 +56,35 @@ struct FoundBlock {
     Amounts       payout;       // the coinbase outputs broadcast in b (K_fair)
     bool          canonical = true;
 };
+
+// Outcome of a durable owed seed (F-1). Applied == the write-ahead log grew by
+// exactly two events and the ledger moved; AlreadyDurable == the store already
+// carries this seed (this is a RESTART), so NOTHING was written and NOTHING
+// moved; Refused == the seed was malformed and was not written.
+enum class SeedOwedResult : std::uint8_t { Applied = 0, AlreadyDurable = 1, Refused = 2 };
+
+// The STABLE identity of the --owed-demo-amount startup seed inside one
+// data-dir. It is deliberately a fixed string, not a function of the amount or
+// the payee: one demo seed per data-dir, EVER. Re-passing the flag with a
+// different amount after the seed is durable is reported as already-durable and
+// IGNORED (loudly) rather than credited a second time — a second credit is
+// exactly the double-apply F-1 closed. It cannot collide with a Monero block id
+// (64 lowercase hex chars) or with a sidecar bid.
+inline constexpr const char* kOwedDemoSeedBid = "v37-owed-demo-seed";
+// The K_fair age stamp the seed arms at. 1 == the oldest arm-able age (0 is
+// reserved / unarmed), so the seeded row sorts oldest-owed-first ahead of every
+// row a later real FINALIZE arms. Persisted in the WAL and replayed verbatim,
+// so the age ordering is identical on every boot (F1).
+inline constexpr std::uint64_t kOwedDemoSeedBinHeight = 1;
+
+inline const char* to_string(SeedOwedResult r) {
+    switch (r) {
+        case SeedOwedResult::Applied:        return "applied";
+        case SeedOwedResult::AlreadyDurable: return "already-durable";
+        case SeedOwedResult::Refused:        return "refused";
+    }
+    return "?";
+}
 
 // Result of one advance, for the smoke/KAT to assert the F1 discipline.
 struct FinalizeStep {
@@ -91,6 +121,74 @@ public:
         m_ledger.on_block_found(b.bid, b.credit, b.payout);
         m_found.emplace(b.bid, b);
         m_by_height[b.height].push_back(b.bid);
+    }
+
+    // ── F-1 (2026-09-10): THE DURABLE, RESTART-IDEMPOTENT OWED SEED ────────
+    // The ONLY supported way to put a startup-seeded owed row into the LIVE,
+    // store-backed ledger.
+    //
+    // THE DEFECT THIS CLOSES. Before this, --owed-demo-amount called
+    // OwedLedger::on_block_found()/on_block_finalized() DIRECTLY on the node's
+    // ledger, bypassing this driver and therefore the settle-store write-ahead
+    // log. The credit leg was in-memory only; the PAYOUT leg that later drew on
+    // it went through this driver and WAS write-ahead-logged. So after a restart
+    // against the same data-dir, RecoveryDriver replayed the payout with no
+    // matching credit and finalW(k) landed at -(amount paid): a NEGATIVE
+    // effective_owed row that SURVIVES the restart — a §9 no-double-pay /
+    // OI-W4-5 credit-at-finality violation, silent because this store's
+    // RecoveryDriver (unlike w6_persistence's) has no ledger_seq cross-check.
+    // Re-passing the flag then re-credited on top of the recovered ledger, so
+    // the row was applied once PER BOOT rather than once ever.
+    //
+    // THE FIX. The seed becomes two ordinary write-ahead events under a STABLE
+    // bid: FOUND(credit, payout={}) then FINALIZE(bin_height). Two consequences,
+    // both from machinery that already exists:
+    //   * REPLAY-EXACT — on the next boot RecoveryDriver replays those two
+    //     events, so the credit leg is restored exactly like the payout leg and
+    //     finalW nets to the same value a never-restarted node holds. No row can
+    //     go negative for want of a persisted credit.
+    //   * IDEMPOTENT — after that replay the bid sits in the ledger's SETTLED
+    //     (terminal) set, and OwedLedger::on_block_found() is already idempotent
+    //     per bid. We check the same two sets here and return AlreadyDurable
+    //     WITHOUT writing, so the WAL never grows a duplicate seed either.
+    // Net: the seeded row is applied EXACTLY ONCE for the life of the data-dir,
+    // however many times the daemon restarts with the flag still set.
+    //
+    // `bid` must be a stable, caller-owned identifier (NOT a Monero block id);
+    // it is deliberately kept out of m_found/m_by_height, because a seed is not
+    // a mined block and must never be walked by the D_conf finalize cursor.
+    // `bin_height` is the K_fair age stamp; it is persisted and replayed
+    // verbatim (F1), so the age ordering is identical on every boot.
+    //
+    // CONSENSUS-NEUTRAL: this defines no digest and invents no rule. It only
+    // sequences the SAME two OwedLedger calls the seed already made, through the
+    // durable path the rest of this driver already uses.
+    SeedOwedResult seed_owed_durable(const std::string& bid, const Amounts& credit,
+                                     std::uint64_t bin_height) {
+        if (bid.empty() || credit.empty()) return SeedOwedResult::Refused;
+        for (const auto& [k, v] : credit) { (void)k; if (v <= 0) return SeedOwedResult::Refused; }
+        // Already durable: replayed out of the WAL on this boot, or seeded
+        // earlier in this run. Write nothing, move nothing.
+        if (m_ledger.is_settled(bid) || m_ledger.is_pending(bid) || m_seeded.count(bid))
+            return SeedOwedResult::AlreadyDurable;
+
+        SettleEvent found;
+        found.kind   = SettleEvKind::Found;
+        found.bid    = bid;
+        found.credit = credit;                 // payout stays {} — a seed only credits
+        write_event(found);
+        m_ledger.on_block_found(bid, credit, /*payout=*/{});
+
+        SettleEvent fin;
+        fin.kind       = SettleEvKind::Finalize;
+        fin.bid        = bid;
+        fin.bin_height = bin_height;
+        write_event(fin);
+        m_ledger.on_block_finalized(bid, bin_height);
+
+        m_seeded.insert(bid);
+        persist_hw();
+        return SeedOwedResult::Applied;
     }
 
     // A block left the best chain (MainchainEvent Orphan / a Reorg that dropped
@@ -224,6 +322,7 @@ private:
 
     std::map<std::string, FoundBlock>              m_found;      // bid -> block
     std::map<std::uint64_t, std::vector<std::string>> m_by_height; // mined height -> bids
+    std::set<std::string>                          m_seeded;     // F-1: durable owed seeds written this run
 };
 
 } // namespace c2pool::v37n::xmr

--- a/src/c2pool/v37/xmr/xmr_live_submit.hpp
+++ b/src/c2pool/v37/xmr/xmr_live_submit.hpp
@@ -77,6 +77,7 @@
 #include <cstring>
 #include <deque>
 #include <functional>
+#include <map>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -154,7 +155,19 @@ inline bool patch_u32_le(std::vector<std::uint8_t>& blob, std::size_t off, std::
 // the same block header (varint major ‖ varint minor ‖ varint ts ‖ prev[32]) —
 // and validate_candidate() enforces it, so a mismatched pair can never be
 // submitted under the wrong id.
+//
+// R-7 (2026-09-10): the candidate ALSO carries `coinbase_owed` — the Role::Owed
+// outputs of the coinbase in `full_blob`, by identity key. This is the seam the
+// map is captured at ON PURPOSE: the candidate is resolved from the very
+// snapshot whose bytes are submitted, so the FOUND record can never book a
+// payout that a different (or evicted) template would have paid.
 // ===========================================================================
+
+// { identity_key : piconero } over the K_fair OWED outputs of a coinbase. Spelled
+// structurally (bytes32 == std::array<std::uint8_t,32>) so this consumer header
+// never pulls w4_settlement.hpp; it IS OwedLedger::Amounts, and assigns freely.
+using OwedPayout = std::map<std::array<std::uint8_t, 32>, long long>;
+
 struct BlockCandidate {
     std::uint32_t template_id = 0;
     std::uint64_t height = 0;                 // Monero height of the block
@@ -181,6 +194,13 @@ struct BlockCandidate {
     Hash          prev_id{};                  // template prev_hash (zero = unknown)
     std::uint64_t expected_reward = 0;        // piconero (get_block_template.expected_reward)
     std::uint8_t  major_version = 0;          // template major_version (diagnostic)
+
+    // R-7: the K_fair OWED outputs this exact block pays, { identity : amount },
+    // read from the EMITTED coinbase outputs (CoinbaseOutput::Role::Owed only —
+    // never Fixed, never Sink, never a re-run of the W4 projection). EMPTY under
+    // option A (monerod's get_block_template block is not a v37 settlement, so
+    // it extinguishes no owed) and empty for a sink-only option-B block.
+    OwedPayout    coinbase_owed;
 };
 
 // Validate a candidate BEFORE any bytes are touched. Returns "" when sane.
@@ -548,6 +568,11 @@ struct FoundBlockEvent {
     double        rpc_ms = 0.0;
     std::chrono::steady_clock::time_point at{};
 
+    // R-7: carried verbatim from the BlockCandidate that produced the submitted
+    // bytes — the K_fair OWED set this block actually paid. The main thread
+    // books EXACTLY this as OwedLedger's `payout` term.
+    OwedPayout    coinbase_owed;
+
     std::string block_id_hex() const { return mj::hash_to_hex(block_id); }
 };
 
@@ -646,6 +671,10 @@ public:
         ev.id_mismatch  = o.id_mismatch;
         ev.header_check = o.header_check;
         ev.rpc_ms       = o.rpc_ms;
+        // R-7: the K_fair OWED set the SUBMITTED bytes pay, captured from the
+        // same candidate. Never re-looked-up later (a template can be evicted
+        // from the provider ring between submit and the main thread's tick).
+        ev.coinbase_owed = c.coinbase_owed;
         ev.at           = std::chrono::steady_clock::now();
         m_found.push(std::move(ev));
         set_error({});
@@ -702,6 +731,11 @@ inline std::string describe(const FoundBlockEvent& e) {
     if (!e.worker.empty() || !e.address.empty())
         s += " worker=" + (e.worker.empty() ? std::string("-") : e.worker) +
              " addr=" + (e.address.size() > 12 ? e.address.substr(0, 12) + "…" : e.address);
+    // R-7 observability: how much owed this block actually extinguishes.
+    long long owed_sum = 0;
+    for (const auto& [k, v] : e.coinbase_owed) { (void)k; owed_sum += v; }
+    s += " owed_rows=" + std::to_string(e.coinbase_owed.size()) +
+         " owed_paid=" + std::to_string(owed_sum) + "pico";
     return s;
 }
 

--- a/src/c2pool/v37/xmr/xmr_node_config.hpp
+++ b/src/c2pool/v37/xmr/xmr_node_config.hpp
@@ -185,6 +185,13 @@ struct XmrNodeConfig {
     // The owed payee is a distinct torsion-valid payee derived from the sink
     // material with spend/view swapped (see main). Proof-only; no live ledger yet.
     std::uint64_t   owed_demo_amount = 0;
+    // What the coinbase's MM-root leaf (tx_extra 0x03) BINDS, and what seeds the
+    // deterministic tx secret key r. RULED 2026-09-10 (multi-node): the
+    // whitepaper §13 StateCommitment Merkle root ("state-root", the default).
+    // "owed-digest" is the pre-ruling narrower binding and is accepted ONLY
+    // together with --lane-commitment-local-only, for single-pool experiments.
+    std::string     lane_commitment_source = "state-root";
+    bool            lane_commitment_local_only = false;
 
     // --- storage ------------------------------------------------------------
     // When empty, config_path()/<net>/v37_settle_db is used (see xmr_node.hpp).

--- a/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
@@ -1106,6 +1106,209 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
                 !FinalizeConnect::parse_sidecar_line(
                     "2 " + bid5 + " 4242 - 0 - 0 2 " + hex_of(payee) + ":1", junk_bid, junk));
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // phase 4 — F-1: THE STARTUP OWED SEED ACROSS A RESTART
+    //
+    // WHY PHASES 1-3 MASKED F-1. They arm owed the RIGHT way — a FOUND carrying
+    // an S-1-shaped E_b credit, write-ahead-logged by XmrFinalizeDriver — so the
+    // credit leg replays on restart exactly like the payout leg, and FC8a/FC10b
+    // pass. The LIVE daemon's --owed-demo-amount armed owed a DIFFERENT way:
+    // straight into OwedLedger, bypassing the write-ahead log. No phase covered
+    // that path at all, so no assertion could fail on it. "The R-7 acceptance
+    // probe only checks the fresh-boot path" is exactly this: the restart
+    // assertions existed, but never over the seed the daemon actually used.
+    //
+    // 4a is the NEGATIVE CONTROL: it reproduces the OLD non-durable seed and
+    // REQUIRES the restart to come back NEGATIVE. Without it the non-negative
+    // assertion in 4b could pass vacuously (a run that never really paid out of
+    // the seed would satisfy it), and F-1 could walk back in unnoticed.
+    // 4b is the FIX: the same scenario through seed_owed_durable(), which must
+    // come back NON-NEGATIVE and must apply the seed EXACTLY ONCE.
+    // ═══════════════════════════════════════════════════════════════════════
+    {
+        const long long DEMO = 250000000000ll;      // the seeded owed row
+        const ::v37::bytes32 demo_payee = smoke::key_of(0xD1);
+        auto demo_owed = [&](long long a) { Amounts m; if (a) m[demo_payee] = a; return m; };
+
+        // min over effective_owed_all(), read straight off the ledger — this IS
+        // the acceptance probe (FinalizeConnect::min_effective_owed's rule).
+        auto min_eo = [](XmrNode& n) {
+            long long m = 0;
+            for (const auto& [k, v] : n.ledger().effective_owed_all()) { (void)k; if (v < m) m = v; }
+            return m;
+        };
+
+        // Drive one store dir through: seed -> win whose coinbase pays the WHOLE
+        // seed -> bury past D_conf -> FINALIZE -> destroy the node ("crash").
+        // `durable` picks which seed path is used.
+        auto run_and_crash = [&](const std::string& dir, bool durable) -> bool {
+            XmrNodeConfig c;
+            c.network = MoneroNetwork::Stagenet;
+            c.lane_chain = CHAIN;
+            c.d_conf = D_CONF;
+            c.settle_db_path = dir;
+            std::filesystem::create_directories(dir);
+
+            FinalizeConnectOptions fo;
+            fo.sidecar_path = (std::filesystem::path(dir) / "pfound.tsv").string();
+            fo.out = nullptr;
+
+            MockMonerodTransport mock;
+            XmrNode node(c, mock, &smoke::test_point_check);
+            try { node.bring_up(); } catch (const std::exception&) { return false; }
+
+            if (durable) {
+                // THE FIX: two write-ahead events under the stable seed bid.
+                if (node.finalize_driver().seed_owed_durable(
+                        kOwedDemoSeedBid, demo_owed(DEMO), kOwedDemoSeedBinHeight)
+                    != SeedOwedResult::Applied) return false;
+            } else {
+                // THE OLD PATH, verbatim: straight into the ledger, no WAL.
+                node.ledger().on_block_found("legacy-demo-seed", demo_owed(DEMO), /*payout=*/{});
+                node.ledger().on_block_finalized("legacy-demo-seed", kOwedDemoSeedBinHeight);
+            }
+            if (node.ledger().effective_owed(demo_payee) != DEMO) return false;
+
+            FoundBlockQueue lq;
+            FinalizeConnect lfc(node, c, lq, fo);
+            (void)lfc.reseed_after_bring_up();
+
+            chain(node, 1, 5);
+            FoundBlockEvent w;
+            w.height = 5; w.block_id_hex = bid5; w.prev_id_hex = hex_of(smoke::blk_id(4));
+            w.reward_piconero = REWARD; w.payee = demo_payee;
+            w.coinbase_owed = demo_owed(DEMO);       // the coinbase pays the whole seed
+            lq.push(w);
+            auto tt = lfc.tick();
+            if (tt.registered != 1) return false;
+            chain(node, 6, 8);                       // 5 + D_CONF = 8 => FINALIZE
+            tt = lfc.tick();
+            return tt.settled == 1 && node.ledger().is_settled(bid5);
+        };
+
+        // ── 4a NEGATIVE CONTROL — the pre-fix seed MUST come back negative ───
+        const std::string dir_a = (tmp_root / "f1-legacy-seed").string();
+        const bool ran_a = run_and_crash(dir_a, /*durable=*/false);
+        {
+            XmrNodeConfig c;
+            c.network = MoneroNetwork::Stagenet; c.lane_chain = CHAIN; c.d_conf = D_CONF;
+            c.settle_db_path = dir_a;
+            MockMonerodTransport mock;
+            XmrNode node(c, mock, &smoke::test_point_check);
+            bool up = true;
+            try { node.bring_up(); } catch (const std::exception&) { up = false; }
+            const long long m = up ? min_eo(node) : 0;
+            rep.add("FC20 F-1 NEGATIVE CONTROL: the OLD non-durable seed (written straight into the "
+                    "ledger, never into the write-ahead log) DOES leave a negative effective_owed "
+                    "row across a restart — so FC21's non-negative assertion is not vacuous",
+                    ran_a && up && m == -DEMO,
+                    "min_effective_owed=" + std::to_string(m) + " want=" + std::to_string(-DEMO));
+        }
+
+        // ── 4b THE FIX — durable seed, restart, NON-NEGATIVE, applied ONCE ───
+        const std::string dir_b = (tmp_root / "f1-durable-seed").string();
+        const bool ran_b = run_and_crash(dir_b, /*durable=*/true);
+        {
+            XmrNodeConfig c;
+            c.network = MoneroNetwork::Stagenet; c.lane_chain = CHAIN; c.d_conf = D_CONF;
+            c.settle_db_path = dir_b;
+            MockMonerodTransport mock;
+            XmrNode node(c, mock, &smoke::test_point_check);
+            bool up = true;
+            try { node.bring_up(); } catch (const std::exception&) { up = false; }
+
+            const long long m = up ? min_eo(node) : -1;
+            rep.add("FC21 F-1: after a RESTART against the SAME data-dir, NO effective_owed row is "
+                    "negative (min_effective_owed >= 0) — the seed's credit leg replayed out of the "
+                    "write-ahead log alongside the payout that drew on it",
+                    ran_b && up && m >= 0,
+                    "min_effective_owed=" + std::to_string(m));
+            rep.add("FC21b F-1: the seeded row nets to EXACTLY zero after the restart — credited "
+                    "once, paid once (whitepaper 9 no-double-pay / OI-W4-5)",
+                    up && node.ledger().effective_owed(demo_payee) == 0,
+                    "eo=" + std::to_string(up ? node.ledger().effective_owed(demo_payee) : -1));
+            rep.add("FC21c F-1: the store replay restored the seed as SETTLED (terminal) under its "
+                    "stable bid",
+                    up && node.ledger().is_settled(kOwedDemoSeedBid));
+
+            // Re-passing --owed-demo-amount on the restart must be a NO-OP: no
+            // ledger movement, and no new write-ahead event either.
+            const auto seq_before = up ? node.ledger().ledger_seq() : 0;
+            const auto evt_before = up ? node.finalize_driver().event_seq() : 0;
+            const auto again = up ? node.finalize_driver().seed_owed_durable(
+                                        kOwedDemoSeedBid, demo_owed(DEMO), kOwedDemoSeedBinHeight)
+                                  : SeedOwedResult::Refused;
+            rep.add("FC22 F-1: re-passing the startup seed after a restart is reported "
+                    "already-durable and applies NOTHING — ledger_seq and the write-ahead event "
+                    "sequence both unchanged (applied EXACTLY ONCE per data-dir)",
+                    up && again == SeedOwedResult::AlreadyDurable &&
+                    node.ledger().ledger_seq() == seq_before &&
+                    node.finalize_driver().event_seq() == evt_before &&
+                    min_eo(node) >= 0,
+                    std::string("result=") + to_string(again) +
+                    " seq=" + std::to_string(up ? node.ledger().ledger_seq() : 0) +
+                    "/" + std::to_string(seq_before) +
+                    " evt=" + std::to_string(up ? node.finalize_driver().event_seq() : 0) +
+                    "/" + std::to_string(evt_before));
+
+            // A seed with a DIFFERENT amount is equally refused — one demo seed
+            // per data-dir, ever. (Silently crediting a second amount is the
+            // same double-apply wearing a different number.)
+            const auto other = up ? node.finalize_driver().seed_owed_durable(
+                                        kOwedDemoSeedBid, demo_owed(DEMO * 3), kOwedDemoSeedBinHeight)
+                                  : SeedOwedResult::Refused;
+            rep.add("FC22b F-1: a restart passing a DIFFERENT --owed-demo-amount is also "
+                    "already-durable — the flag is ignored, never credited a second time",
+                    up && other == SeedOwedResult::AlreadyDurable && min_eo(node) >= 0);
+        }
+
+        // ── 4c restart INSIDE the D_conf window (the payout still pending):
+        //    effective_owed must be seed - in-flight payout == 0, never negative.
+        {
+            const std::string dir_c = (tmp_root / "f1-durable-midwindow").string();
+            std::filesystem::create_directories(dir_c);
+            XmrNodeConfig c;
+            c.network = MoneroNetwork::Stagenet; c.lane_chain = CHAIN; c.d_conf = D_CONF;
+            c.settle_db_path = dir_c;
+            FinalizeConnectOptions fo;
+            fo.sidecar_path = (std::filesystem::path(dir_c) / "pfound.tsv").string();
+            fo.out = nullptr;
+            bool armed = false;
+            {
+                MockMonerodTransport mock;
+                XmrNode node(c, mock, &smoke::test_point_check);
+                try { node.bring_up(); } catch (const std::exception&) {}
+                armed = node.finalize_driver().seed_owed_durable(
+                            kOwedDemoSeedBid, demo_owed(DEMO), kOwedDemoSeedBinHeight)
+                        == SeedOwedResult::Applied;
+                FoundBlockQueue lq;
+                FinalizeConnect lfc(node, c, lq, fo);
+                (void)lfc.reseed_after_bring_up();
+                chain(node, 1, 5);
+                FoundBlockEvent w;
+                w.height = 5; w.block_id_hex = bid5; w.prev_id_hex = hex_of(smoke::blk_id(4));
+                w.reward_piconero = REWARD; w.payee = demo_payee;
+                w.coinbase_owed = demo_owed(DEMO);
+                lq.push(w);
+                auto tt = lfc.tick();
+                armed = armed && tt.registered == 1;
+                chain(node, 6, 7);                   // hw = 7 < 5 + 3: still pending
+                tt = lfc.tick();
+                armed = armed && tt.settled == 0 && node.ledger().is_pending(bid5);
+            }
+            MockMonerodTransport mock;
+            XmrNode node(c, mock, &smoke::test_point_check);
+            bool up = true;
+            try { node.bring_up(); } catch (const std::exception&) { up = false; }
+            rep.add("FC23 F-1: a restart INSIDE the D_conf window (the payout still pending) also "
+                    "recovers non-negative — effective_owed == seed - in-flight payout == 0",
+                    armed && up && min_eo(node) >= 0 && node.ledger().is_pending(bid5) &&
+                    node.ledger().effective_owed(demo_payee) == 0,
+                    "min=" + std::to_string(up ? min_eo(node) : -1) +
+                    " eo=" + std::to_string(up ? node.ledger().effective_owed(demo_payee) : -1));
+        }
+    }
     return rep;
 }
 

--- a/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
@@ -29,11 +29,44 @@
 //       submit_block returned "OK"; the main loop drains it in tick().
 //       Replaces the WIP FoundEvent/FoundQueue (xmr_o2_serve.hpp:338-358),
 //       which carried only a height.
-//   (2) Amount-honest credit/payout for the option-A (monerod-template) block:
-//       credit == payout == { identity_key(payout XMR_STD ref) : reward }, so
-//       finalW nets to 0 at FINALIZE and the FOUND/FINALIZE audit trail carries
-//       the real amount. Without a payee key the degenerate {}/{} record is
-//       used (the ledger still bumps; the block is recorded as valueless).
+//   (2) R-7 RECONCILIATION (2026-09-10) — the FOUND record books what the
+//       COINBASE ACTUALLY PAID, against the SAME OwedLedger the coinbase drew
+//       EffectiveOwed from (XmrNode::ledger()).
+//         payout := the emitted CoinbaseOutput::Role::Owed set of the block's
+//                   own coinbase, { identity : amount }, carried across the
+//                   listener->main thread boundary in FoundBlockEvent (filled
+//                   at the submit seam from the very snapshot whose bytes were
+//                   submitted). NEVER Role::Fixed / Role::Sink — those keys were
+//                   never credited, so booking them would drive their finalW
+//                   permanently negative. NEVER a re-run of project_w4_owed —
+//                   X6 may legitimately emit fewer rows than W4 proposed.
+//         credit := {} — E_b, the per-key entitlement from the fold over b's
+//                   burial-gated prefix, requires an XMR sharechain emission
+//                   that does NOT exist yet (Track A2 S-1). The empty map is
+//                   the honest value; when S-1 lands it fills
+//                   FoundBlockEvent::credit and nothing else here changes.
+//       This replaces the previous "amount-honest" record credit == payout ==
+//       { --payee-* identity : FULL block reward }. That record was FICTIONAL
+//       under option B: the operator's --payee key is not a payee of the v37
+//       coinbase at all (the coinbase pays the K_fair owed rows plus the
+//       residual sink), and it produced TWO empirically confirmed defects —
+//         (a) effective_owed(payee) = finalW(0) - SUM_pending payout went
+//             NEGATIVE by one full reward per concurrent pending FOUND;
+//         (b) the settlement ledger the coinbase read was a DIFFERENT object
+//             from the node ledger FINALIZE booked into, so it was never
+//             decremented and re-proposed the SAME owed row at its full
+//             EffectiveOwed on EVERY block — a no-double-pay violation of the
+//             whitepaper section 9 / OI-W4-5 credit-at-finality contract.
+//       Under option A (monerod get_block_template, --payout-address) the block
+//       is not a v37 settlement at all and both maps are EMPTY: the ledger still
+//       registers the block, its ledger_seq still bumps, no key is created.
+//       INVARIANTS this restores (w4_settlement.hpp:531-542 / :485-500):
+//         INV-1  effective_owed(k) >= 0 at every step, FOUND and FINALIZE alike;
+//         INV-2  on_block_finalized moves effective_owed(k) by EXACTLY
+//                +credit[k] (it removes the same payout from the pending term
+//                that it subtracts from finalW) — invariant when credit == {},
+//                never decreasing. effective_owed legitimately DROPS at FOUND:
+//                that is the pending-payout deduction the coinbase drew on.
 //   (3) The LATE-FOUND guard: XmrFinalizeDriver::advance_to_tip steps only
 //       heights ABOVE its cursor (:155). A FOUND registered at a height the
 //       cursor already passed would sit pending FOREVER (its payout deducted
@@ -160,7 +193,21 @@ struct FoundBlockEvent {
                                           // compares hex_of(index.by_height(H).id) == bid
     std::string   prev_id_hex;            // template prev_hash (informational; cross-check only)
     std::uint64_t reward_piconero = 0;    // get_block_template.expected_reward (or chain_main.reward)
-    std::optional<::v37::bytes32> payee;  // identity_key of the payout descriptor (payee_identity_key)
+    std::optional<::v37::bytes32> payee;  // identity_key of the --payee-* descriptor.
+                                          // INFORMATIONAL ONLY since R-7: it is the
+                                          // operator's own wallet, NOT a coinbase payee
+                                          // under option B, and is never booked.
+
+    // ── R-7: what the block's coinbase ACTUALLY paid / credited ─────────────
+    // coinbase_owed: the emitted CoinbaseOutput::Role::Owed outputs of THIS
+    //   block, { identity_key : piconero }. Filled at the submit seam from the
+    //   snapshot whose bytes were submitted (submit::BlockCandidate::
+    //   coinbase_owed). EMPTY under option A and for a sink-only block.
+    // credit: E_b, the per-key entitlement over b's burial-gated prefix.
+    //   ALWAYS EMPTY today — there is no XMR sharechain fold yet (Track A2 S-1).
+    //   The field exists so the S-1 landing is a fill, not a re-wiring.
+    Amounts       coinbase_owed;
+    Amounts       credit;
     std::uint32_t template_id = 0;        // stratum bookkeeping (logged only)
     std::uint32_t nonce = 0;
     std::uint32_t extra_nonce = 0;
@@ -220,10 +267,21 @@ class FinalizeConnect {
 public:
     struct PendingRec {
         std::uint64_t height = 0;
-        std::optional<::v37::bytes32> payee;
-        std::uint64_t reward = 0;
+        std::optional<::v37::bytes32> payee;   // informational (see FoundBlockEvent::payee)
+        std::uint64_t reward = 0;              // informational
         std::string   prev_id_hex;
         std::uint64_t found_unix_s = 0;
+        // R-7: the MAPS THAT WERE BOOKED must survive a restart inside the
+        // D_conf window. Before R-7 the sidecar carried only payee+reward and
+        // the re-drive reconstructed a payout from them — so a restart could
+        // re-drive a DIFFERENT payout than the block paid. Persisted since
+        // sidecar schema v2.
+        Amounts       coinbase_owed;           // the booked `payout` term
+        Amounts       credit;                  // the booked `credit` term ({} until S-1)
+        // A v1 (pre-R-7) sidecar line carries no maps. Such a record is
+        // re-driven with EMPTY maps (the fail-safe direction: owed is never
+        // over-decremented) and says so, loudly, once per boot.
+        bool          legacy_v1 = false;
     };
     struct RegisterResult {
         bool        registered = false;
@@ -244,6 +302,8 @@ public:
     struct Stats {
         std::uint64_t registered = 0, refused = 0, late_refused = 0, settled = 0,
                       orphaned = 0, sidecar_write_failures = 0;
+        long long     owed_booked = 0;   // R-7: Σ piconero of owed the FOUNDs extinguish
+        std::uint64_t split_brain_refused = 0;   // payout > effective_owed (INV-1 precheck)
     };
 
     // Construct AFTER node.bring_up() (the finalize driver exists) and AFTER
@@ -319,9 +379,16 @@ public:
             // `pending` == false: the sidecar was written but the crash hit before
             // the FOUND write-ahead -> this IS the registration (monerod had
             // accepted the block before the sidecar was written).
-            Amounts credit = amounts_from(rec.payee, rec.reward, nullptr);
-            Amounts payout = credit;
-            const bool ok = m_node.on_network_block_won(rec.height, id, credit, payout);
+            // R-7: re-drive the SAME maps the original FOUND booked, read back
+            // from the sidecar — never re-derived from payee/reward.
+            if (rec.legacy_v1)
+                say("boot: PRE-R-7 (schema v1) sidecar record " + short_bid(bid) +
+                    " carries no coinbase-owed map; re-driving with EMPTY credit/payout. "
+                    "If the ledger already holds this bid pending (store replay) its booked "
+                    "payout is unchanged (on_block_found is idempotent per bid); otherwise the "
+                    "owed this block paid stays owed and will be paid again by a later block — "
+                    "operator must reconcile by hand");
+            const bool ok = m_node.on_network_block_won(rec.height, id, rec.credit, rec.coinbase_owed);
             if (!ok || !m_node.ledger().is_pending(bid)) {
                 ++rep.stale_dropped;
                 say("boot: sidecar " + short_bid(bid) + " not admitted by the node/ledger; dropped");
@@ -395,9 +462,44 @@ public:
                                   "drain the found queue BEFORE pump_poll / lower --poll-ms");
         }
 
+        // ── R-7: book what the coinbase ACTUALLY paid ───────────────────────
+        // payout := the emitted Role::Owed set (empty under option A / for a
+        //           sink-only block); credit := E_b ({} until Track A2 S-1).
+        // A payout key must be one the ledger CREDITED (w4_settlement.hpp:
+        // 485-500 subtracts the payout term from finalW), so a row whose amount
+        // is <= 0 is dropped rather than booked — a defensive fail-closed, the
+        // emitted set never carries one.
+        Amounts payout;
+        for (const auto& [k, v] : ev.coinbase_owed) if (v > 0) payout[k] = v;
+        Amounts credit;
+        for (const auto& [k, v] : ev.credit) if (v != 0) credit[k] = v;
+
+        // NON-NEGATIVITY PRECHECK (INV-1, fail-closed). propose_coinbase caps
+        // each take at EffectiveOwed, so a well-formed payout can never push a
+        // key negative; a payout that WOULD is proof that the coinbase was built
+        // against a different ledger than this one — exactly the split-brain R-7
+        // closes. Refuse loudly rather than poison the ledger. (The block is
+        // already on-chain either way; refusing costs the v37 record, booking a
+        // negative costs every future K_fair proposal.)
+        for (const auto& [k, v] : payout) {
+            const long long eo = m_node.ledger().effective_owed(k);
+            if (v > eo) {
+                ++m_stats.split_brain_refused;
+                return refuse(r, bid,
+                    "R-7 REFUSED: coinbase pays " + std::to_string(v) + " to key " +
+                    hex_of(k).substr(0, 12) + "… but its effective_owed is only " +
+                    std::to_string(eo) + " — the coinbase was built against a DIFFERENT "
+                    "ledger than the finalize driver writes (split-brain); not booking a "
+                    "negative owed");
+            }
+        }
+
         std::string why_valueless;
-        Amounts credit = amounts_from(ev.payee, ev.reward_piconero, &why_valueless);
-        Amounts payout = credit;
+        if (payout.empty() && credit.empty())
+            why_valueless = ev.coinbase_owed.empty()
+                ? "no K_fair owed outputs in this coinbase (option A, or the whole reward "
+                  "went to the residual sink) and no E_b credit yet (Track A2 S-1 pending)"
+                : "every coinbase owed row was non-positive";
 
         PendingRec rec;
         rec.height = ev.height;
@@ -405,6 +507,8 @@ public:
         rec.reward = ev.reward_piconero;
         rec.prev_id_hex = lower_hex(ev.prev_id_hex);
         rec.found_unix_s = ev.found_unix_s;
+        rec.coinbase_owed = payout;
+        rec.credit = credit;
 
         // write-ahead the sidecar, then the FOUND event (inside on_network_block_won)
         m_pending[bid] = rec;
@@ -428,9 +532,17 @@ public:
             return refuse(r, bid, "ledger did not admit the FOUND (bid already known?)");
         }
         ++m_stats.registered;
+        long long owed_paid = 0;
+        for (const auto& [k, v] : payout) { (void)k; owed_paid += v; }
+        m_stats.owed_booked += owed_paid;
         say("FOUND registered " + short_bid(bid) + " h=" + std::to_string(ev.height) +
-            " reward=" + std::to_string(ev.reward_piconero) + " piconero payee=" +
+            " reward=" + std::to_string(ev.reward_piconero) + " piconero" +
+            " owed_rows=" + std::to_string(payout.size()) +
+            " owed_paid=" + std::to_string(owed_paid) +
+            " credit_rows=" + std::to_string(credit.size()) +
+            " (operator payee=" +
             (ev.payee ? hex_of(*ev.payee).substr(0, 12) + "…" : std::string("-")) +
+            ", informational)" +
             (why_valueless.empty() ? "" : " [VALUELESS record: " + why_valueless + "]") +
             (ev.worker.empty() ? "" : " worker=" + ev.worker) +
             " tid=" + std::to_string(ev.template_id) + " nonce=" + std::to_string(ev.nonce) +
@@ -440,23 +552,25 @@ public:
         return r;
     }
 
-    // credit == payout == { payee : reward } (amount-honest, nets to 0 at
-    // FINALIZE); {} when no payee / zero reward (the degenerate valueless record).
-    static Amounts amounts_from(const std::optional<::v37::bytes32>& payee, std::uint64_t reward,
-                                std::string* why_valueless) {
-        Amounts a;
-        auto because = [&](const char* s) { if (why_valueless) *why_valueless = s; };
-        if (!payee)   { because("no payee identity key (address boundary not decoded)"); return a; }
-        if (reward == 0) { because("zero reward"); return a; }
-        if (reward > static_cast<std::uint64_t>(LLONG_MAX)) { because("reward exceeds long long"); return a; }
-        a[*payee] = static_cast<long long>(reward);
-        return a;
-    }
+    // (R-7, 2026-09-10) The former `amounts_from(payee, reward)` helper — which
+    // synthesised credit == payout == { --payee-* identity : FULL block reward }
+    // — is GONE. It booked a record no coinbase ever paid; see the banner. The
+    // FOUND maps now come from the block's own emitted outputs, carried in
+    // FoundBlockEvent, and option A books the degenerate {}/{} directly.
 
     // ── read seams (main thread) ────────────────────────────────────────────
     const std::map<std::string, PendingRec>& pending()       const { return m_pending; }
     const std::map<std::string, PendingRec>& unrecoverable() const { return m_unrecoverable; }
     const Stats& stats() const { return m_stats; }
+
+    // R-7 acceptance probe: min over effective_owed_all(). Must be >= 0 at every
+    // point of a healthy run, INCLUDING while blocks are pending. 0 on an empty
+    // ledger. This is the number the regtest re-proof records.
+    long long min_effective_owed() const {
+        long long m = 0;
+        for (const auto& [k, v] : m_node.ledger().effective_owed_all()) { (void)k; if (v < m) m = v; }
+        return m;
+    }
 
 private:
     RegisterResult& refuse(RegisterResult& r, const std::string& bid, std::string reason) {
@@ -477,11 +591,21 @@ private:
             const PendingRec&  rec = it->second;
             if (m_node.ledger().is_settled(bid)) {
                 ++t.settled; ++m_stats.settled;
+                // R-7 observability: effective_owed of the keys THIS block paid
+                // (the operator's --payee-* key is not one of them under option
+                // B), plus the ledger-wide minimum. Both must stay >= 0 for the
+                // whole run — that is the acceptance criterion the split-ledger
+                // wiring violated by one full reward per pending FOUND.
+                std::string per_key;
+                for (const auto& [k, v] : rec.coinbase_owed) {
+                    (void)v;
+                    per_key += " effective_owed(" + hex_of(k).substr(0, 12) + "…)=" +
+                               std::to_string(m_node.ledger().effective_owed(k));
+                }
                 say("FINALIZED " + short_bid(bid) + " h=" + std::to_string(rec.height) +
                     " SETTLED at bin_height=" + std::to_string(rec.height + m_cfg.d_conf) +
-                    (rec.payee ? " effective_owed(payee)=" +
-                                 std::to_string(m_node.ledger().effective_owed(*rec.payee))
-                               : std::string("")) +
+                    per_key +
+                    " min_effective_owed=" + std::to_string(min_effective_owed()) +
                     " ledger_seq=" + std::to_string(m_node.ledger().ledger_seq()));
                 it = m_pending.erase(it); changed = true;
             } else if (!m_node.ledger().is_pending(bid)) {
@@ -530,15 +654,55 @@ private:
         return bid.size() > 12 ? bid.substr(0, 12) + "…" : bid;
     }
 
+public:
     // ── sidecar codec: one record per line, space-separated, no escaping needed
-    //    (bids/keys are hex; '-' = absent):
-    //    1 <bid64> <height> <payee64|-> <reward> <prev64|-> <found_unix_s>
+    //    (bids/keys are hex; '-' = absent).
+    //    PUBLIC since R-7 so the self-check can pin the schema-v2 round trip and
+    //    the v1 legacy path directly, without standing up a live node.
+    //
+    //    SCHEMA v2 (R-7, 2026-09-10) — the BOOKED MAPS are persisted, because a
+    //    restart inside the D_conf window must re-drive the SAME payout the block
+    //    paid, not one re-derived from payee/reward:
+    //      2 <bid64> <height> <payee64|-> <reward> <prev64|-> <found_unix_s>
+    //        <n_owed> [<key64>:<amount> ...] <n_credit> [<key64>:<amount> ...]
+    //
+    //    SCHEMA v1 (pre-R-7) is still PARSED, so a node that crashed under the
+    //    old build still finds its pending FOUNDs at boot. A v1 record carries no
+    //    maps: it is flagged legacy_v1 and re-driven with EMPTY credit/payout
+    //    (the fail-safe direction — owed is never over-decremented — and loudly
+    //    reported). v1 is never WRITTEN again.
+    static std::string amounts_field(const Amounts& a) {
+        std::string s = std::to_string(a.size());
+        for (const auto& [k, v] : a) s += " " + hex_of(k) + ":" + std::to_string(v);
+        return s;
+    }
+    static bool parse_amounts_field(std::istringstream& is, Amounts& out) {
+        out.clear();
+        unsigned long long n = 0;
+        if (!(is >> n)) return false;
+        if (n > 100000) return false;              // sanity bound: a coinbase has far fewer outputs
+        for (unsigned long long i = 0; i < n; ++i) {
+            std::string tok;
+            if (!(is >> tok)) return false;
+            const std::size_t colon = tok.find(':');
+            if (colon != 64) return false;         // exactly a 64-hex key then ':'
+            ::v37::bytes32 k{};
+            if (!hash_from_hex(lower_hex(tok.substr(0, 64)), k)) return false;
+            long long v = 0;
+            try { v = std::stoll(tok.substr(colon + 1)); } catch (...) { return false; }
+            out[k] = v;
+        }
+        return true;
+    }
+
     static std::string sidecar_line(const std::string& bid, const PendingRec& r) {
-        std::string s = "1 " + bid + " " + std::to_string(r.height) + " " +
+        std::string s = "2 " + bid + " " + std::to_string(r.height) + " " +
                         (r.payee ? hex_of(*r.payee) : std::string("-")) + " " +
                         std::to_string(r.reward) + " " +
                         (r.prev_id_hex.size() == 64 ? r.prev_id_hex : std::string("-")) + " " +
-                        std::to_string(r.found_unix_s) + "\n";
+                        std::to_string(r.found_unix_s) + " " +
+                        amounts_field(r.coinbase_owed) + " " +
+                        amounts_field(r.credit) + "\n";
         return s;
     }
     static bool parse_sidecar_line(const std::string& line, std::string& bid, PendingRec& r) {
@@ -546,7 +710,7 @@ private:
         std::string ver, payee, prev;
         unsigned long long h = 0, reward = 0, ts = 0;
         if (!(is >> ver >> bid >> h >> payee >> reward >> prev >> ts)) return false;
-        if (ver != "1") return false;
+        if (ver != "1" && ver != "2") return false;
         std::array<std::uint8_t, 32> tmp{};
         bid = lower_hex(bid);
         if (!hash_from_hex(bid, tmp)) return false;
@@ -565,9 +729,18 @@ private:
             if (!hash_from_hex(prev, tmp)) return false;
             r.prev_id_hex = prev;
         }
+        if (ver == "1") {                 // pre-R-7 record: no maps on the wire
+            r.legacy_v1 = true;
+            r.coinbase_owed.clear();
+            r.credit.clear();
+            return true;
+        }
+        if (!parse_amounts_field(is, r.coinbase_owed)) return false;
+        if (!parse_amounts_field(is, r.credit)) return false;
         return true;
     }
 
+private:
     bool sidecar_flush() {
         if (m_o.sidecar_path.empty()) return true;
         std::string body;
@@ -615,10 +788,25 @@ private:
 // ===========================================================================
 // SELF-CHECK — network-free, RandomX-free, against the monerod STUB; the same
 // shape as xmr_node_smoke.hpp so it can run under `--mock-smoke` / the CI
-// smoke target. Proves: queued win -> FOUND (amount-honest) -> restart inside
-// the D_conf window -> sidecar re-drive -> FINALIZE at bin_height = H_b+D_conf
-// -> finalW nets to 0 -> sidecar retired; plus the late-FOUND and malformed
-// refusals, the valueless record, idempotence, and the orphan disposition.
+// smoke target.
+//
+// RE-PINNED for R-7 (2026-09-10). The old FC3/FC10/FC16 asserted the FICTIONAL
+// record (credit == payout == { --payee-* : FULL reward }, effective_owed ==
+// -reward while pending). They ENCODED the defect. They now assert the
+// reconciled contract:
+//   INV-1  effective_owed(k) >= 0 at EVERY step (FOUND and FINALIZE alike);
+//   INV-2  a FINALIZE moves effective_owed(k) by EXACTLY +credit[k] — invariant
+//          when credit == {}, never decreasing. effective_owed legitimately
+//          DROPS at FOUND: that is the pending-payout deduction the coinbase
+//          drew on, and asserting monotonicity across FOUND would be wrong.
+//
+// Proves, end to end: an S-1-shaped credit block arms owed -> a settlement win
+// whose coinbase pays part of that owed -> restart inside the D_conf window ->
+// the schema-v2 sidecar re-drives the SAME payout map (never one re-derived
+// from payee/reward) -> FINALIZE at bin_height = H_b + D_conf extinguishes the
+// owed EXACTLY ONCE -> sidecar retired; plus the split-brain precheck, the
+// late-FOUND / malformed / zero-bid refusals, the valueless (option-A) record,
+// idempotence, the v1 legacy-sidecar path, and the orphan disposition.
 // ===========================================================================
 #include "xmr_node_smoke.hpp"   // smoke::Report, apply_row, blk_id, key_of, test_point_check
 #include "impl/xmr/node/monerod_transport.hpp"   // MockMonerodTransport
@@ -630,7 +818,11 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
     smoke::Report rep;
     const ::v37::ChainId CHAIN = 7;
     const std::uint64_t  D_CONF = 3;
-    const std::uint64_t  REWARD = 600000000000ull;   // 0.6 XMR in piconero
+    const std::uint64_t  REWARD = 600000000000ull;    // 0.6 XMR in piconero (block reward)
+    // The K_fair owed this lane holds, and what two coinbases pay out of it.
+    const long long SEED  = 600000000000ll;           // E_b credit that ARMS the owed
+    const long long TAKE  = 100000000000ll;           // block 5's Role::Owed output
+    const long long TAKE2 =  50000000000ll;           // block 11's (orphaned) output
 
     XmrNodeConfig cfg;
     cfg.network = MoneroNetwork::Stagenet;
@@ -644,8 +836,9 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
     o.out = nullptr;   // silent
 
     const ::v37::bytes32 payee = smoke::key_of(0xC3);
-    const std::string bid5 = hex_of(smoke::blk_id(5));
-    const std::string bid8 = hex_of(smoke::blk_id(8));
+    const std::string bid2  = hex_of(smoke::blk_id(2));
+    const std::string bid5  = hex_of(smoke::blk_id(5));
+    const std::string bid8  = hex_of(smoke::blk_id(8));
     const std::string bid11 = hex_of(smoke::blk_id(11));
     FoundBlockQueue q;
 
@@ -659,31 +852,90 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
             smoke::apply_row(node, h, smoke::blk_id(static_cast<std::uint8_t>(h)),
                              smoke::blk_id(static_cast<std::uint8_t>(h - 1)));
     };
+    // One owed row: { payee : amount }. The SHAPE of an emitted Role::Owed set.
+    auto owed_of = [&](long long amount) {
+        Amounts a;
+        if (amount != 0) a[payee] = amount;
+        return a;
+    };
 
-    // ── phase 1: node A — win at 5, buried 2 (< D_conf), then "crash" ────────
+    // ── phase 1: node A — arm owed, win at 5, bury 2 (< D_conf), then "crash" ─
     {
         MockMonerodTransport mock;
         XmrNode node(cfg, mock, &smoke::test_point_check);
         try { node.bring_up(); } catch (const std::exception& e) {
             rep.add("FC0 bring_up (node A)", false, e.what()); return rep;
         }
-        chain(node, 1, 5);
         FinalizeConnect fc(node, cfg, q, o);
         auto boot = fc.reseed_after_bring_up();
         rep.add("FC1 fresh boot: no sidecar, nothing reseeded",
                 !boot.sidecar_present && boot.reseeded == 0 && boot.reregistered == 0);
 
+        // ── ARM the owed through the DURABLE path (a FOUND carrying an
+        //    S-1-shaped E_b credit and no coinbase owed outputs), so the credit
+        //    is in the settle-store write-ahead log and survives the restart.
+        chain(node, 1, 2);
+        FoundBlockEvent seed_ev;
+        seed_ev.height = 2; seed_ev.block_id_hex = bid2;
+        seed_ev.prev_id_hex = hex_of(smoke::blk_id(1));
+        seed_ev.reward_piconero = REWARD; seed_ev.payee = payee;
+        seed_ev.credit = owed_of(SEED);              // E_b (Track A2 S-1 shape)
+        q.push(seed_ev);
+        auto t = fc.tick();
+        const long long eo_before_credit_finalize = node.ledger().effective_owed(payee);
+        rep.add("FC-A0 a credit-only FOUND registers and leaves effective_owed UNCHANGED "
+                "(credit lands at FINALITY, not at FOUND — OI-W4-5)",
+                t.registered == 1 && node.ledger().is_pending(bid2) &&
+                eo_before_credit_finalize == 0,
+                "eo=" + std::to_string(eo_before_credit_finalize));
+
+        chain(node, 3, 5);                            // hw=5 => bin_height 2 => FINALIZE bid2
+        t = fc.tick();
+        rep.add("FC-A1 INV-2: FINALIZE raised effective_owed by EXACTLY credit[k]",
+                t.settled == 1 && node.ledger().is_settled(bid2) &&
+                node.ledger().effective_owed(payee) == eo_before_credit_finalize + SEED,
+                "eo=" + std::to_string(node.ledger().effective_owed(payee)));
+
+        // ── the settlement win: its coinbase pays TAKE of the armed owed ──────
         FoundBlockEvent ev;
         ev.height = 5; ev.block_id_hex = bid5; ev.prev_id_hex = hex_of(smoke::blk_id(4));
         ev.reward_piconero = REWARD; ev.payee = payee; ev.worker = "rig0"; ev.template_id = 42;
+        ev.coinbase_owed = owed_of(TAKE);             // the EMITTED Role::Owed set
         q.push(ev); q.push(ev);                       // duplicate push (idempotent per bid)
-        auto t = fc.tick();
+        t = fc.tick();
         rep.add("FC2 queued win -> on_network_block_won: ledger pending, idempotent per bid",
                 t.drained == 2 && t.registered == 1 && t.refused == 0 &&
                 fc.pending().size() == 1 && node.ledger().is_pending(bid5),
                 "drained=" + std::to_string(t.drained) + " registered=" + std::to_string(t.registered));
-        rep.add("FC3 amount-honest: effective_owed(payee) == -reward while pending",
-                node.ledger().effective_owed(payee) == -static_cast<long long>(REWARD));
+        rep.add("FC3 R-7 INV-1: effective_owed(payee) == seeded - take and is NON-NEGATIVE "
+                "while the block is pending (never -reward)",
+                node.ledger().effective_owed(payee) == SEED - TAKE &&
+                node.ledger().effective_owed(payee) >= 0 && fc.min_effective_owed() == 0,
+                "eo=" + std::to_string(node.ledger().effective_owed(payee)) +
+                " min=" + std::to_string(fc.min_effective_owed()));
+        rep.add("FC3b the FOUND booked EXACTLY the coinbase-paid owed set",
+                fc.pending().count(bid5) == 1 &&
+                fc.pending().at(bid5).coinbase_owed == owed_of(TAKE) &&
+                fc.pending().at(bid5).credit.empty() &&
+                fc.stats().owed_booked == TAKE);
+
+        // FC3c SPLIT-BRAIN PRECHECK: a coinbase claiming to pay more owed than
+        // this ledger holds is proof it was built against a DIFFERENT ledger.
+        // Refused loudly instead of poisoning effective_owed negative.
+        {
+            FoundBlockEvent over = ev;
+            over.block_id_hex = hex_of(smoke::blk_id(6));
+            over.height = 6;
+            over.coinbase_owed = owed_of(SEED * 4);
+            q.push(over);
+            const auto before = node.ledger().effective_owed(payee);
+            t = fc.tick();
+            rep.add("FC3c split-brain payout (> effective_owed) is REFUSED, ledger untouched",
+                    t.refused == 1 && fc.stats().split_brain_refused == 1 &&
+                    !node.ledger().is_pending(hex_of(smoke::blk_id(6))) &&
+                    node.ledger().effective_owed(payee) == before);
+        }
+
         rep.add("FC4 pending-FOUND sidecar written (write-ahead, 1 record)",
                 count_lines(o.sidecar_path) == 1);
 
@@ -696,6 +948,7 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
 
         // late FOUND: cursor is 7-3=4, a win claimed at h=3 can never be stepped
         FoundBlockEvent late = ev; late.height = 3; late.block_id_hex = hex_of(smoke::blk_id(3));
+        late.coinbase_owed.clear();
         q.push(late);
         t = fc.tick();
         rep.add("FC6 late FOUND (height <= finalize cursor) refused, not poisoned into the ledger",
@@ -724,6 +977,11 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
             rep.add("FC0 bring_up (node B)", false, e.what()); return rep;
         }
         const bool recovered_pending = node.ledger().is_pending(bid5);
+        rep.add("FC8a the store replay restored the ARMED owed and the pending payout "
+                "(effective_owed == seeded - take across the restart)",
+                node.ledger().effective_owed(payee) == SEED - TAKE,
+                "eo=" + std::to_string(node.ledger().effective_owed(payee)));
+
         FinalizeConnect fc(node, cfg, q, o);
         auto boot = fc.reseed_after_bring_up();
         rep.add("FC8 restart: sidecar re-drives the pending FOUND into the fresh driver",
@@ -734,46 +992,119 @@ inline smoke::Report finalize_connect_selfcheck(const std::filesystem::path& tmp
         const auto seq_before = node.ledger().ledger_seq();
         rep.add("FC8b re-drive left the ledger untouched (ledger_seq unchanged, still pending)",
                 node.ledger().ledger_seq() == seq_before && node.ledger().is_pending(bid5));
+        // R-7: the SCHEMA-v2 sidecar round-trips the booked payout map BYTE-FOR-
+        // BYTE. Before the schema bump the re-drive rebuilt a payout out of
+        // payee+reward — a DIFFERENT map from the one the block paid.
+        rep.add("FC8c sidecar v2 round-trip: the re-driven payout map is byte-equal to the "
+                "map the block paid (not re-derived from payee/reward)",
+                fc.pending().count(bid5) == 1 &&
+                fc.pending().at(bid5).coinbase_owed.size() == 1 &&
+                fc.pending().at(bid5).coinbase_owed.count(payee) == 1 &&
+                fc.pending().at(bid5).coinbase_owed.at(payee) == TAKE &&
+                !fc.pending().at(bid5).legacy_v1);
 
         chain(node, 5, 8);                            // index rebuilt from 5; hw -> 8 = 5+3
+        const long long eo_before = node.ledger().effective_owed(payee);
         auto t = fc.tick();
         rep.add("FC9 FOUND -> FINALIZE at D_conf burial after restart (bin_height = 5+3 = 8)",
                 t.settled == 1 && node.ledger().is_settled(bid5) && fc.pending().empty(),
                 "settled=" + std::to_string(t.settled));
-        rep.add("FC10 finalW nets to 0 for the payee (credit == payout)",
-                node.ledger().effective_owed(payee) == 0);
+        rep.add("FC10 R-7 INV-2: FINALIZE with credit == {} leaves effective_owed UNCHANGED "
+                "(the take was extinguished exactly ONCE, at FOUND)",
+                node.ledger().effective_owed(payee) == eo_before &&
+                node.ledger().effective_owed(payee) == SEED - TAKE,
+                "eo=" + std::to_string(node.ledger().effective_owed(payee)));
+        rep.add("FC10b INV-1 holds across the whole run: no ledger row is negative",
+                fc.min_effective_owed() == 0);
         rep.add("FC11 sidecar retired after FINALIZE", count_lines(o.sidecar_path) == 0);
         bool logged = false;
         for (const auto& l : node.construction_log())
             if (l.find("SETTLED at bin_height=8") != std::string::npos) logged = true;
         rep.add("FC12 the node logged the FINALIZE step with the per-height bin_height (echoed by tick)", logged);
 
-        // valueless win (no payee decoded) still records the block
+        // OPTION-A / valueless win: monerod's own template pays no v37 owed, so
+        // the record is the degenerate {}/{} — the ledger registers the block and
+        // its ledger_seq bumps, but NO key is created and NO owed moves.
+        const long long eo_pre_a = node.ledger().effective_owed(payee);
+        const std::size_t keys_pre_a = node.ledger().effective_owed_all().size();
         FoundBlockEvent v; v.height = 8; v.block_id_hex = bid8;
         q.push(v);
         t = fc.tick();
-        rep.add("FC13 valueless win (no payee) still registers (degenerate {}/{})",
-                t.registered == 1 && node.ledger().is_pending(bid8));
+        rep.add("FC13 option-A / valueless win registers as the degenerate {}/{} record",
+                t.registered == 1 && node.ledger().is_pending(bid8) &&
+                fc.pending().at(bid8).coinbase_owed.empty() &&
+                fc.pending().at(bid8).credit.empty() &&
+                node.ledger().effective_owed(payee) == eo_pre_a &&
+                node.ledger().effective_owed_all().size() == keys_pre_a);
         chain(node, 9, 11);
         t = fc.tick();
-        rep.add("FC14 valueless win finalizes at 8+3=11", t.settled == 1 && node.ledger().is_settled(bid8));
+        rep.add("FC14 valueless win finalizes at 8+3=11 and moves no owed",
+                t.settled == 1 && node.ledger().is_settled(bid8) &&
+                node.ledger().effective_owed(payee) == eo_pre_a);
 
-        // orphan disposition: win at 11, then a competing 11 wins the chain
-        FoundBlockEvent w; w.height = 11; w.block_id_hex = bid11; w.payee = payee; w.reward_piconero = REWARD;
+        // orphan disposition: win at 11 paying TAKE2, then a competing 11 wins
+        FoundBlockEvent w; w.height = 11; w.block_id_hex = bid11; w.payee = payee;
+        w.reward_piconero = REWARD; w.coinbase_owed = owed_of(TAKE2);
         q.push(w);
         t = fc.tick();
         const bool reg11 = t.registered == 1 && node.ledger().is_pending(bid11);
+        const bool owed_dropped_at_found =
+            node.ledger().effective_owed(payee) == SEED - TAKE - TAKE2;
         smoke::apply_row(node, 11, smoke::blk_id(99), smoke::blk_id(10));   // reorg at 11
         chain(node, 12, 14);                          // bury the competitor: 11+3 = 14
         t = fc.tick();
         // the Orphan event or the canonical predicate at maturity disposed it
         rep.add("FC15 orphaned win leaves the pending set (never SETTLED) and the sidecar",
-                reg11 && !node.ledger().is_pending(bid11) && !node.ledger().is_settled(bid11) &&
+                reg11 && owed_dropped_at_found &&
+                !node.ledger().is_pending(bid11) && !node.ledger().is_settled(bid11) &&
                 fc.pending().empty() && count_lines(o.sidecar_path) == 0 && fc.stats().orphaned == 1,
                 "orphaned=" + std::to_string(fc.stats().orphaned));
-        rep.add("FC16 orphan: payee's effective_owed back to 0 (pure pending removal)",
-                node.ledger().effective_owed(payee) == 0);
+        rep.add("FC16 orphan: the pending payout is returned — effective_owed back to "
+                "seeded - take (pure pending removal, never a clawback)",
+                node.ledger().effective_owed(payee) == SEED - TAKE &&
+                fc.min_effective_owed() == 0,
+                "eo=" + std::to_string(node.ledger().effective_owed(payee)));
         (void)fc.drain_before_stop();
+    }
+
+    // ── phase 3: the sidecar CODEC itself (schema v2 + the v1 legacy path) ────
+    {
+        FinalizeConnect::PendingRec r;
+        r.height = 4242;
+        r.payee = payee;
+        r.reward = REWARD;
+        r.prev_id_hex = hex_of(smoke::blk_id(4));
+        r.found_unix_s = 1700000000ull;
+        r.coinbase_owed[payee] = TAKE;
+        r.coinbase_owed[smoke::key_of(0xA1)] = TAKE2;
+        r.credit[smoke::key_of(0xB2)] = SEED;
+
+        const std::string line = FinalizeConnect::sidecar_line(bid5, r);
+        std::string bid_out;
+        FinalizeConnect::PendingRec back;
+        const bool ok = FinalizeConnect::parse_sidecar_line(line, bid_out, back);
+        rep.add("FC17 sidecar v2 codec round-trips both maps exactly",
+                ok && bid_out == bid5 && back.height == r.height &&
+                back.coinbase_owed == r.coinbase_owed && back.credit == r.credit &&
+                !back.legacy_v1);
+
+        // A pre-R-7 (v1) line still parses, carries no maps, and says so.
+        const std::string v1 = "1 " + bid5 + " 4242 " + hex_of(payee) + " " +
+                               std::to_string(REWARD) + " " + hex_of(smoke::blk_id(4)) +
+                               " 1700000000";
+        FinalizeConnect::PendingRec legacy;
+        std::string legacy_bid;
+        const bool ok1 = FinalizeConnect::parse_sidecar_line(v1, legacy_bid, legacy);
+        rep.add("FC18 a pre-R-7 (schema v1) sidecar line still parses, with EMPTY maps and the "
+                "legacy flag set (fail-safe: owed is never over-decremented)",
+                ok1 && legacy.legacy_v1 && legacy.coinbase_owed.empty() && legacy.credit.empty() &&
+                legacy.height == 4242);
+
+        FinalizeConnect::PendingRec junk;
+        std::string junk_bid;
+        rep.add("FC19 a truncated v2 line is REFUSED (never a half-parsed payout map)",
+                !FinalizeConnect::parse_sidecar_line(
+                    "2 " + bid5 + " 4242 - 0 - 0 2 " + hex_of(payee) + ":1", junk_bid, junk));
     }
     return rep;
 }

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
@@ -55,11 +55,14 @@
 // consensus digest. It only READS OwedLedger::owed_digest() and serialises it
 // into the Monero coinbase's tx_extra 0x03; the Monero block is validated by
 // monerod (RandomX + HF13 exact-sum), not by any v37 rule. The single-pool
-// proof needs no operator tap. Two knobs become LANE consensus the moment
-// Option B goes multi-node and each must then ship as an operator-tap DRAFT
-// (never a silent flip): `kfair` (W4Propose vs X6Allocate) and `lc_source`
-// (which digest r and the MM root bind). They are EXPLICIT flags here until
-// tapped — the whole point of surfacing them in the config value.
+// proof needs no operator tap. Two knobs are LANE consensus the moment Option B
+// goes multi-node — `kfair` (which K_fair rule picks the payees) and
+// `lc_source` (which value r and the MM root bind). Both were RULED by the
+// operator on 2026-09-10 and are now PINNED, fail-closed, in
+// validate_structural(): kfair == W4Propose (the one ratified K_fair rule,
+// whitepaper E-1) and lc_source == StateRoot (the whitepaper §13
+// StateCommitment Merkle root). This PR ships them as a DRAFT: the operator
+// merges/activates, never a silent flip.
 //
 // FAIL-CLOSED (defence in depth over XmrOwedSettlementSource::build's own):
 //   * residual_sink MUST be a well-formed XMR ref (kind XMR_STD/XMR_SUB, 64-B
@@ -100,17 +103,31 @@ namespace c2pool::v37n::xmr::o2 {
 // Which digest r and the MM root bind. A consensus ruling the moment Option B
 // is multi-node (survey gate flag (2)); explicit here until tapped.
 // ---------------------------------------------------------------------------
+// RULED 2026-09-10 (multi-node): StateRoot. The other two are refused by
+// validate_structural unless allow_nonruled_local_only is set for a
+// single-pool experiment (never for a lane with peers).
+// ---------------------------------------------------------------------------
 enum class LaneCommitmentSource : std::uint8_t {
-    OwedDigest = 0,   // ledger.owed_digest() — the §4.5 OWED commitment (recommended)
+    OwedDigest = 0,   // ledger.owed_digest() — the §4.5 OWED commitment (pre-ruling default)
     Explicit   = 1,   // an operator-supplied bytes32 (lane digest / SettlementView::digest)
+    StateRoot  = 2,   // RULED: the whitepaper §13 StateCommitment Merkle root
 };
 
 inline const char* to_string(LaneCommitmentSource s) {
     switch (s) {
         case LaneCommitmentSource::OwedDigest: return "owed-digest";
         case LaneCommitmentSource::Explicit:   return "explicit";
+        case LaneCommitmentSource::StateRoot:  return "state-root";
     }
     return "?";
+}
+
+// Parse the --lane-commitment operator flag. Returns false on an unknown name.
+inline bool parse_lane_commitment_source(const std::string& s, LaneCommitmentSource& out) {
+    if (s == "state-root"  || s == "state_root")  { out = LaneCommitmentSource::StateRoot;  return true; }
+    if (s == "owed-digest" || s == "owed_digest") { out = LaneCommitmentSource::OwedDigest; return true; }
+    if (s == "explicit")                          { out = LaneCommitmentSource::Explicit;   return true; }
+    return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -156,10 +173,16 @@ struct XmrSettlementConfig {
     // --- mandated fixed outputs (dev / donation / finder), usually empty ---
     std::vector<x6::FixedOutput> fixed;
 
-    // --- rulings (operator-tap DRAFT once multi-node; explicit flags here) ---
+    // --- RULED 2026-09-10 (multi-node consensus): both values are now pinned.
+    //     kfair     == W4Propose : the ONE ratified K_fair rule (E-1).
+    //     lc_source == StateRoot : the coinbase commits the §13 state root.
+    //     Any other combination is REFUSED by validate_structural unless
+    //     allow_nonruled_local_only is set (single-pool experiments only —
+    //     a node that sets it can never agree with a ruled peer).
     KFairSource          kfair     = KFairSource::W4Propose;
-    LaneCommitmentSource lc_source = LaneCommitmentSource::OwedDigest;
+    LaneCommitmentSource lc_source = LaneCommitmentSource::StateRoot;
     ::v37::bytes32       lane_commitment_explicit{};   // used iff lc_source == Explicit
+    bool                 allow_nonruled_local_only = false;
 
     // ---- sink constructors (payout-target bytes, never address strings) ----
     // Set the sink from raw 32-byte key material; also fills residual_sink_identity.
@@ -210,6 +233,16 @@ struct XmrSettlementConfig {
         if (lc_source == LaneCommitmentSource::Explicit &&
             lane_commitment_explicit == ::v37::bytes32{})
             return no("XmrSettlementConfig: lc_source == Explicit but lane_commitment_explicit is zero");
+        // ---- the two multi-node rulings, enforced before any crypto ----
+        if (kfair != KFairSource::W4Propose)
+            return no("RULED 2026-09-10: KFairSource must be W4Propose "
+                      "(canonical K_fair propose_coinbase, whitepaper E-1); got " +
+                      std::string(to_string(kfair)));
+        if (lc_source != LaneCommitmentSource::StateRoot && !allow_nonruled_local_only)
+            return no("RULED 2026-09-10: lane_commitment must be the §13 StateCommitment "
+                      "state root (--lane-commitment state-root); got " +
+                      std::string(to_string(lc_source)) +
+                      " (set allow_nonruled_local_only only for a single-pool experiment)");
         if (why) why->clear();
         return true;
     }
@@ -266,8 +299,9 @@ inline ::v37::bytes32 resolve_lane_commitment(const XmrSettlementConfig& cfg,
     switch (cfg.lc_source) {
         case LaneCommitmentSource::OwedDigest: return lane_commitment_from_owed_digest(ledger);
         case LaneCommitmentSource::Explicit:   return cfg.lane_commitment_explicit;
+        case LaneCommitmentSource::StateRoot:  return lane_commitment_from_state_root(ledger);
     }
-    return lane_commitment_from_owed_digest(ledger);
+    return lane_commitment_from_state_root(ledger);   // RULED default
 }
 
 // ---------------------------------------------------------------------------
@@ -352,6 +386,25 @@ inline x6::CoinbaseInputs assembly_settle_inputs(const XmrOwedSettlementSource& 
     return in;
 }
 
+// ---------------------------------------------------------------------------
+// The RULED per-reward re-projection callback for AssemblyInputs.reproject_owed
+// (RULED 2026-09-10). Binding it makes the assembler re-derive the canonical
+// K_fair owed rows — OwedLedger::propose_coinbase — at EVERY reward its
+// count-invariance fixpoint visits, and at the RESOLVED (weight-aware) total
+// output cap, so the payee set the block pays is the proposal at the reward the
+// block actually pays. Both the daemon provider and the KATs bind THIS
+// function, so there is exactly one wiring to review.
+//
+// The ledger is captured by POINTER (never by reference to a caller local): the
+// callback is copied into the assembler's seam, which the AssembledTemplate
+// owns for as long as that template is retained. `fixture` must therefore
+// outlive every template built with the returned callback.
+// ---------------------------------------------------------------------------
+class XmrOwedFixture;   // defined below
+inline ReprojectOwedFn make_reproject_owed(const XmrSettlementConfig& cfg,
+                                           XmrOwedFixture& fixture);
+
+
 // ===========================================================================
 // XmrOwedFixture — the deterministic proof ledger (survey item E). The X9
 // observe-side daemon has no live XMR OwedLedger yet, so the FOUND->FINALIZE
@@ -370,7 +423,23 @@ inline x6::CoinbaseInputs assembly_settle_inputs(const XmrOwedSettlementSource& 
 // ===========================================================================
 class XmrOwedFixture {
 public:
-    explicit XmrOwedFixture(::v37::ChainId chain) : m_ledger(chain) {}
+    // OWNING form (KATs, self-checks, single-shot experiments): the fixture
+    // holds its own OwedLedger.
+    explicit XmrOwedFixture(::v37::ChainId chain)
+        : m_owned(std::in_place, chain), m_ledger(*m_owned) {}
+
+    // NON-OWNING form — R-7 (2026-09-10), the ONE-LEDGER wiring. The live
+    // daemon MUST hand the provider the SAME OwedLedger the finalize driver
+    // writes (XmrNode::ledger(): store-backed, RecoveryDriver-replayed,
+    // XmrFinalizeDriver-driven). Two disjoint ledgers — a settlement one the
+    // coinbase pays from and a node one FINALIZE books into — is the split-brain
+    // this ctor exists to kill: block N+1's propose_coinbase would never see
+    // block N's pending payout deducted, so it would re-propose the SAME owed
+    // row at its full EffectiveOwed on EVERY block (a no-double-pay violation of
+    // whitepaper section 9 / OI-W4-5), while the node ledger's effective_owed
+    // went negative by one reward per pending FOUND.
+    // `external` must outlive this fixture and every template built from it.
+    explicit XmrOwedFixture(OwedLedger& external) : m_ledger(external) {}
 
     // Credit + finalize `amount` piconero owed to XMR ref `pay`. Its ledger key
     // is the canon identity_key(pay); the resolver learns pay for that key.
@@ -409,11 +478,29 @@ public:
     std::size_t       seeded() const { return m_paymap.size(); }
 
 private:
-    OwedLedger                            m_ledger;
+    // Declaration order is load-bearing: m_owned is constructed before the
+    // reference that binds to it.
+    std::optional<OwedLedger>             m_owned;   // engaged only in the OWNING form
+    OwedLedger&                           m_ledger;  // the ledger actually used
     std::map<::v37::bytes32, ::v37::ScriptRef> m_paymap;
     std::uint64_t                         m_next_bid = 0;
     std::uint64_t                         m_next_age = 1;   // 0 reserved / unarmed
 };
+
+inline ReprojectOwedFn make_reproject_owed(const XmrSettlementConfig& cfg,
+                                           XmrOwedFixture& fixture) {
+    XmrOwedFixture*     fx      = &fixture;
+    PayOfFn             pay_of  = fixture.pay_of();
+    const std::uint64_t h_min   = cfg.h_min;
+    const std::size_t   n_fixed = cfg.fixed.size();
+    std::uint64_t       fixed_sum = 0;
+    for (const auto& f : cfg.fixed) fixed_sum += f.amount;
+    return [fx, pay_of, h_min, n_fixed, fixed_sum](std::uint64_t reward, std::uint32_t output_cap,
+                                                    std::vector<x6::OwedEntry>& out, std::string* why) {
+        return project_w4_owed(fx->ledger(), pay_of, h_min, n_fixed, fixed_sum,
+                               reward, output_cap, out, nullptr, why);
+    };
+}
 
 // ===========================================================================
 // Structural self-check (no crypto backend needed). A KAT TU can call
@@ -459,7 +546,7 @@ inline bool run(std::string* why = nullptr) {
         if (bad.validate_structural(&w)) return fail("S3: cap-too-small (fixed+sink) accepted");
     }
     // (S4) make_xmr_coinbase_context copies every field through and defaults the
-    //      lane commitment to the empty ledger's owed_digest.
+    //      lane commitment to the RULED §13 StateCommitment state root.
     {
         XmrOwedFixture fx(7);
         XmrParentContext parent;
@@ -469,8 +556,11 @@ inline bool run(std::string* why = nullptr) {
         if (!ctx) return fail("S4: context build refused: " + w);
         if (ctx->chain_id != 7)                       return fail("S4: chain_id not copied");
         if (ctx->output_cap != cfg.resolved_output_cap()) return fail("S4: output_cap not resolved");
-        if (!(ctx->lane_commitment == fx.ledger().owed_digest()))
-            return fail("S4: lane_commitment != owed_digest (default source)");
+        if (!(ctx->lane_commitment ==
+              ::c2pool::v37n::coinbase::StateCommitment(fx.ledger(), fx.ledger().chain()).root()))
+            return fail("S4: lane_commitment != §13 state root (RULED default source)");
+        if (ctx->lane_commitment == ::v37::bytes32{})
+            return fail("S4: §13 state root is zero (summary leaf must always exist)");
         if (!(ctx->residual_sink == cfg.residual_sink)) return fail("S4: sink not copied");
     }
     // (S5) chain-id mismatch between config and ledger is refused.
@@ -492,6 +582,55 @@ inline bool run(std::string* why = nullptr) {
         if (!::v37::xmr::is_xmr_kind(po(key).kind))    return fail("S6: resolver lost the seeded ref");
         ::v37::bytes32 miss{}; miss[0] = 0xEE;
         if (::v37::xmr::is_xmr_kind(po(miss).kind))    return fail("S6: resolver invented a ref (must be RAW/carry)");
+    }
+    // (S7) resolve_lane_commitment(StateRoot) IS StateCommitment::root(), and it
+    //      MOVES when one balance moves by a single piconero (the negative
+    //      control the §13 binding rests on).
+    {
+        XmrOwedFixture fx(7);
+        std::array<std::uint8_t, 32> b = ::v37::xmr::kat::STD_KAT.p0;
+        std::array<std::uint8_t, 32> a = ::v37::xmr::kat::STD_KAT.p1;
+        fx.seed_owed_std(b, a, 1000000);
+        const ::v37::bytes32 want =
+            ::c2pool::v37n::coinbase::StateCommitment(fx.ledger(), fx.ledger().chain()).root();
+        if (!(resolve_lane_commitment(cfg, fx.ledger()) == want))
+            return fail("S7: resolve_lane_commitment(StateRoot) != StateCommitment::root()");
+
+        XmrOwedFixture fx2(7);
+        fx2.seed_owed_std(b, a, 1000001);            // ONE piconero apart
+        const ::v37::bytes32 other =
+            ::c2pool::v37n::coinbase::StateCommitment(fx2.ledger(), fx2.ledger().chain()).root();
+        if (want == other) return fail("S7: §13 root did not move for a 1-piconero balance change");
+
+        XmrSettlementConfig od = cfg;
+        od.lc_source = LaneCommitmentSource::OwedDigest;
+        od.allow_nonruled_local_only = true;
+        if (!(resolve_lane_commitment(od, fx.ledger()) == fx.ledger().owed_digest()))
+            return fail("S7: the owed-digest escape hatch no longer resolves to owed_digest");
+        if (resolve_lane_commitment(od, fx.ledger()) == want)
+            return fail("S7: owed_digest == §13 root (the two bindings must differ)");
+    }
+    // (S8) the two RULED knobs are refused at config level, before any crypto.
+    {
+        XmrSettlementConfig bad = cfg;
+        bad.kfair = KFairSource::X6Allocate;
+        std::string w;
+        if (bad.validate_structural(&w)) return fail("S8: X6Allocate accepted");
+        if (w.find("RULED") == std::string::npos) return fail("S8: X6Allocate refusal does not name the ruling");
+
+        XmrSettlementConfig bad2 = cfg;
+        bad2.lc_source = LaneCommitmentSource::OwedDigest;
+        if (bad2.validate_structural(&w)) return fail("S8: non-ruled lane_commitment accepted");
+        if (w.find("RULED") == std::string::npos) return fail("S8: lane-commitment refusal does not name the ruling");
+
+        bad2.allow_nonruled_local_only = true;       // single-pool experiment escape hatch
+        if (!bad2.validate_structural(&w)) return fail("S8: local-only override still refused: " + w);
+
+        LaneCommitmentSource p{};
+        if (!parse_lane_commitment_source("state-root", p) || p != LaneCommitmentSource::StateRoot)
+            return fail("S8: parse_lane_commitment_source(state-root)");
+        if (parse_lane_commitment_source("nonsense", p))
+            return fail("S8: parse_lane_commitment_source accepted an unknown name");
     }
     if (why) why->clear();
     return true;

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_fixture.hpp
@@ -441,13 +441,64 @@ public:
     // `external` must outlive this fixture and every template built from it.
     explicit XmrOwedFixture(OwedLedger& external) : m_ledger(external) {}
 
+    // DURABLE non-owning form — F-1 (2026-09-10). Same wiring as above, but the
+    // caller declares that `external` is backed by the settle-store write-ahead
+    // log (XmrNode::ledger()). That single bit is what lets this fixture REFUSE
+    // a non-durable in-memory seed instead of silently creating a credit leg the
+    // store cannot replay (see seed_owed below). The live daemon uses THIS ctor;
+    // KATs driving a bare in-memory OwedLedger use the plain one above.
+    struct DurableLedger {};   // tag
+    XmrOwedFixture(OwedLedger& external, DurableLedger)
+        : m_ledger(external), m_durable(true) {}
+
+    // Is this fixture's ledger the fixture's OWN in-memory one?
+    bool owns_ledger() const { return m_owned.has_value(); }
+    // Is it declared settle-store backed (so a direct ledger write is not durable)?
+    bool durable_ledger() const { return m_durable; }
+
+    // ── F-1 (2026-09-10): RESOLVER-ONLY LEARN ──────────────────────────────
+    // Teach the pay_of resolver that identity_key(pay) is paid to `pay`, WITHOUT
+    // touching the ledger. This is what the live daemon calls on EVERY boot: the
+    // owed ROW is durable (settle-store WAL, replayed by RecoveryDriver) but this
+    // key->ScriptRef map is in-memory and must be rebuilt each run, or a
+    // recovered owed row would resolve to the RAW sentinel and be CARRIED
+    // forever instead of paid. Idempotent by construction. Returns the key.
+    ::v37::bytes32 learn_pay(const ::v37::ScriptRef& pay) {
+        ::v37::bytes32 key = ::v37::xmr::xmr_identity_key(pay);
+        m_paymap[key] = pay;
+        return key;
+    }
+    ::v37::bytes32 learn_pay_std(const std::array<std::uint8_t, 32>& spend_B,
+                                 const std::array<std::uint8_t, 32>& view_A) {
+        return learn_pay(::v37::xmr::make_xmr_std(spend_B, view_A));
+    }
+
     // Credit + finalize `amount` piconero owed to XMR ref `pay`. Its ledger key
     // is the canon identity_key(pay); the resolver learns pay for that key.
     // bin_height auto-increments so each seed arms at a distinct (older-first)
     // age — matching the K_fair oldest-owed-first order. Returns the key.
+    //
+    // ── F-1 FAIL-CLOSED (2026-09-10) ────────────────────────────────────────
+    // This writes into the ledger DIRECTLY, which is fine for an in-memory
+    // ledger (the OWNING form, and the plain non-owning form the KATs drive:
+    // nothing there has to survive anything).
+    // Against a SETTLE-STORE-BACKED ledger it is the F-1 defect: a direct write
+    // is invisible to the write-ahead log, so RecoveryDriver cannot replay the
+    // credit leg on the next boot — while the PAYOUT that drew on it, which DID
+    // go through XmrFinalizeDriver's WAL, replays fine. finalW then lands at
+    // -(amount paid): a NEGATIVE effective_owed row that survives the restart
+    // (§9 no-double-pay / OI-W4-5), and re-passing the flag re-credits on top of
+    // the recovered ledger, so the row is applied once per boot instead of once
+    // ever. Silent, because this store's RecoveryDriver has no ledger_seq
+    // cross-check to trip on the missing events.
+    // So when the caller declared the ledger durable, this REFUSES: it learns
+    // the payee for the resolver and returns the key, but moves NO owed. The
+    // durable route is XmrFinalizeDriver::seed_owed_durable(), which is
+    // replay-exact and restart-idempotent. Refusing in code, rather than
+    // trusting a comment, is what keeps the defect from walking back in.
     ::v37::bytes32 seed_owed(const ::v37::ScriptRef& pay, std::uint64_t amount) {
-        ::v37::bytes32 key = ::v37::xmr::xmr_identity_key(pay);
-        m_paymap[key] = pay;
+        ::v37::bytes32 key = learn_pay(pay);
+        if (m_durable) return key;   // F-1: never a non-durable write to a store-backed ledger
         const std::string bid = "fixture-seed-" + std::to_string(m_next_bid++);
         OwedLedger::Amounts credit; credit[key] = static_cast<long long>(amount);
         m_ledger.on_block_found(bid, credit, /*payout=*/{});
@@ -485,6 +536,7 @@ private:
     std::map<::v37::bytes32, ::v37::ScriptRef> m_paymap;
     std::uint64_t                         m_next_bid = 0;
     std::uint64_t                         m_next_age = 1;   // 0 reserved / unarmed
+    bool                                  m_durable = false; // F-1: settle-store backed
 };
 
 inline ReprojectOwedFn make_reproject_owed(const XmrSettlementConfig& cfg,

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_provider.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_provider.hpp
@@ -101,6 +101,12 @@ struct SettlementSnapshot {
     std::size_t                              n_outputs = 0;
     std::size_t                              n_tx = 0;
     bool                                     valid = false;
+    // The settlement source this template was cut from. RETAINED (it used to be
+    // dropped at the end of assemble()) so the FOUND record can reach
+    // owed_digest() / ledger_seq() / lane_commitment — the §13 state root the
+    // block commits — instead of having to re-derive them from a ledger that
+    // may have moved on. Immutable after build; shared by value with the ring.
+    std::shared_ptr<const XmrOwedSettlementSource> src;
 };
 
 // ---------------------------------------------------------------------------
@@ -218,7 +224,31 @@ public:
         out.prev_id         = snap.prev_id;
         out.expected_reward = snap.reward;
         out.major_version   = snap.major_version;
+        // R-7 (2026-09-10): the K_fair OWED set THESE bytes pay, read from the
+        // EMITTED coinbase outputs of the SAME AssembledTemplate that produced
+        // full_blob. Captured here, at the submit seam, so the FOUND record can
+        // never book a payout belonging to a different (or since-evicted)
+        // template. Role::Fixed / Role::Sink are EXCLUDED: their identities were
+        // never credited into finalW, so booking them would drive those keys
+        // permanently negative (w4_settlement.hpp:485-500).
+        out.coinbase_owed = owed_payout_of(*snap.tpl);
         return true;
+    }
+
+    // { identity : piconero } over the emitted Role::Owed outputs of an
+    // assembled template. Amounts are extra_nonce-INDEPENDENT (the nonce only
+    // enters tx_extra), so one map is authoritative for every share of this
+    // template. Never re-runs project_w4_owed: X6's owed pass may legitimately
+    // emit FEWER rows than W4 proposed (the budget-truncated sub-h_min tail
+    // BREAKs and the sink absorbs it, xmr_coinbase.cpp:135-139, while W4 CARRYs
+    // and keeps scanning, w4_settlement.hpp:586-587), and booking the proposal
+    // would decrement owed for money the residual sink actually swallowed.
+    static submit::OwedPayout owed_payout_of(const asm_::AssembledTemplate& tpl) {
+        submit::OwedPayout m;
+        for (const auto& o : tpl.outputs())
+            if (o.role == x6::CoinbaseOutput::Role::Owed)
+                m[o.identity] += static_cast<long long>(o.amount);
+        return m;
     }
 
     // Fill a stratum job blob for (template_id, extra_nonce). Shared by get_job
@@ -296,6 +326,11 @@ private:
         a.miner   = xmr_md;
         a.mempool = asm_::from_backlog(md.tx_backlog);       // empty on regtest => n_tx == 0
         a.settle  = assembly_settle_inputs(*src, /*weight_aware_cap=*/true);
+        // RULED 2026-09-10: re-derive the canonical K_fair set at every reward
+        // the assembler's fixpoint visits, at the RESOLVED weight-aware cap.
+        // Main-thread only — the assembler runs entirely inside this call, and
+        // assemble() is main-thread by the provider's contract.
+        a.reproject_owed = make_reproject_owed(scfg, m_ledger);   // m_ledger outlives the ring
 
         std::string as_why;
         std::unique_ptr<asm_::AssembledTemplate> tpl = asm_::XmrBlockAssembler::build(a, &as_why);
@@ -317,6 +352,7 @@ private:
         std::memcpy(snap.seed_hash.data(), md.seed_hash.data(), strat::HASH_SIZE);
         snap.n_outputs        = snap.tpl->outputs().size();
         snap.n_tx             = snap.tpl->n_tx();
+        snap.src              = std::shared_ptr<const XmrOwedSettlementSource>(src.release());
         snap.valid            = true;
         why.clear();
         return true;

--- a/src/c2pool/v37/xmr/xmr_o2_settlement_source.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_settlement_source.hpp
@@ -24,8 +24,12 @@
 // It never touches src/sharechain/v37 (its descriptor_xmr header is a
 // read-only value consumer, exactly as X6 uses it).
 //
-// WHERE THE K_FAIR SET COMES FROM (the survey's gate flag, ruling owed):
-//   * KFairSource::W4Propose (DEFAULT, recommended): the owed output set and
+// WHERE THE K_FAIR SET COMES FROM — RULED 2026-09-10 (multi-node): W4Propose,
+// and ONLY W4Propose. build() REFUSES any other source (fail-closed), and the
+// projection lives in the free function project_w4_owed() below so the
+// assembler can RE-PROJECT it at every reward its fixpoint visits — the block
+// pays the proposal at the reward it ACTUALLY settles on, not at a stale hint.
+//   * KFairSource::W4Propose (RULED): the owed output set and
 //     order are OwedLedger::propose_coinbase (w4_settlement.hpp:565 — the
 //     canonical (first_eligible ASC, key ASC) walk with take = min(owed,
 //     budget) and CARRY on take < h_min). X6 is then a pure crypto/serialize
@@ -33,7 +37,9 @@
 //     index), h_min := 0, so allocate_exact_sum reproduces the proposal
 //     byte-for-byte and appends the residual sink. This is the BTC W5 shape
 //     ("the order is W4's and cannot drift", w5_coinbase.hpp:299-322).
-//   * KFairSource::X6Allocate (alternative, needs AgeOf): owed := every
+//   * KFairSource::X6Allocate (REFUSED since the ruling; the enum value is
+//     kept for one release so an old config fails LOUDLY instead of silently
+//     changing meaning): owed := every
 //     EffectiveOwed > 0 with first_eligible := age_of(key) and h_min := ctx.h_min;
 //     X6's own sort + skip/break rule decides (mbp_wiring.hpp OwedCoinbaseBridge
 //     shape). Kept ONLY so the operator ruling is a one-line flip.
@@ -49,6 +55,13 @@
 //   keccak(MM_LEAF_DOMAIN || chain_id_le32 || lane_commitment) are fixed for
 //   the template's lifetime. Only the AMOUNTS vary with the reward the template
 //   settles on, and those are re-allocated deterministically in split_reward().
+//
+// LANE COMMITMENT — RULED 2026-09-10 (multi-node): ctx.lane_commitment is the
+// whitepaper §13 StateCommitment Merkle root (lane_commitment_from_state_root
+// below), NOT the narrower owed_digest. The §13 summary leaf already contains
+// owed_digest, so the new binding strictly subsumes the old one. It also seeds
+// the deterministic tx secret key r, so the whole coinbase moves — every pinned
+// option-B byte golden had to be regenerated with this change.
 //
 // COUNT INVARIANCE (survey must_implement 3a — NOT solved here, by design):
 //   XmrBlockTemplate::update() calls split_reward twice (dry run at
@@ -104,6 +117,7 @@
 #include <vector>
 
 #include <c2pool/v37/w4_settlement.hpp>            // OwedLedger (merged; propose_coinbase, owed_digest)
+#include <c2pool/v37/w5_coinbase.hpp>              // StateCommitment (the whitepaper §13 state root)
 #include <sharechain/v37/v37_descriptor.hpp>        // ScriptRef, ScriptKind (read-only canon)
 #include <sharechain/v37/v37_descriptor_xmr.hpp>    // xmr_ref_valid, is_xmr_kind, xmr_precarrot_ok
 #include <sharechain/v37/v37_hash.hpp>              // bytes32
@@ -198,12 +212,156 @@ struct XmrCoinbaseContext {
 };
 
 // The lane_commitment source the survey recommends: the §4.5 OWED commitment
-// over the finalized partition (public, const, deterministic). Whether this or
-// the lane digest / SettlementView::digest goes into r and the MM root is a
-// consensus ruling; the provider picks EXPLICITLY and passes it in ctx.
+// over the finalized partition (public, const, deterministic). Superseded as
+// the DEFAULT by the §13 state root below (operator ruling 2026-09-10); kept
+// for single-pool experiments and for the golden-regeneration KAT.
 inline ::v37::bytes32 lane_commitment_from_owed_digest(const OwedLedger& ledger) {
     return ledger.owed_digest();
 }
+
+// RULED 2026-09-10 (multi-node): the MM-root leaf in the coinbase tx_extra 0x03
+// commits the FULL whitepaper §13 StateCommitment Merkle root — the SAME root
+// w5_coinbase.hpp builds (summary leaf "V37S" || chain || ledger_seq ||
+// num_balances || owed_digest, then per-key "V37E" || key || balance leaves,
+// key ASC). STRICT SUBSUMPTION: the summary leaf already CONTAINS owed_digest,
+// so committing the root strictly strengthens the previous owed_digest binding.
+//
+// We commit the ROOT VALUE the engine computes, never a re-derivation from
+// pinned constants, so the binding is robust to any later change in what §13
+// hashes — but note that such a change MOVES the root and is therefore
+// lane-consensus-visible (needs an activation gate; see the PR's ruling R-3).
+inline ::v37::bytes32 lane_commitment_from_state_root(const OwedLedger& ledger) {
+    return ::c2pool::v37n::coinbase::StateCommitment(ledger, ledger.chain()).root();
+}
+
+// ---------------------------------------------------------------------------
+// project_w4_owed — the ONE place the canonical K_fair owed set is computed.
+//
+// RULED 2026-09-10: KFairSource == W4Propose. The XMR coinbase selects payees
+// by the ONE ratified K_fair rule — OwedLedger::propose_coinbase (oldest-owed-
+// first: first_eligible ASC then identity ASC, whitepaper erratum E-1) — so
+// every node derives the SAME output set from the same ledger. X6 is then a
+// pure crypto/serialize + exact-sum sink executor: it is fed owed := take_i,
+// first_eligible := i (the proposal index) and h_min := 0, which makes
+// allocate_exact_sum reproduce the proposal byte-for-byte.
+//
+// This is a FREE function (not a build() private) because the assembler must
+// RE-PROJECT at every reward its count-invariance fixpoint visits — the payee
+// set has to be W4's proposal at the reward the block ACTUALLY pays, not at the
+// first sizing hint. One body, one order, no second implementation.
+//
+//   h_min           : the owed floor W4 applies (XMR dust = 0 today).
+//   n_fixed         : ctx.fixed.size() (mandated outputs, each takes a slot).
+//   fixed_sum       : Σ fixed amounts (subtracted from the owed budget).
+//   reward          : the exact-sum budget the set is chosen at.
+//   total_output_cap: the RESOLVED total-output cap C (never the 0 sentinel).
+//   out             : receives the projected x6::OwedEntry rows (cleared first).
+//   unpayable       : optional count of keys CARRIED for an unpayable ref.
+//   why             : filled on refusal.
+// ---------------------------------------------------------------------------
+inline bool project_w4_owed(const OwedLedger& ledger, const PayOfFn& pay_of,
+                            std::uint64_t h_min, std::size_t n_fixed,
+                            std::uint64_t fixed_sum, std::uint64_t reward,
+                            std::uint32_t total_output_cap,
+                            std::vector<x6::OwedEntry>& out,
+                            std::size_t* unpayable = nullptr,
+                            std::string* why = nullptr) {
+    auto no = [&](const std::string& m) { if (why) *why = m; return false; };
+    out.clear();
+    if (!pay_of)                        return no("project_w4_owed: no pay_of resolver");
+    if (reward == 0)                    return no("project_w4_owed: zero reward");
+    if (total_output_cap < n_fixed + 1) return no("project_w4_owed: output_cap leaves no room for fixed + sink");
+    if (fixed_sum > reward)             return no("project_w4_owed: Σfixed exceeds the reward");
+
+    // A key whose ref is not a payable XMR ref is downgraded to a RAW sentinel;
+    // W4's h_min_of(RAW) = UINT64_MAX then CARRIES it (canon branch,
+    // deterministic across nodes with the same point-check backend).
+    std::size_t carried = 0;
+    auto payable_ref = [&](const ::v37::bytes32& k) -> ::v37::ScriptRef {
+        ::v37::ScriptRef r = pay_of(k);
+        if (!::v37::xmr::xmr_ref_valid(r)) {
+            ++carried;
+            ::v37::ScriptRef raw; raw.kind = ::v37::ScriptKind::RAW; raw.payload.clear();
+            return raw;
+        }
+        return r;
+    };
+
+    const unsigned cap_owed = static_cast<unsigned>(
+        std::min<std::size_t>(static_cast<std::size_t>(total_output_cap) - n_fixed - 1,
+                              std::numeric_limits<unsigned>::max()));
+    // ── COUNT-INVARIANCE GUARD (2026-09-10) ─────────────────────────────────
+    // The two layers that meet here use the SAME arithmetic with OPPOSITE
+    // conventions for 0:
+    //   * W4 canon reads slot_budget_C == 0 as UNBOUNDED output count
+    //     (w4_settlement.hpp:580-583, symmetric with W5's max_payout_bytes==0);
+    //   * X6 reads its own cap_owed == 0 as "no room for any owed output"
+    //     (xmr_coinbase.cpp:113-114 + :135).
+    // cap_owed == 0 <=> total_output_cap == n_fixed + 1: room for the mandated
+    // outputs and the residual sink and NOTHING else. Forwarding that 0 to W4
+    // would propose EVERY eligible key while X6 emits zero owed outputs — the
+    // whole owed budget silently lands in the residual sink while the proposal
+    // claims N rows. Reachable on ordinary FULL blocks, not a synthetic edge:
+    // weight_aware_output_cap floors its result at 1 ("always room for at least
+    // the residual sink", xmr_coinbase.cpp:430-433), so any block whose selected
+    // txs fill the penalty-free zone resolves the cap to 1 == n_fixed + 1 under
+    // the default empty `fixed` set.
+    //
+    // Disposition: CLEAR AND SUCCEED — emit ZERO owed rows and CARRY every key.
+    //   (a) it matches X6's OWN legality boundary (BuildError::CapTooSmall is
+    //       output_cap < fixed.size() + 1, xmr_coinbase.hpp:200 / .cpp:110-111),
+    //       so the projection accepts exactly the templates X6 accepts;
+    //   (b) a refusal here is PERMANENTLY fatal, not a retry signal: the outer
+    //       pass loop dies (xmr_block_assembly.hpp:585-586) and the split_reward
+    //       path asks for a rebuild at the same reward, whose weight-aware cap
+    //       is the same deterministic function of the same inputs — it would
+    //       refuse identically until max_passes is exhausted. The node would
+    //       STOP SERVING every time its block is full: fail-STOPPED, not
+    //       fail-closed;
+    //   (c) it IS fail-closed where it matters: nothing is over-paid, no payee
+    //       is short-changed. Every owed row is CARRIED with the SAME
+    //       disposition as W4's own sub-h_min CARRY ("skip, first_eligible
+    //       untouched -- no starvation, the entry keeps its age",
+    //       w4_settlement.hpp:586-587), so the K_fair queue ages are undamaged
+    //       and the next block with cap room pays them.
+    // A named refusal would be right only if cap_owed == 0 could signal an
+    // upstream sentinel leak. It cannot: total_output_cap == 0 is already
+    // refused at the :273 guard above, and xmr_block_assembly.hpp:572-573
+    // resolves the 0 sentinel before this hook is ever called.
+    if (cap_owed == 0) {
+        if (unpayable) *unpayable = 0;   // nothing was even walked
+        if (why) why->clear();
+        return true;                     // `out` was cleared at the top
+    }
+
+    const std::uint64_t owed_budget = reward - fixed_sum;
+    auto h_min_of = [&](::v37::ScriptKind k) -> std::uint64_t {
+        return ::v37::xmr::is_xmr_kind(k) ? h_min : std::numeric_limits<std::uint64_t>::max();
+    };
+
+    OwedLedger::Proposal prop = ledger.propose_coinbase(owed_budget, cap_owed,
+                                                        payable_ref, h_min_of);
+    out.reserve(prop.outs.size());
+    for (std::size_t i = 0; i < prop.outs.size(); ++i) {
+        x6::OwedEntry e;
+        e.pay            = prop.outs[i].pay;
+        e.owed           = prop.outs[i].amount;   // exactly the proposed take
+        e.first_eligible = i;                     // proposal index == canonical order
+        e.identity       = prop.outs[i].key;
+        out.push_back(std::move(e));
+    }
+    if (unpayable) *unpayable = carried;
+    if (why) why->clear();
+    return true;
+}
+
+// The per-reward re-projection callback the assembler consumes. Structurally
+// identical to XmrBlockAssembler's X6SettlementSource::ReprojectOwedFn (the
+// impl tree must not include consumer headers, so the type is spelled twice —
+// it is the SAME std::function specialisation, so they assign freely).
+using ReprojectOwedFn =
+    std::function<bool(std::uint64_t reward, std::uint32_t output_cap,
+                       std::vector<x6::OwedEntry>& out, std::string* why)>;
 
 // ===========================================================================
 // XmrOwedSettlementSource
@@ -250,8 +408,16 @@ public:
                 return refuse(std::string("refused: ") + x6::to_string(x6::BuildError::FixedExceedsBudget));
             fixed_sum += f.amount;
         }
-        if (source == KFairSource::X6Allocate && !age_of)
-            return refuse("refused: KFairSource::X6Allocate needs an AgeOf resolver");
+        // RULED 2026-09-10 (multi-node consensus): the ONLY admissible K_fair
+        // source is W4Propose — OwedLedger::propose_coinbase, the one ratified
+        // rule (oldest-owed-first, whitepaper erratum E-1). X6Allocate would
+        // let a node derive a DIFFERENT output set from the same ledger, so it
+        // is refused here, fail-closed, rather than left silently selectable.
+        if (source != KFairSource::W4Propose)
+            return refuse("RULED 2026-09-10: KFairSource must be W4Propose "
+                          "(canonical K_fair propose_coinbase, whitepaper E-1); "
+                          "X6Allocate is refused for multi-node settlement");
+        (void)age_of;   // W4Propose never asks the ledger for an age
 
         std::unique_ptr<XmrOwedSettlementSource> s(new XmrOwedSettlementSource());
         s->m_ctx         = ctx;
@@ -273,60 +439,26 @@ public:
         in.output_cap             = ctx.output_cap;
         in.extra_nonce.clear();
 
-        // A key whose ref is not a payable XMR ref is downgraded to a RAW
-        // sentinel; W4's h_min_of(RAW) = UINT64_MAX then CARRIES it (canon
-        // branch, deterministic across nodes with the same backend).
+        // The canonical K_fair projection — the SAME free function the
+        // assembler's per-reward re-projection hook calls, so the set the block
+        // pays is OwedLedger::propose_coinbase output at the block's reward.
         std::size_t unpayable = 0;
-        auto payable_ref = [&](const ::v37::bytes32& k) -> ::v37::ScriptRef {
-            ::v37::ScriptRef r = pay_of(k);
-            if (!::v37::xmr::xmr_ref_valid(r)) {
-                ++unpayable;
-                ::v37::ScriptRef raw; raw.kind = ::v37::ScriptKind::RAW; raw.payload.clear();
-                return raw;
-            }
-            return r;
-        };
-
-        const unsigned cap_owed = static_cast<unsigned>(
-            std::min<std::size_t>(ctx.output_cap - ctx.fixed.size() - 1,
-                                  std::numeric_limits<unsigned>::max()));
-
-        if (source == KFairSource::W4Propose) {
-            // W4 canon picks the set over budget - Σfixed with C = cap - fixed - sink.
-            const std::uint64_t owed_budget = reward_hint - fixed_sum;
-            auto h_min_of = [&](::v37::ScriptKind k) -> std::uint64_t {
-                return ::v37::xmr::is_xmr_kind(k) ? ctx.h_min
-                                                  : std::numeric_limits<std::uint64_t>::max();
-            };
-            OwedLedger::Proposal prop = ledger.propose_coinbase(owed_budget, cap_owed,
-                                                                payable_ref, h_min_of);
-            in.owed.reserve(prop.outs.size());
-            for (std::size_t i = 0; i < prop.outs.size(); ++i) {
-                x6::OwedEntry e;
-                e.pay            = prop.outs[i].pay;
-                e.owed           = prop.outs[i].amount;   // exactly the proposed take
-                e.first_eligible = i;                     // proposal index == canonical order
-                e.identity       = prop.outs[i].key;
-                in.owed.push_back(std::move(e));
-            }
-            in.h_min = 0;                                 // W4 already applied the floor
-        }
-        else {
-            // X6 decides: every EffectiveOwed > 0 with its real age; X6 sorts
-            // (first_eligible ASC, identity ASC) and applies its own h_min rule.
-            for (const auto& [k, owed] : ledger.effective_owed_all()) {
-                if (owed <= 0) continue;
-                ::v37::ScriptRef r = payable_ref(k);
-                if (!::v37::xmr::is_xmr_kind(r.kind)) continue;   // unpayable => carry
-                x6::OwedEntry e;
-                e.pay            = r;
-                e.owed           = static_cast<std::uint64_t>(owed);
-                e.first_eligible = age_of(k);
-                e.identity       = k;
-                in.owed.push_back(std::move(e));
-            }
-            in.h_min = ctx.h_min;
-        }
+        std::string pw;
+        if (!project_w4_owed(ledger, pay_of, ctx.h_min, ctx.fixed.size(), fixed_sum,
+                             reward_hint, ctx.output_cap, in.owed, &unpayable, &pw))
+            return refuse("refused: " + pw);
+        // LOAD-BEARING 0 (do not "restore" ctx.h_min here). W4 has already
+        // applied the owed floor while choosing the set, and each row's `owed`
+        // IS its accepted take. Feeding X6 a NON-zero h_min would reintroduce a
+        // two-conventions divergence of exactly the class the count-invariance
+        // guard above closes: on a budget-truncated final partial W4 CARRYs and
+        // KEEPS SCANNING (w4_settlement.hpp:586-587) while X6 BREAKs and stops
+        // (xmr_coinbase.cpp:137-139), so X6 would emit a strict PREFIX of the
+        // proposal and the residual sink would swallow the difference. The
+        // FOUND payout map is read from the EMITTED outputs (Role::Owed), so it
+        // stays correct either way — but the proposal/emission divergence would
+        // silently under-pay carried payees. Keep it 0.
+        in.h_min = 0;                                     // W4 already applied the floor
         s->m_unpayable = unpayable;
 
         // ---- run X6 once at reward_hint: fixes r, R, keys, view tags, MM leaf, ORDER ----
@@ -482,12 +614,35 @@ public:
         return outputs_at(reward).size();
     }
 
-    // FOUND-record `payout`: { identity_key : piconero } over EVERY output the
-    // coinbase actually pays (owed keys, fixed identities, the sink identity),
-    // at the reward the template settled on (XmrBlockTemplate::get_reward()).
-    // Duplicate identities (e.g. a sink that is also an owed key) SUM. Empty
-    // when the allocation at `reward` fails or its shape does not match.
-    Amounts payout_map_at(std::uint64_t reward) const {
+    // FOUND-record `payout` — R-7 (2026-09-10): the Role::Owed SUBSET ONLY,
+    // { identity_key : piconero }, at the reward the template settled on
+    // (XmrBlockTemplate::get_reward()). This is what OwedLedger::on_block_found
+    // may be handed: the payout term is SUBTRACTED from finalW at FINALIZE
+    // (w4_settlement.hpp:485-500) and is legal only for keys the ledger
+    // CREDITED. A Fixed or Sink identity was never credited, so booking it
+    // would drive that key's finalW permanently negative — they are EXCLUDED.
+    // Duplicate owed identities SUM. Empty when the allocation at `reward`
+    // fails or its shape does not match.
+    //
+    // NOTE for the live daemon: prefer the EMITTED outputs of the FINAL
+    // AssembledTemplate (AssembledTemplate::outputs()) over this re-derivation.
+    // They agree on the snapshot's own shape by construction (same_shape), but
+    // the assembled template is the thing the block actually broadcast.
+    Amounts owed_payout_map_at(std::uint64_t reward) const {
+        Amounts m;
+        bool ok = false;
+        const std::vector<x6::CoinbaseOutput> outs = outputs_at(reward, &ok);
+        if (!ok) return m;
+        for (const auto& o : outs)
+            if (o.role == x6::CoinbaseOutput::Role::Owed)
+                m[o.identity] += static_cast<long long>(o.amount);
+        return m;
+    }
+    Amounts owed_payout_map() const { return owed_payout_map_at(m_reward_hint); }
+
+    // EVERY output the coinbase pays (owed ++ fixed ++ sink), for AUDIT /
+    // exact-sum diagnostics only. NEVER a FOUND payout map — see above.
+    Amounts all_outputs_map_at(std::uint64_t reward) const {
         Amounts m;
         bool ok = false;
         const std::vector<x6::CoinbaseOutput> outs = outputs_at(reward, &ok);
@@ -495,7 +650,6 @@ public:
         for (const auto& o : outs) m[o.identity] += static_cast<long long>(o.amount);
         return m;
     }
-    Amounts payout_map() const { return payout_map_at(m_reward_hint); }
 
 private:
     XmrOwedSettlementSource() = default;

--- a/src/impl/xmr/template/xmr_block_assembly.hpp
+++ b/src/impl/xmr/template/xmr_block_assembly.hpp
@@ -185,6 +185,14 @@ inline std::vector<unsigned char> extra_nonce_bytes(std::uint32_t extra_nonce, s
 // amounts, which is why re-deriving is unnecessary and the template's two-pass
 // flow stays sound.
 //
+// RULED 2026-09-10 (multi-node): when a `reproject_owed` callback is supplied,
+// the OWED ROWS are re-derived from the canonical K_fair rule at every reward
+// the template proposes, BEFORE X6 allocates. The same_set() gate is unchanged
+// and still governs adoption -- a re-projection that changes the SET is
+// refused, the reward is handed back, and the assembler rebuilds at it. So the
+// block's payee set is OwedLedger::propose_coinbase output at the reward the
+// block pays. With no callback the behaviour is byte-identical to before.
+//
 // Call protocol with XmrBlockTemplate::update() (upstream order, pinned to the
 // p2pool commit named in xmr_block_template.hpp):
 //   payees() ... merkle_tree_data() ... split_reward(base + sum(fees))   [1]
@@ -204,11 +212,22 @@ public:
     // Build the snapshot. `in.budget()` is the reward hint. Returns nullptr and
     // fills *why (if given) when X6 refuses (CARROT fence, bad sink/payee ref,
     // fixed > budget, cap too small, derivation failure) -- fail closed.
+    // Re-project the canonical K_fair owed rows at ONE reward and ONE resolved
+    // total-output cap. Supplied by the consumer tree (the option-B provider
+    // binds it to project_w4_owed over the live OwedLedger). EMPTY => the
+    // pre-ruling frozen-rows behaviour, so a caller that does not set it (every
+    // impl-only KAT) is byte-identical to the previous release.
+    using ReprojectOwedFn =
+        std::function<bool(std::uint64_t reward, std::uint32_t output_cap,
+                           std::vector<::v37::xmr::settle::OwedEntry>& out, std::string* why)>;
+
     static std::unique_ptr<X6SettlementSource> build(const CoinbaseInputs& in,
                                                      std::uint64_t subsidy,
-                                                     std::string* why) {
+                                                     std::string* why,
+                                                     ReprojectOwedFn reproject = {}) {
         std::unique_ptr<X6SettlementSource> s(new X6SettlementSource());
         s->m_in = in;
+        s->m_reproject = std::move(reproject);
         s->m_in.extra_nonce = extra_nonce_bytes(0, EXTRA_NONCE_SIZE); // keys/amounts are nonce-independent
         s->m_subsidy = subsidy;
         s->m_cb = ::v37::xmr::settle::build_coinbase(s->m_in);
@@ -256,10 +275,20 @@ public:
         }
         if (reward == m_in.budget()) { fill_amounts(rewards); return true; }
 
-        // A different real reward: accept iff X6's canonical allocation at that
-        // reward pays the SAME ordered payee set; then adopt its amounts.
+        // A different real reward. RULED 2026-09-10: the payee set must be the
+        // canonical K_fair proposal AT THE REWARD THE BLOCK PAYS, so re-project
+        // the owed rows first (when the consumer supplied the hook) and only
+        // then ask X6 to allocate. Accept iff the allocation at that reward pays
+        // the SAME ordered payee set; then adopt its amounts AND its rows.
         CoinbaseInputs probe = m_in;
         set_budget(probe, m_subsidy, reward);
+        if (m_reproject) {
+            std::string w;
+            if (!m_reproject(reward, probe.output_cap, probe.owed, &w)) {
+                m_wanted = reward;
+                return false;   // fail closed: the assembler rebuilds at `reward`
+            }
+        }
         BuildError err = BuildError::None;
         std::vector<CoinbaseOutput> alt = ::v37::xmr::settle::allocate_exact_sum(probe, &err);
         if (alt.empty() || !same_set(alt)) {
@@ -268,6 +297,10 @@ public:
         }
         for (std::size_t i = 0; i < alt.size(); ++i) m_cb.outputs[i].amount = alt[i].amount;
         set_budget(m_in, m_subsidy, reward);
+        // Carry the re-projected rows into the FINAL inputs so the FOUND record
+        // and any peer's ACCEPT re-derivation (coinbase_inputs()) hold the
+        // canonical set for the reward actually paid, not the sizing hint's.
+        if (m_reproject) m_in.owed = std::move(probe.owed);
         m_cb.budget = reward;
         fill_amounts(rewards);
         return true;
@@ -287,8 +320,22 @@ public:
     [[nodiscard]] unsigned split_calls() const { return m_split_calls; }
 
     // The FINAL inputs (budget adopted) and outputs (amounts adopted): what a
-    // peer's canonical_coinbase_matches() must be fed, and the FOUND payout
-    // map {identity : amount} over ALL outputs (owed / fixed / sink).
+    // peer's canonical_coinbase_matches() must be fed.
+    //
+    // R-7 CORRECTION (2026-09-10): an earlier revision of this comment claimed
+    // the FOUND payout map runs over ALL outputs (owed / fixed / sink). That is
+    // WRONG under the W4 contract. OwedLedger's payout term is SUBTRACTED from
+    // finalW at FINALIZE (w4_settlement.hpp:485-500) and is only ever legal for
+    // keys that were CREDITED into finalW — the K_fair owed rows the coinbase
+    // drew EffectiveOwed for. A Fixed or Sink identity was never credited, so
+    // booking it would drive that key's finalW permanently negative. The FOUND
+    // payout map is the Role::Owed SUBSET ONLY; consumers filter on
+    // CoinbaseOutput::Role::Owed (see c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
+    // and main_v37_xmr.cpp's candidate lookup).
+    // And read THIS vector — never a re-run of the W4 projection: X6's owed pass
+    // can legitimately emit FEWER rows than W4 proposed (a budget-truncated
+    // sub-h_min tail BREAKs here and the sink absorbs it, xmr_coinbase.cpp:
+    // 135-139, while W4 CARRYs and keeps scanning, w4_settlement.hpp:586-587).
     [[nodiscard]] const CoinbaseInputs& inputs() const { return m_in; }
     [[nodiscard]] const std::vector<CoinbaseOutput>& outputs() const { return m_cb.outputs; }
     [[nodiscard]] const BuiltCoinbase& built() const { return m_cb; }
@@ -312,6 +359,7 @@ private:
         return true;
     }
 
+    ReprojectOwedFn        m_reproject;   // empty => frozen rows (pre-ruling behaviour)
     mutable CoinbaseInputs m_in;
     mutable BuiltCoinbase  m_cb;
     std::uint64_t          m_subsidy = 0;
@@ -497,6 +545,17 @@ struct AssemblyInputs {
     CoinbaseInputs                settle;
     std::uint32_t                 wire_cap = 2700;   // output cap ceiling when output_cap == 0
     int                           max_passes = 6;    // fixpoint bound (fail closed beyond)
+
+    // RULED 2026-09-10 (multi-node): re-derive the canonical K_fair owed rows at
+    // EVERY reward the fixpoint visits, so the block's payee set is
+    // OwedLedger::propose_coinbase output at the reward the block ACTUALLY pays.
+    // The consumer tree binds this to project_w4_owed over the live ledger; it
+    // is handed `in.output_cap`, i.e. the RESOLVED weight-aware cap, which also
+    // closes the cap disagreement between the W4 proposal (cut at the config's
+    // cap) and X6's allocation (cut at the weight-aware cap).
+    // EMPTY => frozen rows, byte-identical to the pre-ruling assembler; every
+    // impl-only KAT below leaves it empty on purpose.
+    X6SettlementSource::ReprojectOwedFn reproject_owed;
 };
 
 class XmrBlockAssembler {
@@ -534,8 +593,14 @@ public:
         for (int pass = 1; pass <= a.max_passes; ++pass) {
             CoinbaseInputs in = base;
             set_budget(in, subsidy, hint);
+            // RULED: the owed rows are the canonical K_fair proposal AT THIS
+            // reward and at the RESOLVED (weight-aware) cap — fail closed.
+            if (a.reproject_owed &&
+                !a.reproject_owed(hint, in.output_cap, in.owed, &sub))
+                return fail("pass " + std::to_string(pass) + ": reproject_owed refused: " + sub);
 
-            std::unique_ptr<X6SettlementSource> seam = X6SettlementSource::build(in, subsidy, &sub);
+            std::unique_ptr<X6SettlementSource> seam =
+                X6SettlementSource::build(in, subsidy, &sub, a.reproject_owed);
             if (!seam) return fail("pass " + std::to_string(pass) + ": " + sub);
 
             std::unique_ptr<XmrBlockTemplate> tpl(new XmrBlockTemplate(seam.get()));

--- a/src/impl/xmr/test/xmr_template_primitives_kat.cpp
+++ b/src/impl/xmr/test/xmr_template_primitives_kat.cpp
@@ -127,7 +127,15 @@ void kat_varint() {
     struct V { uint64_t v; const char* hexv; } canon[] = {
         {0, "00"}, {1, "01"}, {127, "7f"}, {128, "8001"}, {255, "ff01"}, {300, "ac02"},
         {16383, "ff7f"}, {16384, "808001"}, {0xFFFFFFFFULL, "ffffffff0f"},
-        {600000000000ULL, "80a094a58b11"},                       // 0.6 XMR tail reward
+        // 0.6 XMR tail reward. The literal here was a hand-written constant and
+        // was WRONG: LEB128(600000000000) is 80 e0 a5 96 bb 11 (600000000000 =
+        // 0x8BA43B7400; septets from the LSB are 0x00,0x60,0x25,0x16,0x3B,0x11).
+        // The old "80a094a58b11" decodes to 587146268672. The implementation was
+        // always right — xmr_block_assembly_kat's K0 already pins
+        // writeVarint(600000000000) against the vendored tools::write_varint —
+        // but this KAT was never in the CI target list, so the bad golden went
+        // unseen until the option-B KATs were wired into build.yml.
+        {600000000000ULL, "80e0a596bb11"},
         {(1ULL << 56) - 1, "ffffffffffffff7f"},                   // MAX_OUTPUT_VALUE
         {UINT64_MAX, "ffffffffffffffffff01"},
     };


### PR DESCRIPTION
## [DRAFT] Multi-node XMR settlement: canonical K_fair payees + section-13 state-root commitment

Wires the **two operator rulings of 2026-09-10** into the X9 option-B settlement coinbase. This is multi-node **consensus** wiring, so it ships as a DRAFT: the operator merges and activates.

**Scope fence.** Consumer + impl trees only — `src/c2pool/v37/xmr/*`, `src/impl/xmr/template/*`, plus the new KAT and its CI wiring. **`src/sharechain/v37` canon is untouched, and so is the W4 `owed_digest` fold.** `w5_coinbase.hpp` is only *read* (the `StateCommitment` builder); `w4_settlement.hpp` is only *called* (`propose_coinbase`).

---

### Ruling 1 — K_fair source is `W4Propose`, and it is re-derived at every reward

The XMR coinbase selects payees by the ONE ratified K_fair rule: `OwedLedger::propose_coinbase` — oldest-owed-first (`first_eligible` ASC then identity ASC), `take = min(EffectiveOwed, remaining)`, **CARRY** a sub-`h_min` take, count-capped at C. That is whitepaper erratum **E-1**. Every node derives the SAME output set from the same ledger.

`W4Propose` was already the default — but the set was projected **once**, at the first reward hint, and then re-cut by X6 arithmetic at every other reward the assembler's count-invariance fixpoint visited. **That is the real gap this closes.**

| change | where |
|---|---|
| the projection moves out of `build()` into a free function `project_w4_owed()` — one body, one order, no second implementation | `xmr_o2_settlement_source.hpp` |
| `AssemblyInputs::reproject_owed`, called at every reward the fixpoint visits **and** in `split_reward`'s accept-a-different-reward branch, *before* X6 allocates | `xmr_block_assembly.hpp` |
| on adoption the re-projected rows are copied into the FINAL `CoinbaseInputs`, so the FOUND record and any peer ACCEPT re-derivation carry the canonical set for the reward actually paid | `xmr_block_assembly.hpp` |
| the callback receives the **RESOLVED weight-aware cap**, closing a real cap disagreement (proposal cut at the config ceiling vs X6 truncating at the weight-aware cap ⇒ the emitted tail was not the proposal at any budget) | `xmr_block_assembly.hpp` |
| `KFairSource::X6Allocate` REFUSED fail-closed at both the config gate and the build gate, ruling named in the message | fixture + source |
| the daemon binds the hook through one shared helper `make_reproject_owed()` — the same one the KATs bind | fixture + provider |

`same_set()` is **unchanged** and still governs adoption: a re-projection that changes the SET is refused, the reward is handed back, and the assembler rebuilds at it. `max_passes` and the cycle guard still fail closed with a named reason surfaced through `provider.last_error()`. **An empty `reproject_owed` is byte-identical to the previous release**, so every impl-only caller is unaffected (pinned by KC-4).

### Ruling 2 — the MM commitment binds the section-13 StateCommitment root

The MM-root leaf in the coinbase `tx_extra` `0x03` now commits the FULL whitepaper section-13 `StateCommitment` Merkle root — the same root `w5_coinbase.hpp` builds (summary leaf `V37S` + per-key `V37E` balance leaves) — instead of the narrower `owed_digest`.

* **Strict subsumption**: the section-13 summary leaf already *contains* `owed_digest`, so this strengthens the previous binding rather than replacing it.
* We commit the **root VALUE the engine computes**, never a re-derivation from pinned constants — so the wiring is robust to any later change in what section 13 hashes.
* `LaneCommitmentSource::StateRoot` is the new default; anything else is refused unless `allow_nonruled_local_only` is set for a single-pool experiment.
* New operator flags `--lane-commitment <state-root|owed-digest|explicit>` and `--lane-commitment-local-only`. The serve banner now prints the resolved K_fair source **and the 32-byte committed root**, so a node is auditable straight from its log.
* `lane_commitment` also seeds the deterministic tx secret key `r`, so `r`, `R`, every `P_i` and view tag move: **every pinned option-B byte golden was regenerated.** Expected, not a regression (pinned by KS-5).

---

### New KATs — `v37_xmr_o2_settlement_kat`, 62 checks, GREEN

The first test executable over the *consumer* option-B settlement path (the impl-side self-check covers only the halves that need no `OwedLedger`).

* **KW-1** the payee set equals an **INDEPENDENT** canonical K_fair walk written in the KAT, at the FINAL reward and the RESOLVED cap, in a penalty-zone case where the tail payee's take falls below `h_min`. With the hook unwired the same lane emits a sub-floor dust output the canonical rule forbids — **this is the regression pin.**
* **KW-2** `X6Allocate` refused at both gates. **KW-3** canonical order survives the template (owed ++ fixed ++ sink last, configured sink identity). **KW-4** payout-map honesty.
* **KS-1..KS-5** the section-13 root is what the block commits; a verifier holding the same ledger recovers it; a **one-piconero** ledger difference moves it; the section-13 **O(log n) balance proof verifies against exactly the committed root** (`Lane::verify_proof`) — proven end to end for the first time; and the `r`/`R`/`P_i` movement is pinned.
* **KC-1..KC-4** the fixpoint under a set that changes size (2 passes), cap agreement, fail-closed refusals with named causes, and byte-identical back-compat.
* fixture selftest extended: **S4** now pins the state-root default, **S7** the resolver, **S8** both RULED refusals.

### CI

`-DXMR_BUILD_OPTION_B_KATS=ON` on **both** the Linux x86_64 leg and the ASan+UBSan leg, with all three option-B targets in both `--target` lists. Locally green on both configurations (gcc-15):

| target | plain | ASan+UBSan |
|---|---|---|
| `v37_xmr_o2_settlement_kat` | 62/62 | 62/62 |
| `xmr_block_assembly_kat` | 192/192 | 192/192 |
| `xmr_template_primitives_kat` | ALL PASS | ALL PASS |

**Bug found by turning that option on**: `xmr_template_primitives_kat` carried a wrong hand-written golden — `LEB128(600000000000)` is `80e0a596bb11`, not `80a094a58b11` (which decodes to 587146268672). The implementation was always right (`xmr_block_assembly_kat`'s K0 pins `writeVarint` against the vendored `tools::write_varint`), but that KAT was never in a CI target list, so the bad constant went unseen. Fixed with the derivation in a comment.

---

### FOUND → FINALIZE re-proven on an ISOLATED private regtest

`monerod --regtest --offline --fixed-difficulty 20000` with its **own** data dir and **own** ports (18189 rpc / 18188 p2p / 18190 zmq), pool stratum on 18189-adjacent port 3433 — every endpoint on `127.0.0.1` of the build host, sharing nothing with any other job. **The live stagenet node was never touched** (verified still up and running, untouched, after the run). Real `xmrig` at `rx/0`, 4 threads, against the pool's own stratum port; RandomX runtime verify + the exact 128-bit network gate on the submit path.

```
found registered=30  settled=25  orphaned=2  refused=0  pending=3
gate calls=30 accept=30 reject=0 | submit calls=30 ok=30 rejected=0
```

Offline verification of every canonical block, by an **independent** pure-Python Keccak-256 + block-blob parser (not the code under test):

```
blocks=28 verified=28 failed=0  (block ids matching the pool's FOUND set: 28)
RESULT: GREEN
```

Per block it asserts:
1. **payees == the canonical K_fair set** — the owed payee first at its full `EffectiveOwed`, then the exact-sum residual sink; `sum(vout) == reward` on every block;
2. **section-13 root committed** — `tx_extra` `0x03` root `f091f3734c82c659…` equals `keccak256("c2pool-v37-xmr-mm-leaf-v1" || chain_id_le32 || state_root)` for the lane's section-13 root `6b84bf170e886678ae8c648783c4ca6346b2570ee8079600778cf399b2729d57`, recomputed independently;
3. **block id == the pool's FOUND bid** — all 28 canonical ids matched (the 2 non-canonical are same-height races, correctly ORPHANED pre-SETTLED per O3.5);
4. **FINALIZE at `H_b + D_conf`** — e.g. `h=1 SETTLED at bin_height=4`, `h=2 → 5`, with `D_conf=3`, for 26 settled blocks.

The previous option-B run's accept rate (19/19) is matched and exceeded: **30/30 submits accepted, 0 rejected.**

---

## R-7 reconciliation + the count-invariance guard (added 2026-09-10)

Two must-fix defects found by an adversarial survey of this branch. Both are **consumer/impl-tree only** — `src/sharechain/v37` and the W4 `owed_digest` fold have a **0-line diff vs master** (`git diff --stat origin/master -- src/sharechain/v37/ src/c2pool/v37/w4_settlement.hpp src/c2pool/v37/w5_coinbase.hpp` is empty).

### Defect R-7 — two disjoint ledgers, and a fictional FOUND record

The daemon held **two** `OwedLedger` objects. The coinbase was built from the provider's settlement ledger; FINALIZE booked into `XmrNode`'s store-backed one. On top of that, `FinalizeConnect` synthesised `credit == payout == { operator --payee-* identity : FULL block reward }` — a payee that under option B is **not a coinbase payee at all** (the coinbase pays the K_fair owed rows plus the residual sink).

Two empirically confirmed consequences:

**(a) `EffectiveOwed` went negative.** `EffectiveOwed = finalW − Σ_pending payout`, so with the reported run's own `pending=3` it is `−3·reward` — the observed `−105,547,781,241,725`.

**(b) No-double-pay violation** (the harder half, not stated in the original PR body). The settlement ledger was never decremented, so `propose_coinbase` re-proposed the **same owed row at its full `EffectiveOwed` on every block**. This PR's own offline verifier says exactly that — *"the owed payee first at its full EffectiveOwed"* on all 28 verified blocks. That is 28 payments of a balance the paper (§9 / OI-W4-5 credit-at-finality) extinguishes **once**.

### The fix

Against the canonical contract in `w4_settlement.hpp` (`:446-458` on_block_found, `:485-500` on_block_finalized, `:531-542` effective_owed) — **unmodified** here.

1. **ONE LEDGER.** `XmrOwedFixture` gains a non-owning ctor over an external `OwedLedger`; `main_v37_xmr.cpp` hands the provider `XmrNode::ledger()` — the durable, `RecoveryDriver`-replayed, `XmrFinalizeDriver`-driven one. Block *N+1*'s proposal now sees block *N*'s pending payout already deducted, so a row in flight cannot be re-proposed. The owning ctor is kept for the KATs.
2. **PAYOUT = THE EMITTED `Role::Owed` SET** — never the proposal, never the reward. Read from `AssembledTemplate::outputs()` filtered to `CoinbaseOutput::Role::Owed`, and captured at the **submit seam** (`submit::BlockCandidate::coinbase_owed` → `submit::FoundBlockEvent` → `o2::FoundBlockEvent`) so the map belongs to the very snapshot whose bytes went to monerod and cannot be lost to provider-ring eviction. `Role::Fixed` / `Role::Sink` are **excluded**: those identities were never credited, so booking them would drive their `finalW` permanently negative. Reading the *emitted* set rather than re-running `project_w4_owed` is load-bearing: X6's owed pass can legitimately emit **fewer** rows than W4 proposed (it BREAKs on a budget-truncated sub-`h_min` tail and the sink absorbs it, `xmr_coinbase.cpp:135-139`; W4 CARRYs and keeps scanning, `w4_settlement.hpp:586-587`) — booking the proposal would decrement owed for money the sink actually took.
3. **CREDIT = `{}`** until Track A2 S-1 emission exists. `E_b` is the fold over *b*'s burial-gated prefix; there is no XMR sharechain fold yet, so the empty map is the honest value. `FoundBlockEvent::credit` exists so S-1 becomes a fill, not a re-wiring. Option A books the degenerate `{}/{}`. The old `amounts_from()` helper is deleted.
4. **The maps survive the thread boundary and the restart.** The pending-FOUND sidecar moves to **schema v2**, persisting both maps. A v1 line still parses, is flagged legacy, and is re-driven with **empty** maps (the fail-safe direction — owed is never over-decremented) with a loud warning. Without this, a restart inside the `D_conf` window re-drove a *different* payout than the block paid.
5. **A fail-closed INV-1 precheck** refuses any FOUND whose payout exceeds this ledger's `EffectiveOwed` for that key — which can only mean the coinbase was built against a different ledger — instead of poisoning owed negative. Surfaced as `split_brain_refused` in the status line.

**Invariants restored**

* **INV-1** — `EffectiveOwed(k) ≥ 0` at every step, FOUND and FINALIZE alike.
* **INV-2 (OI-W4-5)** — `on_block_finalized` moves `EffectiveOwed(k)` by **exactly `+credit[k]`** (it removes the same payout from the pending term that it subtracts from `finalW`): invariant when `credit == {}`, never decreasing. `EffectiveOwed` legitimately **drops at FOUND** — that is the pending-payout deduction the coinbase drew on — so monotonicity is a property of the FINALIZE transition, not of the whole run. (Asserting otherwise makes the KAT wrong; the first draft of KF-1 got this wrong and failed.)

### Defect: count-invariance — two opposite conventions for `0`

W4 canon reads `slot_budget_C == 0` as **UNBOUNDED** output count (`w4_settlement.hpp:580-583`, symmetric with W5's `max_payout_bytes == 0`). X6 reads its own `cap_owed == 0` as **"no room"** (`xmr_coinbase.cpp:113-114` + `:135`). `project_w4_owed` computed X6's number and fed it to W4's parameter **without translating**, so at `total_output_cap == n_fixed + 1` W4 proposed *every* eligible key while X6 emitted *zero* owed outputs and the residual sink silently swallowed the whole owed budget — `same_set()` still converged on the sink-only shape and the block shipped paying nobody their owed.

**This is a reachable production path, not an edge case.** `weight_aware_output_cap` floors its result at 1 (*"always room for at least the residual sink"*, `xmr_coinbase.cpp:430-433`), so any block whose selected txs fill the penalty-free zone to within ~212 bytes resolves the cap to `1 == n_fixed + 1` under the default empty `fixed` set. It fires when the chain is **busiest**.

**Fix:** `project_w4_owed` **clears and succeeds** at `cap_owed == 0` — zero owed rows, every key CARRIED with its `first_eligible` age intact (the same disposition as W4's own sub-`h_min` CARRY). *Clear-and-succeed, not refuse*, for three independent reasons: (i) X6 itself treats `output_cap == fixed.size() + 1` as **legal** (`BuildError::CapTooSmall` is `< fixed.size() + 1`), so refusing would make the consumer reject a template X6 accepts; (ii) a refusal here is **permanently fatal**, not a retry signal — the weight-aware cap is a deterministic function of the same inputs, so the rebuild refuses identically until `max_passes` is spent and the node stops serving every time its block is full (fail-*stopped*, not fail-closed); (iii) zero owed rows means nothing over-paid and no payee short-changed — the owed is paid by the next block with cap room.

**The two fixes must land together.** With R-7 wired proposal-side and the guard missing, a cosmetic divergence would become real loss to payees.

Also corrects a design comment in `xmr_block_assembly.hpp` that asserted the opposite of the W4 contract (*"the FOUND payout map … over ALL outputs (owed / fixed / sink)"*), and pins why `in.h_min = 0` into X6 is load-bearing.

### New KATs

`v37_xmr_o2_settlement_kat` — **115 checks, was 62**:

| KAT | What it pins |
|---|---|
| **KF-1** | One-ledger INV-1/INV-2 over **three concurrent pending FOUNDs** (the exact `pending=3` shape). **Regression pin**: the split ledger drives `EffectiveOwed` to `−3·reward`. |
| **KF-2** | The ledger decrement is exactly the emitted `Role::Owed` set; fixed and sink identities are never ledger keys; and a non-zero X6 `h_min` is shown to make the executor emit a **strict prefix** of the proposal — the reason the FOUND map must be read from the emitted outputs. |
| **KF-3** | No double pay: a row in flight yields a **sink-only** next block. **Regression pin**: the shipped split wiring re-pays it at full `EffectiveOwed`. |
| **KC-5** | `cap_owed == 0` emits zero owed rows at `n_fixed` 0 and 2; the block is exactly `n_fixed + 1` outputs; carried ages undamaged. |
| **KC-6** | Reachability (`weight_aware_output_cap(300000, 299900, 2700) == 1`) and the two `0`-conventions asserted side by side — the guard against "simplifying" the new early return away. |
| **KC-7** | The guard is unreachable at the default cap (back-compat). |

`v37_xmr_o2_finalize_connect_selfcheck` — **28 checks, was 20**. FC3 / FC10 / FC16 used to **assert the buggy contract** (`effective_owed(payee) == -reward` while pending) and now assert the reconciled one; plus the split-brain precheck (FC3c), the sidecar-v2 round trip (FC8c/FC17), the v1 legacy path (FC18) and a truncated-line refusal (FC19).

### Build + KAT results (host `workstation-191`, gcc-15, `-DXMR_BUILD_RANDOMX=ON -DXMR_BUILD_OPTION_B_KATS=ON`)

```
c2pool-v37-xmr                              built, 0 errors
v37_xmr_o2_settlement_kat                   115 passed, 0 failed   RESULT: GREEN
v37_xmr_o2_finalize_connect_selfcheck        28/28 passed
v37_xmr_o2_live_submit_selfcheck             55 passed, 0 failed
v37_xmr_node_smoke                           11/11
xmr_block_assembly_kat                      192 passed, 0 failed   RESULT: GREEN
xmr_template_primitives_kat                 ALL PASS (0 failures)
```

### Re-proof on an isolated private regtest

`monerod --regtest --offline --fixed-difficulty`, own data dir, own ports `18189/18188/18190`, stratum `3433`, all on `127.0.0.1` of the build host; real `xmrig` `rx/0` → RandomX gate → `submit_block`. The live stagenet node was never touched. The run includes a **deliberate kill and restart inside the `D_conf` window**.

```
44 FOUND registered, 35 FINALIZED, 4 orphaned, pending=3 at the kill point
negative min_effective_owed lines across BOTH runs:  0
```

**min `EffectiveOwed` for the whole run = `0`** — never negative, including while blocks were pending. Sample lines:

```
FOUND registered 4ab23aa54b7e… h=1 reward=35184338534400 piconero owed_rows=1
  owed_paid=1000000000000 credit_rows=0 (operator payee=b9d5bd32d700…, informational)
FOUND registered 07eeab1088b9… h=2 ... owed_rows=0 owed_paid=0 credit_rows=0
FINALIZED 4ab23aa54b7e… h=1 SETTLED at bin_height=4 effective_owed(dc9eac09c13a…)=0
  min_effective_owed=0 ledger_seq=7
owed: min_effective_owed=0 booked=1000000000000 ledger_seq=51 split_brain_refused=0
```

The seeded owed was paid by **exactly one** block (`owed_rows=1`, `owed_paid=1000000000000`) and every later block was **sink-only** (`owed_rows=0`) — the emitted `Role::Owed` set **shrank to empty** instead of repeating the same payee at full `EffectiveOwed` on every block. The schema-v2 sidecar re-drove all 3 pending FOUNDs after the restart (`boot: re-drove pending FOUND … h=24/25/26`) and they finalized normally.

---

## F-1 — the startup owed seed could leave a NEGATIVE row across a restart (FIXED)

Found by the R-7 verify, closed here.

### The defect

`--owed-demo-amount` called `OwedLedger::on_block_found()` / `on_block_finalized()` **directly** on the ledger, bypassing the settle-store write-ahead log. R-7 had just made that ledger the node's own — durable and `RecoveryDriver`-replayed — so the seed's **credit** leg was in-memory only, while the coinbase **payout** that drew on it went through `XmrFinalizeDriver`'s WAL and *was* persisted.

A restart against the same data-dir therefore replayed the payout with **no matching credit**, and `finalW(k)` landed at `-(amount paid)`: a negative `effective_owed` row that **survives the restart** — a whitepaper §9 no-double-pay / OI-W4-5 violation. It was silent because this store's `RecoveryDriver` (unlike `w6_persistence`'s) has no `ledger_seq` cross-check to trip on the missing events. Re-passing the flag then re-credited on top of the recovered ledger, so the row was applied **once per boot** rather than once ever.

Live evidence at the previous head (`6a56fca2`), from the R-7 verify's own regtest logs — a restart without the flag:

```
recovery: hw_height=65 cursor=62 events=132 (resumed)
owed: min_effective_owed=-1000000000000 booked=0 ledger_seq=129 split_brain_refused=0
```

`-1000000000000` is exactly the seeded amount.

### Why the R-7 acceptance KAT masked it

Phases 1–3 of `finalize_connect_selfcheck` arm owed the **right** way — a FOUND carrying an S-1-shaped `E_b` credit, write-ahead-logged — so the credit leg replays exactly like the payout leg and `FC8a` / `FC10b` pass across their restart. The daemon's seed used a **different** path that no phase covered at all, so no assertion could fail on it. "The probe only checks the fresh-boot path" is precisely this: the restart assertions existed, but never over the seed the daemon actually used.

### The fix

| change | where |
|---|---|
| `XmrFinalizeDriver::seed_owed_durable(bid, credit, bin_height)` — writes the seed as two ordinary write-ahead events (`FOUND(credit)` / `FINALIZE`) under a stable bid, so `RecoveryDriver` replays it exactly like any other event | `xmr_finalize_driver.hpp` |
| restart-idempotence for free: the replay leaves the bid in the ledger's **SETTLED (terminal)** set, and `on_block_found` is already idempotent per bid, so a later call is a no-op — applied **exactly once** for the life of the data-dir. The seed bid is kept out of the driver's found/by-height maps: a seed is not a mined block and must never be walked by the `D_conf` cursor | `xmr_finalize_driver.hpp` |
| the daemon routes the flag through it and reports `applied` / `already-durable` (flag ignored, loudly) / `refused` | `main_v37_xmr.cpp` |
| the payee resolver is learned **unconditionally when serving** — the owed ROW is durable but the `key -> ScriptRef` map is in-memory; without this a recovered row would resolve to the RAW sentinel and be CARRIED forever once the flag was dropped | `main_v37_xmr.cpp` + fixture |
| `XmrOwedFixture` gains resolver-only `learn_pay()` and a `DurableLedger` ctor tag; `seed_owed()` **REFUSES** a direct write against a ledger declared store-backed, so the defect cannot walk back in. KATs driving a bare in-memory `OwedLedger` are unaffected | `xmr_o2_settlement_fixture.hpp` |
| every boot prints the post-recovery `min_effective_owed`, so a restart-negative is visible immediately instead of surfacing later as a coinbase that quietly pays nothing | `main_v37_xmr.cpp` |

### The corrected acceptance KAT

New phase 4, with `FC20` as a **negative control** that reproduces the OLD non-durable seed and **requires** the restart to come back negative — so `FC21`'s non-negative assertion cannot pass vacuously:

```
[PASS] FC20  NEGATIVE CONTROL: the OLD non-durable seed DOES leave a negative row
             across a restart  -- min_effective_owed=-250000000000 want=-250000000000
[PASS] FC21  after a RESTART against the SAME data-dir, min_effective_owed >= 0  -- 0
[PASS] FC21b the seeded row nets to EXACTLY zero (credited once, paid once)  -- eo=0
[PASS] FC21c the store replay restored the seed as SETTLED under its stable bid
[PASS] FC22  re-passing the seed applies NOTHING -- ledger_seq 4/4, WAL seq 4/4
[PASS] FC22b a DIFFERENT --owed-demo-amount on restart is equally ignored
[PASS] FC23  restart INSIDE the D_conf window also recovers non-negative  -- min=0 eo=0
```

### Re-proof on an isolated regtest

Own data-dir and ports (`monerod --regtest --offline`, RPC 18489 / ZMQ 18490 / stratum 3633), real `xmrig` rx/0 into the RandomX gate into `monerod submit_block`. Seed 500 XMR:

```
run A  (fresh)   owed-demo: seeded 500000000000000 piconero ... through the settle-store
                 write-ahead log (bid=v37-owed-demo-seed, bin_height=1) -- durable,
                 replayed on restart, applied exactly once
                 owed: post-recovery min_effective_owed=0 (INV-1 holds)
                 owed: min_effective_owed=0 booked=316624017924021

run B  RESTART against the SAME data-dir, and WITHOUT the flag
                 recovery: hw_height=63 cursor=60 events=17 (resumed)
                 owed: post-recovery min_effective_owed=0 (INV-1 holds)
                 owed: min_effective_owed=0 booked=183375982075979
```

`316624017924021 + 183375982075979 = 500000000000000` **exactly** — seeded once, paid once, across the restart, and the residual row was still payable with the flag dropped. A separate run restarted **with** the flag still set reported:

```
owed-demo: --owed-demo-amount IGNORED -- this data-dir already carries the durable seed
(bid=v37-owed-demo-seed) ... effective_owed(demo payee)=0
owed: post-recovery min_effective_owed=0 (INV-1 holds)
```

Run B additionally recovered a store whose previous process had been killed mid-flight, with no torn-store refusal.

### Build

`g++-15` 15.2.0 on the dedicated build host. `v37_xmr_o2_finalize_connect_selfcheck` **35/35**, daemon `--mock-smoke` **46/46**, `v37_xmr_o2_settlement_kat` **115/115** — all GREEN.

`src/sharechain/v37` canon and the W4 `owed_digest` fold remain untouched: the diff is 4 files, all under `src/c2pool/v37/xmr/*` plus `main_v37_xmr.cpp`.


### REQUIRED OPERATOR RULINGS (paper-silent — implemented fail-closed, not self-picked)

* **F-1-R1 — what must a node DO with a negative row it recovers?** §4.4 explicitly permits a negative `EffectiveOwed` as over-credit netted **forward** (never a clawback), so refusing to serve would contradict canon; but serving a K_fair coinbase off a ledger carrying an *unexplained* negative row is the §9 hazard F-1 produced. This ships the non-committal side — **warn loudly, keep serving** — and does **not** self-pick. The operator rules whether a recovered negative must be fail-closed (refuse to serve) or netted forward.
* **R-7a — is the FOUND `payout` term the `Role::Owed` subset only?** The paper defines payout as *"the coinbase outputs broadcast in b (K_fair over EffectiveOwed, from propose())"*, which reads as owed-only, and the arithmetic forces it: a Fixed/Sink identity was never credited, so booking it drives that key's `finalW` permanently negative. Implemented that way; the paper does not say it in so many words.
* **R-7c — two same-height blocks whose coinbases pay the SAME owed row.** Both are assembled from the same ledger state, so the second FOUND's payout exceeds the (already deducted) `EffectiveOwed`. This revision REFUSES the second, fail-closed toward INV-1, and counts it as `split_brain_refused`. That is safe for non-negativity but is **not free**: if the refused block turns out to be the canonical one and the first orphans, the owed it paid is never extinguished and a later block can pay it again. The alternatives — book it and go negative, or clamp to `EffectiveOwed` and mis-state what the block paid — are each wrong in a different way, and the paper does not cover concurrent FOUNDs drawing on the same row. **Not self-picked**; the regtest run above hit same-height races (4 orphaned, one `header=MISMATCH` at h=9) but with sink-only coinbases, so the case did not fire. A proper fix probably belongs with S-1 emission, when a FOUND carries its own `E_b`.

* **R-7b — is an option-A (monerod-template) block accounted as a v37 settlement at all?** Implemented as the degenerate `{}/{}` record: the ledger registers the block and `ledger_seq` bumps, but no key is created and no owed moves.

---

### Honest gaps / rulings owed

* **R-7: FIXED in this revision** (was: "carried, unchanged by this PR"). The finalize record is no longer option-A shaped and the daemon no longer holds two disjoint ledgers — see the **R-7 reconciliation** section above. Two paper-silent sub-choices are surfaced as **R-7a / R-7b** below rather than self-picked.
* **R-3: section-13 root evolution is lane-consensus-visible.** master's `StateCommitment` has ONLY the `V37S` summary and `V37E` balance leaves — `grep -rn "NRG1\|NRC1\|NRX1" src/` is empty at the base commit. Adding an NR* sub-block later CHANGES the root and therefore every coinbase; it needs its own activation gate. **Operator ruling owed** on that gate.
* **R-2: the block carries a hash-BINDING of the root, not the 32 root bytes.** `keccak(domain || chain_id || state_root)`. A verifier holding the same ledger re-derives and compares (that is KS-2), but a headers-only device cannot extract the root from the coinbase to run the section-13 O(log n) balance proof against the block alone. **Operator ruling owed** on whether a future tag should carry the root in the clear.
* **R-4: the `h_min` CARRY-vs-BREAK window is currently empty on XMR** (`XMR_DUST == 0`), so the divergence the KW-1 regression pin exercises needs an explicitly configured `--settle-h-min`. The wiring is correct either way; this is a note, not a defect.
* **`--owed-demo-amount`: FIXED in this revision as F-1** (was: "written into the node's real ledger but not through the write-ahead log, so it does not survive a restart and is re-applied on every boot" — that sentence WAS the defect; see the F-1 section above). The seed is now durable and applied exactly once per data-dir. It remains a proof knob, not lane state; real owed arrives with Track A2 S-1 emission.
* **F-2 (PRE-EXISTING, out of scope, newly characterised): the daemon segfaults on `SIGINT` shutdown while the stratum listener is still delivering shares.** Reproduced on the **unmodified** `6a56fca2` binary and on this revision, both `EXIT_CODE=139` under the identical load, so F-1 neither causes nor worsens it. It is a teardown ordering race, not an owed-path bug, and the settle store survived it (run B above recovered such a store cleanly, `(resumed)`, no torn-store refusal). Worth its own fix; not attempted here.
* `FinalizeConnect::min_effective_owed()` walks `effective_owed_all()` on every FINALIZE and every status tick — O(K). Fine at prototype key counts; it should become an incremental minimum if K grows.
* The proof ledger is still the deterministic `XmrOwedFixture` (one seeded K_fair payee + the sink), because there is no live XMR `OwedLedger` yet — Track A2 S-1 emission. The section-13 root is therefore constant across the run.
* An incidental finding: the ed25519 points from `monero-project tests/crypto/tests.txt` that the impl-side assembly KAT uses do **not** pass `xmr_ref_valid` (X6 requires only well-formedness of an owed ref; the consumer projection requires torsion validity, and silently CARRIES a key whose ref fails). The new KAT uses canon KAT identities and the regtest wallet keys instead. Worth a follow-up look at whether the impl-side KAT should use valid points.

### Base

Rebased onto `05983eeb` (master, #1552 — a README-only change; the tested code is identical to the `b3e415b6` base the build ran against). The branch already carries option B merged at `2013555e` (#1539).


