### PR TITLE
xmr(native): M0 — assemble the node and follow a live tip over levin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,7 +244,7 @@ jobs:
                     xmr_native_p2p_dos_kat xmr_native_peer_pool_kat \
                     xmr_native_template_kat xmr_native_template_coinbase_kat \
                     xmr_native_block_relay_kat xmr_c5_regtest_push \
-                    xmr_native_parity_kat \
+                    xmr_native_parity_kat xmr_native_node_kat xmr_native_node \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -682,7 +682,7 @@ jobs:
                     xmr_native_p2p_dos_kat xmr_native_peer_pool_kat \
                     xmr_native_template_kat xmr_native_template_coinbase_kat \
                     xmr_native_block_relay_kat xmr_c5_regtest_push \
-                    xmr_native_parity_kat \
+                    xmr_native_parity_kat xmr_native_node_kat xmr_native_node \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison

--- a/src/impl/xmr/native/CMakeLists.txt
+++ b/src/impl/xmr/native/CMakeLists.txt
@@ -116,6 +116,48 @@ if (BUILD_TESTING AND UNIX)
     target_compile_features(xmr_c5_regtest_push PRIVATE cxx_std_20)
 endif()
 
+# ─────────────────────────────────────────────────────────────────────────────
+# M0 (node/): THE ASSEMBLY. The wave-1 components are header-only and each one
+# states a threading contract it does not itself provide; node/ builds the
+# threads, the boot, the sync schedule and the status surface that turn them
+# into a running node, and node/tools/ is the entrypoint that runs it.
+#
+# Same discipline as xmr_c5_regtest_push above: BUILT in both build.yml
+# --target lists so it cannot bit-rot, RUN by nobody in CI (it needs a daemon
+# and a network), and registering no ctest test -- so the #1539 Not-Run rule
+# does not apply to it. What IS registered is test/xmr_native_node_kat, which
+# covers the parts of the assembly that can be judged without a daemon: the
+# queue adapters, the io-thread fence, the boot's derivation of the genesis
+# row, and the sync driver's schedule.
+#
+# Links boost::asio (header-only in the pinned Boost 1.90), a thread library,
+# and xmr_native_txpool (which brings xmr_coin for keccak, the tree hash and
+# the vendored difficulty retarget). It links `randomx` when
+# XMR_BUILD_RANDOMX is on, and defines XMR_NATIVE_NODE_HAVE_RANDOMX so the
+# node compiles the real LightVerifier in; without it the binary still builds
+# (the sanitizer leg has no RandomX) and refuses to call any block verified.
+# ─────────────────────────────────────────────────────────────────────────────
+if (BUILD_TESTING AND UNIX)
+    add_executable(xmr_native_node node/tools/xmr_native_node_main.cpp)
+    target_include_directories(xmr_native_node PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(xmr_native_node PRIVATE xmr_native_txpool)
+    target_compile_features(xmr_native_node PRIVATE cxx_std_20)
+    if (TARGET Boost::headers)
+        target_link_libraries(xmr_native_node PRIVATE Boost::headers)
+    elseif (TARGET Boost::boost)
+        target_link_libraries(xmr_native_node PRIVATE Boost::boost)
+    elseif (DEFINED Boost_INCLUDE_DIRS)
+        target_include_directories(xmr_native_node PRIVATE ${Boost_INCLUDE_DIRS})
+    endif()
+    if (TARGET Threads::Threads)
+        target_link_libraries(xmr_native_node PRIVATE Threads::Threads)
+    endif()
+    if (TARGET randomx)
+        target_link_libraries(xmr_native_node PRIVATE randomx)
+        target_compile_definitions(xmr_native_node PRIVATE XMR_NATIVE_NODE_HAVE_RANDOMX=1)
+    endif()
+endif()
+
 if (BUILD_TESTING)
     add_subdirectory(test)
 endif()

--- a/src/impl/xmr/native/README.md
+++ b/src/impl/xmr/native/README.md
@@ -24,6 +24,8 @@ activates v37 consensus and nothing here touches `src/sharechain/v37`.
 | `rct/` | Wave 1 / C3: non-input consensus — commitment balance, the Bulletproof+ verifier, the key-image domain check. The one part of this tree that compiles rather than being header-only |
 | `txpool/` | Wave 1 / C3: the relay-side transaction decoder and the relayed transaction pool itself |
 | `relay/` | Wave 1 / C5: the dual-arm found-block relay — the self-contained 2008 fluffy push, the on-demand monerod backup arm, the 2009 responder, and the c2pool-side redundant-broadcast carrier |
+| `parity/` | Wave 1 / C6: the monerod-parity oracle — the anchor-keyed graduation ledger and the three seams (tip, template, submit) it judges against a real daemon |
+| `node/` | M0: the ASSEMBLY — the threads the components were written against, the boot, the sync schedule, the status surface, and `xmr_native_node`, the entrypoint that runs the whole thing against a daemon |
 | `test/` | the KATs |
 
 ### contracts/
@@ -634,15 +636,20 @@ component does not answer it. An ingress with no coinbase check wired refuses to
 relay rather than relaying blind, and records that as our own gap rather than
 the peer's fault.
 
-## Not here yet
+## Where the milestones stand
 
-Landed so far, each authored against the contracts here: the levin codec (C1a),
-the levin transport (C1b), the peer pool and its DoS policy (C1c), the consensus
-state (C2a), the trust-anchor bundle (C2b), the chain index with its fork
-choice (C2c), the relayed txpool (C3), the template source (C4) and the block
-relay (C5). Still to come: the parity oracle (C6).
+All thirteen components are landed, each authored against the contracts here:
+the levin codec (C1a), the levin transport (C1b), the peer pool and its DoS
+policy (C1c), the consensus state (C2a), the trust-anchor bundle (C2b), the
+chain index with its fork choice (C2c), the relayed txpool (C3), the template
+source (C4), the block relay (C5) and the parity oracle (C6).
 
-C1b stops at one connection. The dial plan, the peer store, the primary
-election, the refill and rotation loops, the token buckets, the chain locator
-and the `IBroadcastPort` / `IChainFetcher` / `IChainServing` implementations are
-C1c, which is where `LevinLink`'s `on_frame` demux gets its consumers.
+**M0 is closed on the short proof**: `node/` assembles them, and
+`node/README.md` carries the run — a private regtest chain followed from the
+genesis block over levin alone (20 heights backfilled, 4 followed live as they
+were mined), RandomX verified on the verify thread with a zero io-thread
+counter, P-TIP CLEAN on all nine fields at every sampled height, and zero
+monerod RPC on the tip-follow path. The plan's 48–72 h P-TIP soak is a separate,
+operator-scoped run; M1 (txpool equality), M2 (template rebind), M3 (block
+relay) and M4 (graduation) each have their seam wired and unexercised on
+purpose.

--- a/src/impl/xmr/native/chain/xmr_chain_index.hpp
+++ b/src/impl/xmr/native/chain/xmr_chain_index.hpp
@@ -805,6 +805,22 @@ private:
             r.connect = co.status;
             if (co.status == ConnectStatus::Ok) {
                 alt_.erase(r.id);
+                // A block that arrived BEFORE its parent was parked in the alt
+                // pool, and until now nothing ever revisited it: the branch path
+                // below resolves descendants, the fast path did not. So a node
+                // that was handed a block out of order kept it forever and
+                // stopped following the tip -- while its peers went on relaying
+                // blocks it had already been given.
+                //
+                // This is not a rare case, it is EVERY COLD START: monerod sends
+                // its top block to a peer whose advertised height is behind its
+                // own (process_payload_sync_data), so the first block a syncing
+                // node receives is normally one it cannot connect yet. Found by
+                // the M0 assembly on a live regtest run, where the index stopped
+                // at the height it had backfilled to and four pushed blocks sat
+                // parked behind it.
+                resolve_descendants_locked_(r.id);
+                connect_parked_children_locked_();
                 r.outcome = OfferOutcome::Connected;
                 return r;
             }
@@ -1023,6 +1039,40 @@ private:
                 alt_.insert(std::move(c));
                 stack.push_back(child_id);
             }
+        }
+    }
+
+    // Drain the parked children of the tip, in order, as ordinary EXTENDS.
+    //
+    // Going through maybe_switch_locked_() instead would work but would LIE: a
+    // switch whose fork point IS the current tip disconnects nothing, and it
+    // announces one Reorg of depth 0 for what is simply the next block. A
+    // consumer that un-confirms on a reorg would un-confirm nothing, repeatedly.
+    void connect_parked_children_locked_() {
+        for (std::size_t guard = 0; guard < 4096; ++guard) {
+            const RowRecord* tip = rows_.tip();
+            if (!tip) return;
+            const Hash tip_id = tip->row.id;
+
+            // Copied out of the pool before anything is connected: connecting
+            // mutates the caches a live pointer into the pool would outlive.
+            std::optional<AltBlock> pick;
+            for (const AltBlock* c : alt_.children_of(tip_id)) {
+                if (c->resolved && c->adoptable && c->has_entry) { pick = *c; break; }
+            }
+            if (!pick) return;
+
+            EvaluatedBlock ev;
+            std::string    why;
+            if (evaluate_block(pick->entry, ev, why) != EvalStatus::Ok) {
+                alt_.erase_branch(pick->id);
+                continue;
+            }
+            const ConnectOutcomeLocal co =
+                connect_to_tip_locked_(pick->entry, ev, pick->pow_verified, Hash{},
+                                       pick->own_mined, why);
+            if (co.status != ConnectStatus::Ok) return;   // leave it parked, and say nothing new
+            alt_.erase(pick->id);
         }
     }
 

