### PR TITLE
ltc(pool): bound the inbound-share path so RSS stops climbing to the self-abort

### DIFF
--- a/src/impl/ltc/ingest_budget.hpp
+++ b/src/impl/ltc/ingest_budget.hpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// LTC inbound-share ADMISSION BOUNDS (memory, not consensus).
+//
+// Why this exists: the LTC pool node self-aborted on rss_limit_mb under an
+// ingest storm (contabo 2026-09-09..11). The only bound on the ingest path was
+// NodeImpl::MAX_PENDING_ADDS, which caps the number of DEFERRED BATCHES waiting
+// for the tracker lock. That cap is (a) downstream of the phase-1 verify-pool
+// backlog, which had no bound at all, and (b) a count of batches, not of shares
+// or bytes — one batch is one sharereply (up to 1000 shares) or one unsolicited
+// `shares` message (bounded only by the 32 MiB socket cap). Both holes let a
+// single peer push hundreds of MB of deserialised shares into the process
+// before MAX_PENDING_ADDS was ever consulted.
+//
+// IngestBudget bounds the ingest pipeline in SHARES and BYTES at the point of
+// admission (NodeImpl::processing_shares), i.e. BEFORE any scrypt job is posted.
+// The reservation is held by the owning HandleSharesData and released by its
+// destructor, so it covers the whole life of a batch: verify-pool backlog,
+// m_pending_adds queue, and phase 2.
+//
+// REWARD-SAFETY: this is an admission bound, nothing else. A refused batch is
+// indistinguishable, for consensus purposes, from a batch the peer never sent —
+// no share is accepted, rejected, re-scored, or paid differently because of it.
+// Peers re-advertise their best share on every handshake and every best-change,
+// think() recomputes `desired` every cycle, and the ancestor walk re-requests a
+// parent it still does not have, so a refused batch is re-offered.
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace ltc
+{
+
+/// Inflight accounting for admitted-but-not-yet-destroyed share batches.
+///
+/// THREAD MODEL: try_admit() is called ONLY from the io thread
+/// (processing_shares is reached from the protocol handlers and from the
+/// download_shares reply callback, both io-thread). release() can run on any
+/// thread, because the last owning reference to a HandleSharesData may be
+/// dropped by a verify-pool worker. That is why the counters are atomics and
+/// why try_admit may reserve-then-roll-back: with a single admitter the
+/// transient overshoot is invisible to anyone but the rolling-back caller
+/// itself, and release() only ever decrements amounts a successful admit
+/// reserved, so neither counter can go negative.
+class IngestBudget
+{
+public:
+    IngestBudget(std::size_t max_shares, std::size_t max_bytes)
+        : m_max_shares(max_shares), m_max_bytes(max_bytes) {}
+
+    /// Reserve n shares / b bytes. Returns false and reserves NOTHING when
+    /// either ceiling would be crossed.
+    bool try_admit(std::size_t n, std::size_t b)
+    {
+        const std::size_t shares_after = m_shares.fetch_add(n, std::memory_order_acq_rel) + n;
+        const std::size_t bytes_after  = m_bytes.fetch_add(b, std::memory_order_acq_rel) + b;
+        if (shares_after <= m_max_shares && bytes_after <= m_max_bytes)
+            return true;
+        m_shares.fetch_sub(n, std::memory_order_acq_rel);
+        m_bytes.fetch_sub(b, std::memory_order_acq_rel);
+        return false;
+    }
+
+    /// Give back a reservation made by a successful try_admit().
+    void release(std::size_t n, std::size_t b)
+    {
+        if (n) m_shares.fetch_sub(n, std::memory_order_acq_rel);
+        if (b) m_bytes.fetch_sub(b, std::memory_order_acq_rel);
+    }
+
+    std::size_t shares() const { return m_shares.load(std::memory_order_relaxed); }
+    std::size_t bytes()  const { return m_bytes.load(std::memory_order_relaxed); }
+    std::size_t max_shares() const { return m_max_shares; }
+    std::size_t max_bytes()  const { return m_max_bytes; }
+
+private:
+    std::atomic<std::size_t> m_shares{0};
+    std::atomic<std::size_t> m_bytes{0};
+    std::size_t m_max_shares;
+    std::size_t m_max_bytes;
+};
+
+/// Depth bound for the recursive ancestor walk in download_shares().
+///
+/// The walk ("the oldest share in this reply has an unknown parent, so ask for
+/// that parent too") had NO termination condition other than reaching a hash we
+/// already hold — it would walk to genesis. think() refuses to emit `desired`
+/// for anything in the pruning zone (share_tracker.hpp: 2*chain_length+10), but
+/// the recursion never consulted that rule, so it fetched shares that
+/// clean_tracker Step 3 would drop again as soon as they landed.
+///
+/// REWARD-SAFETY: the PPLNS window is chain_length; everything deeper than
+/// 2*chain_length+10 below a head is what drop-tails removes and what think()
+/// already declines to request. Stopping the fetch there cannot change any
+/// payout, because such a share can never enter a payout computation.
+///
+/// `depth` is the number of shares already pulled by THIS walk.
+inline bool walk_may_continue(std::uint64_t depth, std::uint64_t chain_length)
+{
+    return depth < (2 * chain_length + 10);
+}
+
+} // namespace ltc

--- a/src/impl/ltc/node.cpp
+++ b/src/impl/ltc/node.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <iomanip>
 #include <random>
+#include <unordered_map>
 #ifndef _WIN32
 #include <execinfo.h>  // backtrace() for think() watchdog stack dump (glibc-only)
 #endif
@@ -400,12 +401,49 @@ std::optional<pool::PeerConnectionType> NodeImpl::handle_version(std::unique_ptr
         return pool::PeerConnectionType::legacy;
 }
 
-void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
+bool NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
 {
     // Take ownership immediately so the caller can return/free its local.
     auto data = std::make_shared<HandleSharesData>(std::move(data_ref));
     size_t n = data->m_items.size();
-    if (n == 0) return;
+    if (n == 0) return false;
+
+    // ── ADMISSION (RSS self-abort fix) ────────────────────────────────────
+    // Bound the ingest pipeline BEFORE a single scrypt job is posted. The only
+    // pre-existing bound, MAX_PENDING_ADDS, counts deferred BATCHES and sits
+    // downstream of this point: the phase-1 verify backlog below had no bound at
+    // all, so a peer that replies faster than ~200 shares/s (4 threads * ~20 ms
+    // scrypt) grew resident memory without limit while the batches were still
+    // waiting their turn. The reservation is held by `data` and given back by
+    // ~HandleSharesData, so it spans phase 1, the m_pending_adds queue and
+    // phase 2 — the whole life of the batch.
+    //
+    // REFUSE NEWEST here (a posted scrypt job cannot be un-posted); the
+    // drop-OLDEST policy at the pending_adds cap below is untouched.
+    //
+    // REWARD-SAFE: refusing a batch is indistinguishable from the peer never
+    // having sent it. Peers re-advertise their best share, think() recomputes
+    // `desired` every cycle, and the ancestor walk re-requests a parent it still
+    // lacks — so nothing refused here is lost accounting state, and no share
+    // acceptance decision, PPLNS input or payout is touched.
+    std::size_t admit_bytes = 0;
+    for (size_t i = 0; i < n; i++)
+    {
+        const std::size_t raw = (i < data->m_raw_items.size())
+            ? data->m_raw_items[i].contents.m_data.size() : 0;
+        admit_bytes += raw ? raw : INGEST_BYTES_FALLBACK_PER_SHARE;
+    }
+    if (!m_ingest_budget.try_admit(n, admit_bytes))
+    {
+        LOG_WARNING << "[INGEST] BACKPRESSURE: refusing " << n << " shares / "
+                    << admit_bytes << " B from " << addr.to_string()
+                    << " (inflight=" << m_ingest_budget.shares() << "/"
+                    << m_ingest_budget.max_shares() << " shares, "
+                    << m_ingest_budget.bytes() << "/" << m_ingest_budget.max_bytes()
+                    << " B) — verify pool is behind; peer will re-offer";
+        return false;   // `data` dies here: ~HandleSharesData frees every share
+    }
+    data->attach_budget(&m_ingest_budget, n, admit_bytes);
 
     // Phase 1 (thread pool, parallel): run share_init_verify() for each share.
     // share_init_verify() does scrypt-1024 (~20ms each) — must NOT block io_context.
@@ -448,6 +486,7 @@ void NodeImpl::processing_shares(HandleSharesData& data_ref, NetService addr)
                 }
             });
     }
+    return true;
 }
 
 void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
@@ -518,6 +557,26 @@ void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
     std::vector<ShareType> shares = prepare_shares.build_list();
 
     // Step 3: Process sorted shares
+    //
+    // OWNERSHIP (RSS self-abort fix): `data` OWNS every ShareType in m_items
+    // until the sharechain adopts it, and ~HandleSharesData frees whatever is
+    // still held — the verify failures, the duplicates, anything the topological
+    // build above dropped, and (via the pending_adds cap) whole dropped batches.
+    // Before this those objects were simply lost: nothing else referenced them
+    // and no erase path existed.
+    //
+    // The hand-over below is keyed by POINTER IDENTITY, never by hash: the
+    // duplicate branch a few lines down carries the same hash as an object the
+    // chain already owns but is a DIFFERENT allocation, so releasing by hash
+    // would hand the chain's own share to the batch destructor.
+    //
+    // The release happens AT the hand-over, not in a sweep after the loop: a
+    // throw further down (pack(share) can throw) would skip a post-loop sweep
+    // and the destructor would then free memory the sharechain owns.
+    std::unordered_map<const void*, std::size_t> batch_slot;
+    batch_slot.reserve(data.m_items.size());
+    for (std::size_t bi = 0; bi < data.m_items.size(); ++bi)
+        batch_slot.emplace(ltc::share_ptr_id(data.m_items[bi]), bi);
     int32_t new_count = 0;
     int32_t dup_count = 0;
     std::map<uint256, coin::MutableTransaction> all_new_txs;
@@ -569,6 +628,19 @@ void NodeImpl::processing_shares_phase2(HandleSharesData& data, NetService addr)
         });
 
         m_tracker.add(share);
