### PR TITLE
ci(web-static): checkout-provenance debug + hard lockfile assert

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1075,6 +1075,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Debug — checkout provenance (evidence only, never masks)
+        working-directory: ${{ github.workspace }}
+        continue-on-error: true
+        run: |
+          echo "HEAD:            $(git rev-parse HEAD || true)"
+          git log -1 --oneline || true
+          echo "merge parents (P1=base P2=PR head): $(git log -1 --format=%P || true)"
+          echo "-- ls web-static/sharechain-explorer/ --"
+          ls -la web-static/sharechain-explorer/ || true
+
+      - name: Assert lockfile present (fail clearly on broken checkout)
+        working-directory: ${{ github.workspace }}
+        run: |
+          f=web-static/sharechain-explorer/package-lock.json
+          if [ ! -f "$f" ]; then
+            echo "::error title=Checkout integrity::${f} is committed but ABSENT on disk — broken checkout / wrong merge-ref, not a code defect. See the Debug step above for HEAD and merge parents." >&2
+            exit 1
+          fi
+          echo "lockfile present: $f"
+
       - uses: actions/setup-node@v5
         with:
           # Node 22 — node --test supports glob expansion natively


### PR DESCRIPTION
The web-static job has been aborting in ~20s with an opaque setup-node cache error and zero evidence of *why* the lockfile is unreadable. Direct heavy-2 probes (integrator) showed the workspace clean and `web-static/sharechain-explorer/package-lock.json` present on disk — so a workspace/sparse reset is NOT the fix. Per our standing rule, the test is the fix: make the next occurrence produce evidence.

Adds, immediately after checkout@v6 and before setup-node@v5:
- **Debug step** (`continue-on-error`, `|| true` — never masks the real failure): prints `git rev-parse HEAD`, `git log -1 --oneline`, the merge parents (`%P`; P1=base, P2=PR head), and `ls -la web-static/sharechain-explorer/`.
- **Hard lockfile assertion**: fails *before* setup-node with a clearly-worded `::error` if the committed `package-lock.json` is absent, so a broken checkout surfaces as a checkout-integrity failure instead of an opaque npm cache miss.

**Deliberate decision on `cache-dependency-path`:** an absent lockfile is a HARD, clearly-worded failure — NOT tolerated. The file is committed; its absence means a broken checkout, and tolerating it would mask the exact defect we are hunting.

Note: the merge-parents print directly tests the wrong-merge-ref anomaly integrator observed (a #1571 job checkout logging a merge whose PR-head parent was #1577). If that recurs, this turns it into a labelled parent SHA. Signed; no self-merge.