### PR TITLE
ltc(web): pace PPLNS precompute walk under the boot io_context watchdog

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -3199,6 +3199,18 @@ void MiningInterface::start_pplns_precompute()
         LOG_INFO << "[PPLNS-Cache] Computing PPLNS for " << total << " shares...";
         auto start_time = std::chrono::steady_clock::now();
 
+        // --- precompute pacing (confined to this entrypoint; live caller main_ltc.cpp:4349) ---
+        // Each per-share m_pplns_fn walk takes the share-tracker lock that the boot
+        // backfill / think loop also needs; an unpaced burst can starve the io_context
+        // past its freeze-watchdog (~40s, main_ltc lambda) on a large persisted sharechain.
+        // Pace by a wall-clock work budget far under that watchdog, yielding the lock
+        // between bursts. BTC/DASH do not call this (comments only), so this is LTC-scoped.
+        constexpr auto kPrecomputeBootSettle  = std::chrono::seconds(30);      // let boot backfill/think quiesce
+        constexpr auto kPrecomputeBurstBudget = std::chrono::milliseconds(250); // ~160x under the 40s watchdog
+        constexpr auto kPrecomputeYield       = std::chrono::milliseconds(50);  // hand the tracker lock back
+        std::this_thread::sleep_for(kPrecomputeBootSettle);
+        auto burst_start = std::chrono::steady_clock::now();
+
         for (int i = 0; i < total; ++i) {
             auto& s = shares[i];
             if (!s.contains("H") || !s.contains("h")) continue;
@@ -3262,8 +3274,12 @@ void MiningInterface::start_pplns_precompute()
                              << " (" << (computed * 100 / total) << "%)";
                 }
 
-                // Yield to mining thread — don't hog the tracker lock
-                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                // Pace: once this burst has held the tracker for the work budget,
+                // yield long enough for the io_context/think loop to reclaim the lock.
+                if (std::chrono::steady_clock::now() - burst_start >= kPrecomputeBurstBudget) {
+                    std::this_thread::sleep_for(kPrecomputeYield);
+                    burst_start = std::chrono::steady_clock::now();
+                }
             } catch (const std::exception& e) {
                 // Skip shares that fail (e.g., at chain boundary)
                 continue;


### PR DESCRIPTION
## What
Pace the background PPLNS pre-computation walk so it cannot starve the boot io_context past its freeze-watchdog. Change is **confined to the precompute entrypoint** `MiningInterface::start_pplns_precompute()` (src/core/web_server.cpp:3130) — it does **not** touch `refresh_work()` or the `set_dashboard_always_ready` readiness gate, per BTC lane constraint.

## Seam
Live caller (the only active one, repo-wide):
```
src/c2pool/main_ltc.cpp:4349
    web_server.get_mining_interface()->start_pplns_precompute();
```
The thread body does, per share:
```
auto raw_pplns = m_pplns_fn(share_hash, block_target, subsidy, m_donation_script);
...
std::this_thread::sleep_for(std::chrono::milliseconds(2));  // old fixed yield
```
`m_pplns_fn` takes the share-tracker lock the boot backfill / think loop also needs; an unpaced burst on a large persisted sharechain can hold it long enough to freeze the io_context.

## Pacing budget vs the 40s watchdog
- `kPrecomputeBootSettle  = 30s`  — walk never starts during the boot storm.
- `kPrecomputeBurstBudget = 250ms` — after 250ms of continuous walk, yield. **~160x under the ~40s io_context freeze-watchdog** (main_ltc lambda), so a single lock-holding burst can never approach it.
- `kPrecomputeYield       = 50ms`  — long enough for the think loop to reclaim the tracker lock.

## BTC/DASH no-op (independently reconfirmed on origin/master 81553e48f)
- `main_btc.cpp:2800` — comment only, no call.
- `main_dash.cpp:2012` — comment only, no call.
- Only `main_ltc.cpp:4349` calls it → **zero BTC/DASH boot impact by construction.** BTC WebServer MI is display-only (NULL IMiningNode). Reconcile: integrator noted :4337 — that line is a comment inside the pplns_map lambda; the live call is :4349.

## Merge posture
Held for integrator merge — **no self-merge** (money/consensus-path). Green CI is the condition. LTC + DASH gate only; dash-consensus has the [fyi].