--- a/src/impl/xmr/native/node/README.md
+++ b/src/impl/xmr/native/node/README.md
@@ -1,0 +1,243 @@
+# M0 — the assembly, and the run that judges it
+
+`node/` is where the thirteen wave-0/wave-1 components stop being a library and
+start being a node: it constructs them, gives them the threads their own banners
+ask for, seeds the index, decides when to ask a peer for a chain, and prints
+enough about all of it that "connected and receiving nothing" is a pair of
+numbers rather than a debugging session.
+
+| file | what |
+|---|---|
+| `xmr_worker_loops.hpp` | the threads — `WorkerLoop` (one thread, one bounded queue, a blocking `call()` for the control path), `VerifyInbound` and `TxSinkLoop` (the enqueue-and-return adapters between the io thread and the components), and `ThreadWitnessPowSource` (the io-thread fence, as a counter) |
+| `xmr_chain_boot.hpp` | where history starts: the anchor path, the genesis path, and the pre-boot serving answers that keep a peer from closing us before the trust root lands |
+| `xmr_sync_driver.hpp` | the half of chain sync no component owns — who to ask, when, and what else |
+| `xmr_monerod_http.hpp` | the parity/backup arm's transport, and nothing else's |
+| `xmr_native_node.hpp` | `NativeNode`: the wiring, the two networks, the status surface |
+| `tools/xmr_native_node_main.cpp` | `xmr_native_node`, the entrypoint: follow / probe / parity |
+
+The KAT is `test/xmr_native_node_kat.cpp` (`ctest -R xmr_native_node_kat`): the
+queues, the deferred txpool verdict, the RandomX witness, the genesis
+derivation against monerod's own numbers, the pre-boot advertisement, the sync
+schedule, and one regression that is a real defect this assembly found (below).
+
+## What this layer adds that no component did
+
+1. **The threads.** Three component banners demand a thread that none of them
+   creates. C1c calls `IChainIndexInbound` and `IRelayedTxSink` from the io
+   thread and says "enqueue-and-return"; C2c says "one owner (the verify
+   thread) mutates" and runs a ~10–15 ms RandomX evaluation inside
+   `offer_block`; C3 says its caller "must not be the io thread once the heavy
+   leg is on". So: io thread for sockets and codec, verify thread for consensus
+   and RandomX, pool thread for transaction decode and range proofs.
+2. **The first question.** Nothing in the tree sends the first
+   `NOTIFY_REQUEST_CHAIN`, and nothing seeds row zero. Without both, a node sits
+   handshaked, liveness-green and empty forever.
+3. **The two networks.** A Monero node needs two answers to "which network":
+   the WIRE identity (network id, genesis id, default port — `levin::XmrNet`)
+   and the CONSENSUS rules (the hard-fork table — `native::XmrNet`). regtest is
+   the case that proves they are different facts: monerod's fakechain carries
+   the MAINNET network id and serves the MAINNET genesis block at height 0,
+   while running a hard-fork table that starts at v16 from height 1.
+4. **The admissions.** The status line reports the RandomX witness, the queue
+   depths, the peers that are handshaked but silent, and the RPC call count
+   beside the block count.
+
+## The io-thread fence is a number, not a promise
+
+`ThreadWitnessPowSource` wraps the PoW source, records the thread every RandomX
+evaluation actually ran on, and counts the ones that ran on a thread the node
+declared forbidden (the io threads). The node prints it and the KAT asserts the
+counter itself works — a witness that could not catch a forbidden call would be
+worth nothing:
+
+```
+randomx        : mode=1 hashes=24 prefetches=1 rekeys=1 verified=24 failed=0 foreign=0 threads=128870032328384
+threads        : io=128870015542976 verify=128870032328384
+```
+
+## The M0 run (regtest, 2026-09-11)
+
+Two isolated `monerod 0.18.5.1 --regtest --fixed-difficulty 1` daemons on
+loopback, own data dirs and own ports, peered only with each other — the rig
+from `relay/tools/README.md`, with one addition. Give the two daemons
+**different loopback addresses** (A on 127.0.0.1, B on 127.0.0.2): monerod does
+not source-bind its outbound connections to its p2p bind address, so on a single
+loopback address the two daemons' mutual links occupy each other's
+one-connection-per-remote-IP slot and a third participant is refused with
+`CONNECTION FROM 127.0.0.1 REFUSED, too many connections from the same address`
+before it can say hello. The native node dials from a third address
+(`--p2p-bind-ip 127.0.0.3`, which is `XmrPeerPool::Config::bind_ip`).
+
+```bash
+M=<path>/monerod
+common="--regtest --fixed-difficulty 1 --no-igd --hide-my-port --non-interactive \
+        --no-zmq --disable-rpc-ban --keep-fakechain --detach"
+
+$M $common --data-dir ~/xmr-m0-rig/A --log-file ~/xmr-m0-rig/A/logs/monerod.log \
+   --rpc-bind-ip 127.0.0.1 --rpc-bind-port 41189 \
+   --p2p-bind-ip 127.0.0.1 --p2p-bind-port 41188 --add-exclusive-node 127.0.0.2:41288
+$M $common --data-dir ~/xmr-m0-rig/B --log-file ~/xmr-m0-rig/B/logs/monerod.log \
+   --rpc-bind-ip 127.0.0.2 --rpc-bind-port 41289 \
+   --p2p-bind-ip 127.0.0.2 --p2p-bind-port 41288 --add-exclusive-node 127.0.0.1:41188
+
+xmr_native_node --net regtest --connect 127.0.0.1:41188 --p2p-bind-ip 127.0.0.3 \
+                --monerod-rpc 127.0.0.1:41189 --commit "$(git rev-parse HEAD)" \
+                --follow-to 24 --run-seconds 200
+```
+
+`--fixed-difficulty 1` is monerod's own fakechain knob and needs no mirror on
+our side: the genesis timestamp is 0, so for any chain shorter than the 735-row
+window our `next_difficulty` computes 1 as well — and the parity oracle compares
+the two at every sampled height rather than taking it on trust.
+
+What the node did:
+
+```
+[node] net=regtest wire-net=0 consensus-net=regtest boot=genesis peers=1 parity=1 probe=0
+[tip] height=1  id=1705bccea704... prev=418015bb9ae9... difficulty=1 cumdiff=2  timestamp=1789089762 reward=35184338534400 weight=85
+...
+[tip] height=24 id=d09d52593... prev=c97790ea09c0... difficulty=1 cumdiff=25 timestamp=1789091255 reward=35182795064383 weight=85
+[XMR-PARITY] seam=TIP h=21 verdict=CLEAN classes=Steady+EpochEdge compared=9/9 note="9 field(s) equal [P-TIP first=native]"
+[XMR-PARITY] seam=TIP h=22 verdict=CLEAN ...
+[XMR-PARITY] seam=TIP h=23 verdict=CLEAN ...
+[XMR-PARITY] seam=TIP h=24 verdict=CLEAN ...
+
+=== summary ===
+tip            : height=24 verified_frontier=24 rows=25 synced=1 alt=0 orphans=0 reorgs=0
+boot           : genesis booted=1 inspected=1 refusals=0 dropped=0 (genesis row seeded from the levin-delivered blob)
+chain-entry    : start=0 total=21 ids=21 first=418015bb9ae9... last=66979fcc5a85... first_block=1/129 bytes
+peers          : handshaked=1 total=1 netgroups=1 silent=0 handshakes=1 dials=2/0 last_close= ()
+levin in       : blocks=4 chain_entries=1 objects=2 txs=0 frames=7 dos_drops=0
+randomx        : mode=1 hashes=24 prefetches=1 rekeys=1 verified=24 failed=0 foreign=0
+monerod rpc    : calls=10 (parity/bootstrap only; never on the tip-follow path)
+parity         : clean=5 fail=0 served_mismatch=0 void=0
+M0-VERDICT: PASS heights=24 parity_clean=5 parity_fail=0 randomx_foreign=0
+```
+
+Read the two halves of that:
+
+* **Heights 1–20 were BACKFILLED over levin.** One `NOTIFY_REQUEST_CHAIN` from a
+  genesis-terminated locator, one `RESPONSE_CHAIN_ENTRY` with 21 ids, and the
+  index's own `NOTIFY_REQUEST_GET_OBJECTS` for what it lacked (`objects=2`
+  frames after C1c's ≤100-id chunking).
+* **Heights 21–24 were FOLLOWED LIVE.** Four blocks mined on the daemon,
+  `blocks=4` inbound `NOTIFY_NEW_FLUFFY_BLOCK` pushes, `chain_requests` flat at
+  1 — the driver went quiet and the height kept moving, which is the observable
+  difference between catching up and following.
+* **P-TIP was CLEAN at every sampled height**, comparing all nine fields
+  (`id`, `prev_id`, `cumulative_difficulty`, `difficulty`, `timestamp`,
+  `reward`, `block_weight`, `long_term_weight`, `major_version`) against
+  monerod's own `get_info` + `get_last_block_header`. The oracle coalesces a
+  BURST of tips to its newest by design, so the twenty backfilled heights
+  produced one sample between them; the four live heights produced one each.
+* **`monerod rpc calls=10` is exactly two per parity sample.** Nothing on the
+  tip-follow path made an RPC: `--probe-only` and `--no-parity` runs report
+  `calls=0` while the index still follows.
+
+## The live stagenet probe (read-only)
+
+Against the synced-and-syncing stagenet daemon on `192.168.86.44:38080`, one
+connection, one question, no blocks fetched:
+
+```
+xmr_native_node --net stagenet --connect 192.168.86.44:38080 --probe-only --no-parity
+
+chain-entry : start=0 total=1067456 ids=10000 first=76ee3cc98646292206cd3e86f74d88b4dcc1d937088645e9b0cbca84b7ce74eb
+              last=ef2163d4a1bb0561ef53def8367caec3ab4b7feaa1aeeab1cbc47b354fba3b9d first_block=1/317 bytes
+peers       : handshaked=1 total=1 handshakes=1 dials=2/0
+levin in    : blocks=0 chain_entries=1 objects=0 txs=0 frames=1
+monerod rpc : calls=0
+```
+
+`total_height` is the daemon's own count and it moved between two probes twenty
+minutes apart (997 377 → 1 067 456): .44 is mid-sync, which is exactly the state
+this probe had to be safe against.
+
+`--probe-only` also pins the DIAL PLAN to the peers it was given. The pool
+learns addresses from the handshake peerlist and refills toward its target, so
+the first version of this probe opened a connection to a public stagenet node it
+had just learned from the daemon it was probing. A read-only probe dials what it
+was told to dial and nothing else.
+
+`ids[0]` is `STAGENET_GENESIS`, which is the daemon's own proof that it accepted
+our network id, our handshake and our locator terminus. `--probe-only` sends
+exactly one `NOTIFY_REQUEST_CHAIN` and never a `GET_OBJECTS`: a chain entry
+costs the daemon a walk of its id index, a block span costs it disk and
+bandwidth it is using to sync.
+
+One observation worth recording: the probe's `first_block` (317 bytes) did NOT
+parse as the stagenet genesis block, and the boot refused it rather than
+believing it — `refusals=1`, and the object-request path is what actually seeds
+a node. The opportunistic use of `first_block` is best effort by design; what
+the field really carries on that daemon version is an open question, not a
+dependency.
+
+## The defects this assembly found
+
+Both were invisible to every component KAT, because both are about what happens
+when the parts are wired to each other and to a real daemon.
+
+1. **A parked block was never revisited when its parent connected.** `C2c`'s
+   branch path resolves descendants; the fast path (a block that extends the
+   tip) did not. monerod sends its top block to any peer it sees as behind, so
+   the first block a cold node receives is normally one it cannot connect yet —
+   this is every cold start, not a corner case. The live symptom was a node that
+   backfilled to height 8, sat there, and let four already-delivered blocks rot
+   in the alt pool while its peer climbed, with no error anywhere because
+   nothing had failed. Fixed in `chain/xmr_chain_index.hpp` by draining the
+   tip's parked children as ordinary EXTENDS (going through the fork-choice
+   switch would announce a Reorg of depth 0 for what is simply the next block),
+   and pinned by `test_out_of_order_push_connects()` — which fails 2 checks on
+   the code as it stood.
+2. **The first chain request waited out the boot fetch's timeout.** The sync
+   driver kept one in-flight flag for two different questions, so the chain
+   request went out a full `chain_request_timeout_ms` (20 s) after the trust
+   root had landed. Twenty seconds of "connected, synced=0, nothing happening"
+   on every cold start — the exact shape of failure this layer exists to make
+   unmisreadable. Fixed in `xmr_sync_driver.hpp`, pinned in the KAT.
+
+A third thing worth knowing rather than fixing here: `ChainIndex::refetch_wanted()`
+is a STANDING want list — it is not cleared when a block arrives. A driver that
+asked for all of it every tick asked twice a second forever (observed: 361
+`RESPONSE_GET_OBJECTS` frames for a 12-block backfill, every one of them an
+answer to a question already answered). The driver now rate-limits per id and
+skips ids the index already has. Whether the index should prune the list is a
+C2c question; that the SCHEDULE must not be a busy loop is this file's.
+
+## Wired, and deliberately not driven
+
+* **C5 `LevinBlockRelay`** is constructed and its 2009 responder is armed, but
+  nothing in M0 calls `relay()`: a found block comes from the stratum /
+  settlement path, which is M3.
+* **C4's arms** are constructed, readable and reported in the status line
+  (`tmpl=native`), but the option-B settlement provider is not rebound through
+  them yet: that is M2.
+* **C3's txpool** is fed from levin and selectable, and its chain-event
+  subscription (mined-id drop, key-image eviction, rollback re-admission) is
+  wired; proving per-transaction equality against monerod's own pool is M1.
+* **Anchor boot** (`--boot anchor`) is wired and is the production path, but M0
+  ran on the genesis path because a fresh regtest chain is younger than the
+  anchor format can describe (`generate_anchor` refuses any height below the
+  100 000-block long-term weight window). The embedded stagenet bundle is not
+  exercised live here.
+
+Each of those is wired to its seam and left unexercised ON PURPOSE, so the
+milestone that owns it has something to prove rather than something to discover.
+
+## Owed operator calls
+
+* **R-ARMORDER — the found-block arm order.** `contracts/relay.hpp` defaults
+  `ArmOrder::DaemonFirst` (the plan's M0–M4 posture: monerod validates for free
+  before our P2P identity is behind the block), while C5's own
+  `self_contained_policy()` defaults to `Parallel` with the P2P arm first (the
+  daemonless posture the track exists to reach). The node currently takes
+  `DaemonFirst` as its default and exposes `--relay-order`; which one a
+  PRODUCTION pool ships with is an operator ruling, and it is the last knob
+  before M3 can claim a daemonless find.
+* **P-TIP soak scope.** M0's exit criterion in the plan is a 48–72 h P-TIP run
+  with ≥1 EpochEdge and zero field diffs over ≥2200 blocks. This run is a SHORT
+  proof (24 heights, 5 samples, 22 s of wall clock); the sustained soak needs a
+  host, a network and a window, and the graduation ledger says so itself
+  (`state: Observing`, `window: 22 s observed, need 60 s` at the regtest
+  policy). Which network it runs against (stagenet from a host that is not
+  .44's syncing daemon) and for how long is the operator's call.

--- a/src/impl/xmr/native/node/tools/xmr_native_node_main.cpp
+++ b/src/impl/xmr/native/node/tools/xmr_native_node_main.cpp
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/node/tools/xmr_native_node_main.cpp
+//
+// `xmr_native_node` -- the M0 entrypoint: run the assembled native Monero node
+// and print what it did.
+//
+// It is a HARNESS, not the pool. The pool proper reaches this node through
+// C4's IMinerDataSource seam (M2) and C5's relay (M3); this binary exists so
+// that the node can be started, pointed at a daemon, and judged on its own --
+// which is the only way "the chain index follows the tip over levin" is a fact
+// rather than a design.
+//
+// THREE MODES, one binary:
+//
+//   * FOLLOW (default). Boot, dial, sync, then follow. `--follow-to H` exits
+//     as soon as the native tip reaches H, which is what makes it scriptable:
+//     mine a block, wait for the node to reach that height, compare against the
+//     daemon, repeat.
+//   * PROBE (`--probe-only`). Handshake, TIMED_SYNC, exactly one
+//     NOTIFY_REQUEST_CHAIN, print what came back, exit. Nothing is fetched and
+//     no block is verified: this is what is allowed against somebody else's
+//     daemon that is busy syncing.
+//   * PARITY (`--monerod-rpc host:port`, on by default when set). C6's P-TIP
+//     seam runs at every height the node adopts, and every sample is printed.
+//     The daemon is the judge, never the source: `rpc_calls` is printed beside
+//     `blocks_in` so the two can be read against each other.
+//
+// THE ONE CLAIM THIS BINARY IS BUILT TO SUPPORT is printed in the summary and
+// is deliberately a pair of numbers rather than an assertion:
+//
+//     randomx: hashes=N threads=[verify] foreign=0
+//
+// `foreign` counts RandomX evaluations that happened on a thread the node
+// declared forbidden -- the io threads. A wiring regression that put the
+// verifier back on the io thread would make it non-zero without anybody having
+// to notice a call graph changed.
+//
+// SCOPE FENCE (standing XMR-lane rule): everything under src/impl/xmr/.
+// ---------------------------------------------------------------------------
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <cstdio>
+#include <cstring>
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "impl/xmr/native/node/xmr_native_node.hpp"
+#include "impl/xmr/native/parity/xmr_parity_report.hpp"
+
+namespace rt     = ::c2pool::xmr::native::rt;
+namespace native = ::c2pool::xmr::native;
+namespace parity = ::c2pool::xmr::native::parity;
+
+namespace {
+
+volatile std::sig_atomic_t g_stop = 0;
+void on_signal(int) { g_stop = 1; }
+
+std::string hex(const native::Hash& h) {
+    static const char* d = "0123456789abcdef";
+    std::string s;
+    s.reserve(64);
+    for (std::uint8_t b : h) { s.push_back(d[b >> 4]); s.push_back(d[b & 0xf]); }
+    return s;
+}
+
+std::string u128(const native::U128& v) {
+    // Small enough for every number this harness prints (regtest cumulative
+    // difficulty, a stagenet block difficulty); the high word is reported
+    // separately rather than silently dropped.
+    if (v.hi == 0) return std::to_string(v.lo);
+    return std::to_string(v.hi) + ":" + std::to_string(v.lo);
+}
+
+bool split_host_port(const std::string& s, std::string& host, std::uint16_t& port) {
+    const std::size_t c = s.rfind(':');
+    if (c == std::string::npos || c == 0 || c + 1 >= s.size()) return false;
+    host = s.substr(0, c);
+    const long v = std::strtol(s.c_str() + c + 1, nullptr, 10);
+    if (v <= 0 || v > 65535) return false;
+    port = static_cast<std::uint16_t>(v);
+    return true;
+}
+
+void usage() {
+    std::cout <<
+        "xmr_native_node -- the M0 native Monero node harness\n"
+        "\n"
+        "  --net <mainnet|stagenet|testnet|regtest>   which network (default stagenet)\n"
+        "  --connect <ip:port>                        a pinned levin peer (repeatable)\n"
+        "  --seeds                                    also use the network's seed nodes\n"
+        "  --boot <genesis|anchor>                    where the index's history starts\n"
+        "  --anchor-path <file>                       anchor boot from a .inc (default: embedded)\n"
+        "  --monerod-rpc <host:port>                  the parity/backup arm (read-only)\n"
+        "  --no-parity                                construct no parity oracle\n"
+        "  --parity-ledger <file>                     persist the graduation ledger\n"
+        "  --commit <sha>                             the c2pool commit, a graduation key\n"
+        "  --serve-arm <native|monerod>               which template arm serves\n"
+        "  --relay-order <daemon-first|parallel|p2p-only>\n"
+        "  --follow-to <height>                       exit once the native tip reaches it\n"
+        "  --run-seconds <n>                          hard stop (default 120)\n"
+        "  --status-every <ms>                        status line cadence (default 2000)\n"
+        "  --force-synced                             set the publication gate (regtest)\n"
+        "  --probe-only                               handshake + one chain request, then exit\n"
+        "  --allow-unverified-pow                     start even though this build cannot\n"
+        "                                             check proof of work (no librandomx)\n";
+}
+
+void print_status(const rt::NodeStatus& s) {
+    std::printf(
+        "[status] h=%llu/%llu verified=%llu anchor=%llu synced=%d rows=%llu | "
+        "alt=%llu orphans=%llu reorgs=%llu | "
+        "peers=%zu/%zu silent=%zu | in: blocks=%llu chains=%llu objs=%llu txs=%llu | "
+        "drv: chain=%llu boot=%llu refetch=%llu timeouts=%llu target=%s | "
+        "q: verify=%zu/%llu pool=%zu/%llu refused=%llu | "
+        "rx: mode=%d hashes=%llu rekeys=%llu foreign=%llu | rpc=%llu | tmpl=%s\n",
+        (unsigned long long)s.sync.header_frontier, (unsigned long long)s.sync.cohort_height,
+        (unsigned long long)s.sync.verified_frontier, (unsigned long long)s.sync.anchor_height,
+        s.sync.synced ? 1 : 0, (unsigned long long)s.sync.rows,
+        (unsigned long long)s.sync.alt_rows, (unsigned long long)s.sync.orphans,
+        (unsigned long long)s.sync.reorgs,
+        s.pool.peers_handshaked, s.pool.peers_total, s.pool.relay_silent_peers,
+        (unsigned long long)s.pool.blocks_in, (unsigned long long)s.pool.chain_entries_in,
+        (unsigned long long)s.pool.objects_in, (unsigned long long)s.pool.txs_in,
+        (unsigned long long)s.driver.chain_requests, (unsigned long long)s.driver.boot_requests,
+        (unsigned long long)s.driver.refetch_requests,
+        (unsigned long long)s.driver.chain_timeouts, s.driver.target.c_str(),
+        s.verify_queue.depth, (unsigned long long)s.verify_queue.executed,
+        s.pool_queue.depth, (unsigned long long)s.pool_queue.executed,
+        (unsigned long long)(s.verify_queue.refused + s.inbound.refused),
+        (int)s.randomx_mode, (unsigned long long)s.randomx.hashes,
+        (unsigned long long)s.sync.seed_rekeys, (unsigned long long)s.randomx.foreign_calls,
+        (unsigned long long)s.rpc_calls, s.template_arm.c_str());
+    std::fflush(stdout);
+}
+
+void print_tip(const rt::TipRecord& r) {
+    const std::string reorg =
+        r.reorg ? (" REORG depth=" + std::to_string(r.reorg_depth)) : std::string();
+    std::printf("[tip] height=%llu id=%s prev=%s difficulty=%s cumdiff=%s "
+                "timestamp=%llu reward=%llu weight=%llu%s\n",
+                (unsigned long long)r.height, hex(r.id).c_str(), hex(r.prev_id).c_str(),
+                u128(r.difficulty).c_str(), u128(r.cumulative_difficulty).c_str(),
+                (unsigned long long)r.timestamp, (unsigned long long)r.reward,
+                (unsigned long long)r.weight, reorg.c_str());
+    std::fflush(stdout);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    rt::NativeNodeConfig cfg;
+    cfg.net          = rt::NativeNet::Stagenet;
+    cfg.boot         = rt::BootMode::Genesis;
+    std::uint64_t follow_to    = 0;
+    std::uint64_t run_seconds  = 120;
+    std::uint64_t status_every = 2000;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        auto next = [&](const char* what) -> std::string {
+            if (i + 1 >= argc) {
+                std::cerr << "missing value for " << what << "\n";
+                std::exit(2);
+            }
+            return argv[++i];
+        };
+        if (a == "--help" || a == "-h") { usage(); return 0; }
+        else if (a == "--net") {
+            if (!rt::parse_native_net(next("--net"), cfg.net)) {
+                std::cerr << "unknown network\n";
+                return 2;
+            }
+        }
+        else if (a == "--connect")       cfg.connect.push_back(next("--connect"));
+        else if (a == "--p2p-bind-ip")   cfg.p2p_bind_ip = next("--p2p-bind-ip");
+        else if (a == "--seeds")         cfg.use_seeds = true;
+        else if (a == "--boot") {
+            const std::string v = next("--boot");
+            if (v == "genesis")     cfg.boot = rt::BootMode::Genesis;
+            else if (v == "anchor") cfg.boot = rt::BootMode::Anchor;
+            else { std::cerr << "unknown boot mode\n"; return 2; }
+        }
+        else if (a == "--anchor-path")   cfg.anchor_path = next("--anchor-path");
+        else if (a == "--monerod-rpc") {
+            if (!split_host_port(next("--monerod-rpc"), cfg.monerod_rpc_host,
+                                 cfg.monerod_rpc_port)) {
+                std::cerr << "--monerod-rpc wants host:port\n";
+                return 2;
+            }
+        }
+        else if (a == "--no-parity")     cfg.parity = false;
+        else if (a == "--parity-ledger") cfg.parity_ledger_path = next("--parity-ledger");
+        else if (a == "--commit")        cfg.c2pool_commit = next("--commit");
+        else if (a == "--serve-arm") {
+            const std::string v = next("--serve-arm");
+            if (v == "native")       cfg.serve_arm = native::TemplateArm::Native;
+            else if (v == "monerod") cfg.serve_arm = native::TemplateArm::Monerod;
+            else { std::cerr << "unknown serve arm\n"; return 2; }
+        }
+        else if (a == "--relay-order") {
+            const std::string v = next("--relay-order");
+            if (v == "daemon-first")  cfg.relay_order = native::ArmOrder::DaemonFirst;
+            else if (v == "parallel") cfg.relay_order = native::ArmOrder::Parallel;
+            else if (v == "p2p-only") cfg.relay_order = native::ArmOrder::P2pOnly;
+            else { std::cerr << "unknown relay order\n"; return 2; }
+        }
+        else if (a == "--follow-to")     follow_to    = std::strtoull(next("--follow-to").c_str(), nullptr, 10);
+        else if (a == "--run-seconds")   run_seconds  = std::strtoull(next("--run-seconds").c_str(), nullptr, 10);
+        else if (a == "--status-every")  status_every = std::strtoull(next("--status-every").c_str(), nullptr, 10);
+        else if (a == "--force-synced")  cfg.force_synced = true;
+        else if (a == "--probe-only")    cfg.probe_only = true;
+        else if (a == "--allow-unverified-pow") cfg.allow_unverified_pow = true;
+        else { std::cerr << "unknown argument: " << a << "\n"; usage(); return 2; }
+    }
+
+    if (cfg.connect.empty() && !cfg.use_seeds) {
+        std::cerr << "nothing to dial: pass --connect <ip:port> or --seeds\n";
+        return 2;
+    }
+
+    std::signal(SIGINT, on_signal);
+    std::signal(SIGTERM, on_signal);
+
+    rt::NativeNode node(cfg);
+    std::string    why;
+    std::printf("[node] net=%s wire-net=%d consensus-net=%s boot=%s peers=%zu "
+                "parity=%d probe=%d\n",
+                rt::to_string(cfg.net), (int)node.nets().wire,
+                native::to_string(node.nets().consensus), rt::to_string(cfg.boot),
+                cfg.connect.size(), cfg.parity ? 1 : 0, cfg.probe_only ? 1 : 0);
+    if (!node.start(why)) {
+        std::cerr << "[node] start refused: " << why << "\n";
+        return 1;
+    }
+
+    const auto    t0 = std::chrono::steady_clock::now();
+    std::uint64_t last_status = 0;
+    std::size_t   tips_seen   = 0;
+    std::uint64_t clean = 0, failed = 0, mismatch = 0, voided = 0;
+    int exit_code = 0;
+
+    // Draining is a function rather than a loop body because it has to happen
+    // ONE MORE TIME after the exit condition fires: the tip that satisfied
+    // --follow-to is normally recorded a few milliseconds after the read that
+    // would have printed it, and a run that proved a height and then did not
+    // say so is a run nobody can check.
+    auto drain = [&] {
+        const std::vector<rt::TipRecord> tips = node.tips();
+        if (tips.size() > tips_seen) {
+            for (std::size_t i = tips_seen; i < tips.size(); ++i) print_tip(tips[i]);
+            tips_seen = tips.size();
+            // The oracle renders every sample through its own log sink, which
+            // is drained just below -- printing it here as well would double
+            // every line.
+            for (const parity::SeamResult& r : node.parity_sample()) {
+                switch (r.sample.verdict) {
+                    case native::ParityVerdict::Clean:          ++clean;    break;
+                    case native::ParityVerdict::Fail:           ++failed;   break;
+                    case native::ParityVerdict::ServedMismatch: ++mismatch; break;
+                    case native::ParityVerdict::Void:           ++voided;   break;
+                }
+            }
+        }
+        for (const std::string& line : node.take_log()) std::printf("%s\n", line.c_str());
+        std::fflush(stdout);
+    };
+
+    for (;;) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        const auto now = std::chrono::steady_clock::now();
+        const std::uint64_t elapsed_ms = static_cast<std::uint64_t>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(now - t0).count());
+
+        drain();
+
+        if (elapsed_ms - last_status >= status_every) {
+            last_status = elapsed_ms;
+            print_status(node.status());
+        }
+
+        // --- exit conditions ---------------------------------------------------
+        if (g_stop) break;
+        if (cfg.probe_only) {
+            const rt::NodeStatus s = node.status();
+            if (s.boot.last_entry.have) break;
+            if (elapsed_ms > 30'000) { exit_code = 1; break; }
+        }
+        if (follow_to != 0) {
+            const rt::NodeStatus s = node.status();
+            if (s.sync.header_frontier >= follow_to) break;
+        }
+        if (elapsed_ms >= run_seconds * 1000) {
+            if (follow_to != 0) exit_code = 1;
+            break;
+        }
+    }
+
+    drain();
+    const rt::NodeStatus s = node.status();
+    print_status(s);
+
+    std::printf("\n=== summary ===\n");
+    std::printf("tip            : height=%llu verified_frontier=%llu rows=%llu synced=%d "
+                "alt=%llu orphans=%llu reorgs=%llu\n",
+                (unsigned long long)s.sync.header_frontier,
+                (unsigned long long)s.sync.verified_frontier,
+                (unsigned long long)s.sync.rows, s.sync.synced ? 1 : 0,
+                (unsigned long long)s.sync.alt_rows, (unsigned long long)s.sync.orphans,
+                (unsigned long long)s.sync.reorgs);
+    std::printf("boot           : %s booted=%d inspected=%llu refusals=%llu dropped=%llu (%s)\n",
+                rt::to_string(cfg.boot), s.boot.booted ? 1 : 0,
+                (unsigned long long)s.boot.blobs_inspected,
+                (unsigned long long)s.boot.refusals,
+                (unsigned long long)s.boot.dropped_preboot, s.boot.why.c_str());
+    if (s.boot.last_entry.have) {
+        std::printf("chain-entry    : start=%llu total=%llu ids=%zu first=%s last=%s "
+                    "first_block=%d/%zu bytes\n",
+                    (unsigned long long)s.boot.last_entry.start_height,
+                    (unsigned long long)s.boot.last_entry.total_height,
+                    s.boot.last_entry.ids, hex(s.boot.last_entry.first_id).c_str(),
+                    hex(s.boot.last_entry.last_id).c_str(),
+                    s.boot.last_entry.first_block_present ? 1 : 0,
+                    s.boot.last_entry.first_block_size);
+    }
+    std::printf("peers          : handshaked=%zu total=%zu netgroups=%zu silent=%zu "
+                "handshakes=%llu dials=%llu/%llu last_close=%s (%s)\n",
+                s.pool.peers_handshaked, s.pool.peers_total, s.pool.netgroups,
+                s.pool.relay_silent_peers, (unsigned long long)s.pool.handshakes,
+                (unsigned long long)s.pool.dials_started,
+                (unsigned long long)s.pool.dials_failed,
+                s.pool.last_close_peer.c_str(), s.pool.last_close_why.c_str());
+    std::printf("levin in       : blocks=%llu chain_entries=%llu objects=%llu txs=%llu "
+                "frames=%llu dos_drops=%llu\n",
+                (unsigned long long)s.pool.blocks_in,
+                (unsigned long long)s.pool.chain_entries_in,
+                (unsigned long long)s.pool.objects_in, (unsigned long long)s.pool.txs_in,
+                (unsigned long long)s.pool.frames_in,
+                (unsigned long long)s.pool.frames_dropped_dos);
+    std::printf("levin served   : chain=%llu objects=%llu fluffy=%llu declined=%llu\n",
+                (unsigned long long)s.pool.served_chain,
+                (unsigned long long)s.pool.served_objects,
+                (unsigned long long)s.pool.served_fluffy,
+                (unsigned long long)s.pool.served_declined);
+    if (s.randomx_mode == native::RandomXMode::Disabled)
+        std::printf("randomx        : NOT COMPILED IN -- every block above connected "
+                    "WITHOUT a proof-of-work check\n");
+    std::printf("randomx        : mode=%d hashes=%llu prefetches=%llu rekeys=%llu "
+                "verified=%llu failed=%llu foreign=%llu threads=",
+                (int)s.randomx_mode, (unsigned long long)s.randomx.hashes,
+                (unsigned long long)s.randomx.prefetches,
+                (unsigned long long)s.sync.seed_rekeys,
+                (unsigned long long)s.sync.pow_verified,
+                (unsigned long long)s.sync.pow_failed,
+                (unsigned long long)s.randomx.foreign_calls);
+    for (const std::string& t : s.randomx.threads) std::printf("%s ", t.c_str());
+    std::printf("\n");
+    std::printf("threads        : io=%s verify=%s\n", s.io_threads.c_str(),
+                s.verify_thread.c_str());
+    std::printf("monerod rpc    : calls=%llu (parity/bootstrap only; never on the "
+                "tip-follow path)\n", (unsigned long long)s.rpc_calls);
+    std::printf("parity         : clean=%llu fail=%llu served_mismatch=%llu void=%llu\n",
+                (unsigned long long)clean, (unsigned long long)failed,
+                (unsigned long long)mismatch, (unsigned long long)voided);
+    if (node.oracle())
+        std::printf("%s\n", node.oracle()->verdict_report().c_str());
+
+    // The M0 verdict, in one line a script can grep.
+    const bool ok = (exit_code == 0) && failed == 0 && mismatch == 0 &&
+                    s.randomx.foreign_calls == 0;
+    std::printf("M0-VERDICT: %s heights=%zu parity_clean=%llu parity_fail=%llu "
+                "randomx_foreign=%llu\n",
+                ok ? "PASS" : "FAIL", tips_seen, (unsigned long long)clean,
+                (unsigned long long)(failed + mismatch),
+                (unsigned long long)s.randomx.foreign_calls);
+
+    node.stop();
+    return ok ? 0 : 1;
+}