+        // Adopted iff the chain now holds THIS allocation under that hash: null
+        // the batch's slot so ~HandleSharesData cannot double-free what
+        // ShareChain::remove()/~ShareChain will free.
+        {
+            const void* adopted_id = ltc::share_ptr_id(share);
+            if (m_chain->contains(share.hash()) &&
+                ltc::share_ptr_id(m_chain->get_share(share.hash())) == adopted_id)
+            {
+                auto slot = batch_slot.find(adopted_id);
+                if (slot != batch_slot.end())
+                    ltc::share_release(data.m_items[slot->second]);
+            }
+        }
 
         // Log fork detection: if this share's prev_hash has other children, it forks
         {
@@ -1261,7 +1333,8 @@ void NodeImpl::readvertise_best_share()
              << " head share(s) to " << m_peers.size() << " peer(s) (ROOT-2)";
 }
 
-void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
+void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash,
+                               std::uint64_t walk_depth)
 {
     // download_shares(): C++ implementation of the p2pool share-download loop.
     //
@@ -1398,12 +1471,13 @@ void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
     auto peer_addr_for_log = peer->addr();
 
     request_shares(req_id, peer, hashes, parents, stops,
-        [this, weak_peer, target_hash, peer_addr_for_log, req_id, chosen_key_val](ltc::ShareReplyData reply)
+        [this, weak_peer, target_hash, peer_addr_for_log, req_id, chosen_key_val,
+         walk_depth](ltc::ShareReplyData reply)
         {
             m_downloading_shares.erase(target_hash);
             m_pending_share_reqs.erase(req_id);
 
-            if (reply.m_items.empty())
+            if (reply.empty())
             {
                 // Empty reply = timeout or this peer had no matching shares.
                 // #25(C): remember the (hash, peer) failure so we fail over to a
@@ -1433,31 +1507,78 @@ void NodeImpl::download_shares(peer_ptr advertiser, const uint256& target_hash)
             }
             m_desired_pacer.record_success(target_hash);
 
-            LOG_INFO << "[Pool] Received " << reply.m_items.size() << " shares for download request";
+            auto& owned = *reply.m_owned;
+            const std::size_t reply_count = owned.m_items.size();
+            LOG_INFO << "[Pool] Received " << reply_count << " shares for download request";
 
-            // Feed into processing pipeline
-            HandleSharesData data;
-            for (size_t idx = 0; idx < reply.m_items.size(); ++idx)
-            {
-                if (idx < reply.m_raw_items.size())
-                    data.add(reply.m_items[idx], {}, reply.m_raw_items[idx]);
-                else
-                    data.add(reply.m_items[idx], {});
-            }
-            processing_shares(data, peer_addr_for_log);
-
-            // Find the oldest share's parent — if unknown, keep fetching
+            // Read the oldest share's parent BEFORE ownership moves out below.
             uint256 oldest_parent;
-            reply.m_items.back().invoke([&](auto* obj) { oldest_parent = obj->m_prev_hash; });
+            owned.m_items.back().invoke([&](auto* obj) { oldest_parent = obj->m_prev_hash; });
 
+            // Feed into processing pipeline. Ownership of the deserialised share
+            // objects MOVES from the reply into the batch here: `data` frees
+            // whatever the sharechain does not adopt, and clearing the reply's
+            // vector (which holds raw pointers and has no destructor of its own)
+            // keeps ~OwnedShares from freeing the same objects a second time.
+            // Before this, a reply that was admitted leaked every duplicate and
+            // every verify failure, and a reply that arrived after its 15 s
+            // timeout — or after cancel() on disconnect — leaked in full.
+            HandleSharesData data;
+            for (size_t idx = 0; idx < owned.m_items.size(); ++idx)
+            {
+                if (idx < owned.m_raw_items.size())
+                    data.add(owned.m_items[idx], {}, owned.m_raw_items[idx]);
+                else
+                    data.add(owned.m_items[idx], {});
+            }
+            owned.m_items.clear();
+            const bool admitted = processing_shares(data, peer_addr_for_log);
+
+            // ── Ancestor-walk bounds (RSS self-abort fix) ────────────────
+            // 1. Do not recurse on a batch the ingest budget REFUSED. The old
+            //    code queued the next hop unconditionally, and because the
+            //    refused batch never reaches the chain, contains(oldest_parent)
+            //    stays false — the walk re-requests the same segment forever
+            //    while think() is busy. That treadmill is what kept the storm
+            //    running long enough to hit the RSS limit.
+            // 2. Stop at the pruning zone. The recursion had no depth bound at
+            //    all: it walked to genesis, fetching shares that clean_tracker
+            //    Step 3 drops as soon as they land, while think() itself already
+            //    refuses to emit `desired` for that zone.
+            // 3. Respect DESIRED_QUEUE_MAX, which the think() path at the IO
+            //    phase enforces but this push bypassed.
+            //
+            // REWARD-SAFE: nothing here changes which shares are accepted. (1)
+            // only declines to ASK for a parent this cycle — think() re-derives
+            // `desired` every 5 s and asks again. (2) stops fetching shares
+            // deeper than 2*chain_length+10 below a head, which are exactly the
+            // shares drop-tails removes; the PPLNS window is chain_length, so
+            // such a share can never enter a payout.
+            if (!admitted)
+                return;
+
+            const std::uint64_t next_depth = walk_depth + reply_count;
             if (!oldest_parent.IsNull() && !m_chain->contains(oldest_parent))
             {
+                if (!ltc::walk_may_continue(
+                        next_depth,
+                        static_cast<std::uint64_t>(m_tracker.m_params->chain_length)))
+                {
+                    LOG_INFO << "[Pool] ancestor walk depth cap: " << next_depth
+                             << " >= " << (2 * m_tracker.m_params->chain_length + 10)
+                             << " for " << oldest_parent.ToString().substr(0,16)
+                             << " — leaving further backfill to think()";
+                    return;
+                }
                 auto locked = weak_peer.lock();
                 if (locked) {
                     // half-2: route the recursive re-request through the budgeted
                     // drain so backward chain-walk fan-out stays bounded on the io
                     // thread (same guard as the IO-phase desired drain).
-                    m_pending_desired.emplace_back(locked->addr(), oldest_parent);
+                    if (m_pending_desired.size() >= DESIRED_QUEUE_MAX)
+                        return;  // recomputed and re-queued next think() cycle
+                    m_pending_desired.push_back(
+                        DesiredRequest{locked->addr(), oldest_parent, next_depth});
                     drain_pending_desired();
                 }
             }
@@ -1486,13 +1607,13 @@ void NodeImpl::drain_pending_desired()
         // its backoff expires; unknown and healthy hashes are always eligible.
         // A skip does NOT consume budget -- it is a map lookup, and the point of
         // the pass is to reach the hashes that can still be served.
-        if (!m_desired_pacer.eligible(entry.second, now))
+        if (!m_desired_pacer.eligible(entry.hash, now))
             continue;
         peer_ptr advertiser;
         for (auto& [nonce, p] : m_peers) {
-            if (p && p->addr() == entry.first) { advertiser = p; break; }
+            if (p && p->addr() == entry.addr) { advertiser = p; break; }
         }
-        download_shares(advertiser, entry.second);
+        download_shares(advertiser, entry.hash, entry.depth);
         ++processed;
     }
     if (!m_pending_desired.empty())
@@ -1752,61 +1873,31 @@ void NodeImpl::start_outbound_connections()
     m_connect_timer->start(30, try_connect_peers);
 }
 
-void NodeImpl::prune_shares(const uint256& /*best_share*/)
+void NodeImpl::evict_caches_io_phase()
 {
-    // Tail-dropping (as in p2pool's clean_tracker):
-    // - Check each tail: if min(height(head) for heads) < 2*CL+10 → skip
-    // - Remove ONE child of qualifying tail per iteration
-    // - Loop up to 1000 times (gradual, not bulk)
-    // - Also cascade removal to verified
-    const auto CL = static_cast<int32_t>(m_tracker.m_params->chain_length);
-    const int32_t min_depth = 2 * CL + 10;
-
-    for (int iter = 0; iter < 1000; ++iter)
-    {
-        // p2pool node.py:382-398: find ONE qualifying tail child to remove
-        uint256 to_remove;
-        bool found = false;
-        auto tails_copy = m_tracker.chain.get_tails();
-        for (auto& [tail_hash, head_hashes] : tails_copy)
-        {
-            // Check min height across ALL heads for this tail
-            int32_t min_height = std::numeric_limits<int32_t>::max();
-            for (auto& hh : head_hashes) {
-                if (!m_tracker.chain.contains(hh)) continue;
-                try {
-                    min_height = std::min(min_height, m_tracker.chain.get_height(hh));
-                } catch (...) { continue; }
-            }
-            if (min_height < min_depth) continue;
-
-            // Find ONE child of this tail (p2pool removes one at a time)
-            auto& rev = m_tracker.chain.get_reverse();
-            auto rev_it = rev.find(tail_hash);
-            if (rev_it != rev.end() && !rev_it->second.empty()) {
-                to_remove = *rev_it->second.begin();
-                found = true;
-                break;  // one per iteration
-            }
-        }
-
-        if (!found) break;
-
-        if (!m_tracker.chain.contains(to_remove)) continue;
-        // p2pool node.py:393 — safety check: parent must be a tail
-        auto* idx = m_tracker.chain.get_index(to_remove);
-        if (!idx) continue;
-        bool parent_is_tail = m_tracker.chain.get_tails().contains(idx->tail);
-        if (!parent_is_tail) {
-            LOG_DEBUG_POOL << "prune skip: parent " << idx->tail.ToString().substr(0,16)
-                           << " not a tail";
-            continue;
-        }
-        if (m_tracker.verified.contains(to_remove))
-            m_tracker.verified.remove(to_remove, /*owns_data=*/false);
-        m_tracker.chain.remove(to_remove);
-    }
-
+    // WAS prune_shares(). That function had NO CALL SITE anywhere in the tree
+    // (git grep prune_shares: definition, declaration, three comments), so the
+    // three cache_max_* operator knobs it implemented were inert and the caches
+    // below grew for the life of the process — m_known_txs holds full
+    // coin::Transaction objects fed straight from peers, m_shared_share_hashes
+    // one uint256 per share ever broadcast.
+    //
+    // Its tail-drop loop is NOT resurrected: it duplicated clean_tracker Step 3
+    // (which IS called, every 5 s) and running both would change pruning cadence.
+    // Only the eviction survives, and it is now actually called — from the
+    // clean_tracker IO-phase.
+    //
+    // IO-THREAD ONLY. m_known_txs is inserted into lock-free by remember_tx on
+    // the io thread (node.hpp thread-discipline note); evicting from the compute
+    // thread under the tracker lock — which is what the dead prune_shares would
+    // have done — races that unlocked insert. Running here removes that race
+    // instead of arming it. m_shared_share_hashes is likewise io-thread-only
+    // (broadcast path).
+    //
+    // REWARD-SAFE: neither container is consensus state. m_shared_share_hashes
+    // is a re-broadcast de-dup set; m_known_txs is the tx-forwarding pool whose
+    // oldest-first bounded eviction shipped as reward-safe in #843 — this only
+    // makes it execute. No share acceptance, PPLNS input or payout reads either.
     // Cache cleanup (kept from original)
     if (m_shared_share_hashes.size() > m_max_shared_hashes)
         m_shared_share_hashes.clear();
@@ -1819,8 +1910,8 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
         core::evict_known_txs_to_cap(m_known_txs, m_known_txs_order, m_max_known_txs);
 
     // /p2p_stats gauges (observe-only): the SEND-side truth behind a peer
-    // dashboard reporting TXPOOL=0 for us. Published here because prune_shares
-    // is the periodic pass that already touches both containers. Relaxed
+    // dashboard reporting TXPOOL=0 for us. Published here because this is the
+    // periodic pass that already touches both containers. Relaxed
     // stores, no lock, no consensus/mint/payout state read or written.
     core::obs::p2p_stats().known_txs_size.store(
         m_known_txs.size(), std::memory_order_relaxed);
@@ -1828,8 +1919,11 @@ void NodeImpl::prune_shares(const uint256& /*best_share*/)
         static_cast<std::int64_t>(m_known_txs_order.size()), std::memory_order_relaxed);
     core::obs::p2p_stats().known_txs_updated_at.store(
         static_cast<std::int64_t>(core::timestamp()), std::memory_order_relaxed);
-    if (m_raw_share_cache.size() > m_max_raw_shares)
-        m_raw_share_cache.clear();
+    // NOTE: m_raw_share_cache is deliberately NOT touched here. Its primary
+    // eviction is now the ShareChain on_removed hook (node.hpp
+    // wire_chain_hooks), which fires on the COMPUTE thread under the exclusive
+    // tracker lock, as does its size backstop in clean_tracker. Clearing it from
+    // the io thread would race that erase.
 }
 
 // (old phases 5-7 removed — replaced by p2pool-style pruning above)
