### PR TITLE
xmr(native): M3 — daemonless FIND (native levin tip, switchable arm-order) [DO NOT MERGE]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,7 @@ jobs:
                     xmr_native_backlog_famine_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
+                    v37_xmr_m3_arm_order_kat \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -689,6 +690,7 @@ jobs:
                     xmr_native_backlog_famine_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
+                    v37_xmr_m3_arm_order_kat \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison

--- a/src/c2pool/v37/main_v37_xmr.cpp
+++ b/src/c2pool/v37/main_v37_xmr.cpp
@@ -86,6 +86,8 @@
 #include "xmr/xmr_o2_settlement_provider.hpp" // O-2 option B: v37 K_fair settlement template provider + source
 #include "xmr/xmr_settlement_coinbase_shape.hpp"  // M2: the K_fair shape gate, read off the assembled block bytes
 #include "xmr/xmr_native_template_backend.hpp"    // M2: the native-minimal Monero node as the miner-data source
+#include "xmr/xmr_native_chain_source.hpp"        // M3: the native levin chain as the tip + canonical test
+#include "xmr/xmr_p2p_block_publisher.hpp"        // M3: found block -> levin 2008 (no submit_block)
 
 using namespace c2pool::v37n::xmr;
 namespace strat = ::v37::xmr::stratum;
@@ -172,8 +174,13 @@ static int run_mock_smoke() {
 template <class Provider, class Snapshot>
 class GatedShareSinkT final : public strat::IShareSink {
 public:
+    // `inner` is the PUBLISHER: sub::LiveSubmitShareSink (monerod submit_block)
+    // under --arm-order daemon-first, o2::P2pBlockPublisher (a levin 2008)
+    // under p2p-first. Taken as the INTERFACE rather than the concrete type so
+    // that the exact 128-bit gate in front of it is the same code on both arm
+    // orders -- the one property that must not fork when the publish path does.
     GatedShareSinkT(o2::O2RandomXVerifier& rx, const Provider& provider,
-                    strat::ITemplateSource& source, sub::LiveSubmitShareSink& inner)
+                    strat::ITemplateSource& source, strat::IShareSink& inner)
         : m_rx(rx), m_provider(provider), m_source(source), m_inner(inner) {}
 
     void on_accepted_share(const strat::AcceptedShare& s) override { m_inner.on_accepted_share(s); }
@@ -230,7 +237,7 @@ private:
     o2::O2RandomXVerifier&              m_rx;
     const Provider&                     m_provider;
     strat::ITemplateSource&             m_source;
-    sub::LiveSubmitShareSink&           m_inner;
+    strat::IShareSink&                  m_inner;
     std::atomic<std::uint64_t> m_calls{0}, m_accepted{0}, m_rejected{0}, m_refused{0}, m_stale{0};
     mutable std::mutex m_mtx;
     std::string        m_last;
@@ -260,6 +267,23 @@ struct ServeHooks {
     std::function<void(bool /*refreshed*/, bool /*new_template*/)> after_refresh;
     // Called from the status cadence, after the standard status line.
     std::function<void()> status_extra;
+
+    // M3: THE TIP DRIVER, as one call per loop pass.
+    //
+    // Unset (daemon-first, the default) means the built-in one: pump the
+    // transport's get_miner_data poll and top up the RandomX seed reach, both
+    // of which are monerod round trips. Set (p2p-first) means the caller drives
+    // the tip from the native node's own levin chain instead, and NOTHING in
+    // this loop may touch the daemon -- which is the whole claim, so the built-
+    // in pump is REPLACED here rather than merely skipped at its call site.
+    std::function<void()> pump_tip;
+
+    // M3: the found-block publish arm, when it is not the monerod submitter.
+    // Non-null routes the RandomX-gated winner to C5's levin 2008 relay; null
+    // keeps submit_block. serve_and_run builds the sink over this rather than
+    // taking a built one, because the FOUND queue the sink pushes into is
+    // loop-local -- one queue, one drain, whichever arm filled it.
+    ::c2pool::xmr::native::relay::LevinBlockRelay* p2p_relay = nullptr;
 };
 
 // ---------------------------------------------------------------------------
@@ -285,9 +309,25 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
 
     sub::LiveBlockSubmitter submitter(transport);   // fresh socket per RPC: safe off-thread
     sub::FoundBlockQueue    submit_q;
-    sub::LiveSubmitShareSink live_sink(submitter, submit_q, std::move(candidate_lookup));
-    submitter.enable_network_submit(rx.network_blocks_allowed());   // fail-closed gate
-    GatedShareSinkT<Provider, Snapshot> sink(rx, provider, template_source, live_sink);
+    sub::LiveSubmitShareSink live_sink(submitter, submit_q, candidate_lookup);
+
+    // M3: WHICH arm publishes a found block. The daemon submitter is ARMED only
+    // when it is that arm -- in p2p-first it is constructed (the object is
+    // cheap and opens no socket) and left disabled, so even a mis-wired gate
+    // cannot reach submit_block. Both arms push into the SAME loop-local FOUND
+    // queue, so wire 4 downstream of here is identical on either order.
+    const bool p2p_publish = (hooks.p2p_relay != nullptr);
+    std::unique_ptr<o2::P2pBlockPublisher> publisher;
+    if (p2p_publish) {
+        publisher = std::make_unique<o2::P2pBlockPublisher>(*hooks.p2p_relay, submit_q,
+                                                            candidate_lookup);
+        publisher->enable_network_relay(rx.network_blocks_allowed());   // fail-closed gate
+    }
+    submitter.enable_network_submit(!p2p_publish && rx.network_blocks_allowed());
+    strat::IShareSink& publish_sink =
+        p2p_publish ? static_cast<strat::IShareSink&>(*publisher)
+                    : static_cast<strat::IShareSink&>(live_sink);
+    GatedShareSinkT<Provider, Snapshot> sink(rx, provider, template_source, publish_sink);
 
     o2::StratumListenerOptions lo;
     lo.bind_host = cfg.stratum_bind_host;
@@ -326,10 +366,14 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
                         provider.last_error().c_str(), to_string(cfg.coinbase));
         }
         listener.start();
-        std::printf("stratum: listening on %s:%u (%s coinbase, share diff %s, network submit %s)\n",
+        std::printf("stratum: listening on %s:%u (%s coinbase, share diff %s, publish arm %s, "
+                    "network submit %s)\n",
                     cfg.stratum_bind_host.c_str(), listener.bound_port(), to_string(cfg.coinbase),
                     cfg.stratum_share_diff ? std::to_string(cfg.stratum_share_diff).c_str() : "network",
-                    submitter.network_submit_enabled() ? "ENABLED" : "DISABLED (fail-closed)");
+                    p2p_publish ? "LEVIN 2008 (p2p-first, no submit_block)"
+                                : "monerod submit_block (daemon-first)",
+                    (p2p_publish || submitter.network_submit_enabled())
+                        ? "ENABLED" : "DISABLED (fail-closed)");
     } else {
         std::printf("stratum: NOT served (%s) — observe-side only\n", not_served_reason);
     }
@@ -337,8 +381,14 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
     std::signal(SIGINT, on_sigint);
     std::signal(SIGTERM, on_sigint);
     const std::uint32_t poll_ms = cfg.poll_ms ? cfg.poll_ms : 5000;
-    std::printf("node up. Ctrl-C to stop. (ZMQ push drives the tip; RPC poll fallback every %u ms)\n",
-                poll_ms);
+    if (hooks.pump_tip)
+        std::printf("node up. Ctrl-C to stop. (arm-order %s: the NATIVE levin chain drives the "
+                    "tip; no monerod poll, every %u ms)\n",
+                    to_string(cfg.arm_order), poll_ms);
+    else
+        std::printf("node up. Ctrl-C to stop. (arm-order %s: ZMQ push drives the tip; RPC poll "
+                    "fallback every %u ms)\n",
+                    to_string(cfg.arm_order), poll_ms);
 
     auto bridge_found = [&]() {
         sub::FoundBlockEvent s;
@@ -374,7 +424,7 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
                     "orphaned=%llu refused=%llu pending=%zu\n",
                     static_cast<unsigned long long>(node.hw().hw_height),
                     static_cast<unsigned long long>(node.finalize_driver().cursor_height()),
-                    static_cast<unsigned long long>(node.adapter().index().best_height()),
+                    static_cast<unsigned long long>(node.best_height()),
                     t.template_id, static_cast<unsigned long long>(t.height),
                     static_cast<unsigned long long>(t.difficulty),
                     static_cast<unsigned long long>(provider.refreshes()),
@@ -404,8 +454,21 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
         std::printf("  %s\n", rx.describe().c_str());
         const std::string g = sink.last();
         if (!g.empty()) std::printf("  gate: last=%s\n", g.c_str());
-        const std::string se = submitter.last_error();
-        if (!se.empty()) std::printf("  submit: last_error=%s\n", se.c_str());
+        if (p2p_publish) {
+            std::printf("  p2p publish: calls=%llu relayed=%llu peers_written=%llu refused=%llu "
+                        "reached_nobody=%llu stale=%llu\n",
+                        static_cast<unsigned long long>(publisher->calls()),
+                        static_cast<unsigned long long>(publisher->relayed()),
+                        static_cast<unsigned long long>(publisher->peers()),
+                        static_cast<unsigned long long>(publisher->refused()),
+                        static_cast<unsigned long long>(publisher->failed()),
+                        static_cast<unsigned long long>(publisher->stale()));
+            const std::string pe = publisher->last_error();
+            if (!pe.empty()) std::printf("  p2p publish: last=%s\n", pe.c_str());
+        } else {
+            const std::string se = submitter.last_error();
+            if (!se.empty()) std::printf("  submit: last_error=%s\n", se.c_str());
+        }
         std::fflush(stdout);
     };
 