--- a/src/impl/xmr/native/node/xmr_chain_boot.hpp
+++ b/src/impl/xmr/native/node/xmr_chain_boot.hpp
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/node/xmr_chain_boot.hpp
+//
+// M0: WHERE THE INDEX'S HISTORY IS ALLOWED TO START, and the gate that puts it
+// there before a single peer message reaches the index.
+//
+// C2c's index refuses to judge anything until it has a trust root: `offer_block`
+// parks a block whose parent it does not know, and `on_chain_entry` refuses an
+// entry whose splice point `ids[0]` is not a block it already holds. Both are
+// correct and both mean the SAME thing at boot: something has to seed row zero.
+// There are two honest ways to do that and this file implements both.
+//
+// ANCHOR (the production path, plan M0..M5). `load_anchor()` gives a
+// self-checked AnchorBundle -- a release-pinned or daemon-minted statement of
+// what the chain looked like at H_a, carrying the five windows the consensus
+// state needs -- and `ChainIndex::boot_from_anchor()` installs it. Nothing below
+// H_a is ever verified or reorgable, which is what bounds a cold start to the
+// anchor's AGE rather than the chain's LENGTH.
+//
+// GENESIS (the private-chain path). A regtest chain is younger than the anchor
+// format can describe: `generate_anchor()` refuses any height below the
+// 100 000-block long-term weight window, and a fresh fakechain has ten blocks.
+// So on regtest the trust root is the block the whole network agrees on for
+// free -- height 0 -- and the useful part is that it can be obtained WITHOUT
+// A DAEMON RPC: the genesis id is pinned per network in chain_seeds.hpp (it has
+// to be, it is the mandatory terminus of every locator we send), so the node
+// asks its peer for that one id over levin `NOTIFY_REQUEST_GET_OBJECTS` and
+// derives every number in the row from the bytes that come back.
+//
+// DERIVED, NOT TAKEN. The only thing this gate accepts from the wire is the
+// BLOB. The id is recomputed from it and compared against the pinned genesis id
+// (a peer that answers with different bytes is refused, not believed); the
+// weight, the coinbase sum and therefore already_generated_coins come out of
+// this repository's own parser. That is the same discipline the anchor loader
+// applies to a bundle, and it is why the boot path cannot be used to walk the
+// node onto a chain of the peer's choosing.
+//
+// WHY IT IS A GATE AND NOT A FUNCTION. The blob arrives as a normal
+// `on_objects` callback, which the index would answer by parking a block with
+// an unknown parent. So the boot sits IN FRONT of the index on the same
+// (verify) thread, watches for the one id it is waiting for, seeds, and from
+// then on is a transparent forwarder. Everything before the seed is dropped
+// with a counter rather than queued: the sync driver re-asks, and holding an
+// unbounded pre-boot backlog is the same unbounded allocation the queue caps
+// exist to prevent.
+//
+// SCOPE FENCE (standing XMR-lane rule): everything under src/impl/xmr/. No
+// consensus digest, no src/sharechain/v37.
+//
+// Header-only. STL only (plus the tree's own consensus primitives, which link
+// xmr_coin for keccak and the tree hash).
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/native/anchor/xmr_anchor_load.hpp"
+#include "impl/xmr/native/chain/xmr_chain_index.hpp"
+#include "impl/xmr/native/consensus/xmr_block_id.hpp"
+#include "impl/xmr/native/consensus/xmr_block_parse.hpp"
+#include "impl/xmr/native/consensus/xmr_hf_table.hpp"
+#include "impl/xmr/native/contracts/chain_index.hpp"
+#include "impl/xmr/native/contracts/serving.hpp"
+#include "impl/xmr/native/contracts/types.hpp"
+
+namespace c2pool::xmr::native::rt {
+
+enum class BootMode : std::uint8_t {
+    Genesis = 0,   // seed row 0 from the genesis blob, fetched over levin
+    Anchor,        // seed from a loaded, self-checked AnchorBundle
+};
+
+inline const char* to_string(BootMode m) noexcept {
+    switch (m) {
+        case BootMode::Genesis: return "genesis";
+        case BootMode::Anchor:  return "anchor";
+    }
+    return "?";
+}
+
+// ---------------------------------------------------------------------------
+// The genesis row, derived from the genesis blob.
+//
+// difficulty and cumulative_difficulty are 1 because monerod's own
+// `get_difficulty_for_next_block` answers 1 at db height 0 and the genesis
+// block's stored cumulative difficulty is that same 1 -- which
+// `get_block_header_by_height(0)` reports on every network, and which the
+// parity oracle re-checks against the daemon at every sampled height, so a
+// wrong constant here cannot pass unnoticed.
+// ---------------------------------------------------------------------------
+inline bool genesis_row_from_blob(const std::vector<std::uint8_t>& blob,
+                                  const Hash& expected_id, ChainRow& out,
+                                  std::string& why) {
+    out = ChainRow{};
+    why.clear();
+
+    ParsedBlock pb;
+    const BlockParseStatus ps = parse_block(blob, pb);
+    if (ps != BlockParseStatus::Ok) {
+        why = std::string("genesis blob does not parse: ") + to_string(ps);
+        return false;
+    }
+    const BlockIdentity id = block_identity(blob.data(), pb);
+    if (id.id != expected_id) {
+        why = "the block a peer answered with is not this network's genesis block";
+        return false;
+    }
+    CoinbaseFields cb;
+    if (!parse_coinbase_fields(blob.data(), pb, cb)) {
+        why = "genesis coinbase fields do not read back";
+        return false;
+    }
+    if (cb.height != 0 || !pb.tx_hashes.empty()) {
+        why = "the genesis block must be height 0 with no transactions";
+        return false;
+    }
+
+    out.height           = 0;
+    out.id               = id.id;
+    out.prev_id          = pb.header.prev_id;
+    out.timestamp        = pb.header.timestamp;
+    out.major_version    = static_cast<std::uint8_t>(pb.header.major_version);
+    out.minor_version    = static_cast<std::uint8_t>(pb.header.minor_version);
+    out.block_weight     = pb.miner_tx.weight;
+    out.long_term_weight = pb.miner_tx.weight;
+    out.difficulty            = U128{1, 0};
+    out.cumulative_difficulty = U128{1, 0};
+    out.base_reward      = cb.output_sum;
+    out.fees             = 0;
+    out.reward           = cb.output_sum;
+    out.already_generated_coins = cb.output_sum;
+    // The trust root is verified by agreement, not by work: it is the one block
+    // every implementation of this network compiles in.
+    out.pow_verified     = true;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// ChainBoot
+//
+// It is BOTH halves of the boot, and the second half is the one that is easy to
+// miss until a real daemon is on the other end of the socket.
+//
+// THE INBOUND HALF is the obvious one: watch for the genesis blob, seed, then
+// forward.
+//
+// THE SERVING HALF is what keeps the connection alive long enough for that to
+// happen. monerod's process_payload_sync_data asks `m_core.have_block(top_id)`
+// about the tip its peer advertised; when the answer is no it moves the
+// connection to state_synchronizing and sends NOTIFY_REQUEST_CHAIN. An index
+// with no rows advertises an ALL-ZERO top id -- a block no daemon has -- so
+// every peer immediately asks us for a chain we cannot supply, our
+// find_supplement answers nullopt, and monerod's own rule (no common block =>
+// close) drops the connection before the boot fetch can be issued. Observed
+// exactly that way on the first live regtest run: `handshakes=2` and
+// `last_close=... (no common block for a chain request)`.
+//
+// So before the seed lands this class answers the io-thread serving reads
+// ITSELF, with the truthful description of a node that holds only the block
+// every implementation of this network compiles in:
+//
+//     current_height = 1, top_id = <pinned genesis id>, cumulative_difficulty = 1
+//
+// which is byte-for-byte what a freshly initialised monerod on the same network
+// advertises. Once the index is seeded every one of these calls is a plain
+// forward and this class stops having an opinion.
+// ---------------------------------------------------------------------------
+class ChainBoot final : public IChainIndexInbound, public IChainServing {
+public:
+    // What a RESPONSE_CHAIN_ENTRY said, recorded whether or not the index was
+    // ready to consume it. This is the read-only probe's whole evidence: a
+    // daemon that answers a genesis-terminated locator with its own height and
+    // a run of ids has accepted our network id, our handshake and our locator
+    // terminus -- the three things a levin client can get wrong and see nothing
+    // but silence for.
+    struct ChainEntryNote {
+        bool          have         = false;
+        std::uint64_t start_height = 0;
+        std::uint64_t total_height = 0;
+        std::size_t   ids          = 0;
+        Hash          first_id{};
+        Hash          last_id{};
+        bool          first_block_present = false;
+        std::size_t   first_block_size    = 0;
+    };
+
+    struct Stats {
+        bool          booted           = false;
+        std::uint64_t blobs_inspected  = 0;
+        std::uint64_t dropped_preboot  = 0;
+        std::uint64_t refusals         = 0;   // a blob that claimed to be genesis and was not
+        std::uint64_t chain_entries    = 0;
+        std::string   why;                    // the last refusal, or the boot's own note
+        ChainEntryNote last_entry{};
+    };
+
+    ChainBoot(ChainIndex& index, BootMode mode, Hash genesis_id, XmrNet net)
+        : index_(index), mode_(mode), genesis_id_(genesis_id), net_(net) {}
+
+    // The anchor path boots before the network is touched at all.
+    bool boot_from_anchor(const std::string& path_or_empty, XmrNet net,
+                          const std::vector<std::uint64_t>& timestamps_60,
+                          std::string& why) {
+        AnchorBundle b;
+        if (!load_anchor(path_or_empty, net, b, why)) return false;
+        if (!index_.boot_from_anchor(b, timestamps_60, why)) return false;
+        std::lock_guard<std::mutex> lk(mu_);
+        booted_ = true;
+        stats_.booted = true;
+        stats_.why = "anchor at height " + std::to_string(b.height);
+        return true;
+    }
+
+    bool booted() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return booted_;
+    }
+
+    Stats stats() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return stats_;
+    }
+
+    // The one id the genesis path is waiting for; the sync driver asks for it.
+    const Hash& wanted_genesis() const noexcept { return genesis_id_; }
+    BootMode    mode()           const noexcept { return mode_; }
+
+    // --- IChainIndexInbound ------------------------------------------------
+    // Peer bookkeeping is never gated: the cohort height (and the synced flag
+    // derived from it) must track peers from the first handshake, boot or no
+    // boot.
+    void on_peer_sync_data(const PeerRef& p, const PeerSyncData& d) override {
+        index_.on_peer_sync_data(p, d);
+    }
+
+    void on_peer_gone(const PeerRef& p) override { index_.on_peer_gone(p); }
+
+    void on_objects(const PeerRef& p, std::vector<BlockEntry>&& blocks,
+                    std::vector<Hash>&& missed, std::uint64_t peer_height) override {
+        if (!booted()) {
+            for (const BlockEntry& b : blocks) {
+                if (try_seed_(b.block_blob)) break;
+            }
+            if (!booted()) {
+                drop_("pre-boot objects");
+                return;
+            }
+        }
+        index_.on_objects(p, std::move(blocks), std::move(missed), peer_height);
+    }
+
+    void on_chain_entry(const PeerRef& p, ChainEntry&& e) override {
+        note_entry_(e);
+        if (!booted()) {
+            // monerod puts the blob of the block at `start_height` in
+            // `first_block`, so a locator that terminates at genesis gets the
+            // genesis block for free with the very first answer. Taking it here
+            // saves a round trip; the object request is still the path that is
+            // guaranteed to work (an older daemon may leave the field empty).
+            if (!e.first_block.empty()) (void)try_seed_(e.first_block);
+            if (!booted()) {
+                drop_("pre-boot chain entry");
+                return;
+            }
+        }
+        index_.on_chain_entry(p, std::move(e));
+    }
+
+    void on_new_block(const PeerRef& p, BlockEntry&& block, std::uint64_t peer_height,
+                      bool fluffy) override {
+        if (!booted()) { drop_("pre-boot block push"); return; }
+        index_.on_new_block(p, std::move(block), peer_height, fluffy);
+    }
+
+    // --- IChainServing (io thread) -----------------------------------------
+    PeerSyncData our_sync_data() const override {
+        if (booted()) return index_.our_sync_data();
+        PeerSyncData d;
+        d.current_height        = 1;             // one PAST the tip, monerod's spelling
+        d.cumulative_difficulty = U128{1, 0};    // the genesis block's own
+        d.top_id                = genesis_id_;
+        d.top_version           = hf_version_for_height(net_, 0);
+        d.pruning_seed          = 0;
+        d.support_flags         = 1;             // fluffy blocks
+        return d;
+    }
+
+    bool have_block(const Hash& id) const override {
+        if (booted()) return index_.have_block(id);
+        return id == genesis_id_;
+    }
+
+    std::vector<Hash> locator() const override {
+        if (booted()) return index_.locator();
+        return {genesis_id_};
+    }
+
+    std::optional<ChainEntry> find_supplement(const std::vector<Hash>& peer_locator) const override {
+        if (booted()) return index_.find_supplement(peer_locator);
+        for (const Hash& id : peer_locator) {
+            if (id != genesis_id_) continue;
+            ChainEntry e;
+            e.start_height = 0;
+            e.total_height = 1;
+            e.cumulative_difficulty_hint = U128{1, 0};
+            e.ids.push_back(genesis_id_);
+            return e;
+        }
+        return std::nullopt;
+    }
+
+    // We know the genesis ID before we hold its BYTES, and serving a block we
+    // cannot produce is worse than reporting it missed.
+    std::optional<BlockEntry> get_block_entry(const Hash& id, bool prune) const override {
+        if (booted()) return index_.get_block_entry(id, prune);
+        return std::nullopt;
+    }
+
+private:
+    bool try_seed_(const std::vector<std::uint8_t>& blob) {
+        if (blob.empty()) return false;
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            ++stats_.blobs_inspected;
+        }
+        ChainRow    row;
+        std::string why;
+        if (!genesis_row_from_blob(blob, genesis_id_, row, why)) {
+            std::lock_guard<std::mutex> lk(mu_);
+            ++stats_.refusals;
+            stats_.why = why;
+            return false;
+        }
+        index_.seed_direct(row,
+                           /*difficulty_window=*/{DifficultyRow{row.timestamp,
+                                                                row.cumulative_difficulty}},
+                           /*short_term_weights=*/{row.block_weight},
+                           /*long_term_weights=*/{row.long_term_weight},
+                           /*timestamps_60=*/{row.timestamp},
+                           /*seed_ids=*/{{0, row.id}});
+        std::lock_guard<std::mutex> lk(mu_);
+        booted_       = true;
+        stats_.booted = true;
+        stats_.why    = "genesis row seeded from the levin-delivered blob";
+        return true;
+    }
+
+    void note_entry_(const ChainEntry& e) {
+        std::lock_guard<std::mutex> lk(mu_);
+        ++stats_.chain_entries;
+        ChainEntryNote n;
+        n.have                = true;
+        n.start_height        = e.start_height;
+        n.total_height        = e.total_height;
+        n.ids                 = e.ids.size();
+        if (!e.ids.empty()) { n.first_id = e.ids.front(); n.last_id = e.ids.back(); }
+        n.first_block_present = !e.first_block.empty();
+        n.first_block_size    = e.first_block.size();
+        stats_.last_entry     = n;
+    }
+
+    void drop_(const char* what) {
+        std::lock_guard<std::mutex> lk(mu_);
+        ++stats_.dropped_preboot;
+        stats_.why = what;
+    }
+
+    ChainIndex&        index_;
+    BootMode           mode_;
+    Hash               genesis_id_;
+    XmrNet             net_;
+    mutable std::mutex mu_;
+    bool               booted_ = false;
+    Stats              stats_{};
+};
+
+} // namespace c2pool::xmr::native::rt

--- a/src/impl/xmr/native/node/xmr_monerod_http.hpp
+++ b/src/impl/xmr/native/node/xmr_monerod_http.hpp
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/node/xmr_monerod_http.hpp
+//
+// The PARITY ARM's transport, and nothing else's.
+//
+// WHAT IT IS FOR. C6's MonerodTipObserver and C4's MonerodMinerDataSource both
+// take a `node::IMonerodTransport`. The native node needs one for exactly two
+// jobs, and both of them are OFF the tip-follow path by construction:
+//
+//   * the parity oracle's monerod arm -- the judge the native chain is measured
+//     against while the daemon is still armed (plan M0..M4);
+//   * the monerod template arm, when one is configured.
+//
+// It is NEVER reached by anything that follows the chain. The node's levin path
+// -- peer pool, chain index, txpool -- includes this header nowhere, and the
+// status line reports `rpc_calls` beside `blocks_in` so that "the tip moved
+// without an RPC" is a pair of numbers rather than a claim.
+//
+// WHY NOT REUSE c2pool/v37/xmr/xmr_live_transport.hpp, which already does this.
+// Because that file lives in the CONSUMER tree and this one lives in the
+// component tree: `src/impl/xmr/**` is included by `src/c2pool/**` and must not
+// include it back. A transport is ~150 lines of POSIX sockets; an inverted
+// dependency is a layering rule that stops being true. The two are deliberately
+// not shared and neither is the "production" one -- the pool proper keeps using
+// the consumer-tree transport it always did.
+//
+// DELIBERATELY SMALL. Blocking HTTP/1.1 POST, no keep-alive, no TLS, no digest
+// auth (a login string is refused loudly rather than sent in the clear), no
+// chunked-transfer support beyond what monerod actually emits (it sends
+// Content-Length for JSON-RPC). `zmq_subscribe` is a refusal, not a stub: the
+// native node takes its tip from levin, so a ZMQ subscriber here would be a
+// second source of truth for the one fact this whole track exists to own.
+//
+// SCOPE FENCE (standing XMR-lane rule): everything under src/impl/xmr/.
+//
+// Header-only, POSIX. STL plus <sys/socket.h>.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/node/monerod_transport.hpp"
+
+namespace c2pool::xmr::native::rt {
+
+class MonerodHttp final : public ::c2pool::xmr::node::IMonerodTransport {
+public:
+    using RpcResponse = ::c2pool::xmr::node::RpcResponse;
+    using ZmqFrame    = ::c2pool::xmr::node::ZmqFrame;
+
+    MonerodHttp(std::string host, std::uint16_t port, std::uint32_t timeout_ms = 5000)
+        : host_(std::move(host)), port_(port), timeout_ms_(timeout_ms) {}
+
+    std::uint64_t calls()    const noexcept { return calls_.load(); }
+    std::uint64_t failures() const noexcept { return failures_.load(); }
+    std::string   endpoint() const { return host_ + ":" + std::to_string(port_); }
+
+    void rpc_post(const std::string& json_body,
+                  std::function<void(const RpcResponse&)> on_done) override {
+        RpcResponse resp;
+        ++calls_;
+        const std::string method = extract_method_(json_body);
+        const std::string path   = json_rpc_method_(method) ? "/json_rpc" : ("/" + method);
+        std::string body;
+        const std::string err = post_(path, json_body, body);
+        if (!err.empty()) {
+            ++failures_;
+            resp.error = err;
+            on_done(resp);
+            return;
+        }
+        resp.body.assign(body.begin(), body.end());
+        on_done(resp);
+    }
+
+    // See the banner: the native node's tip comes from levin, and a second live
+    // source of the same fact is a bug waiting for a disagreement.
+    void zmq_subscribe(const std::string&, std::function<void(const ZmqFrame&)>) override {}
+
+private:
+    static bool json_rpc_method_(const std::string& m) {
+        // The handful of monerod endpoints that are NOT under /json_rpc.
+        return !(m == "get_transactions" || m == "get_transaction_pool" ||
+                 m == "send_raw_transaction" || m == "get_o_indexes" ||
+                 m == "get_outs" || m == "is_key_image_spent" || m == "get_height" ||
+                 m == "get_peer_list" || m == "start_mining" || m == "stop_mining");
+    }
+
+    // The method name out of a JSON-RPC body, without a JSON parser: the bodies
+    // are ours, one line each, and pulling in a parser to read back what we just
+    // wrote would be the wrong kind of thorough.
+    static std::string extract_method_(const std::string& body) {
+        const std::string key = "\"method\"";
+        const std::size_t k = body.find(key);
+        if (k == std::string::npos) return {};
+        std::size_t i = body.find(':', k + key.size());
+        if (i == std::string::npos) return {};
+        i = body.find('"', i);
+        if (i == std::string::npos) return {};
+        const std::size_t j = body.find('"', i + 1);
+        if (j == std::string::npos) return {};
+        return body.substr(i + 1, j - i - 1);
+    }
+
+    std::string post_(const std::string& path, const std::string& body, std::string& out) {
+        out.clear();
+
+        addrinfo hints{};
+        hints.ai_family   = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        addrinfo* res = nullptr;
+        const std::string port_s = std::to_string(port_);
+        if (::getaddrinfo(host_.c_str(), port_s.c_str(), &hints, &res) != 0 || !res)
+            return "resolve failed for " + endpoint();
+
+        const int fd = ::socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+        if (fd < 0) { ::freeaddrinfo(res); return "socket() failed"; }
+
+        timeval tv{};
+        tv.tv_sec  = static_cast<time_t>(timeout_ms_ / 1000);
+        tv.tv_usec = static_cast<suseconds_t>((timeout_ms_ % 1000) * 1000);
+        ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+        ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+        int one = 1;
+        ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+
+        if (::connect(fd, res->ai_addr, res->ai_addrlen) != 0) {
+            ::freeaddrinfo(res);
+            ::close(fd);
+            return "connect failed to " + endpoint();
+        }
+        ::freeaddrinfo(res);
+
+        std::string req = "POST " + path + " HTTP/1.1\r\nHost: " + host_ + ":" + port_s +
+                          "\r\nContent-Type: application/json\r\nConnection: close"
+                          "\r\nContent-Length: " + std::to_string(body.size()) + "\r\n\r\n" + body;
+        std::size_t sent = 0;
+        while (sent < req.size()) {
+            const ssize_t n = ::send(fd, req.data() + sent, req.size() - sent, 0);
+            if (n <= 0) { ::close(fd); return "send failed"; }
+            sent += static_cast<std::size_t>(n);
+        }
+
+        std::string raw;
+        char        buf[8192];
+        for (;;) {
+            const ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+            if (n < 0) { ::close(fd); return "recv failed/timed out"; }
+            if (n == 0) break;
+            raw.append(buf, static_cast<std::size_t>(n));
+            if (raw.size() > 64u * 1024 * 1024) { ::close(fd); return "response too large"; }
+        }
+        ::close(fd);
+
+        const std::size_t hdr_end = raw.find("\r\n\r\n");
+        if (hdr_end == std::string::npos) return "malformed HTTP response";
+        out = raw.substr(hdr_end + 4);
+        if (raw.compare(0, 9, "HTTP/1.1 ") == 0 && raw.compare(9, 3, "200") != 0)
+            return "HTTP " + raw.substr(9, 3);
+        return {};
+    }
+
+    std::string                host_;
+    std::uint16_t              port_;
+    std::uint32_t              timeout_ms_;
+    std::atomic<std::uint64_t> calls_{0};
+    std::atomic<std::uint64_t> failures_{0};
+};
+
+} // namespace c2pool::xmr::native::rt

