### PR TITLE
ci(web-static): pin verify checkout to head.sha + fail-closed SHA assert

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1073,7 +1073,27 @@ jobs:
       run:
         working-directory: web-static/sharechain-explorer
     steps:
+      # Pin to the PR head commit (push-event fallback to github.sha).
+      # The default checkout resolves refs/pull/N/merge asynchronously, so it
+      # can materialize a merge tree neither this PR nor master ever had — the
+      # wrong-tree race behind #1571s 20s web-static aborts. Pinning to
+      # head.sha removes the race: we always build the exact PR head.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      # For an observability defect the check IS the fix: fail closed if the
+      # checked-out HEAD is ever not the head we asked for.
+      - name: Assert checkout matches expected head SHA (fail closed)
+        working-directory: ${{ github.workspace }}
+        run: |
+          expected='${{ github.event.pull_request.head.sha || github.sha }}'
+          actual="$(git rev-parse HEAD)"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error title=Checkout integrity::checked-out HEAD ${actual} != expected head ${expected} — broken/stale merge-ref, not a code defect." >&2
+            exit 1
+          fi
+          echo "checkout verified: HEAD=${actual} matches expected head"
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Root-cause fix for the web-static merge-ref wrong-tree race (integrator NOD 2026-09-11).

## What
1. Pin the web-static verify checkout to `${{ github.event.pull_request.head.sha || github.sha }}` (push-event fallback). The default checkout resolves `refs/pull/N/merge` asynchronously and can materialize a merge tree neither the PR nor master ever had — the wrong-tree class behind #1571's 20s web-static aborts (it built #1577's merge). Pinning to head.sha removes the race: CI builds the exact PR head.
2. Fold in the regression assertion (auto-merge is off, so it ships here, not a follow-up). For an observability defect the check is the fix: assert checked-out HEAD == expected head SHA, fail closed on mismatch.

## What NOT changed
- No concurrency-group: it only reduces collision frequency and leaves the wrong-tree bug alive while serializing an already-saturated fleet (CI-flood rule). Ref-pin is the root-cause fix.
- fetch-depth left as-is: the empty `%P` in #1587's debug was a shallow-clone artifact, not a foreign checkout — not a defect to fix.

GPG-signed. No attribution footer (attribution-gate).