### PR TITLE
ltc(pool): rate-cap the desired-share drain and back off futile requests

### DIFF
--- a/src/impl/ltc/desired_request_pacer.hpp
+++ b/src/impl/ltc/desired_request_pacer.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+// desired_request_pacer.hpp — pure, per-hash futility backoff for the desired
+// parent-share request drain (node.cpp drain_pending_desired). Extracted into a
+// header so the backoff policy can be exercised by a KAT without a live node.
+//
+// WHY. run_think's IO phase recomputes result.desired authoritatively every
+// cycle and hands it to the budgeted drain. On a large persisted sharechain that
+// set is huge, and when the shares it names are not obtainable the replies come
+// back EMPTY — so the set is refilled unchanged next think() and the drain runs
+// at full rate forever. Measured on the public LTC node (chain=17950) after the
+// #1556 cutover: 6146 requests over 210s (~29/s) for 5137 DISTINCT hashes,
+// answered ~1:1 by "[Pool] Share request empty for", with the io thread pinned
+// at 98% CPU (ps -L: one thread in R, the other 13 sleeping) and :8080
+// unreachable for 12.7 minutes without a single 200. The process never aborts —
+// #1556 removed the watchdog kill — it just burns a core and stops serving.
+//
+// This is NOT the per-(hash,peer) failover memory in share_fetch_failover.hpp.
+// That one answers "WHICH peer should I ask for this hash", and suppresses a
+// hash only once EVERY connected peer has failed it, for a flat 90s TTL. It
+// cannot damp a desired set whose members are each failing their FIRST attempt
+// across a rotating peer set. This one answers "should I ask for this hash AT
+// ALL right now", with an exponential, per-hash backoff.
+//
+// EXPIRY IS PART OF THE CONTRACT, not an optimization. A hash nobody can serve
+// now may be servable later, when a peer carrying that history connects. The
+// backoff therefore has a ceiling (never an indefinite ban) and entries are
+// dropped outright once they age well past eligibility, so the hash returns to
+// the normal request path. A permanent denylist here would convert a transient
+// gap into a permanent chain hole.
+//
+// Pure / templated: no c2pool types, no consensus surface, no reward surface.
+// HashT is any ordered, copyable key type (production: uint256).
+
+#include <cstddef>
+#include <map>
+
+namespace ltc {
+
+template <typename HashT>
+class DesiredRequestPacer {
+public:
+    // First empty reply costs kBaseBackoff; each subsequent one doubles, up to
+    // kMaxBackoff. 5s is above the observed reply latency (so a hash is never
+    // backed off while its own request is still in flight); the 300s ceiling is
+    // ~2 SHARE_PERIODs, short enough that a newly-connected peer with the
+    // history is used promptly.
+    static constexpr double kBaseBackoff = 5.0;
+    static constexpr double kMaxBackoff = 300.0;
+
+    // Entries are forgotten once they have been eligible again for this long
+    // without being re-requested — bounds memory and guarantees no permanent ban.
+    static constexpr double kForgetAfter = 2.0 * kMaxBackoff;
+
+    explicit DesiredRequestPacer(double base = kBaseBackoff,
+                                 double cap = kMaxBackoff,
+                                 double forget_after = kForgetAfter)
+        : m_base(base), m_cap(cap), m_forget_after(forget_after) {}
+
+    double base() const { return m_base; }
+    double cap() const { return m_cap; }
+
+    // May we issue a request for `hash` right now? Unknown hashes are always
+    // eligible — the pacer only ever damps hashes that have actually failed.
+    bool eligible(const HashT& hash, double now) const
+    {
+        auto it = m_state.find(hash);
+        return it == m_state.end() || now >= it->second.next_eligible;
+    }
+
+    // An empty reply came back for `hash`: double its backoff (clamped to cap).
+    void record_empty(const HashT& hash, double now)
+    {
+        auto& s = m_state[hash];
+        double delay = m_base;
+        for (int i = 0; i < s.attempts && delay < m_cap; ++i)
+            delay *= 2.0;
+        if (delay > m_cap)
+            delay = m_cap;
+        ++s.attempts;
+        s.next_eligible = now + delay;
+    }
+
+    // The hash was served — it is healthy again, forget it entirely so a later
+    // failure starts from the base delay rather than a stale exponent.
+    void record_success(const HashT& hash)
+    {
+        m_state.erase(hash);
+    }
+
+    // Drop entries that have been eligible again for longer than kForgetAfter.
+    // Called once per think() cycle alongside the failover-memory prune.
+    void prune(double now)
+    {
+        for (auto it = m_state.begin(); it != m_state.end();) {
+            if (now - it->second.next_eligible > m_forget_after)
+                it = m_state.erase(it);
+            else
+                ++it;
+        }
+    }
+
+    std::size_t size() const { return m_state.size(); }
+
+    // Backoff currently applied to `hash` (0 if none) — diagnostics and KAT.
+    int attempts(const HashT& hash) const
+    {
+        auto it = m_state.find(hash);
+        return it == m_state.end() ? 0 : it->second.attempts;
+    }
+
+private:
+    struct State {
+        int attempts{0};
+        double next_eligible{0.0};
+    };
+
+    std::map<HashT, State> m_state;
+    double m_base;
+    double m_cap;
+    double m_forget_after;
+};
+
+}  // namespace ltc

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -1392,6 +1392,11 @@ void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
                     m_fetch_failures.record(target_hash, chosen_key_val,
                                             static_cast<double>(std::time(nullptr)));
                 }
