### PR TITLE
web(#921 v36-crossing-summary): emit real V36 signaling in /global_stats and /local_stats

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2947,6 +2947,28 @@ nlohmann::json MiningInterface::rest_miner_thresholds()
     return result;
 }
 
+// #921: observability-only additive V36 crossing summary. Flattens the real
+// ratchet figures rest_version_signaling() already computes (the same numbers
+// the /v36_status card and the debug.log crossing gauge read) into four flat
+// keys, so a dashboard polling /global_stats or /local_stats sees the V35->V36
+// cross without a second fetch. Additive only: no existing key is renamed or
+// removed. Never a stub -- every value tracks live sharechain state.
+static nlohmann::json v36_crossing_summary(const nlohmann::json& vs, int64_t cached_share_version)
+{
+    int64_t v36_shares = vs.value("overall_v36_shares", static_cast<int64_t>(0)); // format-latched
+    int64_t v36_votes  = vs.value("overall_v36_votes",  static_cast<int64_t>(0)); // desired-version
+    double  sampling   = vs.value("sampling_signaling", 0.0);                     // work-weighted %
+    bool    active     = cached_share_version >= 36;
+    if (vs.contains("auto_ratchet") && vs["auto_ratchet"].is_object())
+        active = vs["auto_ratchet"].value("v36_active", active);
+    return nlohmann::json{
+        {"v36_active",     active},
+        {"v36_percentage", sampling},
+        {"v36signaling",   v36_votes > v36_shares ? v36_votes - v36_shares : static_cast<int64_t>(0)},
+        {"v36native",      v36_shares},
+    };
+}
+
 nlohmann::json MiningInterface::rest_global_stats()
 {
     // Return p2pool-compatible pool statistics
@@ -2974,8 +2996,10 @@ nlohmann::json MiningInterface::rest_global_stats()
     std::optional<double> sc_pool_stale_prop;
 
     // Populate from sharechain
+    nlohmann::json sc_snapshot;  // #921: reused for the additive V36 crossing summary below
     if (m_sharechain_stats_fn) {
-        auto sc = m_sharechain_stats_fn();
+        sc_snapshot = m_sharechain_stats_fn();
+        auto& sc = sc_snapshot;
         if (sc.contains("total_shares"))
             total_shares = sc["total_shares"].get<int>();
         if (sc.contains("orphan_shares"))
@@ -3079,6 +3103,12 @@ nlohmann::json MiningInterface::rest_global_stats()
         result["last_block_ts"] =
             last_ts ? nlohmann::json(last_ts) : nlohmann::json(nullptr);
     }
+
+    // #921: additive V36 crossing summary (see v36_crossing_summary). Reuses the
+    // snapshot already read above; no key renamed or removed.
+    result.update(v36_crossing_summary(
+        rest_version_signaling(sc_snapshot.is_null() ? nullptr : &sc_snapshot),
+        m_cached_share_version));
 
     return result;
 }
@@ -4767,6 +4797,13 @@ nlohmann::json MiningInterface::rest_local_stats()
 
         result["warnings"] = warnings;
     }
+
+    // #921: additive V36 crossing summary (see v36_crossing_summary). Reuses the
+    // cached sharechain snapshot; no key renamed or removed.
+    result.update(v36_crossing_summary(
+        rest_version_signaling(cached_sc.is_null() ? nullptr : &cached_sc),
+        m_cached_share_version));
+
     result["donation_proportion"] = m_pool_fee_percent / 100.0;
     result["fee"] = m_pool_fee_percent;  // percentage (e.g. 1.0)
     // UNITS, stated (hotel, 2026-08-05: the operator could not tell from the

--- a/test/test_web_honesty_regression.cpp
+++ b/test/test_web_honesty_regression.cpp
@@ -1870,3 +1870,66 @@ TEST(WebStaticMergedGating, LoadingPageSpvRowsAreTopologyDriven) {
     EXPECT_NE(html.find("ci.symbol"), std::string::npos)
         << "the parent SPV row label is not currency_info-driven.";
 }
