### PR TITLE
dash/mn-ckpt: size replay budgets from the CURRENT tip, not once at arm

### DIFF
--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -1530,6 +1530,13 @@ public:
     uint32_t requested_through()  const { return m_requested_through; }
     uint32_t stalled_pumps()      const { return m_stalled_pumps; }
     size_t   sml_recovery_cap()   const { return m_sml_recovery_cap; }
+    /// How many times a window-sized budget has been CLAMPED by its ceiling
+    /// on THIS bridge -- one per budget, not one per pump. Sized budgets are
+    /// re-evaluated every pump, so a per-pump warning would be a flood and a
+    /// silent clamp would be exactly the quiet degradation this lane refuses;
+    /// this counter is what lets a test (and an operator) see which of the two
+    /// actually happened. Reset with the rest of the per-bridge counters.
+    size_t   budget_ceiling_warnings() const { return m_budget_ceiling_warnings; }
     /// The machine's SPENT per-bridge demotion-walk budget. MnStateMachine::
     /// load() does not zero it, so a re-armed bridge would otherwise inherit
     /// the previous bridge's spend and fail closed on its first PoSe ban.
@@ -2545,6 +2552,7 @@ private:
     {
         if (!clamped || already_logged) return;
         already_logged = true;
+        ++m_budget_ceiling_warnings;
         LOG_WARNING << "[MN-CKPT] budget CEILING reached: " << name
                     << " sized " << want << " for this replay window but is"
                        " clamped to " << ceiling
@@ -4186,6 +4194,7 @@ public:
         m_walk_ceiling_logged     = false;
         m_ondemand_ceiling_logged = false;
         m_revive_ceiling_logged   = false;
+        m_budget_ceiling_warnings = 0;
         if (!m_revive_probe_cap_forced) m_revive_probe_cap = kReviveProbeBase;
         m_pose_removed    = 0;
         m_pose_reinstated = 0;
@@ -4395,6 +4404,7 @@ public:
     size_t    m_revive_probe_cap{kReviveProbeBase};
     bool      m_revive_probe_cap_forced{false};
     bool      m_revive_probe_cap_hit{false};
+    size_t    m_budget_ceiling_warnings{0};
     bool      m_walk_ceiling_logged{false};
     bool      m_ondemand_ceiling_logged{false};
     bool      m_revive_ceiling_logged{false};

--- a/src/impl/dash/coin/mn_checkpoint_lane.hpp
+++ b/src/impl/dash/coin/mn_checkpoint_lane.hpp
@@ -1647,6 +1647,10 @@ public:
                   " (--coin-rpc-*) so the authoritative protx seed is used");
         }
 