--- a/src/impl/xmr/native/node/xmr_native_node.hpp
+++ b/src/impl/xmr/native/node/xmr_native_node.hpp
@@ -1,0 +1,657 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/node/xmr_native_node.hpp
+//
+// M0: THE NODE. The thirteen wave-0/wave-1 components, constructed, wired and
+// given the threads they were written against.
+//
+//   C1b LevinLink ─┐
+//   C1c XmrPeerPool ──(io thread)──> VerifyInbound ──(verify thread)──>
+//         │                              ChainBoot ──> C2c ChainIndex
+//         │                                               │ RandomX (C2c PowGate
+//         │                                               │  -> LightVerifier)
+//         │                              TxSinkLoop ──(pool thread)──> C3 RelayedTxPool
+//         │                                                               │
+//         ├── IChainServing  <── C2c (the state_normal obligation)         │
+//         ├── IChainFetcher  <── SyncDriver (verify thread) ───────────────┘
+//         └── IBroadcastPort ──> C5 LevinBlockRelay
+//                                    ▲
+//   C4 NativeMinerDataSource (C2c IChainView + C3 ITxpoolSnapshot/ITxBlobSource)
+//   C4 MonerodMinerDataSource (RPC, parity/backup arm only)
+//        └── C4 ArmResolver ──> C6 ParityOracle (native tip vs monerod tip)
+//
+// WHAT THIS FILE ADDS THAT NO COMPONENT DID. Four things, and each of them is a
+// gap that only shows up when the parts are put together:
+//
+//   1. THE THREADS. Three component banners demand threads none of them
+//      creates; xmr_worker_loops.hpp builds them and this file hands them out.
+//      The io thread does sockets and codec, the verify thread does consensus
+//      and RandomX, the pool thread does transaction decode and range proofs.
+//   2. THE FIRST QUESTION. Nothing in the tree sends NOTIFY_REQUEST_CHAIN
+//      (xmr_sync_driver.hpp), and nothing seeds row zero (xmr_chain_boot.hpp).
+//   3. THE TWO NETS. A Monero node needs two answers to "which network": the
+//      WIRE identity (network id, genesis id, default port -- levin::XmrNet) and
+//      the CONSENSUS rules (the hard-fork table -- native::XmrNet). They are
+//      separate enums because they are separate facts, and regtest is the case
+//      that proves it: monerod's fakechain carries the MAINNET network id and
+//      the MAINNET genesis block while running a hard-fork table that starts at
+//      v16 from height 1. `resolve_nets()` below is the one place that mapping
+//      lives.
+//   4. THE ADMISSIONS. The status line reports what a component would otherwise
+//      only know internally -- the RandomX witness, the queue depths, the peers
+//      that are handshaked but silent, the RPC call count next to the block
+//      count -- because the X9 bring-up's lesson was that "connected and
+//      receiving nothing" must be answerable without a debugger.
+//
+// WHAT IS DELIBERATELY NOT DRIVEN HERE. C5's relay is CONSTRUCTED and its 2009
+// responder is armed, but nothing in M0 calls relay(): a found block comes from
+// the stratum/settlement path, which is M3. C4's arms are constructed and
+// readable; rebinding the option-B settlement provider through them is M2. The
+// txpool is fed from levin and selectable, but M1 is where its per-transaction
+// equality against monerod's pool is proven. Each of those is wired to the seam
+// and left unexercised ON PURPOSE, so that the milestone that owns it has
+// something to prove rather than something to discover.
+//
+// SCOPE FENCE (standing XMR-lane rule): everything under src/impl/xmr/. This
+// tree is a WORK SOURCE for the pool, not part of the v37 share-chain record;
+// nothing here activates v37 consensus and src/sharechain/v37 is not touched.
+//
+// Header-only. STL plus boost::asio; RandomX only when
+// XMR_NATIVE_NODE_HAVE_RANDOMX is defined (the CMake option XMR_BUILD_RANDOMX).
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <boost/asio.hpp>
+
+#include "impl/xmr/native/chain/xmr_chain_index.hpp"
+#include "impl/xmr/native/chain/xmr_pow_gate.hpp"
+#include "impl/xmr/native/node/xmr_chain_boot.hpp"
+#include "impl/xmr/native/node/xmr_monerod_http.hpp"
+#include "impl/xmr/native/node/xmr_sync_driver.hpp"
+#include "impl/xmr/native/node/xmr_worker_loops.hpp"
+#include "impl/xmr/native/p2p/chain_seeds.hpp"
+#include "impl/xmr/native/p2p/xmr_peer_pool.hpp"
+#include "impl/xmr/native/parity/xmr_parity_oracle.hpp"
+#include "impl/xmr/native/parity/xmr_parity_report.hpp"
+#include "impl/xmr/native/relay/xmr_block_relay.hpp"
+#include "impl/xmr/native/template/xmr_monerod_miner_data.hpp"
+#include "impl/xmr/native/template/xmr_native_miner_data.hpp"
+#include "impl/xmr/native/template/xmr_template_arm.hpp"
+#include "impl/xmr/native/txpool/xmr_relayed_txpool.hpp"
+
+#if defined(XMR_NATIVE_NODE_HAVE_RANDOMX)
+#include "impl/xmr/pow/randomx_verify.hpp"
+#endif
+
+namespace c2pool::xmr::native::rt {
+
+namespace levinns = ::c2pool::xmr::native::levin;
+
+// ---------------------------------------------------------------------------
+// Which network, twice.
+//
+// FAKECHAIN (monerod --regtest) is the case that makes the two enums necessary
+// rather than redundant: cryptonote::get_config(FAKECHAIN) returns the MAINNET
+// config, so a regtest daemon speaks the mainnet network id, listens with the
+// mainnet genesis block at height 0, and would drop a peer whose locator
+// terminated in anything else -- while its hard-fork table is
+// { v16 @ height 1 }, which is neither mainnet's nor any other network's.
+// Verified against a live monerod 0.18.5.1 fakechain: get_block(0).hash ==
+// 418015bb…32e3 (the mainnet genesis id) and hard_fork_info reports version 16
+// at earliest_height 1.
+// ---------------------------------------------------------------------------
+enum class NativeNet : std::uint8_t { Mainnet = 0, Testnet = 1, Stagenet = 2, Regtest = 3 };
+
+inline const char* to_string(NativeNet n) noexcept {
+    switch (n) {
+        case NativeNet::Mainnet:  return "mainnet";
+        case NativeNet::Testnet:  return "testnet";
+        case NativeNet::Stagenet: return "stagenet";
+        case NativeNet::Regtest:  return "regtest";
+    }
+    return "?";
+}
+
+inline bool parse_native_net(const std::string& s, NativeNet& out) noexcept {
+    if (s == "mainnet")  { out = NativeNet::Mainnet;  return true; }
+    if (s == "testnet")  { out = NativeNet::Testnet;  return true; }
+    if (s == "stagenet") { out = NativeNet::Stagenet; return true; }
+    if (s == "regtest" || s == "fakechain") { out = NativeNet::Regtest; return true; }
+    return false;
+}
+
+struct NetPair {
+    levinns::XmrNet wire;        // network id + genesis id + default p2p port
+    XmrNet          consensus;   // hard-fork table
+};
+
+inline NetPair resolve_nets(NativeNet n) noexcept {
+    switch (n) {
+        case NativeNet::Testnet:  return {levinns::XmrNet::Testnet,  XmrNet::Testnet};
+        case NativeNet::Stagenet: return {levinns::XmrNet::Stagenet, XmrNet::Stagenet};
+        case NativeNet::Regtest:  return {levinns::XmrNet::Mainnet,  XmrNet::Regtest};
+        case NativeNet::Mainnet:  break;
+    }
+    return {levinns::XmrNet::Mainnet, XmrNet::Mainnet};
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+struct NativeNodeConfig {
+    NativeNet                net = NativeNet::Stagenet;
+    std::vector<std::string> connect;              // operator-pinned "ip:port" peers
+    // Source address for outbound levin connections; see XmrPeerPool::Config.
+    // On the loopback regtest rig this is what keeps monerod's one-connection-
+    // per-remote-IP rule from refusing us before the handshake.
+    std::string              p2p_bind_ip;
+    bool                     use_seeds = false;    // M0 runs against pinned peers
+    std::uint64_t            peer_id   = 0;        // 0 => random, never 0 on the wire
+
+    BootMode                 boot = BootMode::Genesis;
+    std::string              anchor_path;          // BootMode::Anchor; "" = embedded
+
+    // A build without librandomx cannot check proof of work: the gate answers
+    // Skipped, and the index connects blocks it never verified. That is a
+    // legitimate thing to want (a build leg that cannot link RandomX, a
+    // topology test) and an illegitimate thing to do by accident, so it is
+    // opt-in and the status line says so. With RandomX compiled in this flag
+    // does nothing: the verifier is always used.
+    bool                     allow_unverified_pow = false;
+
+    // The parity / backup arm. Empty host = no daemon at all, which C6 scores as
+    // VOID samples rather than as agreement.
+    std::string              monerod_rpc_host;
+    std::uint16_t            monerod_rpc_port = 0;
+    bool                     parity           = true;
+    std::string              parity_ledger_path;
+    std::string              c2pool_commit;        // one of the four graduation keys
+
+    TemplateArm              serve_arm = TemplateArm::Native;
+    ArmOrder                 relay_order = ArmOrder::DaemonFirst;   // see the owed ruling
+
+    // READ-ONLY PROBE against somebody else's daemon: handshake, TIMED_SYNC,
+    // one NOTIFY_REQUEST_CHAIN, and not one block requested. See
+    // SyncDriverConfig::probe_only.
+    bool                     probe_only = false;
+
+    std::uint64_t            driver_tick_ms = 500;
+    std::size_t              verify_queue   = 4096;
+    std::size_t              txpool_queue   = 2048;
+
+    // OR-C2-8: on a private chain with one pinned peer the cohort test cannot
+    // distinguish "at the tip" from "alone", so the publication gate is set
+    // rather than inferred -- and the status line says it was forced.
+    bool                     force_synced = false;
+};
+
+// One line per tip the node adopted: the M0 evidence record.
+struct TipRecord {
+    std::uint64_t height = 0;
+    Hash          id{};
+    Hash          prev_id{};
+    U128          difficulty{};
+    U128          cumulative_difficulty{};
+    std::uint64_t timestamp = 0;
+    std::uint64_t reward    = 0;
+    std::uint64_t weight    = 0;
+    bool          reorg     = false;
+    std::uint64_t reorg_depth = 0;
+};
+
+struct NodeStatus {
+    SyncState                    sync{};
+    p2p::PoolTelemetry           pool{};
+    SyncDriver::Stats            driver{};
+    VerifyInbound::Stats         inbound{};
+    TxSinkLoop::Stats            txsink{};
+    WorkerLoop::Stats            verify_queue{};
+    WorkerLoop::Stats            pool_queue{};
+    ThreadWitnessPowSource::Witness randomx{};
+    RandomXMode                  randomx_mode = RandomXMode::Disabled;
+    ChainBoot::Stats             boot{};
+    TxpoolStats                  txpool{};
+    std::uint64_t                rpc_calls = 0;
+    std::string                  template_arm;
+    std::string                  io_threads;
+    std::string                  verify_thread;
+};
+
+// ---------------------------------------------------------------------------
+// NativeNode
+// ---------------------------------------------------------------------------
+class NativeNode {
+public:
+    explicit NativeNode(NativeNodeConfig cfg)
+        : cfg_(std::move(cfg)),
+          nets_(resolve_nets(cfg_.net)),
+          verify_loop_("verify", cfg_.verify_queue),
+          pool_loop_("txpool", cfg_.txpool_queue),
+          index_(make_index_options_(), pow_witness_or_null_()),
+          boot_(index_, cfg_.boot, p2p::genesis_id(nets_.wire), nets_.consensus),
+          inbound_(verify_loop_, boot_),
+          txpool_(make_txpool_config_()),
+          tx_sink_(pool_loop_, txpool_),
+          native_src_(index_, txpool_, make_template_policy_(), &txpool_),
+          tick_(io_) {}
+
+    NativeNode(const NativeNode&)            = delete;
+    NativeNode& operator=(const NativeNode&) = delete;
+    ~NativeNode() { stop(); }
+
+    // -----------------------------------------------------------------------
+    bool start(std::string& why) {
+        why.clear();
+
+        // --- RandomX ---------------------------------------------------------
+        if (!init_pow_(why)) return false;
+
+        // --- the trust root, when it does not come off the wire ---------------
+        if (cfg_.boot == BootMode::Anchor) {
+            // The 60 timestamps are not in the bundle by its own contract; the
+            // state treats a short window as "no median", which is why an empty
+            // vector is a degraded-but-honest boot rather than a wrong one.
+            if (!boot_.boot_from_anchor(cfg_.anchor_path, nets_.consensus, {}, why))
+                return false;
+        }
+
+        index_.set_clock([] { return unix_seconds_(); });
+        if (cfg_.force_synced) index_.force_synced(true);
+
+        // Every tip the index adopts is recorded here and handed to the parity
+        // oracle. This runs ON THE VERIFY THREAD (the index flushes its events
+        // after releasing its own lock), which is what makes the native
+        // observation the oracle takes later safe to read.
+        index_.subscribe([this](const node::MainchainEvent& ev) { on_mainchain_(ev); });
+        index_.subscribe_txs([this](const BlockTxEvent& ev) {
+            // C2 -> C3: drop mined ids, evict key-image conflicts, re-admit on a
+            // rollback. Posted to the pool thread for the same reason the relay
+            // path is: it re-decodes bodies.
+            pool_loop_.post([this, ev] {
+                if (ev.kind == BlockTxEvent::Kind::Connected) txpool_.on_block_connected(ev);
+                else                                          txpool_.on_block_disconnected(ev);
+            });
+        });
+
+        verify_loop_.start();
+        pool_loop_.start();
+
+        // --- the daemon arm (parity / backup only) ---------------------------
+        if (!cfg_.monerod_rpc_host.empty() && cfg_.monerod_rpc_port != 0) {
+            rpc_    = std::make_unique<MonerodHttp>(cfg_.monerod_rpc_host, cfg_.monerod_rpc_port);
+            mon_src_ = std::make_unique<tmpl::MonerodMinerDataSource>(*rpc_);
+            mon_tip_ = std::make_unique<parity::MonerodTipObserver>(*rpc_);
+        }
+
+        tmpl::TemplateArmConfig arm_cfg;
+        arm_cfg.serve = cfg_.serve_arm;
+        arm_cfg.shadow = (cfg_.serve_arm == TemplateArm::Native)
+                             ? (mon_src_ ? std::optional<TemplateArm>(TemplateArm::Monerod)
+                                         : std::nullopt)
+                             : std::optional<TemplateArm>(TemplateArm::Native);
+        arms_ = std::make_unique<tmpl::ArmResolver>(mon_src_.get(), &native_src_, arm_cfg);
+
+        // --- the peer pool ---------------------------------------------------
+        p2p::XmrPeerPool::Config pc;
+        pc.net                    = nets_.wire;
+        pc.link.handshake.net     = nets_.wire;
+        pc.link.handshake.our_peer_id = cfg_.peer_id ? cfg_.peer_id : random_peer_id_();
+        pc.manual_peers           = cfg_.connect;
+        pc.bind_ip                = cfg_.p2p_bind_ip;
+        if (cfg_.probe_only) {
+            // A READ-ONLY probe dials exactly what it was told to dial. The
+            // pool learns addresses from the handshake peerlist and the plan
+            // refills toward its target, so a probe left on the default would
+            // quietly open connections to strangers on the public network --
+            // observed once against stagenet, where the probe dialed a peer it
+            // had just learned from the daemon it was probing.
+            pc.dial.target_outbound      = cfg_.connect.size();
+            pc.dial.max_outbound         = cfg_.connect.size();
+            pc.dial.max_concurrent_dials = cfg_.connect.size();
+            pc.use_seeds                 = false;
+        }
+        pc.use_seeds              = cfg_.use_seeds;
+
+        p2p::XmrPeerPool::Deps pd;
+        pd.serving = &boot_;       // io-thread reads; the state_normal obligation
+                                   // (pre-boot it answers for the genesis itself)
+        pd.index   = &inbound_;    // enqueue-and-return onto the verify thread
+        pd.txpool  = &tx_sink_;    // enqueue-and-return onto the pool thread
+        pool_ = p2p::XmrPeerPool::create(io_, pc, pd);
+
+        index_.set_fetcher(pool_.get());
+        tx_sink_.set_faults([this](const PeerRef& p, PeerFault f, const std::string& w) {
+            if (pool_) pool_->penalize(p, f, w);
+        });
+
+        // --- C5, constructed and armed, not driven in M0 ---------------------
+        relay::RelayConfig rcfg;
+        rcfg.policy.order = cfg_.relay_order;
+        block_relay_ = std::make_unique<relay::LevinBlockRelay>(
+            *pool_, relay::DaemonSubmitSink{}, &native_src_, &index_, rcfg);
+
+        // --- C6 --------------------------------------------------------------
+        if (cfg_.parity) {
+            native_tip_ = std::make_unique<parity::ChainViewTipObserver>(index_.view());
+            parity::ParityOracle::Deps od;
+            od.native_tip  = native_tip_.get();
+            od.monerod_tip = mon_tip_.get();
+            od.served_arm  = arms_->arm(cfg_.serve_arm);
+            od.shadow_arm  = arms_->shadow();
+            GraduationKey key;
+            key.c2pool_commit   = cfg_.c2pool_commit;
+            key.monerod_version = "unknown";
+            key.net             = to_string(cfg_.net);
+            parity::ParityOracleConfig oc;
+            oc.ledger_path = cfg_.parity_ledger_path;
+            oracle_ = std::make_unique<parity::ParityOracle>(
+                od, key, parity::GraduationPolicy::regtest_fast(), oc,
+                [] { return unix_seconds_(); },
+                [this](const std::string& line) { note_(line); });
+        }
+
+        // --- the sync driver -------------------------------------------------
+        SyncDriverConfig dcfg;
+        dcfg.probe_only = cfg_.probe_only;
+        driver_ = std::make_unique<SyncDriver>(
+            *pool_, boot_, index_, p2p::genesis_id(nets_.wire),
+            [this] { return boot_.booted(); },
+            [this] { return index_.refetch_wanted(); }, dcfg);
+
+        // --- threads ----------------------------------------------------------
+        running_ = true;
+        guard_   = std::make_unique<boost::asio::executor_work_guard<
+            boost::asio::io_context::executor_type>>(io_.get_executor());
+        io_thread_ = std::thread([this] { io_.run(); });
+        {
+            // The witness has to know which thread must never hash. It is
+            // registered from INSIDE the io thread rather than guessed, so it
+            // names the thread that actually runs the sockets.
+            std::promise<void> ready;
+            auto fut = ready.get_future();
+            boost::asio::post(io_, [this, &ready] {
+                if (witness_) witness_->forbid(std::this_thread::get_id());
+                io_thread_id_ = std::this_thread::get_id();
+                ready.set_value();
+            });
+            fut.wait();
+        }
+
+        pool_->start();
+        for (const std::string& key : cfg_.connect) pool_->dial_now(key);
+        arm_tick_();
+        return true;
+    }
+
+    void stop() {
+        if (!running_.exchange(false)) return;
+        tick_.cancel();
+        if (pool_) pool_->stop();
+        if (guard_) guard_->reset();
+        io_.stop();
+        if (io_thread_.joinable()) io_thread_.join();
+        verify_loop_.stop();
+        pool_loop_.stop();
+    }
+
+    // -----------------------------------------------------------------------
+    // Observation
+    // -----------------------------------------------------------------------
+    NodeStatus status() {
+        NodeStatus s;
+        s.sync    = index_.sync_state();
+        s.pool    = pool_ ? pool_->telemetry() : p2p::PoolTelemetry{};
+        s.inbound = inbound_.stats();
+        s.txsink  = tx_sink_.stats();
+        s.verify_queue = verify_loop_.stats();
+        s.pool_queue   = pool_loop_.stats();
+        s.boot         = boot_.stats();
+        s.txpool       = txpool_.stats();
+        s.rpc_calls    = rpc_ ? rpc_->calls() : 0;
+        if (witness_) s.randomx = witness_->witness();
+        s.randomx_mode = index_.pow_gate().mode();
+        if (arms_)    s.template_arm = arms_->describe();
+        // The driver's counters are only ever written on the verify thread, so
+        // they are read there too rather than racing them.
+        verify_loop_.call([this, &s] { if (driver_) s.driver = driver_->stats(); });
+        s.io_threads   = thread_id_string_(io_thread_id_);
+        s.verify_thread = thread_id_string_(verify_loop_.thread_id());
+        return s;
+    }
+
+    std::vector<TipRecord> tips() const {
+        std::lock_guard<std::mutex> lk(rec_mu_);
+        return tips_;
+    }
+
+    std::vector<std::string> take_log() {
+        std::lock_guard<std::mutex> lk(rec_mu_);
+        std::vector<std::string> out;
+        out.swap(log_);
+        return out;
+    }
+
+    // The C6 seam, run in the order the oracle's threading contract requires:
+    // the daemon round trip on the CALLER's thread, the comparison on the
+    // verify thread (a native observation reads the chain state view, which the
+    // verify thread owns).
+    std::vector<parity::SeamResult> parity_sample() {
+        std::vector<parity::SeamResult> out;
+        if (!oracle_) return out;
+        if (mon_tip_) (void)mon_tip_->poll();
+        verify_loop_.call([this, &out] { out = oracle_->drain(); });
+        return out;
+    }
+
+    parity::ParityOracle* oracle() noexcept { return oracle_.get(); }
+    ChainIndex&           index()  noexcept { return index_; }
+    RelayedTxPool&        txpool() noexcept { return txpool_; }
+    tmpl::ArmResolver*    arms()   noexcept { return arms_.get(); }
+    const NativeNodeConfig& config() const noexcept { return cfg_; }
+    const NetPair&          nets()   const noexcept { return nets_; }
+
+    // Force the publication gate after the fact (the regtest / single-peer case).
+    void force_synced(bool v) { index_.force_synced(v); }
+
+private:
+    // --- construction helpers (called from the member initialiser list) -----
+    ChainIndexOptions make_index_options_() const {
+        ChainIndexOptions o;
+        o.net = nets_.consensus;
+        return o;
+    }
+
+    TxpoolConfig make_txpool_config_() const {
+        TxpoolConfig c;
+        return c;
+    }
+
+    tmpl::NativeTemplatePolicy make_template_policy_() const {
+        tmpl::NativeTemplatePolicy p;
+        // On a private chain one pinned peer is the correct configuration, so
+        // the peer floor is off; it is a flag rather than a refusal anyway.
+        p.min_peers = 0;
+        return p;
+    }
+
+    // The index takes an IPowSource by reference in its constructor, before
+    // start() can decide whether RandomX is available. So the witness is
+    // constructed first over a placeholder source and re-pointed at the real
+    // verifier in init_pow_() through PowGate::set_source() -- which is exactly
+    // why that setter exists.
+    IPowSource& pow_witness_or_null_() {
+        if (!witness_) witness_ = std::make_unique<ThreadWitnessPowSource>(null_pow_);
+        return *witness_;
+    }
+
+    bool init_pow_(std::string& why) {
+#if defined(XMR_NATIVE_NODE_HAVE_RANDOMX)
+        verifier_ = std::make_unique<::c2pool::xmr::LightVerifier>();
+        if (!verifier_->init()) {
+            why = "RandomX LightVerifier init failed (two 256 MiB caches + a light VM)";
+            return false;
+        }
+        rx_source_ = std::make_unique<LightVerifierPowSource<::c2pool::xmr::LightVerifier>>(
+            *verifier_, RandomXMode::LightJit);
+        // Re-point the witness at the real verifier IN PLACE. The witness object
+        // keeps its address on purpose: the index cached the IPowSource* it was
+        // constructed with, so replacing the object here would dangle it.
+        witness_->set_inner(*rx_source_);
+        return true;
+#else
+        if (!cfg_.allow_unverified_pow) {
+            why = "this build has no librandomx, so proof of work cannot be checked: "
+                  "every block would connect unverified. Pass --allow-unverified-pow "
+                  "to run anyway, or build with -DXMR_BUILD_RANDOMX=ON";
+            return false;
+        }
+        return true;
+#endif
+    }
+
+    static std::uint64_t random_peer_id_() {
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
+        std::uint64_t v = 0;
+        while (v == 0) v = gen();   // a zero peer id is a handshake refusal
+        return v;
+    }
+
+    static std::string thread_id_string_(const std::thread::id& id) {
+        std::ostringstream os;
+        os << id;
+        return os.str();
+    }
+
+    static std::uint64_t unix_seconds_() {
+        using namespace std::chrono;
+        return static_cast<std::uint64_t>(
+            duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
+    }
+
+    void arm_tick_() {
+        if (!running_) return;
+        tick_.expires_after(std::chrono::milliseconds(cfg_.driver_tick_ms));
+        tick_.async_wait([this](const boost::system::error_code& ec) {
+            if (ec || !running_) return;
+            const std::uint64_t now = now_ms_();
+            verify_loop_.post([this, now] { if (driver_) driver_->tick(now); },
+                              /*control=*/true);
+            arm_tick_();
+        });
+    }
+
+    std::uint64_t now_ms_() const {
+        using namespace std::chrono;
+        return static_cast<std::uint64_t>(
+            duration_cast<milliseconds>(steady_clock::now() - epoch_).count());
+    }
+
+    // ON THE VERIFY THREAD.
+    void on_mainchain_(const node::MainchainEvent& ev) {
+        if (ev.kind == node::MainchainEventKind::Orphan) return;
+        TipRecord r;
+        r.height      = ev.block.height;
+        r.id          = ev.block.id;
+        r.prev_id     = ev.block.prev_id;
+        r.difficulty  = ev.block.difficulty;
+        r.timestamp   = ev.block.timestamp;
+        r.reward      = ev.block.reward;
+        r.reorg       = (ev.kind == node::MainchainEventKind::Reorg);
+        r.reorg_depth = ev.depth;
+        // The event carries the consumer-facing ChainMainBlock, which has no
+        // cumulative difficulty and no weight; both live on the index's own row.
+        // The row is found BY ID rather than by reading the tip: a backfill
+        // connects many blocks and flushes their events afterwards, so by the
+        // time this runs the tip is usually several blocks past the one the
+        // event is about -- and comparing against the tip silently recorded
+        // zeros for every block but the last.
+        for (auto it = index_.view().state().rows().rbegin();
+             it != index_.view().state().rows().rend(); ++it) {
+            if (it->id != ev.block.id) continue;
+            r.cumulative_difficulty = it->cumulative_difficulty;
+            r.weight                = it->block_weight;
+            break;
+        }
+        {
+            std::lock_guard<std::mutex> lk(rec_mu_);
+            tips_.push_back(r);
+            if (tips_.size() > 8192) tips_.erase(tips_.begin());
+        }
+        if (oracle_) oracle_->on_tip(ev, "native");
+    }
+
+    void note_(const std::string& line) {
+        std::lock_guard<std::mutex> lk(rec_mu_);
+        log_.push_back(line);
+        if (log_.size() > 4096) log_.erase(log_.begin());
+    }
+
+    // --- state --------------------------------------------------------------
+    NativeNodeConfig cfg_;
+    NetPair          nets_;
+
+    NoPowSource                              null_pow_;
+    std::unique_ptr<ThreadWitnessPowSource>  witness_;
+#if defined(XMR_NATIVE_NODE_HAVE_RANDOMX)
+    std::unique_ptr<::c2pool::xmr::LightVerifier> verifier_;
+    std::unique_ptr<LightVerifierPowSource<::c2pool::xmr::LightVerifier>> rx_source_;
+#endif
+
+    WorkerLoop     verify_loop_;
+    WorkerLoop     pool_loop_;
+    ChainIndex     index_;
+    ChainBoot      boot_;
+    VerifyInbound  inbound_;
+    RelayedTxPool  txpool_;
+    TxSinkLoop     tx_sink_;
+    tmpl::NativeMinerDataSource native_src_;
+
+    boost::asio::io_context    io_;
+    boost::asio::steady_timer  tick_;
+    std::thread                io_thread_;
+    std::thread::id            io_thread_id_{};
+    std::unique_ptr<boost::asio::executor_work_guard<
+        boost::asio::io_context::executor_type>> guard_;
+
+    std::shared_ptr<p2p::XmrPeerPool>                pool_;
+    std::unique_ptr<MonerodHttp>                     rpc_;
+    std::unique_ptr<tmpl::MonerodMinerDataSource>    mon_src_;
+    std::unique_ptr<parity::MonerodTipObserver>      mon_tip_;
+    std::unique_ptr<parity::ChainViewTipObserver>    native_tip_;
+    std::unique_ptr<tmpl::ArmResolver>               arms_;
+    std::unique_ptr<relay::LevinBlockRelay>          block_relay_;
+    std::unique_ptr<parity::ParityOracle>            oracle_;
+    std::unique_ptr<SyncDriver>                      driver_;
+
+    std::atomic<bool>                     running_{false};
+    std::chrono::steady_clock::time_point epoch_ = std::chrono::steady_clock::now();
+
+    mutable std::mutex        rec_mu_;
+    std::vector<TipRecord>    tips_;
+    std::vector<std::string>  log_;
+};
+
+} // namespace c2pool::xmr::native::rt

--- a/src/impl/xmr/native/node/xmr_sync_driver.hpp
+++ b/src/impl/xmr/native/node/xmr_sync_driver.hpp
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/node/xmr_sync_driver.hpp
+//
+// M0: THE HALF OF CHAIN SYNC NO COMPONENT OWNS -- deciding WHEN to ask, and WHO
+// to ask.
+//
+// C2c is explicit about the split. `on_chain_entry` ends with
+//
+//     "the SCHEDULE is the sync driver's business; the index only says what is
+//      missing and in what order"
+//
+// and it proves it: the index turns a RESPONSE_CHAIN_ENTRY straight into a
+// `request_objects` for the ids it lacks. What nothing in the tree does is send
+// the FIRST `NOTIFY_REQUEST_CHAIN`, and without it a freshly booted node sits
+// handshaked, liveness-green and empty forever -- which is exactly the silent
+// starvation shape the X9 stagenet bring-up spent a day on. This file is that
+// missing edge, and it is deliberately small: three decisions, all of them on
+// the verify thread, all of them stateless enough to be re-derived every tick.
+//
+//   1. WHO. The peer with the greatest advertised CUMULATIVE DIFFICULTY, not the
+//      greatest height. Height is a number a peer can pick; cumulative
+//      difficulty is the same claim priced in work, and the index re-derives it
+//      anyway before believing anything -- so choosing on it costs nothing and
+//      refuses to be steered by a cheap lie about length.
+//   2. WHEN. Only while the best peer claims to be ahead of us, and never with
+//      two chain requests in flight on the same link (C1b matches
+//      notify-answered requests through ONE expect latch, so a second overlapping
+//      question is a dropped connection). An unanswered request times out and is
+//      re-asked -- of a DIFFERENT peer where one exists, because "the peer that
+//      answers nothing" and "the peer that answers slowly" look identical from
+//      here and only the retry distinguishes them.
+//   3. WHAT ELSE. `refetch_wanted()` -- the parents of blocks the index parked
+//      as orphans. A fluffy push that arrives while we are still behind lands
+//      with an unknown parent; asking for that parent is what turns a park into
+//      a connect without waiting for the next chain entry.
+//
+// THE BOOT ASK. Before the index has a trust root the driver asks for exactly
+// one object: the network's pinned genesis id (see xmr_chain_boot.hpp). It is
+// the only request in this file that is not driven by a height comparison,
+// because before the seed there is no height to compare.
+//
+// TIP-FOLLOW USES NONE OF THIS. Once we are level with the cohort, new blocks
+// arrive as NOTIFY_NEW_FLUFFY_BLOCK pushes from peers that hold us in
+// state_normal, and the driver goes quiet -- `chain_requests` stops rising while
+// the height keeps moving, which is the observable difference between
+// "following the tip" and "still catching up".
+//
+// SCOPE FENCE (standing XMR-lane rule): everything under src/impl/xmr/.
+//
+// Header-only. STL only.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/native/contracts/chain_index.hpp"
+#include "impl/xmr/native/contracts/fetcher.hpp"
+#include "impl/xmr/native/contracts/serving.hpp"
+#include "impl/xmr/native/contracts/types.hpp"
+
+namespace c2pool::xmr::native::rt {
+
+struct SyncDriverConfig {
+    // How long an unanswered NOTIFY_REQUEST_CHAIN may stay outstanding before it
+    // is re-asked. monerod answers in milliseconds on a LAN and in a second or
+    // two across the internet; 20 s is "this peer is not going to answer".
+    std::uint64_t chain_request_timeout_ms = 20'000;
+    // The same, for the one-object genesis fetch at boot.
+    std::uint64_t boot_request_timeout_ms  = 10'000;
+    // Ids per refetch request. C1c chunks a span into <=100-id wire requests on
+    // its own (D-3); this is the span size, not the wire size.
+    std::size_t   refetch_batch            = 64;
+    // How long before the same missing id is asked for again. The index's
+    // refetch list is a STANDING WANT LIST -- it is not cleared when a block
+    // arrives -- so a driver that asked for all of it every tick would re-ask
+    // twice a second forever. Observed exactly that way: 361 RESPONSE_GET_OBJECTS
+    // frames for a 12-block backfill, all of them answers to questions already
+    // answered. Whether the index should prune the list is a C2c question; that
+    // the SCHEDULE must not be a busy loop is this file's.
+    std::uint64_t refetch_reask_ms          = 15'000;
+
+    // READ-ONLY PROBE. Ask one NOTIFY_REQUEST_CHAIN from a genesis-terminated
+    // locator, record the answer, and never ask for a block. This is what a
+    // live probe against somebody else's synced daemon is allowed to do: a
+    // chain entry costs the daemon a walk of its own id index, while a
+    // GET_OBJECTS span costs it disk and bandwidth it is using to sync.
+    bool          probe_only               = false;
+};
+
+class SyncDriver {
+public:
+    struct Stats {
+        std::uint64_t ticks            = 0;
+        std::uint64_t boot_requests    = 0;
+        std::uint64_t chain_requests   = 0;
+        std::uint64_t chain_timeouts   = 0;
+        std::uint64_t refetch_requests = 0;
+        std::uint64_t no_peer_ticks    = 0;
+        std::uint64_t our_height       = 0;
+        std::uint64_t best_peer_height = 0;
+        std::string   target;            // the peer key we are asking, "" = none
+    };
+
+    // `booted` is a predicate rather than a flag so the driver never caches the
+    // one piece of state it does not own. `refetch` is a function for the same
+    // reason and one more: refetch_wanted() is ChainIndex's own surface rather
+    // than part of IChainView, and reaching for the concrete class here would
+    // make this file untestable against the W0 fakes.
+    using BootedFn  = std::function<bool()>;
+    using RefetchFn = std::function<std::vector<Hash>()>;
+
+    SyncDriver(IChainFetcher& fetcher, IChainServing& serving, IChainView& view,
+               Hash genesis_id, BootedFn booted, RefetchFn refetch,
+               SyncDriverConfig cfg = {})
+        : fetcher_(fetcher),
+          serving_(serving),
+          view_(view),
+          genesis_id_(genesis_id),
+          booted_(std::move(booted)),
+          refetch_(std::move(refetch)),
+          cfg_(cfg) {}
+
+    // One pass. MUST be called on the verify thread: it reads the index and
+    // hands the index's own locator to the fetcher.
+    void tick(std::uint64_t now_ms) {
+        ++stats_.ticks;
+
+        const std::vector<std::pair<PeerRef, PeerSyncData>> peers = fetcher_.peers();
+        if (peers.empty()) {
+            ++stats_.no_peer_ticks;
+            stats_.target.clear();
+            in_flight_ = false;
+            return;
+        }
+
+        // --- who -------------------------------------------------------------
+        std::size_t best = 0;
+        for (std::size_t i = 1; i < peers.size(); ++i) {
+            if (u128_less(peers[best].second.cumulative_difficulty,
+                          peers[i].second.cumulative_difficulty))
+                best = i;
+        }
+        const PeerRef&      peer = peers[best].first;
+        const PeerSyncData& sync = peers[best].second;
+        stats_.target            = peer.addr;
+        stats_.best_peer_height  = sync.current_height;
+
+        // --- the read-only probe ---------------------------------------------
+        if (cfg_.probe_only) {
+            if (probe_sent_) return;
+            probe_sent_ = fetcher_.request_chain(peer, {genesis_id_}, /*prune=*/true);
+            if (probe_sent_) ++stats_.chain_requests;
+            return;
+        }
+
+        // The boot fetch and the first chain request are two different
+        // questions, and the second must not wait out the first one's timeout.
+        // Without this the node sat handshaked and empty for a full
+        // chain_request_timeout_ms after its trust root had landed -- 20 s of
+        // "connected, synced=0, nothing happening" on every cold start, which
+        // is the exact shape of failure this whole layer exists to make
+        // impossible to misread.
+        const bool booted_now = booted_();
+        if (booted_now && !was_booted_) {
+            was_booted_ = true;
+            in_flight_  = false;
+        }
+
+        // --- the boot ask ----------------------------------------------------
+        if (!booted_now) {
+            if (in_flight_ && now_ms - sent_at_ms_ < cfg_.boot_request_timeout_ms) return;
+            in_flight_  = fetcher_.request_objects(peer, {genesis_id_}, /*prune=*/false);
+            sent_at_ms_ = now_ms;
+            if (in_flight_) ++stats_.boot_requests;
+            return;
+        }
+
+        const SyncState st = view_.sync_state();
+        stats_.our_height  = st.header_frontier;
+
+        // Our height moved since the request went out: it was answered, and the
+        // index is already fetching what it named.
+        if (in_flight_ && st.header_frontier != height_at_request_) in_flight_ = false;
+
+        // --- the parked parents ---------------------------------------------
+        // Done before the height comparison: an orphan's parent is missing
+        // whether or not the cohort is ahead of us.
+        const std::vector<Hash> want = refetch_ ? refetch_() : std::vector<Hash>{};
+        if (!want.empty()) {
+            std::vector<Hash> ask;
+            for (const Hash& id : want) {
+                if (ask.size() >= cfg_.refetch_batch) break;
+                if (view_.by_id(id)) continue;          // it arrived; stop asking
+                const std::string key(reinterpret_cast<const char*>(id.data()), id.size());
+                const auto it = asked_.find(key);
+                if (it != asked_.end() && now_ms - it->second < cfg_.refetch_reask_ms) continue;
+                asked_[key] = now_ms;
+                ask.push_back(id);
+            }
+            if (!ask.empty() && fetcher_.request_objects(peer, std::move(ask), /*prune=*/true))
+                ++stats_.refetch_requests;
+            // The ask-book is a rate limiter, not a record: a bounded forget is
+            // better than an unbounded memory of every id we ever wanted.
+            if (asked_.size() > 4096) asked_.clear();
+        }
+
+        // --- the chain ask ---------------------------------------------------
+        // `current_height` is monerod's own spelling: one PAST the peer's tip.
+        // So "the peer is ahead of us" is current_height > our_tip + 1.
+        if (sync.current_height <= st.header_frontier + 1) {
+            in_flight_ = false;
+            return;
+        }
+        if (in_flight_) {
+            if (now_ms - sent_at_ms_ < cfg_.chain_request_timeout_ms) return;
+            ++stats_.chain_timeouts;
+            // Re-ask somebody else where there is somebody else: a peer that
+            // answered nothing twice is not going to answer the third time.
+            avoid_ = peer.addr;
+        }
+
+        const PeerRef* ask = &peer;
+        if (!avoid_.empty() && peer.addr == avoid_) {
+            for (const auto& [ref, sd] : peers) {
+                if (ref.addr == avoid_) continue;
+                if (sd.current_height <= st.header_frontier + 1) continue;
+                ask = &ref;
+                break;
+            }
+        }
+
+        std::vector<Hash> locator = serving_.locator();
+        if (locator.empty()) return;
+        in_flight_          = fetcher_.request_chain(*ask, std::move(locator), /*prune=*/true);
+        sent_at_ms_         = now_ms;
+        height_at_request_  = st.header_frontier;
+        if (in_flight_) {
+            ++stats_.chain_requests;
+            stats_.target = ask->addr;
+        }
+    }
+
+    const Stats& stats() const noexcept { return stats_; }
+
+private:
+    IChainFetcher& fetcher_;
+    IChainServing& serving_;
+    IChainView&    view_;
+    Hash           genesis_id_;
+    BootedFn       booted_;
+    RefetchFn      refetch_;
+    SyncDriverConfig cfg_;
+
+    std::map<std::string, std::uint64_t> asked_;   // refetch id -> when we last asked
+    bool          was_booted_        = false;
+    bool          probe_sent_        = false;
+    bool          in_flight_         = false;
+    std::uint64_t sent_at_ms_        = 0;
+    std::uint64_t height_at_request_ = 0;
+    std::string   avoid_;
+    Stats         stats_{};
+};
+
+} // namespace c2pool::xmr::native::rt

--- a/src/impl/xmr/native/node/xmr_worker_loops.hpp
+++ b/src/impl/xmr/native/node/xmr_worker_loops.hpp
@@ -1,0 +1,475 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/node/xmr_worker_loops.hpp
+//
+// M0, the ASSEMBLY: the threads the components were written to be driven from,
+// and the fence that keeps the expensive ones off the io thread.
+//
+// Every wave-1 component states its threading contract in its own banner and
+// none of them provides the thread:
+//
+//   * C1c (xmr_peer_pool.hpp) calls IChainIndexInbound and IRelayedTxSink from
+//     the io thread, and the header says "enqueue-and-return".
+//   * C2c (xmr_chain_index.hpp) says "one owner (the verify thread) mutates",
+//     and offer_block() is where PowGate::check() runs a ~10-15 ms RandomX
+//     evaluation. Calling it from the io thread would stall every other peer on
+//     the same io_context and let one crafted push wedge the node -- the exact
+//     failure C1b's "RandomX never runs on the io thread" fence exists to
+//     prevent, which C1b can only enforce for ITSELF (it hashes nothing).
+//   * C3 (xmr_relayed_txpool.hpp) says "decoding and proof verification happen
+//     INSIDE on_relayed, so the caller must not be the io thread once the heavy
+//     leg is on" -- a Bulletproof+ verification per relayed transaction.
+//
+// So the wire-up owes three things, and they are all here:
+//
+//   1. WorkerLoop  -- one thread, one bounded queue, a blocking call() for the
+//      control path. The thread IS the component's contract made real.
+//   2. VerifyInbound / TxSinkLoop -- the enqueue-and-return adapters that sit
+//      between the io thread and the component, so no component had to be
+//      changed to acquire a thread.
+//   3. ThreadWitnessPowSource -- the proof, not the promise. It records the
+//      thread every RandomX evaluation actually ran on and counts the ones that
+//      ran on a thread declared forbidden (the io threads). "RandomX is off the
+//      io thread" then stops being an argument about call graphs and becomes a
+//      number the node prints, and the node KAT asserts.
+//
+// WHY A BOUNDED QUEUE, AND WHY `control` JUMPS IT. The queue is the one place a
+// peer can make us allocate without bound: blocks arrive at whatever rate the
+// network offers and the verify thread drains at the speed of RandomX. So the
+// data queue is capped and an overflow is REFUSED and COUNTED rather than
+// grown -- a refused block is re-offered by the next peer announcement or
+// re-fetched by the sync driver, an unbounded queue is an out-of-memory kill.
+// Control tasks (the driver tick, a status read, the parity drain) are posted
+// by us, are O(1) in number, and must never be dropped by a peer's flood, so
+// they are admitted past the cap.
+//
+// TXPOOL VERDICTS SURVIVE THE DEFERRAL. IRelayedTxSink::on_relayed returns the
+// per-transaction verdicts C1c scores the peer on, and a deferred call cannot
+// return them. Answering with an invented "accepted" would silently disarm the
+// relay-offence path, so TxSinkLoop answers with NO verdicts (C1c raises no
+// fault on an empty vector) and reports every drop-offence afterwards through a
+// FaultSink bound to IChainFetcher::penalize, which is thread-safe by contract
+// and posts back to the io thread. The DoS signal is delayed, never lost.
+//
+// SCOPE FENCE (standing XMR-lane rule): everything under src/impl/xmr/. This
+// tree is a WORK SOURCE for the pool, not part of the v37 share-chain record;
+// nothing here activates v37 consensus and src/sharechain/v37 is not touched.
+//
+// NAMESPACE. `c2pool::xmr::native::rt` (runtime), NOT `...::native::node`:
+// contracts/types.hpp opens `namespace node = ::c2pool::xmr::node` inside
+// `c2pool::xmr::native`, so a nested namespace called `node` would shadow the
+// alias every component in this tree spells its value types through.
+//
+// Header-only. STL only.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/native/chain/xmr_pow_gate.hpp"
+#include "impl/xmr/native/contracts/chain_index.hpp"
+#include "impl/xmr/native/contracts/txpool.hpp"
+#include "impl/xmr/native/contracts/types.hpp"
+
+namespace c2pool::xmr::native::rt {
+
+// ---------------------------------------------------------------------------
+// WorkerLoop: one thread, one bounded queue.
+// ---------------------------------------------------------------------------
+class WorkerLoop {
+public:
+    using Task = std::function<void()>;
+
+    struct Stats {
+        std::uint64_t posted    = 0;
+        std::uint64_t executed  = 0;
+        std::uint64_t refused   = 0;   // queue full and the task was not control
+        std::size_t   depth     = 0;
+        std::size_t   max_depth = 0;
+    };
+
+    explicit WorkerLoop(std::string name, std::size_t capacity = 4096)
+        : name_(std::move(name)), capacity_(capacity ? capacity : 1) {}
+
+    WorkerLoop(const WorkerLoop&)            = delete;
+    WorkerLoop& operator=(const WorkerLoop&) = delete;
+    ~WorkerLoop() { stop(); }
+
+    const std::string& name() const noexcept { return name_; }
+
+    void start() {
+        std::lock_guard<std::mutex> lk(mu_);
+        if (running_) return;
+        running_ = true;
+        thread_  = std::thread([this] { run_(); });
+        tid_     = thread_.get_id();
+    }
+
+    // Idempotent, and safe to call from any thread except this loop's own.
+    void stop() {
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            if (!running_) return;
+            running_ = false;
+        }
+        cv_.notify_all();
+        if (thread_.joinable() && std::this_thread::get_id() != thread_.get_id())
+            thread_.join();
+    }
+
+    bool running() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return running_;
+    }
+
+    std::thread::id thread_id() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return tid_;
+    }
+
+    bool on_this_thread() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return running_ && std::this_thread::get_id() == tid_;
+    }
+
+    // false == refused because the data queue is full (never for control tasks,
+    // and never silently: `refused` counts it).
+    bool post(Task t, bool control = false) {
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            if (!running_) return false;
+            if (!control && queue_.size() >= capacity_) {
+                ++stats_.refused;
+                return false;
+            }
+            queue_.push_back(std::move(t));
+            ++stats_.posted;
+            if (queue_.size() > stats_.max_depth) stats_.max_depth = queue_.size();
+        }
+        cv_.notify_one();
+        return true;
+    }
+
+    // Blocking round trip, for the control path only (a status read, a parity
+    // drain). Runs inline when the caller already IS this loop, so a task that
+    // calls back into its own loop cannot deadlock itself.
+    bool call(const Task& t) {
+        if (on_this_thread()) { t(); return true; }
+        std::mutex m;
+        std::condition_variable cv;
+        bool done = false;
+        if (!post([&] {
+                t();
+                { std::lock_guard<std::mutex> lk(m); done = true; }
+                cv.notify_one();
+            },
+            /*control=*/true))
+            return false;
+        std::unique_lock<std::mutex> lk(m);
+        cv.wait(lk, [&] { return done; });
+        return true;
+    }
+
+    Stats stats() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        Stats s = stats_;
+        s.depth = queue_.size();
+        return s;
+    }
+
+private:
+    void run_() {
+        for (;;) {
+            Task t;
+            {
+                std::unique_lock<std::mutex> lk(mu_);
+                cv_.wait(lk, [this] { return !running_ || !queue_.empty(); });
+                if (!running_ && queue_.empty()) return;
+                t = std::move(queue_.front());
+                queue_.pop_front();
+                ++stats_.executed;
+            }
+            t();
+        }
+    }
+
+    mutable std::mutex      mu_;
+    std::condition_variable cv_;
+    std::string             name_;
+    std::size_t             capacity_;
+    std::deque<Task>        queue_;
+    std::thread             thread_;
+    std::thread::id         tid_{};
+    bool                    running_ = false;
+    Stats                   stats_{};
+};
+
+// ---------------------------------------------------------------------------
+// VerifyInbound: IChainIndexInbound on the io thread -> the verify loop.
+//
+// Every method copies what it was handed onto the queue and returns. The index
+// behind it is then touched by exactly one thread, which is what its own
+// "one owner mutates" contract asks for -- and RandomX runs there.
+// ---------------------------------------------------------------------------
+class VerifyInbound final : public IChainIndexInbound {
+public:
+    struct Stats {
+        std::uint64_t sync_data   = 0;
+        std::uint64_t chain_entry = 0;
+        std::uint64_t objects     = 0;
+        std::uint64_t new_block   = 0;
+        std::uint64_t peer_gone   = 0;
+        std::uint64_t refused     = 0;   // queue full: the message was dropped
+    };
+
+    VerifyInbound(WorkerLoop& loop, IChainIndexInbound& target)
+        : loop_(loop), target_(target) {}
+
+    void on_peer_sync_data(const PeerRef& p, const PeerSyncData& d) override {
+        bump_(stats_.sync_data);
+        defer_([this, p, d] { target_.on_peer_sync_data(p, d); });
+    }
+
+    void on_chain_entry(const PeerRef& p, ChainEntry&& e) override {
+        bump_(stats_.chain_entry);
+        defer_([this, p, e = std::move(e)]() mutable {
+            target_.on_chain_entry(p, std::move(e));
+        });
+    }
+
+    void on_objects(const PeerRef& p, std::vector<BlockEntry>&& blocks,
+                    std::vector<Hash>&& missed, std::uint64_t peer_height) override {
+        bump_(stats_.objects);
+        defer_([this, p, blocks = std::move(blocks), missed = std::move(missed),
+                peer_height]() mutable {
+            target_.on_objects(p, std::move(blocks), std::move(missed), peer_height);
+        });
+    }
+
+    void on_new_block(const PeerRef& p, BlockEntry&& block, std::uint64_t peer_height,
+                      bool fluffy) override {
+        bump_(stats_.new_block);
+        defer_([this, p, block = std::move(block), peer_height, fluffy]() mutable {
+            target_.on_new_block(p, std::move(block), peer_height, fluffy);
+        });
+    }
+
+    void on_peer_gone(const PeerRef& p) override {
+        bump_(stats_.peer_gone);
+        // A peer going away must always be delivered: the index's peer cohort
+        // (and with it the synced flag) is derived from it, and a dropped
+        // departure leaves a ghost peer holding the cohort height up forever.
+        defer_([this, p] { target_.on_peer_gone(p); }, /*control=*/true);
+    }
+
+    Stats stats() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return stats_;
+    }
+
+private:
+    void bump_(std::uint64_t& counter) {
+        std::lock_guard<std::mutex> lk(mu_);
+        ++counter;
+    }
+
+    void defer_(WorkerLoop::Task t, bool control = false) {
+        if (loop_.post(std::move(t), control)) return;
+        std::lock_guard<std::mutex> lk(mu_);
+        ++stats_.refused;
+    }
+
+    WorkerLoop&         loop_;
+    IChainIndexInbound& target_;
+    mutable std::mutex  mu_;
+    Stats               stats_{};
+};
+
+// ---------------------------------------------------------------------------
+// TxSinkLoop: IRelayedTxSink on the io thread -> the pool loop.
+//
+// See the banner: the verdicts cannot come back synchronously, so none are
+// invented. Drop-offences are reported afterwards through `faults`.
+// ---------------------------------------------------------------------------
+class TxSinkLoop final : public IRelayedTxSink {
+public:
+    using FaultSink = std::function<void(const PeerRef&, PeerFault, const std::string&)>;
+
+    struct Stats {
+        std::uint64_t batches       = 0;
+        std::uint64_t blobs         = 0;
+        std::uint64_t refused       = 0;
+        std::uint64_t drop_offences = 0;
+    };
+
+    TxSinkLoop(WorkerLoop& loop, IRelayedTxSink& target, FaultSink faults = {})
+        : loop_(loop), target_(target), faults_(std::move(faults)) {}
+
+    // The fault route is bound after construction because the peer pool it
+    // penalizes through does not exist until the sinks it is built from do.
+    void set_faults(FaultSink f) {
+        std::lock_guard<std::mutex> lk(mu_);
+        faults_ = std::move(f);
+    }
+
+    std::vector<TxRelayVerdict> on_relayed(const PeerRef&                         from,
+                                           std::vector<std::vector<std::uint8_t>> blobs,
+                                           bool dandelionpp_fluff) override {
+        {
+            std::lock_guard<std::mutex> lk(mu_);
+            ++stats_.batches;
+            stats_.blobs += blobs.size();
+        }
+        const bool queued = loop_.post(
+            [this, from, blobs = std::move(blobs), dandelionpp_fluff]() mutable {
+                const std::vector<TxRelayVerdict> v =
+                    target_.on_relayed(from, std::move(blobs), dandelionpp_fluff);
+                for (const TxRelayVerdict& r : v) {
+                    if (!r.drop_offense) continue;
+                    FaultSink fs;
+                    {
+                        std::lock_guard<std::mutex> lk(mu_);
+                        ++stats_.drop_offences;
+                        fs = faults_;
+                    }
+                    if (fs) fs(from, PeerFault::BadData, "relayed transaction offence");
+                    break;
+                }
+            });
+        if (!queued) {
+            std::lock_guard<std::mutex> lk(mu_);
+            ++stats_.refused;
+        }
+        return {};   // no verdict is invented; see the banner
+    }
+
+    // A cheap read under the pool's own mutex; it allocates a vector of ids and
+    // touches no proof, so it answers in place rather than costing a round trip
+    // on the path that is about to write a frame.
+    std::vector<Hash> complement_request_ids() const override {
+        return target_.complement_request_ids();
+    }
+
+    Stats stats() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return stats_;
+    }
+
+private:
+    WorkerLoop&        loop_;
+    IRelayedTxSink&    target_;
+    FaultSink          faults_;
+    mutable std::mutex mu_;
+    Stats              stats_{};
+};
+
+// ---------------------------------------------------------------------------
+// ThreadWitnessPowSource: the io-thread fence, measured.
+//
+// It wraps any IPowSource and records the thread ids RandomX actually ran on.
+// `forbid()` names a thread that must never appear (the io threads); every call
+// that arrives on one is counted in `foreign_calls`, which the status line
+// prints and the node KAT asserts is zero. A structural argument about who
+// calls whom is worth less than a counter that would be non-zero if the wiring
+// ever regressed.
+// ---------------------------------------------------------------------------
+class ThreadWitnessPowSource final : public IPowSource {
+public:
+    struct Witness {
+        std::uint64_t               hashes        = 0;
+        std::uint64_t               prefetches    = 0;
+        std::uint64_t               foreign_calls = 0;   // MUST be 0
+        std::vector<std::string>    threads;             // where it really ran
+    };
+
+    explicit ThreadWitnessPowSource(IPowSource& inner) : inner_p_(&inner) {}
+
+    // Re-point at the real verifier once it exists. The WITNESS OBJECT must
+    // outlive this change and keep its address: ChainIndex caches the
+    // IPowSource* it was constructed with (its sync_state() reads mode()
+    // through it), so swapping the witness itself for a new one leaves that
+    // cached pointer dangling -- which is a segfault on the first status read,
+    // found exactly that way on the first live run.
+    void set_inner(IPowSource& inner) {
+        std::lock_guard<std::mutex> lk(mu_);
+        inner_p_ = &inner;
+    }
+
+    // Name a thread RandomX must never run on. Called once per io thread.
+    void forbid(std::thread::id id) {
+        std::lock_guard<std::mutex> lk(mu_);
+        forbidden_.insert(id);
+    }
+
+    bool prefetch(const Hash& current_seed, const std::optional<Hash>& next_seed) override {
+        note_(/*hash=*/false);
+        return inner_()->prefetch(current_seed, next_seed);
+    }
+
+    bool seed_resident(const Hash& seed) const override {
+        return inner_()->seed_resident(seed);
+    }
+
+    PowVerdict verify(const std::uint8_t* blob, std::size_t blob_len, const Hash& seed,
+                      const U128& difficulty, Hash& pow_hash_out) override {
+        note_(/*hash=*/true);
+        return inner_()->verify(blob, blob_len, seed, difficulty, pow_hash_out);
+    }
+
+    RandomXMode mode() const override { return inner_()->mode(); }
+
+    Witness witness() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        Witness w;
+        w.hashes        = hashes_;
+        w.prefetches    = prefetches_;
+        w.foreign_calls = foreign_;
+        for (const std::thread::id& id : seen_) {
+            std::ostringstream os;
+            os << id;
+            w.threads.push_back(os.str());
+        }
+        return w;
+    }
+
+private:
+    void note_(bool hash) {
+        const std::thread::id me = std::this_thread::get_id();
+        std::lock_guard<std::mutex> lk(mu_);
+        if (hash) ++hashes_; else ++prefetches_;
+        seen_.insert(me);
+        if (forbidden_.count(me)) ++foreign_;
+    }
+
+    IPowSource* inner_() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return inner_p_;
+    }
+
+    IPowSource*                    inner_p_ = nullptr;
+    mutable std::mutex             mu_;
+    std::set<std::thread::id>      seen_;
+    std::set<std::thread::id>      forbidden_;
+    std::uint64_t                  hashes_     = 0;
+    std::uint64_t                  prefetches_ = 0;
+    std::uint64_t                  foreign_    = 0;
+};
+
+} // namespace c2pool::xmr::native::rt