@@ -2189,7 +2283,8 @@ void NodeImpl::run_think()
                 for (auto& [peer_addr, hash] : result.desired) {
                     if (m_pending_desired.size() >= DESIRED_QUEUE_MAX)
                         break;  // remainder is recomputed and re-queued next cycle
-                    m_pending_desired.emplace_back(peer_addr, hash);
+                    // depth 0: a think()-originated request starts a fresh walk.
+                    m_pending_desired.push_back(DesiredRequest{peer_addr, hash, 0});
                 }
                 drain_pending_desired();
             }
@@ -2397,7 +2492,11 @@ void NodeImpl::heartbeat_log()
 
         shares_line << " [heads=" << m_tracker.chain.get_heads().size()
                     << " v_heads=" << m_tracker.verified.get_heads().size()
-                    << " rss=" << get_rss_mb() << "MB]";
+                    << " rss=" << get_rss_mb() << "MB"
+                    << " ingest=" << m_ingest_budget.shares() << "/" << MAX_INFLIGHT_SHARES
+                    << " sh," << (m_ingest_budget.bytes() >> 20) << "/"
+                    << (MAX_INFLIGHT_BYTES >> 20) << "MB"
+                    << " rawcache=" << m_raw_share_cache.size() << "]";
         LOG_INFO << shares_line.str();
     }
 
@@ -2757,6 +2856,21 @@ void NodeImpl::clean_tracker()
         m_removal_flush_buf.clear();
     }
 
