### PR TITLE
xmr(native): multi-node prefer-own same-height tiebreak [DO NOT MERGE]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,7 +248,7 @@ jobs:
                     xmr_native_backlog_famine_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
-                    v37_xmr_m3_arm_order_kat \
+                    v37_xmr_m3_arm_order_kat v37_xmr_prefer_own_race_kat \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -690,7 +690,7 @@ jobs:
                     xmr_native_backlog_famine_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
-                    v37_xmr_m3_arm_order_kat \
+                    v37_xmr_m3_arm_order_kat v37_xmr_prefer_own_race_kat \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison

--- a/src/c2pool/v37/main_v37_xmr.cpp
+++ b/src/c2pool/v37/main_v37_xmr.cpp
@@ -451,6 +451,40 @@ static int serve_and_run(const XmrNodeConfig& cfg, LiveMonerodTransport& transpo
                     static_cast<unsigned long long>(fs.orphaned),
                     static_cast<unsigned long long>(fs.refused),
                     fc.pending().size());
+        // c2pool#1551. r7=0 is the claim that matters: it counts settlements the
+        // same-height gate did not authorise, which is the only shape an
+        // orphan-credit or a double-credit can take.
+        {
+            const auto& rs = fc.race().stats();
+            const auto contested = fc.race().contested_heights();
+            std::printf("  same-height: tiebreak=%s D_conf=%llu | own=%llu other=%llu "
+                        "contests=%llu (own-vs-other=%llu, open now=%zu) | credited=%llu "
+                        "refused[orphaned=%llu other-only=%llu] deferred=%llu renotified=%llu "
+                        "| R-7 violations=%llu double-credit blocked=%llu\n",
+                        to_string(cfg.same_height_tiebreak),
+                        static_cast<unsigned long long>(cfg.d_conf),
+                        static_cast<unsigned long long>(rs.own_observed),
+                        static_cast<unsigned long long>(rs.other_observed),
+                        static_cast<unsigned long long>(rs.contests_opened),
+                        static_cast<unsigned long long>(rs.own_vs_other_opened),
+                        contested.size(),
+                        static_cast<unsigned long long>(fs.race_credited),
+                        static_cast<unsigned long long>(fs.race_refused_orphaned),
+                        static_cast<unsigned long long>(fs.race_refused_other_only),
+                        static_cast<unsigned long long>(fs.race_deferred),
+                        static_cast<unsigned long long>(fs.race_renotified),
+                        static_cast<unsigned long long>(fs.r7_violations),
+                        static_cast<unsigned long long>(rs.double_credit_blocked));
+            for (const std::uint64_t h : contested) {
+                const auto* cs = fc.race().candidates_at(h);
+                if (!cs) continue;
+                std::string line;
+                for (const auto& c : *cs)
+                    line += " " + c.bid.substr(0, 12) + (c.own ? "(ours)" : "(theirs)");
+                std::printf("    contested h=%llu:%s\n",
+                            static_cast<unsigned long long>(h), line.c_str());
+            }
+        }
         std::printf("  %s\n", rx.describe().c_str());
         const std::string g = sink.last();
         if (!g.empty()) std::printf("  gate: last=%s\n", g.c_str());