+                // Futility backoff (io thread): damp THIS hash for a growing
+                // interval so a desired set nobody can serve stops being
+                // re-requested at full rate every think() cycle.
+                m_desired_pacer.record_empty(
+                    target_hash, static_cast<double>(std::time(nullptr)));
                 LOG_INFO << "[Pool] Share request empty for "
                          << target_hash.ToString().substr(0,16)
                          << " from " << peer_addr_for_log.to_string()
@@ -1404,6 +1409,7 @@ void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
                 std::lock_guard<std::mutex> g(m_fetch_failover_mtx);
                 m_fetch_failures.clear_hash(target_hash);
             }
+            m_desired_pacer.record_success(target_hash);
 
             LOG_INFO << "[Pool] Received " << reply.m_items.size() << " shares for download request";
 
@@ -1449,10 +1455,17 @@ void NodeImpl::drain_pending_desired()
         m_pending_desired.clear();
         return;
     }
+    const double now = static_cast<double>(std::time(nullptr));
     std::size_t processed = 0;
     while (!m_pending_desired.empty() && processed < DESIRED_REQUEST_BUDGET) {
         auto entry = m_pending_desired.front();
         m_pending_desired.pop_front();
+        // Futility backoff. A hash whose last reply was empty is skipped until
+        // its backoff expires; unknown and healthy hashes are always eligible.
+        // A skip does NOT consume budget -- it is a map lookup, and the point of
+        // the pass is to reach the hashes that can still be served.
+        if (!m_desired_pacer.eligible(entry.second, now))
+            continue;
         peer_ptr advertiser;
         for (auto& [nonce, p] : m_peers) {
             if (p && p->addr() == entry.first) { advertiser = p; break; }
@@ -1461,7 +1474,27 @@ void NodeImpl::drain_pending_desired()
         ++processed;
     }
     if (!m_pending_desired.empty())
-        boost::asio::post(*m_context, [this]() { drain_pending_desired(); });
+        schedule_desired_drain();
+}
+
+void NodeImpl::schedule_desired_drain()
+{
+    // Space the next pass with a timer instead of reposting immediately. The
+    // bare asio::post this replaces yielded to other handlers but imposed no
+    // rate limit, so a desired set that keeps refilling (every reply empty) kept
+    // the io thread at 98% CPU indefinitely. IO thread only.
+    if (m_desired_drain_scheduled)
+        return;
+    if (!m_desired_drain_timer)
+        m_desired_drain_timer = std::make_unique<boost::asio::steady_timer>(*m_context);
+    m_desired_drain_scheduled = true;
+    m_desired_drain_timer->expires_after(DESIRED_DRAIN_INTERVAL);
+    m_desired_drain_timer->async_wait([this](const boost::system::error_code& ec) {
+        m_desired_drain_scheduled = false;
+        if (ec)  // cancelled at shutdown
+            return;
+        drain_pending_desired();
+    });
 }
 
 void NodeImpl::load_persisted_shares()