--- a/src/impl/xmr/native/p2p/xmr_peer_pool.hpp
+++ b/src/impl/xmr/native/p2p/xmr_peer_pool.hpp
@@ -166,6 +166,20 @@ public:
         Millis maintenance_tick_ms = 1'000;
         Millis connect_timeout_ms  = levinns::P2P_DEFAULT_CONNECTION_TIMEOUT_MS;
 
+        // Local address to SOURCE-BIND outbound connections to. Empty = let the
+        // OS choose, which is what a single-homed node wants.
+        //
+        // It is here because monerod enforces ONE CONNECTION PER REMOTE IP
+        // ("CONNECTION FROM x REFUSED, too many connections from the same
+        // address", net_node.inl) and does NOT source-bind its own outbound
+        // connections to its p2p bind address. So on a loopback regtest rig the
+        // two daemons' mutual links already occupy each other's 127.0.0.1 slot,
+        // and a third participant that does not choose its own source address is
+        // refused before it can say hello. Same knob, same reason, as the C5
+        // live-push tool's C5_SRC_IP. On a real network it is the multi-homed /
+        // egress-selection control.
+        std::string bind_ip;
+
         // D-3 back-pressure.
         std::size_t max_spans_per_peer = MAX_SPANS_PER_PEER;
         std::size_t max_spans_total    = MAX_SPANS_TOTAL;
