### PR TITLE
ci(heavy-leg-lock): honor HEAVY_LEG_HOLDER_ENV in build.yml + codeql (gate CASE3 red on master)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -468,7 +468,7 @@ jobs:
           ' </dev/null >/dev/null 2>&1 &
           HOLDER=$!
           disown "$HOLDER" 2>/dev/null || true
-          echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
+          echo "${HEAVY_LEG_HOLDER_ENV:-HEAVY_LEG_LOCK_HOLDER}=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
 
           # --- wait for the acquire handshake ---
           while kill -0 "$HOLDER" 2>/dev/null && [ ! -s "$ACQ" ]; do

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -208,7 +208,7 @@ jobs:
           ' </dev/null >/dev/null 2>&1 &
           HOLDER=$!
           disown "$HOLDER" 2>/dev/null || true
-          echo "HEAVY_LEG_LOCK_HOLDER=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
+          echo "${HEAVY_LEG_HOLDER_ENV:-HEAVY_LEG_LOCK_HOLDER}=$HOLDER" >> "${GITHUB_ENV:-/dev/null}"
 
           # --- wait for the acquire handshake ---
           while kill -0 "$HOLDER" 2>/dev/null && [ ! -s "$ACQ" ]; do


### PR DESCRIPTION
## What

The per-host heavy-leg reap-guard exports its holder pid under a hardcoded
`HEAVY_LEG_LOCK_HOLDER`, ignoring the `HEAVY_LEG_HOLDER_ENV` override. The shared
`acquire.sh` was already corrected to honor the override, but the two inline
copies in `build.yml` and `codeql-analysis.yml` lagged behind, so the
disk-semaphore reuse path (`HEAVY_LEG_HOLDER_ENV=HEAVY_DISK_LOCK_HOLDER`) never
exported its holder. `test.sh` CASE 3 (holder-env override) is currently RED on
master as a result.

This exports under `${HEAVY_LEG_HOLDER_ENV:-HEAVY_LEG_LOCK_HOLDER}` in both
workflows, realigning them with the canonical `acquire.sh`.

## Verified

`heavy-leg-lock/test.sh` (extracts the shipped build.yml step and drives it) now
passes all 4 cases -- perturb -> reaped -> green ; restore leak -> red -- exit 0,
where master was exit 1. Same gate green when driven against the shared
`acquire.sh` directly.

## Follow-up (this branch, next commit)

Wire `build.yml` + `codeql-analysis.yml` to `run:` the shared `acquire.sh` so the
semaphore has a single source of truth and cannot drift again. Draft until that
cutover lands and full-matrix CI is green.