@@ -587,6 +621,11 @@ static std::unique_ptr<o2::NativeTemplateBackend> start_native_backend(const Xmr
     ncfg.c2pool_commit        = C2POOL_VERSION;
     ncfg.ready_timeout_s      = cfg.native_ready_timeout_s;
     ncfg.backlog_refresh_s    = cfg.native_backlog_refresh_s;
+    // D-14 lever (1): what the fork choice adopts at EQUAL work at the same
+    // height. Same flag as the accounting tiebreak -- see xmr_same_height_race.hpp.
+    ncfg.fork_tie             = (cfg.same_height_tiebreak == SameHeightTieBreak::PreferOwn)
+                                    ? ::c2pool::xmr::native::TieBreak::PreferOwn
+                                    : ::c2pool::xmr::native::TieBreak::FirstSeen;
 
     std::printf("template source: NATIVE — the embedded Monero node (levin, %zu pinned peer(s)) "
                 "feeds the option-B assembler%s\n",
@@ -665,7 +704,34 @@ static int run_live(const XmrNodeConfig& cfg) {
     o2::FoundBlockQueue found_q;
     o2::FinalizeConnectOptions fo;
     if (cfg.found_sidecar) fo.sidecar_path = cfg.resolved_settle_db_path() + "/pfound.tsv";
+    // c2pool#1551: the per-height verdict journal. Default it next to the
+    // settle store so that a multi-node run leaves one comparable file per node
+    // without the operator having to ask for it.
+    if (cfg.same_height_journal != "off")
+        fo.race_journal_path = cfg.same_height_journal.empty()
+                                   ? cfg.resolved_settle_db_path() + "/race.log"
+                                   : cfg.same_height_journal;
+    // Lever (2): the bounded prefer-own re-announce. Only the native levin
+    // relay can do it -- under daemon-first the block went out through
+    // monerod's submit_block and re-submitting a block monerod already has is
+    // a no-op, so the lever is simply absent there and the gate says so.
+    if (p2p_first && native && native->node() && native->node()->block_relay()) {
+        auto* relay = native->node()->block_relay();
+        fo.renotify = [relay](std::uint64_t height, const std::string& bid_hex) {
+            (void)height;
+            c2pool::xmr::node::Hash id{};
+            if (!o2::hash_from_hex(bid_hex, id)) return false;
+            std::size_t peers = 0;
+            return relay->renotify(id, &peers);
+        };
+    }
     o2::FinalizeConnect fc(node, cfg, found_q, fo);
+    std::printf("same-height policy: tiebreak=%s D_conf=%llu renotify<=%u journal=%s "
+                "| credit requires burial: YES  orphan-credit: NEVER  double-credit: BLOCKED\n",
+                to_string(cfg.same_height_tiebreak),
+                static_cast<unsigned long long>(cfg.d_conf),
+                cfg.same_height_renotify,
+                fo.race_journal_path.empty() ? "off" : fo.race_journal_path.c_str());
     {
         const auto boot = fc.reseed_after_bring_up();
         std::printf("finalize-connect: sidecar=%s reseeded=%zu reregistered=%zu stale=%zu "
@@ -847,6 +913,17 @@ static int run_live(const XmrNodeConfig& cfg) {
                         if (ev.block.height > tip_best) tip_best = ev.block.height;
                     }
                     node.pump_mainchain_event(ev);
+                }
+                // c2pool#1551: the candidates we HOLD but did not adopt. In the
+                // branch where our own block stays best the rival never becomes
+                // a mainchain event at all, so without this sweep the race book
+                // would report the height uncontested and credit as if we had
+                // run unopposed.
+                if (chain_src.alt_candidates) {
+                    std::vector<o2::FinalizeConnect::AltObservation> alts;
+                    for (const auto& a : chain_src.alt_candidates())
+                        alts.push_back(o2::FinalizeConnect::AltObservation{a.height, a.bid_hex, a.own_mined});
+                    fc.observe_alt_tips(alts);
                 }
             };
         }
@@ -1067,6 +1144,20 @@ int main(int argc, char** argv) {
         else if (a == "--lane-chain") cfg.lane_chain =
                      static_cast<::v37::ChainId>(std::stoul(next("0")));
         else if (a == "--d-conf") cfg.d_conf = std::stoull(next("60"));
+        // c2pool#1551: the same-height double-block tiebreak. One flag drives
+        // BOTH levers -- the fork choice's D-14 build-on rule and the
+        // accounting's nomination -- because two flags could disagree.
+        else if (a == "--same-height-tiebreak") {
+            const std::string m = next("prefer-own");
+            if (!parse_tie_break(m, cfg.same_height_tiebreak)) {
+                std::printf("REFUSED: --same-height-tiebreak takes prefer-own or first-seen, "
+                            "not \"%s\" (refusing rather than picking a side for you)\n", m.c_str());
+                return 2;
+            }
+        }
+        else if (a == "--same-height-renotify") cfg.same_height_renotify =
+                     static_cast<std::uint32_t>(std::stoul(next("3")));
+        else if (a == "--same-height-journal") cfg.same_height_journal = next("");
         else if (a == "--data-dir") cfg.settle_db_path = next("");
         else if (a == "--i-understand-mainnet") cfg.i_understand_mainnet = true;
         else if (a == "--randomx") cfg.randomx_enabled = true;
@@ -1078,6 +1169,13 @@ int main(int argc, char** argv) {
                 "  --network <stagenet|testnet|mainnet|regtest>   default stagenet\n"
                 "  --rpc-host <h>  --rpc-port <p>  --zmq-port <p>\n"
                 "  --lane-chain <id>  --d-conf <n>  --poll-ms <ms>  --status-every <s>\n"
+                "  --same-height-tiebreak <prefer-own|first-seen>   same-height race policy\n"
+                "                               (default prefer-own; drives BOTH the D-14 fork\n"
+                "                               choice and the settlement nomination)\n"
+                "  --same-height-renotify <n>   bounded re-announce of our own block on a\n"
+                "                               contested height (default 3; 0 = off)\n"
+                "  --same-height-journal <path|off>   per-height verdict journal\n"
+                "                               (default: race.log next to the settle store)\n"
                 "  --data-dir <path>            override the settlement store dir\n"
                 "  --no-found-sidecar           do not persist pending FOUNDs across restarts\n"
                 "  --i-understand-mainnet       required to settle a mainnet block\n"

--- a/src/c2pool/v37/test/CMakeLists.txt
+++ b/src/c2pool/v37/test/CMakeLists.txt
@@ -404,6 +404,41 @@ if (BUILD_TESTING)
     target_link_libraries(v37_xmr_m3_arm_order_kat PRIVATE xmr_node xmr_coin Threads::Threads)
     add_test(NAME v37_xmr_m3_arm_order_kat COMMAND v37_xmr_m3_arm_order_kat)
 
+    # ------------------------------------------------------------------
+    # c2pool#1551 -- the SAME-HEIGHT double-block refusal, decided prefer-own
+    # within bounds.
+    #
+    #   v37_xmr_prefer_own_race_kat
+    #     Pins the credit table for a height carrying two blocks, one of them
+    #     ours: unburied refuses everybody, buried credits ours ONLY if the
+    #     chain kept it, an orphan of ours credits NOTHING, a stranger's block
+    #     credits NOTHING, and a height credits at most once (R-7).
+    #
+    #     The property that makes the bound real is run, not asserted in prose:
+    #     the same fixture is decided under BOTH tie-break policies and the
+    #     verdicts must be identical while the nominations differ -- so
+    #     prefer-own demonstrably moves the lever and cannot reach the ledger.
+    #
+    #     Suites E and F drive the REAL XmrNode + FinalizeConnect over a pumped
+    #     native chain: E is one node winning, losing and sitting out a fork; F
+    #     is two nodes racing each other at one height, where the winner credits
+    #     once, the loser fabricates nothing, and the fleet-wide credited set has
+    #     exactly one entry. No sockets, no RandomX, no daemon.
+    #
+    #     SAME HOLLOW-GREEN GUARD as its siblings: ALSO listed in BOTH build.yml
+    #     `--target` lists (the Linux x86_64 leg and the ASan+UBSan leg), because
+    #     a registered-but-unbuilt target reports "***Not Run" and fails ctest
+    #     with exit 8 -- a red that is not a test failure (the #1539 lesson).
+    # ------------------------------------------------------------------
+    add_executable(v37_xmr_prefer_own_race_kat v37_xmr_prefer_own_race_kat.cpp)
+    target_compile_features(v37_xmr_prefer_own_race_kat PRIVATE cxx_std_20)
+    target_include_directories(v37_xmr_prefer_own_race_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/vendor
+        ${CMAKE_SOURCE_DIR}/src/impl/xmr/coin/compat)
+    target_link_libraries(v37_xmr_prefer_own_race_kat PRIVATE xmr_node xmr_coin Threads::Threads)
+    add_test(NAME v37_xmr_prefer_own_race_kat COMMAND v37_xmr_prefer_own_race_kat)
+
     # Track A2 CONSUMER half — multi-node carrier accounting over a REAL socket.
     # Proves the gap the Phase-B single-node daemon had: node B accounts node A's
     # shares. Wires the SAME production consumer code the daemon does — the W3

--- a/src/c2pool/v37/test/v37_xmr_prefer_own_race_kat.cpp
+++ b/src/c2pool/v37/test/v37_xmr_prefer_own_race_kat.cpp
@@ -1,0 +1,755 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/test/v37_xmr_prefer_own_race_kat.cpp
+//
+// c2pool#1551 -- THE SAME-HEIGHT DOUBLE-BLOCK REFUSAL, DECIDED PREFER-OWN
+// WITHIN BOUNDS. The decision table, pinned.
+//
+// Two Monero blocks at one parent height, one of them carrying our K_fair
+// settlement coinbase. The rule is that every lever WE control is biased toward
+// our own block, and that the bias stops dead at the chain: credit follows
+// burial and canonicality, never preference.
+//
+// THE TABLE THIS FILE PINS
+//
+//   own  other  buried  ours canonical | verdict            credit
+//   ---  -----  ------  --------------- ------------------  ------
+//    0     0      -           -         no-candidate        none
+//    0    >=1     -           -         other-only          none   <- an aux
+//                                                                     block
+//                                                                     settles
+//                                                                     us
+//                                                                     nothing
+//   >=1    *     no           -         defer-unburied      none   <- THE
+//                                                                     REFUSAL
+//   >=1    *     yes         yes        credit-own          ours
+//   >=1    *     yes         no         refuse-orphaned     none   <- NO
+//                                                                     orphan
+//                                                                     credit
+//    *     *      *           *         already-credited    frozen <- R-7
+//
+// AND THE PROPERTY THAT MAKES THE BOUNDS REAL. Suite B runs the SAME fixture
+// under both tie-break policies and asserts the VERDICTS are identical while
+// the NOMINATIONS differ. That is what "prefer-own never buys credit" means as
+// something checkable rather than as a sentence in a header: the policy moves
+// the lever and cannot reach the ledger.
+//
+// Suites:
+//   A  credit_rule() -- the table as a pure function, exhaustively
+//   B  SameHeightRaceLedger -- observation, nomination, policy-independence
+//   C  R-7 -- one credit per height, frozen against a later reorg
+//   D  the bounded prefer-own re-announce (lever (2)) and where it refuses
+//   E  END TO END through XmrNode + FinalizeConnect on a pumped native chain:
+//      ours-wins credits, ours-orphaned does NOT, other-only does NOT, and the
+//      R-7 cross-check between the finalize driver and the gate stays at zero
+//   F  MULTI-NODE convergence: two nodes, each holding its OWN candidate at the
+//      same contested height, agree on which block the chain kept -- the winner
+//      credits once, the loser fabricates nothing, and the fleet-wide credited
+//      set has exactly one entry at that height
+//
+// No sockets, no RandomX, no live daemon: builds and runs on BOTH build.yml
+// legs, which is also why it is listed in both --target lists -- a
+// registered-but-unbuilt target reads as "***Not Run" and fails ctest with exit
+// 8 (the #1539 lesson).
+// ===========================================================================
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include "c2pool/v37/xmr/xmr_node.hpp"
+#include "c2pool/v37/xmr/xmr_node_config.hpp"
+#include "c2pool/v37/xmr/xmr_o2_finalize_connect.hpp"
+#include "c2pool/v37/xmr/xmr_same_height_race.hpp"
+#include "impl/xmr/node/monerod_transport.hpp"
+
+using namespace c2pool::v37n::xmr;
+namespace node = ::c2pool::xmr::node;
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+static int g_pass = 0, g_fail = 0;
+
+static void check(bool ok, const std::string& what, const std::string& detail = {}) {
+    if (ok) {
+        ++g_pass;
+        std::printf("  [ok]   %s\n", what.c_str());
+        return;
+    }
+    ++g_fail;
+    std::printf("  [FAIL] %s%s%s\n", what.c_str(), detail.empty() ? "" : " -- ", detail.c_str());
+}
+
+static bool test_point_check(const std::uint8_t* pt) {
+    for (int i = 0; i < 32; ++i)
+        if (pt[i] != 0) return true;
+    return false;
+}
+
+static node::Hash blk_id(std::uint8_t b) {
+    node::Hash h{};
+    for (int i = 0; i < 32; ++i) h[i] = static_cast<std::uint8_t>(b + i);
+    return h;
+}
+static std::string bid_of(std::uint8_t b) { return hex_of(blk_id(b)); }
+
+static ::v37::bytes32 key_of(std::uint8_t b) {
+    ::v37::bytes32 k{};
+    for (int i = 0; i < 32; ++i) k[i] = static_cast<std::uint8_t>(b + 3 * i + 1);
+    return k;
+}
+
+// A canonical predicate over a plain height -> id map, the same shape
+// native_chain_source() binds to the running index.
+struct FakeChain {
+    std::map<std::uint64_t, std::string> at;
+    SameHeightRaceLedger::CanonicalFn fn() const {
+        return [this](std::uint64_t h, const std::string& bid) {
+            const auto it = at.find(h);
+            return it != at.end() && it->second == bid;
+        };
+    }
+};
+
+// ===========================================================================
+// A -- the table as a pure function
+// ===========================================================================
+static void suite_a() {
+    std::printf("A: credit_rule() -- the decision table, exhaustively\n");
+
+    // Row 1: nothing known.
+    check(credit_rule(0, 0, false, false, false) == RaceVerdict::NoCandidate,
+          "A1 no candidates at all -> no-candidate");
+    check(credit_rule(0, 0, false, true, false) == RaceVerdict::NoCandidate,
+          "A2 burial does not invent a candidate");
+
+    // Row 2: only a stranger's block. An aux block settles our ledger nothing.
+    check(credit_rule(0, 1, false, false, false) == RaceVerdict::OtherOnly,
+          "A3 other-only, unburied -> other-only (no credit)");
+    check(credit_rule(0, 3, false, true, false) == RaceVerdict::OtherOnly,
+          "A4 other-only, BURIED -> still other-only: burying a stranger's block "
+          "does not pay us");
+
+    // Row 3: THE REFUSAL. We hold a candidate, the height is not yet buried.
+    check(credit_rule(1, 0, false, false, true) == RaceVerdict::DeferUnburied,
+          "A5 ours, unburied, and already canonical -> DEFER (canonical is not buried)");
+    check(credit_rule(1, 1, false, false, false) == RaceVerdict::DeferUnburied,
+          "A6 same-height double block, unburied -> DEFER: credit nobody yet");
+    check(credit_rule(2, 2, false, false, true) == RaceVerdict::DeferUnburied,
+          "A7 a four-way contest, unburied -> DEFER");
+
+    // Row 4: buried and ours.
+    check(credit_rule(1, 0, false, true, true) == RaceVerdict::CreditOwn,
+          "A8 ours, buried, canonical -> CREDIT OURS");
+    check(credit_rule(1, 5, false, true, true) == RaceVerdict::CreditOwn,
+          "A9 ours wins a crowded height once buried -> CREDIT OURS");
+
+    // Row 5: buried and NOT ours. Bound (a) and bound (b) in one row.
+    check(credit_rule(1, 1, false, true, false) == RaceVerdict::RefuseOrphaned,
+          "A10 ours ORPHANED by the network, buried -> NO CREDIT (bound a: we cannot "
+          "override Monero consensus)");
+    check(credit_rule(3, 0, false, true, false) == RaceVerdict::RefuseOrphaned,
+          "A11 three of our own at one height, none canonical -> NO CREDIT");
+
+    // Row 6: R-7 dominates every other row.
+    for (int own = 0; own <= 2; ++own)
+        for (int oth = 0; oth <= 2; ++oth)
+            for (int b = 0; b <= 1; ++b)
+                for (int c = 0; c <= 1; ++c)
+                    if (credit_rule(static_cast<std::size_t>(own), static_cast<std::size_t>(oth),
+                                    true, b != 0, c != 0) != RaceVerdict::AlreadyCredited) {
+                        check(false, "A12 already-credited dominates every row");
+                        return;
+                    }
+    check(true, "A12 already-credited dominates every row (24 combinations)");
+
+    // Exactly one verdict authorises a credit.
+    int crediting = 0;
+    for (std::uint8_t v = 0; v <= 5; ++v)
+        if (verdict_credits(static_cast<RaceVerdict>(v))) ++crediting;
+    check(crediting == 1, "A13 exactly ONE of the six verdicts authorises a credit",
+          "crediting=" + std::to_string(crediting));
+
+    // The policy has no escape hatch.
+    check(SameHeightPolicy::credit_requires_burial && !SameHeightPolicy::orphan_credit_allowed,
+          "A14 the policy carries burial-required / no-orphan-credit as constants, not knobs");
+
+    SameHeightTieBreak t = SameHeightTieBreak::FirstSeen;
+    check(parse_tie_break("prefer-own", t) && t == SameHeightTieBreak::PreferOwn,
+          "A15 --same-height-tiebreak prefer-own parses");
+    check(parse_tie_break("first-seen", t) && t == SameHeightTieBreak::FirstSeen,
+          "A16 --same-height-tiebreak first-seen parses");
+    SameHeightTieBreak keep = SameHeightTieBreak::PreferOwn;
+    check(!parse_tie_break("whatever", keep) && keep == SameHeightTieBreak::PreferOwn,
+          "A17 an unknown spelling is REFUSED and leaves the setting alone");
+}
+
+// ===========================================================================
+// B -- the ledger: observation, nomination, and policy-independence of credit
+// ===========================================================================
+static void suite_b() {
+    std::printf("B: SameHeightRaceLedger -- the lever moves, the credit does not\n");
+
+    const std::uint64_t H = 100, D = 3;
+    const std::string OURS = bid_of(10), THEIRS = bid_of(20);
+
+    FakeChain chain;
+
+    // The rival is seen FIRST, so first-seen and prefer-own disagree about the
+    // nomination. That disagreement is the whole point of the fixture.
+    auto build = [&](SameHeightTieBreak tie) {
+        SameHeightPolicy p;
+        p.tie_break = tie;
+        p.d_conf    = D;
+        SameHeightRaceLedger L(p);
+        L.observe_other(H, THEIRS);
+        L.observe_own(H, OURS);
+        return L;
+    };
+
+    SameHeightRaceLedger own_biased   = build(SameHeightTieBreak::PreferOwn);
+    SameHeightRaceLedger first_seen   = build(SameHeightTieBreak::FirstSeen);
+
+    check(own_biased.contested_heights().size() == 1 &&
+          own_biased.contested_heights()[0] == H,
+          "B1 one own + one stranger at the same height IS a contest");
+    check(own_biased.stats().own_vs_other_opened == 1 &&
+          own_biased.stats().contests_opened == 1,
+          "B2 the contest is counted ONCE when it opens, not once per look");
+
+    // Re-observing does not re-count and does not re-label.
+    own_biased.observe_other(H, OURS);      // our own block, echoed back by the chain
+    own_biased.observe_own(H, OURS);
+    check(own_biased.holds_own(H, OURS) &&
+          own_biased.stats().contests_opened == 1,
+          "B3 our own block echoed back as a chain block stays OURS, and re-counts nothing");
+
+    // --- the lever -----------------------------------------------------
+    {
+        chain.at[H] = OURS;
+        const RaceDecision a = own_biased.decide(H, H - 1, chain.fn());
+        const RaceDecision b = first_seen.decide(H, H - 1, chain.fn());
+        check(a.nomination.bid == OURS && a.nomination.is_own,
+              "B4 prefer-own NOMINATES our block even though the rival was seen first");
+        check(b.nomination.bid == THEIRS && !b.nomination.is_own,
+              "B5 first-seen nominates the rival (the bias, turned off)");
+        check(a.verdict == b.verdict && a.verdict == RaceVerdict::DeferUnburied,
+              "B6 ... and BOTH policies refuse to credit while the height is unburied");
+    }
+
+    // --- policy-independence, across the whole burial walk -------------
+    {
+        bool same = true;
+        std::string nom_diff_at;
+        for (std::uint64_t hw = H - 2; hw <= H + D + 2; ++hw) {
+            const RaceDecision a = own_biased.decide(H, hw, chain.fn());
+            const RaceDecision b = first_seen.decide(H, hw, chain.fn());
+            if (a.verdict != b.verdict || a.credit_bid != b.credit_bid) same = false;
+            if (a.nomination.bid != b.nomination.bid) nom_diff_at = std::to_string(hw);
+        }
+        check(same, "B7 the CREDIT is byte-identical under both policies at every high-water");
+        check(!nom_diff_at.empty(),
+              "B8 ... while the NOMINATION differs (the lever is real, not decorative)");
+    }
+
+    // --- the burial bar -------------------------------------------------
+    check(own_biased.decide(H, H + D - 1, chain.fn()).verdict == RaceVerdict::DeferUnburied,
+          "B9 one block short of D_conf is still a refusal");
+    {
+        const RaceDecision d = own_biased.decide(H, H + D, chain.fn());
+        check(d.verdict == RaceVerdict::CreditOwn && d.credit_bid == OURS,
+              "B10 exactly at h + D_conf, with the chain carrying ours -> CREDIT OURS");
+        check(d.need_hw == H + D, "B11 the decision reports the burial bar it used");
+    }
+
+    // --- bound (a): the chain kept the rival ---------------------------
+    {
+        FakeChain lost;
+        lost.at[H] = THEIRS;
+        const RaceDecision d = own_biased.decide(H, H + D + 10, lost.fn());
+        check(d.verdict == RaceVerdict::RefuseOrphaned && d.credit_bid.empty(),
+              "B12 the network buried the RIVAL -> no credit, and no bid on the decision");
+        const RaceDecision e = first_seen.decide(H, H + D + 10, lost.fn());
+        check(e.verdict == d.verdict,
+              "B13 ... and prefer-own vs first-seen makes no difference to that either");
+    }
+
+    // --- other-only: an aux block at a height we never mined -----------
+    {
+        SameHeightRaceLedger L{SameHeightPolicy{SameHeightTieBreak::PreferOwn, 3, 3}};
+        L.observe_other(200, bid_of(30));
+        FakeChain c;
+        c.at[200] = bid_of(30);
+        const RaceDecision d = L.decide(200, 500, c.fn());
+        check(d.verdict == RaceVerdict::OtherOnly && d.credit_bid.empty(),
+              "B14 a stranger's block, buried a mile deep, credits us NOTHING");
+        check(!d.nomination.is_own && d.nomination.bid == bid_of(30),
+              "B15 ... and prefer-own nominates it anyway, because we hold nothing to prefer");
+    }
+
+    // --- the book is bounded -------------------------------------------
+    {
+        SameHeightRaceLedger L;
+        for (std::uint64_t h = 1; h <= 50; ++h) L.observe_other(h, bid_of(static_cast<std::uint8_t>(h)));
+        check(L.book_size() == 50, "B16 the book holds what it was told");
+        L.prune_below(40);
+        check(L.book_size() == 11, "B17 prune_below drops the heights beneath the floor",
+              "size=" + std::to_string(L.book_size()));
+    }
+
+    // --- heights_of_interest: a lone stranger is not a race ------------
+    {
+        SameHeightRaceLedger L;
+        L.observe_other(1, bid_of(1));                 // a plain chain block
+        L.observe_other(2, bid_of(2));
+        L.observe_other(2, bid_of(3));                 // a fork we are not in
+        L.observe_own(3, bid_of(4));                   // ours, unopposed
+        const auto hoi = L.heights_of_interest();
+        check(hoi.size() == 2 && hoi[0] == 2 && hoi[1] == 3,
+              "B18 the gate walks contests and our own heights, not every block ever seen",
+              "n=" + std::to_string(hoi.size()));
+    }
+
+    // --- a malformed id never becomes a ledger key ---------------------
+    {
+        SameHeightRaceLedger L;
+        check(!L.observe_own(7, "not-a-block-id") && L.book_size() == 0,
+              "B19 a malformed block id is refused, not stored");
+    }
+}
+
+// ===========================================================================
+// C -- R-7: one credit per height, frozen
+// ===========================================================================
+static void suite_c() {
+    std::printf("C: R-7 -- a height credits one block, once, and never moves it\n");
+
+    const std::uint64_t H = 300, D = 3;
+    const std::string OURS = bid_of(40), ALSO_OURS = bid_of(41), THEIRS = bid_of(42);
+
+    SameHeightPolicy p;
+    p.d_conf = D;
+    SameHeightRaceLedger L(p);
+    L.observe_own(H, OURS);
+    L.observe_own(H, ALSO_OURS);     // two of our own at one height (regtest reality)
+    L.observe_other(H, THEIRS);
+
+    FakeChain chain;
+    chain.at[H] = OURS;
+
+    const RaceDecision d = L.decide(H, H + D, chain.fn());
+    check(d.verdict == RaceVerdict::CreditOwn && d.credit_bid == OURS,
+          "C1 among three candidates the chain picks one, and that is the one credited");
+    check(d.own_candidates == 2 && d.other_candidates == 1,
+          "C2 the decision reports the whole field it decided over");
+
+    check(L.note_credited(H, OURS), "C3 the first credit at a height is recorded");
+    check(!L.note_credited(H, OURS), "C4 the SAME credit again is BLOCKED (replay)");
+    check(!L.note_credited(H, ALSO_OURS),
+          "C5 a DIFFERENT block at the same height is BLOCKED (a reorg may not move a credit)");
+    check(L.stats().double_credit_blocked == 2 && L.stats().credited == 1,
+          "C6 the blocked attempts are counted, not silently dropped",
+          "blocked=" + std::to_string(L.stats().double_credit_blocked));
+
+    const RaceDecision after = L.decide(H, H + D + 100, chain.fn());
+    check(after.verdict == RaceVerdict::AlreadyCredited && after.credit_bid == OURS,
+          "C7 the height now answers already-credited, with the bid it actually credited");
+
+    // A reorg that hands the height to the rival, AFTER we credited: the gate
+    // still says already-credited. Undoing a settled credit is the merged
+    // ledger's post-SETTLED residual rule (O3.5), not a second credit decision.
+    FakeChain reorged;
+    reorged.at[H] = THEIRS;
+    const RaceDecision post = L.decide(H, H + D + 200, reorged.fn());
+    check(post.verdict == RaceVerdict::AlreadyCredited,
+          "C8 a post-credit reorg does not reopen the decision (O3.5 owns what happens next)");
+    check(L.credited_at(H) && *L.credited_at(H) == OURS,
+          "C9 the credit record survives the reorg unchanged");
+}
+
+// ===========================================================================
+// D -- lever (2): the bounded re-announce
+// ===========================================================================
+static void suite_d() {
+    std::printf("D: the prefer-own re-announce is a lever, and it is bounded\n");
+
+    const std::uint64_t H = 400, D = 3;
+    const std::string OURS = bid_of(50), THEIRS = bid_of(51);
+
+    SameHeightPolicy p;
+    p.d_conf       = D;
+    p.max_renotify = 2;
+    SameHeightRaceLedger L(p);
+    L.observe_own(H, OURS);
+    L.observe_other(H, THEIRS);
+
+    FakeChain theirs;                 // the chain currently carries the rival
+    theirs.at[H] = THEIRS;
+
+    const RaceDecision d = L.decide(H, H, theirs.fn());
+    check(d.verdict == RaceVerdict::DeferUnburied && d.own_vs_other,
+          "D1 contested and unburied is where the lever applies");
+    check(L.take_renotify(H, d, theirs.fn()), "D2 first re-announce granted");
+    check(L.take_renotify(H, d, theirs.fn()), "D3 second re-announce granted");
+    check(!L.take_renotify(H, d, theirs.fn()),
+          "D4 the THIRD is refused: max_renotify bounds it (we do not DoS our own peers)");
+    check(L.stats().renotify_requested == 2, "D5 the spend is counted");
+
+    // Refusals, each for its own reason.
+    {
+        FakeChain ours;
+        ours.at[H] = OURS;
+        SameHeightRaceLedger M(p);
+        M.observe_own(H, OURS);
+        M.observe_other(H, THEIRS);
+        const RaceDecision e = M.decide(H, H, ours.fn());
+        check(!M.take_renotify(H, e, ours.fn()),
+              "D6 no re-announce when the chain ALREADY carries our block");
+    }
+    {
+        SameHeightPolicy off = p;
+        off.tie_break = SameHeightTieBreak::FirstSeen;
+        SameHeightRaceLedger M(off);
+        M.observe_own(H, OURS);
+        M.observe_other(H, THEIRS);
+        const RaceDecision e = M.decide(H, H, theirs.fn());
+        check(!M.take_renotify(H, e, theirs.fn()),
+              "D7 with the bias OFF there is no lever to pull");
+    }
+    {
+        SameHeightRaceLedger M(p);
+        M.observe_own(H, OURS);       // unopposed
+        const RaceDecision e = M.decide(H, H, theirs.fn());
+        check(!M.take_renotify(H, e, theirs.fn()),
+              "D8 an UNCONTESTED height is not a relay race: nothing to re-announce");
+    }
+    {
+        SameHeightRaceLedger M(p);
+        M.observe_own(H, OURS);
+        M.observe_other(H, THEIRS);
+        const RaceDecision e = M.decide(H, H + D + 1, theirs.fn());
+        check(e.verdict == RaceVerdict::RefuseOrphaned && !M.take_renotify(H, e, theirs.fn()),
+              "D9 once the height is BURIED the race is over -- re-announcing a block "
+              "the network already rejected is noise");
+    }
+    {
+        SameHeightPolicy zero = p;
+        zero.max_renotify = 0;
+        SameHeightRaceLedger M(zero);
+        M.observe_own(H, OURS);
+        M.observe_other(H, THEIRS);
+        const RaceDecision e = M.decide(H, H, theirs.fn());
+        check(!M.take_renotify(H, e, theirs.fn()),
+              "D10 --same-height-renotify 0 turns the lever off entirely");
+    }
+}
+
+// ===========================================================================
+// E / F -- end to end through the real node + the real accounting glue
+// ===========================================================================
+namespace {
+
+// One c2pool node, wired the way the daemon wires it under --arm-order
+// p2p-first: no monerod adapter, the tip and the canonical test supplied by a
+// chain the node verified itself (here, a map the test drives).
+struct Rig {
+    FakeChain                      chain;
+    node::MockMonerodTransport     mock;
+    XmrNodeConfig                  cfg;
+    std::unique_ptr<XmrNode>       node;
+    o2::FoundBlockQueue            q;
+    std::unique_ptr<o2::FinalizeConnect> fc;
+
+    Rig(const std::filesystem::path& dir, ::v37::ChainId lane, std::uint64_t d_conf,
+        SameHeightTieBreak tie = SameHeightTieBreak::PreferOwn) {
+        cfg.network              = MoneroNetwork::Stagenet;
+        cfg.lane_chain           = lane;
+        cfg.d_conf               = d_conf;
+        cfg.settle_db_path       = dir.string();
+        cfg.arm_order            = ArmOrderMode::P2PFirst;
+        cfg.coinbase             = CoinbaseMode::V37Settlement;
+        cfg.template_source      = TemplateSourceMode::Native;
+        cfg.same_height_tiebreak = tie;
+        cfg.native_connect.push_back("127.0.0.1:18080");
+        std::filesystem::create_directories(dir);
+
+        node = std::make_unique<XmrNode>(cfg, mock, &test_point_check);
+        node->set_native_chain_presence([this](std::uint64_t h, const std::string& bid) {
+            return this->chain.fn()(h, bid);
+        });
+        node->bring_up();
+
+        o2::FinalizeConnectOptions o;
+        o.out = nullptr;               // silent; the KAT asserts, it does not narrate
+        fc = std::make_unique<o2::FinalizeConnect>(*node, cfg, q, o);
+    }
+
+    // Extend the chain to `h` carrying `id`, then let the accounting react --
+    // the same two calls the daemon's main loop makes, in the same order.
+    void extend(std::uint64_t h, const std::string& id_hex, const std::string& prev_hex) {
+        chain.at[h] = id_hex;
+        node::MainchainEvent ev;
+        ev.kind = node::MainchainEventKind::Extend;
+        ev.block.height = h;
+        (void)o2::hash_from_hex(id_hex, ev.block.id);
+        (void)o2::hash_from_hex(prev_hex, ev.block.prev_id);
+        node->pump_mainchain_event(ev);
+        fc->tick();
+    }
+
+    void walk(std::uint64_t from, std::uint64_t to) {
+        for (std::uint64_t h = from; h <= to; ++h)
+            extend(h, bid_of(static_cast<std::uint8_t>(h)), bid_of(static_cast<std::uint8_t>(h - 1)));
+    }
+
+    // A block WE found at `h`, through the same queue the stratum sink pushes.
+    void found(std::uint64_t h, const std::string& id_hex, std::uint64_t reward,
+               const ::v37::bytes32& payee) {
+        o2::FoundBlockEvent e;
+        e.height          = h;
+        e.block_id_hex    = id_hex;
+        e.reward_piconero = reward;
+        e.payee           = payee;
+        q.push(e);
+        fc->tick();
+    }
+};
+
+} // namespace
+
+static void suite_e(const std::filesystem::path& root) {
+    std::printf("E: end to end -- the chain decides, the gate agrees, nothing is fabricated\n");
+
+    const std::uint64_t D = 3;
+    const std::uint64_t REWARD = 600000000000ull;
+    const ::v37::bytes32 PAYEE = key_of(0xC5);
+
+    // ── E1: ours wins ──────────────────────────────────────────────────
+    {
+        Rig r(root / "e1", 11, D);
+        r.walk(1, 9);
+
+        const std::uint64_t H = 10;
+        const std::string OURS = bid_of(10), RIVAL = bid_of(90);
+
+        r.found(H, OURS, REWARD, PAYEE);
+        check(r.node->ledger().is_pending(OURS), "E1a our block is pending in the ledger");
+        check(r.node->ledger().effective_owed(PAYEE) == -static_cast<long long>(REWARD),
+              "E1b amount-honest while pending");
+
+        // The rival exists -- held in the alt pool, never adopted. This is the
+        // branch an event-stream-only accounting layer is blind in.
+        r.fc->observe_alt_tips({o2::FinalizeConnect::AltObservation{H, RIVAL, false}});
+
+        r.extend(H, OURS, bid_of(9));
+        {
+            const auto d = r.fc->race().decide(H, r.node->hw().hw_height, r.chain.fn());
+            check(d.own_vs_other && d.contested,
+                  "E1c the height is seen as CONTESTED even though the rival never became our tip");
+            check(d.verdict == RaceVerdict::DeferUnburied,
+                  "E1d unburied -> the double-block refusal holds, for both blocks");
+            check(d.nomination.bid == OURS && d.nomination.is_own,
+                  "E1e prefer-own nominates ours");
+        }
+        check(r.fc->race().credited().empty(), "E1f nothing credited before burial");
+
+        r.walk(H + 1, H + D);
+        check(r.node->ledger().is_settled(OURS), "E1g at h + D_conf the driver SETTLES our block");
+        check(r.node->ledger().effective_owed(PAYEE) == 0, "E1h finalW nets to 0");
+        check(r.fc->stats().race_credited == 1 && r.fc->stats().r7_violations == 0,
+              "E1i the gate independently authorised that credit (R-7 violations = 0)",
+              "credited=" + std::to_string(r.fc->stats().race_credited) +
+              " r7=" + std::to_string(r.fc->stats().r7_violations));
+        const auto* cr = r.fc->race().credited_at(H);
+        check(cr && *cr == OURS, "E1j the credited block at that height is OURS, by id");
+        check(r.fc->race().credited().size() == 1,
+              "E1k exactly one height credited in the whole run");
+    }
+
+    // ── E2: ours is orphaned -- bound (a) and bound (b) ────────────────
+    {
+        Rig r(root / "e2", 12, D);
+        r.walk(1, 9);
+
+        const std::uint64_t H = 10;
+        const std::string OURS = bid_of(10), THEIRS = bid_of(80);
+
+        r.found(H, OURS, REWARD, PAYEE);
+        check(r.node->ledger().is_pending(OURS), "E2a our block registers as a FOUND");
+
+        // Monero keeps the OTHER block at this height. Nothing we can do.
+        r.extend(H, THEIRS, bid_of(9));
+        {
+            const auto d = r.fc->race().decide(H, r.node->hw().hw_height, r.chain.fn());
+            check(d.own_vs_other, "E2b the rival arrived on the chain: contested, own-vs-other");
+            check(d.verdict == RaceVerdict::DeferUnburied,
+                  "E2c still unburied -> still refusing, even though we are already losing");
+            check(d.nomination.is_own,
+                  "E2d prefer-own still nominates ours -- nominating is not crediting");
+        }
+
+        r.walk(H + 1, H + D + 2);
+        check(!r.node->ledger().is_settled(OURS),
+              "E2e our orphaned block is NEVER settled");
+        check(!r.node->ledger().is_pending(OURS),
+              "E2f ... and it left the pending set (O3.5 disposition)");
+        check(r.node->ledger().effective_owed(PAYEE) == 0,
+              "E2g the payee is back to zero: no phantom entitlement survives the orphan");
+        {
+            const auto d = r.fc->race().decide(H, r.node->hw().hw_height, r.chain.fn());
+            check(d.verdict == RaceVerdict::RefuseOrphaned,
+                  "E2h buried, and the chain kept theirs -> REFUSE ORPHANED");
+            check(d.credit_bid.empty(), "E2i a refusal carries no bid to credit");
+        }
+        check(r.fc->race().credited().empty() && r.fc->stats().race_credited == 0,
+              "E2j NO credit was fabricated for our orphaned block (no orphan-credit)");
+        check(r.fc->stats().r7_violations == 0,
+              "E2k and no R-7 violation: the driver and the gate agreed to refuse");
+        check(r.fc->stats().race_refused_orphaned >= 1,
+              "E2l the refusal is counted, so a run can be audited for it");
+    }
+
+    // ── E3: a height that was never ours ───────────────────────────────
+    {
+        Rig r(root / "e3", 13, D);
+        r.walk(1, 5);
+        const std::uint64_t H = 6;
+        // Two strangers fork at H. We hold nothing. One of them gets buried.
+        r.fc->observe_alt_tips({o2::FinalizeConnect::AltObservation{H, bid_of(70), false}});
+        r.extend(H, bid_of(6), bid_of(5));
+        r.walk(H + 1, H + D + 1);
+        const auto d = r.fc->race().decide(H, r.node->hw().hw_height, r.chain.fn());
+        check(d.verdict == RaceVerdict::OtherOnly && d.credit_bid.empty(),
+              "E3a a fork we were not in credits us NOTHING, however deeply buried");
+        check(r.fc->race().credited().empty() && r.fc->stats().r7_violations == 0,
+              "E3b nothing credited, nothing violated");
+    }
+}
+
+static void suite_f(const std::filesystem::path& root) {
+    std::printf("F: MULTI-NODE -- two nodes, one contested height, one credit in the fleet\n");
+
+    const std::uint64_t D = 3;
+    const std::uint64_t REWARD = 600000000000ull;
+    const ::v37::bytes32 PAYEE_A = key_of(0xA1);
+    const ::v37::bytes32 PAYEE_B = key_of(0xB2);
+
+    const std::uint64_t H = 10;
+    const std::string A_BLOCK = bid_of(10);    // node A's own settlement block
+    const std::string B_BLOCK = bid_of(60);    // node B's own settlement block, same height
+
+    // Two independent nodes, independent settlement stores, independent race
+    // books -- exactly as two hosts would be. They are handed the SAME chain
+    // history, which is what "the network resolved the fork" looks like from
+    // inside each of them.
+    Rig A(root / "f_a", 21, D);
+    Rig B(root / "f_b", 22, D);
+    A.walk(1, 9);
+    B.walk(1, 9);
+
+    // Each node finds ITS OWN block at the same height: the real multi-node
+    // race, not a simulated one.
+    A.found(H, A_BLOCK, REWARD, PAYEE_A);
+    B.found(H, B_BLOCK, REWARD, PAYEE_B);
+
+    // Each node also learns of the other's block -- A holds B's in its alt pool
+    // and vice versa. Until the fork resolves, both nodes are contested.
+    A.fc->observe_alt_tips({o2::FinalizeConnect::AltObservation{H, B_BLOCK, false}});
+    B.fc->observe_alt_tips({o2::FinalizeConnect::AltObservation{H, A_BLOCK, false}});
+
+    check(A.fc->race().contested_heights().size() == 1 &&
+          B.fc->race().contested_heights().size() == 1,
+          "F1 both nodes see the same height as contested");
+
+    // The network resolves it: A's block is the one that gets built on. B
+    // reorgs onto it -- and B's own block becomes the orphan.
+    A.extend(H, A_BLOCK, bid_of(9));
+    B.extend(H, A_BLOCK, bid_of(9));
+    {
+        const auto da = A.fc->race().decide(H, A.node->hw().hw_height, A.chain.fn());
+        const auto db = B.fc->race().decide(H, B.node->hw().hw_height, B.chain.fn());
+        check(da.verdict == RaceVerdict::DeferUnburied && db.verdict == RaceVerdict::DeferUnburied,
+              "F2 both nodes refuse to credit anybody while the height is unburied");
+        check(da.nomination.bid == A_BLOCK && db.nomination.bid == B_BLOCK,
+              "F3 each node nominates ITS OWN block -- prefer-own is a local preference, "
+              "and local preferences are allowed to disagree");
+    }
+
+    A.walk(H + 1, H + D);
+    B.walk(H + 1, H + D);
+
+    // --- the convergence claim -----------------------------------------
+    check(A.node->ledger().is_settled(A_BLOCK), "F4 the WINNER credits its own block");
+    check(!B.node->ledger().is_settled(B_BLOCK), "F5 the LOSER never settles its own block");
+    check(!B.node->ledger().is_pending(B_BLOCK), "F6 ... and disposes of it (O3.5)");
+    check(B.node->ledger().effective_owed(PAYEE_B) == 0,
+          "F7 the loser's payee keeps no phantom entitlement");
+    check(A.node->ledger().effective_owed(PAYEE_A) == 0,
+          "F8 the winner's finalW nets to 0");
+
+    const auto ca = A.fc->race().credited();
+    const auto cb = B.fc->race().credited();
+    check(ca.size() == 1 && ca.count(H) && ca.at(H) == A_BLOCK,
+          "F9 node A's credited map: exactly {h -> the block the chain kept}");
+    check(cb.empty(), "F10 node B credited NOTHING -- it fabricated no credit for its orphan");
+
+    // Both nodes agree about the chain, which is the thing they must agree on:
+    // the same block is canonical at the contested height on both.
+    check(A.chain.fn()(H, A_BLOCK) && B.chain.fn()(H, A_BLOCK),
+          "F11 both nodes agree which block the chain carries at the contested height");
+
+    // The fleet-wide credited set: one height, one block, one credit.
+    std::map<std::uint64_t, std::string> fleet = ca;
+    for (const auto& kv : cb) fleet[kv.first] = kv.second;
+    check(fleet.size() == 1 && fleet.at(H) == A_BLOCK,
+          "F12 across the fleet the height is credited ONCE, to the block Monero buried");
+
+    check(A.fc->stats().r7_violations == 0 && B.fc->stats().r7_violations == 0,
+          "F13 neither node's finalize driver outran its own same-height gate");
+    check(B.fc->stats().race_refused_orphaned >= 1,
+          "F14 the loser's refusal is on the record, not merely absent");
+
+    // And the journal shape both nodes would have written can be compared directly.
+    const auto da = A.fc->race().decide(H, A.node->hw().hw_height, A.chain.fn());
+    const std::string line = race_journal_line(da, A.node->hw().hw_height);
+    check(line.find("h=" + std::to_string(H)) != std::string::npos &&
+          line.find("verdict=already-credited") != std::string::npos,
+          "F15 the journal line names the height and the verdict", line);
+}
+
+// ===========================================================================
+int main() {
+    std::printf("== v37_xmr_prefer_own_race_kat: c2pool#1551 same-height prefer-own, bounded ==\n");
+
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() /
+        ("v37-xmr-race-" + std::to_string(static_cast<long>(::getpid())));
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(root);
+
+    suite_a();
+    suite_b();
+    suite_c();
+    suite_d();
+    try {
+        suite_e(root);
+        suite_f(root);
+    } catch (const std::exception& e) {
+        check(false, "E/F bring-up", e.what());
+    }
+
+    std::filesystem::remove_all(root);
+
+    std::printf("== %s: %d passed, %d failed ==\n", g_fail ? "FAIL" : "OK", g_pass, g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/src/c2pool/v37/xmr/README.md
+++ b/src/c2pool/v37/xmr/README.md
@@ -20,6 +20,7 @@ the merged `V37Engine` / `OwedLedger` / lane executor / X6 coinbase builder.
 | `xmr_settle_store.hpp` | W6 `ISettleStore` seam + `FileSettleStore` + `RecoveryDriver` (fail-closed open) |
 | `xmr_finalize_driver.hpp` | **the F1 finalize driver** — `on_block_finalized` once per coin-height, in order, `bin_height` = the high-water AT THE STEP, never the live tip |
 | `xmr_node.hpp` | `XmrNode` — owns the wiring + donor lifecycle order |
+| `xmr_same_height_race.hpp` | **c2pool#1551** — the same-height double-block refusal, decided prefer-own **within bounds**: the tie-break moves the levers we control (what we build on, what we re-announce, what we nominate) and can never make an unburied or an orphaned block creditable |
 | `xmr_live_transport.hpp` | production `IMonerodTransport` (dependency-free raw-socket RPC; RPC-poll ZMQ fallback) |
 | `xmr_node_smoke.hpp` | shared network-free smoke (monerod stub) |
 | `../main_v37_xmr.cpp` | the `c2pool-v37-xmr` entrypoint |

--- a/src/c2pool/v37/xmr/xmr_native_chain_source.hpp
+++ b/src/c2pool/v37/xmr/xmr_native_chain_source.hpp
@@ -73,6 +73,20 @@ struct NativeChainSource {
     // without this, and they have opposite fixes.
     std::function<std::uint64_t()> events_seen;
 
+    // c2pool#1551: the same-height candidates the node HOLDS but has not
+    // adopted. Needed because the branch where our own block stays best
+    // produces no mainchain event for the rival at all: an accounting layer fed
+    // only by `drain` would see that height as uncontested and credit as if we
+    // had run unopposed. Unset in daemon-first (the X2 adapter mirrors monerod's
+    // best chain and keeps no alternatives), which is an honest gap and is why
+    // the field is checkable rather than assumed.
+    struct AltCandidate {
+        std::uint64_t height = 0;
+        std::string   bid_hex;
+        bool          own_mined = false;
+    };
+    std::function<std::vector<AltCandidate>()> alt_candidates;
+
     explicit operator bool() const noexcept {
         return static_cast<bool>(drain) && static_cast<bool>(is_canonical);
     }
@@ -109,6 +123,18 @@ inline NativeChainSource native_chain_source(NativeTemplateBackend& backend) {
     };
 
     src.events_seen = [n] { return n->mainchain_events_seen(); };
+
+    src.alt_candidates = [n] {
+        std::vector<NativeChainSource::AltCandidate> out;
+        for (const auto& a : n->index().alt_tips()) {
+            NativeChainSource::AltCandidate c;
+            c.height    = a.height;
+            c.bid_hex   = chain_id_hex(a.id);
+            c.own_mined = a.own_mined;
+            out.push_back(std::move(c));
+        }
+        return out;
+    };
     return src;
 }
 

--- a/src/c2pool/v37/xmr/xmr_native_template_backend.hpp
+++ b/src/c2pool/v37/xmr/xmr_native_template_backend.hpp
@@ -128,6 +128,12 @@ struct NativeTemplateConfig {
 
     // How long start_and_wait() gives the node to reach a ready native arm.
     std::uint32_t            ready_timeout_s = 120;
+
+    // D-14 / c2pool#1551: the fork choice's rule at EQUAL cumulative difficulty
+    // at the same height. Driven from the same --same-height-tiebreak flag the
+    // settlement accounting reads, so "what we build on" and "what we nominate"
+    // cannot be configured apart.
+    native::TieBreak         fork_tie = native::TieBreak::PreferOwn;
 };
 
 class NativeTemplateBackend {
@@ -159,6 +165,7 @@ public:
         nc.template_fallback    = cfg_.fallback;
         nc.force_synced         = cfg_.force_synced;
         nc.backlog_refresh_s    = cfg_.backlog_refresh_s;
+        nc.fork_tie             = cfg_.fork_tie;
 
         node_ = std::make_unique<nrt::NativeNode>(std::move(nc));
         if (!node_->start(why)) { node_.reset(); return false; }

--- a/src/c2pool/v37/xmr/xmr_node.hpp
+++ b/src/c2pool/v37/xmr/xmr_node.hpp
@@ -125,6 +125,30 @@ public:
     // p2p-first: adapter() must not be called, and nothing may poll monerod.
     bool daemon_tip_active() const noexcept { return m_adapter != nullptr; }
 
+    // ── c2pool#1551: the ONE chain-observation seam ────────────────────────
+    //
+    // Every block this node's chain tells it about -- a new tip, a reorg tip, an
+    // orphan -- is announced here, whichever arm drives the tip. The accounting
+    // layer above needs it to SEE a same-height race at all, and it has to be
+    // one seam and not two: a prefer-own tiebreak fed by the daemon adapter in
+    // one mode and by the native index in the other would be two policies that
+    // happened to share a name.
+    using ChainObserverFn = std::function<void(std::uint64_t height, const std::string& bid_hex)>;
+    void set_chain_observer(ChainObserverFn fn) { m_chain_observer = std::move(fn); }
+
+    // The canonical test the F1 finalize driver runs at maturity, exposed so the
+    // accounting layer asks the SAME question of the SAME chain. A tiebreak that
+    // consulted a different oracle than the one that finalizes would be a
+    // second, disagreeing consensus -- and the one it disagreed with would be
+    // the one holding the money.
+    bool chain_carries(std::uint64_t height, const std::string& bid_hex) {
+        if (m_adapter) {
+            auto b = m_adapter->index().by_height(height);
+            return b && hex_of(b->id) == bid_hex;
+        }
+        return m_native_presence ? m_native_presence(height, bid_hex) : false;
+    }
+
     // The best height the settlement path is working against, from whichever
     // driver is live. In p2p-first this is the highest height a pumped event
     // carried, which is the same number the finalize cursor chases.
@@ -197,13 +221,7 @@ public:
         m_finalize = std::make_unique<XmrFinalizeDriver>(
             m_ledger, m_hw, *m_store, m_cfg.lane_chain, m_cfg.d_conf,
             m_recovered.finalize_cursor_height, m_recovered.max_event_seq,
-            [this](std::uint64_t h, const std::string& bid) {
-                if (m_adapter) {
-                    auto b = m_adapter->index().by_height(h);
-                    return b && hex_of(b->id) == bid;
-                }
-                return m_native_presence ? m_native_presence(h, bid) : false;
-            });
+            [this](std::uint64_t h, const std::string& bid) { return chain_carries(h, bid); });
 
         if (daemon_tip) {
             m_adapter->set_event_sink(
@@ -290,6 +308,13 @@ private:
     // Route the X2 mainchain event stream into the F1 finalize driver.
     void on_mainchain_event(const c2pool::xmr::node::MainchainEvent& ev) {
         using K = c2pool::xmr::node::MainchainEventKind;
+        // c2pool#1551: announce the block BEFORE settlement moves on it, so a
+        // rival that arrives in the same event is already in the race book when
+        // the finalize driver reaches the height.
+        if (m_chain_observer) {
+            if (ev.kind == K::Orphan) m_chain_observer(ev.block.height, hex_of(ev.orphaned_id));
+            else                      m_chain_observer(ev.block.height, hex_of(ev.block.id));
+        }
         switch (ev.kind) {
             case K::Extend:
             case K::Reorg: {
@@ -333,6 +358,9 @@ private:
     // daemonless posture; an adapter and no predicate is the default one.
     ChainPresenceFn                        m_native_presence;
     std::uint64_t                          m_tip_height = 0;
+
+    // c2pool#1551: installed by the accounting layer (FinalizeConnect).
+    ChainObserverFn                        m_chain_observer;
 
     std::vector<std::string>               m_log;
     bool                                   m_up = false;

--- a/src/c2pool/v37/xmr/xmr_node_config.hpp
+++ b/src/c2pool/v37/xmr/xmr_node_config.hpp
@@ -27,6 +27,7 @@
 #include <sharechain/v37/v37_lane.hpp>       // ::v37::LaneParams
 #include <sharechain/v37/v37_roundabout.hpp> // ::v37::ChainId
 #include "impl/xmr/node/xmr_node_types.hpp"  // c2pool::xmr::node::DaemonEndpoint
+#include "xmr_same_height_race.hpp"          // SameHeightPolicy, SameHeightTieBreak
 
 namespace c2pool::v37n::xmr {
 
@@ -167,6 +168,36 @@ struct XmrNodeConfig {
     // MainchainIndex retention below the tip (>= D_conf so a finalizing block is
     // always resident; seed anchors are pinned on top regardless).
     std::uint64_t   index_retain_recent = 720;
+
+    // --- c2pool#1551: the same-height double-block tiebreak -----------------
+    // Two Monero blocks at the same parent height, one of them ours. The policy
+    // sets the LEVERS (what we build on, what we re-announce, what we nominate)
+    // and carries the D_conf the credit gate uses; no setting here can make an
+    // unburied or an orphaned block creditable (xmr_same_height_race.hpp).
+    //
+    // `d_conf` above stays the single source of truth for the burial bar:
+    // same_height_policy() copies it in, so the accounting gate and the F1
+    // finalize driver cannot be configured apart.
+    //   --same-height-tiebreak prefer-own (default) | first-seen
+    //   --same-height-renotify <n>   (0 disables the bounded re-announce)
+    SameHeightTieBreak same_height_tiebreak = SameHeightTieBreak::PreferOwn;
+    std::uint32_t      same_height_renotify = 3;
+    // Per-height verdict journal. "" = race.log next to settle.img; "off" =
+    // none. Two nodes that watched the same race must agree on every height
+    // either of them credited, and a journal is what turns that claim into a
+    // diff an auditor can run.
+    std::string        same_height_journal;
+
+    // The policy as the accounting layer consumes it -- assembled HERE so the
+    // D_conf coupling is structural rather than a convention every call site
+    // has to remember.
+    SameHeightPolicy same_height_policy() const {
+        SameHeightPolicy p;
+        p.tie_break    = same_height_tiebreak;
+        p.d_conf       = d_conf;
+        p.max_renotify = same_height_renotify;
+        return p;
+    }
 
     // --- stratum front-end (X5) --------------------------------------------
     std::string     stratum_bind_host = "127.0.0.1";

--- a/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
+++ b/src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp
@@ -102,6 +102,7 @@
 #include "impl/xmr/node/xmr_node_types.hpp"        // c2pool::xmr::node::Hash
 #include "xmr_node.hpp"                            // XmrNode, hex_of, Amounts (via xmr_settle_store.hpp)
 #include "xmr_node_config.hpp"                     // XmrNodeConfig, MoneroNetwork
+#include "xmr_same_height_race.hpp"                // SameHeightRaceLedger (c2pool#1551)
 
 namespace c2pool::v37n::xmr::o2 {
 
@@ -213,6 +214,17 @@ struct FinalizeConnectOptions {
     bool        progress      = true;   // print burial progress whenever hw advances
     std::FILE*  out           = stdout; // nullptr = silent (the self-check uses this)
     std::string tag           = "[v37-xmr-fc]";
+
+    // ── c2pool#1551 ────────────────────────────────────────────────────────
+    // Per-height verdict journal, appended on every verdict TRANSITION. Empty =
+    // no journal. Two nodes that watched the same race must agree on every
+    // height either of them credited; this file is what makes that a diff.
+    std::string race_journal_path;
+
+    // Lever (2): re-announce our nominated block on a contested, unburied
+    // height. Bounded by SameHeightPolicy::max_renotify. Unset = no re-announce
+    // (the observe-side posture, and what the self-check runs).
+    std::function<bool(std::uint64_t height, const std::string& bid_hex)> renotify;
 };
 
 // ── the glue ────────────────────────────────────────────────────────────────
@@ -244,6 +256,12 @@ public:
     struct Stats {
         std::uint64_t registered = 0, refused = 0, late_refused = 0, settled = 0,
                       orphaned = 0, sidecar_write_failures = 0;
+        // c2pool#1551. `r7_violations` is the one that must stay at zero: it
+        // counts settlements the race gate did NOT authorise, which is the only
+        // way a double-credit or an orphan-credit could reach the ledger.
+        std::uint64_t race_credited = 0, race_refused_orphaned = 0,
+                      race_refused_other_only = 0, race_deferred = 0,
+                      race_renotified = 0, r7_violations = 0;
     };
 
     // Construct AFTER node.bring_up() (the finalize driver exists) and AFTER
@@ -252,7 +270,14 @@ public:
     FinalizeConnect(XmrNode& node, const XmrNodeConfig& cfg, FoundBlockQueue& queue,
                     FinalizeConnectOptions opts = {})
         : m_node(node), m_cfg(cfg), m_q(queue), m_o(std::move(opts)),
-          m_log_cursor(node.construction_log().size()) {}
+          m_log_cursor(node.construction_log().size()),
+          m_race(cfg.same_height_policy()) {
+        // c2pool#1551: take the node's single chain-observation seam. Both arm
+        // orders route through it, so the race book sees the same blocks the
+        // finalize driver does, in the same order, in either mode.
+        m_node.set_chain_observer(
+            [this](std::uint64_t h, const std::string& bid) { observe_chain_block(h, bid); });
+    }
 
     FinalizeConnect(const FinalizeConnect&) = delete;
     FinalizeConnect& operator=(const FinalizeConnect&) = delete;
@@ -328,6 +353,7 @@ public:
                 continue;
             }
             m_pending[bid] = rec;
+            m_race.observe_own(rec.height, bid, rec.found_unix_s);
             if (pending) ++rep.reseeded; else ++rep.reregistered;
             say(std::string("boot: ") + (pending ? "re-drove pending FOUND " : "RE-REGISTERED lost FOUND ") +
                 short_bid(bid) + " h=" + std::to_string(rec.height) +
@@ -353,10 +379,56 @@ public:
             else if (!r.registered)            ++t.refused;
         }
         reconcile(t);
+        race_gate(t);                          // c2pool#1551 -- after reconcile, so a
+                                               // credit the driver just took is already
+                                               // recorded when the gate cross-checks it
         echo_node_log();                       // the node's own "win: FOUND ..." lines
         progress();
         return t;
     }
+
+    // ── c2pool#1551: observation ───────────────────────────────────────────
+    // A block the node's chain told us about, at `height`. Ours (it will have
+    // been registered as a FOUND, or will be in a moment -- the race book
+    // promotes either way) or a stranger's. Installed as XmrNode's chain
+    // observer by the constructor; also callable directly by a consumer that
+    // learns of a same-height block from somewhere else.
+    void observe_chain_block(std::uint64_t height, const std::string& bid_hex) {
+        const std::string bid = lower_hex(bid_hex);
+        if (bid.size() != 64) return;
+        if (m_race.holds_own(height, bid)) { m_race.observe_own(height, bid); return; }
+        if (m_pending.count(bid) || m_unrecoverable.count(bid)) {
+            m_race.observe_own(height, bid);     // ours, seen through the chain
+            return;
+        }
+        m_race.observe_other(height, bid);
+    }
+
+    // Candidate blocks the node is HOLDING but has not adopted (the alt pool).
+    // Without them the race book is blind in exactly the branch that matters: if
+    // our own block stays best, the rival never becomes a mainchain event, and
+    // an accounting layer fed only by the event stream would report the height
+    // uncontested and credit as if we had run unopposed.
+    struct AltObservation {
+        std::uint64_t height = 0;
+        std::string   bid_hex;
+        bool          own_mined = false;
+    };
+    std::size_t observe_alt_tips(const std::vector<AltObservation>& alts) {
+        std::size_t n = 0;
+        for (const AltObservation& a : alts) {
+            const std::string bid = lower_hex(a.bid_hex);
+            if (bid.size() != 64 || a.height == 0) continue;
+            if (a.own_mined || m_race.holds_own(a.height, bid) || m_pending.count(bid))
+                n += m_race.observe_own(a.height, bid) ? 1 : 0;
+            else
+                n += m_race.observe_other(a.height, bid) ? 1 : 0;
+        }
+        return n;
+    }
+
+    const SameHeightRaceLedger& race() const noexcept { return m_race; }
+    SameHeightRaceLedger&       race()       noexcept { return m_race; }
 
     // ── shutdown: one last drain so a win that landed after the final tick has
     //    its FOUND written before node.stop(). Order: listener.stop() ->
@@ -428,6 +500,10 @@ public:
             return refuse(r, bid, "ledger did not admit the FOUND (bid already known?)");
         }
         ++m_stats.registered;
+        // c2pool#1551: the block enters the race book at the same instant it
+        // enters the ledger's pending set, so no window exists in which a rival
+        // at the same height could be judged against an empty book.
+        m_race.observe_own(ev.height, bid, ev.found_unix_s);
         say("FOUND registered " + short_bid(bid) + " h=" + std::to_string(ev.height) +
             " reward=" + std::to_string(ev.reward_piconero) + " piconero payee=" +
             (ev.payee ? hex_of(*ev.payee).substr(0, 12) + "…" : std::string("-")) +
@@ -477,6 +553,7 @@ private:
             const PendingRec&  rec = it->second;
             if (m_node.ledger().is_settled(bid)) {
                 ++t.settled; ++m_stats.settled;
+                race_confirm_credit(bid, rec.height);
                 say("FINALIZED " + short_bid(bid) + " h=" + std::to_string(rec.height) +
                     " SETTLED at bin_height=" + std::to_string(rec.height + m_cfg.d_conf) +
                     (rec.payee ? " effective_owed(payee)=" +
@@ -499,6 +576,116 @@ private:
             else ++it;
         }
         if (changed) (void)sidecar_flush();
+    }
+
+    // ── c2pool#1551: THE GATE ──────────────────────────────────────────────
+    // Walk the heights that are actually races, decide each against the SAME
+    // chain the finalize driver asks, journal the transitions, and spend the
+    // bounded re-announce budget on a contested height whose nominee is ours.
+    //
+    // Nothing here credits anything. The credit belongs to the F1 finalize
+    // driver; this gate's job is to have an INDEPENDENT verdict ready so that
+    // race_confirm_credit() can check the driver's answer against it. A gate
+    // that also did the crediting would agree with itself by construction and
+    // would prove nothing.
+    void race_gate(TickReport& t) {
+        (void)t;
+        const std::uint64_t hw = m_node.hw().hw_height;
+        auto canonical = [this](std::uint64_t h, const std::string& b) {
+            return m_node.chain_carries(h, b);
+        };
+
+        for (const std::uint64_t h : m_race.heights_of_interest()) {
+            const RaceDecision d = m_race.decide(h, hw, canonical);
+
+            const auto lv = m_last_verdict.find(h);
+            if (lv == m_last_verdict.end() || lv->second != d.verdict) {
+                m_last_verdict[h] = d.verdict;
+                m_race.account(d);
+                switch (d.verdict) {
+                    case RaceVerdict::DeferUnburied:   ++m_stats.race_deferred; break;
+                    case RaceVerdict::RefuseOrphaned:  ++m_stats.race_refused_orphaned; break;
+                    case RaceVerdict::OtherOnly:       ++m_stats.race_refused_other_only; break;
+                    default: break;
+                }
+                journal_race(d, hw);
+                say("race h=" + std::to_string(h) + " " + to_string(d.verdict) +
+                    " [own=" + std::to_string(d.own_candidates) +
+                    " other=" + std::to_string(d.other_candidates) +
+                    (d.own_vs_other ? " OWN-vs-OTHER" : (d.contested ? " own-vs-own" : "")) +
+                    "] hw=" + std::to_string(hw) + " need=" + std::to_string(d.need_hw) +
+                    " nominated=" + (d.nomination.bid.empty() ? std::string("-")
+                                                              : short_bid(d.nomination.bid)) +
+                    (d.nomination.is_own ? " (ours)" : " (theirs)") +
+                    (d.credit_bid.empty() ? "" : " credit=" + short_bid(d.credit_bid)) +
+                    " :: " + d.nomination.why);
+            }
+
+            // Lever (2). take_renotify() is what enforces the bound: it fires
+            // only on a contested, unburied height whose nominee is ours and is
+            // not already the block the chain carries, and at most
+            // max_renotify times per height.
+            if (m_o.renotify && m_race.take_renotify(h, d, canonical)) {
+                const bool sent = m_o.renotify(h, d.nomination.bid);
+                if (sent) ++m_stats.race_renotified;
+                say(std::string("race h=") + std::to_string(h) + " prefer-own RE-ANNOUNCE " +
+                    short_bid(d.nomination.bid) + (sent ? " pushed" : " NOT pushed (relay declined)"));
+            }
+        }
+
+        // Bound the book. The gate keeps a few D_conf windows of candidates and
+        // a full retention window of credit records -- long enough that any
+        // reorg the index itself could follow still finds its R-7 answer here.
+        const std::uint64_t keep = m_cfg.d_conf * 4 + 64;
+        if (hw > keep) {
+            const std::uint64_t floor = hw - keep;
+            m_race.prune_below(floor, m_cfg.index_retain_recent);
+            for (auto it = m_last_verdict.begin(); it != m_last_verdict.end();) {
+                if (it->first < floor) it = m_last_verdict.erase(it); else break;
+            }
+        }
+    }
+
+    // The finalize driver has just SETTLED `bid`, mined at `height`. The race
+    // gate now has to agree, independently, that this exact block at this exact
+    // height was creditable -- buried D_conf deep, carried by the best chain,
+    // and the FIRST credit at that height. A disagreement is not a warning to
+    // shrug at: a double-credit and an orphan-credit have no other shape.
+    void race_confirm_credit(const std::string& bid, std::uint64_t height) {
+        const std::uint64_t hw = m_node.hw().hw_height;
+        const RaceDecision d = m_race.decide(height, hw,
+            [this](std::uint64_t h, const std::string& b) { return m_node.chain_carries(h, b); });
+
+        const bool authorised = (d.verdict == RaceVerdict::CreditOwn) && (d.credit_bid == bid);
+        const bool first      = authorised && m_race.note_credited(height, bid);
+        if (first) {
+            ++m_stats.race_credited;
+            m_last_verdict[height] = RaceVerdict::AlreadyCredited;
+            RaceDecision rec = d;
+            rec.verdict = RaceVerdict::AlreadyCredited;
+            journal_race(rec, hw);
+            return;
+        }
+        ++m_stats.r7_violations;
+        const std::string* already = m_race.credited_at(height);
+        say("R-7 VIOLATION: the finalize driver SETTLED " + short_bid(bid) + " at h=" +
+            std::to_string(height) + " but the same-height gate says " + to_string(d.verdict) +
+            " (own=" + std::to_string(d.own_candidates) + " other=" + std::to_string(d.other_candidates) +
+            " hw=" + std::to_string(hw) + " need=" + std::to_string(d.need_hw) +
+            (already ? " already-credited=" + short_bid(*already) : std::string()) +
+            "). This is the shape an orphan-credit or a double-credit takes -- "
+            "the settlement store and this height need an operator's eyes.");
+        journal_race(d, hw);
+    }
+
+    void journal_race(const RaceDecision& d, std::uint64_t hw) {
+        if (m_o.race_journal_path.empty()) return;
+        std::ofstream f(m_o.race_journal_path, std::ios::app);
+        if (!f) return;
+        f << static_cast<unsigned long long>(
+                 std::chrono::duration_cast<std::chrono::seconds>(
+                     std::chrono::system_clock::now().time_since_epoch()).count())
+          << ' ' << race_journal_line(d, hw) << '\n';
     }
 
     void progress() {
@@ -608,6 +795,11 @@ private:
     Stats         m_stats;
     std::size_t   m_log_cursor = 0;
     std::uint64_t m_last_hw_printed = ~std::uint64_t{0};
+
+    // c2pool#1551: the race book and the last verdict reported per height (so a
+    // quiet loop stays quiet and the journal records transitions, not ticks).
+    SameHeightRaceLedger                    m_race;
+    std::map<std::uint64_t, RaceVerdict>    m_last_verdict;
 };
 
 } // namespace c2pool::v37n::xmr::o2

--- a/src/c2pool/v37/xmr/xmr_same_height_race.hpp
+++ b/src/c2pool/v37/xmr/xmr_same_height_race.hpp
@@ -1,0 +1,559 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ===========================================================================
+// src/c2pool/v37/xmr/xmr_same_height_race.hpp   (c2pool#1551 — the same-height
+//                                                double-block refusal, decided
+//                                                prefer-own WITHIN BOUNDS)
+//
+// THE SITUATION. Two Monero blocks exist at the same parent height. One of them
+// carries OUR c2pool K_fair settlement coinbase and settles our ledger; the
+// other is a stranger's -- a competing template, a P2Pool aux block, a control
+// peer's generateblocks -- and settles us nothing. Monero will eventually bury
+// exactly one of them. Until it does, a pool's accounting has to answer a
+// question the chain has not answered yet: who gets credited?
+//
+// THE RULE, AND WHERE IT STOPS. The race is decided by OUR benefit, so every
+// lever WE control is biased toward our own block. There are exactly three of
+// them and they are all local:
+//
+//   (1) WHAT WE BUILD ON. At EQUAL cumulative difficulty the native fork choice
+//       adopts our own block over a stranger's (D-14, xmr_fork_choice.hpp:76).
+//       Monero's rule there is first-seen; equal work means the network has not
+//       decided, so choosing our own tip is a local preference inside the space
+//       consensus left open, not an override of it.
+//   (2) WHAT WE RE-ANNOUNCE. A contested height is a relay race, and the block
+//       that reaches more of the network first is the one more of it builds on.
+//   (3) WHAT WE NOMINATE. The accounting says out loud, per height, which block
+//       it expects to be credited -- so an operator can see a contest happening
+//       instead of finding out from a missing payout.
+//
+// And there the bias stops, because the fourth thing is not ours to bias:
+//
+//   (a) WE CANNOT OVERRIDE MONERO CONSENSUS. If the network buries the rival,
+//       that is the chain. No policy in this file can make a block canonical.
+//   (b) CREDIT REQUIRES BURIAL. Our block is credited only once it is buried
+//       D_conf deep on the best chain. There is NO orphan-credit: a block
+//       Monero discarded is never credited, however ours it was.
+//   (c) NO DOUBLE-CREDIT (R-7). A height credits at most one block, once, and
+//       a later reorg cannot move that credit or mint a second one.
+//
+// THE SHAPE THAT MAKES (a)/(b)/(c) CHECKABLE. The two outputs of this module are
+// deliberately separated:
+//
+//     nominate()  -- POLICY-DEPENDENT. The lever. PreferOwn nominates ours;
+//                    FirstSeen nominates whatever arrived first (monerod's own
+//                    rule, kept so a parity run can turn the bias off).
+//     decide()    -- POLICY-INDEPENDENT. The credit. A pure function of
+//                    (own candidates, other candidates, burial, canonicality),
+//                    identical under BOTH policies.
+//
+// So "prefer-own never buys credit" is not a claim in a comment: it is a
+// property a KAT pins by running the same fixture under both policies and
+// asserting the verdicts are byte-identical while the nominations differ.
+//
+// WHAT THE REFUSAL ACTUALLY REFUSES. While a contested height is unburied the
+// verdict is DeferUnburied for EVERY candidate -- ours included. The naive
+// alternatives are both wrong in the same direction: crediting on arrival pays
+// out on a block the chain may still discard (an R-7 regression), and disposing
+// our own candidate the moment a rival appears throws away credit Monero was
+// about to award us. Refusing to decide, while nominating ours and pushing it,
+// is the only posture that is both honest and self-interested.
+//
+// SCOPE FENCE: consumer tree, header-only, STL-only. No consensus digest is
+// defined or altered here; nothing under src/sharechain/ is touched. This module
+// SEQUENCES and AUDITS calls that the merged OwedLedger and the F1 finalize
+// driver already own -- it never mutates a ledger itself.
+// ===========================================================================
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace c2pool::v37n::xmr {
+
+// ---------------------------------------------------------------------------
+// The policy knob. A flag and not a constant because a parity run against
+// monerod wants the bias OFF -- first-seen is the behaviour being compared --
+// and because an operator who disagrees with the bias should be able to say so
+// without running a different binary.
+//
+// The SAME value drives the native fork choice's D-14 tie-break, so "what we
+// build on" and "what we nominate" can never disagree with each other.
+// ---------------------------------------------------------------------------
+enum class SameHeightTieBreak : std::uint8_t { FirstSeen = 0, PreferOwn = 1 };
+
+inline const char* to_string(SameHeightTieBreak t) noexcept {
+    return t == SameHeightTieBreak::PreferOwn ? "prefer-own" : "first-seen";
+}
+
+// Parse the CLI spelling. Returns false (and leaves `out` alone) on anything
+// else, so the daemon can refuse rather than silently pick a side.
+inline bool parse_tie_break(const std::string& s, SameHeightTieBreak& out) noexcept {
+    if (s == "prefer-own" || s == "prefer_own" || s == "own") { out = SameHeightTieBreak::PreferOwn; return true; }
+    if (s == "first-seen" || s == "first_seen" || s == "firstseen") { out = SameHeightTieBreak::FirstSeen; return true; }
+    return false;
+}
+
+struct SameHeightPolicy {
+    // The lever (1)+(3). Never reaches decide().
+    SameHeightTieBreak tie_break = SameHeightTieBreak::PreferOwn;
+
+    // Burial depth required before a found block may be credited. The same
+    // D_conf the F1 finalize driver steps on (XmrNodeConfig::d_conf); carried
+    // here so the accounting gate and the driver cannot drift apart.
+    std::uint64_t d_conf = 60;
+
+    // How many times a nominated-but-not-yet-adopted own block may be
+    // re-announced per height (lever (2)). 0 disables the re-announce. Bounded
+    // on purpose: an unbounded re-push of a block the network has already
+    // rejected is a self-inflicted denial of service on our own peers.
+    std::uint32_t max_renotify = 3;
+
+    // NOT KNOBS. Written as named constants rather than left implicit so that a
+    // reader looking for the escape hatch can see there is none: no
+    // configuration makes an unburied or an orphaned block creditable.
+    static constexpr bool credit_requires_burial = true;
+    static constexpr bool orphan_credit_allowed  = false;
+};
+
+// ---------------------------------------------------------------------------
+// The decision table, as an enum. Every row is reachable and every row is
+// pinned by the KAT.
+// ---------------------------------------------------------------------------
+enum class RaceVerdict : std::uint8_t {
+    // Nothing is known at this height at all.
+    NoCandidate = 0,
+    // Only a block that is not ours is known here. An aux/stranger block settles
+    // our ledger nothing, so there is nothing to credit -- and nothing to refuse
+    // either, because we never had a claim. Distinguished from NoCandidate so an
+    // operator can tell "we mined nothing here" from "we lost this height".
+    OtherOnly = 1,
+    // We hold at least one candidate, and the height is NOT yet buried D_conf
+    // deep. Credit is REFUSED for everyone until burial resolves it. This is the
+    // same-height double-block refusal.
+    DeferUnburied = 2,
+    // Buried, and the chain carries one of OUR candidates at this height.
+    CreditOwn = 3,
+    // Buried, and the chain carries something else (or nothing we can see) at
+    // this height: our candidate lost. NO credit. Bound (a) and bound (b).
+    RefuseOrphaned = 4,
+    // This height has already been credited. The decision is frozen: a later
+    // reorg may not mint a second credit nor move the first (bound (c), R-7).
+    AlreadyCredited = 5,
+};
+
+inline const char* to_string(RaceVerdict v) noexcept {
+    switch (v) {
+        case RaceVerdict::NoCandidate:     return "no-candidate";
+        case RaceVerdict::OtherOnly:       return "other-only";
+        case RaceVerdict::DeferUnburied:   return "defer-unburied";
+        case RaceVerdict::CreditOwn:       return "credit-own";
+        case RaceVerdict::RefuseOrphaned:  return "refuse-orphaned";
+        case RaceVerdict::AlreadyCredited: return "already-credited";
+    }
+    return "?";
+}
+
+// True iff this verdict authorises a settlement credit. Exactly one row does.
+inline bool verdict_credits(RaceVerdict v) noexcept { return v == RaceVerdict::CreditOwn; }
+
+// ---------------------------------------------------------------------------
+// THE CREDIT RULE, as a pure function of four booleans/counts and NOTHING else.
+//
+// It takes no policy argument, and that absence is the point: there is no
+// parameter a caller could pass to make an unburied or non-canonical block
+// creditable. SameHeightRaceLedger::decide() computes its verdict through this
+// function and cross-checks itself against it, so the table a reader checks here
+// is the table the daemon runs.
+// ---------------------------------------------------------------------------
+inline RaceVerdict credit_rule(std::size_t own_candidates,
+                               std::size_t other_candidates,
+                               bool already_credited,
+                               bool buried,
+                               bool one_of_ours_is_canonical) noexcept {
+    if (already_credited) return RaceVerdict::AlreadyCredited;
+    if (own_candidates == 0)
+        return other_candidates == 0 ? RaceVerdict::NoCandidate : RaceVerdict::OtherOnly;
+    if (!buried) return RaceVerdict::DeferUnburied;
+    return one_of_ours_is_canonical ? RaceVerdict::CreditOwn : RaceVerdict::RefuseOrphaned;
+}
+
+// ---------------------------------------------------------------------------
+// One candidate at one height.
+// ---------------------------------------------------------------------------
+struct RaceCandidate {
+    std::string   bid;                 // 64 lowercase hex, the OwedLedger key
+    bool          own = false;         // did WE find and settle-coinbase it?
+    std::uint64_t seen_seq = 0;        // monotone arrival counter (first-seen)
+    std::uint64_t seen_unix_s = 0;     // wall clock, for the journal only
+    std::uint32_t renotified = 0;      // lever (2) budget already spent
+};
+
+struct RaceNomination {
+    std::string bid;          // empty when there is nothing at this height
+    bool        is_own = false;
+    const char* why    = "nothing known at this height";
+};
+
+struct RaceDecision {
+    RaceVerdict verdict = RaceVerdict::NoCandidate;
+    // Non-empty ONLY for CreditOwn / AlreadyCredited: the block that is (or was)
+    // credited. Deliberately not filled on any refusal row, so a caller cannot
+    // accidentally read a bid out of a decision that did not authorise one.
+    std::string credit_bid;
+    RaceNomination nomination;
+    bool        contested = false;      // >= 2 distinct candidates known here
+    bool        own_vs_other = false;   // contested, and at least one of each side
+    std::size_t own_candidates = 0;
+    std::size_t other_candidates = 0;
+    std::uint64_t height = 0;
+    std::uint64_t need_hw = 0;          // height + d_conf, the burial bar
+};
+
+// ---------------------------------------------------------------------------
+// SameHeightRaceLedger — the per-height race book and the gate over it.
+//
+// It is an ACCOUNTING object: it observes, it decides, and it records what was
+// credited. It never mutates the OwedLedger, never talks to the network, and
+// never answers the canonicality question itself -- that comes in as a callback
+// bound to the SAME chain the F1 finalize driver asks, because a tiebreak that
+// consulted a different oracle than the one that finalizes would be a second,
+// disagreeing consensus.
+//
+// Single-threaded by contract (the daemon's main loop), like the finalize driver
+// and the OwedLedger it sits beside.
+// ---------------------------------------------------------------------------
+class SameHeightRaceLedger {
+public:
+    using CanonicalFn = std::function<bool(std::uint64_t height, const std::string& bid_hex)>;
+
+    struct Stats {
+        std::uint64_t own_observed        = 0;
+        std::uint64_t other_observed      = 0;
+        std::uint64_t contests_opened     = 0;   // heights that reached >= 2 candidates
+        std::uint64_t own_vs_other_opened = 0;   // ... with at least one of each side
+        std::uint64_t credited            = 0;
+        std::uint64_t refused_orphaned    = 0;
+        std::uint64_t refused_other_only  = 0;
+        std::uint64_t deferred            = 0;   // DeferUnburied decisions taken
+        std::uint64_t double_credit_blocked = 0; // R-7 guard fired
+        std::uint64_t renotify_requested  = 0;
+    };
+
+    explicit SameHeightRaceLedger(SameHeightPolicy p = {}) : m_p(p) {}
+
+    void set_policy(const SameHeightPolicy& p) { m_p = p; }
+    const SameHeightPolicy& policy() const noexcept { return m_p; }
+    const Stats& stats() const noexcept { return m_stats; }
+
+    // ── observation ────────────────────────────────────────────────────────
+    // A block WE found at `height` carrying our settlement coinbase. Returns
+    // true when it was new here. Idempotent per (height, bid).
+    bool observe_own(std::uint64_t height, const std::string& bid, std::uint64_t unix_s = 0) {
+        return observe_(height, bid, /*own=*/true, unix_s);
+    }
+
+    // A block at `height` that is NOT ours: seen on the chain, in the alt pool,
+    // or as an orphan. Idempotent. A bid already recorded as ours STAYS ours --
+    // our own block comes back to us through the chain and through the alt pool
+    // and must not be re-labelled a stranger's by its own echo.
+    bool observe_other(std::uint64_t height, const std::string& bid, std::uint64_t unix_s = 0) {
+        return observe_(height, bid, /*own=*/false, unix_s);
+    }
+
+    // ── the decision ───────────────────────────────────────────────────────
+    // `hw_height` is the best-chain high-water the settlement path is working
+    // against (SettleHW::hw_height). `canonical` answers "does the best chain
+    // carry this bid at this height" -- the same predicate the F1 driver runs.
+    RaceDecision decide(std::uint64_t height, std::uint64_t hw_height,
+                        const CanonicalFn& canonical) const {
+        RaceDecision d;
+        d.height  = height;
+        d.need_hw = height + m_p.d_conf;
+
+        const auto it = m_book.find(height);
+        const std::vector<RaceCandidate>* cands = (it == m_book.end()) ? nullptr : &it->second.cands;
+
+        std::size_t own_n = 0, other_n = 0;
+        if (cands)
+            for (const RaceCandidate& c : *cands) { if (c.own) ++own_n; else ++other_n; }
+        d.own_candidates   = own_n;
+        d.other_candidates = other_n;
+        d.contested        = (own_n + other_n) >= 2;
+        d.own_vs_other     = own_n >= 1 && other_n >= 1;
+        d.nomination       = nominate_(cands);
+
+        const auto cr = m_credited.find(height);
+        const bool already = (cr != m_credited.end());
+
+        const bool buried = hw_height >= d.need_hw;
+
+        // Ask the chain only when the answer can matter. Bound (a): this is the
+        // ONLY input that decides between CreditOwn and RefuseOrphaned, and it
+        // is Monero's answer, not ours.
+        std::string canonical_own;
+        if (!already && own_n > 0 && buried && canonical && cands) {
+            for (const RaceCandidate& c : *cands) {
+                if (!c.own) continue;
+                if (canonical(height, c.bid)) { canonical_own = c.bid; break; }
+            }
+        }
+
+        d.verdict = credit_rule(own_n, other_n, already, buried, !canonical_own.empty());
+        if (d.verdict == RaceVerdict::CreditOwn)          d.credit_bid = canonical_own;
+        else if (d.verdict == RaceVerdict::AlreadyCredited) d.credit_bid = cr->second;
+        return d;
+    }
+
+    // ── the credit record (bound (c), R-7) ─────────────────────────────────
+    // Record that `bid` was credited at `height`. Returns false and counts a
+    // blocked double-credit when the height already carries a credit -- whether
+    // for the same bid (a replay) or a different one (a reorg trying to move
+    // it). The caller treats false as "do not credit"; the merged OwedLedger's
+    // own is_settled() idempotence is the second belt.
+    bool note_credited(std::uint64_t height, const std::string& bid) {
+        const auto it = m_credited.find(height);
+        if (it != m_credited.end()) {
+            ++m_stats.double_credit_blocked;
+            return false;
+        }
+        m_credited.emplace(height, bid);
+        ++m_stats.credited;
+        return true;
+    }
+
+    // What was credited at this height, if anything.
+    const std::string* credited_at(std::uint64_t height) const {
+        const auto it = m_credited.find(height);
+        return it == m_credited.end() ? nullptr : &it->second;
+    }
+
+    // The whole credited set, for a cross-node convergence diff: two nodes that
+    // watched the same race must agree on this map exactly.
+    const std::map<std::uint64_t, std::string>& credited() const noexcept { return m_credited; }
+
+    // Count a decision that the caller acted on, so the stats reflect the run
+    // rather than however many times a status line happened to ask.
+    void account(const RaceDecision& d) {
+        switch (d.verdict) {
+            case RaceVerdict::DeferUnburied:  ++m_stats.deferred; break;
+            case RaceVerdict::RefuseOrphaned: ++m_stats.refused_orphaned; break;
+            case RaceVerdict::OtherOnly:      ++m_stats.refused_other_only; break;
+            default: break;
+        }
+    }
+
+    // ── lever (2): the bounded re-announce ─────────────────────────────────
+    // Should we re-push our nominated block at this height right now? True at
+    // most `max_renotify` times per height, and only while the height is
+    // genuinely contested against a rival, unburied, and our nominee is not the
+    // block the chain currently carries. Consumes one unit of the budget.
+    bool take_renotify(std::uint64_t height, const RaceDecision& d, const CanonicalFn& canonical) {
+        if (m_p.max_renotify == 0) return false;
+        if (m_p.tie_break != SameHeightTieBreak::PreferOwn) return false;
+        if (d.verdict != RaceVerdict::DeferUnburied) return false;
+        if (!d.own_vs_other) return false;
+        if (!d.nomination.is_own || d.nomination.bid.empty()) return false;
+        if (canonical && canonical(height, d.nomination.bid)) return false;  // already ours
+        const auto it = m_book.find(height);
+        if (it == m_book.end()) return false;
+        for (RaceCandidate& c : it->second.cands) {
+            if (c.bid != d.nomination.bid) continue;
+            if (c.renotified >= m_p.max_renotify) return false;
+            ++c.renotified;
+            ++m_stats.renotify_requested;
+            return true;
+        }
+        return false;
+    }
+
+    // ── read seams ─────────────────────────────────────────────────────────
+    std::vector<std::uint64_t> heights() const {
+        std::vector<std::uint64_t> out;
+        out.reserve(m_book.size());
+        for (const auto& kv : m_book) out.push_back(kv.first);
+        return out;
+    }
+
+    // Heights holding >= 2 candidates with at least one of each side: the real
+    // races, as opposed to a height where we simply found two of our own.
+    std::vector<std::uint64_t> contested_heights() const {
+        std::vector<std::uint64_t> out;
+        for (const auto& kv : m_book) {
+            std::size_t own_n = 0, other_n = 0;
+            for (const RaceCandidate& c : kv.second.cands) { if (c.own) ++own_n; else ++other_n; }
+            if (own_n >= 1 && other_n >= 1) out.push_back(kv.first);
+        }
+        return out;
+    }
+
+    // The heights a gate actually has to walk: one we hold a candidate of our
+    // own at, or one carrying more than one candidate at all. A height where the
+    // chain simply delivered one stranger's block is not a race and does not
+    // need deciding every tick -- and on a node that has been up for a week,
+    // walking every height it has ever seen is the difference between a gate and
+    // a leak.
+    std::vector<std::uint64_t> heights_of_interest() const {
+        std::vector<std::uint64_t> out;
+        for (const auto& kv : m_book) {
+            std::size_t own_n = 0;
+            for (const RaceCandidate& c : kv.second.cands) if (c.own) ++own_n;
+            if (own_n >= 1 || kv.second.cands.size() >= 2) out.push_back(kv.first);
+        }
+        return out;
+    }
+
+    const std::vector<RaceCandidate>* candidates_at(std::uint64_t height) const {
+        const auto it = m_book.find(height);
+        return it == m_book.end() ? nullptr : &it->second.cands;
+    }
+
+    bool holds_own(std::uint64_t height, const std::string& bid) const {
+        const auto it = m_book.find(height);
+        if (it == m_book.end()) return false;
+        for (const RaceCandidate& c : it->second.cands)
+            if (c.own && c.bid == bid) return true;
+        return false;
+    }
+
+    // Forget heights strictly below `floor`. The book is bounded by the same
+    // retention the settlement path already keeps; a node that ran for a month
+    // must not carry a candidate list for every height it ever saw. Credited
+    // records are kept for `credit_keep` heights below the floor so the R-7
+    // guard still answers for anything a reorg could plausibly reach.
+    std::size_t prune_below(std::uint64_t floor, std::uint64_t credit_keep = 0) {
+        std::size_t n = 0;
+        for (auto it = m_book.begin(); it != m_book.end();) {
+            if (it->first < floor) { it = m_book.erase(it); ++n; } else break;
+        }
+        const std::uint64_t cfloor = floor > credit_keep ? floor - credit_keep : 0;
+        for (auto it = m_credited.begin(); it != m_credited.end();) {
+            if (it->first < cfloor) it = m_credited.erase(it); else break;
+        }
+        return n;
+    }
+
+    std::size_t book_size() const noexcept { return m_book.size(); }
+
+private:
+    // The per-height book, plus the two "counted already" latches. Without them
+    // a contest would be counted again every time a candidate was re-observed
+    // or promoted, and the run's contest count is evidence -- it has to mean
+    // "races that happened", not "times we looked".
+    struct HeightBook {
+        std::vector<RaceCandidate> cands;
+        bool contest_counted = false;   // reached >= 2 candidates
+        bool ovo_counted     = false;   // reached >= 1 own AND >= 1 other
+    };
+
+    bool observe_(std::uint64_t height, const std::string& bid, bool own, std::uint64_t unix_s) {
+        if (bid.size() != 64) return false;          // never key on a malformed id
+        HeightBook& hb = m_book[height];
+
+        bool added = true;
+        bool promoted = false;
+        for (RaceCandidate& c : hb.cands) {
+            if (c.bid != bid) continue;
+            added = false;
+            // Promotion is one-way: a block we found is ours forever, even when
+            // the chain hands it back to us as an ordinary block.
+            if (own && !c.own) { c.own = true; promoted = true; }
+            break;
+        }
+        if (added) {
+            RaceCandidate c;
+            c.bid = bid;
+            c.own = own;
+            c.seen_seq = ++m_seq;
+            c.seen_unix_s = unix_s;
+            hb.cands.push_back(std::move(c));
+        }
+        if (added || promoted) {
+            if (own) ++m_stats.own_observed; else ++m_stats.other_observed;
+        }
+        note_contest_(hb);
+        return added;
+    }
+
+    // Count a contest exactly once, at the moment it opens.
+    void note_contest_(HeightBook& hb) {
+        std::size_t own_n = 0, other_n = 0;
+        for (const RaceCandidate& c : hb.cands) { if (c.own) ++own_n; else ++other_n; }
+        if (!hb.contest_counted && own_n + other_n >= 2) {
+            hb.contest_counted = true;
+            ++m_stats.contests_opened;
+        }
+        if (!hb.ovo_counted && own_n >= 1 && other_n >= 1) {
+            hb.ovo_counted = true;
+            ++m_stats.own_vs_other_opened;
+        }
+    }
+
+    // THE LEVER. This is the only place the policy is read.
+    RaceNomination nominate_(const std::vector<RaceCandidate>* cands) const {
+        RaceNomination n;
+        if (!cands || cands->empty()) return n;
+
+        const RaceCandidate* first_own   = nullptr;
+        const RaceCandidate* first_other = nullptr;
+        const RaceCandidate* earliest    = nullptr;
+        for (const RaceCandidate& c : *cands) {
+            if (c.own) { if (!first_own || c.seen_seq < first_own->seen_seq) first_own = &c; }
+            else       { if (!first_other || c.seen_seq < first_other->seen_seq) first_other = &c; }
+            if (!earliest || c.seen_seq < earliest->seen_seq) earliest = &c;
+        }
+
+        if (m_p.tie_break == SameHeightTieBreak::PreferOwn && first_own) {
+            n.bid = first_own->bid;
+            n.is_own = true;
+            n.why = first_other ? "prefer-own: our settlement block over the rival"
+                                : "our settlement block, unopposed so far";
+            return n;
+        }
+        if (earliest) {
+            n.bid = earliest->bid;
+            n.is_own = earliest->own;
+            n.why = (m_p.tie_break == SameHeightTieBreak::FirstSeen)
+                        ? "first-seen (bias off: monerod's own rule)"
+                        : "first-seen: we hold no candidate of our own here";
+        }
+        return n;
+    }
+
+    SameHeightPolicy m_p;
+    std::map<std::uint64_t, HeightBook>   m_book;      // height -> candidates
+    std::map<std::uint64_t, std::string>  m_credited;  // height -> credited bid
+    std::uint64_t m_seq = 0;
+    Stats         m_stats;
+};
+
+// ---------------------------------------------------------------------------
+// One journal line per verdict TRANSITION, in a shape two nodes can diff.
+// Cross-node convergence after burial is exactly "these files agree on every
+// height either of them credited", which is a claim a `diff` settles.
+// ---------------------------------------------------------------------------
+inline std::string race_journal_line(const RaceDecision& d, std::uint64_t hw_height) {
+    std::string s = "h=" + std::to_string(d.height)
+                  + " verdict=" + to_string(d.verdict)
+                  + " hw=" + std::to_string(hw_height)
+                  + " need=" + std::to_string(d.need_hw)
+                  + " own=" + std::to_string(d.own_candidates)
+                  + " other=" + std::to_string(d.other_candidates)
+                  + " contested=" + (d.own_vs_other ? "own-vs-other" : (d.contested ? "own-vs-own" : "no"))
+                  + " nominated=" + (d.nomination.bid.empty() ? std::string("-") : d.nomination.bid)
+                  + " nominated_own=" + (d.nomination.is_own ? "1" : "0")
+                  + " credit=" + (d.credit_bid.empty() ? std::string("-") : d.credit_bid);
+    return s;
+}
+
+} // namespace c2pool::v37n::xmr

--- a/src/impl/xmr/native/chain/xmr_chain_index.hpp
+++ b/src/impl/xmr/native/chain/xmr_chain_index.hpp
@@ -627,6 +627,28 @@ public:
     std::uint64_t bans() const { std::lock_guard<std::mutex> lk(mu_); return bans_; }
     std::uint64_t orphans_parked() const { std::lock_guard<std::mutex> lk(mu_); return orphans_; }
     std::size_t   alt_size() const { std::lock_guard<std::mutex> lk(mu_); return alt_.size(); }
+
+    // c2pool#1551: the same-height candidates this node HOLDS but has not
+    // adopted. The settlement accounting above needs them to see a race at all
+    // -- in the branch where our own block stays best, the rival produces no
+    // mainchain event, and an accounting layer fed only by that stream would
+    // credit as if the height had been uncontested.
+    struct AltTip {
+        Hash          id{};
+        Hash          prev_id{};
+        std::uint64_t height    = 0;
+        bool          own_mined = false;
+        bool          resolved  = false;   // difficulty computed on its own branch
+    };
+    std::vector<AltTip> alt_tips() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        std::vector<AltTip> out;
+        out.reserve(alt_.size());
+        alt_.for_each([&out](const AltBlock& b) {
+            out.push_back(AltTip{b.id, b.prev_id, b.height, b.own_mined, b.resolved});
+        });
+        return out;
+    }
     PowGate&      pow_gate() noexcept { return gate_; }
 
     // Ids the index wants fetched: what a chain entry told us we are missing,

--- a/src/impl/xmr/native/chain/xmr_fork_choice.hpp
+++ b/src/impl/xmr/native/chain/xmr_fork_choice.hpp
@@ -210,6 +210,14 @@ public:
         return n;
     }
 
+    // Every candidate the pool is holding, in key order. The accounting layer
+    // above needs this to see a same-height race in the branch where our own
+    // block stays best: the rival never becomes a mainchain event there, so a
+    // consumer fed only by the event stream would report the height uncontested.
+    void for_each(const std::function<void(const AltBlock&)>& fn) const {
+        for (const auto& kv : blocks_) fn(kv.second);
+    }
+
     std::vector<const AltBlock*> children_of(const Hash& prev_id) const {
         std::vector<const AltBlock*> out;
         const auto it = children_.find(key_(prev_id));

--- a/src/impl/xmr/native/node/xmr_native_node.hpp
+++ b/src/impl/xmr/native/node/xmr_native_node.hpp
@@ -228,6 +228,14 @@ struct NativeNodeConfig {
     // --arm-order p2p-first, where the daemon is not consulted at all.
     ArmOrder                 relay_order = ArmOrder::DaemonFirst;
 
+    // D-14, c2pool#1551: what the fork choice does at EQUAL cumulative
+    // difficulty at the same height. PreferOwn adopts our own block (the
+    // default, and the "what we build on" lever of the prefer-own rule);
+    // FirstSeen is monerod's rule and is what a parity run compares against.
+    // The consumer drives this from the SAME --same-height-tiebreak flag the
+    // settlement accounting reads, so the two can never disagree.
+    TieBreak                 fork_tie = TieBreak::PreferOwn;
+
     // READ-ONLY PROBE against somebody else's daemon: handshake, TIMED_SYNC,
     // one NOTIFY_REQUEST_CHAIN, and not one block requested. See
     // SyncDriverConfig::probe_only.
@@ -712,6 +720,7 @@ private:
     ChainIndexOptions make_index_options_() const {
         ChainIndexOptions o;
         o.net = nets_.consensus;
+        o.tie = cfg_.fork_tie;          // D-14, driven by --same-height-tiebreak
         return o;
     }
 

--- a/src/impl/xmr/native/relay/xmr_block_relay.hpp
+++ b/src/impl/xmr/native/relay/xmr_block_relay.hpp
@@ -254,6 +254,8 @@ struct RelayStats {
     std::uint64_t daemon_rejected      = 0;
     std::uint64_t missing_tx_served    = 0;
     std::uint64_t missing_tx_declined  = 0;
+    // c2pool#1551: bounded prefer-own re-announces on a contested height.
+    std::uint64_t renotified           = 0;
 };
 
 // ---------------------------------------------------------------------------
@@ -518,6 +520,50 @@ public:
     std::size_t retained_count() const {
         std::lock_guard<std::mutex> lk(m_mx);
         return m_book.size();
+    }
+
+    // c2pool#1551, lever (2): push a block we already announced ONCE MORE, from
+    // the bytes we retained. A contested height is a relay race, and the block
+    // that reaches more of the network first is the one more of it builds on --
+    // so on a same-height contest the prefer-own gate spends a small, bounded
+    // budget re-announcing our own block.
+    //
+    // It re-frames from the retained body rather than re-running the relay's
+    // acceptance path on purpose: this block was already checked, already
+    // accepted and already ours, and re-deciding it here would be a second
+    // opinion about our own block with nothing new to decide it on. Returns
+    // false when the block is no longer retained (expired, or never ours), so a
+    // caller can tell "pushed" from "had nothing to push" -- which are different
+    // stories and have different fixes.
+    bool renotify(const Hash& block_id, std::size_t* peers_sent = nullptr) {
+        std::vector<std::uint8_t> blob;
+        std::vector<TxBlobEntry>  bodies;
+        std::uint64_t             height = 0;
+        {
+            std::lock_guard<std::mutex> lk(m_mx);
+            const Retained* r = find_locked(block_id);
+            if (!r) return false;
+            blob   = r->block_blob;
+            bodies = r->bodies;
+            height = r->height;
+        }
+        std::vector<std::uint8_t> body;
+        std::string why;
+        if (!build_fluffy_body(blob, bodies, height + 1, body, why)) {
+            say(true, "renotify: could not re-frame block " + hex(block_id) + ": " + why);
+            return false;
+        }
+        const std::size_t n = m_port.broadcast_notify(levin::CMD_NEW_FLUFFY_BLOCK, body);
+        {
+            std::lock_guard<std::mutex> lk(m_mx);
+            ++m_stats.p2p_frames_written;
+            m_stats.p2p_peers_written += static_cast<std::uint64_t>(n);
+            ++m_stats.renotified;
+        }
+        if (peers_sent) *peers_sent = n;
+        say(false, "renotify: re-announced block " + hex(block_id) + " at h=" +
+                   std::to_string(height) + " to " + std::to_string(n) + " peer(s)");
+        return n > 0;
     }
 
 private:


### PR DESCRIPTION
**DO NOT MERGE** — DRAFT, stacked on `v37/xmr-native-m3` (c2pool#1591, the daemonless node that finds and finalizes). Base is that branch, not `v37-dev`.

Closes the owed **c2pool#1551** item: *same-height double-block refusal -> prefer-own*.

## The situation

Two Monero blocks at one parent height. One carries our K_fair settlement coinbase and settles our ledger; the other is a stranger's — a competing template, a P2Pool aux block, a control peer's `generateblocks` — and settles us nothing. Until this branch the accounting had no answer for that at all. The F1 finalize driver credited whatever was buried and canonical at maturity, which is correct, and *nothing anywhere* recorded that the height had been contested, said which block we expected to be paid for, or checked the credit against a second opinion.

## The rule, and where it stops

The race is decided by **our benefit**, so every lever we control is biased toward our own block. There are exactly three and they are all local:

1. **What we build on** — the native fork choice adopts our own block at *equal* cumulative difficulty (D-14, `xmr_fork_choice.hpp`). Monero's rule there is first-seen; equal work means the network has not decided, so preferring our own tip is a choice inside the space consensus left open.
2. **What we re-announce** — a contested height is a relay race, so a small, bounded re-push of our own block.
3. **What we nominate** — the accounting says out loud, per height, which block it expects to be credited, so an operator sees a contest happening instead of finding out from a missing payout.

One flag (`--same-height-tiebreak`) drives all three, because two flags could disagree.

And there the bias stops:

- **(a) We cannot override Monero consensus.** If the network buries the rival, that is the chain.
- **(b) Credit requires burial.** A block is credited only once buried `D_conf` deep on the best chain. **No orphan-credit.**
- **(c) No double-credit (R-7).** A height credits at most one block, once; a later reorg neither mints a second credit nor moves the first.

## The shape that makes (a)/(b)/(c) checkable

`nominate()` is policy-**dependent**. `decide()` is policy-**independent** — a pure function of *(own candidates, other candidates, burial, canonicality)* with no policy argument to pass, so there is no setting a caller could reach for. The KAT runs one fixture under **both** tie-break policies and asserts the verdicts are byte-identical while the nominations differ. "Prefer-own never buys credit" is therefore a property that is run, not a sentence in a header.

The gate keeps its **own** verdict rather than doing the crediting, and `FinalizeConnect` cross-checks every settlement the F1 driver takes against it (`r7_violations`, which must stay at zero). A gate that also credited would agree with itself by construction and would prove nothing.

Alt-pool candidates are swept in alongside mainchain events, because the branch where our own block *stays best* produces no event for the rival at all — an accounting layer fed only by the event stream would report that height uncontested and credit as if it had run unopposed.

### The decision table (pinned by the KAT)

| own | other | buried | ours canonical | verdict | credit |
|----|----|----|----|----|----|
| 0 | 0 | – | – | `no-candidate` | none |
| 0 | >=1 | – | – | `other-only` | none |
| >=1 | * | no | – | `defer-unburied` | none (**the refusal**) |
| >=1 | * | yes | yes | `credit-own` | ours |
| >=1 | * | yes | no | `refuse-orphaned` | none (**no orphan-credit**) |
| * | * | * | * | `already-credited` | frozen (**R-7**) |

## What changed

| file | what |
|---|---|
| **new** `src/c2pool/v37/xmr/xmr_same_height_race.hpp` | `SameHeightRaceLedger`: the per-height race book, `credit_rule()` as a pure function, the nomination, the R-7 credit record, the bounded re-announce budget, the journal line |
| `src/c2pool/v37/xmr/xmr_o2_finalize_connect.hpp` | observes own FOUNDs and chain/alt blocks, runs the gate each tick, journals verdict **transitions**, cross-checks every credit |
| `src/c2pool/v37/xmr/xmr_node.hpp` | one chain-observation seam for **both** arm orders; `chain_carries()` so the gate asks the same oracle the finalize driver does |
| `src/c2pool/v37/xmr/xmr_node_config.hpp` | `--same-height-tiebreak` / `--same-height-renotify` / `--same-height-journal`; `d_conf` stays the single source of truth for the burial bar |
| `src/c2pool/v37/xmr/xmr_native_chain_source.hpp`, `xmr_native_template_backend.hpp` | alt-candidate feed; the D-14 tie-break plumbed from the same flag |
| `src/impl/xmr/native/chain/xmr_chain_index.hpp`, `xmr_fork_choice.hpp` | `alt_tips()` / `AltPool::for_each` — the candidates we hold but did not adopt; `ChainIndexOptions::tie` becomes a setting |
| `src/impl/xmr/native/relay/xmr_block_relay.hpp` | `renotify()` — re-announce a retained block once more (lever 2) |
| `src/c2pool/v37/test/v37_xmr_prefer_own_race_kat.cpp` | the KAT |
| `.github/workflows/build.yml` | the new target in **both** `--target` lists |

**Canon wall:** zero files under `src/sharechain/`. No consensus digest is defined or altered; this module sequences and audits calls the merged `OwedLedger` and F1 driver already own.

## Tests

`v37_xmr_prefer_own_race_kat` — **95 checks, 0 failed**, six suites:

- **A** `credit_rule()` exhaustively, including all 24 combinations where `already-credited` dominates
- **B** the ledger: observation, nomination, and credit identical under both policies at every high-water while the nomination differs
- **C** R-7: one credit per height, blocked replay, blocked move, frozen against a post-credit reorg
- **D** the re-announce lever and its five refusals (already ours / bias off / uncontested / buried / budget 0)
- **E** end to end through the real `XmrNode` + `FinalizeConnect` on a pumped native chain: ours-wins credits, ours-orphaned does not, a fork we were not in does not
- **F** two nodes, each holding its own candidate at one contested height: the winner credits once, the loser fabricates nothing, the fleet-wide credited set has exactly one entry

Registered with `add_test` **and** in both `build.yml --target` lists (the #1539 `***Not Run` lesson). Siblings re-run green: `v37_xmr_o2_finalize_connect_selfcheck`, `v37_xmr_m3_arm_order_kat`, `v37_xmr_node_smoke`, `xmr_native_chain_index_kat`, `xmr_native_block_relay_kat`, `xmr_native_node_kat`. Built with `XMR_BUILD_RANDOMX=ON`, g++-15, `cppstd=20`.

## Live proof (isolated regtest, minutes — NOT a stagenet milestone)

Rig: two **partitioned** regtest monerods (neither dials out; they do not know each other), a **control peer** that dials both and whose presence is the merge and whose absence is the partition, and **two daemonless c2pool nodes** (`--arm-order p2p-first`, `--coinbase v37`, `--xmr-template-source native`, `D_conf=3`, distinct settlement payees). `rpc_on_find_path=0` on both nodes throughout.

**Race 1 — two c2pool nodes, each with its own settlement block at h=31.** Partitioned, each node mined and relayed its own block; monerod A kept `f3ddad…`, monerod B kept `1d787e…`, same height, different tips. Both nodes refused to credit anybody while unburied. The control peer merged the partitions and the A branch was extended, so the network buried `f3ddad…`:

```
node1  h=31 verdict=defer-unburied   hw=30 need=34 own=5 other=0  credit=-
node1  h=31 verdict=already-credited hw=37 need=34 own=9 other=0  credit=f3ddad7bc211…
node2  h=31 verdict=defer-unburied   hw=30 need=34 own=1 other=0  credit=-
node2  h=31 verdict=refuse-orphaned  hw=37 need=34 own=6 other=1  credit=-        <- own-vs-other
```

Node 2's own view of the contest, with prefer-own still nominating its own block while refusing to credit it:

```
race h=31 refuse-orphaned [own=6 other=1 OWN-vs-OTHER] hw=37 need=34
          nominated=1d787ed1b6d1… (ours) :: prefer-own: our settlement block over the rival
contested h=31: 1d787ed1b6d1(ours) 336e53cdc989(ours) 78dd0d9ec94e(ours)
                8fbe2ab6afa8(ours) a1b4ea41ad7e(ours) fbea75d4ef7b(ours) f3ddad7bc211(theirs)
```

**Race 2 — our block against a block with no c2pool coinbase, and theirs wins.** Partitioned again; node 1 mined at h=44 on one side while the other side generated a plain monerod block. The aux branch was made heavier and the merge buried **theirs**:

```
node1  h=44 verdict=defer-unburied  hw=44 need=47 own=3 other=1  credit=-
node1  h=44 verdict=refuse-orphaned hw=48 need=47 own=3 other=1  credit=-
contested h=44: c88ae59342e4(ours) ce298a04b93b(ours) f827ac1f50a1(ours) 09575036856b(theirs)
```

All three monerods agree `h=31 -> f3ddad…` and `h=44 -> 09575036…`. Across both nodes' journals the fleet credited **one height, one block** — the one Monero buried — and `R-7 violations = 0` on both nodes in both races.

## Honest scope and disclosures

- **Regtest and minutes is not a stagenet milestone.** `D_conf=3` and `--fixed-difficulty 1` make a same-height race happen on demand in seconds; on stagenet `D_conf=60` and real inter-block times, a same-height race is rare and a reorg deeper than `D_conf` is rarer still. This branch proves the decision table and the two bounds on a real chain with real RandomX-verified blocks between real levin peers — it does not prove anything about stagenet cadence, and nothing here has been run against mainnet value.
- **Found in the base, disclosed, not fixed here:** a **running** native node did not follow the winning branch after losing a same-height race. It parked the rival branch and stayed on its own tip for several minutes; both races needed a node restart (a fresh sync from genesis) before the node adopted the buried chain. The finalize/refusal path is correct either way — the restarted node re-drove its pending FOUNDs from the sidecar and refused them at maturity, which is what the journal above records — but the reorg-follow path in `M3`'s sync driver needs its own look. It is out of this change's blast radius (the tie-break is accounting; the gap is chain sync) and is tracked for the next batch rather than patched blind here.
- **The race book's credited map is in-memory.** Across a restart the R-7 guard is the merged `OwedLedger`'s durable `is_settled()`, not the race book; the book re-observes and re-decides. That is correct today because a settled bid can never re-enter the pending set, but a durable credited map belongs with the W6 store and is a follow-on.
- **Under `--arm-order daemon-first` there is no re-announce lever** (the block went out through monerod's `submit_block`, and re-submitting a block monerod already holds is a no-op) and the X2 adapter keeps no alternatives, so `alt_candidates` is unset. Both are stated in the code rather than papered over; the gate still runs off the mainchain event stream.
- **CI on this PR is the two gates only.** `build.yml` triggers on PRs into `master` / `btc-embedded` / `dash-spv-embedded` / `dgb/**`; a PR based on `v37/xmr-native-m3` gets no build matrix, so `attribution-gate` and `reap-guard-honesty` are the only checks that run here. The build/test evidence above is the local run on the build host (g++-15, `XMR_BUILD_RANDOMX=ON`, `cppstd=20`), and the new target is registered in both `--target` lists so it is covered the moment this stack reaches a branch CI does watch.
- **Pre-existing, untouched:** teardown `rc=139` seen on other XMR rigs; the option-B KAT wrong-literal already fixed on `v37-dev` (c2pool#1544).
- The rig stood up its own monerods, datadirs and ports and was fully torn down; the `.40` observer and the `.44` stagenet daemon were never touched.