@@ -2127,9 +2160,15 @@ void NodeImpl::run_think()
             // pulse (main_ltc.cpp watchdog) -> abort during boot. result.desired
             // is recomputed authoritatively each think(), so replace the queue.
             m_pending_desired.clear();
+            // Forget stale backoff entries so a hash that became servable is
+            // retried (the backoff is a damper, never a permanent ban).
+            m_desired_pacer.prune(static_cast<double>(std::time(nullptr)));
             if (!result.desired.empty()) {
-                for (auto& [peer_addr, hash] : result.desired)
+                for (auto& [peer_addr, hash] : result.desired) {
+                    if (m_pending_desired.size() >= DESIRED_QUEUE_MAX)
+                        break;  // remainder is recomputed and re-queued next cycle
                     m_pending_desired.emplace_back(peer_addr, hash);
+                }
                 drain_pending_desired();
             }
 

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -9,6 +9,7 @@
 #include "messages.hpp"
 #include "head_retention.hpp"        // v36-0.24 convergence: clean_tracker Guard predicate (F2 + #25B)
 #include "share_fetch_failover.hpp"  // v36-0.24 convergence: parent-fetch failover memory (#25C)
+#include "desired_request_pacer.hpp"   // futility backoff for the desired-request drain
 
 #include <core/coin_params.hpp>
 #include <core/tx_advertiser.hpp>
@@ -580,6 +581,11 @@ public:
     /// IO thread only.
     void drain_pending_desired();
 
+    /// Arm the timer for the next drain pass (idempotent while one is pending).
+    /// Rate-caps the drain: the budget bounds work per pass, this bounds passes
+    /// per second. IO thread only.
+    void schedule_desired_drain();
+
     /// Return the hash of our tallest chain head, or uint256::ZERO if empty.
     uint256 best_share_hash();
 
@@ -820,6 +826,38 @@ protected:
     // above -- never touch off the io thread. Mirrors m_think_needs_continue.
     static constexpr std::size_t DESIRED_REQUEST_BUDGET = 50;
     std::deque<std::pair<NetService, uint256>> m_pending_desired;