@@ -414,8 +477,15 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
     while (!g_stop.load()) {
         bridge_found();
         fc.tick();
-        transport.pump_poll();
-        node.adapter().ensure_seed_reach();
+        // M3: THE cut. daemon-first keeps the monerod poll + seed backfill;
+        // p2p-first replaces both with the native chain's own event drain, and
+        // this is the only place either of them is driven -- so "no daemon call
+        // on the find path" is a property of one branch, not of good behaviour.
+        if (hooks.pump_tip) hooks.pump_tip();
+        else {
+            transport.pump_poll();
+            node.adapter().ensure_seed_reach();
+        }
         if (serving) {
             const bool refreshed = provider.refresh();
             bool new_template = false;
@@ -466,17 +536,121 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
     return 0;
 }
 
+// ---------------------------------------------------------------------------
+// M3: build and start the embedded native node.
+//
+// Hoisted out of the option-B branch because the ORDER changed. Under
+// --arm-order p2p-first this node is the tip driver, and XmrNode::bring_up()
+// binds the finalize driver's canonical test at construction -- so the native
+// chain has to exist BEFORE bring_up, not after it. Under daemon-first the
+// order is immaterial and this is the same code M2h ran.
+//
+// Returns null on refusal, with the reason already printed.
+// ---------------------------------------------------------------------------
+static std::unique_ptr<o2::NativeTemplateBackend> start_native_backend(const XmrNodeConfig& cfg) {
+    if (cfg.native_connect.empty()) {
+        std::printf("REFUSED: the native Monero node needs at least one --native-connect "
+                    "<ip:port> levin peer (it dials only what it is told to)\n");
+        return nullptr;
+    }
+    const bool p2p_first = (cfg.arm_order == ArmOrderMode::P2PFirst);
+
+    o2::NativeTemplateConfig ncfg;
+    ncfg.net                  = native_net_of(cfg.network);
+    ncfg.connect              = cfg.native_connect;
+    ncfg.p2p_bind_ip          = cfg.native_p2p_bind_ip;
+    ncfg.boot                 = cfg.native_anchor_path.empty()
+                                    ? ::c2pool::xmr::native::rt::BootMode::Genesis
+                                    : ::c2pool::xmr::native::rt::BootMode::Anchor;
+    ncfg.anchor_path          = cfg.native_anchor_path;
+    // The daemon endpoint is the C6 PARITY judge, and under daemon-first also
+    // the submit arm. Under p2p-first it is the parity judge and nothing else:
+    // the oracle reads it off the status cadence, which is not the find path.
+    // --no-daemon-rpc withholds it entirely, and then the node has no daemon
+    // arm to make a call with -- the strongest form of the claim, at the cost
+    // of the parity judge.
+    if (!cfg.no_daemon_rpc) {
+        ncfg.monerod_rpc_host = cfg.monerod.rpc_host;
+        ncfg.monerod_rpc_port = cfg.monerod.rpc_port;
+    }
+    ncfg.serve                = ::c2pool::xmr::native::TemplateArm::Native;
+    ncfg.relay_order          = p2p_first ? ::c2pool::xmr::native::ArmOrder::P2pOnly
+                                          : ::c2pool::xmr::native::ArmOrder::DaemonFirst;
+    // p2p-first pins the fallback OFF whatever the flag said: a daemonless find
+    // whose template silently came from the daemon is not a daemonless find,
+    // and the operator should not be able to weaken the claim by accident.
+    ncfg.fallback             = p2p_first ? false : cfg.native_template_fallback;
+    ncfg.force_synced         = cfg.native_force_synced;
+    ncfg.allow_unverified_pow = cfg.native_allow_unverified_pow;
+    ncfg.parity               = true;
+    ncfg.parity_ledger_path   = cfg.resolved_settle_db_path() + "/xmr_parity_ledger.json";
+    ncfg.c2pool_commit        = C2POOL_VERSION;
+    ncfg.ready_timeout_s      = cfg.native_ready_timeout_s;
+    ncfg.backlog_refresh_s    = cfg.native_backlog_refresh_s;
+
+    std::printf("template source: NATIVE — the embedded Monero node (levin, %zu pinned peer(s)) "
+                "feeds the option-B assembler%s\n",
+                cfg.native_connect.size(),
+                p2p_first ? "; it is ALSO the tip, the canonical test and the block relay "
+                            "(--arm-order p2p-first): monerod is not on the find path"
+                          : "; monerod stays the parity judge and the submit arm, and is NOT "
+                            "on the template path");
+
+    auto native = std::make_unique<o2::NativeTemplateBackend>(std::move(ncfg));
+    std::string why;
+    if (!native->start_and_wait(why, [](const std::string& w) {
+            std::printf("  native: not ready yet — %s\n", w.c_str());
+            std::fflush(stdout);
+        })) {
+        std::printf("REFUSED: %s\n", why.c_str());
+        return nullptr;
+    }
+    std::printf("  native: template arm READY, fallback %s\n",
+                native->config().fallback
+                    ? "ON (the daemon arm may serve if the native one loses a window)"
+                    : "OFF (native-only: no template is served if the native arm is not ready)");
+    return native;
+}
+
 static int run_live(const XmrNodeConfig& cfg) {
-    std::printf("c2pool-v37-xmr: EXPERIMENTAL prototype — network=%s monerod=%s:%u (zmq %u)\n",
+    std::printf("c2pool-v37-xmr: EXPERIMENTAL prototype — network=%s monerod=%s:%u (zmq %u) "
+                "arm-order=%s\n",
                 to_string(cfg.network), cfg.monerod.rpc_host.c_str(),
-                cfg.monerod.rpc_port, cfg.monerod.zmq_port);
+                cfg.monerod.rpc_port, cfg.monerod.zmq_port, to_string(cfg.arm_order));
     if (cfg.network == MoneroNetwork::Mainnet && !cfg.i_understand_mainnet) {
         std::printf("REFUSED: mainnet requires --i-understand-mainnet (prototype safety)\n");
         return 2;
     }
 
+    // ── M3: p2p-first is fail-closed on its own preconditions ───────────────
+    // The rules live in the config header as a pure function, so the thing the
+    // daemon refuses on and the thing the KAT pins are the same code.
+    const bool p2p_first = (cfg.arm_order == ArmOrderMode::P2PFirst);
+    if (const std::string refusal = arm_order_refusal(cfg); !refusal.empty()) {
+        std::printf("REFUSED: %s\n", refusal.c_str());
+        return 2;
+    }
+
+    // The native node comes up FIRST in p2p-first: it is the chain XmrNode's
+    // finalize driver will be bound to, and that binding happens in bring_up().
+    std::unique_ptr<o2::NativeTemplateBackend> native;
+    if (cfg.coinbase == CoinbaseMode::V37Settlement &&
+        cfg.template_source == TemplateSourceMode::Native) {
+        native = start_native_backend(cfg);
+        if (!native) return 2;
+    }
+
     LiveMonerodTransport transport(cfg.monerod);
     XmrNode node(cfg, transport);
+    o2::NativeChainSource chain_src;
+    if (p2p_first) {
+        chain_src = o2::native_chain_source(*native);
+        if (!chain_src) {
+            std::printf("REFUSED: the native node exposed no chain source (internal wiring bug)\n");
+            return 2;
+        }
+        node.set_native_chain_presence(chain_src.is_canonical);
+    }
     try {
         node.bring_up();
     } catch (const std::exception& e) {
@@ -585,57 +759,11 @@ static int run_live(const XmrNodeConfig& cfg) {
         // Nothing below this block knows the difference. The assembler, the X6
         // settlement source, the reward/payee fixpoint, the exact-sum residual
         // sink and the owed_digest in tx_extra 0x03 are the same code either
-        // way; only the seam the numbers arrive through moves.
-        std::unique_ptr<o2::NativeTemplateBackend> native;
-        if (cfg.template_source == TemplateSourceMode::Native) {
-            if (cfg.native_connect.empty()) {
-                std::printf("REFUSED: --xmr-template-source native needs at least one "
-                            "--native-connect <ip:port> levin peer (the embedded node dials "
-                            "only what it is told to)\n");
-                node.stop();
-                return 2;
-            }
-            o2::NativeTemplateConfig ncfg;
-            ncfg.net                  = native_net_of(cfg.network);
-            ncfg.connect              = cfg.native_connect;
-            ncfg.p2p_bind_ip          = cfg.native_p2p_bind_ip;
-            ncfg.boot                 = cfg.native_anchor_path.empty()
-                                            ? ::c2pool::xmr::native::rt::BootMode::Genesis
-                                            : ::c2pool::xmr::native::rt::BootMode::Anchor;
-            ncfg.anchor_path          = cfg.native_anchor_path;
-            ncfg.monerod_rpc_host     = cfg.monerod.rpc_host;   // parity judge + submit arm ONLY
-            ncfg.monerod_rpc_port     = cfg.monerod.rpc_port;
-            ncfg.serve                = ::c2pool::xmr::native::TemplateArm::Native;
-            ncfg.fallback             = cfg.native_template_fallback;
-            ncfg.force_synced         = cfg.native_force_synced;
-            ncfg.allow_unverified_pow = cfg.native_allow_unverified_pow;
-            ncfg.parity               = true;
-            ncfg.parity_ledger_path   = cfg.resolved_settle_db_path() + "/xmr_parity_ledger.json";
-            ncfg.c2pool_commit        = C2POOL_VERSION;
-            ncfg.ready_timeout_s      = cfg.native_ready_timeout_s;
-            ncfg.backlog_refresh_s    = cfg.native_backlog_refresh_s;
-
-            std::printf("template source: NATIVE — the embedded Monero node (levin, %zu pinned "
-                        "peer(s)) feeds the option-B assembler; monerod stays the parity judge "
-                        "and the submit arm, and is NOT on the template path\n",
-                        cfg.native_connect.size());
-            native = std::make_unique<o2::NativeTemplateBackend>(std::move(ncfg));
-            std::string nwhy;
-            if (!native->start_and_wait(nwhy, [](const std::string& w) {
-                    std::printf("  native: not ready yet — %s\n", w.c_str());
-                    std::fflush(stdout);
-                })) {
-                std::printf("REFUSED: %s\n", nwhy.c_str());
-                node.stop();
-                return 2;
-            }
-            std::printf("  native: template arm READY, fallback %s\n",
-                        cfg.native_template_fallback
-                            ? "ON (the daemon arm may serve if the native one loses a window)"
-                            : "OFF (native-only: no template is served if the native arm is not ready)");
-        } else {
+        // way; only the seam the numbers arrive through moves. `native` was
+        // started above run_live's bring_up (M3: in p2p-first it IS the chain
+        // the finalize driver is bound to, so it cannot be started down here).
+        if (!native)
             std::printf("template source: MONEROD — one get_miner_data per template refresh\n");
-        }
 
         std::unique_ptr<o2::XmrSettlementTemplateProvider> provider_owner =
             native ? std::make_unique<o2::XmrSettlementTemplateProvider>(
@@ -686,8 +814,42 @@ static int run_live(const XmrNodeConfig& cfg) {
             return provider.candidate_by_id(tid, en, out, &w);
         };
 
-        // ── the M2 evidence, off the serve path ─────────────────────────────
+        // ── M3: the daemonless FIND path, assembled ─────────────────────────
+        //
+        // Three things move together or none of them counts: the TIP the
+        // template is built on, the CANONICAL TEST settlement matures against
+        // (installed above, before bring_up), and the ARM a found block leaves
+        // on. All three are the native node's here, and the RPC counters below
+        // are printed next to the claim so it stays falsifiable.
+        // Tip-feed bookkeeping, main-thread-owned: what the native chain told
+        // us, and what we did with it.
+        std::uint64_t tip_extends = 0, tip_reorgs = 0, tip_orphans = 0, tip_best = 0;
+
         ServeHooks hooks;
+        if (p2p_first) {
+            if (!native->node()->block_relay()) {
+                std::printf("REFUSED: the native node built no block relay (internal wiring bug)\n");
+                node.stop();
+                return 2;
+            }
+            hooks.p2p_relay = native->node()->block_relay();
+
+            // THE TIP, from the chain we verified ourselves. Drained here, on
+            // the main thread, at exactly the point in the loop where
+            // pump_poll() used to issue get_miner_data -- one substitution, in
+            // one place, so the RPC that is gone is gone by construction.
+            hooks.pump_tip = [&]() {
+                for (const auto& ev : chain_src.drain()) {
+                    using K = node::MainchainEventKind;
+                    if (ev.kind == K::Orphan) ++tip_orphans;
+                    else {
+                        if (ev.kind == K::Reorg) ++tip_reorgs; else ++tip_extends;
+                        if (ev.block.height > tip_best) tip_best = ev.block.height;
+                    }
+                    node.pump_mainchain_event(ev);
+                }
+            };
+        }
         hooks.after_refresh = [&](bool refreshed, bool new_template) {
             if (!native || !refreshed || !new_template) return;
             auto* orc = native->oracle();
@@ -751,6 +913,39 @@ static int run_live(const XmrNodeConfig& cfg) {
                         node_rpc, poll_rpc, other_rpc,
                         static_cast<unsigned long long>(ns.rpc_failures),
                         static_cast<unsigned long long>(transport.rpc_failures()));
+
+            // ── M3: THE HEADLINE, AND ITS DEFINITION ────────────────────────
+            //
+            // rpc_on_find_path is every monerod round trip made by anything
+            // that decides WHAT WE MINE or WHERE IT GOES: the template's own
+            // daemon resolves, and everything the pool's consumer transport put
+            // on the socket (which is the tip poll, the seed backfill and
+            // submit_block -- all three of them find-path by construction).
+            //
+            // What is deliberately OUTSIDE it: the C6 parity judge, which is
+            // driven from this status cadence and never from a template
+            // refresh or a submit. Printing them together would let a
+            // parity-enabled run look like a failed claim; printing only the
+            // headline would let an auditor's packet capture look like a lie.
+            // So both are printed, and they sum to the wire.
+            const unsigned long long find_rpc =
+                static_cast<unsigned long long>(native->source().daemon_pumps()) +
+                static_cast<unsigned long long>(transport.rpc_calls());
+            std::printf("  arm-order=%s rpc_on_find_path=%llu "
+                        "(template %llu + pool-transport %llu) | off-path parity=%llu\n",
+                        to_string(cfg.arm_order), find_rpc,
+                        static_cast<unsigned long long>(native->source().daemon_pumps()),
+                        static_cast<unsigned long long>(transport.rpc_calls()), node_rpc);
+            if (p2p_first)
+                std::printf("  native tip feed: events=%llu (extend=%llu reorg=%llu orphan=%llu) "
+                            "best=%llu | node.best_height=%llu\n",
+                            static_cast<unsigned long long>(
+                                chain_src.events_seen ? chain_src.events_seen() : 0),
+                            static_cast<unsigned long long>(tip_extends),
+                            static_cast<unsigned long long>(tip_reorgs),
+                            static_cast<unsigned long long>(tip_orphans),
+                            static_cast<unsigned long long>(tip_best),
+                            static_cast<unsigned long long>(node.best_height()));
             if (auto* mon = native->node()->monerod_source())
                 std::printf("  daemon arm: cache age=%llums (limit %llums)%s\n",
                             static_cast<unsigned long long>(mon->age_ms()),
@@ -862,6 +1057,13 @@ int main(int argc, char** argv) {
                      static_cast<std::uint64_t>(std::stoull(next("0")));
         else if (a == "--native-ready-timeout") cfg.native_ready_timeout_s =
                      static_cast<std::uint32_t>(std::stoul(next("120")));
+        // M3 (R-ARMORDER, switchable): daemon-first stays the default.
+        else if (a == "--arm-order") {
+            const std::string m = next("daemon-first");
+            cfg.arm_order = (m == "p2p-first" || m == "p2p" || m == "daemonless")
+                                ? ArmOrderMode::P2PFirst : ArmOrderMode::DaemonFirst;
+        }
+        else if (a == "--no-daemon-rpc") cfg.no_daemon_rpc = true;
         else if (a == "--lane-chain") cfg.lane_chain =
                      static_cast<::v37::ChainId>(std::stoul(next("0")));
         else if (a == "--d-conf") cfg.d_conf = std::stoull(next("60"));
@@ -919,7 +1121,25 @@ int main(int argc, char** argv) {
                 "  --native-backlog-refresh <s> rebuild the template when the POOL moves, at most\n"
                 "                               once per <s> seconds (0 = tip-only, the default:\n"
                 "                               a tip-only arm serves the empty template built at\n"
-                "                               the start of each block interval)\n");
+                "                               the start of each block interval)\n"
+                " M3 — WHICH ARM DRIVES THE FIND PATH (R-ARMORDER, switchable):\n"
+                "  --arm-order <daemon-first|p2p-first>\n"
+                "                               daemon-first (DEFAULT): monerod drives the tip\n"
+                "                               (get_miner_data poll / ZMQ), answers the finalize\n"
+                "                               driver's canonical test, and publishes a found block\n"
+                "                               with submit_block. The bring-up posture.\n"
+                "                               p2p-first: the embedded native node drives all three.\n"
+                "                               Its levin, RandomX-verified chain IS the tip and the\n"
+                "                               canonical test, and a found block goes out as a levin\n"
+                "                               2008 NOTIFY_NEW_FLUFFY_BLOCK. NO monerod call is made\n"
+                "                               on the find path. Requires --coinbase v37 and\n"
+                "                               --xmr-template-source native, and pins the template\n"
+                "                               fallback OFF (a daemonless find cannot have a daemon\n"
+                "                               fallback on it and still be one).\n"
+                "  --no-daemon-rpc              give the embedded node NO monerod RPC endpoint at\n"
+                "                               all. With p2p-first this makes the claim a packet\n"
+                "                               capture can settle in one line, at the cost of the\n"
+                "                               C6 parity judge (its samples become VOID).\n");
             return 0;
         }
     }

--- a/src/c2pool/v37/test/CMakeLists.txt
+++ b/src/c2pool/v37/test/CMakeLists.txt
@@ -371,6 +371,39 @@ if (BUILD_TESTING)
     target_link_libraries(v37_xmr_m2_native_settlement_kat PRIVATE xmr_template xmr_node xmr_coin)
     add_test(NAME v37_xmr_m2_native_settlement_kat COMMAND v37_xmr_m2_native_settlement_kat)
 
+    # ------------------------------------------------------------------
+    # M3 — R-ARMORDER, the switchable FIND path.
+    #
+    #   v37_xmr_m3_arm_order_kat
+    #     Pins BOTH positions of the switch against one counting monerod
+    #     transport. daemon-first must still build the X2 adapter and TOUCH the
+    #     daemon (a zero there would be the default path having broken, not M3
+    #     having worked); p2p-first must build no adapter and make EXACTLY ZERO
+    #     touches across bring-up and a complete FOUND -> SETTLED driven by a
+    #     pumped native chain. It also pins the fail-closed rules: the arm-order
+    #     preconditions as a pure function, bring_up refusing p2p-first with no
+    #     canonical test installed, and the levin publisher refusing to push a
+    #     FOUND event for a block that reached no peer.
+    #
+    #     No sockets, no RandomX, no live daemon -- it links xmr_node for the
+    #     node + X2 adapter and xmr_coin for the keccak and block parsing C5
+    #     needs, and injects a test point-check rather than the ref10 registrar.
+    #
+    #     SAME HOLLOW-GREEN GUARD as its siblings: ALSO listed in BOTH build.yml
+    #     `--target` lists (the Linux x86_64 leg and the ASan+UBSan leg), because
+    #     a registered-but-unbuilt target reports "***Not Run" and fails ctest
+    #     with exit 8 -- a red that is not a test failure (the #1539 lesson).
+    # ------------------------------------------------------------------
+    add_executable(v37_xmr_m3_arm_order_kat v37_xmr_m3_arm_order_kat.cpp)
+    target_compile_features(v37_xmr_m3_arm_order_kat PRIVATE cxx_std_20)
+    target_include_directories(v37_xmr_m3_arm_order_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/native/test
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/vendor
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/compat)
+    target_link_libraries(v37_xmr_m3_arm_order_kat PRIVATE xmr_node xmr_coin Threads::Threads)
+    add_test(NAME v37_xmr_m3_arm_order_kat COMMAND v37_xmr_m3_arm_order_kat)
+
     # Track A2 CONSUMER half — multi-node carrier accounting over a REAL socket.
     # Proves the gap the Phase-B single-node daemon had: node B accounts node A's
     # shares. Wires the SAME production consumer code the daemon does — the W3

--- a/src/c2pool/v37/test/v37_xmr_m3_arm_order_kat.cpp
+++ b/src/c2pool/v37/test/v37_xmr_m3_arm_order_kat.cpp
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/test/v37_xmr_m3_arm_order_kat.cpp   --  M3
+//
+// R-ARMORDER, pinned on BOTH settings.
+//
+// M3 makes the FIND path switchable: daemon-first (the default, and what M0
+// through M2h ran) keeps monerod as the tip, the canonical test and the block
+// publisher; p2p-first moves all three onto the embedded native node. A switch
+// is only worth having if both of its positions are held to their claim, so
+// this file asserts the two of them side by side, against the same daemon
+// transport, and counts what that transport was asked to do.
+//
+// THE COUNT IS THE POINT. CountingTransport wraps the monerod stub and counts
+// every rpc_post and every zmq_subscribe. Under daemon-first that count must be
+// NON-ZERO -- the adapter really is talking to a daemon, and a "zero" there
+// would mean the default path had quietly stopped working rather than that M3
+// succeeded. Under p2p-first it must be EXACTLY ZERO, through bring-up and
+// through a complete FOUND -> SETTLED, because that is the milestone's whole
+// claim and an off-by-one is a failed claim.
+//
+// Suites:
+//   A  the switch's declared rules (arm_order_refusal), pure and exhaustive
+//   B  daemon-first is UNCHANGED: adapter live, tip drives finalize, RPC > 0
+//   C  p2p-first is DAEMONLESS: no adapter, a pumped native chain drives the
+//      same finalize contract, and the daemon transport is never touched
+//   D  p2p-first is FAIL-CLOSED: no canonical test installed -> bring_up
+//      refuses, rather than starting into a window where every settled block
+//      would be orphaned by a predicate that cannot answer
+//   E  the publisher: a found block goes out as a levin 2008 through C5, and a
+//      relay that reached NOBODY pushes NO FOUND event
+//
+// No sockets, no RandomX, no live daemon: builds and runs on BOTH build.yml
+// legs (the Linux x86_64 leg and the ASan+UBSan one), which is also why it is
+// listed in both --target lists -- a registered-but-unbuilt target reads as
+// "***Not Run" and fails ctest with exit 8 (the #1539 lesson).
+// ===========================================================================
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <map>
+#include <unistd.h>
+#include <string>
+#include <vector>
+
+#include "c2pool/v37/xmr/xmr_node.hpp"
+#include "c2pool/v37/xmr/xmr_node_config.hpp"
+#include "c2pool/v37/xmr/xmr_p2p_block_publisher.hpp"
+#include "impl/xmr/native/contracts/fakes/fakes.hpp"
+#include "impl/xmr/native/relay/xmr_block_relay.hpp"
+#include "impl/xmr/node/monerod_transport.hpp"
+
+#include "xmr_c2a_golden.hpp"
+
+using namespace c2pool::v37n::xmr;
+namespace node   = ::c2pool::xmr::node;
+namespace native = ::c2pool::xmr::native;
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+static int g_pass = 0, g_fail = 0;
+
+static void check(bool ok, const std::string& what, const std::string& detail = {}) {
+    if (ok) {
+        ++g_pass;
+    } else {
+        ++g_fail;
+        std::printf("  [FAIL] %s%s%s\n", what.c_str(), detail.empty() ? "" : " -- ",
+                    detail.c_str());
+        return;
+    }
+    std::printf("  [ok]   %s\n", what.c_str());
+}
+
+// A point-check backend for the light build: not a torsion check, just enough
+// for the P-1 XMR descriptor validator to be LIVE so XmrNode will start (the
+// real ref10 check is pinned by xmr_torsion_kat).
+static bool test_point_check(const std::uint8_t* pt) {
+    for (int i = 0; i < 32; ++i)
+        if (pt[i] != 0) return true;
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// CountingTransport -- the monerod stub, with a turnstile on it.
+// ---------------------------------------------------------------------------
+class CountingTransport final : public node::IMonerodTransport {
+public:
+    void rpc_post(const std::string& body,
+                  std::function<void(const node::RpcResponse&)> on_done) override {
+        ++rpc_calls;
+        last_method = node::MockMonerodTransport::extract_method(body);
+        node::RpcResponse r;
+        r.error = "counting-transport: no responder installed";
+        on_done(r);
+    }
+    void zmq_subscribe(const std::string& topic,
+                       std::function<void(const node::ZmqFrame&)>) override {
+        ++zmq_subs;
+        last_topic = topic;
+    }
+
+    std::uint64_t rpc_calls = 0;
+    std::uint64_t zmq_subs  = 0;
+    std::string   last_method;
+    std::string   last_topic;
+
+    std::uint64_t touches() const { return rpc_calls + zmq_subs; }
+};
+
+static node::Hash blk_id(std::uint8_t b) {
+    node::Hash h{};
+    for (int i = 0; i < 32; ++i) h[i] = static_cast<std::uint8_t>(b + i);
+    return h;
+}
+
+static node::MainchainEvent extend_at(std::uint64_t h, std::uint8_t seed, std::uint8_t prev_seed) {
+    node::MainchainEvent ev;
+    ev.kind          = node::MainchainEventKind::Extend;
+    ev.block.height  = h;
+    ev.block.id      = blk_id(seed);
+    ev.block.prev_id = blk_id(prev_seed);
+    return ev;
+}
+
+static XmrNodeConfig base_cfg(const std::filesystem::path& dir, ::v37::ChainId chain,
+                              std::uint64_t d_conf) {
+    XmrNodeConfig c;
+    c.network        = MoneroNetwork::Stagenet;
+    c.lane_chain     = chain;
+    c.d_conf         = d_conf;
+    c.settle_db_path = dir.string();
+    return c;
+}
+
+// ===========================================================================
+// A -- the switch's declared rules
+// ===========================================================================
+static void suite_a() {
+    std::printf("A: the arm-order preconditions\n");
+
+    check(std::string(to_string(ArmOrderMode::DaemonFirst)) == "daemon-first",
+          "A1 daemon-first renders as its flag spelling");
+    check(std::string(to_string(ArmOrderMode::P2PFirst)) == "p2p-first",
+          "A2 p2p-first renders as its flag spelling");
+
+    XmrNodeConfig c;
+    check(c.arm_order == ArmOrderMode::DaemonFirst,
+          "A3 DaemonFirst is the DEFAULT (bring-up posture, ruling R-ARMORDER)");
+
+    // daemon-first accepts every coinbase / template combination, exactly as
+    // M0..M2h did: the switch adds a mode, it does not narrow the old one.
+    check(arm_order_refusal(c).empty(), "A4 daemon-first + option A is accepted");
+    c.coinbase = CoinbaseMode::V37Settlement;
+    check(arm_order_refusal(c).empty(), "A5 daemon-first + option B is accepted");
+    c.template_source = TemplateSourceMode::Native;
+    check(arm_order_refusal(c).empty(), "A6 daemon-first + native template is accepted");
+
+    // p2p-first refuses anything that would leave a daemon on the find path.
+    XmrNodeConfig p;
+    p.arm_order = ArmOrderMode::P2PFirst;
+    check(!arm_order_refusal(p).empty(),
+          "A7 p2p-first REFUSES option A (its block IS get_block_template)");
+    p.coinbase = CoinbaseMode::V37Settlement;
+    check(!arm_order_refusal(p).empty(),
+          "A8 p2p-first REFUSES the monerod template source (get_miner_data per refresh)");
+    p.template_source = TemplateSourceMode::Native;
+    check(!arm_order_refusal(p).empty(),
+          "A9 p2p-first REFUSES an empty --native-connect (no chain, nowhere to relay)");
+    p.native_connect.push_back("127.0.0.1:18080");
+    check(arm_order_refusal(p).empty(),
+          "A10 p2p-first + option B + native template + a peer is accepted");
+}
+
+// ===========================================================================
+// B -- daemon-first is unchanged
+// ===========================================================================
+static void suite_b(const std::filesystem::path& root) {
+    std::printf("B: daemon-first (default) still drives the tip from monerod\n");
+
+    CountingTransport tx;
+    XmrNode node(base_cfg(root / "daemon_first", 7, 3), tx, &test_point_check);
+    bool up = true;
+    try {
+        node.bring_up();
+    } catch (const std::exception& e) {
+        up = false;
+        check(false, "B1 bring_up succeeds under daemon-first", e.what());
+    }
+    if (!up) return;
+    check(true, "B1 bring_up succeeds under daemon-first");
+
+    check(node.daemon_tip_active(),
+          "B2 the X2 adapter IS the tip driver under daemon-first");
+    check(tx.touches() > 0,
+          "B3 the daemon transport WAS used (adapter start + initial_sync)",
+          "rpc=" + std::to_string(tx.rpc_calls) + " zmq=" + std::to_string(tx.zmq_subs));
+    check(tx.zmq_subs > 0, "B4 the ZMQ topics were subscribed");
+
+    // The adapter's own index drives settlement, as it always did.
+    node::ChainMainBlock r;
+    r.height  = 11;
+    r.id      = blk_id(11);
+    r.prev_id = blk_id(10);
+    node.adapter().index().apply(r);
+    check(node.best_height() == 11,
+          "B5 best_height reads the adapter's index under daemon-first",
+          "best=" + std::to_string(node.best_height()));
+}
+
+// ===========================================================================
+// C -- p2p-first is daemonless, end to end
+// ===========================================================================
+static void suite_c(const std::filesystem::path& root) {
+    std::printf("C: p2p-first drives the find path from the native chain, at zero RPC\n");
+
+    const ::v37::ChainId CHAIN  = 7;
+    const std::uint64_t  D_CONF = 3;
+
+    // The native chain, as a main-thread model of what NativeNode's tip feed
+    // hands over: a height -> id map the canonical test reads, and a queue of
+    // events the loop pumps. Same two shapes native_chain_source() binds.
+    std::map<std::uint64_t, std::string> chain;
+
+    XmrNodeConfig cfg = base_cfg(root / "p2p_first", CHAIN, D_CONF);
+    cfg.arm_order       = ArmOrderMode::P2PFirst;
+    cfg.coinbase        = CoinbaseMode::V37Settlement;
+    cfg.template_source = TemplateSourceMode::Native;
+    cfg.native_connect.push_back("127.0.0.1:18080");
+
+    CountingTransport tx;
+    XmrNode node(cfg, tx, &test_point_check);
+    node.set_native_chain_presence([&chain](std::uint64_t h, const std::string& bid) {
+        auto it = chain.find(h);
+        return it != chain.end() && it->second == bid;
+    });
+
+    bool up = true;
+    try {
+        node.bring_up();
+    } catch (const std::exception& e) {
+        up = false;
+        check(false, "C1 bring_up succeeds under p2p-first", e.what());
+    }
+    if (!up) return;
+    check(true, "C1 bring_up succeeds under p2p-first");
+
+    check(!node.daemon_tip_active(),
+          "C2 NO X2 adapter is built under p2p-first");
+    check(tx.touches() == 0,
+          "C3 bring_up made ZERO daemon touches (rpc + zmq)",
+          "rpc=" + std::to_string(tx.rpc_calls) + " zmq=" + std::to_string(tx.zmq_subs));
+
+    // The block we found, at height 20, on the chain we verified ourselves.
+    const std::uint64_t FOUND_H = 20;
+    const node::Hash    FOUND_ID = blk_id(20);
+    chain[FOUND_H] = hex_of(FOUND_ID);
+
+    // A valueless {}/{} record, exactly as the daemon writes one without payee
+    // keys: the ledger still registers the block, which is what matures.
+    const bool won = node.on_network_block_won(FOUND_H, FOUND_ID, Amounts{}, Amounts{});
+    check(won, "C4 a found block registers through the SAME wire-4 entry point");
+
+    // Walk the native chain past D_CONF burial, one pumped event at a time --
+    // the substitution for pump_poll(), and nothing else.
+    for (std::uint64_t h = FOUND_H; h <= FOUND_H + D_CONF + 1; ++h) {
+        chain[h] = hex_of(blk_id(static_cast<std::uint8_t>(h)));
+        node.pump_mainchain_event(extend_at(h, static_cast<std::uint8_t>(h),
+                                            static_cast<std::uint8_t>(h - 1)));
+    }
+
+    check(node.best_height() == FOUND_H + D_CONF + 1,
+          "C5 best_height follows the PUMPED native tip",
+          "best=" + std::to_string(node.best_height()));
+    check(node.hw().hw_height == FOUND_H + D_CONF + 1,
+          "C6 the settlement high-water advanced off the native tip",
+          "hw=" + std::to_string(node.hw().hw_height));
+    check(node.finalize_driver().cursor_height() >= FOUND_H,
+          "C7 the F1 finalize cursor stepped PAST the found height (SETTLED)",
+          "cursor=" + std::to_string(node.finalize_driver().cursor_height()));
+
+    check(tx.touches() == 0,
+          "C8 FOUND -> SETTLED made ZERO daemon touches: rpc_on_find_path == 0",
+          "rpc=" + std::to_string(tx.rpc_calls) + " zmq=" + std::to_string(tx.zmq_subs));
+
+    // An orphan disposes through the same seam, still without a daemon.
+    node::MainchainEvent orph;
+    orph.kind        = node::MainchainEventKind::Orphan;
+    orph.orphaned_id = blk_id(20);
+    node.pump_mainchain_event(orph);
+    check(tx.touches() == 0, "C9 an orphan disposition made ZERO daemon touches");
+}
+
+// ===========================================================================
+// D -- p2p-first is fail-closed on its canonical test
+// ===========================================================================
+static void suite_d(const std::filesystem::path& root) {
+    std::printf("D: p2p-first refuses to start without a canonical test\n");
+
+    XmrNodeConfig cfg = base_cfg(root / "failclosed", 7, 3);
+    cfg.arm_order       = ArmOrderMode::P2PFirst;
+    cfg.coinbase        = CoinbaseMode::V37Settlement;
+    cfg.template_source = TemplateSourceMode::Native;
+    cfg.native_connect.push_back("127.0.0.1:18080");
+
+    CountingTransport tx;
+    XmrNode node(cfg, tx, &test_point_check);
+    bool threw = false;
+    std::string why;
+    try {
+        node.bring_up();
+    } catch (const std::exception& e) {
+        threw = true;
+        why   = e.what();
+    }
+    check(threw, "D1 bring_up REFUSES p2p-first with no presence test installed");
+    check(threw && why.find("p2p-first") != std::string::npos,
+          "D2 the refusal names the mode it refused", why);
+    check(tx.touches() == 0, "D3 the refusal itself touched no daemon");
+}
+
+// ===========================================================================
+// E -- the publisher: a levin 2008 instead of submit_block
+// ===========================================================================
+namespace {
+
+// A block the relay will accept: a real captured stagenet block, re-identified
+// by this repository's own code rather than trusted from the fixture.
+struct BlockFixture {
+    std::vector<std::uint8_t> blob;
+    native::Hash              id{};
+    std::vector<std::uint8_t> hashing_blob;
+    std::uint64_t             height       = 0;
+    std::uint32_t             nonce        = 0;
+    std::size_t               nonce_offset = 0;
+};
+
+std::vector<std::uint8_t> bytes_from_hex(const std::string& hex) {
+    std::vector<std::uint8_t> out;
+    out.reserve(hex.size() / 2);
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    for (std::size_t i = 0; i + 1 < hex.size(); i += 2)
+        out.push_back(static_cast<std::uint8_t>(nib(hex[i]) * 16 + nib(hex[i + 1])));
+    return out;
+}
+
+bool load_fixture(BlockFixture& f) {
+    f.blob   = bytes_from_hex(native::golden_c2a::BLOCKS[0].blob_hex);
+    f.height = native::golden_c2a::BLOCKS[0].height;
+    native::ParsedBlock   pb;
+    native::BlockIdentity ident;
+    if (native::parse_and_identify(f.blob, pb, ident) != native::BlockParseStatus::Ok)
+        return false;
+    if (pb.header_size < 4) return false;
+    f.id           = ident.id;
+    f.hashing_blob = ident.hashing_blob;
+    f.nonce        = pb.header.nonce;
+    f.nonce_offset = pb.header_size - 4;   // the u32 nonce ends the header
+    // The fixture is only usable if OUR identity matches the one monerod
+    // reported for these bytes; otherwise every assertion below would be
+    // checking this file against itself.
+    const std::vector<std::uint8_t> want = bytes_from_hex(native::golden_c2a::BLOCKS[0].id_hex);
+    return want.size() == f.id.size() &&
+           std::equal(want.begin(), want.end(), f.id.begin());
+}
+
+} // namespace
+
+static void suite_e() {
+    std::printf("E: the p2p publisher relays a found block and never invents one\n");
+
+    BlockFixture f;
+    if (!load_fixture(f)) {
+        check(false, "E0 the captured block fixture parses and re-identifies");
+        return;
+    }
+    check(true, "E0 the captured block fixture parses and re-identifies");
+
+    native::fakes::FakeBroadcastPort port;
+    native::fakes::FakeMinerDataSource bodies;
+    native::fakes::FakeChain           chain;
+
+    native::relay::RelayConfig rcfg;
+    rcfg.policy.order                 = native::ArmOrder::P2pOnly;
+    rcfg.policy.include_all_tx_bodies = true;
+    native::relay::LevinBlockRelay relay(port, native::relay::DaemonSubmitSink{}, &bodies,
+                                         &chain, rcfg);
+
+    submit::FoundBlockQueue found;
+    auto lookup = [&f](std::uint32_t, std::uint32_t, submit::BlockCandidate& out) {
+        out.template_id     = 1;
+        out.height          = f.height;
+        out.full_blob       = f.blob;
+        out.hashing_blob    = f.hashing_blob;
+        out.nonce_offset    = f.nonce_offset;
+        out.expected_reward = 600000000000ull;
+        return true;
+    };
+
+    o2::P2pBlockPublisher pub(relay, found, lookup);
+
+    // (1) fail-closed before the RandomX verifier says so.
+    pub.submit_network_block(1, f.nonce, 0);
+    check(pub.refused() == 1 && found.pushed() == 0,
+          "E1 a disabled relay REFUSES and pushes no FOUND event",
+          pub.last_error());
+
+    // (2) armed, with peers: the block goes out and a FOUND event follows.
+    pub.enable_network_relay(true);
+    port.state_normal_peers = 3;
+    pub.submit_network_block(1, f.nonce, 0);
+    check(pub.relayed() == 1, "E2 the block was relayed over levin", pub.last_error());
+    check(found.pushed() == 1, "E3 exactly one FOUND event was pushed");
+    submit::FoundBlockEvent ev;
+    const bool got = found.pop(ev);
+    check(got && ev.block_id == f.id,
+          "E4 the FOUND event carries OUR block id, off the bytes we relayed");
+    check(got && ev.id_source == submit::IdSource::Local,
+          "E5 the id source is Local -- no daemon named this block");
+    check(got && ev.header_check == submit::HeaderCheck::NotRun,
+          "E6 header_check stays NotRun: nothing confirmed the height for us");
+    check(got && ev.rpc_ms == 0.0, "E7 the publish cost zero RPC milliseconds");
+    check(port.broadcasts.size() == 1 && port.broadcasts[0].cmd == 2008u,
+          "E8 exactly one 2008 NOTIFY_NEW_FLUFFY_BLOCK went to the port");
+    // THE BODY, NOT A FRAME. IBroadcastPort takes the epee message body and the
+    // transport writes the levin bucket header around it. C5 handed it a
+    // complete frame until M3's live run, and every Monero peer answered
+    // "portable_storage: wrong binary format - signature mismatch" while the
+    // peers-written count read perfectly -- the bytes reached the socket and
+    // the block reached no chain. The epee storage signature is the pin:
+    // 01 11 01 01 | 01 01 02 01 | version, never a levin header (01 21 01 01).
+    {
+        const std::vector<std::uint8_t>& b = port.broadcasts[0].bytes;
+        const std::uint8_t want[9] = {0x01, 0x11, 0x01, 0x01, 0x01, 0x01, 0x02, 0x01, 0x01};
+        bool bare = b.size() >= 9;
+        for (int i = 0; bare && i < 9; ++i)
+            bare = (b[static_cast<std::size_t>(i)] == want[i]);
+        check(bare, "E8b the port got a BARE epee body, not a doubly-framed notify");
+    }
+
+    // (3) THE FAIL-CLOSED ONE: a relay that reached nobody must not push a
+    //     FOUND event. A block in the settlement ledger that no peer ever
+    //     received would mature, be refused by the canonical test and be
+    //     disposed as an orphan -- after the share that paid for it was spent.
+    port.state_normal_peers = 0;
+    port.broadcasts.clear();
+    pub.submit_network_block(1, f.nonce, 0);
+    check(pub.failed() == 1, "E9 zero peers is a LOUD failure, not a shrug",
+          pub.last_error());
+    check(found.pushed() == 1,
+          "E10 a block that reached NOBODY pushes NO FOUND event (fail-closed)",
+          "pushed=" + std::to_string(found.pushed()));
+
+    // (4) a candidate with no served hashing blob has no verified id to attest.
+    port.state_normal_peers = 3;
+    auto blind = [&f](std::uint32_t, std::uint32_t, submit::BlockCandidate& out) {
+        out.template_id  = 1;
+        out.height       = f.height;
+        out.full_blob    = f.blob;
+        out.nonce_offset = f.nonce_offset;
+        return true;                       // note: no hashing_blob
+    };
+    o2::P2pBlockPublisher blind_pub(relay, found, blind);
+    blind_pub.enable_network_relay(true);
+    blind_pub.submit_network_block(1, f.nonce, 0);
+    check(blind_pub.refused() == 1 && blind_pub.relayed() == 0,
+          "E11 no hashing blob -> no attestable id -> REFUSED, never relayed",
+          blind_pub.last_error());
+}
+
+// ===========================================================================
+int main() {
+    std::printf("== v37_xmr_m3_arm_order_kat: R-ARMORDER pinned on both settings ==\n");
+
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() /
+        ("v37-xmr-m3-armorder-" + std::to_string(static_cast<long>(::getpid())));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+
+    suite_a();
+    suite_b(root);
+    suite_c(root);
+    suite_d(root);
+    suite_e();
+
+    std::filesystem::remove_all(root);
+
+    std::printf("== %s: %d passed, %d failed ==\n", g_fail ? "FAIL" : "OK", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/src/c2pool/v37/xmr/xmr_native_chain_source.hpp
+++ b/src/c2pool/v37/xmr/xmr_native_chain_source.hpp
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_native_chain_source.hpp   (M3)
+//
+// THE TIP, CUT OVER.
+//
+// Everything above settlement in this daemon asks the parent chain exactly two
+// questions, and until M3 a daemon answered both of them:
+//
+//   1. "what happened to the chain" -- Extend / Reorg / Orphan, which is what
+//      advances the F1 finalize cursor and disposes an orphaned settlement.
+//      Answered by LiveMonerodTransport::pump_poll() re-issuing get_miner_data
+//      on a timer, decoded into the X2 MonerodAdapter's MainchainIndex.
+//   2. "is block X still at height H on the best chain" -- the canonical test
+//      XmrFinalizeDriver runs at maturity, before it finalizes anything.
+//      Answered out of that same monerod-mirroring index.
+//
+// M0 built a node that answers both of those from a chain it verified ITSELF:
+// blocks fetched over levin from real peers, RandomX-checked at L4, connected
+// under the C2 fork-choice rule. Nothing consumed that stream. This file is the
+// consumption -- two std::functions, bound to the running native node, handed to
+// XmrNode before bring_up() so that in --arm-order p2p-first the settlement
+// path never learns anything from a daemon.
+//
+// WHAT IS NOT HERE, AND WHY. There is no "if the native answer looks wrong, ask
+// monerod" branch. A find path with a daemon fallback on it is a daemon-ful find
+// path that happens to be quiet, and the number this milestone reports -- RPCs
+// on the find path -- would then depend on how lucky the run was. The native
+// arm answers or nothing does.
+//
+// THREADING. The native index flushes its events on the node's VERIFY thread;
+// drain_mainchain_events() queues them there under the node's own mutex and
+// hands them to the caller's thread. is_canonical() goes through ChainIndex's
+// mutex-guarded by_height(). Both are safe from the daemon's main loop, which
+// is the only thread that calls them.
+//
+// SCOPE FENCE: consumer tree. No consensus digest; src/sharechain/v37 untouched.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/node/xmr_node_types.hpp"   // c2pool::xmr::node::MainchainEvent
+#include "xmr_native_template_backend.hpp"
+
+namespace c2pool::v37n::xmr::o2 {
+
+// The parent chain, as the settlement path needs it. Empty (operator bool
+// false) when no native node is running, which is the only honest value in
+// daemon-first mode and is why the type is checkable rather than assumed.
+struct NativeChainSource {
+    // Every mainchain event the native index produced since the last call, in
+    // arrival order. Extend/Reorg advance the finalize cursor; Orphan disposes.
+    std::function<std::vector<::c2pool::xmr::node::MainchainEvent>()> drain;
+
+    // The canonical test XmrFinalizeDriver runs at maturity: is `bid_hex` the
+    // block this chain carries at `height`? A height the retention window has
+    // dropped answers false, which is the fail-closed direction (a settlement
+    // is refused, never wrongly finalized).
+    std::function<bool(std::uint64_t height, const std::string& bid_hex)> is_canonical;
+
+    // Events produced since start, drained or not. A tip driver that produced
+    // nothing and a consumer that dropped everything are indistinguishable
+    // without this, and they have opposite fixes.
+    std::function<std::uint64_t()> events_seen;
+
+    explicit operator bool() const noexcept {
+        return static_cast<bool>(drain) && static_cast<bool>(is_canonical);
+    }
+};
+
+// Lowercase hex of a Monero block id, in the spelling the OwedLedger keys on
+// (the same one xmr_node.hpp's hex_of produces; repeated here so this header
+// does not have to pull the engine in to format 32 bytes).
+inline std::string chain_id_hex(const ::c2pool::xmr::node::Hash& h) {
+    static const char* k = "0123456789abcdef";
+    std::string s;
+    s.reserve(64);
+    for (std::uint8_t b : h) {
+        s.push_back(k[b >> 4]);
+        s.push_back(k[b & 0xf]);
+    }
+    return s;
+}
+
+// Bind the source to a STARTED backend. The node must be up: both closures
+// capture it by pointer and are called for the life of the daemon, which ends
+// before the backend is stopped (main stops the listener, then the node, then
+// the backend).
+inline NativeChainSource native_chain_source(NativeTemplateBackend& backend) {
+    NativeChainSource src;
+    ::c2pool::xmr::native::rt::NativeNode* n = backend.node();
+    if (!n) return src;
+
+    src.drain = [n] { return n->drain_mainchain_events(); };
+
+    src.is_canonical = [n](std::uint64_t height, const std::string& bid_hex) {
+        const auto b = n->index().by_height(height);
+        return b.has_value() && chain_id_hex(b->id) == bid_hex;
+    };
+
+    src.events_seen = [n] { return n->mainchain_events_seen(); };
+    return src;
+}
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_native_template_backend.hpp
+++ b/src/c2pool/v37/xmr/xmr_native_template_backend.hpp
@@ -97,6 +97,13 @@ struct NativeTemplateConfig {
     // Monerod is the M2 ladder's first rung (serve=monerod / shadow=native).
     native::TemplateArm      serve = native::TemplateArm::Native;
 
+    // M3 (R-ARMORDER): which arm a FOUND block goes out on. DaemonFirst is the
+    // default and is what M0..M2h ran -- though under it the POOL, not this
+    // node, does the submitting (the node's own daemon sink is empty), so C5
+    // is simply not on the path at all. P2pOnly is --arm-order p2p-first: the
+    // block goes out as a levin 2008 and monerod is never asked.
+    native::ArmOrder         relay_order = native::ArmOrder::DaemonFirst;
+
     // Fall back to the other arm when the serving arm is not ready. ON is the
     // production posture; the M2 evidence run turns it OFF so that "no monerod
     // call on the template path" cannot be satisfied by a silent fallback.
@@ -148,6 +155,7 @@ public:
         nc.parity_ledger_path   = cfg_.parity_ledger_path;
         nc.c2pool_commit        = cfg_.c2pool_commit;
         nc.serve_arm            = cfg_.serve;
+        nc.relay_order          = cfg_.relay_order;
         nc.template_fallback    = cfg_.fallback;
         nc.force_synced         = cfg_.force_synced;
         nc.backlog_refresh_s    = cfg_.backlog_refresh_s;

--- a/src/c2pool/v37/xmr/xmr_node.hpp
+++ b/src/c2pool/v37/xmr/xmr_node.hpp
@@ -32,6 +32,7 @@
 
 #include <cstdint>
 #include <filesystem>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -92,6 +93,46 @@ public:
     XmrNode(const XmrNode&) = delete;
     XmrNode& operator=(const XmrNode&) = delete;
 
+    // ── M3: the DAEMONLESS tip driver seam ─────────────────────────────────
+    //
+    // Under --arm-order daemon-first (the default) the X2 MonerodAdapter is the
+    // tip: it fills a MainchainIndex from get_miner_data / ZMQ and answers the
+    // finalize driver's "is this block still at this height" from that mirror.
+    //
+    // Under --arm-order p2p-first there is no adapter at all. The tip is the
+    // native node's own levin-driven, RandomX-verified C2 index, and these two
+    // functions are how it gets in: the consumer installs the presence test
+    // BEFORE bring_up(), and pumps each mainchain event the native index
+    // produced from its own loop.
+    //
+    // The presence test is installed before bring_up rather than after because
+    // an uninstalled one cannot be made safe: XmrFinalizeDriver asks it at
+    // maturity, a false answer ORPHANS a block that is perfectly canonical, and
+    // there is no third value to return. So bring_up() REFUSES p2p-first
+    // without it rather than starting into a window where the answer is wrong.
+    using ChainPresenceFn = std::function<bool(std::uint64_t height, const std::string& bid_hex)>;
+    void set_native_chain_presence(ChainPresenceFn fn) { m_native_presence = std::move(fn); }
+
+    // Feed ONE mainchain event from the native index. Same body the adapter's
+    // event sink runs, called from the consumer's main loop instead of from a
+    // monerod callback -- so Extend/Reorg advance settlement and Orphan disposes
+    // exactly as they always did, off a chain no daemon described to us.
+    void pump_mainchain_event(const c2pool::xmr::node::MainchainEvent& ev) {
+        on_mainchain_event(ev);
+    }
+
+    // True when the daemon-backed X2 adapter is the tip driver. False in
+    // p2p-first: adapter() must not be called, and nothing may poll monerod.
+    bool daemon_tip_active() const noexcept { return m_adapter != nullptr; }
+
+    // The best height the settlement path is working against, from whichever
+    // driver is live. In p2p-first this is the highest height a pumped event
+    // carried, which is the same number the finalize cursor chases.
+    std::uint64_t best_height() const {
+        if (m_adapter) return m_adapter->index().best_height();
+        return m_tip_height;
+    }
+
     // Full bring-up in donor order. Throws std::runtime_error on a fail-closed
     // condition (no descriptor backend; a torn store; a rejected AddLane; a
     // mainnet coinbase without acknowledgement is refused later, at submit).
@@ -135,26 +176,48 @@ public:
         log("engine: started; AddLane(chain=" + std::to_string(m_cfg.lane_chain) +
             ") committed; lane v1 seeded");
 
-        // 5) bind the X2 adapter and route its event stream into the F1 driver.
-        m_adapter = std::make_unique<c2pool::xmr::node::MonerodAdapter>(
-            m_transport, m_cfg.monerod,
-            static_cast<std::uint64_t>(m_cfg.index_retain_recent));
+        // 5) bind the tip driver and route its event stream into the F1 driver.
+        //    M3 (R-ARMORDER): WHICH driver is the switch. daemon-first builds
+        //    the X2 adapter; p2p-first builds none and takes the native node's
+        //    own chain index instead, which is what makes the find path
+        //    daemonless rather than merely daemon-light.
+        const bool daemon_tip = (m_cfg.arm_order == ArmOrderMode::DaemonFirst);
+        if (!daemon_tip && !m_native_presence)
+            throw std::runtime_error(
+                "XmrNode: --arm-order p2p-first requires the native chain presence test to be "
+                "installed before bring_up() (set_native_chain_presence). Fail-closed: a finalize "
+                "driver that cannot ask whether a block is still on the best chain would orphan "
+                "every block it settles.");
+
+        if (daemon_tip)
+            m_adapter = std::make_unique<c2pool::xmr::node::MonerodAdapter>(
+                m_transport, m_cfg.monerod,
+                static_cast<std::uint64_t>(m_cfg.index_retain_recent));
 
         m_finalize = std::make_unique<XmrFinalizeDriver>(
             m_ledger, m_hw, *m_store, m_cfg.lane_chain, m_cfg.d_conf,
             m_recovered.finalize_cursor_height, m_recovered.max_event_seq,
             [this](std::uint64_t h, const std::string& bid) {
-                auto b = m_adapter->index().by_height(h);
-                return b && hex_of(b->id) == bid;
+                if (m_adapter) {
+                    auto b = m_adapter->index().by_height(h);
+                    return b && hex_of(b->id) == bid;
+                }
+                return m_native_presence ? m_native_presence(h, bid) : false;
             });
 
-        m_adapter->set_event_sink(
-            [this](const c2pool::xmr::node::MainchainEvent& ev) { on_mainchain_event(ev); });
+        if (daemon_tip) {
+            m_adapter->set_event_sink(
+                [this](const c2pool::xmr::node::MainchainEvent& ev) { on_mainchain_event(ev); });
 
-        // 6) start the adapter: subscribe ZMQ topics + one-shot RPC sync.
-        m_adapter->start();
-        m_adapter->initial_sync();
-        log("adapter: started; subscribed miner_data/chain_main/txpool; initial_sync issued");
+            // 6) start the adapter: subscribe ZMQ topics + one-shot RPC sync.
+            m_adapter->start();
+            m_adapter->initial_sync();
+            log("adapter: started; subscribed miner_data/chain_main/txpool; initial_sync issued");
+        } else {
+            log("adapter: NOT built (--arm-order p2p-first) — the tip, the canonical test and "
+                "the found-block relay all come from the native node's own levin chain; "
+                "monerod is not on the find path");
+        }
 
         m_up = true;
         log("bring_up: complete");
@@ -230,6 +293,7 @@ private:
         switch (ev.kind) {
             case K::Extend:
             case K::Reorg: {
+                if (ev.block.height > m_tip_height) m_tip_height = ev.block.height;
                 // Advance settlement finality per the F1 contract off the new
                 // best height (the driver steps per-height internally; it NEVER
                 // jumps to the tip for bin_height).
@@ -264,6 +328,11 @@ private:
 
     std::unique_ptr<c2pool::xmr::node::MonerodAdapter> m_adapter;
     std::unique_ptr<XmrFinalizeDriver>                 m_finalize;
+
+    // M3: the p2p-first tip driver. Null adapter + this predicate is the
+    // daemonless posture; an adapter and no predicate is the default one.
+    ChainPresenceFn                        m_native_presence;
+    std::uint64_t                          m_tip_height = 0;
 
     std::vector<std::string>               m_log;
     bool                                   m_up = false;

--- a/src/c2pool/v37/xmr/xmr_node_config.hpp
+++ b/src/c2pool/v37/xmr/xmr_node_config.hpp
@@ -83,6 +83,35 @@ inline const char* to_string(TemplateSourceMode m) {
     return m == TemplateSourceMode::Native ? "native" : "monerod";
 }
 
+// M3 (R-ARMORDER): which arm drives the FIND path -- the parent tip the
+// template is built on, the block-presence test the finalize driver asks, and
+// the arm a found block goes out on.
+//
+//   DaemonFirst (the DEFAULT, and what M0..M2h shipped): monerod drives. The
+//     tip arrives through LiveMonerodTransport's get_miner_data poll (or ZMQ),
+//     the MonerodAdapter's MainchainIndex answers "is this block still at this
+//     height", and a found block is published with submit_block. The native
+//     node may still BUILD the template (--xmr-template-source native), which
+//     is what M2h proved; the daemon stays on the find path either way.
+//
+//   P2PFirst: the embedded native node drives, end to end. Its levin-driven C2
+//     chain index is the tip, the same index answers the finalize driver's
+//     canonical test, and a found block goes out over levin as a 2008
+//     NOTIFY_NEW_FLUFFY_BLOCK (C5 ARM A, ArmOrder::P2pOnly). monerod is NOT
+//     consulted anywhere on that path -- not for the tip, not for the
+//     template, not for the submit. It may still be configured, and is then
+//     read ONLY by the C6 parity oracle off the status cadence, which is not
+//     the find path and is counted separately so the claim stays falsifiable.
+//
+// A runtime switch and not a build flag on purpose: daemon-assisted bring-up
+// and the daemonless posture are the same binary, and an operator moving
+// between them should not have to trust two builds to be the same program.
+enum class ArmOrderMode : std::uint8_t { DaemonFirst = 0, P2PFirst = 1 };
+
+inline const char* to_string(ArmOrderMode m) {
+    return m == ArmOrderMode::P2PFirst ? "p2p-first" : "daemon-first";
+}
+
 inline const char* to_string(CoinbaseMode m) {
     switch (m) {
         case CoinbaseMode::MonerodTemplate: return "monerod-template (option A)";
@@ -236,6 +265,20 @@ struct XmrNodeConfig {
     // is why the default does not move.
     std::uint64_t   native_backlog_refresh_s = 0;
 
+    // --- M3: the arm order on the FIND path ---------------------------------
+    // --arm-order daemon-first (default) | p2p-first. See ArmOrderMode above.
+    // p2p-first is fail-closed on its preconditions: it REFUSES to start unless
+    // the coinbase is the v37 settlement coinbase built from the native arm,
+    // because a daemonless find whose template came from a daemon is not one.
+    ArmOrderMode    arm_order = ArmOrderMode::DaemonFirst;
+    // --no-daemon-rpc: do not configure a monerod RPC endpoint for the embedded
+    // node AT ALL. Meaningful only with p2p-first, where it is the difference
+    // between "no daemon call on the find path" (a claim about which of the
+    // calls are where) and "no daemon call" (a claim a packet capture settles in
+    // one line). The C6 parity oracle then has no judge and scores its samples
+    // VOID, which is the honest cost and is exactly why this is not the default.
+    bool            no_daemon_rpc = false;
+
     // --- storage ------------------------------------------------------------
     // When empty, config_path()/<net>/v37_settle_db is used (see xmr_node.hpp).
     // Set to override the settlement-store directory (tests set a temp dir).
@@ -254,5 +297,31 @@ struct XmrNodeConfig {
     // to keep this header free of <filesystem>/core includes for cheap inclusion.
     std::string resolved_settle_db_path() const;
 };
+
+// M3: the arm-order preconditions, as a PURE function of the configuration, so
+// that the rules the daemon refuses on are the rules a KAT can pin. Returns ""
+// when the configuration is coherent, otherwise why it is refused.
+//
+// A daemonless FIND is a claim about three things at once -- the tip, the
+// template and the publish -- and only the first of them is the arm order's own.
+// Option A's block bytes ARE monerod's get_block_template, and the monerod
+// template source is a get_miner_data round trip per refresh; either of them
+// under p2p-first would leave a daemon on the find path while the flag said
+// otherwise. Refusing is the only honest answer, and it is given before
+// anything starts rather than degraded into a mode whose name has stopped
+// describing it.
+inline std::string arm_order_refusal(const XmrNodeConfig& c) {
+    if (c.arm_order != ArmOrderMode::P2PFirst) return {};
+    if (c.coinbase != CoinbaseMode::V37Settlement)
+        return "--arm-order p2p-first requires --coinbase v37: option A's block IS monerod's "
+               "get_block_template, so a daemonless find of it is a contradiction";
+    if (c.template_source != TemplateSourceMode::Native)
+        return "--arm-order p2p-first requires --xmr-template-source native: a find path whose "
+               "template came from get_miner_data is not daemonless";
+    if (c.native_connect.empty())
+        return "--arm-order p2p-first requires at least one --native-connect <ip:port> levin peer: "
+               "with no peer there is no chain to find on and nowhere to relay a found block";
+    return {};
+}
 
 } // namespace c2pool::v37n::xmr

--- a/src/c2pool/v37/xmr/xmr_p2p_block_publisher.hpp
+++ b/src/c2pool/v37/xmr/xmr_p2p_block_publisher.hpp
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_p2p_block_publisher.hpp   (M3)
+//
+// THE LAST DAEMON CALL ON THE FIND PATH, REMOVED.
+//
+// LiveSubmitShareSink is the X5 IShareSink that turns a winning share into a
+// Monero block: look the candidate up, POST submit_block to monerod, and on OK
+// push a FoundBlockEvent for the finalize driver. Everything about that is
+// right except the middle step, which is an RPC to the thing this track exists
+// to remove.
+//
+// P2pBlockPublisher is the same sink with a different middle: the assembled
+// block goes out over levin as a 2008 NOTIFY_NEW_FLUFFY_BLOCK to every
+// handshaked peer, through C5's LevinBlockRelay (ArmOrder::P2pOnly, bodies
+// included so no peer needs a 2009 round trip to validate it), and the relay's
+// PREFER-OWN submit_to_own_index hands the block to our own chain index so our
+// tip moves without waiting to hear our own block back from somebody else.
+//
+// WHAT COUNTS AS SUCCESS, AND WHY IT IS A WEAKER CLAIM THAN monerod's "OK".
+// submit_block is an ADJUDICATION: monerod validated the block and told us so.
+// A 2008 write is a DELIVERY: bytes reached N peers, and no peer answers an
+// unsolicited block notification. So the honest success condition here is
+// BlockRelayVerdict::reached_network() -- at least one peer took the frame --
+// and the block id is ours, computed from the hashing blob the RandomX gate
+// just verified (IdSource::Local), never a daemon's. header_check stays NotRun
+// for the same reason: nothing confirmed the height for us.
+//
+// That weakness is real and is not hidden. What backs the block instead is the
+// chain: if the network rejected it, the native index never sees it reach
+// D_conf burial on the best chain, the canonical test fails at maturity, and
+// the settlement is disposed as an orphan rather than finalized. The daemon's
+// synchronous yes is traded for the chain's asynchronous one, which is the
+// trade a daemonless node is FOR.
+//
+// FAIL-CLOSED, three ways:
+//   * enable_network_relay() defaults FALSE, exactly like LiveBlockSubmitter's
+//     network_submit_enabled -- a build with no RandomX relays nothing;
+//   * a candidate with no hashing blob has no verified id to attest to, and
+//     CandidateBlockRelay refuses an unattested push rather than trusting us;
+//   * a verdict that reached nobody pushes NO FoundBlockEvent. A block nobody
+//     received must never enter the settlement ledger as found.
+//
+// THREADING: submit_network_block runs on the stratum listener thread. The
+// peer pool's IBroadcastPort is documented as called from exactly that thread
+// (xmr_peer_pool.hpp), and it posts onto the io thread internally.
+//
+// SCOPE FENCE: consumer tree plus the C5 bridge under src/impl/xmr/native/.
+// No consensus digest; src/sharechain/v37 untouched.
+// ===========================================================================
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "impl/xmr/native/relay/xmr_block_relay_submit_bridge.hpp"
+#include "impl/xmr/stratum/xmr_stratum.hpp"
+#include "xmr_live_submit.hpp"
+
+namespace c2pool::v37n::xmr::o2 {
+
+namespace strat  = ::v37::xmr::stratum;
+namespace sub    = ::c2pool::v37n::xmr::submit;
+namespace nrelay = ::c2pool::xmr::native::relay;
+
+class P2pBlockPublisher final : public strat::IShareSink {
+public:
+    using CandidateLookup = sub::LiveSubmitShareSink::CandidateLookup;
+
+    P2pBlockPublisher(nrelay::LevinBlockRelay& relay, sub::FoundBlockQueue& found,
+                      CandidateLookup lookup)
+        : m_relay(relay), m_found(found), m_lookup(std::move(lookup)) {}
+
+    // The RandomX fail-closed gate, mirroring LiveBlockSubmitter's. OFF until
+    // the verifier is live, so a build that cannot check proof of work can
+    // never put a block on somebody else's wire.
+    void enable_network_relay(bool on) { m_enabled.store(on); }
+    bool network_relay_enabled() const { return m_enabled.load(); }
+
+    void on_accepted_share(const strat::AcceptedShare& s) override {
+        m_accepted.fetch_add(1);
+        if (s.is_network_block)
+            m_found.annotate(s.template_id, s.nonce, s.extra_nonce, s.worker, s.address);
+    }
+
+    void submit_network_block(std::uint32_t template_id, std::uint32_t nonce,
+                              std::uint32_t extra_nonce) override {
+        m_calls.fetch_add(1);
+
+        sub::BlockCandidate c;
+        if (!m_lookup || !m_lookup(template_id, extra_nonce, c)) {
+            m_stale.fetch_add(1);
+            set_error("relay: template " + std::to_string(template_id) + " gone (stale)");
+            return;
+        }
+        if (!m_enabled.load()) {
+            m_refused.fetch_add(1);
+            set_error("relay: REFUSED (network relay disabled, fail-closed)");
+            return;
+        }
+        if (const std::string bad = sub::validate_candidate(c); !bad.empty()) {
+            m_refused.fetch_add(1);
+            set_error("relay: REFUSED (" + bad + ")");
+            return;
+        }
+        if (c.hashing_blob.empty()) {
+            // No served hashing blob means no id the RandomX gate can be said
+            // to have verified. C5 would refuse the unattested push anyway;
+            // refusing here names the actual cause.
+            m_refused.fetch_add(1);
+            set_error("relay: REFUSED (no hashing blob -> no verified block id to attest)");
+            return;
+        }
+
+        // The exact 128-bit network gate ran in front of this sink, on these
+        // bytes, moments ago -- that is the ONLY way this method is reached.
+        // pow_accepted=true is that fact, and the attestation still ties it to
+        // one block id, so a wiring bug that hands us different bytes is caught.
+        nrelay::CandidateBlockRelay bridge(m_relay);
+        const ::c2pool::xmr::native::BlockRelayVerdict v =
+            bridge.relay(c, nonce, extra_nonce, /*pow_accepted=*/true);
+
+        if (!v.reached_network()) {
+            m_failed.fetch_add(1);
+            set_error("relay: block reached NO peer: " +
+                      (v.why.empty() ? std::string("(no reason given)") : v.why));
+            return;
+        }
+
+        m_relayed.fetch_add(1);
+        m_peers.fetch_add(static_cast<std::uint64_t>(v.p2p_peers_sent));
+
+        sub::FoundBlockEvent ev;
+        ev.height       = c.height;
+        ev.block_id     = v.block_id;          // ours, off the bytes we relayed
+        ev.prev_id      = c.prev_id;
+        ev.reward       = c.expected_reward;
+        ev.template_id  = template_id;
+        ev.nonce        = nonce;
+        ev.extra_nonce  = extra_nonce;
+        ev.id_source    = sub::IdSource::Local;
+        ev.id_mismatch  = false;
+        ev.header_check = sub::HeaderCheck::NotRun;   // no daemon confirmed it
+        ev.rpc_ms       = 0.0;                        // and none was called
+        ev.at           = std::chrono::steady_clock::now();
+        m_found.push(std::move(ev));
+        set_error({});
+    }
+
+    // --- diagnostics ---------------------------------------------------------
+    std::uint64_t calls()    const { return m_calls.load(); }
+    std::uint64_t relayed()  const { return m_relayed.load(); }
+    std::uint64_t peers()    const { return m_peers.load(); }
+    std::uint64_t refused()  const { return m_refused.load(); }
+    std::uint64_t failed()   const { return m_failed.load(); }
+    std::uint64_t stale()    const { return m_stale.load(); }
+    std::size_t   accepted_shares() const { return m_accepted.load(); }
+    std::string   last_error() const {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        return m_last_error;
+    }
+
+private:
+    void set_error(std::string e) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_last_error = std::move(e);
+    }
+
+    nrelay::LevinBlockRelay& m_relay;
+    sub::FoundBlockQueue&    m_found;
+    CandidateLookup          m_lookup;
+    std::atomic<bool>        m_enabled{false};
+    std::atomic<std::uint64_t> m_calls{0}, m_relayed{0}, m_peers{0},
+                               m_refused{0}, m_failed{0}, m_stale{0};
+    std::atomic<std::size_t>   m_accepted{0};
+    mutable std::mutex         m_mtx;
+    std::string                m_last_error;
+};
+
+} // namespace c2pool::v37n::xmr::o2

--- a/src/impl/xmr/native/contracts/broadcast.hpp
+++ b/src/impl/xmr/native/contracts/broadcast.hpp
@@ -11,10 +11,20 @@
 // C1 -> C5 (D-10): the outbound notify port. C1 implements it and posts to the
 // io thread; C5 owns the retained-block book, not C1.
 //
-// broadcast_notify() returns the number of peers the frame was actually written
+// WHAT THE CALLER PASSES IS THE MESSAGE BODY, NOT A FRAME. The implementation
+// writes the 33-byte levin bucket header around it (LevinLink::send_notify ->
+// make_notify). Passing an already-framed buffer produces a doubly-framed
+// notification that every Monero peer answers with
+//   portable_storage: wrong binary format - signature mismatch
+// and drops -- with the peers-written count still reading perfectly, because
+// the bytes DID reach the socket. C5 shipped exactly that bug until a live
+// monerod said so; the parameter is named `body` here for that reason.
+//
+// broadcast_notify() returns the number of peers the body was actually written
 // to, and it counts ONLY handshaked peers in state_normal. That number is the
 // input to the never-silent-drop rule: a found block that reached zero peers
-// and had no daemon arm is a loud failure, never a shrug.
+// and had no daemon arm is a loud failure, never a shrug. It is a DELIVERY
+// count and never an acceptance: no peer answers an unsolicited notification.
 // ---------------------------------------------------------------------------
 #pragma once
 
@@ -30,8 +40,9 @@ namespace c2pool::xmr::native {
 
 // Handler installed by C5 to answer a peer asking for the transactions it is
 // missing from a fluffy block we pushed (REQUEST_FLUFFY_MISSING_TX, 2009).
-// Fills `reply_2008` with a complete NOTIFY_NEW_FLUFFY_BLOCK frame and returns
-// true, or returns false to decline.
+// Fills `reply_2008` with the NOTIFY_NEW_FLUFFY_BLOCK message BODY (the caller
+// frames it, same rule as broadcast_notify) and returns true, or returns false
+// to decline.
 using FluffyMissingHandler = std::function<bool(const PeerRef&,
                                                 const Hash&                       block_id,
                                                 std::uint64_t                     height,
@@ -42,14 +53,16 @@ class IBroadcastPort {
 public:
     virtual ~IBroadcastPort() = default;
 
-    // Send to every handshaked peer in state_normal. Returns the count written.
+    // Send to every handshaked peer in state_normal. `body` is the epee message
+    // body; the implementation frames it. Returns the count written.
     virtual std::size_t broadcast_notify(std::uint32_t             cmd,
-                                         std::vector<std::uint8_t> frame) = 0;
+                                         std::vector<std::uint8_t> body) = 0;
 
-    // Send to one peer. False when the peer is gone or not writable.
+    // Send to one peer, same body-not-frame contract. False when the peer is
+    // gone or not writable.
     virtual bool send_notify(const PeerRef&,
                              std::uint32_t             cmd,
-                             std::vector<std::uint8_t> frame) = 0;
+                             std::vector<std::uint8_t> body) = 0;
 
     virtual void set_fluffy_missing_handler(FluffyMissingHandler) = 0;
 

--- a/src/impl/xmr/native/node/xmr_native_node.hpp
+++ b/src/impl/xmr/native/node/xmr_native_node.hpp
@@ -49,10 +49,14 @@
 //      count -- because the X9 bring-up's lesson was that "connected and
 //      receiving nothing" must be answerable without a debugger.
 //
-// WHAT IS DELIBERATELY NOT DRIVEN HERE. C5's relay is CONSTRUCTED and its 2009
-// responder is armed, but nothing in M0 calls relay(): a found block comes from
-// the stratum/settlement path, which is M3. C4's arms are constructed and
-// readable; rebinding the option-B settlement provider through them is M2.
+// WHAT M3 CONNECTED. C5's relay was CONSTRUCTED and its 2009 responder armed
+// from M0 on, but nothing called relay(): a found block comes from the
+// stratum/settlement path, which is the consumer's. M3 gave that path two
+// seams here -- block_relay(), so the found block can go out over levin, and
+// drain_mainchain_events(), so the tip this node verified for itself can drive
+// the pool's settlement finality. With both bound and --arm-order p2p-first,
+// the find path makes no monerod call at all. C4's arms became the template
+// source in M2.
 //
 // The txpool IS now driven: M1 added the P-POOL seam (txpool_parity_sample()),
 // the harness injection port (inject_relayed()), and publish_tx_gate_() -- the
@@ -218,7 +222,11 @@ struct NativeNodeConfig {
     // second answer available, "the template path made no daemon call" cannot
     // be satisfied by a quiet fallback.
     bool                     template_fallback = true;
-    ArmOrder                 relay_order = ArmOrder::DaemonFirst;   // see the owed ruling
+    // R-ARMORDER, ruled SWITCHABLE: DaemonFirst stays the default (monerod
+    // validates the block for free before our P2P identity is behind it, which
+    // is what a daemon-assisted bring-up wants); the consumer sets P2pOnly for
+    // --arm-order p2p-first, where the daemon is not consulted at all.
+    ArmOrder                 relay_order = ArmOrder::DaemonFirst;
 
     // READ-ONLY PROBE against somebody else's daemon: handshake, TIMED_SYNC,
     // one NOTIFY_REQUEST_CHAIN, and not one block requested. See
@@ -659,6 +667,43 @@ public:
     const NativeNodeConfig& config() const noexcept { return cfg_; }
     const NetPair&          nets()   const noexcept { return nets_; }
 
+    // -----------------------------------------------------------------------
+    // M3: THE DAEMONLESS TIP FEED.
+    //
+    // M0 proved the node follows a live tip; nothing consumed that stream. The
+    // pool's settlement finality did -- but from the OTHER index, the
+    // monerod-mirroring one the X2 adapter fills from get_miner_data. This is
+    // the seam that lets the pool's finalize driver be driven by the chain this
+    // node verified itself.
+    //
+    // WHY A QUEUE AND NOT A CALLBACK. The index flushes its events on the
+    // VERIFY thread, and everything downstream of the finalize driver -- the
+    // W6 settlement store, the OWED ledger, the V37 engine submission -- is
+    // main-thread-owned in this daemon. Handing the verify thread a callback
+    // into that would put consensus bookkeeping behind a lock it has never
+    // taken. So the events are queued here and the main loop drains them, in
+    // arrival order, at exactly the point where it used to call pump_poll().
+    //
+    // The C5 relay's PREFER-OWN submit_to_own_index feeds this same queue for
+    // our OWN found block: we do not wait to hear our block back from a peer.
+    std::vector<node::MainchainEvent> drain_mainchain_events() {
+        std::lock_guard<std::mutex> lk(rec_mu_);
+        std::vector<node::MainchainEvent> out;
+        out.swap(chain_events_);
+        return out;
+    }
+
+    // How many events the feed has produced since start, whether or not anyone
+    // drained them. A tip driver that produced nothing and a consumer that
+    // dropped everything look identical without this.
+    std::uint64_t mainchain_events_seen() const {
+        std::lock_guard<std::mutex> lk(rec_mu_);
+        return chain_events_seen_;
+    }
+
+    // C5, for the consumer that actually found a block. Null before start().
+    relay::LevinBlockRelay* block_relay() noexcept { return block_relay_.get(); }
+
     // Force the publication gate after the fact (the regtest / single-peer case).
     void force_synced(bool v) { index_.force_synced(v); }
 
@@ -790,6 +835,20 @@ private:
     }
 
     void on_mainchain_(const node::MainchainEvent& ev) {
+        // M3: the daemonless tip feed. EVERY event is queued, Orphan included,
+        // because the consumer's settlement driver has a disposition for an
+        // orphan that it has for nothing else -- and it is queued HERE, above
+        // the Orphan early-return, which is exactly why it is not folded into
+        // the tip record below.
+        {
+            std::lock_guard<std::mutex> lk(rec_mu_);
+            ++chain_events_seen_;
+            chain_events_.push_back(ev);
+            // Bounded like tips_. A consumer that stopped draining is a bug, and
+            // dropping the OLDEST is the right failure: the newest events are
+            // the ones a finalize cursor still needs.
+            if (chain_events_.size() > 8192) chain_events_.erase(chain_events_.begin());
+        }
         if (ev.kind == node::MainchainEventKind::Orphan) return;
         TipRecord r;
         r.height      = ev.block.height;
@@ -878,6 +937,10 @@ private:
     mutable std::mutex        rec_mu_;
     std::vector<TipRecord>    tips_;
     std::vector<std::string>  log_;
+    // M3 tip feed (see drain_mainchain_events). Same mutex as tips_/log_: these
+    // are all written from the verify thread and read from the consumer's.
+    std::vector<node::MainchainEvent> chain_events_;
+    std::uint64_t                     chain_events_seen_ = 0;
 };
 
 } // namespace c2pool::xmr::native::rt

--- a/src/impl/xmr/native/relay/xmr_block_relay.hpp
+++ b/src/impl/xmr/native/relay/xmr_block_relay.hpp
@@ -377,14 +377,14 @@ public:
         }
 
         // --- 4. the 2008 frame --------------------------------------------
-        std::vector<std::uint8_t> frame;
+        std::vector<std::uint8_t> body2008;
         if (!p2p_suppressed) {
             std::string why;
-            if (!build_fluffy_frame(req.block_blob,
-                                    m_cfg.policy.include_all_tx_bodies ? bodies
-                                                                       : std::vector<TxBlobEntry>{},
-                                    height + 1u,   // rule 6: OUR height after this block
-                                    frame, why)) {
+            if (!build_fluffy_body(req.block_blob,
+                                   m_cfg.policy.include_all_tx_bodies ? bodies
+                                                                      : std::vector<TxBlobEntry>{},
+                                   height + 1u,   // rule 6: OUR height after this block
+                                   body2008, why)) {
                 p2p_suppressed = true;
                 p2p_why        = "2008 encode failed: " + why;
             }
@@ -401,19 +401,19 @@ public:
                     p2p_suppressed = true;
                     if (p2p_why.empty()) p2p_why = "daemon arm rejected the block";
                 } else {
-                    fire_p2p(frame, v, p2p_suppressed);
+                    fire_p2p(body2008, v, p2p_suppressed);
                 }
                 break;
             }
             case ArmOrder::Parallel: {
                 // Daemonless-primary: P2P first, always, and the daemon is the
                 // on-demand backup behind it.
-                fire_p2p(frame, v, p2p_suppressed);
+                fire_p2p(body2008, v, p2p_suppressed);
                 fire_daemon(req, v);
                 break;
             }
             case ArmOrder::P2pOnly: {
-                fire_p2p(frame, v, p2p_suppressed);
+                fire_p2p(body2008, v, p2p_suppressed);
                 break;
             }
         }
@@ -498,7 +498,7 @@ public:
         }
 
         std::string why;
-        if (!build_fluffy_frame(blob, wanted, height + 1u, reply_frame, why)) {
+        if (!build_fluffy_body(blob, wanted, height + 1u, reply_frame, why)) {
             say(true, "2009: could not encode the reply for " + hex(block_id) + ": " + why);
             reply_frame.clear();
             return decline();
@@ -624,11 +624,25 @@ private:
         return true;
     }
 
-    static bool build_fluffy_frame(const std::vector<std::uint8_t>& block_blob,
-                                   const std::vector<TxBlobEntry>&  txs,
-                                   std::uint64_t                    our_height,
-                                   std::vector<std::uint8_t>&       frame,
-                                   std::string&                     why) {
+    // THE BODY, NOT A FRAME. IBroadcastPort takes the epee-encoded MESSAGE BODY
+    // and the transport writes the 33-byte levin bucket header around it
+    // (LevinLink::send_notify -> make_notify). Building a complete frame here
+    // and handing THAT to broadcast_notify produced a doubly-framed 2008: the
+    // receiving daemon read our outer header, then tried to parse the inner
+    // header as portable_storage, and answered
+    //
+    //     portable_storage: wrong binary format - signature mismatch
+    //     Failed to load_from_binary in notify 2008
+    //
+    // for every block we sent -- so the block reached the peer's socket and
+    // never reached its chain. Found by running the relay against a real
+    // monerod; no fake port could have shown it, because a fake port frames
+    // nothing, and the peers-written count looked perfect the whole time.
+    static bool build_fluffy_body(const std::vector<std::uint8_t>& block_blob,
+                                  const std::vector<TxBlobEntry>&  txs,
+                                  std::uint64_t                    our_height,
+                                  std::vector<std::uint8_t>&       body,
+                                  std::string&                     why) {
         levin::NewBlock m;
         m.b.block_blob                = block_blob;
         m.b.txs                       = txs;
@@ -636,20 +650,19 @@ private:
         m.b.block_weight_claimed_hint = 0;       // a hint we do not need to send
         m.current_blockchain_height   = our_height;
 
-        std::vector<std::uint8_t> body;
-        levin::MessageError       err = levin::MessageError::None;
+        levin::MessageError err = levin::MessageError::None;
         if (!levin::encode_new_fluffy_block(m, body, err)) {
             why = levin::to_string(err);
             return false;
         }
-        frame = levin::make_notify(levin::CMD_NEW_FLUFFY_BLOCK, body);
         return true;
     }
 
-    void fire_p2p(const std::vector<std::uint8_t>& frame, BlockRelayVerdict& v,
+    // `body` is the epee message body; the transport adds the levin header.
+    void fire_p2p(const std::vector<std::uint8_t>& body, BlockRelayVerdict& v,
                   bool suppressed) {
-        if (suppressed || frame.empty()) return;
-        const std::size_t n = m_port.broadcast_notify(levin::CMD_NEW_FLUFFY_BLOCK, frame);
+        if (suppressed || body.empty()) return;
+        const std::size_t n = m_port.broadcast_notify(levin::CMD_NEW_FLUFFY_BLOCK, body);
         v.p2p_peers_sent    = n;
         {
             std::lock_guard<std::mutex> lk(m_mx);

--- a/src/impl/xmr/native/test/xmr_native_block_relay_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_native_block_relay_kat.cpp
@@ -253,10 +253,22 @@ BlockRelayRequest request_for(const BlockFixture& f) {
     return r;
 }
 
-// Decode a frame this component produced, the way a peer would.
-bool decode_frame(const std::vector<std::uint8_t>& frame,
+// Read back what this component produced, the way a peer would.
+//
+// C5 hands the transport a message BODY and the transport frames it
+// (LevinLink::send_notify -> make_notify). So this helper frames the body the
+// way C1 would and then parses the result. That order is deliberate: it is what
+// catches a body that was ALREADY framed, because the re-framed buffer then
+// carries a levin header where the epee storage signature should be and the
+// parse fails. C5 shipped exactly that bug -- broadcast_notify was handed a
+// complete frame -- and every Monero peer answered "portable_storage: wrong
+// binary format - signature mismatch" while the peers-written count read
+// perfectly. A fake port frames nothing, so nothing here could see it.
+bool decode_frame(const std::vector<std::uint8_t>& body,
                   levin::BucketHead&               head,
                   levin::NewBlock&                 msg) {
+    const std::vector<std::uint8_t> frame =
+        levin::make_notify(levin::CMD_NEW_FLUFFY_BLOCK, body);
     levin::HeaderPolicy pol;
     pol.handshaked = true;
     levin::HeaderError herr = levin::HeaderError::None;
@@ -265,6 +277,17 @@ bool decode_frame(const std::vector<std::uint8_t>& frame,
     levin::MessageError merr = levin::MessageError::None;
     return levin::decode_new_fluffy_block(frame.data() + levin::HEADER_SIZE,
                                           static_cast<std::size_t>(head.cb), msg, merr);
+}
+
+// The body C5 produced must START with the epee portable_storage signature
+// (01 11 01 01 | 01 01 02 01 | version), never with a levin bucket header
+// (01 21 01 01 ...). One byte comparison, and it is the whole of the bug.
+bool is_bare_epee_body(const std::vector<std::uint8_t>& body) {
+    if (body.size() < 9) return false;
+    const std::uint8_t want[9] = {0x01, 0x11, 0x01, 0x01, 0x01, 0x01, 0x02, 0x01, 0x01};
+    for (int i = 0; i < 9; ++i)
+        if (body[static_cast<std::size_t>(i)] != want[i]) return false;
+    return true;
 }
 
 // ===========================================================================
@@ -334,6 +357,10 @@ void suite_a() {
     levin::NewBlock   msg;
     const bool ok = decode_frame(port.broadcasts[0].bytes, head, msg);
     CHECK(ok, "A3  a peer can read the frame back with the C1a decoder");
+    CHECK(is_bare_epee_body(port.broadcasts[0].bytes),
+          "A3b the port was handed a BARE epee body, not an already-framed 2008 "
+          "(the transport adds the levin header; a doubly-framed notify is a "
+          "signature mismatch at every Monero peer)");
     CHECK(head.command == 2008 && levin::classify(head) == levin::FrameClass::Notify,
           "A4  the levin header says command 2008, class Notify (no answer owed)");
     CHECK(head.return_code == 0 && head.protocol_version == levin::PROTOCOL_VER_1,


### PR DESCRIPTION
**DO NOT MERGE.** Stacked DRAFT on `v37/xmr-native-m2h` (`c2pool#1588`). Base = `v37/xmr-native-m2h` @ `f44886c8`.

M2h closed F-1 and proved the option-B K_fair settlement template is assembled from a real native backlog with no daemon call on the **template** path. What was still daemon-driven was the **find** path: `LiveMonerodTransport::pump_poll()` re-issuing `get_miner_data` on a timer, the X2 adapter's monerod-mirroring index answering the finalize driver's canonical test, and `submit_block` publishing the block. M3 cuts all three over, and makes which arm drives them a runtime switch.

## R-ARMORDER = SWITCHABLE (DaemonFirst stays the default)

`--arm-order daemon-first` (default) is byte-for-byte the M0..M2h posture. `--arm-order p2p-first` moves the whole find path onto the embedded node:

| | daemon-first (default) | p2p-first |
|---|---|---|
| tip | `get_miner_data` poll / ZMQ -> X2 MainchainIndex | native C2 index, levin + RandomX-verified |
| canonical test at maturity | the same monerod mirror | the same native index |
| publish a found block | `submit_block` | levin 2008 `NOTIFY_NEW_FLUFFY_BLOCK`, `ArmOrder::P2pOnly` |
| `rpc_on_find_path` | non-zero | **0** |

The switch is fail-closed on its own preconditions (`arm_order_refusal()`, a pure function so the daemon and the KAT refuse on the same code): p2p-first REFUSES option A and the monerod template source outright, and pins the template fallback OFF -- a daemonless find whose template came from `get_miner_data`, or that can quietly fall back to it, is not one. `--no-daemon-rpc` goes further and gives the embedded node no daemon endpoint at all.

## The two seams

* `NativeNode::drain_mainchain_events()` -- every event the native index flushes, queued on the verify thread and drained by the consumer's main loop at exactly the point where `pump_poll()` used to issue an RPC. A queue and not a callback: everything downstream of the finalize driver is main-thread-owned, and handing the verify thread a callback into it would put consensus bookkeeping behind a lock it has never taken.
* `NativeNode::block_relay()` -- C5, so the winning share can be published without an RPC. `o2::P2pBlockPublisher` is the `IShareSink` that does it, behind the SAME exact 128-bit RandomX gate as the daemon submitter.

`XmrNode` builds no X2 adapter at all in p2p-first, and REFUSES to start unless the canonical test was installed before `bring_up()`: the predicate is asked at maturity, a false answer orphans a perfectly canonical block, and there is no third value to return.

## The defect this found

C5 handed `IBroadcastPort` a **complete levin frame**, while the transport frames what it is given (`LevinLink::send_notify` -> `make_notify`). Every 2008 went out doubly framed, and every Monero peer answered

```
portable_storage: wrong binary format - signature mismatch
Failed to load_from_binary in notify 2008
```

and dropped it -- with `peers_written` reading perfectly the whole time, because the bytes really did reach the socket. Found only by relaying at a real monerod; no fake port could have shown it, because a fake port frames nothing. C5 now emits the message BODY, `contracts/broadcast.hpp` says so in those words, and both `xmr_native_block_relay_kat` and the new M3 KAT pin the epee storage signature (`01 11 01 01 | 01 01 02 01 | 01`) at the first byte of what the port is handed.

## Evidence (isolated regtest, own datadirs and ports, `XMR_BUILD_RANDOMX=ON`, RandomX mode=jit)

**p2p-first.** `rpc_on_find_path=0` in the program's own counters, and an independent TCP tap in front of monerod's RPC recorded `CONNECTIONS: 0` for the whole run -- not zero requests, zero sockets. The tip advanced 333 -> 366 entirely from levin events (`native tip feed: events=366 extend=366`). `p2p publish: relayed=5407 peers_written=5407 refused=0`. FOUND -> SETTLED ran to completion.

Block **335** on monerod's own chain -- and on an independent control daemon peered to it, so real Monero P2P carried it a second hop:

```
height 335  hash fcfa825b...  num_txes 3  reward 35169728911898  block_weight 6662
miner_tx outputs: 2
   amount 1000000000          <- K_fair OWED payee
   amount 35168728911898      <- exact-sum residual sink
```

which matches the pool's own gate line for that template:

```
coinbase: n_tx=3 outputs=2 (owed=1 fixed=0 sink=1)
          sum=35169728911898 budget=35169728911898
          (base=35161931311898+fees=7797600000) K_FAIR-SHAPE=OK
```

The three transactions are the ones a wallet relayed to monerod, which reached the native C3 pool over levin (`txpool_accepted=3`) and were selected by the native arm.

**daemon-first, same binary, same rig.** `rpc_on_find_path` climbing (2314 and rising), `submit calls=1036 ok=1036`, `id-source=monerod` on every FOUND, and the tap recording `CONNECTIONS: 2713` with `submit_block: 1195`, `get_miner_data: 275`. The default path is unchanged and demonstrably still daemon-driven.

## Tests

`v37_xmr_m3_arm_order_kat` -- **40 checks, 0 failures**. Both arm orders against one counting monerod transport: daemon-first must TOUCH the daemon (a zero there is the default path having broken, not M3 having worked); p2p-first must make EXACTLY ZERO touches across bring-up and a complete FOUND -> SETTLED driven by a pumped native chain. Plus the fail-closed rules, and the publisher refusing to push a FOUND event for a block that reached no peer. No sockets, no RandomX, no live daemon -- it builds and runs on BOTH build.yml legs, and is registered with `add_test` AND in **both** `--target` lists (the #1539 "***Not Run" lesson).

Regressions on the same build: `xmr_native_block_relay_kat` 98/0, `xmr_native_node_kat` 88/0, `v37_xmr_m2_native_settlement_kat`, `v37_xmr_node_smoke`, the C1/C2/C3 suites -- all green.

## Scope, honestly

* **Regtest and minutes is NOT the stagenet milestone.** M4 owns the parity soak; nothing here has run against a real network or for longer than a few minutes.
* Levin delivery is a DELIVERY, not an adjudication: no peer answers an unsolicited block notification. What backs the block instead is the chain -- a rejected block never reaches D_conf burial, the canonical test fails at maturity, and the settlement is disposed as an orphan. The daemon's synchronous yes is traded for the chain's asynchronous one, which is the trade a daemonless node is for.
* At regtest difficulty 1 the miner wins on nearly every nonce, so the run produced thousands of same-height blocks and a large orphan count; later blocks reported `reached_nobody` once the peer stopped taking them. An artifact of the rig's pace, not of the path.
* `header=MISMATCH` on the daemon-first FOUND records is the confirmation check racing a chain advancing hundreds of blocks a second at difficulty 1 -- the same artifact M2h's runs showed, not an M3 regression.
* Disclosed pre-existing, NOT fixed here: the teardown `rc=139` in `serve_and_run`'s final `status()` after `node.stop()` (it did not reproduce in p2p-first, which builds no adapter to tear down); the option-B KAT wrong-literal already fixed on `v37-dev` by `c2pool#1544`.

Canon untouched: **zero files under `src/sharechain/`**. Everything is under `src/impl/xmr/native/**`, `src/c2pool/v37/xmr/**`, `main_v37_xmr.cpp`, CMake and `build.yml`.