@@ -511,6 +525,23 @@ private:
         auto sock = std::make_shared<tcp::socket>(io_);
         auto self = shared_from_this();
         const tcp::endpoint ep(addr, port);
+
+        if (!cfg_.bind_ip.empty()) {
+            boost::system::error_code bec;
+            const auto local = boost::asio::ip::make_address(cfg_.bind_ip, bec);
+            if (!bec) sock->open(ep.protocol(), bec);
+            if (!bec) sock->bind(tcp::endpoint(local, 0), bec);
+            if (bec) {
+                // A source address we cannot bind is a configuration error, and
+                // dialing from the wrong one would silently become a different
+                // peer identity at the far end.
+                store_.on_dial_failed(key, now);
+                ++tel_.dials_failed;
+                tel_.last_close_peer = key;
+                tel_.last_close_why  = "cannot bind source address " + cfg_.bind_ip;
+                return;
+            }
+        }
 
         // A connect timer, because async_connect on a black-holed address can
         // hang for the OS default (minutes) and would hold a dial slot the

--- a/src/impl/xmr/native/test/CMakeLists.txt
+++ b/src/impl/xmr/native/test/CMakeLists.txt
@@ -481,4 +481,42 @@ if (BUILD_TESTING)
     endif()
     add_test(NAME xmr_native_block_relay_kat COMMAND xmr_native_block_relay_kat)
 
