### PR TITLE
ci: cap remaining raw -j in release.yml + build.yml build steps (BUILD_J knob)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1469,7 +1469,7 @@ jobs:
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} -DCMAKE_PREFIX_PATH=${{ steps.tc.outputs.prefix }} -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
 
       - name: Build
-        run: cmake --build build --target c2pool -j$(sysctl -n hw.ncpu)
+        run: cmake --build build --target c2pool -j"${BUILD_J:-4}"
 
       - name: Verify binary
         # `file` inspects the Mach-O without executing. The --help smoke actually

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,12 +196,12 @@ jobs:
       - name: Boost sentinel
         if: steps.presence.outputs.exists == '1'
         run: |
-          cmake --build build_${{ matrix.coin }} --target boost_sentinel -j$(nproc)
+          cmake --build build_${{ matrix.coin }} --target boost_sentinel -j"${BUILD_J:-4}"
           ctest --test-dir build_${{ matrix.coin }} -R '^boost_sentinel$' --output-on-failure
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
-        run: cmake --build build_${{ matrix.coin }} --target c2pool-${{ matrix.coin }} -j$(nproc)
+        run: cmake --build build_${{ matrix.coin }} --target c2pool-${{ matrix.coin }} -j"${BUILD_J:-4}"
 
       - name: Smoke test (--help)
         if: steps.presence.outputs.exists == '1'
@@ -350,7 +350,7 @@ jobs:
 
       - name: Build c2pool-${{ matrix.coin }}
         if: steps.presence.outputs.exists == '1'
-        run: cmake --build build --target c2pool-${{ matrix.coin }} -j$(sysctl -n hw.ncpu)
+        run: cmake --build build --target c2pool-${{ matrix.coin }} -j"${BUILD_J:-4}"
 
       - name: Smoke test (--help)
         if: steps.presence.outputs.exists == '1'


### PR DESCRIPTION
## What

Caps the remaining raw `-j` in workflow **build steps** to `-j"${BUILD_J:-4}"`, mirroring the #1522 / #1554 knob convention.

Same cgroup-OOM class root-caused in #1554: raw `-j$(nproc)` / `-j$(sysctl -n hw.ncpu)` lets compile + gtest TU parallelism exceed the `MemoryMax=10G` limit on self-hosted runners (e.g. .198: 16 cores, 10G cap, 0 swap), producing OOM-kills that read as runner death. A static per-runner `BUILD_J` knob (default 4) bounds it; operator can raise it where RAM allows.

## Build steps changed (every raw `-j` site folded into this one PR)

| File | Line | Step | Before |
|------|------|------|--------|
| release.yml | 199 | Boost sentinel (Linux) | `-j$(nproc)` |
| release.yml | 204 | Build c2pool-<coin> (Linux) | `-j$(nproc)` |
| release.yml | 353 | Build c2pool-<coin> (macOS) | `-j$(sysctl -n hw.ncpu)` |
| build.yml | 1472 | Build c2pool (macOS) | `-j$(sysctl -n hw.ncpu)` |

The two macOS lanes (sysctl) are **not** under the 10G cgroup and were folded in for convention-consistency only — set a higher `BUILD_J` on the macOS runners if `-j4` is too conservative there.

## Sweep result (so we can stop re-auditing)

`grep -rnE '\-j\$\(nproc\)|\-j\$\(sysctl' .github/workflows/` over the whole tree now returns **only**:
- `coin-matrix.yml:198` and `:218` — deliberately untouched; these are capped by in-flight **#1554** (do not double-fix / avoid conflict).

No other raw `-j$(nproc)` / `-j$(sysctl -n hw.ncpu)` remains in any build step. Windows lanes (`%NUMBER_OF_PROCESSORS%`, `-j 8`) are out of scope and already bounded.

## Validation
- `python3 -c "import yaml"` parses both files clean.
- Commit GPG-signed (key 50AB1379285EFE76).
- Based on master `05983eeb`, not stacked on #1554.

Held for push-approval — no self-merge.