+
+    // ---- desired-drain RATE cap (the budget above is not one) ----
+    // DESIRED_REQUEST_BUDGET bounds the work per PASS, and the continuation was
+    // reposted with a bare asio::post — i.e. immediately. That buys interleaving
+    // with other handlers but no rate limit at all: the queue is re-entered at
+    // once, 50 requests per pass, for as long as it is non-empty. Because empty
+    // replies leave result.desired unchanged, run_think refills the queue every
+    // cycle and the drain never stops. Measured on the public LTC node after the
+    // #1556 cutover: the io thread pinned at 98% CPU (ps -L: 1 thread R, 13 S)
+    // and :8080 dead for 12.7 minutes while the process happily logged ~29
+    // parent-share requests/s, 5137 distinct hashes, ~1:1 answered "empty".
+    // #1556 removed the abort; it could not remove the burn.
+    //
+    // Space the passes with a timer instead. At 50 requests per pass this caps
+    // the drain near 1000 req/s in the worst case while leaving the io thread
+    // idle between passes, and in the failing shape above it cuts the burn by
+    // the duty-cycle ratio. IO-THREAD CONFINED, like m_pending_desired.
+    static constexpr std::chrono::milliseconds DESIRED_DRAIN_INTERVAL{50};
+    std::unique_ptr<boost::asio::steady_timer> m_desired_drain_timer;
+    bool m_desired_drain_scheduled{false};
+
+    // Hard ceiling on the queue. result.desired is authoritative and replaces the
+    // queue each think(), so a pathological set cannot accumulate across cycles —
+    // but it CAN arrive huge in a single cycle on a large persisted sharechain.
+    // Truncating costs nothing: the remainder is recomputed and re-queued next
+    // cycle, now that the pacer keeps the futile members out of the way.
+    static constexpr std::size_t DESIRED_QUEUE_MAX = 2000;
+
+    // Per-hash futility backoff — the CAUSE-side half of the fix. See
+    // desired_request_pacer.hpp for why this is not the same thing as the
+    // per-(hash,peer) failover memory below. IO-THREAD CONFINED.
+    ltc::DesiredRequestPacer<uint256> m_desired_pacer;
 
     // v36-0.24 kr1z1s convergence hotfix #25(C): per-(hash,peer) parent-fetch
     // failure memory. Replaces the old peer-BLIND per-hash counter

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -33,7 +33,7 @@ if (BUILD_TESTING AND GTest_FOUND)
     # pool_rate_head_select.hpp, issue #1482) — verified best when live, else the
     # fastest LIVE raw head; stale-prop = stales/(lookbehind+stales). Pure
     # header-only KAT. Same folding rule: into the existing allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp pool_rate_head_select_test.cpp template_topology_spend_test.cpp)
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp desired_request_pacer_test.cpp pool_rate_head_select_test.cpp template_topology_spend_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/desired_request_pacer_test.cpp
+++ b/src/impl/ltc/test/desired_request_pacer_test.cpp
@@ -1,0 +1,144 @@
+// desired_request_pacer_test.cpp — KAT for the desired-request futility backoff.
+//
+// RED on master semantics (no backoff at all: every desired hash is re-requested
+// every think() cycle regardless of how many empty replies it just produced),
+// GREEN with the pacer.
+//
+// Models the failure measured on the public LTC node after the #1556 cutover:
+// 5137 DISTINCT desired hashes, replies ~1:1 empty, io thread pinned at 98% CPU
+// and :8080 unreachable for 12.7 minutes.
+
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include "../desired_request_pacer.hpp"
+
+using Pacer = ltc::DesiredRequestPacer<std::string>;
+
+// An unseen hash is always requestable — the pacer only damps proven failures.
+TEST(DesiredPacer, unknown_hash_is_eligible)
+{
+    Pacer p;
+    EXPECT_TRUE(p.eligible("H", 0.0));
+    EXPECT_EQ(p.attempts("H"), 0);
+}
+
+// One empty reply holds the hash back for the base interval, then releases it.
+TEST(DesiredPacer, empty_reply_backs_off_then_releases)
+{
+    Pacer p;
+    p.record_empty("H", 100.0);
+    EXPECT_FALSE(p.eligible("H", 100.0));
+    EXPECT_FALSE(p.eligible("H", 104.9));
+    EXPECT_TRUE(p.eligible("H", 105.0));  // base = 5s
+}
+
+// Repeated empties double the interval, and the doubling stops at the ceiling —
+// this is what keeps a permanently-unservable hash from being asked 30x/minute.
+TEST(DesiredPacer, backoff_doubles_and_clamps_to_cap)
+{
+    Pacer p;
+    double t = 0.0;
+    p.record_empty("H", t);
+    EXPECT_TRUE(p.eligible("H", t + 5.0));    // 5
+    p.record_empty("H", t);
+    EXPECT_FALSE(p.eligible("H", t + 9.9));
+    EXPECT_TRUE(p.eligible("H", t + 10.0));   // 10
+    p.record_empty("H", t);
+    EXPECT_TRUE(p.eligible("H", t + 20.0));   // 20
+
+    for (int i = 0; i < 20; ++i)
+        p.record_empty("H", t);
+    // Clamped: never longer than the cap, so the hash is never banned outright.
+    EXPECT_FALSE(p.eligible("H", t + Pacer::kMaxBackoff - 0.1));
+    EXPECT_TRUE(p.eligible("H", t + Pacer::kMaxBackoff));
+}
+
+// A served hash is forgotten, so a later failure starts from the base delay
+// instead of resuming a stale exponent.
+TEST(DesiredPacer, success_resets_the_exponent)
+{
+    Pacer p;
+    p.record_empty("H", 0.0);
+    p.record_empty("H", 0.0);
+    p.record_empty("H", 0.0);
+    ASSERT_EQ(p.attempts("H"), 3);
+
+    p.record_success("H");
+    EXPECT_EQ(p.attempts("H"), 0);
+    EXPECT_TRUE(p.eligible("H", 0.0));
+
+    p.record_empty("H", 200.0);
+    EXPECT_TRUE(p.eligible("H", 205.0));  // base again, not 40s
+}
+
+// EXPIRY IS THE CONTRACT: a hash nobody could serve must return to the normal
+// request path once a peer carrying that history can connect. Without this the
+// damper would turn a transient gap into a permanent chain hole.
+TEST(DesiredPacer, entries_expire_and_never_ban_permanently)
+{
+    Pacer p;
+    for (int i = 0; i < 20; ++i)
+        p.record_empty("H", 0.0);
+    ASSERT_EQ(p.size(), 1u);
+    ASSERT_FALSE(p.eligible("H", 10.0));
+
+    // Long after it became eligible again, the entry is dropped entirely.
+    p.prune(Pacer::kMaxBackoff + Pacer::kForgetAfter + 1.0);
+    EXPECT_EQ(p.size(), 0u);
+    EXPECT_TRUE(p.eligible("H", Pacer::kMaxBackoff + Pacer::kForgetAfter + 1.0));
+    EXPECT_EQ(p.attempts("H"), 0);
+}
+
+// Pruning must NOT release a hash whose backoff is still running.
+TEST(DesiredPacer, prune_keeps_live_backoffs)
+{
+    Pacer p;
+    p.record_empty("H", 1000.0);
+    p.prune(1001.0);
+    EXPECT_EQ(p.size(), 1u);
+    EXPECT_FALSE(p.eligible("H", 1001.0));
+}
+
+// THE RATE KAT the fix exists for. Replay the measured failure shape — a desired
+// set where every reply is empty, recomputed by think() every cycle — and count
+// the requests that would actually be issued over the window.
+//
+// Without the pacer every hash is re-requested on every cycle: N * cycles.
+// With it, a hash is asked only when its backoff has expired, so the count grows
+// logarithmically in the window instead of linearly.
+TEST(DesiredPacer, all_empty_replies_collapse_the_request_count)
+{
+    constexpr int kHashes = 500;
+    constexpr double kThinkInterval = 10.0;
+    constexpr double kWindow = 300.0;
+
+    std::vector<std::string> hashes;
+    hashes.reserve(kHashes);
+    for (int i = 0; i < kHashes; ++i)
+        hashes.push_back("hash-" + std::to_string(i));
+
+    Pacer p;
+    long paced = 0;
+    long unpaced = 0;
+
+    for (double now = 0.0; now < kWindow; now += kThinkInterval) {
+        p.prune(now);
+        for (const auto& h : hashes) {
+            ++unpaced;  // master: recomputed desired set, asked unconditionally
+            if (p.eligible(h, now)) {
+                ++paced;
+                p.record_empty(h, now);  // the reply comes back empty, as measured
+            }
+        }
+    }
+
+    const int cycles = static_cast<int>(kWindow / kThinkInterval);
+    EXPECT_EQ(unpaced, static_cast<long>(kHashes) * cycles);
+
+    // Every hash is still tried repeatedly — this is a damper, not a mute.
+    EXPECT_GT(paced, static_cast<long>(kHashes));
+    // ...but the storm is gone: at least a 3x cut over this window, and the
+    // margin widens the longer the futile set persists.
+    EXPECT_LT(paced * 3, unpaced);
+}