+    # ------------------------------------------------------------------
+    # M0 -- the assembly (../node/).
+    #
+    #   xmr_native_node_kat -- everything about the wire-up that can be judged
+    #   without a daemon: the worker loops and their bounded queues, the
+    #   enqueue-and-return adapters (including the deferred txpool verdict,
+    #   which must not be invented), the RandomX io-thread WITNESS that makes
+    #   the node's foreign-call counter trustworthy, the genesis row derived
+    #   from a real monerod genesis blob against monerod's own published
+    #   numbers for it, the pre-boot advertisement that keeps a peer from
+    #   closing us before the boot fetch lands, and the sync driver schedule.
+    #
+    # Links xmr_coin (block identity: keccak + tree hash) and boost's
+    # header-only multiprecision, which the vendored difficulty retarget types
+    # its difficulty as -- the same LIGHT link as the chain-index KAT. No
+    # RandomX, no sockets, no daemon; the node binary itself is what needs
+    # those, and it is built (never run) by CI as xmr_native_node.
+    add_executable(xmr_native_node_kat xmr_native_node_kat.cpp)
+    target_include_directories(xmr_native_node_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(xmr_native_node_kat PRIVATE xmr_coin)
+    target_compile_features(xmr_native_node_kat PRIVATE cxx_std_20)
+    if (TARGET Boost::headers)
+        target_link_libraries(xmr_native_node_kat PRIVATE Boost::headers)
+    elseif (TARGET Boost::boost)
+        target_link_libraries(xmr_native_node_kat PRIVATE Boost::boost)
+    elseif (DEFINED Boost_INCLUDE_DIRS)
+        target_include_directories(xmr_native_node_kat PRIVATE ${Boost_INCLUDE_DIRS})
+    endif()
+    if (TARGET Threads::Threads)
+        target_link_libraries(xmr_native_node_kat PRIVATE Threads::Threads)
+    endif()
+    add_test(NAME xmr_native_node_kat COMMAND xmr_native_node_kat)
+    # It parks a worker thread on a spin-wait to fill a queue; bounded, but
+    # never let it be unbounded on a loaded runner.
+    set_tests_properties(xmr_native_node_kat PROPERTIES TIMEOUT 120)
+
 endif()

--- a/src/impl/xmr/native/test/xmr_native_node_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_native_node_kat.cpp
@@ -1,0 +1,676 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/test/xmr_native_node_kat.cpp
+//
+// M0: the parts of the ASSEMBLY that can be judged without a daemon.
+//
+// The node itself is proven against a real monerod (node/README.md carries the
+// regtest run). What is proven HERE is everything that would otherwise only be
+// true because a live run happened to pass, and each of these is a regression
+// the live run would show as a puzzling symptom rather than as a failed check:
+//
+//   * THE IO-THREAD FENCE, as a number. ThreadWitnessPowSource counts RandomX
+//     evaluations that ran on a forbidden thread. The claim "RandomX never runs
+//     on the io thread" is only as good as this counter being zero, so the
+//     counter itself is tested: it must catch a call made on a forbidden thread
+//     and must not fire on the worker.
+//   * THE QUEUES. A bounded queue that silently grew, or a control task that a
+//     peer's flood could push out, would both look fine right up to the moment
+//     they mattered.
+//   * THE DEFERRED TXPOOL VERDICT. TxSinkLoop answers the io thread with NO
+//     verdicts and reports drop-offences afterwards. Inventing an "accepted"
+//     verdict would disarm C1c's peer scoring invisibly, so the test asserts
+//     both halves: the immediate answer is empty AND the offence still arrives.
+//   * THE GENESIS DERIVATION. Every number in row zero is computed from the
+//     genesis BLOB, against monerod's own published values for that block
+//     (block_weight 80, reward 17592186044415, timestamp 0, major_version 1).
+//     The blob is the one a real monerod returned for height 0; nothing in this
+//     repository produced any of the numbers it is checked against.
+//   * THE PRE-BOOT ADVERTISEMENT. The first live regtest run died here: an
+//     empty index advertises an all-zero top id, monerod does not have that
+//     block, so it asks for a chain, we have no common block, and monerod's own
+//     rule closes the connection before the boot fetch is issued. The fix is
+//     that ChainBoot answers the serving reads itself until the seed lands, and
+//     it is pinned here.
+//   * THE SYNC SCHEDULE. Who gets asked (greatest cumulative difficulty, not
+//     greatest height), when nobody is asked (we are level), and that the
+//     read-only probe asks exactly once and never for a block.
+//
+// STL, boost::asio (header-only) and xmr_coin. No RandomX, no network, no
+// daemon: everything here runs in the ordinary ctest lane on both CI legs.
+// ---------------------------------------------------------------------------
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "impl/xmr/native/contracts/fakes/fake_chain.hpp"
+#include "impl/xmr/native/contracts/fakes/fake_fetcher.hpp"
+#include "impl/xmr/native/contracts/fakes/fake_txpool.hpp"
+#include "impl/xmr/native/node/xmr_chain_boot.hpp"
+#include "impl/xmr/native/node/xmr_sync_driver.hpp"
+#include "impl/xmr/native/node/xmr_worker_loops.hpp"
+#include "impl/xmr/native/p2p/chain_seeds.hpp"
+#include "xmr_p2p_kat_util.hpp"
+
+namespace native = c2pool::xmr::native;
+namespace rt     = c2pool::xmr::native::rt;
+namespace kat    = c2pool::xmr::native::kat;
+
+using native::BlockEntry;
+using native::ChainEntry;
+using native::Hash;
+using native::PeerFault;
+using native::PeerRef;
+using native::PeerSyncData;
+using native::U128;
+
+namespace {
+
+// The genesis block of the Monero MAINNET chain, exactly as monerod 0.18.5.1
+// returned it from get_block(height=0). monerod's own header for it says
+// block_weight 80, reward 17592186044415, timestamp 0, major_version 1,
+// difficulty 1, cumulative_difficulty 1 -- the numbers this file checks the
+// derivation against. A regtest (fakechain) daemon serves the SAME block at
+// height 0, which is why the regtest boot path can use the mainnet genesis id.
+constexpr const char* MAINNET_GENESIS_BLOB_HEX =
+    "010000000000000000000000000000000000000000000000000000000000000000000010"
+    "270000013c01ff0001ffffffffffff03029b2e4c0281c0b02e7c53291a94d1d0cbff8883"
+    "f8024f5142ee494ffbbd08807121017767aafcde9be00dcfd098715ebcf7f410daebc582"
+    "fda69d24a28e9d0bc890d100";
+
+std::vector<std::uint8_t> from_hex(const std::string& h) {
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    std::vector<std::uint8_t> out;
+    for (std::size_t i = 0; i + 1 < h.size(); i += 2) {
+        const int hi = nib(h[i]), lo = nib(h[i + 1]);
+        if (hi < 0 || lo < 0) return {};
+        out.push_back(static_cast<std::uint8_t>((hi << 4) | lo));
+    }
+    return out;
+}
+
+std::vector<std::uint8_t> genesis_blob() { return from_hex(MAINNET_GENESIS_BLOB_HEX); }
+
+// The first two blocks of a private regtest (fakechain) chain, exactly as
+// monerod 0.18.5.1 returned them from get_block. Both sit on the genesis above:
+// block 1's prev_id IS the mainnet genesis id, and block 2's prev_id is block 1.
+// monerod's own headers for them say block_weight 85 and rewards
+// 35184338534400 / 35184271425600.
+//
+// They are here for ONE regression, and it is a defect the M0 assembly found
+// against a live daemon rather than one anybody predicted: see
+// test_out_of_order_push_connects().
+constexpr const char* REGTEST_BLOCK_1_HEX =
+    "1010e2af8dd506418015bb9ae982a1975da7d79277c2705727a56894ba0fb246adaabb1f46"
+    "32e300000000023d01ff0101808080f0ffff070347f2bfeafe0e647adeaf3f60dfa55f9c74"
+    "ce51468d78f4ddd70023df13e6a3e64424017b23d07ca10040c63700a3cddffb0c49bfc29f"
+    "702153657d238a9323a7d16c950201000000";
+constexpr const char* REGTEST_BLOCK_2_HEX =
+    "1010e7af8dd5061705bccea7049d81ac4d7ab1ac72ddb52e97647dcc6cef386796f9de3554"
+    "f86300000000023e01ff0201c08080d0ffff07032f8039e5730424f008a9a5261d4ae18994"
+    "09f036f4b86e12438f3210fdc79971a32401c8190b259647845761ef6bb5542dec7e7c47ac"
+    "9355588c0bf26f17205704383b0201000000";
+
+
+PeerRef peer(const char* addr, std::uint64_t id) {
+    PeerRef p;
+    p.addr    = addr;
+    p.peer_id = id;
+    return p;
+}
+
+PeerSyncData sync_at(std::uint64_t height, std::uint64_t cumdiff) {
+    PeerSyncData d;
+    d.current_height        = height;
+    d.cumulative_difficulty = U128{cumdiff, 0};
+    d.top_version           = 16;
+    return d;
+}
+
+// =========================================================================
+// 1. WorkerLoop
+// =========================================================================
+void test_worker_loop() {
+    // A loop roomy enough that nothing is refused: this half is about ORDER.
+    rt::WorkerLoop loop("t", /*capacity=*/64);
+
+    // Nothing is accepted before start(): a post that vanished into a stopped
+    // loop would look exactly like a task that ran.
+    kat::check(!loop.post([] {}), "a stopped loop refuses a post");
+
+    loop.start();
+    std::atomic<int> ran{0};
+    int accepted_posts = 0;
+    for (int i = 0; i < 10; ++i) if (loop.post([&] { ++ran; })) ++accepted_posts;
+    kat::check(accepted_posts == 10, "ten posts into a roomy queue are all accepted");
+
+    bool seen_after_all = false;
+    loop.call([&] { seen_after_all = (ran.load() == 10); });
+    kat::check(seen_after_all, "call() is ordered behind every earlier post");
+
+    // The loop's own thread runs call() inline rather than deadlocking on
+    // itself.
+    bool inline_ok = false;
+    loop.call([&] { loop.call([&] { inline_ok = true; }); });
+    kat::check(inline_ok, "call() from inside the loop runs inline");
+    loop.stop();
+
+    // The other half is about the CAP. Park the worker on a blocking task so
+    // nothing drains, then prove the queue refuses rather than grows.
+    rt::WorkerLoop small("small", /*capacity=*/4);
+    small.start();
+    std::atomic<bool> release{false};
+    small.post([&] {
+        while (!release.load()) std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    int accepted = 0;
+    for (int i = 0; i < 8; ++i) if (small.post([] {})) ++accepted;
+    kat::checkf(accepted == 4, "the data queue is bounded at its capacity (accepted %d)", accepted);
+    kat::check(small.post([] {}, /*control=*/true), "a control task is admitted past the cap");
+    kat::checkf(small.stats().refused == 4, "every refusal is counted (refused=%llu)",
+                (unsigned long long)small.stats().refused);
+
+    release.store(true);
+    small.stop();
+    kat::check(!small.running(), "stop() stops the loop");
+}
+
+// =========================================================================
+// 2. VerifyInbound
+// =========================================================================
+class ThreadRecordingChain final : public native::IChainIndexInbound {
+public:
+    std::atomic<int> calls{0};
+    std::thread::id  last_thread{};
+
+    void on_peer_sync_data(const PeerRef&, const PeerSyncData&) override { note(); }
+    void on_chain_entry(const PeerRef&, ChainEntry&&) override { note(); }
+    void on_objects(const PeerRef&, std::vector<BlockEntry>&&, std::vector<Hash>&&,
+                    std::uint64_t) override { note(); }
+    void on_new_block(const PeerRef&, BlockEntry&&, std::uint64_t, bool) override { note(); }
+    void on_peer_gone(const PeerRef&) override { note(); }
+
+private:
+    void note() {
+        last_thread = std::this_thread::get_id();
+        ++calls;
+    }
+};
+
+void test_verify_inbound() {
+    rt::WorkerLoop        loop("verify", /*capacity=*/2);
+    ThreadRecordingChain  target;
+    rt::VerifyInbound     inbound(loop, target);
+    loop.start();
+
+    const std::thread::id caller = std::this_thread::get_id();
+    inbound.on_new_block(peer("1.2.3.4:18080", 7), BlockEntry{}, 42, true);
+    loop.call([] {});                      // drain
+    kat::check(target.calls.load() == 1, "the message reached the index");
+    kat::check(target.last_thread != caller,
+               "the index was touched on the loop's thread, never the caller's");
+    kat::check(target.last_thread == loop.thread_id(), "and it was THIS loop's thread");
+
+    // Overflow drops data messages, counts them, and still delivers a peer
+    // departure: a lost on_peer_gone strands the cohort height forever.
+    std::atomic<bool> release{false};
+    loop.post([&] { while (!release.load()) std::this_thread::sleep_for(std::chrono::milliseconds(1)); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    for (int i = 0; i < 6; ++i) inbound.on_new_block(peer("1.2.3.4:18080", 7), BlockEntry{}, 42, true);
+    inbound.on_peer_gone(peer("1.2.3.4:18080", 7));
+    release.store(true);
+    loop.call([] {});
+    const rt::VerifyInbound::Stats s = inbound.stats();
+    kat::checkf(s.refused >= 1, "an overflowing queue refuses and counts (refused=%llu)",
+                (unsigned long long)s.refused);
+    kat::check(s.new_block == 7, "every offered message is counted, refused or not");
+    loop.stop();
+}
+
+// =========================================================================
+// 3. TxSinkLoop
+// =========================================================================
+class OffendingPool final : public native::IRelayedTxSink {
+public:
+    std::atomic<int> batches{0};
+    std::thread::id  last_thread{};
+    bool             offend = true;
+
+    std::vector<native::TxRelayVerdict> on_relayed(const PeerRef&,
+                                                   std::vector<std::vector<std::uint8_t>>,
+                                                   bool) override {
+        last_thread = std::this_thread::get_id();
+        ++batches;
+        native::TxRelayVerdict v;
+        v.reason       = native::TxRelayVerdict::Reason::Structural;
+        v.drop_offense = offend;
+        return {v};
+    }
+    std::vector<Hash> complement_request_ids() const override { return {}; }
+};
+
+void test_txsink_loop() {
+    rt::WorkerLoop  loop("txpool", 16);
+    OffendingPool   pool;
+    std::atomic<int> faults{0};
+    PeerFault        got = PeerFault::Unresponsive;
+    rt::TxSinkLoop  sink(loop, pool, [&](const PeerRef&, PeerFault f, const std::string&) {
+        got = f;
+        ++faults;
+    });
+    loop.start();
+
+    const std::vector<native::TxRelayVerdict> immediate =
+        sink.on_relayed(peer("5.6.7.8:18080", 9), {{1, 2, 3}}, true);
+    kat::check(immediate.empty(),
+               "no verdict is invented on the io thread (an invented Accepted would "
+               "silently disarm C1c's peer scoring)");
+    loop.call([] {});
+    kat::check(pool.batches.load() == 1, "the batch reached the pool");
+    kat::check(pool.last_thread == loop.thread_id(), "the pool decoded on its own thread");
+    kat::check(faults.load() == 1 && got == PeerFault::BadData,
+               "a drop-offence still reaches the peer's fail score, just later");
+
+    pool.offend = false;
+    sink.on_relayed(peer("5.6.7.8:18080", 9), {{4, 5}}, true);
+    loop.call([] {});
+    kat::check(faults.load() == 1, "a clean batch raises no fault");
+    loop.stop();
+}
+
+// =========================================================================
+// 4. ThreadWitnessPowSource
+// =========================================================================
+class CountingPow final : public native::IPowSource {
+public:
+    int calls = 0;
+    bool prefetch(const Hash&, const std::optional<Hash>&) override { return true; }
+    bool seed_resident(const Hash&) const override { return true; }
+    native::PowVerdict verify(const std::uint8_t*, std::size_t, const Hash&, const U128&,
+                              Hash&) override {
+        ++calls;
+        return native::PowVerdict::Accept;
+    }
+    native::RandomXMode mode() const override { return native::RandomXMode::LightJit; }
+};
+
+void test_pow_witness() {
+    native::NoPowSource          null_pow;
+    rt::ThreadWitnessPowSource   witness(null_pow);
+    CountingPow                  real;
+
+    kat::check(witness.mode() == native::RandomXMode::Disabled,
+               "the witness reports the inner source's mode");
+    witness.set_inner(real);
+    kat::check(witness.mode() == native::RandomXMode::LightJit,
+               "set_inner re-points it without changing its address");
+
+    // A call on a FORBIDDEN thread must be caught: this is the whole assertion
+    // the node's status line makes.
+    witness.forbid(std::this_thread::get_id());
+    Hash out{};
+    const std::uint8_t blob[4] = {0, 1, 2, 3};
+    (void)witness.verify(blob, sizeof(blob), Hash{}, U128{1, 0}, out);
+    kat::check(witness.witness().foreign_calls == 1,
+               "a RandomX evaluation on a forbidden thread is counted");
+
+    // And a call on a worker thread must not be.
+    rt::WorkerLoop loop("verify", 8);
+    loop.start();
+    loop.call([&] { (void)witness.verify(blob, sizeof(blob), Hash{}, U128{1, 0}, out); });
+    loop.stop();
+    const rt::ThreadWitnessPowSource::Witness w = witness.witness();
+    kat::check(w.foreign_calls == 1, "a call on a permitted thread is not counted foreign");
+    kat::check(w.hashes == 2, "every evaluation is counted");
+    kat::check(w.threads.size() == 2, "and the threads it ran on are named");
+    kat::check(real.calls == 2, "the inner source did the work");
+}
+
+// =========================================================================
+// 5. The genesis derivation
+// =========================================================================
+void test_genesis_row() {
+    const std::vector<std::uint8_t> blob = genesis_blob();
+    kat::checkf(blob.size() == 120, "the genesis blob is 120 bytes (got %zu)", blob.size());
+
+    native::ChainRow row;
+    std::string      why;
+    const bool ok = rt::genesis_row_from_blob(blob, native::p2p::MAINNET_GENESIS, row, why);
+    kat::checkf(ok, "the genesis blob derives a row (%s)", why.c_str());
+    if (ok) {
+        kat::check(row.height == 0, "height 0");
+        kat::check(row.id == native::p2p::MAINNET_GENESIS, "the id recomputes to the pinned one");
+        kat::check(row.prev_id == Hash{}, "prev_id is zero");
+        kat::check(row.timestamp == 0, "monerod's genesis timestamp is 0");
+        kat::check(row.major_version == 1, "monerod reports major_version 1 for it");
+        kat::checkf(row.block_weight == 80, "monerod reports block_weight 80 (got %llu)",
+                    (unsigned long long)row.block_weight);
+        kat::check(row.long_term_weight == 80, "long-term weight is the same at height 0");
+        kat::checkf(row.reward == 17592186044415ull,
+                    "monerod reports reward 17592186044415 (got %llu)",
+                    (unsigned long long)row.reward);
+        kat::check(row.already_generated_coins == 17592186044415ull,
+                   "emission after the genesis block is its own coinbase");
+        kat::check(row.difficulty.lo == 1 && row.cumulative_difficulty.lo == 1,
+                   "monerod reports difficulty 1 and cumulative_difficulty 1 at height 0");
+        kat::check(row.pow_verified, "the trust root counts as verified");
+    }
+
+    // The negative controls: the derivation must refuse rather than believe.
+    native::ChainRow bad;
+    std::vector<std::uint8_t> flipped = blob;
+    flipped[10] ^= 0x01;
+    kat::check(!rt::genesis_row_from_blob(flipped, native::p2p::MAINNET_GENESIS, bad, why),
+               "one flipped byte no longer hashes to the pinned genesis id");
+    std::vector<std::uint8_t> truncated(blob.begin(), blob.begin() + 60);
+    kat::check(!rt::genesis_row_from_blob(truncated, native::p2p::MAINNET_GENESIS, bad, why),
+               "a truncated blob is refused");
+    kat::check(!rt::genesis_row_from_blob(blob, native::p2p::STAGENET_GENESIS, bad, why),
+               "the right block for the WRONG network is refused");
+    kat::check(!rt::genesis_row_from_blob({}, native::p2p::MAINNET_GENESIS, bad, why),
+               "an empty blob is refused");
+}
+
+// =========================================================================
+// 6. ChainBoot: the pre-boot advertisement, and the seed
+// =========================================================================
+native::ChainIndexOptions regtest_options() {
+    native::ChainIndexOptions o;
+    o.net         = native::XmrNet::Regtest;
+    o.require_pow = false;    // this test is about wiring, not hashes
+    return o;
+}
+
+void test_chain_boot() {
+    native::NoPowSource pow;
+    native::ChainIndex  index(regtest_options(), pow);
+    rt::ChainBoot       boot(index, rt::BootMode::Genesis, native::p2p::MAINNET_GENESIS,
+                             native::XmrNet::Regtest);
+
+    // --- pre-boot: what we advertise --------------------------------------
+    kat::check(!boot.booted(), "a genesis boot starts un-booted");
+    const PeerSyncData pre = boot.our_sync_data();
+    kat::check(pre.top_id == native::p2p::MAINNET_GENESIS,
+               "pre-boot we advertise the pinned genesis as our top, NOT an all-zero id "
+               "(monerod asks have_block(top_id); a zero id sends it to "
+               "state_synchronizing and closes us)");
+    kat::check(pre.current_height == 1, "current_height is one past the tip, monerod's spelling");
+    kat::check(pre.cumulative_difficulty.lo == 1, "the genesis block's own cumulative difficulty");
+    kat::check(boot.have_block(native::p2p::MAINNET_GENESIS), "we claim the genesis");
+    kat::check(!boot.have_block(native::p2p::STAGENET_GENESIS), "and nothing else");
+    kat::check(boot.locator().size() == 1 && boot.locator().front() == native::p2p::MAINNET_GENESIS,
+               "the pre-boot locator is the genesis alone");
+
+    const auto sup = boot.find_supplement({native::p2p::MAINNET_GENESIS});
+    kat::check(sup.has_value(), "a genesis-terminated locator gets a supplement");
+    if (sup) {
+        kat::check(sup->start_height == 0 && sup->total_height == 1 && sup->ids.size() == 1,
+                   "and it describes a node holding only the genesis");
+    }
+    kat::check(!boot.find_supplement({native::p2p::STAGENET_GENESIS}).has_value(),
+               "a locator with no block of ours gets nullopt (the caller then closes)");
+    kat::check(!boot.get_block_entry(native::p2p::MAINNET_GENESIS, false).has_value(),
+               "we never serve bytes we do not hold, even for a block we claim");
+
+    // --- the seed ----------------------------------------------------------
+    BlockEntry ge;
+    ge.block_blob = genesis_blob();
+    std::vector<BlockEntry> batch{ge};
+    boot.on_objects(peer("127.0.0.1:18080", 1), std::move(batch), {}, 1);
+    kat::check(boot.booted(), "the genesis blob seeds the index");
+    const auto tip = index.tip();
+    kat::check(tip.has_value() && tip->height == 0, "and the index now has row zero");
+    kat::check(boot.stats().blobs_inspected == 1, "the inspection is counted");
+    kat::check(boot.stats().refusals == 0, "the right blob is not a refusal");
+
+    // After the seed everything is a plain forward.
+    kat::check(boot.our_sync_data().top_id == native::p2p::MAINNET_GENESIS,
+               "post-boot the advertisement comes from the index and still says genesis");
+}
+
+void test_chain_boot_refuses_a_foreign_blob() {
+    native::NoPowSource pow;
+    native::ChainIndex  index(regtest_options(), pow);
+    rt::ChainBoot       boot(index, rt::BootMode::Genesis, native::p2p::STAGENET_GENESIS,
+                             native::XmrNet::Stagenet);
+
+    BlockEntry wrong;
+    wrong.block_blob = genesis_blob();   // the MAINNET genesis, on a stagenet node
+    std::vector<BlockEntry> batch{wrong};
+    boot.on_objects(peer("127.0.0.1:38080", 1), std::move(batch), {}, 1);
+    kat::check(!boot.booted(), "a peer cannot seed us with another network's genesis");
+    kat::check(boot.stats().refusals == 1, "the refusal is counted");
+    kat::check(boot.stats().dropped_preboot == 1, "and the batch is dropped, not queued");
+    kat::check(!index.tip().has_value(), "the index is untouched");
+}
+
+
+// The regression the M0 assembly found on a live regtest run.
+//
+// monerod sends its TOP BLOCK to any peer whose advertised height is behind its
+// own (process_payload_sync_data), so the first block a cold node receives is
+// normally one whose parent it does not have yet. The index parked it, exactly
+// as it should. What it then did NOT do was revisit it when the parent arrived:
+// the branch path resolves descendants, the fast path (a block that extends the
+// tip) did not. The live symptom was a node that backfilled to height 8, sat
+// there, and let four already-delivered blocks rot in the alt pool while its
+// peer kept climbing -- with no error anywhere, because nothing had failed.
+void test_out_of_order_push_connects() {
+    native::NoPowSource pow;
+    native::ChainIndex  index(regtest_options(), pow);
+    rt::ChainBoot       boot(index, rt::BootMode::Genesis, native::p2p::MAINNET_GENESIS,
+                             native::XmrNet::Regtest);
+
+    BlockEntry ge;
+    ge.block_blob = genesis_blob();
+    std::vector<BlockEntry> seed{ge};
+    boot.on_objects(peer("127.0.0.1:18080", 1), std::move(seed), {}, 1);
+    kat::check(boot.booted(), "seeded at the genesis");
+
+    BlockEntry b1, b2;
+    b1.block_blob = from_hex(REGTEST_BLOCK_1_HEX);
+    b2.block_blob = from_hex(REGTEST_BLOCK_2_HEX);
+    kat::check(!b1.block_blob.empty() && !b2.block_blob.empty(), "the two blobs decode");
+
+    // Out of order, exactly as the wire delivered them: the child first.
+    const native::OfferResult r2 = index.offer_block(nullptr, b2, /*own_mined=*/false);
+    kat::checkf(r2.outcome == native::OfferOutcome::ParkedOrphan,
+                "a block whose parent is unknown is parked (got %s)",
+                native::to_string(r2.outcome));
+    kat::check(index.tip() && index.tip()->height == 0, "and the tip does not move");
+
+    const native::OfferResult r1 = index.offer_block(nullptr, b1, /*own_mined=*/false);
+    kat::checkf(r1.outcome == native::OfferOutcome::Connected,
+                "the parent connects (got %s: %s)", native::to_string(r1.outcome),
+                r1.why.c_str());
+
+    const auto tip = index.tip();
+    kat::check(tip.has_value(), "there is a tip");
+    if (tip) {
+        kat::checkf(tip->height == 2,
+                    "the parked child is drained onto the new tip in the same pass "
+                    "(height %llu, expected 2)", (unsigned long long)tip->height);
+    }
+    kat::check(index.alt_size() == 0, "and it is no longer parked");
+
+    // It arrived as an EXTEND, not as a Reorg of depth 0: going through the
+    // fork-choice switch would have announced a reorg that never happened.
+    kat::check(index.sync_state().reorgs == 0,
+               "draining a parked child announces no reorg");
+}
+
+// =========================================================================
+// 7. SyncDriver
+// =========================================================================
+void test_sync_driver_schedule() {
+    native::fakes::FakeFetcher fetcher;
+    native::fakes::FakeChain   chain;
+    bool booted = false;
+    std::vector<Hash> refetch;
+
+    rt::SyncDriver driver(fetcher, chain, chain, native::p2p::MAINNET_GENESIS,
+                          [&] { return booted; }, [&] { return refetch; });
+
+    // No peers: nothing is asked, and it is visible that nothing was asked.
+    driver.tick(1000);
+    kat::check(fetcher.chain_requests.empty() && fetcher.object_requests.empty(),
+               "with no peers the driver asks nobody");
+    kat::check(driver.stats().no_peer_ticks == 1, "and says so");
+
+    // Pre-boot: exactly one object, the genesis.
+    fetcher.peer_table.push_back({peer("a:18080", 1), sync_at(100, 100)});
+    driver.tick(2000);
+    kat::check(fetcher.object_requests.size() == 1, "pre-boot the driver asks for one object");
+    if (!fetcher.object_requests.empty()) {
+        kat::check(fetcher.object_requests[0].ids.size() == 1 &&
+                       fetcher.object_requests[0].ids[0] == native::p2p::MAINNET_GENESIS,
+                   "and it is the pinned genesis id");
+    }
+    kat::check(fetcher.chain_requests.empty(), "no chain is asked before the trust root exists");
+
+    // The boot ask is not repeated every tick.
+    driver.tick(2100);
+    kat::check(fetcher.object_requests.size() == 1, "the boot ask is not re-issued while in flight");
+
+    // The moment the boot completes, the FIRST chain request must go out: the
+    // boot fetch and the chain request are different questions, and making the
+    // second wait out the first one's timeout is 20 s of a node that looks
+    // connected, synced=0 and idle on every cold start.
+    booted = true;
+    chain.rows.push_back([] {
+        native::node::ChainMainBlock b;
+        b.height = 0;
+        b.id.fill(0x10);
+        return b;
+    }());
+    chain.state.header_frontier = 0;
+    driver.tick(2200);
+    kat::check(fetcher.chain_requests.size() == 1,
+               "the first chain request follows the boot immediately, not after a timeout");
+    chain.rows.clear();
+    fetcher.chain_requests.clear();
+
+    // Post-boot, behind the cohort: a chain request carrying OUR locator.
+    chain.rows.push_back([] {
+        native::node::ChainMainBlock b;
+        b.height = 10;
+        b.id.fill(0x11);
+        return b;
+    }());
+    chain.state.header_frontier = 10;
+    driver.tick(3000);
+    kat::check(fetcher.chain_requests.size() == 1, "behind the cohort, the driver asks for a chain");
+
+    // Level with the cohort: nothing is asked, which is what tip-follow looks
+    // like -- the height keeps moving while this counter stops.
+    native::fakes::FakeFetcher quiet;
+    quiet.peer_table.push_back({peer("a:18080", 1), sync_at(11, 100)});
+    rt::SyncDriver level(quiet, chain, chain, native::p2p::MAINNET_GENESIS,
+                         [] { return true; }, [] { return std::vector<Hash>{}; });
+    level.tick(4000);
+    kat::check(quiet.chain_requests.empty(),
+               "level with the cohort (peer current_height == our tip + 1) asks for nothing");
+
+    // The parked parents are asked for regardless.
+    native::fakes::FakeFetcher orphan_fetch;
+    orphan_fetch.peer_table.push_back({peer("a:18080", 1), sync_at(11, 100)});
+    Hash want{};
+    want.fill(0x22);
+    rt::SyncDriver orphans(orphan_fetch, chain, chain, native::p2p::MAINNET_GENESIS,
+                           [] { return true; }, [&] { return std::vector<Hash>{want}; });
+    orphans.tick(5000);
+    kat::check(orphan_fetch.object_requests.size() == 1 &&
+                   orphan_fetch.object_requests[0].ids[0] == want,
+               "a parked block's parent is re-fetched even when we are level");
+
+    // The index's refetch list is a standing want list: it is not cleared when
+    // the block arrives. So the driver must rate-limit it, or a 12-block
+    // backfill turns into hundreds of answers to questions already answered.
+    orphans.tick(5100);
+    orphans.tick(6000);
+    kat::check(orphan_fetch.object_requests.size() == 1,
+               "the same missing id is not re-asked on every tick");
+    orphans.tick(5000 + 20'000);
+    kat::check(orphan_fetch.object_requests.size() == 2,
+               "but it IS asked again once the re-ask interval passes");
+}
+
+void test_sync_driver_picks_the_heaviest_peer() {
+    native::fakes::FakeFetcher fetcher;
+    native::fakes::FakeChain   chain;
+    chain.rows.push_back([] {
+        native::node::ChainMainBlock b;
+        b.height = 5;
+        b.id.fill(0x33);
+        return b;
+    }());
+    chain.state.header_frontier = 5;
+
+    // The taller peer is the LIGHTER one: height is a number a peer can pick,
+    // cumulative difficulty is the same claim priced in work.
+    fetcher.peer_table.push_back({peer("tall:18080", 1), sync_at(9000, 10)});
+    fetcher.peer_table.push_back({peer("heavy:18080", 2), sync_at(50, 1'000'000)});
+
+    rt::SyncDriver driver(fetcher, chain, chain, native::p2p::MAINNET_GENESIS,
+                          [] { return true; }, [] { return std::vector<Hash>{}; });
+    driver.tick(1000);
+    kat::check(fetcher.chain_requests.size() == 1, "one chain request");
+    if (!fetcher.chain_requests.empty())
+        kat::check(fetcher.chain_requests[0].peer.addr == "heavy:18080",
+                   "the driver asks the peer with the greatest cumulative difficulty");
+}
+
+void test_sync_driver_probe_is_one_question() {
+    native::fakes::FakeFetcher fetcher;
+    native::fakes::FakeChain   chain;
+    fetcher.peer_table.push_back({peer("live:38080", 1), sync_at(1'000'000, 1'000'000)});
+
+    rt::SyncDriverConfig cfg;
+    cfg.probe_only = true;
+    rt::SyncDriver probe(fetcher, chain, chain, native::p2p::STAGENET_GENESIS,
+                         [] { return false; }, [] { return std::vector<Hash>{}; }, cfg);
+    for (int i = 0; i < 20; ++i) probe.tick(1000 + 100 * i);
+
+    kat::check(fetcher.chain_requests.size() == 1,
+               "the read-only probe asks exactly one NOTIFY_REQUEST_CHAIN, ever");
+    kat::check(fetcher.object_requests.empty(),
+               "and never asks a syncing daemon for a block");
+    if (!fetcher.chain_requests.empty())
+        kat::check(fetcher.chain_requests[0].locator.size() == 1 &&
+                       fetcher.chain_requests[0].locator[0] == native::p2p::STAGENET_GENESIS,
+                   "the probe's locator terminates at the network's genesis id");
+}
+
+} // namespace
+
+int main() {
+    test_worker_loop();
+    test_verify_inbound();
+    test_txsink_loop();
+    test_pow_witness();
+    test_genesis_row();
+    test_chain_boot();
+    test_chain_boot_refuses_a_foreign_blob();
+    test_out_of_order_push_connects();
+    test_sync_driver_schedule();
+    test_sync_driver_picks_the_heaviest_peer();
+    test_sync_driver_probe_is_one_question();
+    return kat::report("xmr_native_node_kat");
+}


### PR DESCRIPTION
**DO NOT MERGE — DRAFT.** Stacked on #1579 (`v37/xmr-native-w1i4`, the complete
13-component native node): this PR's base is that branch, and it should be read
after it.

## What this is

M0 of the native-minimal Monero node plan: the milestone where the components
stop being a library and start being a node that follows a live chain.

Thirteen components landed in waves 0 and 1, each authored against the pinned
contracts and each proven on its own. None of them is a node. Every one of them
states a threading contract it does not itself provide, nothing in the tree
sends the first `NOTIFY_REQUEST_CHAIN`, and nothing seeds row zero. This PR is
that assembly plus the run that judges it.

## The proof

Two isolated `monerod 0.18.5.1 --regtest --fixed-difficulty 1` daemons on
loopback (own data dirs, own ports, peered only with each other), and the native
node dialing one of them over levin:

```
=== summary ===
tip            : height=24 verified_frontier=24 rows=25 synced=1 alt=0 orphans=0 reorgs=0
boot           : genesis booted=1 inspected=1 refusals=0 dropped=0 (genesis row seeded from the levin-delivered blob)
chain-entry    : start=0 total=21 ids=21 first=418015bb9ae9... last=66979fcc5a85...
peers          : handshaked=1 total=1 netgroups=1 silent=0 handshakes=1 dials=2/0 last_close= ()
levin in       : blocks=4 chain_entries=1 objects=2 txs=0 frames=7 dos_drops=0
randomx        : mode=1 hashes=24 prefetches=1 rekeys=1 verified=24 failed=0 foreign=0
monerod rpc    : calls=10 (parity/bootstrap only; never on the tip-follow path)
parity         : clean=5 fail=0 served_mismatch=0 void=0
M0-VERDICT: PASS heights=24 parity_clean=5 parity_fail=0 randomx_foreign=0
```

* **Heights 1–20 backfilled over levin**: one chain request from a
  genesis-terminated locator, one `RESPONSE_CHAIN_ENTRY` with 21 ids, and the
  index's own object requests for what it lacked.
* **Heights 21–24 followed live** as they were mined: four inbound
  `NOTIFY_NEW_FLUFFY_BLOCK` pushes, `chain_requests` flat at 1 — the driver goes
  quiet while the height keeps moving, which is the observable difference
  between catching up and following.
* **C6 P-TIP CLEAN at every sampled height**, all nine fields (`id`, `prev_id`,
  `cumulative_difficulty`, `difficulty`, `timestamp`, `reward`, `block_weight`,
  `long_term_weight`, `major_version`) against monerod's own `get_info` +
  `get_last_block_header`. The oracle coalesces a burst of tips to its newest by
  design, so the twenty backfilled heights produced one sample and the four live
  heights one each.
* **RandomX ran 24 times, all on the verify thread, `foreign=0`** — a counter
  rather than a claim; see below.
* **Zero monerod RPC on the tip-follow path.** The ten calls are exactly two per
  parity sample; `--probe-only` and `--no-parity` runs report `calls=0` while the
  index still follows.

Plus a **read-only live probe** against the stagenet daemon on `192.168.86.44`,
which is mid-sync and was not disturbed: one connection, one question, no blocks
fetched. It answered a genesis-terminated locator with `start=0 total=1067456
ids=10000`, `ids[0] == STAGENET_GENESIS` — the daemon's own proof that it
accepted our network id, our handshake and our locator terminus.

`node/README.md` carries both runs in full, with the rig recipe.

## The io-thread fence is a number

`ThreadWitnessPowSource` records the thread every RandomX evaluation actually ran
on and counts the ones that ran on a thread the node declared forbidden (the io
threads). The node prints it, and the KAT asserts the counter itself works — a
witness that could not catch a forbidden call would be worth nothing.

## Two defects this assembly found

Both were invisible to every component KAT, because both are about the parts
being wired to each other and to a real daemon.

1. **A parked block was never revisited when its parent connected.** C2c's
   branch path resolves descendants; the fast path (a block that extends the
   tip) did not. monerod sends its top block to any peer it sees as behind, so
   the first block a cold node receives is normally one it cannot connect yet —
   every cold start, not a corner case. The live symptom was a node that
   backfilled to height 8, sat there, and let four already-delivered blocks rot
   in the alt pool while its peer climbed, with no error anywhere because
   nothing had failed. Fixed by draining the tip's parked children as ordinary
   Extends (routing them through the fork-choice switch would announce a Reorg
   of depth 0 for what is simply the next block) and pinned by a regression that
   fails 2 checks on the code as it stood.
2. **The first chain request waited out the boot fetch's timeout** — 20 s of
   "connected, synced=0, nothing happening" on every cold start, which is the
   exact shape of failure this layer exists to make unmisreadable.

A third, recorded rather than fixed here: `ChainIndex::refetch_wanted()` is a
STANDING want list and is not cleared when a block arrives, so a driver that
asked for all of it every tick asked twice a second forever (observed: 361
`RESPONSE_GET_OBJECTS` frames for a 12-block backfill). The driver now
rate-limits per id and skips ids the index already has.

## Diff shape

| | |
|---|---|
| new, `src/impl/xmr/native/node/` | the assembly: worker loops, chain boot, sync driver, the parity/bootstrap HTTP arm, `NativeNode`, and `tools/xmr_native_node_main.cpp` |
| new, `test/xmr_native_node_kat.cpp` | 88 checks; registered in ctest and in both `build.yml` `--target` lists |
| changed, `chain/xmr_chain_index.hpp` | defect 1 above |
| changed, `p2p/xmr_peer_pool.hpp` | `Config::bind_ip` — the source address for outbound dials. monerod enforces one connection per remote IP and does not source-bind its own outbound connections, so on a loopback rig the two daemons occupy each other's 127.0.0.1 slot and a third participant is refused before the handshake. Same knob and reason as the C5 live-push tool's `C5_SRC_IP` |
| changed, `CMakeLists.txt` ×2, `build.yml` | `xmr_native_node` (built by both legs, run by neither — it needs a daemon) and `xmr_native_node_kat` (registered and run) |

Scope fence unchanged: everything under `src/impl/xmr/`, no consensus digest,
`src/sharechain/v37` untouched. 24/24 native KATs green on workstation-191
(Release, `-DXMR_BUILD_RANDOMX=ON`), zero warnings.

## Wired and deliberately not driven

C5's relay is constructed with its 2009 responder armed but nothing calls
`relay()` (M3). C4's arms are constructed and reported (`tmpl=native`) but the
option-B settlement provider is not rebound through them (M2). C3's txpool is
fed from levin and its chain-event subscription is wired, but per-transaction
equality against monerod's pool is M1. Anchor boot is wired and is the
production path; M0 ran on the genesis path because a fresh regtest chain is
younger than the anchor format can describe.

## Owed operator calls

* **R-ARMORDER — the found-block arm order.** `contracts/relay.hpp` defaults
  `ArmOrder::DaemonFirst` (the plan's M0–M4 posture); C5's own
  `self_contained_policy()` defaults to `Parallel` with the P2P arm first (the
  daemonless posture the track exists to reach). The node takes `DaemonFirst` as
  its default and exposes `--relay-order`; which one a production pool ships
  with is a ruling, and it is the last knob before M3 can claim a daemonless
  find.
* **The sustained P-TIP soak.** M0's exit criterion in the plan is 48–72 h with
  ≥1 EpochEdge and zero field diffs over ≥2200 blocks. This run is a SHORT proof
  (24 heights, 5 samples, ~22 s of wall clock) and the graduation ledger says so
  itself (`state: Observing`). Which network it soaks against — stagenet from a
  host that is not .44's syncing daemon — and for how long is the operator's
  call.