+        // Budgets are sized from the replay window, which GROWS as headers
+        // sync -- so size them here, every pump, not once at the arm edge.
+        size_window_budgets(tip);
+
         if (m_state == State::Waiting) {
             m_state = State::Bridging;
             // ── #138: THE STATE ARMS ITS OWN PRECONDITION ─────────────────
@@ -1702,8 +1706,7 @@ public:
             // left as-is rather than widened — widening it would license
             // exactly the wholesale-override-by-inference this walk exists to
             // refuse, and the fold already removes the need.
-            m_sml_recovery_cap = 4 + (tip - m_anchor_height) / 1000;
-            m_machine.set_sml_recovery_cap(m_sml_recovery_cap);
+            // (sized by size_window_budgets(), re-evaluated every pump)
             // ── THE ON-DEMAND FOLD CAP ───────────────────────────────────
             // Bounds ROUND TRIPS, not trust: every on-demand fold is DIP-4
             // client-verified against the coinbase of the very block it
@@ -1729,15 +1732,7 @@ public:
             // round trips worst case, which is negligible against the 20000
             // getdata the same bridge already issues — while a runaway
             // stops after 88 instead of after 20000.
-            if (!m_ondemand_cap_forced) {
-                m_ondemand_cap = kOnDemandFoldBase
-                               + (tip - m_anchor_height) / kOnDemandFoldPerBlocks;
-            }
-            if (!m_revive_probe_cap_forced) {
-                m_revive_probe_cap =
-                    kReviveProbeBase
-                    + (tip - m_anchor_height) / kReviveProbePerBlocks;
-            }
+            // (both sized by size_window_budgets(), re-evaluated every pump)
             LOG_INFO << "[MN-CKPT] bridge START: replaying h=" << m_next
                      << ".." << tip << " (" << (tip - m_next + 1)
                      << " blocks) onto the anchored set";
@@ -2473,6 +2468,92 @@ private:
     /// the delivered high-water orphaned every height in between and destroyed
     /// derived state. m_requested_through and m_replay_target are both in scope
     /// here and neither may ever reach the record.
+    /// -- WINDOW-SIZED BUDGETS: re-evaluated as the replay window GROWS ----
+    ///
+    /// The demotion-walk, on-demand-fold and ban-state-probe budgets are all
+    /// sized from the replay distance (tip - anchor). They used to be computed
+    /// ONCE, at the Waiting->Bridging edge. On a COLD start that edge fires
+    /// while the header chain is still at the fast-start checkpoint -- which is
+    /// pinned to COINCIDE with this lane's anchor -- so the window measured
+    /// ZERO blocks and every budget collapsed to its base:
+    ///
+    ///     [MN-CKPT] bridge START: replaying h=2522505..2522504 (0 blocks)
+    ///
+    /// The headers then synced forward and the real replay became ~13.8k
+    /// blocks, but the budgets kept their start-time values. That is how a cold
+    /// mainnet bridge hit "PROBE CAP IS EXHAUSTED (8/8)" and fail-closed at
+    /// h=2529626, while a WARM restart of the SAME binary -- whose headers were
+    /// already at the tip when it armed -- sized the same budget to 146 and
+    /// completed with 23 used and 0 unmeasured. One mechanism, both numbers.
+    ///
+    /// So size them HERE, on every pump, from the CURRENT tip. GROWTH ONLY: a
+    /// budget already granted is never taken back mid-bridge, because shrinking
+    /// one could turn an allowance already spent into an exhaustion. Each is
+    /// clamped to an explicit ceiling so an unusually wide window cannot turn
+    /// the arm into an unbounded round-trip crawl, and reaching a ceiling is
+    /// LOGGED once per bridge -- a clamped budget is exactly the condition
+    /// under which rising "unmeasured" counts mean "this window is wider than
+    /// the lane is sized for" rather than "the chain was quiet".
+    ///
+    /// This widens no trust: every on-demand fold and every ban-state probe is
+    /// DIP-4 client-verified against the coinbase of the block it judges, so a
+    /// larger budget buys more verification round trips, never fewer checks.
+    void size_window_budgets(uint32_t tip)
+    {
+        if (tip < m_anchor_height) return;
+        const uint32_t window = tip - m_anchor_height;
+
+        const size_t want_walk = static_cast<size_t>(4 + window / 1000);
+        const size_t walk = want_walk < kSmlRecoveryCapMax
+                          ? want_walk : kSmlRecoveryCapMax;
+        if (walk > m_sml_recovery_cap) {
+            m_sml_recovery_cap = walk;
+            m_machine.set_sml_recovery_cap(m_sml_recovery_cap);
+        }
+        note_budget_ceiling(want_walk > kSmlRecoveryCapMax,
+                            m_walk_ceiling_logged, "demotion-walk",
+                            want_walk, kSmlRecoveryCapMax);
+
+        if (!m_ondemand_cap_forced) {
+            const size_t want = kOnDemandFoldBase
+                + static_cast<size_t>(window / kOnDemandFoldPerBlocks);
+            const size_t cap = want < kOnDemandFoldCapMax
+                             ? want : kOnDemandFoldCapMax;
+            if (cap > m_ondemand_cap) m_ondemand_cap = cap;
+            note_budget_ceiling(want > kOnDemandFoldCapMax,
+                                m_ondemand_ceiling_logged, "on-demand-fold",
+                                want, kOnDemandFoldCapMax);
+        }
+
+        if (!m_revive_probe_cap_forced) {
+            const size_t want = kReviveProbeBase
+                + static_cast<size_t>(window / kReviveProbePerBlocks);
+            const size_t cap = want < kReviveProbeCapMax
+                             ? want : kReviveProbeCapMax;
+            if (cap > m_revive_probe_cap) m_revive_probe_cap = cap;
+            note_budget_ceiling(want > kReviveProbeCapMax,
+                                m_revive_ceiling_logged, "ban-state-probe",
+                                want, kReviveProbeCapMax);
+        }
+    }
+
+    /// One WARNING line, once per bridge, when a window-sized budget is clamped
+    /// by its ceiling. Silence here would be the "quiet degradation" this lane
+    /// exists to avoid.
+    void note_budget_ceiling(bool clamped, bool& already_logged,
+                             const char* name, size_t want, size_t ceiling)
+    {
+        if (!clamped || already_logged) return;
+        already_logged = true;
+        LOG_WARNING << "[MN-CKPT] budget CEILING reached: " << name
+                    << " sized " << want << " for this replay window but is"
+                       " clamped to " << ceiling
+                    << " -- the window is wider than this lane is sized for;"
+                       " expect UNMEASURED counts to grow rather than a silent"
+                       " crawl. Re-pin a fresher anchor or lower"
+                       " --embedded-mn-bridge-max.";
+    }
+
     void note_persist(bool force)
     {
         if (!m_cursor_store) return;
@@ -2664,6 +2745,18 @@ public:
     /// that hammers a peer, and the blind spot is now nameable either way.
     static constexpr size_t   kReviveProbeBase      = 8;
     static constexpr uint32_t kReviveProbePerBlocks = 100;
+
+    /// -- Ceilings for the window-sized budgets --------------------------
+    /// The replay window is ALREADY bounded by the staleness gate
+    /// (max_bridge_blocks, default 20000), which at the default puts the three
+    /// formulas at 208 / 88 / 24 -- so under stock settings no ceiling is ever
+    /// reached. They exist so that raising --embedded-mn-bridge-max cannot
+    /// silently turn the arm into an unbounded round-trip crawl, and so the
+    /// bound is STATED here instead of being an emergent property of another
+    /// knob. Reaching one is logged, never silent.
+    static constexpr size_t   kReviveProbeCapMax    = 256;
+    static constexpr size_t   kOnDemandFoldCapMax   = 128;
+    static constexpr size_t   kSmlRecoveryCapMax    = 32;
 
     /// The next height at or after `cursor` at which we want a snapshot, or
     /// nullopt when none remains before `tip`. Always includes the tip so the
@@ -4090,6 +4183,9 @@ public:
         m_revive_unmeasured    = 0;
         m_revive_declined      = 0;
         m_revive_probe_cap_hit = false;
+        m_walk_ceiling_logged     = false;
+        m_ondemand_ceiling_logged = false;
+        m_revive_ceiling_logged   = false;
         if (!m_revive_probe_cap_forced) m_revive_probe_cap = kReviveProbeBase;
         m_pose_removed    = 0;
         m_pose_reinstated = 0;
@@ -4299,6 +4395,9 @@ public:
     size_t    m_revive_probe_cap{kReviveProbeBase};
     bool      m_revive_probe_cap_forced{false};
     bool      m_revive_probe_cap_hit{false};
+    bool      m_walk_ceiling_logged{false};
+    bool      m_ondemand_ceiling_logged{false};
+    bool      m_revive_ceiling_logged{false};
     RequestSnapshotFn m_request_snapshot;
     RequestSnapshotFn m_reask_snapshot;   // optional rotate+demote re-ask seam
     // PR-2 FRESH-DATUM RACE single-flight tracker (flag-gated). Keyed by the

--- a/test/test_dash_mn_checkpoint.cpp
+++ b/test/test_dash_mn_checkpoint.cpp
@@ -6526,3 +6526,177 @@ TEST(DashMnCheckpointReseed,
     EXPECT_LE(wire.size() + eaten, 12u)
         << "re-asking a withheld body must stay bounded";
 }
+
+// ===========================================================================
+// N. WINDOW-SIZED BUDGETS -- the value must track a GROWING replay window.
+//
+// The demotion-walk, on-demand-fold and ban-state-probe budgets are all sized
+// from the replay distance (tip - anchor). The formulas were always right; what
+// was wrong was the MOMENT they were evaluated. They were computed ONCE, at the
+// Waiting->Bridging edge -- and on a cold start that edge fires while the header
+// chain is still at the fast-start checkpoint, which is PINNED TO COINCIDE with
+// this lane's anchor. The window therefore measured zero blocks and every
+// budget collapsed to its base:
+//
+//     [MN-CKPT] bridge START: replaying h=2522505..2522504 (0 blocks)
+//
+// Headers then synced ~13.9k blocks forward while the budgets kept their
+// start-time values, and the mainnet cold bridge fail-closed at h=2529626 with
+// "PROBE CAP IS EXHAUSTED (8/8)". A WARM restart of the SAME binary -- armed
+// with headers already at the tip -- sized the same budget to 146 and completed.
+//
+// The reason that survived review is worth stating here, because it is what
+// these cases exist to keep from recurring: NO TEST EVER LOOKED AT A BUDGET
+// WHILE THE TIP MOVED. It was a defect of observability, not of arithmetic, so
+// fixing the behaviour without adding the observation would restore exactly the
+// blind spot -- the next edit near this code re-freezes the budget and nothing
+// notices until a cold start in the field.
+// ===========================================================================
+
+namespace {
+
+// Give the harness a header for every height in [from, to] so the lane can
+// position itself anywhere in the window. Distinct per height; only identity
+// and presence matter to these cases.
+void fill_headers(BridgeHarness& h, uint32_t from, uint32_t to)
+{
+    for (uint32_t i = from; i <= to; ++i) {
+        if (i == kAnchorHeight) { h.headers[i] = uint256S(kAnchorHash); continue; }
+        uint256 x;
+        std::memcpy(x.begin(), &i, sizeof(i));
+        h.headers[i] = x;
+    }
+}
+
+} // namespace
+
+// The cold shape itself: arm with the header chain still AT the checkpoint,
+// then let the headers arrive. Every budget must be re-sized from the CURRENT
+// tip.
+//
+// One deliberate difference from the field: mainnet armed on a window of ZERO
+// blocks, but this harness's 6-MN testnet anchor needs no anchor-body fold, so
+// a zero-block replay COMPLETES on the same pump and the lane leaves Bridging
+// before a second pump can happen. The smallest window that keeps the lane
+// bridging is one un-delivered body, and it collapses every budget to exactly
+// the same base the field recorded -- which is the property under test.
+TEST(DashMnCheckpointBudgets, ColdArmAtTheAnchorDoesNotFreezeTheBudgets)
+{
+    using Lane = MnCheckpointLane;
+    BridgeHarness h;
+    h.auto_deliver = false;            // the body never lands: the lane stays Bridging
+    fill_headers(h, kAnchorHeight, kAnchorHeight + 1);
+    h.tip = kAnchorHeight + 1;         // headers still AT the fast-start checkpoint
+
+    h.lane.arm(good_checkpoint());
+    h.lane.pump();                     // the Waiting->Bridging edge, window = 1 block
+
+    // This is the state the field log recorded -- and it is CORRECT at this
+    // instant. The defect was never that the base was chosen here; it was that
+    // nothing ever revisited it.
+    EXPECT_EQ(h.lane.revive_probe_cap(), Lane::kReviveProbeBase);
+    EXPECT_EQ(h.lane.ondemand_cap(),     Lane::kOnDemandFoldBase);
+
+    // Headers now sync forward -- the same distance the mainnet cold start
+    // covered between arming and publishing (anchor 2522504 -> 2536407).
+    const uint32_t kWindow = 13903;
+    fill_headers(h, kAnchorHeight, kAnchorHeight + kWindow);
+    h.tip = kAnchorHeight + kWindow;
+    h.lane.pump();
+
+    // 8 + 13903/100 = 147. Before the fix this stayed 8, and the bridge
+    // fail-closed the moment an eighth ban-state ambiguity appeared.
+    EXPECT_EQ(h.lane.revive_probe_cap(),
+              Lane::kReviveProbeBase + kWindow / Lane::kReviveProbePerBlocks)
+        << "the ban-state probe budget must be sized from the CURRENT tip;"
+           " frozen at the arm edge it is the h=2529626 cold fail-close";
+    EXPECT_EQ(h.lane.ondemand_cap(),
+              Lane::kOnDemandFoldBase + kWindow / Lane::kOnDemandFoldPerBlocks)
+        << "the on-demand fold budget must grow with the window too";
+    EXPECT_EQ(h.lane.sml_recovery_cap(), 4u + kWindow / 1000u)
+        << "the demotion-walk budget must grow with the window too";
+
+    // Nothing was clamped: this window is well inside every ceiling.
+    EXPECT_EQ(h.lane.budget_ceiling_warnings(), 0u);
+}
+
+// GROWTH ONLY. A budget already granted is never taken back mid-bridge --
+// shrinking one could turn an allowance ALREADY SPENT into an exhaustion, which
+// is the same fail-close the fix exists to remove, arrived at from the other
+// side. A tip that regresses (a reorg, a header-chain rollback) must not do it.
+TEST(DashMnCheckpointBudgets, AGrantedBudgetIsNeverTakenBackWhenTheWindowShrinks)
+{
+    using Lane = MnCheckpointLane;
+    BridgeHarness h;
+    h.auto_deliver = false;
+    const uint32_t kWindow = 13903;
+    fill_headers(h, kAnchorHeight, kAnchorHeight + kWindow);
+    h.tip = kAnchorHeight + 1;
+
+    h.lane.arm(good_checkpoint());
+    h.lane.pump();
+    h.tip = kAnchorHeight + kWindow;
+    h.lane.pump();
+
+    const size_t granted_revive   = h.lane.revive_probe_cap();
+    const size_t granted_ondemand = h.lane.ondemand_cap();
+    const size_t granted_walk     = h.lane.sml_recovery_cap();
+    ASSERT_GT(granted_revive, Lane::kReviveProbeBase);
+
+    // The tip falls back to a hundred blocks past the anchor. Re-evaluated
+    // naively, every formula would now return its base again.
+    h.tip = kAnchorHeight + 100;
+    h.lane.pump();
+
+    EXPECT_EQ(h.lane.revive_probe_cap(), granted_revive)
+        << "shrinking a granted budget can retroactively exhaust an allowance"
+           " this bridge has already spent";
+    EXPECT_EQ(h.lane.ondemand_cap(),     granted_ondemand);
+    EXPECT_EQ(h.lane.sml_recovery_cap(), granted_walk);
+}
+
+// The ceiling is a STATED bound, not an emergent one: raising
+// --embedded-mn-bridge-max must not silently turn the arm into an unbounded
+// round-trip crawl. And because the budgets are now re-evaluated on EVERY pump,
+// the announcement has to be once per budget per BRIDGE -- a per-pump warning
+// would be a flood, and a silent clamp would be the quiet degradation this lane
+// refuses. Both halves are asserted, because both are ways to get it wrong.
+TEST(DashMnCheckpointBudgets, AClampedBudgetIsAnnouncedOncePerBridgeNotOncePerPump)
+{
+    using Lane = MnCheckpointLane;
+    BridgeHarness h;
+    h.auto_deliver = false;
+    const uint32_t kWide = 40000;      // 8+400 / 8+160 / 4+40 -- all three clamp
+    fill_headers(h, kAnchorHeight, kAnchorHeight + kWide + 2000);
+    h.tip = kAnchorHeight + 1;
+
+    h.lane.set_max_bridge_blocks(100000);   // the knob the ceilings guard
+    h.lane.arm(good_checkpoint());
+    h.lane.pump();
+    ASSERT_EQ(h.lane.budget_ceiling_warnings(), 0u);
+
+    h.tip = kAnchorHeight + kWide;
+    h.lane.pump();
+
+    EXPECT_EQ(h.lane.revive_probe_cap(),  Lane::kReviveProbeCapMax);
+    EXPECT_EQ(h.lane.ondemand_cap(),      Lane::kOnDemandFoldCapMax);
+    EXPECT_EQ(h.lane.sml_recovery_cap(),  Lane::kSmlRecoveryCapMax);
+    EXPECT_EQ(h.lane.budget_ceiling_warnings(), 3u)
+        << "a clamped budget must be ANNOUNCED -- silence here is the quiet"
+           " degradation the lane exists to refuse";
+
+    // Twelve more pumps, the window still widening. The clamp holds and the
+    // announcement does not repeat.
+    for (int i = 1; i <= 12; ++i) {
+        h.tip = kAnchorHeight + kWide + static_cast<uint32_t>(i * 100);
+        h.lane.pump();
+    }
+    EXPECT_EQ(h.lane.revive_probe_cap(), Lane::kReviveProbeCapMax);
+    EXPECT_EQ(h.lane.budget_ceiling_warnings(), 3u)
+        << "one warning per budget per BRIDGE -- re-evaluating every pump must"
+           " not turn the ceiling into a log flood";
+
+    // A re-arm is a NEW bridge: the announcement is owed again.
+    h.lane.arm(good_checkpoint());
+    EXPECT_EQ(h.lane.budget_ceiling_warnings(), 0u);
+}


### PR DESCRIPTION
## Problem

The demotion-walk, on-demand-fold and ban-state-probe budgets are all sized from the
replay distance (`tip - anchor`), but they were computed **once**, at the
`Waiting -> Bridging` edge in `pump()`.

On a **cold** start that edge fires while the header chain is still at the fast-start
checkpoint, which is deliberately pinned to *coincide* with this lane's anchor. So the
window measures **zero blocks** and every budget collapses to its base. Straight from a
mainnet run:

```
[MN-CKPT] bridge START: replaying h=2522505..2522504 (0 blocks) onto the anchored set
```

Headers then sync forward and the real replay becomes ~13.8k blocks, but the budgets keep
their start-time values. That is how a cold mainnet bridge reached
`PROBE CAP IS EXHAUSTED (8/8)` and fail-closed at `h=2529626`.

A **warm** restart of the *same binary*, whose headers were already at the tip when it
armed, sized the same budget to `146` and completed with `23` used and `0` unmeasured.

One mechanism explains both numbers. The formulas were never wrong; the moment they were
evaluated was.

## Fix

Size the budgets on every pump from the current tip (`size_window_budgets()`), instead of
once at the arm edge.

- **Growth only.** A budget already granted is never taken back mid-bridge: shrinking one
  could turn an allowance already spent into an exhaustion.
- **Explicit ceilings** (`256 / 128 / 32`) so raising `--embedded-mn-bridge-max` cannot
  silently turn the arm into an unbounded round-trip crawl. Under stock settings the
  staleness gate already bounds the window at 20000 blocks, which puts the formulas at
  `208 / 88 / 24`, so no ceiling is reachable by default.
- **Reaching a ceiling logs one WARNING per bridge**, rather than degrading quietly. A
  clamped budget is exactly the condition under which rising `UNMEASURED` counts mean
  "this window is wider than the lane is sized for" rather than "the chain was quiet".

## Why this widens no trust

Every on-demand fold and every ban-state probe is DIP-4 client-verified against the
coinbase of the block it judges. A larger budget therefore buys **more verification round
trips, never fewer checks**. The failure it removes is a *false* fail-closed, not a real
one.

## Verification status

- Syntax-only compile of the patched header against the project's own `dash` target flags:
  passes.
- Full build plus a cold fresh-datadir bridge run to `would-serve` is in progress and will
  be posted here as a comment with the run output.

## Review note

The third budget, the demotion walk, carries a comment saying the cap is "deliberately left
as-is rather than widened". This change does not widen its formula; it makes the existing
`4 + window/1000` actually apply to the real window instead of to a zero-length one. Called
out explicitly in case the reviewer reads that intent differently.