### PR DESCRIPTION
## What this fixes

After the #1556 cutover the public LTC node **stopped aborting but stopped serving**. Measured on the live node, not inferred:

- `:8080` unreachable for **12.7 minutes** without a single 200 (probes every 10s; two isolated probes at T+42s and T+83s had both landed in a good phase and read as "healthy" — single-point liveness cannot distinguish healthy from *not currently frozen*)
- `ps -L` on the live PID: **one thread in `R` at 98.2% CPU, the other 13 sleeping**; process total 102%
- journal over a 210s freeze window: **6146** `[Pool] Requesting parent share` (~29/s) for **5137 DISTINCT** hashes, answered ~1:1 by **5819** `[Pool] Share request empty for`
- log volume during the freeze *higher* than when healthy (76 vs 70 lines/s) — the process was busy, not hung

`#1556` removed the watchdog kill. It could not remove the burn.

## Root cause

`drain_pending_desired()` has a per-pass budget (`DESIRED_REQUEST_BUDGET = 50`) but **no rate limit**: the continuation was a bare `boost::asio::post`, i.e. immediate. That buys interleaving with other handlers and nothing else — the queue is re-entered at once, 50 requests per pass, for as long as it is non-empty.

And it stays non-empty. `run_think`'s IO phase recomputes `result.desired` authoritatively every cycle; empty replies leave that set unchanged, so it is refilled and the drain never terminates. **A budget without a rate cap is a polite busy-loop.**