+    // Step 5b: raw-share-cache size backstop (compute thread, exclusive lock).
+    // The per-share erase in the on_removed hook is the primary bound and keeps
+    // this cache proportional to chain membership; this is the belt-and-braces
+    // ceiling for entries whose share never entered the chain at all. Kept on
+    // the compute thread because the hook erases here too — a clear() from the
+    // io thread would race it.
+    // REWARD-SAFE: relay bytes only; send_shares and the LevelDB persist path
+    // both fall back to pack(share) on a cache miss.
+    if (m_raw_share_cache.size() > m_max_raw_shares)
+    {
+        LOG_INFO << "[clean] raw-share cache " << m_raw_share_cache.size()
+                 << " > cap " << m_max_raw_shares << " — clearing (relay bytes only)";
+        m_raw_share_cache.clear();
+    }
+
     // Orphan/fork diagnostics — understand chain topology
     {
         auto& chain = m_tracker.chain;
@@ -2808,6 +2922,9 @@ void NodeImpl::clean_tracker()
       // (handle_get_share, send_shares) are never blocked.
       boost::asio::post(*m_context, [this, clean_best_changed]() {
         disarm_think_watchdog();
+        // Enforce the cache_max_* limits. This is the ONLY call site: the code
+        // that used to do it (prune_shares) was never called at all.
+        evict_caches_io_phase();
         if (clean_best_changed && m_on_best_share_changed) {
             LOG_INFO << "[CLEAN] IO-phase: work refresh (best changed)";
             m_on_best_share_changed();

--- a/src/impl/ltc/node.hpp
+++ b/src/impl/ltc/node.hpp
@@ -10,6 +10,7 @@
 #include "head_retention.hpp"        // v36-0.24 convergence: clean_tracker Guard predicate (F2 + #25B)
 #include "share_fetch_failover.hpp"  // v36-0.24 convergence: parent-fetch failover memory (#25C)
 #include "desired_request_pacer.hpp"   // futility backoff for the desired-request drain
+#include "ingest_budget.hpp"            // inbound-share admission bounds + ancestor-walk depth bound
 #include <pool/share_download.hpp>     // shared downloader helpers (build_stops)
 
 #include <core/coin_params.hpp>
@@ -26,6 +27,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstdint>
+#include <deque>
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <random>
@@ -34,10 +38,95 @@
 namespace ltc
 {
 struct HandleSharesData;
-struct ShareReplyData
+
+/// Identity of the heap object a ShareType variant points at. Ownership on this
+/// path is tracked by POINTER, never by hash: a duplicate share carries the same
+/// hash as the copy the sharechain already owns but is a DIFFERENT allocation,
+/// and freeing by hash would free the chain's object.
+inline const void* share_ptr_id(const ShareType& s)
+{
+    return s.invoke_const([](auto* p) { return static_cast<const void*>(p); });
+}
+
+/// Relinquish ownership of the pointee WITHOUT freeing it — used after the
+/// sharechain has adopted the object, so the batch destructor leaves it alone.
+/// Keeps the variant's alternative index, only nulls the pointer (destroy() on a
+/// null pointer is a no-op).
+inline void share_release(ShareType& s)
+{
+    s.invoke([&s](auto* p) {
+        using share_t = std::remove_pointer_t<decltype(p)>;
+        s = static_cast<share_t*>(nullptr);
+    });
+}
+
+/// Deterministic count of share objects freed as ORPHANS — deserialised shares
+/// that no owner ever adopted. Production code never reads it; it is the oracle
+/// the ownership regression test asserts on, because the ASAN CI leg runs with
+/// ASAN_OPTIONS detect_leaks=0 and LeakSanitizer therefore cannot see the leak
+/// class this fixes.
+inline std::atomic<std::uint64_t>& orphan_share_destroy_counter()
+{
+    static std::atomic<std::uint64_t> n{0};
+    return n;
+}
+
+/// Free a share this container still owns (i.e. the sharechain never took it).
+/// A share_release()d slot holds nullptr and is skipped.
+inline void destroy_orphan_share(ShareType& s)
+{
+    if (share_ptr_id(s) == nullptr) return;
+    s.destroy();
+    orphan_share_destroy_counter().fetch_add(1, std::memory_order_relaxed);
+}
+
+/// OWNING payload of one inbound sharereply.
+///
+/// ltc::ShareType is a std::variant of RAW POINTERS with manual lifetime
+/// (sharechain/share.hpp: `new Args()` in load, freed only by an explicit
+/// destroy()). The only container that ever frees a share is the sharechain
+/// itself (ShareChain::remove / ~ShareChain). Before this type existed, every
+/// deserialised share that was NOT adopted by the tracker was simply lost:
+/// a reply that arrived after its 15 s request timeout, a reply whose request
+/// was cancelled on disconnect, a batch dropped by the pending_adds cap, a
+/// duplicate skipped in phase 2, a share whose phase-1 verification failed.
+/// Those leaks have no erase path at all, which is the unbounded growth behind
+/// the RSS self-abort.
+///
+/// Whoever takes an item out MUST either move it into a container that owns it
+/// or share_release() it after the sharechain adopted it.
+struct OwnedShares
 {
     std::vector<ShareType> m_items;
     std::vector<chain::RawShare> m_raw_items;
+
+    OwnedShares() = default;
+    // Always held through a shared_ptr — never copied, never moved.
+    OwnedShares(const OwnedShares&) = delete;
+    OwnedShares& operator=(const OwnedShares&) = delete;
+    OwnedShares(OwnedShares&&) = delete;
+    OwnedShares& operator=(OwnedShares&&) = delete;
+    ~OwnedShares() { for (auto& s : m_items) destroy_orphan_share(s); }
+};
+
+/// ReplyMatcher response type for a sharereply.
+///
+/// The payload is held by shared_ptr and NOT by value: core/reply_matcher.hpp
+/// copies the response twice on the way to the callback (Matcher::got_response
+/// takes it by value, ResponseWrapper::operator()(T result) takes it by value
+/// again), so a value-type destructor here would double free. A null m_owned is
+/// the normal empty response the matcher synthesises on timeout/cancel.
+struct ShareReplyData
+{
+    std::shared_ptr<OwnedShares> m_owned;
+
+    OwnedShares& owned()
+    {
+        if (!m_owned) m_owned = std::make_shared<OwnedShares>();
+        return *m_owned;
+    }
+    std::size_t size() const { return m_owned ? m_owned->m_items.size() : 0; }
+    bool empty() const { return size() == 0; }
 };
 
 class NodeImpl : public pool::SharechainNode<ltc::Config, ltc::ShareChain, ltc::Peer>
@@ -129,6 +218,30 @@ protected:
     // LOG_WARNING backpressure message (peers re-advertise, so dropped shares
     // are re-requested later).
     static constexpr size_t MAX_PENDING_ADDS = 256;
+
+    // ── Ingest admission bounds (RSS self-abort fix) ──────────────────────
+    // MAX_PENDING_ADDS bounds the number of DEFERRED BATCHES. It does not bound
+    // the size of a batch (one sharereply is up to 1000 shares; one unsolicited
+    // `shares` message is bounded only by the 32 MiB socket cap), and it sits
+    // DOWNSTREAM of the phase-1 verify backlog, which had no bound at all: every
+    // share posted to m_verify_pool stays resident until scrypt gets to it, and
+    // the pool drains ~4 threads * ~20 ms = ~200 shares/s while a single peer can
+    // deliver replies far faster than that.
+    //
+    // MAX_INFLIGHT_SHARES = 8192 is ~40 s of verify-pool backlog, the same order
+    // as THINK_WATCHDOG_SECONDS. More than that means the peer is outrunning what
+    // this node can ever verify. A cold full-depth bootstrap is NOT hurt: it
+    // arrives as sequential <=1000-share replies, each hop waiting on the
+    // previous reply, so it self-paces at network RTT.
+    // MAX_INFLIGHT_BYTES = 128 MiB is 8192 * a generous 16 KB raw share, ~3% of
+    // the 4000 MB rss limit, and at most four max-size unsolicited messages.
+    static constexpr std::size_t MAX_INFLIGHT_SHARES = 8192;
+    static constexpr std::size_t MAX_INFLIGHT_BYTES  = 128u * 1024u * 1024u;
+    // Charged for a share whose raw wire bytes were not kept (the legacy
+    // `shares` path constructs HandleSharesData without them), so that path
+    // cannot bypass the byte ceiling by reporting zero.
+    static constexpr std::size_t INGEST_BYTES_FALLBACK_PER_SHARE = 4096;
+    IngestBudget m_ingest_budget{MAX_INFLIGHT_SHARES, MAX_INFLIGHT_BYTES};
     std::atomic<int64_t>  m_think_deadline_ns{0};
     std::atomic<uint64_t> m_think_generation{0};
     std::unique_ptr<boost::asio::steady_timer> m_watchdog_timer;
@@ -342,6 +455,7 @@ public:
         m_context = nullptr;
         m_chain = nullptr;
         m_config = nullptr;
+        wire_chain_hooks();
     }
 
     NodeImpl(boost::asio::io_context* ctx, config_t* config)
@@ -379,13 +493,41 @@ public:
                 flush_verified_to_leveldb();
         };
 
-        // Wire up share removal → LevelDB cleanup (p2pool main.py:269-270)
-        // Buffer removals; clean_tracker() flushes after drop-tails.
-        // Safe on crash: unflushed shares get pruned at next startup by load_persisted_shares().
+        // Wire up share removal → LevelDB cleanup + raw-cache eviction.
+        wire_chain_hooks();
+    }
+
+private:
+    /// Subscribe to ShareChain removal. Called from BOTH constructors so the
+    /// default-ctor (unit-test) path exercises the same invariant.
+    ///
+    /// (a) p2pool main.py:269-270 — buffer removals for the LevelDB delete batch
+    ///     that clean_tracker() flushes after drop-tails. Safe on crash:
+    ///     unflushed shares get pruned at next startup by load_persisted_shares().
+    /// (b) m_raw_share_cache had NO erase path anywhere. It was filled for every
+    ///     distinct valid share ever seen (phase 2, before the dup check) and its
+    ///     only would-be backstop lived in the never-called prune_shares(), so it
+    ///     retained the full wire bytes of every share since boot — including all
+    ///     the pruned challenger/fork shares. Tie its lifetime to chain
+    ///     membership: when the owning chain drops a share, drop its raw bytes.
+    ///     Fires on the compute thread under the exclusive tracker lock (the only
+    ///     callers of chain.remove are think()/clean_tracker under it), and every
+    ///     other toucher of m_raw_share_cache holds that mutex, so this is
+    ///     race-free.
+    ///
+    /// REWARD-SAFE: m_raw_share_cache is a relay convenience (exact bytes as
+    /// received); send_shares and the LevelDB persist path both fall back to
+    /// pack(share) on a miss. A share that is no longer in the chain cannot be
+    /// served or paid anyway.
+    void wire_chain_hooks()
+    {
         m_tracker.chain.on_removed([this](const uint256& hash) {
             m_removal_flush_buf.push_back(hash);
+            m_raw_share_cache.erase(hash);
         });
     }
+
+public:
 
     // INetwork: Pool node does not initiate disconnect — peer connections
     // manage their own lifecycle via close_connection()/error() below.
@@ -402,7 +544,9 @@ public:
 
     // ltc
     void send_version(peer_ptr peer);
-    void processing_shares(HandleSharesData& data, NetService addr);
+    /// Admit + phase-1 verify an inbound batch. Returns false when the
+    /// ingest budget refused it (nothing was posted; the batch is freed).
+    bool processing_shares(HandleSharesData& data, NetService addr);
     void processing_shares_phase2(HandleSharesData& data, NetService addr);
     /// Direct tracker access — compute-thread-only (already holds exclusive lock)
     /// or startup code (before compute thread exists).
@@ -574,7 +718,9 @@ public:
 
     /// Start downloading shares from a peer, beginning at `target_hash`.
     /// Recursively fetches parents until the chain is connected or CHAIN_LENGTH reached.
-    void download_shares(peer_ptr peer, const uint256& target_hash);
+    /// `walk_depth` is how many shares the recursive ancestor walk that led
+    /// here has already pulled; 0 for a fresh think()-originated request.
+    void download_shares(peer_ptr peer, const uint256& target_hash, std::uint64_t walk_depth = 0);
 
     /// Drain up to DESIRED_REQUEST_BUDGET queued desired-share requests
     /// (m_pending_desired) per pass, reposting the remainder to the io_context
@@ -710,11 +856,21 @@ public:
     /// Callers MUST use shared_lock(try_to_lock) — NEVER blocking lock().
     std::shared_mutex& tracker_mutex() { return m_tracker_mutex; }
 
-    /// Unified share retention: single-pass prune of chain + verified + LevelDB.
-    /// Replaces multi-pass trim with work-based dead head detection and
-    /// deferred destruction for verified cascade safety.
-    /// Called from run_think() on the ioc thread.
-    void prune_shares(const uint256& best_share);
+    /// Evict the unbounded per-node caches down to their configured limits.
+    ///
+    /// This is what was left of prune_shares() after its tail-drop loop was
+    /// deleted: that loop duplicated clean_tracker Step 3, and prune_shares had
+    /// NO CALL SITE at all, so the three cache_max_* operator knobs
+    /// (cache_max_shared_hashes / cache_max_known_txs / cache_max_raw_shares)
+    /// were inert and m_shared_share_hashes / m_known_txs grew for the life of
+    /// the process. IO-THREAD ONLY: m_known_txs is written lock-free by
+    /// remember_tx on the io thread (see the thread-discipline note above), so
+    /// evicting from the compute thread would race that insert.
+    void evict_caches_io_phase();
+
+    /// Current ingest reservation (admitted batches not yet destroyed).
+    /// Exposed for the heartbeat line so backpressure is visible on a live node.
+    const IngestBudget& ingest_inflight() const { return m_ingest_budget; }
 
     /// Run the share tracker think() cycle: verifies chains, scores heads,
     /// identifies bad peers, and requests needed shares.
@@ -826,7 +982,11 @@ protected:
     // between chunks. IO-THREAD CONFINED, same discipline as m_downloading_shares
     // above -- never touch off the io thread. Mirrors m_think_needs_continue.
     static constexpr std::size_t DESIRED_REQUEST_BUDGET = 50;
-    std::deque<std::pair<NetService, uint256>> m_pending_desired;
+    // `depth` propagates the ancestor-walk length so the recursion in
+    // download_shares can stop at the pruning zone instead of walking to
+    // genesis (ltc::walk_may_continue). think()-originated entries start at 0.
+    struct DesiredRequest { NetService addr; uint256 hash; std::uint64_t depth{0}; };
+    std::deque<DesiredRequest> m_pending_desired;
 
     // ---- desired-drain RATE cap (the budget above is not one) ----
     // DESIRED_REQUEST_BUDGET bounds the work per PASS, and the continuation was
@@ -966,11 +1126,63 @@ protected:
     std::unordered_map<uint256, chain::RawShare, ShareHasher> m_raw_share_cache;
 };
 
+/// OWNING batch travelling the ingest pipeline: protocol handler -> admission ->
+/// verify pool (phase 1) -> m_pending_adds -> phase 2.
+///
+/// Like OwnedShares, it frees every ShareType still held at destruction. Phase 2
+/// calls share_release() on the items the sharechain ADOPTED, so exactly the
+/// shares that found no owner — verify failures, duplicates, anything the
+/// topological build dropped, and every share in a batch the pending_adds cap
+/// dropped — are destroyed here instead of leaking.
+///
+/// Move-only, with HAND-WRITTEN move operations: a defaulted move would copy the
+/// budget back-pointer into the target and leave it live in the source, so the
+/// moved-from destructor would release the same reservation twice.
 struct HandleSharesData
 {
     std::vector<ShareType> m_items;
     std::vector<chain::RawShare> m_raw_items; // original raw bytes, parallel with m_items
     std::map<uint256, std::vector<coin::MutableTransaction>> m_txs;
+
+    HandleSharesData() = default;
+    HandleSharesData(const HandleSharesData&) = delete;
+    HandleSharesData& operator=(const HandleSharesData&) = delete;
+
+    HandleSharesData(HandleSharesData&& o) noexcept
+        : m_items(std::move(o.m_items)),
+          m_raw_items(std::move(o.m_raw_items)),
+          m_txs(std::move(o.m_txs)),
+          m_budget(o.m_budget),
+          m_admitted_shares(o.m_admitted_shares),
+          m_admitted_bytes(o.m_admitted_bytes)
+    {
+        o.m_items.clear();
+        o.detach_budget();
+    }
+
+    HandleSharesData& operator=(HandleSharesData&& o) noexcept
+    {
+        if (this != &o)
+        {
+            free_owned();
+            release_budget();
+            m_items     = std::move(o.m_items);
+            m_raw_items = std::move(o.m_raw_items);
+            m_txs       = std::move(o.m_txs);
+            m_budget          = o.m_budget;
+            m_admitted_shares = o.m_admitted_shares;
+            m_admitted_bytes  = o.m_admitted_bytes;
+            o.m_items.clear();
+            o.detach_budget();
+        }
+        return *this;
+    }
+
+    ~HandleSharesData()
+    {
+        free_owned();
+        release_budget();
+    }
 
     void add(const ShareType& share, std::vector<coin::MutableTransaction> txs)
     {
@@ -985,6 +1197,39 @@ struct HandleSharesData
         m_items.push_back(share);
         m_raw_items.push_back(raw);
         m_txs[share.hash()] = std::move(txs);
+    }
+
+    /// Record the ingest reservation this batch holds; released by ~this.
+    void attach_budget(IngestBudget* budget, std::size_t shares, std::size_t bytes)
+    {
+        m_budget = budget;
+        m_admitted_shares = shares;
+        m_admitted_bytes = bytes;
+    }
+
+    std::size_t admitted_shares() const { return m_admitted_shares; }
+    std::size_t admitted_bytes()  const { return m_admitted_bytes; }
+
+private:
+    IngestBudget* m_budget{nullptr};
+    std::size_t   m_admitted_shares{0};
+    std::size_t   m_admitted_bytes{0};
+
+    void free_owned()
+    {
+        for (auto& s : m_items) destroy_orphan_share(s);
+        m_items.clear();
+    }
+    void release_budget()
+    {
+        if (m_budget) m_budget->release(m_admitted_shares, m_admitted_bytes);
+        detach_budget();
+    }
+    void detach_budget()
+    {
+        m_budget = nullptr;
+        m_admitted_shares = 0;
+        m_admitted_bytes = 0;
     }
 };
 

--- a/src/impl/ltc/peer.hpp
+++ b/src/impl/ltc/peer.hpp
@@ -4,6 +4,8 @@
 #include "coin/transaction.hpp"
 
 #include <chrono>
+#include <cstdint>
+#include <map>
 #include <set>
 #include <optional>
 #include <core/tx_advertiser.hpp>
@@ -23,9 +25,60 @@ struct Peer
     std::set<uint256> m_remote_txs; // hashes
     // int32_t remote_remembered_txs_size = 0;
 
+    // ── Per-peer remembered-tx store, BYTE-BOUNDED (p2pool parity) ────────
+    // p2pool p2p.py bounds this store and raises PeerMisbehavingError('too much
+    // transaction data stored') past the cap. The c2pool port carried the bound
+    // over as two COMMENTED-OUT lines, so a single peer could grow this map
+    // without limit: the only erase path is that same peer sending forget_tx,
+    // and nothing obliges it to. Full coin::Transaction objects, peer-driven —
+    // one of the unbounded structures behind the RSS self-abort.
+    //
+    // REWARD-SAFE: m_remembered_txs feeds only the send-side tx-completeness
+    // gate and the v13-33 tx lookup; v36 shares carry no new-tx list through it.
+    // Dropping the peer drops its map; shares it already delivered are in the
+    // chain and unaffected. No share acceptance, PPLNS input or payout reads it.
     std::map<uint256, coin::Transaction> m_remembered_txs;
-    // int32_t remembered_txs_size = 0;
-    // const int32_t max_remembered_txs_size = 25000000;
+
+    // Packed size charged per entry, so forget_tx subtracts EXACTLY what
+    // remember_tx added (re-packing on forget could drift and un-bound the cap).
+    std::map<uint256, std::int64_t> m_remembered_txs_bytes;
+    std::int64_t m_remembered_txs_size = 0;
+
+    // p2pool p2p.py: 2.5 MB, plus its ~100 B per-entry bookkeeping charge. (The
+    // 25000000 in the commented-out line this replaces has one zero too many.)
+    static constexpr std::int64_t MAX_REMEMBERED_TXS_SIZE = 2500000;
+    static constexpr std::int64_t REMEMBERED_TX_OVERHEAD = 100;
+
+    /// Store one remembered tx and charge its packed size to this peer.
+    void remember_tx(const uint256& hash, const coin::Transaction& tx,
+                     std::int64_t packed_bytes)
+    {
+        const std::int64_t charge = packed_bytes + REMEMBERED_TX_OVERHEAD;
+        auto it = m_remembered_txs_bytes.find(hash);
+        if (it != m_remembered_txs_bytes.end())
+            m_remembered_txs_size -= it->second;   // insert_or_assign overwrite
+        m_remembered_txs.insert_or_assign(hash, tx);
+        m_remembered_txs_bytes[hash] = charge;
+        m_remembered_txs_size += charge;
+    }
+
+    /// Drop one remembered tx and give back exactly what it was charged.
+    void forget_tx(const uint256& hash)
+    {
+        auto it = m_remembered_txs_bytes.find(hash);
+        if (it != m_remembered_txs_bytes.end())
+        {
+            m_remembered_txs_size -= it->second;
+            m_remembered_txs_bytes.erase(it);
+        }
+        m_remembered_txs.erase(hash);
+        if (m_remembered_txs_size < 0) m_remembered_txs_size = 0;
+    }
+
+    bool remembered_txs_over_cap() const
+    {
+        return m_remembered_txs_size > MAX_REMEMBERED_TXS_SIZE;
+    }
 
     // Send side of the tx-pool advertisement: our reconstruction of what this
     // peer believes WE hold, so each sweep can emit only the delta as

--- a/src/impl/ltc/protocol_actual.cpp
+++ b/src/impl/ltc/protocol_actual.cpp
@@ -177,18 +177,25 @@ void Actual::HANDLER(sharereq)
 
 void Actual::HANDLER(sharereply)
 {
+    // The payload is OWNED from the moment load_share() news it up. Before this,
+    // every share deserialised here was orphaned heap unless the sharechain
+    // adopted it: got_share_reply() swallows std::invalid_argument for a request
+    // that already timed out (15 s) or was cancel()led on disconnect, and that
+    // swallow discarded the whole reply with no free anywhere. A slow peer
+    // therefore leaked every byte it eventually sent.
     ltc::ShareReplyData result;
     if (msg->m_result == ShareReplyResult::good)
     {
-        result.m_items.reserve(msg->m_shares.size());
-        result.m_raw_items.reserve(msg->m_shares.size());
+        auto& owned = result.owned();
+        owned.m_items.reserve(msg->m_shares.size());
+        owned.m_raw_items.reserve(msg->m_shares.size());
         for (auto& rshare : msg->m_shares)
         {
             try
             {
                 auto share = ltc::load_share(rshare, peer->addr());
-                result.m_items.push_back(share);
-                result.m_raw_items.push_back(rshare);
+                owned.m_items.push_back(share);
+                owned.m_raw_items.push_back(rshare);
             }
             catch(const std::exception& e)
             {
@@ -249,7 +256,21 @@ void Actual::HANDLER(remember_tx)
         auto it = m_known_txs.find(tx_hash);
         if (it != m_known_txs.end())
         {
-            peer->m_remembered_txs.insert_or_assign(tx_hash, it->second);
+            // p2pool parity: charge the packed size and drop the peer over cap.
+            // Nothing but this peer's own forget_tx ever erased from the map, so
+            // without the charge one peer could grow it without limit.
+            peer->remember_tx(tx_hash, it->second,
+                              static_cast<std::int64_t>(pack(coin::TX_WITH_WITNESS(it->second)).size()));
+            if (peer->remembered_txs_over_cap())
+            {
+                LOG_WARNING << "[Pool] peer " << peer->addr().to_string()
+                            << " exceeded remembered_txs cap ("
+                            << peer->m_remembered_txs_size << " > "
+                            << ltc::Peer::MAX_REMEMBERED_TXS_SIZE
+                            << " bytes) — disconnecting";
+                close_connection(peer->addr());
+                return;
+            }
         }
         else
         {
@@ -270,7 +291,17 @@ void Actual::HANDLER(remember_tx)
         }
 
         coin::Transaction full_tx(tx);
-        peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
+        peer->remember_tx(tx_hash, full_tx, static_cast<std::int64_t>(packed.size()));
+        if (peer->remembered_txs_over_cap())
+        {
+            LOG_WARNING << "[Pool] peer " << peer->addr().to_string()
+                        << " exceeded remembered_txs cap ("
+                        << peer->m_remembered_txs_size << " > "
+                        << ltc::Peer::MAX_REMEMBERED_TXS_SIZE
+                        << " bytes) — disconnecting";
+            close_connection(peer->addr());
+            return;
+        }
 
         if (!m_known_txs.contains(tx_hash))
         {
@@ -284,7 +315,7 @@ void Actual::HANDLER(forget_tx)
 {
     for (auto tx_hash : msg->m_tx_hashes)
     {
-        peer->m_remembered_txs.erase(tx_hash);
+        peer->forget_tx(tx_hash);
     }
 }
 

--- a/src/impl/ltc/protocol_legacy.cpp
+++ b/src/impl/ltc/protocol_legacy.cpp
@@ -207,18 +207,25 @@ void Legacy::HANDLER(sharereq)
 
 void Legacy::HANDLER(sharereply)
 {
+    // The payload is OWNED from the moment load_share() news it up. Before this,
+    // every share deserialised here was orphaned heap unless the sharechain
+    // adopted it: got_share_reply() swallows std::invalid_argument for a request
+    // that already timed out (15 s) or was cancel()led on disconnect, and that
+    // swallow discarded the whole reply with no free anywhere. A slow peer
+    // therefore leaked every byte it eventually sent.
     ltc::ShareReplyData result;
     if (msg->m_result == ShareReplyResult::good)
     {
-        result.m_items.reserve(msg->m_shares.size());
-        result.m_raw_items.reserve(msg->m_shares.size());
+        auto& owned = result.owned();
+        owned.m_items.reserve(msg->m_shares.size());
+        owned.m_raw_items.reserve(msg->m_shares.size());
         for (auto& rshare : msg->m_shares)
         {
             try
             {
                 auto share = ltc::load_share(rshare, peer->addr());
-                result.m_items.push_back(share);
-                result.m_raw_items.push_back(rshare);
+                owned.m_items.push_back(share);
+                owned.m_raw_items.push_back(rshare);
             }
             catch(const std::exception& e)
             {
@@ -285,7 +292,21 @@ void Legacy::HANDLER(remember_tx)
         auto it = m_known_txs.find(tx_hash);
         if (it != m_known_txs.end())
         {
-            peer->m_remembered_txs.insert_or_assign(tx_hash, it->second);
+            // p2pool parity: charge the packed size and drop the peer over cap.
+            // Nothing but this peer's own forget_tx ever erased from the map, so
+            // without the charge one peer could grow it without limit.
+            peer->remember_tx(tx_hash, it->second,
+                              static_cast<std::int64_t>(pack(coin::TX_WITH_WITNESS(it->second)).size()));
+            if (peer->remembered_txs_over_cap())
+            {
+                LOG_WARNING << "[Pool] peer " << peer->addr().to_string()
+                            << " exceeded remembered_txs cap ("
+                            << peer->m_remembered_txs_size << " > "
+                            << ltc::Peer::MAX_REMEMBERED_TXS_SIZE
+                            << " bytes) — disconnecting";
+                close_connection(peer->addr());
+                return;
+            }
         }
         else
         {
@@ -306,7 +327,17 @@ void Legacy::HANDLER(remember_tx)
         }
 
         coin::Transaction full_tx(tx);
-        peer->m_remembered_txs.insert_or_assign(tx_hash, full_tx);
+        peer->remember_tx(tx_hash, full_tx, static_cast<std::int64_t>(packed.size()));
+        if (peer->remembered_txs_over_cap())
+        {
+            LOG_WARNING << "[Pool] peer " << peer->addr().to_string()
+                        << " exceeded remembered_txs cap ("
+                        << peer->m_remembered_txs_size << " > "
+                        << ltc::Peer::MAX_REMEMBERED_TXS_SIZE
+                        << " bytes) — disconnecting";
+            close_connection(peer->addr());
+            return;
+        }
 
         if (!m_known_txs.contains(tx_hash))
         {
@@ -320,7 +351,7 @@ void Legacy::HANDLER(forget_tx)
 {
     for (auto tx_hash : msg->m_tx_hashes)
     {
-        peer->m_remembered_txs.erase(tx_hash);
+        peer->forget_tx(tx_hash);
     }
 }
 

--- a/src/impl/ltc/test/CMakeLists.txt
+++ b/src/impl/ltc/test/CMakeLists.txt
@@ -33,7 +33,17 @@ if (BUILD_TESTING AND GTest_FOUND)
     # pool_rate_head_select.hpp, issue #1482) — verified best when live, else the
     # fastest LIVE raw head; stale-prop = stales/(lookbehind+stales). Pure
     # header-only KAT. Same folding rule: into the existing allowlisted target.
-    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp desired_request_pacer_test.cpp build_stops_test.cpp pool_rate_head_select_test.cpp template_topology_spend_test.cpp)
+    #
+    # ingest_bounds_test.cpp + ingest_ownership_test.cpp: the LTC inbound-share
+    # memory bounds that replace the rss_limit_mb self-abort (contabo
+    # 2026-09-09..11). The first is KAT + source-structural (IngestBudget,
+    # ancestor-walk depth bound, per-peer remembered-tx cap, and the guards that
+    # keep the cache eviction WIRED — its predecessor prune_shares had no call
+    # site at all). The second drives a REAL ltc::NodeImpl through
+    # processing_shares_phase2 to pin share OWNERSHIP: a dropped/duplicate/
+    # verify-failed/late-reply share is freed, an adopted one is not. Same
+    # folding rule: into the existing allowlisted target.
+    add_executable(share_test share_test.cpp f11_donation_invariance_test.cpp emergency_decay_overflow_test.cpp wirecompat_runtime_test.cpp desired_version_tally_test.cpp auto_ratchet_sim_test.cpp auto_ratchet_tail_guard_test.cpp auto_ratchet_blocked_by_test.cpp chain_walk_window_test.cpp doge_template_underfill_test.cpp broadcast_tx_completeness_test.cpp broadcast_lock_discipline_test.cpp compact_block_merkle_test.cpp share_remove_owns_data_test.cpp share_message_unpack_bounds_test.cpp restart_reorg_supersede_test.cpp peer_block_pow_carry_test.cpp head_retention_test.cpp share_fetch_failover_test.cpp desired_request_pacer_test.cpp build_stops_test.cpp pool_rate_head_select_test.cpp template_topology_spend_test.cpp ingest_bounds_test.cpp ingest_ownership_test.cpp)
     target_link_libraries(share_test PRIVATE
         GTest::gtest_main GTest::gtest
         core ltc

--- a/src/impl/ltc/test/ingest_bounds_test.cpp
+++ b/src/impl/ltc/test/ingest_bounds_test.cpp
@@ -1,0 +1,264 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// D-LTC.INGEST-BOUNDS — KATs + source-structural guards for the LTC ingest
+// memory bounds that replace the RSS self-abort.
+//
+// PRODUCTION SHAPE BEING FIXED (contabo LTC node, 2026-09-09..11): the node
+// self-aborted on rss_limit_mb ("=== RSS LIMIT EXCEEDED === RSS: 4047 MB") with
+// "[ASYNC-DEFER] BACKPRESSURE: pending_adds at cap (256/256), dropping OLDEST
+// queued batch" immediately before each abort. MAX_PENDING_ADDS was the only
+// bound on the ingest path and it bounds neither the phase-1 verify backlog
+// upstream of it, nor the SIZE of a batch, nor the caches downstream.
+//
+// Folded into the EXISTING allowlisted `share_test` target — a standalone
+// add_executable would be absent from build.yml's --target list and reported
+// "Not Run" by CTest (the #769 trap).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include <impl/ltc/ingest_budget.hpp>
+#include <impl/ltc/peer.hpp>
+
+#ifndef C2POOL_IMPL_DIR
+#error "C2POOL_IMPL_DIR must be defined by CMake to the path of src/impl"
+#endif
+
+namespace {
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. IngestBudget — the admission bound that did not exist at all before.
+// ─────────────────────────────────────────────────────────────────────────
+
+TEST(LtcIngestBudget, AdmitsUpToTheShareCeilingThenRefuses)
+{
+    ltc::IngestBudget b(100, 1'000'000);
+    EXPECT_TRUE(b.try_admit(60, 10));
+    EXPECT_TRUE(b.try_admit(40, 10));
+    EXPECT_EQ(b.shares(), 100u);
+    // One share past the ceiling is refused...
+    EXPECT_FALSE(b.try_admit(1, 1));
+    // ...and a refusal reserves NOTHING (this is what makes a storm survivable:
+    // a refused batch must not permanently consume budget).
+    EXPECT_EQ(b.shares(), 100u);
+    EXPECT_EQ(b.bytes(), 20u);
+}
+
+TEST(LtcIngestBudget, AdmitsUpToTheByteCeilingIndependentlyOfTheShareCeiling)
+{
+    ltc::IngestBudget b(1'000'000, 1024);
+    EXPECT_TRUE(b.try_admit(1, 1024));
+    EXPECT_FALSE(b.try_admit(1, 1));          // bytes full, shares nowhere near
+    EXPECT_EQ(b.bytes(), 1024u);
+    EXPECT_EQ(b.shares(), 1u);
+}
+
+TEST(LtcIngestBudget, ReleaseGivesTheReservationBackAndNeverGoesNegative)
+{
+    ltc::IngestBudget b(10, 1000);
+    ASSERT_TRUE(b.try_admit(10, 1000));
+    EXPECT_FALSE(b.try_admit(1, 1));
+    b.release(10, 1000);
+    EXPECT_EQ(b.shares(), 0u);
+    EXPECT_EQ(b.bytes(), 0u);
+    EXPECT_TRUE(b.try_admit(10, 1000));       // capacity is reusable, not spent
+}
+
+TEST(LtcIngestBudget, OneOversizedBatchIsRefusedWholeRatherThanPartiallyAdmitted)
+{
+    ltc::IngestBudget b(8192, 128u * 1024u * 1024u);
+    EXPECT_FALSE(b.try_admit(8193, 1));
+    EXPECT_EQ(b.shares(), 0u);
+    EXPECT_TRUE(b.try_admit(8192, 1));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. Ancestor-walk depth bound. The recursion in download_shares had NO
+//    termination condition other than reaching a hash we already hold, so a
+//    challenger walk ran to genesis, pulling shares that clean_tracker Step 3
+//    drops as soon as they land.
+// ─────────────────────────────────────────────────────────────────────────
+
+TEST(LtcAncestorWalkDepth, StopsExactlyAtThePruningZone)
+{
+    const std::uint64_t CL = 8640;            // ltc mainnet params.hpp
+    const std::uint64_t zone = 2 * CL + 10;   // 17290, mirrors share_tracker's rule
+    EXPECT_TRUE (ltc::walk_may_continue(0, CL));
+    EXPECT_TRUE (ltc::walk_may_continue(zone - 1, CL));
+    EXPECT_FALSE(ltc::walk_may_continue(zone, CL));
+    EXPECT_FALSE(ltc::walk_may_continue(zone + 1000, CL));
+}
+
+TEST(LtcAncestorWalkDepth, ScalesWithChainLengthNotAHardcodedNumber)
+{
+    const std::uint64_t CL = 400;             // ltc testnet params.hpp
+    EXPECT_TRUE (ltc::walk_may_continue(2 * CL + 9, CL));
+    EXPECT_FALSE(ltc::walk_may_continue(2 * CL + 10, CL));
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. Per-peer remembered-tx byte cap. p2pool bounds this store and disconnects
+//    over the cap; the c2pool port carried the bound over COMMENTED OUT, so one
+//    peer could grow a map of full transactions without limit — the only erase
+//    path is that same peer choosing to send forget_tx.
+// ─────────────────────────────────────────────────────────────────────────
+
+TEST(LtcRememberedTxCap, ChargesEachInsertAndTripsOverTheCap)
+{
+    ltc::Peer peer;
+    ltc::coin::MutableTransaction mtx;
+    ltc::coin::Transaction tx(mtx);
+    EXPECT_FALSE(peer.remembered_txs_over_cap());
+    EXPECT_EQ(peer.m_remembered_txs_size, 0);
+
+    // Just under the cap: still accepted.
+    peer.remember_tx(uint256(1), tx, ltc::Peer::MAX_REMEMBERED_TXS_SIZE
+                                     - ltc::Peer::REMEMBERED_TX_OVERHEAD);
+    EXPECT_FALSE(peer.remembered_txs_over_cap());
+    EXPECT_EQ(peer.m_remembered_txs_size, ltc::Peer::MAX_REMEMBERED_TXS_SIZE);
+
+    // One more byte of transaction data and the peer is over.
+    peer.remember_tx(uint256(2), tx, 1);
+    EXPECT_TRUE(peer.remembered_txs_over_cap());
+    EXPECT_EQ(peer.m_remembered_txs.size(), 2u);
+}
+
+TEST(LtcRememberedTxCap, ForgetGivesBackExactlyWhatRememberCharged)
+{
+    ltc::Peer peer;
+    ltc::coin::MutableTransaction mtx;
+    ltc::coin::Transaction tx(mtx);
+    peer.remember_tx(uint256(1), tx, 5000);
+    peer.remember_tx(uint256(2), tx, 7000);
+    const std::int64_t both = peer.m_remembered_txs_size;
+    EXPECT_EQ(both, 5000 + 7000 + 2 * ltc::Peer::REMEMBERED_TX_OVERHEAD);
+
+    peer.forget_tx(uint256(1));
+    EXPECT_EQ(peer.m_remembered_txs_size, 7000 + ltc::Peer::REMEMBERED_TX_OVERHEAD);
+    EXPECT_EQ(peer.m_remembered_txs.count(uint256(1)), 0u);
+
+    // Forgetting something never remembered must not drive the counter negative
+    // (a negative counter would silently un-bound the cap).
+    peer.forget_tx(uint256(999));
+    peer.forget_tx(uint256(2));
+    EXPECT_EQ(peer.m_remembered_txs_size, 0);
+    EXPECT_TRUE(peer.m_remembered_txs.empty());
+}
+
+TEST(LtcRememberedTxCap, ReRememberingTheSameHashDoesNotDoubleCharge)
+{
+    ltc::Peer peer;
+    ltc::coin::MutableTransaction mtx;
+    ltc::coin::Transaction tx(mtx);
+    peer.remember_tx(uint256(1), tx, 5000);
+    peer.remember_tx(uint256(1), tx, 5000);   // insert_or_assign overwrite
+    EXPECT_EQ(peer.m_remembered_txs_size, 5000 + ltc::Peer::REMEMBERED_TX_OVERHEAD);
+    peer.forget_tx(uint256(1));
+    EXPECT_EQ(peer.m_remembered_txs_size, 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 4. Source-structural guard: the cache eviction must stay WIRED.
+//
+//    This is the "not dead again" pin. prune_shares() held the only code that
+//    enforced cache_max_shared_hashes / cache_max_known_txs / cache_max_raw_shares
+//    and it had NO CALL SITE in the whole tree — definition, declaration, three
+//    comments, and nothing else. A runtime test cannot see that: the function
+//    was correct, it simply never ran. Assert the shape in the shipped source.
+// ─────────────────────────────────────────────────────────────────────────
+
+std::string read_text(const std::string& path)
+{
+    std::ifstream in(path);
+    EXPECT_TRUE(in.good()) << "cannot open " << path;
+    std::stringstream ss; ss << in.rdbuf();
+    return ss.str();
+}
+
+// Replace every comment with spaces, preserving byte offsets. The fix's own doc
+// comments deliberately name prune_shares to explain what was removed, so these
+// assertions MUST run over comment-free code.
+std::string strip_comments(const std::string& s)
+{
+    std::string out = s;
+    enum { kCode, kLine, kBlock, kStr, kChr } st = kCode;
+    for (size_t i = 0; i < out.size(); ++i) {
+        const char c = out[i];
+        const char n = (i + 1 < out.size()) ? out[i + 1] : '\0';
+        switch (st) {
+        case kCode:
+            if (c == '/' && n == '/') { st = kLine;  out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '/' && n == '*') { st = kBlock; out[i] = ' '; out[i + 1] = ' '; ++i; }
+            else if (c == '"')  st = kStr;
+            else if (c == '\'') st = kChr;
+            break;
+        case kLine:
+            if (c == '\n') st = kCode; else out[i] = ' ';
+            break;
+        case kBlock:
+            if (c == '*' && n == '/') { out[i] = ' '; out[i + 1] = ' '; ++i; st = kCode; }
+            else if (c != '\n') out[i] = ' ';
+            break;
+        case kStr:
+            if (c == '\\') ++i; else if (c == '"') st = kCode;
+            break;
+        case kChr:
+            if (c == '\\') ++i; else if (c == '\'') st = kCode;
+            break;
+        }
+    }
+    return out;
+}
+
+std::size_t count_of(const std::string& hay, const std::string& needle)
+{
+    std::size_t n = 0, pos = 0;
+    while ((pos = hay.find(needle, pos)) != std::string::npos) { ++n; pos += needle.size(); }
+    return n;
+}
+
+TEST(LtcCacheEvictionWiring, EvictionIsDefinedAndActuallyCalled)
+{
+    const std::string cpp = strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/ltc/node.cpp"));
+    const std::string hpp = strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/ltc/node.hpp"));
+
+    // Definition + at least one call site. One occurrence = dead code again.
+    EXPECT_GE(count_of(cpp, "evict_caches_io_phase("), 2u)
+        << "evict_caches_io_phase must be DEFINED and CALLED in ltc/node.cpp — "
+           "a single occurrence means the cache_max_* knobs are inert again";
+    EXPECT_EQ(count_of(hpp, "evict_caches_io_phase("), 1u);
+
+    // The never-called predecessor must be gone from the code (comments may
+    // still explain the history; those are stripped above).
+    EXPECT_EQ(count_of(cpp, "prune_shares"), 0u)
+        << "prune_shares had no call site; it must not come back";
+    EXPECT_EQ(count_of(hpp, "prune_shares"), 0u);
+}
+
+TEST(LtcCacheEvictionWiring, RawShareCacheIsErasedOnChainRemovalAndWiredInBothCtors)
+{
+    const std::string hpp = strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/ltc/node.hpp"));
+    // m_raw_share_cache had no erase path anywhere: tie it to chain membership.
+    EXPECT_EQ(count_of(hpp, "m_raw_share_cache.erase("), 1u)
+        << "the on_removed hook must erase the raw-share cache entry";
+    // Wired from BOTH constructors (the default ctor is the unit-test path).
+    EXPECT_EQ(count_of(hpp, "wire_chain_hooks()"), 3u)
+        << "wire_chain_hooks must be defined and called from both constructors";
+}
+
+TEST(LtcAncestorWalkDepth, DownloadSharesConsultsTheDepthBound)
+{
+    const std::string cpp = strip_comments(read_text(std::string(C2POOL_IMPL_DIR) + "/ltc/node.cpp"));
+    // The recursion must consult the bound, and must not recurse on a batch the
+    // ingest budget refused (that combination is the re-request treadmill).
+    EXPECT_GE(count_of(cpp, "walk_may_continue("), 1u)
+        << "the download_shares ancestor recursion must be depth-bounded";
+    EXPECT_GE(count_of(cpp, "if (!admitted)"), 1u)
+        << "download_shares must not queue the next hop for a refused batch";
+}
+
+} // namespace

--- a/src/impl/ltc/test/ingest_ownership_test.cpp
+++ b/src/impl/ltc/test/ingest_ownership_test.cpp
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// D-LTC.INGEST-OWNERSHIP — the real unbounded growth behind the LTC RSS
+// self-abort, driven against a REAL ltc::NodeImpl.
+//
+// ltc::ShareType is a std::variant of RAW POINTERS with manual lifetime
+// (sharechain/share.hpp: `new Args()` on load, freed only by an explicit
+// destroy()). The ONLY container that ever frees a share is the sharechain
+// itself. Every ingest path that deserialised a share the tracker did not adopt
+// therefore leaked it, with no erase path anywhere:
+//
+//   * the batch the pending_adds cap DROPS  ("dropping OLDEST queued batch" —
+//     the very line the production log prints just before each abort),
+//   * every duplicate skipped in phase 2 (a relayed share we already hold, or
+//     the overlap of an ancestor reply),
+//   * every share whose phase-1 verification failed,
+//   * every sharereply that arrived after its 15 s request timeout or after
+//     cancel() on disconnect — got_share_reply swallows the matcher's
+//     invalid_argument and the whole reply was dropped on the floor.
+//
+// ORACLE: ltc::orphan_share_destroy_counter(), bumped once per share object a
+// container frees because nobody adopted it. It is used rather than
+// LeakSanitizer because the ASAN CI leg runs with ASAN_OPTIONS detect_leaks=0
+// (build.yml), so LSan is blind to exactly this leak class.
+//
+// Folded into the EXISTING allowlisted `share_test` target (#769 trap).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <vector>
+
+#include <core/uint256.hpp>
+#include <impl/ltc/node.hpp>
+#include <impl/ltc/share.hpp>
+
+namespace {
+
+uint256 H(uint64_t n) { return uint256(n); }
+
+std::uint64_t destroyed() {
+    return ltc::orphan_share_destroy_counter().load(std::memory_order_relaxed);
+}
+
+// Same scaffold as broadcast_lock_discipline_test: the default ltc::NodeImpl
+// ctor takes no io_context, opens no LevelDB and starts no timers.
+struct TestNode : public ltc::NodeImpl
+{
+    TestNode() : ltc::NodeImpl()
+    {
+        m_chain = &m_tracker.chain;
+        // processing_shares_phase2 ends with run_think() when it admitted new
+        // shares, and run_think arms an asio timer on m_context — which the
+        // default ctor deliberately leaves null. The already-running flag makes
+        // run_think take its first early return, exactly as it does on a live
+        // node whose compute thread is busy.
+        m_think_running.store(true);
+    }
+
+    void handle(std::unique_ptr<RawMessage>, const NetService&) override {}
+
+    using ltc::NodeImpl::processing_shares_phase2;
+    using ltc::NodeImpl::m_pending_adds;
+    using ltc::NodeImpl::m_tracker;
+    using ltc::NodeImpl::m_raw_share_cache;
+    using ltc::NodeImpl::m_ingest_budget;
+    using ltc::NodeImpl::m_think_running;
+};
+
+ltc::MergedMiningShare* mk(const uint256& hash, const uint256& prev)
+{
+    auto* s = new ltc::MergedMiningShare(hash, prev);
+    s->m_bits = 0x1d00ffff;   // a sane compact target; phase 2 logs its difficulty
+    s->m_absheight = 1;
+    return s;
+}
+
+ltc::ShareType var(ltc::MergedMiningShare* s)
+{
+    ltc::ShareType v;
+    v = s;
+    return v;
+}
+
+ltc::HandleSharesData one_share_batch(ltc::MergedMiningShare* s)
+{
+    ltc::HandleSharesData d;
+    d.add(var(s), {});
+    return d;
+}
+
+// ── A1a: the batch the pending_adds cap drops ───────────────────────────
+//
+// THE production line. Under the cap the queue erases its oldest entry; before
+// this fix that erase freed the HandleSharesData's three vectors and left every
+// deserialised share in it unreachable. Each "dropping OLDEST queued batch" in
+// the contabo log was one whole batch of shares leaked.
+TEST(LtcIngestOwnership, DroppedOldestPendingBatchFreesItsSharesAndItsBudget)
+{
+    TestNode node;
+    const std::uint64_t before = destroyed();
+
+    // Hold the tracker exclusively on THIS thread so phase 2's try_to_lock fails
+    // and every batch takes the deferred-queue path — the wedged-think() shape.
+    std::unique_lock<std::shared_mutex> hold(node.tracker_mutex());
+    ASSERT_TRUE(hold.owns_lock());
+
+    constexpr std::size_t kBytesPerBatch = 1000;
+    for (int i = 1; i <= 257; ++i) {
+        auto d = one_share_batch(mk(H(i), H(i - 1)));
+        ASSERT_TRUE(node.m_ingest_budget.try_admit(1, kBytesPerBatch));
+        d.attach_budget(&node.m_ingest_budget, 1, kBytesPerBatch);
+        node.processing_shares_phase2(d, NetService{});
+    }
+
+    // The cap held (that part always worked) ...
+    EXPECT_EQ(node.m_pending_adds.size(), 256u);
+    // ... and the ONE batch it dropped actually released its share.
+    EXPECT_EQ(destroyed() - before, 1u)
+        << "the dropped batch must free its shares, not orphan them";
+    // ... and gave its ingest reservation back, so the refused-newest bound
+    // cannot slowly seize up as batches are dropped.
+    EXPECT_EQ(node.m_ingest_budget.shares(), 256u);
+    EXPECT_EQ(node.m_ingest_budget.bytes(), 256u * kBytesPerBatch);
+}
+
+// ── A1b: duplicate in phase 2 ───────────────────────────────────────────
+//
+// Identity here MUST be by pointer, not by hash: the batch's copy has the same
+// hash as the object the chain owns and is a different allocation. Freeing by
+// hash would free the chain's share.
+TEST(LtcIngestOwnership, DuplicateIsFreedWhileTheChainCopySurvives)
+{
+    TestNode node;
+    auto* original = mk(H(1), uint256::ZERO);
+    node.m_tracker.chain.add(original);
+    ASSERT_TRUE(node.m_tracker.chain.contains(H(1)));
+
+    const std::uint64_t before = destroyed();
+    {
+        auto d = one_share_batch(mk(H(1), uint256::ZERO));  // same hash, new heap
+        node.processing_shares_phase2(d, NetService{});
+    }
+    EXPECT_EQ(destroyed() - before, 1u)
+        << "the duplicate the phase-2 dup branch skips must be freed";
+
+    // The chain still owns the ORIGINAL allocation and it is readable.
+    ASSERT_TRUE(node.m_tracker.chain.contains(H(1)));
+    EXPECT_EQ(ltc::share_ptr_id(node.m_tracker.chain.get_share(H(1))),
+              static_cast<const void*>(original));
+    EXPECT_EQ(node.m_tracker.chain.get_share(H(1)).hash(), H(1));
+}
+
+// ── A1c: phase-1 verify failure ─────────────────────────────────────────
+TEST(LtcIngestOwnership, ShareThatFailedVerificationIsFreed)
+{
+    TestNode node;
+    const std::uint64_t before = destroyed();
+    {
+        // Null hash == "share_init_verify threw in phase 1"; phase 2 skips it.
+        auto* s = new ltc::MergedMiningShare();
+        ASSERT_TRUE(s->m_hash.IsNull());
+        auto d = one_share_batch(s);
+        node.processing_shares_phase2(d, NetService{});
+    }
+    EXPECT_EQ(destroyed() - before, 1u);
+}
+
+// ── The other half of the invariant: an ADOPTED share must NOT be freed ──
+//
+// This is what makes the fix safe rather than a double free. If the adoption
+// pass were dropped or keyed on hash instead of pointer, the batch destructor
+// would free memory the sharechain owns and later frees again.
+TEST(LtcIngestOwnership, AdoptedShareIsHandedToTheChainAndNotFreedByTheBatch)
+{
+    TestNode node;
+    auto* s = mk(H(5), uint256::ZERO);
+    const std::uint64_t before = destroyed();
+    {
+        auto d = one_share_batch(s);
+        node.processing_shares_phase2(d, NetService{});
+    }
+    EXPECT_EQ(destroyed() - before, 0u)
+        << "the batch must not free a share the sharechain adopted";
+
+    ASSERT_TRUE(node.m_tracker.chain.contains(H(5)));
+    EXPECT_EQ(ltc::share_ptr_id(node.m_tracker.chain.get_share(H(5))),
+              static_cast<const void*>(s));
+    // Still alive and intact: read through the chain's own variant.
+    EXPECT_EQ(node.m_tracker.chain.get_share(H(5)).prev_hash(), uint256::ZERO);
+}
+
+// ── A1d: sharereply that lost its request (timeout / disconnect cancel) ──
+TEST(LtcIngestOwnership, ShareReplyForAnUnknownRequestIsFreedNotLeaked)
+{
+    TestNode node;
+    const std::uint64_t before = destroyed();
+    {
+        ltc::ShareReplyData reply;
+        auto& owned = reply.owned();
+        owned.m_items.push_back(var(mk(H(7), H(6))));
+        owned.m_items.push_back(var(mk(H(8), H(7))));
+        ASSERT_EQ(reply.size(), 2u);
+
+        // The matcher throws std::invalid_argument for an id it no longer holds
+        // (timed out after 15 s, or cancel()led when the peer disconnected).
+        // got_share_reply swallows it — which used to discard the payload.
+        node.got_share_reply(H(4242), reply);
+    }
+    EXPECT_EQ(destroyed() - before, 2u)
+        << "a reply whose request already died must free its shares";
+}
+
+// ── The raw-share cache had no erase path at all ────────────────────────
+TEST(LtcIngestOwnership, RawShareCacheEntryIsDroppedWhenTheChainDropsTheShare)
+{
+    TestNode node;
+    node.m_tracker.chain.add(mk(H(3), uint256::ZERO));
+    ASSERT_TRUE(node.m_tracker.chain.contains(H(3)));
+
+    chain::RawShare raw;
+    raw.type = 36;
+    node.m_raw_share_cache[H(3)] = raw;
+    ASSERT_EQ(node.m_raw_share_cache.count(H(3)), 1u);
+
+    ASSERT_TRUE(node.m_tracker.chain.remove(H(3)));
+    EXPECT_EQ(node.m_raw_share_cache.count(H(3)), 0u)
+        << "m_raw_share_cache retained the wire bytes of every share ever seen, "
+           "including pruned challenger/fork shares";
+}
+
+// ── Regression invariant, stated once ───────────────────────────────────
+// After any sequence of drops / duplicates / verify failures, the shares that
+// are still alive are exactly the ones the chain owns, and the ingest budget
+// returns to zero.
+TEST(LtcIngestOwnership, MixedBatchLeavesOnlyChainMembersAliveAndBudgetAtZero)
+{
+    TestNode node;
+    node.m_tracker.chain.add(mk(H(10), uint256::ZERO));   // pre-existing
+
+    const std::uint64_t before = destroyed();
+    {
+        ltc::HandleSharesData d;
+        d.add(var(mk(H(10), uint256::ZERO)), {});         // duplicate  -> freed
+        d.add(var(new ltc::MergedMiningShare()), {});     // bad verify -> freed
+        d.add(var(mk(H(11), H(10))), {});                 // new        -> adopted
+        ASSERT_TRUE(node.m_ingest_budget.try_admit(3, 300));
+        d.attach_budget(&node.m_ingest_budget, 3, 300);
+        node.processing_shares_phase2(d, NetService{});
+    }
+    EXPECT_EQ(destroyed() - before, 2u);
+    EXPECT_EQ(node.m_tracker.chain.size(), 2u);
+    EXPECT_TRUE(node.m_tracker.chain.contains(H(11)));
+    EXPECT_EQ(node.m_ingest_budget.shares(), 0u);
+    EXPECT_EQ(node.m_ingest_budget.bytes(), 0u);
+}
+
+} // namespace


### PR DESCRIPTION
Produced by a design → implement → adversarial-review chain. **Draft: one review item is unaddressed (below) and two constants want a live measurement before they are trusted.**

## The defect, read from production

The LTC pool node on contabo self-aborts: `RSS LIMIT EXCEEDED === RSS: 4047 MB (limit: 4000 MB) === ABORTING (clean exit before OOM killer)`. It is a deliberate self-abort on `rss_limit_mb`, not a segfault and not an OOM kill. Aborts came at irregular intervals plus one burst of **eight in 75 seconds**. The limit was raised 4000 → 5000 as a stopgap; that masks the symptom.

**Not the cause:** #1562 fixed a use-after-free on the download-stop path. The claim that it cured these crashes was made and retracted after the abort reason was read.

## What this branch does

Bounds the inbound-share path: an admission budget (shares and bytes) taken before any work is posted; ownership of the `sharereply` payload made explicit so unadopted shares are freed rather than leaked; the raw-share cache wired to the chain's `on_removed` hook; the ancestor walk given an explicit depth predicate; and the per-peer remembered-tx byte cap restored to p2pool's behaviour.

## Review outcome

**APPROVE_WITH_FIXES. No blocking issues.** Reward safety traced rather than asserted: phase-2 acceptance logic is unchanged, the post-add release is a pointer-identity check against the object the tracker actually stored, a refused batch never touched the tracker or the chain, and the depth cap equals the pruning-zone rule the node already applies — so nothing beyond it could have entered a payout.

**Tests bite, shown by mutation:** reverting the ownership fix fails 5 cases; removing the adoption release produces a **double free** that aborts the suite; removing the cache-erase hook fails 2; removing the budget release fails 2. Unmutated: 165/165. Folded into the existing allowlisted `share_test` target — no new executable, so the "new target silently never builds" trap does not apply.

## What is NOT done

1. **The admission refusal defeats the existing drop-OLDEST policy.** Under the wedged shape this was written for, the budget is consumed by a few large deferred batches, so `m_pending_adds` never reaches its cap and the drop-oldest branch becomes unreachable — after which the *newest*, tip-extending batches are refused while stale ones sit queued. Not a reward change, but a convergence regression against the fix that preceded it. This wants the suggested LTC-lane remedy before merge.
2. **Two constants want a live measurement.** Whether 8192 shares / 128 MiB inflight fits under the live limit was not measured. The branch adds `ingest=` and `rawcache=` to the heartbeat next to `rss=` precisely so this can be read on the running node first.
3. **Still unbounded, reported not fixed:** a core-lane defect in `sharechain/share.hpp` (a throw during unserialize loses the pointer — every malformed share leaks), and `m_rejected_share_hashes`, an insert-only set with no erase path.
4. `main_ltc.cpp` still carries `rss_limit_mb = 4000`; the 5000 stopgap lives only in the deployed config.

No self-merge. Review and merge belong to the designated merger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UmtVGYzu1iRk1taczpz1gB