### PR TITLE
coin-matrix: cap smoke build -j via BUILD_J (default 4) to stop .198 cgroup OOM false-reds

### DIFF
--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
-        run: cmake --build build_${{ matrix.coin }} --target c2pool-${{ matrix.binary || matrix.coin }} -j$(nproc)
+        run: cmake --build build_${{ matrix.coin }} --target c2pool-${{ matrix.binary || matrix.coin }} -j"${BUILD_J:-4}"
 
       - name: Smoke test (--help)
         if: steps.presence.outputs.exists == '1' && matrix.gtest != '1'
@@ -215,7 +215,7 @@ jobs:
         # in test_dash_block_replay + DashReplay*/DashMnCheckpoint*/DashMnPayee*/
         # DashMnAnchor*/DashMnBridge* in test_dash_mn_state, plus ReplayUtxo* fold.
         run: |
-          cmake --build build_${{ matrix.coin }} -j$(nproc)
+          cmake --build build_${{ matrix.coin }} -j"${BUILD_J:-4}"
           ctest --test-dir build_${{ matrix.coin }} \
             --output-on-failure --no-tests=error \
             -R '^(DashBlockReplay|DashReplay|DashMnCheckpoint|DashMnPayee|DashMnAnchor|DashMnBridge|ReplayUtxo)'


### PR DESCRIPTION
## Root cause (from evidence, not inference)

The false red on #1538 (run 34414971020, `c2pool-linux-198-2` dash-daemonless leg) was a **cgroup OOM-kill**, not the diff and not a host crash:

- Build step completed; the job died mid-`cmake --build` of the test tree at `2026-09-10T00:15:39Z`, still compiling `test_dash_poolnode_messages`.
- Runner journal: `actions.runner...198-2.service: A process of this unit has been killed by the OOM killer` → `Failed with result 'oom-kill'`; listener exited 143; `Restart=on-failure` relaunched at 00:16:19Z. GH log surfaced `The runner has received a shutdown signal`.
- Host `dev-host` (.198): 31Gi RAM, **0B swap**, nproc=**16**; each runner unit capped `MemoryMax=10G`. The step ran `cmake --build -j$(nproc)` = **-j16** of heavy gtest TUs → overran the 10G cgroup → OOM.

## Recurrence

Chronic, not a one-off: **~17 OOM-kills on 198-2 and ~24 on 198-3 in the last 7 days** (journal `result 'oom-kill'`). #1538 was just the run that landed on a surfacing job.

## Fix

Cap the two uncapped `cmake --build` steps in `coin-matrix.yml` (the `Build` step and the full-tree build inside the daemonless gtest step) to `-j"${BUILD_J:-4}"`, mirroring the #1522 `build.yml` knob so the operator can retune per-host via `.env`. Default 4 fits the 10G cgroup; raise once swap or a higher `MemoryMax` is provisioned.

`release.yml:199/204` carry the same raw `-j$(nproc)` and are left for a follow-up PR (different cadence, not the documented offender).

Host-side remediation (add swap / raise `MemoryMax`) is an operator call and is out of this PR's scope; flagged separately to decisions@.

Do-not-merge without push-approval.