## The change

**Symptom — `schedule_desired_drain()`.** Spaces passes with a `steady_timer` (`DESIRED_DRAIN_INTERVAL = 50ms`) instead of reposting immediately, so the io thread gets gaps regardless of how large or futile the desired set is. Idempotent while a wait is pending. Structurally the same pattern bip110 already uses — `src/impl/bip110/pool/node.cpp:1435` `arm_download_retry_timer`.

**Cause — `DesiredRequestPacer`** (new pure header, `src/impl/ltc/desired_request_pacer.hpp`). Damps a hash whose reply came back empty, doubling from 5s to a 300s ceiling.

This is deliberately **not** the per-`(hash, peer)` failover memory in `share_fetch_failover.hpp`. That one answers *which peer should I ask*, and suppresses a hash only once **every** connected peer has failed it, for a flat 90s TTL — it cannot damp a desired set whose members are each failing their *first* attempt across a rotating peer set. dash carries a flat equivalent (`src/pool/share_download.hpp:65` `DownloadGate`, `MAX_EMPTY_RETRIES = 3`); the exponential form with expiry is strictly gentler on a parent that is only transiently unavailable.

**Expiry is part of the contract, not an optimization.** A hash nobody can serve now may be servable later, when a peer carrying that history connects. So the backoff is capped and entries are dropped once they age past eligibility. A permanent denylist here would convert a transient gap into a permanent chain hole.

**`DESIRED_QUEUE_MAX = 2000`** caps a single cycle's enqueue; the remainder is recomputed and re-queued next cycle, so nothing is lost.

## Reward-safe

This changes the **timing of parent-share requests** only. The accept path, share validation, PPLNS weights and payout construction are untouched — same posture as #1556.

## Scope

LTC-only by construction. `drain_pending_desired` exists **only** in this lane; btc/bch/dgb/dash/bip110 send desired synchronously once per `think()` and have no drain loop, so no sibling lane compiles this code.

Worth a separate, non-urgent look (**not** this PR): those lanes carry the *original* un-chunked shape — one synchronous burst per cycle, bounded only by think cadence rather than by a budget. dgb has no mitigation at all (`src/impl/dgb/node.cpp:1888`, plus a flat `m_download_fail_count` cleared every cycle). That is a milder latent risk, not the crash/freeze defect fixed here.

## Tests

`src/impl/ltc/test/desired_request_pacer_test.cpp`, 7 cases:

| case | asserts |
|---|---|
| `unknown_hash_is_eligible` | the pacer only ever damps proven failures |
| `empty_reply_backs_off_then_releases` | one empty reply costs the base interval, then releases |
| `backoff_doubles_and_clamps_to_cap` | doubling stops at the ceiling — never an outright ban |
| `success_resets_the_exponent` | a served hash starts from base again, not a stale exponent |
| `entries_expire_and_never_ban_permanently` | the expiry contract above |
| `prune_keeps_live_backoffs` | pruning must not release a running backoff |
| `all_empty_replies_collapse_the_request_count` | replays the measured failure shape (500 hashes, every reply empty, 300s window) and asserts the request count collapses by >3x **while every hash is still retried** |

`share_test` **139/139 green**. `c2pool-ltc` target builds clean, 0 errors.

## Follow-up candidate (not here)

At ~29 req/s the CPU cannot be going into the network — it is going into work done *per request*: `stops` is rebuilt for every desired hash by walking `chain.get_heads()` plus `get_nth_parent_via_skip` per head (`node.cpp:1343-1359`), although heads change slowly. Hoisting that out of the per-request path is a real win but a separate change; the rate cap here reduces the frequency by construction.