+
+// ---------------------------------------------------------------------------
+// #921: /global_stats and /local_stats must carry the real V35->V36 crossing
+// summary (v36_active / v36_percentage / v36signaling / v36native). These keys
+// were absent from BOTH aggregate endpoints on two different coin arms
+// (DASH :8097 + :8094) -- a shared-serializer omission, not a per-coin bug.
+// A missing key is not load-dependent, so the fix belongs in the shared
+// web_server serializer. The asserts pin PRESENCE *and* NON-STUB values: a
+// hardcoded 0 would satisfy a presence-only check and silently reproduce the
+// same empty crossing card.
+// ---------------------------------------------------------------------------
+namespace {
+// Mid-cross fixture: 400 shares, 100 already format-latched to V36 (v36native),
+// 250 desiring V36 (=> 150 signaling-but-not-yet-latched), 60% work-weighted.
+json v36_midcross_stats() {
+    json sc;
+    sc["total_shares"]              = 400;
+    sc["chain_height"]              = 400;
+    sc["shares_by_version"]         = {{"35", 300}, {"36", 100}};
+    sc["shares_by_desired_version"] = {{"35", 150}, {"36", 250}};
+    sc["sampling_desired_version"]  = {{"35", 40.0}, {"36", 60.0}};
+    return sc;
+}
+void expect_real_v36_summary(const json& r, const char* endpoint) {
+    ASSERT_TRUE(r.contains("v36_active"))     << endpoint << " dropped v36_active";
+    ASSERT_TRUE(r.contains("v36_percentage")) << endpoint << " dropped v36_percentage";
+    ASSERT_TRUE(r.contains("v36signaling"))   << endpoint << " dropped v36signaling";
+    ASSERT_TRUE(r.contains("v36native"))      << endpoint << " dropped v36native";
+    // NON-STUB: exact counts a hardcoded-0 stub could never produce.
+    EXPECT_EQ(r["v36native"].get<int64_t>(), 100)
+        << endpoint << " v36native not sourced from format-latched share count";
+    EXPECT_EQ(r["v36signaling"].get<int64_t>(), 150)
+        << endpoint << " v36signaling not sourced from desired-version tally";
+    EXPECT_GT(r["v36_percentage"].get<double>(), 0.0)
+        << endpoint << " v36_percentage collapsed to a stub 0";
+    // Node still VOTING (cached share version 35) -> not latched.
+    EXPECT_FALSE(r["v36_active"].get<bool>())
+        << endpoint << " claims a V36 latch while the node still produces V35 shares";
+}
+} // namespace
+
+TEST(WebHonestyRegression, GlobalStatsEmitsRealV36CrossingSummaryNotStub) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::LITECOIN);
+    mi.set_cached_share_version(35);
+    mi.set_sharechain_stats_fn([] { return v36_midcross_stats(); });
+    expect_real_v36_summary(mi.rest_global_stats(), "/global_stats");
+}
+
+TEST(WebHonestyRegression, LocalStatsEmitsRealV36CrossingSummaryNotStub) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::LITECOIN);
+    mi.set_cached_share_version(35);
+    mi.set_sharechain_stats_fn([] { return v36_midcross_stats(); });
+    expect_real_v36_summary(mi.rest_local_stats(), "/local_stats");
+}
+
+TEST(WebHonestyRegression, V36CrossingSummaryLatchesWhenNodeProducesV36) {
+    MiningInterface mi(/*testnet=*/true, /*node=*/nullptr, Blockchain::LITECOIN);
+    mi.set_cached_share_version(36);   // node has latched to V36
+    mi.set_sharechain_stats_fn([] { return v36_midcross_stats(); });
+    json r = mi.rest_global_stats();
+    EXPECT_TRUE(r["v36_active"].get<bool>())
+        << "/global_stats v36_active must follow the live latch to V36";
+}


### PR DESCRIPTION
## What

`/global_stats` and `/local_stats` did not emit any V35→V36 crossing state. The four crossing keys — `v36_active`, `v36_percentage`, `v36signaling`, `v36native` — were absent from **both** aggregate endpoints on two different coin arms (DASH :8097 and :8094). Absent on two coin arms = a shared-serializer omission, not a per-coin bug; a missing key is not load-dependent.

A dashboard polling either aggregate endpoint therefore saw no crossing state without a second `/v36_status` fetch.

## Change (shared serializer — additive only)

- Adds a small file-local `v36_crossing_summary()` helper that flattens the real ratchet figures `rest_version_signaling()` already computes (`overall_v36_shares`, `overall_v36_votes`, `sampling_signaling`, `auto_ratchet.v36_active` — the same numbers the `/v36_status` card and the debug.log crossing gauge read) into the four flat keys.
- `rest_global_stats()` and `rest_local_stats()` each call it, reusing the sharechain snapshot already read in that serializer.

**Observability-only additive emit, no existing key renamed or removed** (older version-coupled dashboards keep rendering unchanged). Reuses the already-read snapshot — no new lock taken on the HTTP path.

Touches only `src/core/web_server.cpp` (+ the test). Zero `src/impl/<coin>/` edits.

Key semantics (aggregate, matching the frontend's per-share client computation):
- `v36native` = shares already format-latched to V36 (`overall_v36_shares`)
- `v36signaling` = desiring V36 but not yet latched (`overall_v36_votes − overall_v36_shares`, floored at 0)
- `v36_percentage` = work-weighted signaling %
- `v36_active` = live latch (tracks `auto_ratchet.v36_active` / cached share version)

## Test — in the same PR, present AND non-stub

Three KATs folded into `test_web_honesty_regression` (no new executable). A mid-cross fixture (400 shares: 100 format-latched, 250 desiring V36, 60% work-weighted) asserts on both endpoints:
- all four keys **present** (fails by construction on the unpatched serializer — `ASSERT_TRUE(contains(...))`),
- **non-stub** exact counts (`v36native == 100`, `v36signaling == 150`) — a hardcoded 0 would pass a presence-only check and reproduce the same silent-empty card, so this rejects it,
- `v36_active` follows the live latch (false while voting at V35, true once cached share version is 36).

Local run: `ctest -R WebHonestyRegression` → 40/40 pass.
