### PR TITLE
xmr(native): M4 parity-soak harness + GraduationLedger (regtest-proven, stagenet-ready) [DO NOT MERGE]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,6 +246,7 @@ jobs:
                     xmr_native_block_relay_kat xmr_c5_regtest_push \
                     xmr_native_parity_kat xmr_native_txpool_parity_kat \
                     xmr_native_backlog_famine_kat \
+                    xmr_native_m4_soak_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
                     v37_xmr_m3_arm_order_kat \
@@ -688,6 +689,7 @@ jobs:
                     xmr_native_block_relay_kat xmr_c5_regtest_push \
                     xmr_native_parity_kat xmr_native_txpool_parity_kat \
                     xmr_native_backlog_famine_kat \
+                    xmr_native_m4_soak_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
                     v37_xmr_m3_arm_order_kat \

--- a/src/impl/xmr/native/CMakeLists.txt
+++ b/src/impl/xmr/native/CMakeLists.txt
@@ -140,7 +140,15 @@ endif()
 if (BUILD_TESTING AND UNIX)
     add_executable(xmr_native_node node/tools/xmr_native_node_main.cpp)
     target_include_directories(xmr_native_node PRIVATE ${CMAKE_SOURCE_DIR}/src)
-    target_link_libraries(xmr_native_node PRIVATE xmr_native_txpool)
+    # xmr_node carries the PRODUCTION get_miner_data parser
+    # (MoneroDaemonRpc::body_get_miner_data / parse_miner_data). It became a
+    # link dependency at M4 rather than earlier because nothing in this binary
+    # had ever POLLED the daemon template arm: the M4 soak drives P-TPL, which
+    # means calling MonerodMinerDataSource::poll(), which instantiates that
+    # parse. The alternative -- a second decode path for the daemon arm -- would
+    # make "we match the daemon" a claim about a re-typed struct, which is
+    # exactly what the C4/C6 targets link xmr_node to avoid.
+    target_link_libraries(xmr_native_node PRIVATE xmr_native_txpool xmr_node)
     target_compile_features(xmr_native_node PRIVATE cxx_std_20)
     if (TARGET Boost::headers)
         target_link_libraries(xmr_native_node PRIVATE Boost::headers)

--- a/src/impl/xmr/native/node/tools/xmr_native_node_main.cpp
+++ b/src/impl/xmr/native/node/tools/xmr_native_node_main.cpp
@@ -53,6 +53,7 @@
 #include <cstdio>
 #include <cstring>
 #include <chrono>
+#include <ctime>
 #include <iostream>
 #include <set>
 #include <string>
@@ -60,7 +61,9 @@
 #include <vector>
 
 #include "impl/xmr/native/node/xmr_native_node.hpp"
+#include "impl/xmr/native/parity/xmr_graduation_ledger.hpp"
 #include "impl/xmr/native/parity/xmr_parity_report.hpp"
+#include "impl/xmr/native/parity/xmr_soak_driver.hpp"
 
 namespace rt     = ::c2pool::xmr::native::rt;
 namespace native = ::c2pool::xmr::native;
@@ -150,7 +153,28 @@ void usage() {
         "                                             (default 0; raise it ONLY for a scenario\n"
         "                                             that holds a divergence on purpose)\n"
         "  --inject-dir <dir>                         feed <dir>/*.hex to C3 verbatim, and\n"
-        "                                             <dir>/*.twin as its key-image twin\n";
+        "                                             <dir>/*.twin as its key-image twin\n"
+        "\n"
+        "  M4 (the parity soak; the posture is whatever --serve-arm says):\n"
+        "  --m4-soak                                  run the two-posture soak driver\n"
+        "  --m4-ledger <file>                         the M4 graduation ledger (persisted,\n"
+        "                                             and the SAME file across both postures)\n"
+        "  --m4-thresholds <stagenet|regtest>         72h/720-block, or the scaled mini-soak\n"
+        "  --m4-min-clean <n>                         override: consecutive CLEAN samples\n"
+        "  --m4-min-blocks <n>                        override: blocks inside the streak\n"
+        "  --m4-min-seconds <n>                       override: wall clock of the streak\n"
+        "  --m4-min-tip <n>                           override: clean P-TIP samples of it\n"
+        "  --m4-min-tpl <n>                           override: clean P-TPL samples of it\n"
+        "  --m4-max-void-run <n>                      consecutive VOIDs before the streak\n"
+        "                                             is declared stalled and reset\n"
+        "  --m4-serve-every <ms>                      P-TPL cadence (default 2000)\n"
+        "  --m4-require graduated|refusal             exit non-zero unless the ledger\n"
+        "                                             GRADUATED / unless it REFUSED\n"
+        "  --m4-inject-field <name>                   NEGATIVE CONTROL: perturb this native\n"
+        "                                             tip field by one unit\n"
+        "  --m4-inject-after <n>                      ... only after n honest observations\n"
+        "  --m4-inject-for <n>                        ... and only for n of them (0 = all)\n"
+        "  --m4-inject-absent                         withhold the field instead\n";
 }
 
 void print_status(const rt::NodeStatus& s) {
@@ -213,6 +237,19 @@ int main(int argc, char** argv) {
     bool          m1_need_conflict_evict = false;
     std::size_t   m1_allow_uncompared    = 0;
     std::string   inject_dir;
+
+    // --- M4 ---------------------------------------------------------------
+    bool          m4_soak        = false;
+    std::string   m4_ledger_path;
+    std::string   m4_threshold_set;          // "" = pick from --net
+    std::uint64_t m4_serve_every = 2000;
+    std::string   m4_require;                // "graduated" | "refusal" | ""
+    parity::SoakThresholds m4_thr{};
+    bool          m4_thr_chosen  = false;
+    bool          m4_ov_clean = false, m4_ov_blocks = false, m4_ov_seconds = false;
+    bool          m4_ov_tip = false, m4_ov_tpl = false, m4_ov_void = false;
+    std::uint64_t m4_v_clean = 0, m4_v_blocks = 0, m4_v_seconds = 0;
+    std::uint64_t m4_v_tip = 0, m4_v_tpl = 0, m4_v_void = 0;
 
     for (int i = 1; i < argc; ++i) {
         const std::string a = argv[i];
@@ -278,6 +315,23 @@ int main(int argc, char** argv) {
             m1_allow_uncompared = static_cast<std::size_t>(
                 std::strtoull(next("--m1-allow-uncompared").c_str(), nullptr, 10));
         else if (a == "--inject-dir")    inject_dir = next("--inject-dir");
+        else if (a == "--m4-soak")       m4_soak = true;
+        else if (a == "--m4-ledger")     m4_ledger_path = next("--m4-ledger");
+        else if (a == "--m4-thresholds") { m4_threshold_set = next("--m4-thresholds"); m4_thr_chosen = true; }
+        else if (a == "--m4-min-clean")  { m4_ov_clean = true;  m4_v_clean   = std::strtoull(next("--m4-min-clean").c_str(), nullptr, 10); }
+        else if (a == "--m4-min-blocks") { m4_ov_blocks = true; m4_v_blocks  = std::strtoull(next("--m4-min-blocks").c_str(), nullptr, 10); }
+        else if (a == "--m4-min-seconds"){ m4_ov_seconds = true; m4_v_seconds = std::strtoull(next("--m4-min-seconds").c_str(), nullptr, 10); }
+        else if (a == "--m4-min-tip")    { m4_ov_tip = true;    m4_v_tip     = std::strtoull(next("--m4-min-tip").c_str(), nullptr, 10); }
+        else if (a == "--m4-min-tpl")    { m4_ov_tpl = true;    m4_v_tpl     = std::strtoull(next("--m4-min-tpl").c_str(), nullptr, 10); }
+        else if (a == "--m4-max-void-run"){ m4_ov_void = true;  m4_v_void    = std::strtoull(next("--m4-max-void-run").c_str(), nullptr, 10); }
+        else if (a == "--m4-serve-every") m4_serve_every = std::strtoull(next("--m4-serve-every").c_str(), nullptr, 10);
+        else if (a == "--m4-require")    m4_require = next("--m4-require");
+        else if (a == "--m4-inject-field")  cfg.tip_fault.field = next("--m4-inject-field");
+        else if (a == "--m4-inject-after")
+            cfg.tip_fault.after_samples = std::strtoull(next("--m4-inject-after").c_str(), nullptr, 10);
+        else if (a == "--m4-inject-for")
+            cfg.tip_fault.for_samples = std::strtoull(next("--m4-inject-for").c_str(), nullptr, 10);
+        else if (a == "--m4-inject-absent") cfg.tip_fault.absent = true;
         else if (a == "--force-synced")  cfg.force_synced = true;
         else if (a == "--probe-only")    cfg.probe_only = true;
         else if (a == "--allow-unverified-pow") cfg.allow_unverified_pow = true;
@@ -290,6 +344,44 @@ int main(int argc, char** argv) {
     }
     if (txpool_parity && cfg.monerod_rpc_host.empty()) {
         std::cerr << "--txpool-parity needs a judge: pass --monerod-rpc host:port\n";
+        return 2;
+    }
+    if (m4_soak) {
+        if (cfg.monerod_rpc_host.empty()) {
+            std::cerr << "--m4-soak needs the arm it is judged against: pass --monerod-rpc host:port\n";
+            return 2;
+        }
+        if (!cfg.parity) {
+            std::cerr << "--m4-soak and --no-parity are contradictory: the soak IS the oracle\n";
+            return 2;
+        }
+        if (m4_ledger_path.empty()) {
+            std::cerr << "--m4-soak needs --m4-ledger <file>: a graduation that is not "
+                         "written down is a recollection\n";
+            return 2;
+        }
+        if (!m4_require.empty() && m4_require != "graduated" && m4_require != "refusal") {
+            std::cerr << "--m4-require wants 'graduated' or 'refusal'\n";
+            return 2;
+        }
+        // The default threshold set follows the network, because getting this
+        // wrong in the quiet direction is the only mistake that matters: a
+        // stagenet run must never silently inherit the mini-soak's numbers.
+        const std::string set = m4_thr_chosen ? m4_threshold_set
+                              : (cfg.net == rt::NativeNet::Regtest ? "regtest" : "stagenet");
+        if (set == "regtest")       m4_thr = parity::SoakThresholds::regtest_mini();
+        else if (set == "stagenet") m4_thr = parity::SoakThresholds::stagenet_m4();
+        else { std::cerr << "--m4-thresholds wants 'stagenet' or 'regtest'\n"; return 2; }
+        if (m4_ov_clean)   m4_thr.min_clean_samples  = m4_v_clean;
+        if (m4_ov_blocks)  m4_thr.min_blocks         = m4_v_blocks;
+        if (m4_ov_seconds) m4_thr.min_seconds        = m4_v_seconds;
+        if (m4_ov_tip)     m4_thr.min_tip_clean      = m4_v_tip;
+        if (m4_ov_tpl)     m4_thr.min_template_clean = m4_v_tpl;
+        if (m4_ov_void)    m4_thr.max_void_run       = m4_v_void;
+    }
+    if (cfg.tip_fault.armed() && !m4_soak) {
+        std::cerr << "--m4-inject-field is the soak's negative control and only means "
+                     "something with --m4-soak\n";
         return 2;
     }
 
@@ -314,6 +406,63 @@ int main(int argc, char** argv) {
     std::uint64_t clean = 0, failed = 0, mismatch = 0, voided = 0;
     int exit_code = 0;
 
+    // -----------------------------------------------------------------------
+    // M4 state. Off by default; costs one branch when it is.
+    //
+    // The ledger is constructed here rather than inside the node because it
+    // OUTLIVES a process: the two postures are two runs of this binary against
+    // the same --m4-ledger file, which is exactly the shape a 72 h + 72 h
+    // stagenet soak has. Persisting is therefore not an optimisation, it is the
+    // mechanism by which a leg survives its own posture flip.
+    // -----------------------------------------------------------------------
+    auto unix_now = [] { return static_cast<std::uint64_t>(std::time(nullptr)); };
+    native::GraduationKey m4_key;
+    m4_key.c2pool_commit   = cfg.c2pool_commit;
+    m4_key.monerod_version = "";               // bound on the daemon's first answer
+    m4_key.net             = rt::to_string(cfg.net);
+    parity::M4GraduationLedger m4_ledger(m4_key, m4_thr);
+    parity::SoakDriver::Config m4_cfg;
+    m4_cfg.posture = (cfg.serve_arm == native::TemplateArm::Native)
+                       ? parity::SoakPosture::ServeNativeShadowMonerod
+                       : parity::SoakPosture::ServeMonerodShadowNative;
+    m4_cfg.ledger_path = m4_ledger_path;
+    parity::SoakDriver m4(m4_ledger, m4_cfg);
+    if (m4_soak) {
+        std::string lwhy;
+        const bool loaded = m4_ledger.load(m4_ledger_path, &lwhy);
+        std::printf("[M4-SOAK] posture=%s thresholds: clean>=%llu blocks>=%llu seconds>=%llu "
+                    "tip>=%llu tpl>=%llu void_run<=%llu | ledger=%s (%s)\n",
+                    parity::posture_tag(m4_cfg.posture),
+                    (unsigned long long)m4_thr.min_clean_samples,
+                    (unsigned long long)m4_thr.min_blocks,
+                    (unsigned long long)m4_thr.min_seconds,
+                    (unsigned long long)m4_thr.min_tip_clean,
+                    (unsigned long long)m4_thr.min_template_clean,
+                    (unsigned long long)m4_thr.max_void_run,
+                    m4_ledger_path.c_str(),
+                    loaded ? "resumed" : (lwhy.empty() ? "new" : lwhy.c_str()));
+    }
+    std::uint64_t m4_last_serve = 0;
+    std::uint64_t m4_serve_ok = 0, m4_serve_refused = 0;
+    std::string   m4_last_serve_why;
+
+    // ONE place where a drained batch is turned into numbers, because there are
+    // now two callers (a tip moved; the M4 cadence fired) and two sets of
+    // counters that must not diverge.
+    auto absorb = [&](const std::vector<parity::SeamResult>& batch) {
+        for (const parity::SeamResult& r : batch) {
+            switch (r.sample.verdict) {
+                case native::ParityVerdict::Clean:          ++clean;    break;
+                case native::ParityVerdict::Fail:           ++failed;   break;
+                case native::ParityVerdict::ServedMismatch: ++mismatch; break;
+                case native::ParityVerdict::Void:           ++voided;   break;
+            }
+        }
+        if (!m4_soak) return;
+        for (const std::string& line : m4.ingest(batch, unix_now()))
+            std::printf("%s\n", line.c_str());
+    };
+
     // Draining is a function rather than a loop body because it has to happen
     // ONE MORE TIME after the exit condition fires: the tip that satisfied
     // --follow-to is normally recorded a few milliseconds after the read that
@@ -327,16 +476,32 @@ int main(int argc, char** argv) {
             // The oracle renders every sample through its own log sink, which
             // is drained just below -- printing it here as well would double
             // every line.
-            for (const parity::SeamResult& r : node.parity_sample()) {
-                switch (r.sample.verdict) {
-                    case native::ParityVerdict::Clean:          ++clean;    break;
-                    case native::ParityVerdict::Fail:           ++failed;   break;
-                    case native::ParityVerdict::ServedMismatch: ++mismatch; break;
-                    case native::ParityVerdict::Void:           ++voided;   break;
-                }
-            }
+            absorb(node.parity_sample());
         }
         for (const std::string& line : node.take_log()) std::printf("%s\n", line.c_str());
+        std::fflush(stdout);
+    };
+
+    // The M4 tick: serve a template from the POSTURE'S arm (which is what makes
+    // P-TPL fire at all -- nothing else in this binary calls on_serve), then
+    // drain. It runs on its own cadence rather than on tip events because a
+    // chain that has gone quiet must still produce samples, or "no samples"
+    // would be indistinguishable from "agreement".
+    auto m4_tick = [&] {
+        const rt::NativeNode::ServeProbe p = node.m4_serve_probe();
+        if (p.served) {
+            ++m4_serve_ok;
+        } else {
+            ++m4_serve_refused;
+            if (p.why != m4_last_serve_why) {
+                m4_last_serve_why = p.why;
+                std::printf("[M4-SOAK] serving arm '%s' produced no template: %s\n",
+                            p.arm.empty() ? "?" : p.arm.c_str(), p.why.c_str());
+            }
+        }
+        if (parity::MonerodTipObserver* mt = node.monerod_tip())
+            m4_ledger.bind_monerod_version(mt->daemon_version(), unix_now());
+        absorb(node.parity_sample());
         std::fflush(stdout);
     };
 
@@ -527,6 +692,10 @@ int main(int argc, char** argv) {
             last_pool_probe = elapsed_ms;
             probe_txpool();
         }
+        if (m4_soak && elapsed_ms - m4_last_serve >= m4_serve_every) {
+            m4_last_serve = elapsed_ms;
+            m4_tick();
+        }
 
         // --- exit conditions ---------------------------------------------------
         if (g_stop) break;
@@ -709,14 +878,90 @@ int main(int argc, char** argv) {
                     m1_why.empty() ? "" : " why=", m1_why.c_str());
     }
 
+    // --- M4 ----------------------------------------------------------------
+    //
+    // TWO KINDS OF RUN, and as with M1 the verdict must not confuse them.
+    //
+    // An HONEST run (--m4-require graduated) claims the posture soaked clean and
+    // is judged on the ledger reaching GRADUATED.
+    //
+    // A REFUSAL run (--m4-require refusal) is the negative control: it injects a
+    // divergence on purpose and its claim is the OPPOSITE one -- the ledger must
+    // NOT graduate, and it must have reset a streak on a real FAIL rather than
+    // merely failed to accumulate one. A refusal run that graduated is a broken
+    // gate; a refusal run whose injection never fired asserts nothing, and both
+    // are FAIL here.
+    bool m4_ok = true;
+    if (m4_soak) {
+        // One last tick, for the same reason M1 takes one last pool sample: the
+        // tail of a run is where the last template lives.
+        m4_tick();
+        std::string swhy;
+        if (!m4.save(&swhy) && !swhy.empty()) std::printf("[M4-SOAK] %s\n", swhy.c_str());
+
+        std::printf("\n=== M4: two-posture parity soak ===\n");
+        std::printf("drains         : %llu (of which produced no sample: %llu)\n",
+                    (unsigned long long)m4.drains(),
+                    (unsigned long long)m4_ledger.no_sample_drains(m4_cfg.posture));
+        std::printf("template probe : served=%llu refused=%llu%s%s\n",
+                    (unsigned long long)m4_serve_ok,
+                    (unsigned long long)m4_serve_refused,
+                    m4_last_serve_why.empty() ? "" : " last_refusal=",
+                    m4_last_serve_why.c_str());
+        if (parity::PerturbingTipObserver* inj = node.tip_fault())
+            std::printf("injection      : ARMED field='%s' observations=%llu perturbed=%llu "
+                        "(this run is a REFUSAL EXPERIMENT)\n",
+                        cfg.tip_fault.field.c_str(),
+                        (unsigned long long)inj->observations(),
+                        (unsigned long long)inj->injected());
+        std::printf("%s", m4_ledger.report().c_str());
+        for (const parity::SoakEntry& e : m4.failures())
+            std::printf("failure        : %s\n", e.render().c_str());
+        std::printf("%s\n", m4.verdict_line().c_str());
+
+        const parity::PostureLeg& L = m4_ledger.leg(m4_cfg.posture);
+        std::string m4_why;
+        if (m4_require == "graduated") {
+            m4_ok = m4_ledger.graduated();
+            if (!m4_ok) {
+                const std::vector<std::string> sf = m4_ledger.shortfalls();
+                m4_why = sf.empty() ? "not graduated" : sf.front();
+            }
+        } else if (m4_require == "refusal") {
+            if (m4_ledger.graduated()) {
+                m4_ok = false;
+                m4_why = "the ledger GRADUATED under an injected divergence";
+            } else if (L.fail == 0 && L.served_mismatch == 0) {
+                m4_ok = false;
+                m4_why = "no sample ever FAILED: the injection did not reach the comparator, "
+                         "so this run refuses nothing";
+            } else if (L.resets == 0) {
+                m4_ok = false;
+                m4_why = "a sample failed but no streak was reset";
+            }
+        }
+        std::printf("M4-RUN: %s require=%s graduated=%d fail=%llu resets=%llu%s%s\n",
+                    m4_ok ? "PASS" : "FAIL",
+                    m4_require.empty() ? "-" : m4_require.c_str(),
+                    m4_ledger.graduated() ? 1 : 0,
+                    (unsigned long long)L.fail, (unsigned long long)L.resets,
+                    m4_why.empty() ? "" : " why=", m4_why.c_str());
+    }
+
     // The M0 verdict, in one line a script can grep.
-    const bool ok = (exit_code == 0) && failed == 0 && mismatch == 0 &&
-                    s.randomx.foreign_calls == 0 && m1_ok;
+    //
+    // A REFUSAL run breaks the M0 line's premise on purpose -- it is engineered
+    // to produce parity failures -- so the M0 gate reads the injection out of
+    // the totals rather than reporting a lost claim it never made.
+    const bool refusal_run = m4_soak && m4_require == "refusal";
+    const bool ok = (exit_code == 0) && (refusal_run || (failed == 0 && mismatch == 0)) &&
+                    s.randomx.foreign_calls == 0 && m1_ok && m4_ok;
     std::printf("M0-VERDICT: %s heights=%zu parity_clean=%llu parity_fail=%llu "
-                "randomx_foreign=%llu\n",
+                "randomx_foreign=%llu%s\n",
                 ok ? "PASS" : "FAIL", tips_seen, (unsigned long long)clean,
                 (unsigned long long)(failed + mismatch),
-                (unsigned long long)s.randomx.foreign_calls);
+                (unsigned long long)s.randomx.foreign_calls,
+                refusal_run ? " (REFUSAL RUN: parity failures are the point)" : "");
 
     node.stop();
     return ok ? 0 : 1;

--- a/src/impl/xmr/native/node/xmr_native_node.hpp
+++ b/src/impl/xmr/native/node/xmr_native_node.hpp
@@ -102,6 +102,7 @@
 #include "impl/xmr/native/p2p/xmr_peer_pool.hpp"
 #include "impl/xmr/native/parity/xmr_parity_oracle.hpp"
 #include "impl/xmr/native/parity/xmr_parity_report.hpp"
+#include "impl/xmr/native/parity/xmr_soak_driver.hpp"
 #include "impl/xmr/native/parity/xmr_txpool_parity.hpp"
 #include "impl/xmr/native/relay/xmr_block_relay.hpp"
 #include "impl/xmr/native/template/xmr_monerod_miner_data.hpp"
@@ -196,6 +197,20 @@ struct NativeNodeConfig {
     bool                     parity           = true;
     std::string              parity_ledger_path;
     std::string              c2pool_commit;        // one of the four graduation keys
+
+    // M4's NEGATIVE CONTROL, disarmed unless a field is named.
+    //
+    // A harness that has never been seen to refuse is not a gate, so the M4
+    // soak can perturb one required EQUALITY field of the NATIVE tip
+    // observation by one unit (or withhold it) and watch the real comparator
+    // fail the sample, the real streak reset, and graduation be refused. It
+    // wraps the native tip observer only while armed; see
+    // parity::PerturbingTipObserver. One consequence is deliberate and is
+    // stated here rather than left to be discovered: while wrapped, the
+    // oracle's dynamic_cast to ChainViewTipObserver no longer resolves, so the
+    // PenaltyZone height class is not claimed during an injection run. An
+    // injection run is a refusal experiment, not a coverage one.
+    parity::TipFaultInjection tip_fault{};
 
     // THE BACKLOG REBUILD TRIGGER, in seconds. 0 -- the default, and what M0
     // through M2 shipped -- means TIP-ONLY: the served template is rebuilt when
@@ -405,8 +420,19 @@ public:
         // --- C6 --------------------------------------------------------------
         if (cfg_.parity) {
             native_tip_ = std::make_unique<parity::ChainViewTipObserver>(index_.view());
+            parity::ITipObserver* native_tip_seam = native_tip_.get();
+            if (cfg_.tip_fault.armed()) {
+                tip_fault_ = std::make_unique<parity::PerturbingTipObserver>(
+                    *native_tip_, cfg_.tip_fault);
+                native_tip_seam = tip_fault_.get();
+                note_("[M4-INJECT] ARMED on the native tip field '" + cfg_.tip_fault.field
+                    + (cfg_.tip_fault.absent ? "' (withhold)" : "' (perturb by one unit)")
+                    + " after " + std::to_string(cfg_.tip_fault.after_samples)
+                    + " observation(s): this run is a REFUSAL EXPERIMENT and its samples "
+                      "are not honest parity evidence");
+            }
             parity::ParityOracle::Deps od;
-            od.native_tip  = native_tip_.get();
+            od.native_tip  = native_tip_seam;
             od.monerod_tip = mon_tip_.get();
             od.served_arm  = arms_->arm(cfg_.serve_arm);
             od.shadow_arm  = arms_->shadow();
@@ -655,6 +681,72 @@ public:
         });
         return out;
     }
+
+    // -----------------------------------------------------------------------
+    // M4: DRIVING THE P-TPL SEAM.
+    //
+    // Nothing in M0..M3 called IParityOracle::on_serve. The tip probe fires by
+    // itself because the index publishes an event at every height; the template
+    // probe only fires when somebody SERVES a template, and in this harness
+    // nobody did -- so a soak run on the existing code would have accumulated a
+    // long P-TIP streak and never once compared a template, which is half of
+    // what the M4 criterion actually asks for.
+    //
+    // This is that caller. Three things about it are deliberate:
+    //
+    //   * THE POSTURE IS STRICT. It resolves arm(serve_arm) directly rather
+    //     than through ArmResolver::serving(), because serving() falls back to
+    //     the other arm when the configured one is not ready. That fallback is
+    //     right in production and fatal to a parity claim: a leg that quietly
+    //     served monerod for an hour is not evidence about the native arm. An
+    //     unready arm therefore yields no sample and says why.
+    //
+    //   * THE ARTEFACT IS CARRIED. on_serve takes the MinerData that would have
+    //     gone out, not an epoch to re-read later, which is what keeps
+    //     SERVED-MISMATCH provable (contracts/parity.hpp says why).
+    //
+    //   * THREADING follows parity_sample(): the daemon round trip happens on
+    //     the CALLER's thread, and the native arm's snapshot -- which reads the
+    //     chain state view the verify thread owns -- happens on the verify
+    //     thread. The oracle's on_serve is enqueue-and-return either way.
+    struct ServeProbe {
+        bool          served = false;
+        std::string   arm;
+        std::uint64_t height = 0;
+        std::size_t   backlog = 0;
+        std::string   why;          // when !served
+    };
+
+    ServeProbe m4_serve_probe() {
+        ServeProbe p;
+        if (!oracle_ || !arms_) { p.why = "no parity oracle on this node"; return p; }
+        if (mon_src_) (void)mon_src_->poll();      // the RPC, on the caller's thread
+        IMinerDataSource* src = arms_->arm(cfg_.serve_arm);
+        if (src == nullptr) {
+            p.why = std::string("configured serving arm '") + to_string(cfg_.serve_arm)
+                  + "' is not present on this node";
+            return p;
+        }
+        p.arm = src->name();
+        verify_loop_.call([&] {
+            const MinerDataReadiness rd = src->readiness();
+            if (!rd.ok()) { p.why = rd.why.empty() ? std::string("arm not ready") : rd.why; return; }
+            std::string why;
+            const std::optional<node::MinerData> md = src->snapshot(&why);
+            if (!md) { p.why = why.empty() ? std::string("arm produced no snapshot") : why; return; }
+            p.height  = md->height;
+            p.backlog = md->tx_backlog.size();
+            p.served  = true;
+            oracle_->on_serve(src->epoch(), *md, src->name());
+        });
+        return p;
+    }
+
+    // The daemon version and nettype, straight from get_info. The M4 ledger's
+    // key names the daemon it was judged against, and "unknown" is not a name.
+    parity::MonerodTipObserver* monerod_tip() noexcept { return mon_tip_.get(); }
+    // Non-null only while the M4 fault injector is armed.
+    parity::PerturbingTipObserver* tip_fault() noexcept { return tip_fault_.get(); }
 
     parity::ParityOracle* oracle() noexcept { return oracle_.get(); }
     ChainIndex&           index()  noexcept { return index_; }
@@ -924,6 +1016,8 @@ private:
     std::unique_ptr<parity::MonerodTxpoolObserver>   mon_pool_;
     parity::TxpoolParityTally                        pool_tally_;
     std::unique_ptr<parity::ChainViewTipObserver>    native_tip_;
+    // M4 negative control; constructed only when cfg_.tip_fault is armed.
+    std::unique_ptr<parity::PerturbingTipObserver>   tip_fault_;
     std::unique_ptr<tmpl::ArmResolver>               arms_;
     std::unique_ptr<relay::LevinBlockRelay>          block_relay_;
     std::unique_ptr<parity::ParityOracle>            oracle_;

--- a/src/impl/xmr/native/parity/README.md
+++ b/src/impl/xmr/native/parity/README.md
@@ -118,3 +118,52 @@ CLEAN when that is all the evidence there is.
 read-only capture from a synced daemon (four calls, nothing written) and refuses
 to emit a golden whose parts are not internally consistent. The committed capture
 is monerod 0.18.5.1-release on stagenet at tip 2205017.
+
+## M4: the two-posture soak (`xmr_graduation_ledger.hpp`, `xmr_soak_driver.hpp`)
+
+C6 answers "have the seams agreed?". M4 asks a different question, and it is
+about a **process**:
+
+    serve = monerod / shadow = native   sustained, every sample CLEAN, then
+    serve = native  / shadow = monerod  sustained, every sample CLEAN.
+
+`M4GraduationLedger` records that as **two legs**, each a fragile streak. CLEAN
+accrues it; `FAIL` and `SERVED_MISMATCH` reset it to zero and take the leg's
+qualification away — there is no budget of allowed failures, because the
+criterion is *every* sample. `VOID` neither accrues nor resets, but a **run** of
+VOIDs past `max_void_run` resets anyway: a leg that has stopped producing
+judgeable samples is a probe that stopped firing, not a streak quietly holding.
+`blocks` counts **forward height progress only**, so a reorg contributes nothing
+(the conservative direction). The key is the same four-part one C6 uses and is
+stamped with the *running* `COMPARATOR_VERSION`, so a streak earned under an
+older comparator cannot be inherited across a bump.
+
+`SoakDriver` is the loop around it, and it exists because two things were
+missing rather than merely unwritten:
+
+* **nothing called `on_serve`.** `on_tip` fires by itself (the index publishes an
+  event at every height); the template probe only fires when somebody serves a
+  template, and in the node harness nobody did. A soak on the pre-M4 code would
+  have run up a long P-TIP streak having never compared a template — which is
+  half of what the M4 criterion asks for. The driver pulls a template from the
+  posture's arm on its own cadence and hands it over as the served artefact, and
+  `min_template_clean` is what stops the cheap seam carrying the expensive one.
+* **the posture has to be exact.** `ArmResolver::serving()` falls back to the
+  other arm when the configured one is not ready — correct in production, fatal
+  to a parity claim. The driver resolves `arm(posture)` strictly; an unready arm
+  produces no sample and says so.
+
+`TipFaultInjection` / `PerturbingTipObserver` are the **negative control**:
+harness-only, disarmed unless a field is named, they perturb one required
+EQUALITY field of the native tip observation by one unit (or withhold it) so the
+refusal path is something the harness was *watched* doing. `--m4-require refusal`
+asserts the opposite claim from a normal run: the ledger must NOT graduate, and
+it must have reset a streak on a real FAIL rather than merely failed to
+accumulate one.
+
+Both postures are two runs of `xmr_native_node` against the **same**
+`--m4-ledger` file, which is the shape a 72 h + 72 h stagenet soak has;
+persistence is the mechanism by which a leg survives its own posture flip.
+`SoakThresholds::stagenet_m4()` carries the plan's numbers unscaled (72 h, 720
+blocks per posture); `regtest_mini()` keeps every threshold non-zero at a scale a
+mini-soak can reach in minutes — a scaled rehearsal, never the gate itself.

--- a/src/impl/xmr/native/parity/xmr_graduation_ledger.hpp
+++ b/src/impl/xmr/native/parity/xmr_graduation_ledger.hpp
@@ -1,0 +1,686 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/parity/xmr_graduation_ledger.hpp
+//
+// M4, the record: the TWO-POSTURE graduation ledger.
+//
+// C6's GraduationLedger (xmr_parity_ledger.hpp) answers "have the seams agreed
+// enough, for long enough, over enough classes?". It is per-seam and per-field,
+// and it is right about all of that. What it does not carry is the shape the M4
+// gate is actually written in, which is not about seams at all:
+//
+//     serve = monerod / shadow = native   for a sustained window, every sample
+//                                         CLEAN, then
+//     serve = native  / shadow = monerod  for a sustained window, every sample
+//                                         CLEAN.
+//
+// TWO LEGS, AND THE SECOND ONE IS THE POINT. The first leg says the native node
+// would have said what the daemon said. The second says the pool ran on what
+// the native node said and the daemon still agreed -- which is the only one of
+// the two that is evidence about DEMOTING the daemon, because it is the only
+// one in which the native arm's answer had consequences. A harness that soaked
+// only the first leg would be measuring a passenger.
+//
+// A LEG IS A STREAK, AND A STREAK IS FRAGILE BY CONSTRUCTION:
+//
+//   * CLEAN accrues it -- one more sample, possibly one more block, more wall
+//     clock.
+//   * FAIL and SERVED-MISMATCH RESET it to zero and clear the leg's
+//     qualification if it had one. There is no averaging, no "mostly clean",
+//     no budget of allowed failures. The M4 criterion is every sample.
+//   * VOID neither accrues nor resets -- there was nothing to judge -- but a
+//     RUN of consecutive VOIDs past `max_void_run` resets the streak anyway,
+//     with its own reason. That is the DASH lesson in its sharpest form: a leg
+//     that has stopped producing judgeable samples is not a leg quietly holding
+//     its streak, it is a probe that stopped firing, and letting it coast would
+//     make silence indistinguishable from agreement.
+//
+// AND IT NEVER INHERITS. The key is {c2pool_commit, comparator_version,
+// monerod_version, net}, exactly as C6's is, and for the same reason: a streak
+// earned by other code, under a judge that looked at a different table, against
+// another daemon, on another network, is not evidence about this one. A ledger
+// on disk whose key differs is DISCARDED, loudly, and both legs start at zero.
+// COMPARATOR_VERSION is stamped from the header rather than taken from the
+// caller, so "the ledger says v2 but the comparator is v3" cannot be spelled.
+//
+// WHAT `blocks` COUNTS, stated because a soak threshold denominated in blocks
+// has to mean something exact: the number of samples in the current run whose
+// height was strictly ABOVE every height seen so far in that run. Forward
+// progress only. A reorg walks the tip backwards and contributes no block to
+// the count, which is the conservative direction -- it can only make a 720-block
+// claim harder to earn, never easier. The run's height span (lo..hi) is carried
+// beside it so a reader can see both numbers rather than trust one.
+//
+// SCOPE FENCE: src/impl/xmr/ only. No consensus digest, no src/sharechain/v37.
+// Header-only, STL only, no clock of its own -- the caller supplies unix time,
+// so a KAT drives 72 hours in microseconds.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+// C6's ledger, for `same_key` and `key_string`. The four-part key means exactly
+// what it means there, and a second spelling of "are these the same
+// experiment?" is a divergence waiting to happen. It is an STL-only include
+// (parity types plus minijson), so this header stays STL-only too.
+#include "impl/xmr/native/parity/xmr_parity_ledger.hpp"
+#include "impl/xmr/native/parity/xmr_parity_types.hpp"
+#include "impl/xmr/node/minijson.hpp"
+
+namespace c2pool::xmr::native::parity {
+
+namespace mj4 = ::c2pool::xmr::node::minijson;
+
+// ---------------------------------------------------------------------------
+// Which way round the arms are wired for this leg.
+//
+// The names say BOTH halves on purpose. "serve=native" alone leaves the reader
+// to remember what the other arm is doing, and the whole claim is about the
+// pair.
+// ---------------------------------------------------------------------------
+enum class SoakPosture : std::uint8_t {
+    ServeMonerodShadowNative = 0,   // leg 1: the daemon serves, we shadow it
+    ServeNativeShadowMonerod = 1,   // leg 2: we serve, the daemon judges us
+};
+
+inline const char* to_string(SoakPosture p) noexcept {
+    switch (p) {
+        case SoakPosture::ServeMonerodShadowNative: return "serve=monerod/shadow=native";
+        case SoakPosture::ServeNativeShadowMonerod: return "serve=native/shadow=monerod";
+    }
+    return "?";
+}
+
+// The short spelling used as a JSON key and on the command line.
+inline const char* posture_tag(SoakPosture p) noexcept {
+    return p == SoakPosture::ServeNativeShadowMonerod ? "serve-native" : "serve-monerod";
+}
+
+inline bool parse_posture(const std::string& s, SoakPosture& out) {
+    if (s == "serve-monerod" || s == "monerod") { out = SoakPosture::ServeMonerodShadowNative; return true; }
+    if (s == "serve-native"  || s == "native")  { out = SoakPosture::ServeNativeShadowMonerod; return true; }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// What a leg has to achieve.
+//
+// `min_tip_clean` and `min_template_clean` are not decoration, and they are the
+// reason a single `min_clean_samples` would not do. P-TIP fires on every block;
+// P-TPL only when a template is served. A leg driven by tip events alone would
+// run up a 720-sample streak having never once compared a template -- and P-TPL
+// is the seam the M4 criterion actually names. Requiring CLEAN samples from
+// BOTH seams inside the same run is what stops the cheap seam from carrying the
+// expensive one.
+// ---------------------------------------------------------------------------
+struct SoakThresholds {
+    std::uint64_t min_clean_samples = 0;   // consecutive CLEAN samples in the run
+    std::uint64_t min_blocks        = 0;   // forward height steps inside the run
+    std::uint64_t min_seconds       = 0;   // wall clock spanned by the run
+    std::uint64_t min_tip_clean     = 0;   // of which, P-TIP samples
+    std::uint64_t min_template_clean = 0;  // of which, P-TPL samples
+    // Consecutive VOIDs tolerated before the run is declared stalled and reset.
+    // 0 means "no cap", which is only ever right for a unit test that drives
+    // the machine by hand.
+    std::uint64_t max_void_run     = 0;
+
+    // THE REAL GATE, from the plan's M4 row: >= 72 h and >= 720 blocks per
+    // posture with every sample CLEAN. Nothing scaled, nothing rounded.
+    static SoakThresholds stagenet_m4() {
+        SoakThresholds t;
+        t.min_seconds        = 72 * 3600;
+        t.min_blocks         = 720;
+        t.min_clean_samples  = 720;
+        t.min_tip_clean      = 720;
+        t.min_template_clean = 240;
+        t.max_void_run       = 64;
+        return t;
+    }
+
+    // The regtest shape: the SAME STRUCTURE with small numbers, so a mini-soak
+    // exercises every branch the stagenet run will. Deliberately not "no
+    // thresholds" -- a harness that graduates on nothing proves nothing, which
+    // is the failure this whole component exists to make impossible.
+    static SoakThresholds regtest_mini() {
+        SoakThresholds t;
+        t.min_seconds        = 20;
+        t.min_blocks         = 4;
+        t.min_clean_samples  = 8;
+        t.min_tip_clean      = 4;
+        t.min_template_clean = 2;
+        t.max_void_run       = 32;
+        return t;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// One posture's state: the current run, and the lifetime tally around it.
+// ---------------------------------------------------------------------------
+struct PostureLeg {
+    // --- the current run ---
+    std::uint64_t clean_run      = 0;   // consecutive CLEAN samples
+    std::uint64_t run_blocks     = 0;   // forward height steps inside the run
+    std::uint64_t run_first_unix = 0;
+    std::uint64_t run_last_unix  = 0;
+    std::uint64_t run_height_lo  = 0;
+    std::uint64_t run_height_hi  = 0;
+    std::uint64_t run_tip_clean  = 0;
+    std::uint64_t run_tmpl_clean = 0;
+    std::uint64_t void_run       = 0;   // consecutive VOIDs since the last judged sample
+
+    // --- lifetime ---
+    std::uint64_t samples         = 0;  // judged: CLEAN + FAIL + SERVED-MISMATCH
+    std::uint64_t clean           = 0;
+    std::uint64_t fail            = 0;
+    std::uint64_t served_mismatch = 0;
+    std::uint64_t voided          = 0;
+    std::uint64_t resets          = 0;
+    std::uint64_t first_unix      = 0;
+    std::uint64_t last_unix       = 0;
+
+    // --- the best this leg ever reached, and whether it stands NOW ---
+    std::uint64_t best_clean_run = 0;
+    std::uint64_t best_blocks    = 0;
+    std::uint64_t best_seconds   = 0;
+    // Sticky only while nothing has gone wrong since: a single FAIL clears it.
+    bool          qualified      = false;
+    std::uint64_t qualified_unix = 0;
+
+    std::string   last_reset_why;
+
+    std::uint64_t run_seconds() const noexcept {
+        return (run_first_unix != 0 && run_last_unix > run_first_unix)
+                 ? (run_last_unix - run_first_unix) : 0;
+    }
+
+    bool meets(const SoakThresholds& t) const noexcept {
+        return clean_run  >= t.min_clean_samples
+            && run_blocks >= t.min_blocks
+            && run_seconds() >= t.min_seconds
+            && run_tip_clean  >= t.min_tip_clean
+            && run_tmpl_clean >= t.min_template_clean;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// M4GraduationLedger
+// ---------------------------------------------------------------------------
+class M4GraduationLedger {
+public:
+    M4GraduationLedger() = default;
+    M4GraduationLedger(GraduationKey key, SoakThresholds thr)
+        : key_(std::move(key)), thr_(thr) {
+        // Stamped, never accepted from the caller. See the header note.
+        key_.comparator_version = COMPARATOR_VERSION;
+    }
+
+    const GraduationKey&  key()        const noexcept { return key_; }
+    const SoakThresholds& thresholds() const noexcept { return thr_; }
+    GraduationState       state()      const noexcept { return state_; }
+    std::uint64_t         graduated_unix() const noexcept { return graduated_unix_; }
+    std::uint64_t         first_sample_unix() const noexcept { return first_unix_; }
+    std::uint64_t         last_sample_unix()  const noexcept { return last_unix_; }
+
+    const PostureLeg& leg(SoakPosture p) const noexcept {
+        return legs_[static_cast<std::size_t>(p)];
+    }
+    const std::vector<std::pair<std::uint64_t, std::string>>& revocations() const noexcept {
+        return revocations_;
+    }
+
+    // The daemon version is not known until the daemon has answered once, and
+    // re-keying mid-soak would silently restart the experiment. So it is BOUND
+    // on first sight and frozen: a later change of the observed version is a
+    // different daemon and revokes, it does not quietly re-key.
+    void bind_monerod_version(const std::string& v, std::uint64_t unix_now) {
+        if (v.empty()) return;
+        if (key_.monerod_version.empty() || key_.monerod_version == "unknown") {
+            key_.monerod_version = v;
+            return;
+        }
+        if (key_.monerod_version != v)
+            revoke("monerod version changed under the soak: '" + key_.monerod_version
+                   + "' -> '" + v + "'", unix_now);
+    }
+
+    // -----------------------------------------------------------------------
+    // record -- the only way a number in here moves.
+    //
+    // `height` is the sample's own height; VOID samples carry one too but it is
+    // not used, because a VOID advances nothing.
+    // -----------------------------------------------------------------------
+    void record(SoakPosture posture, const SeamResult& r, std::uint64_t unix_now) {
+        PostureLeg& L = legs_[static_cast<std::size_t>(posture)];
+
+        if (first_unix_ == 0 || unix_now < first_unix_) first_unix_ = unix_now;
+        if (unix_now > last_unix_) last_unix_ = unix_now;
+        if (L.first_unix == 0 || unix_now < L.first_unix) L.first_unix = unix_now;
+        if (unix_now > L.last_unix) L.last_unix = unix_now;
+
+        switch (r.sample.verdict) {
+            case ParityVerdict::Clean:
+                L.void_run = 0;
+                ++L.samples; ++L.clean;
+                accrue_(L, r, unix_now);
+                break;
+            case ParityVerdict::Fail:
+                L.void_run = 0;
+                ++L.samples; ++L.fail;
+                reset_(L, posture, "P-" + std::string(seam_short(r.sample.kind))
+                                 + " FAIL at height " + Obs::u64(r.sample.height).value
+                                 + (r.sample.note.empty() ? std::string() : (": " + r.sample.note)),
+                       unix_now);
+                break;
+            case ParityVerdict::ServedMismatch:
+                L.void_run = 0;
+                ++L.samples; ++L.served_mismatch;
+                reset_(L, posture, "SERVED-MISMATCH at height "
+                                 + Obs::u64(r.sample.height).value, unix_now);
+                // The worst verdict there is: what went out matched neither arm.
+                // It does not merely reset a streak, it revokes the key.
+                revoke("SERVED-MISMATCH in posture " + std::string(to_string(posture))
+                       + " at height " + Obs::u64(r.sample.height).value, unix_now);
+                break;
+            case ParityVerdict::Void:
+                ++L.voided; ++L.void_run;
+                if (thr_.max_void_run != 0 && L.void_run > thr_.max_void_run && L.clean_run != 0)
+                    reset_(L, posture, Obs::u64(L.void_run).value
+                                     + " consecutive VOID sample(s): the leg stopped producing "
+                                       "judgeable samples, which is not agreement",
+                           unix_now);
+                break;
+        }
+
+        if (r.sentinel_tripped)
+            revoke(r.sentinel_why.empty() ? std::string("sentinel tripped") : r.sentinel_why,
+                   unix_now);
+
+        evaluate_(unix_now);
+    }
+
+    // A probe that fired and produced nothing at all. Distinct from a VOID
+    // sample: there was not even an attempt to compare. It is counted so that
+    // "the soak went quiet" reads as a rising number rather than as calm, and
+    // it never touches a streak.
+    void note_no_sample(SoakPosture posture) {
+        ++no_sample_drains_[static_cast<std::size_t>(posture)];
+    }
+    std::uint64_t no_sample_drains(SoakPosture p) const noexcept {
+        return no_sample_drains_[static_cast<std::size_t>(p)];
+    }
+
+    void revoke(const std::string& why, std::uint64_t unix_now = 0) {
+        state_ = GraduationState::Revoked;
+        revocations_.emplace_back(unix_now, why);
+    }
+
+    // GRADUATED means: this key, both legs, full streak, zero non-CLEAN inside
+    // either. Anything else is a list of reasons why not.
+    bool graduated() const noexcept { return state_ == GraduationState::Graduated; }
+
+    std::vector<std::string> shortfalls() const {
+        std::vector<std::string> out;
+        if (state_ == GraduationState::Revoked) {
+            out.push_back("REVOKED: " + (revocations_.empty() ? std::string("unknown")
+                                                              : revocations_.back().second));
+            return out;
+        }
+        if (key_.c2pool_commit.empty())
+            out.push_back("key: no c2pool commit recorded (graduation must name the code it judged)");
+        if (key_.monerod_version.empty() || key_.monerod_version == "unknown")
+            out.push_back("key: monerod version not observed yet");
+        if (key_.net.empty())
+            out.push_back("key: no network recorded");
+
+        const SoakPosture ps[2] = {SoakPosture::ServeMonerodShadowNative,
+                                   SoakPosture::ServeNativeShadowMonerod};
+        for (SoakPosture p : ps) {
+            const PostureLeg& L = leg(p);
+            if (L.qualified) continue;
+            const std::string tag = std::string(posture_tag(p));
+            if (L.clean_run < thr_.min_clean_samples)
+                out.push_back(tag + ": clean streak " + Obs::u64(L.clean_run).value
+                            + ", need " + Obs::u64(thr_.min_clean_samples).value);
+            if (L.run_blocks < thr_.min_blocks)
+                out.push_back(tag + ": " + Obs::u64(L.run_blocks).value
+                            + " block(s) in the streak, need " + Obs::u64(thr_.min_blocks).value);
+            if (L.run_seconds() < thr_.min_seconds)
+                out.push_back(tag + ": streak spans " + Obs::u64(L.run_seconds()).value
+                            + " s, need " + Obs::u64(thr_.min_seconds).value + " s");
+            if (L.run_tip_clean < thr_.min_tip_clean)
+                out.push_back(tag + ": " + Obs::u64(L.run_tip_clean).value
+                            + " clean P-TIP sample(s) in the streak, need "
+                            + Obs::u64(thr_.min_tip_clean).value);
+            if (L.run_tmpl_clean < thr_.min_template_clean)
+                out.push_back(tag + ": " + Obs::u64(L.run_tmpl_clean).value
+                            + " clean P-TPL sample(s) in the streak, need "
+                            + Obs::u64(thr_.min_template_clean).value);
+            if (!L.last_reset_why.empty())
+                out.push_back(tag + ": last streak reset -- " + L.last_reset_why);
+        }
+        return out;
+    }
+
+    // -----------------------------------------------------------------------
+    // Persistence
+    // -----------------------------------------------------------------------
+    std::string to_json() const {
+        std::ostringstream o;
+        o << "{\n";
+        o << "  \"schema\": \"xmr-m4-graduation/1\",\n";
+        o << "  \"key\": {\"c2pool_commit\": \"" << esc(key_.c2pool_commit)
+          << "\", \"comparator_version\": " << key_.comparator_version
+          << ", \"monerod_version\": \"" << esc(key_.monerod_version)
+          << "\", \"net\": \"" << esc(key_.net) << "\"},\n";
+        o << "  \"state\": \"" << to_string(state_) << "\",\n";
+        o << "  \"graduated_unix\": " << graduated_unix_ << ",\n";
+        o << "  \"first_sample_unix\": " << first_unix_ << ",\n";
+        o << "  \"last_sample_unix\": " << last_unix_ << ",\n";
+        o << "  \"thresholds\": {\"min_clean_samples\": " << thr_.min_clean_samples
+          << ", \"min_blocks\": " << thr_.min_blocks
+          << ", \"min_seconds\": " << thr_.min_seconds
+          << ", \"min_tip_clean\": " << thr_.min_tip_clean
+          << ", \"min_template_clean\": " << thr_.min_template_clean
+          << ", \"max_void_run\": " << thr_.max_void_run << "},\n";
+        o << "  \"legs\": {";
+        const SoakPosture ps[2] = {SoakPosture::ServeMonerodShadowNative,
+                                   SoakPosture::ServeNativeShadowMonerod};
+        for (std::size_t i = 0; i < 2; ++i) {
+            const PostureLeg& L = leg(ps[i]);
+            if (i) o << ",";
+            o << "\n    \"" << posture_tag(ps[i]) << "\": {"
+              << "\"clean_run\": " << L.clean_run
+              << ", \"run_blocks\": " << L.run_blocks
+              << ", \"run_first_unix\": " << L.run_first_unix
+              << ", \"run_last_unix\": " << L.run_last_unix
+              << ", \"run_height_lo\": " << L.run_height_lo
+              << ", \"run_height_hi\": " << L.run_height_hi
+              << ", \"run_tip_clean\": " << L.run_tip_clean
+              << ", \"run_tmpl_clean\": " << L.run_tmpl_clean
+              << ", \"void_run\": " << L.void_run
+              << ", \"samples\": " << L.samples
+              << ", \"clean\": " << L.clean
+              << ", \"fail\": " << L.fail
+              << ", \"served_mismatch\": " << L.served_mismatch
+              << ", \"void\": " << L.voided
+              << ", \"resets\": " << L.resets
+              << ", \"first_unix\": " << L.first_unix
+              << ", \"last_unix\": " << L.last_unix
+              << ", \"best_clean_run\": " << L.best_clean_run
+              << ", \"best_blocks\": " << L.best_blocks
+              << ", \"best_seconds\": " << L.best_seconds
+              << ", \"qualified\": " << (L.qualified ? "true" : "false")
+              << ", \"qualified_unix\": " << L.qualified_unix
+              << ", \"no_sample_drains\": " << no_sample_drains_[static_cast<std::size_t>(ps[i])]
+              << ", \"last_reset_why\": \"" << esc(L.last_reset_why) << "\"}";
+        }
+        o << "\n  },\n";
+        o << "  \"revocations\": [";
+        for (std::size_t i = 0; i < revocations_.size(); ++i) {
+            if (i) o << ",";
+            o << "\n    {\"unix\": " << revocations_[i].first
+              << ", \"why\": \"" << esc(revocations_[i].second) << "\"}";
+        }
+        o << "\n  ]\n}\n";
+        return o.str();
+    }
+
+    // Loads ONLY when the key matches. A foreign ledger is discarded and `why`
+    // says which of the four keys moved. This is the M1 lesson made mechanical:
+    // the comparator bump from 2 to 3 must not carry a streak across.
+    bool from_json(const std::string& text, std::string* why = nullptr) {
+        mj4::Value root;
+        if (!mj4::parse(text.data(), text.size(), root) || !root.is_object()) {
+            if (why) *why = "m4 ledger: not valid JSON";
+            return false;
+        }
+        const mj4::Value& k = root["key"];
+        GraduationKey loaded;
+        loaded.c2pool_commit      = k["c2pool_commit"].as_string();
+        loaded.comparator_version = static_cast<std::uint32_t>(k["comparator_version"].as_u64());
+        loaded.monerod_version    = k["monerod_version"].as_string();
+        loaded.net                = k["net"].as_string();
+
+        // The running key may not have seen the daemon yet. An unbound version
+        // adopts what is on disk rather than refusing to load against itself;
+        // every other field must match exactly.
+        GraduationKey running = key_;
+        if (running.monerod_version.empty() || running.monerod_version == "unknown")
+            running.monerod_version = loaded.monerod_version;
+        if (!same_key(loaded, running)) {
+            if (why) *why = "m4 ledger: key mismatch (" + key_string(loaded)
+                          + " on disk, " + key_string(key_)
+                          + " running): discarded, both posture streaks restart";
+            return false;
+        }
+        key_.monerod_version = running.monerod_version;
+
+        const std::string st = root["state"].as_string();
+        state_ = (st == "Graduated") ? GraduationState::Graduated
+               : (st == "Revoked")   ? GraduationState::Revoked
+               : (st == "Observing") ? GraduationState::Observing
+                                     : GraduationState::Ungraduated;
+        graduated_unix_ = root["graduated_unix"].as_u64();
+        first_unix_     = root["first_sample_unix"].as_u64();
+        last_unix_      = root["last_sample_unix"].as_u64();
+
+        const SoakPosture ps[2] = {SoakPosture::ServeMonerodShadowNative,
+                                   SoakPosture::ServeNativeShadowMonerod};
+        const mj4::Value& legs = root["legs"];
+        for (SoakPosture p : ps) {
+            const mj4::Value& v = legs[posture_tag(p)];
+            PostureLeg& L = legs_[static_cast<std::size_t>(p)];
+            L.clean_run      = v["clean_run"].as_u64();
+            L.run_blocks     = v["run_blocks"].as_u64();
+            L.run_first_unix = v["run_first_unix"].as_u64();
+            L.run_last_unix  = v["run_last_unix"].as_u64();
+            L.run_height_lo  = v["run_height_lo"].as_u64();
+            L.run_height_hi  = v["run_height_hi"].as_u64();
+            L.run_tip_clean  = v["run_tip_clean"].as_u64();
+            L.run_tmpl_clean = v["run_tmpl_clean"].as_u64();
+            L.void_run       = v["void_run"].as_u64();
+            L.samples        = v["samples"].as_u64();
+            L.clean          = v["clean"].as_u64();
+            L.fail           = v["fail"].as_u64();
+            L.served_mismatch = v["served_mismatch"].as_u64();
+            L.voided         = v["void"].as_u64();
+            L.resets         = v["resets"].as_u64();
+            L.first_unix     = v["first_unix"].as_u64();
+            L.last_unix      = v["last_unix"].as_u64();
+            L.best_clean_run = v["best_clean_run"].as_u64();
+            L.best_blocks    = v["best_blocks"].as_u64();
+            L.best_seconds   = v["best_seconds"].as_u64();
+            L.qualified      = v["qualified"].as_bool(false);
+            L.qualified_unix = v["qualified_unix"].as_u64();
+            L.last_reset_why = v["last_reset_why"].as_string();
+            no_sample_drains_[static_cast<std::size_t>(p)] = v["no_sample_drains"].as_u64();
+        }
+        revocations_.clear();
+        const mj4::Value& rv = root["revocations"];
+        if (rv.is_array())
+            for (const mj4::Value& e : rv.arr)
+                revocations_.emplace_back(e["unix"].as_u64(), e["why"].as_string());
+
+        // The state on disk is a CACHE of a decision, never the decision. It is
+        // re-derived from the loaded counters here, so a file that says
+        // "Graduated" over legs that did not qualify -- a hand-edit, a partial
+        // write, a future field this build does not read -- is corrected rather
+        // than believed. A genuinely graduated ledger re-derives to Graduated
+        // and keeps its stamp; a revoked one stays revoked, which evaluate_
+        // refuses to touch.
+        evaluate_(last_unix_);
+        if (why) why->clear();
+        return true;
+    }
+
+    bool save(const std::string& path, std::string* why = nullptr) const {
+        std::ofstream f(path, std::ios::binary | std::ios::trunc);
+        if (!f) { if (why) *why = "m4 ledger: cannot open '" + path + "' for writing"; return false; }
+        const std::string t = to_json();
+        f.write(t.data(), static_cast<std::streamsize>(t.size()));
+        if (!f.good()) { if (why) *why = "m4 ledger: write failed on '" + path + "'"; return false; }
+        return true;
+    }
+
+    // A missing file is NOT an error: an un-run experiment is ungraduated,
+    // which is already the fail-closed answer. A corrupt or foreign one is.
+    bool load(const std::string& path, std::string* why = nullptr) {
+        std::ifstream f(path, std::ios::binary);
+        if (!f) { if (why) why->clear(); return false; }
+        std::ostringstream ss;
+        ss << f.rdbuf();
+        return from_json(ss.str(), why);
+    }
+
+    // -----------------------------------------------------------------------
+    // The operator's line. Everything a reader needs to decide whether to
+    // believe it, including the numbers that are NOT yet met.
+    // -----------------------------------------------------------------------
+    std::string report() const {
+        std::ostringstream o;
+        o << "=== M4 graduation ledger ===\n";
+        o << "key            : commit=" << (key_.c2pool_commit.empty() ? "-" : key_.c2pool_commit)
+          << " comparator=v" << key_.comparator_version
+          << " monerod=" << (key_.monerod_version.empty() ? "-" : key_.monerod_version)
+          << " net=" << key_.net << "\n";
+        o << "thresholds     : per posture -- clean>=" << thr_.min_clean_samples
+          << " blocks>=" << thr_.min_blocks
+          << " seconds>=" << thr_.min_seconds
+          << " tip>=" << thr_.min_tip_clean
+          << " tpl>=" << thr_.min_template_clean
+          << " void_run<=" << thr_.max_void_run << "\n";
+        const SoakPosture ps[2] = {SoakPosture::ServeMonerodShadowNative,
+                                   SoakPosture::ServeNativeShadowMonerod};
+        for (SoakPosture p : ps) {
+            const PostureLeg& L = leg(p);
+            std::string tag = posture_tag(p);
+            while (tag.size() < 14) tag.push_back(' ');
+            o << "leg " << tag
+              << ": streak=" << L.clean_run
+              << " blocks=" << L.run_blocks
+              << " span=" << L.run_seconds() << "s"
+              << " tip=" << L.run_tip_clean << " tpl=" << L.run_tmpl_clean
+              << " heights=" << L.run_height_lo << ".." << L.run_height_hi
+              << " | lifetime clean=" << L.clean << " fail=" << L.fail
+              << " mismatch=" << L.served_mismatch << " void=" << L.voided
+              << " resets=" << L.resets
+              << " no_sample_drains=" << no_sample_drains_[static_cast<std::size_t>(p)]
+              << " | qualified=" << (L.qualified ? "yes" : "no") << "\n";
+            if (!L.last_reset_why.empty())
+                o << "               last reset: " << L.last_reset_why << "\n";
+        }
+        for (const auto& rv : revocations_)
+            o << "revocation     : unix=" << rv.first << " " << rv.second << "\n";
+        o << "state          : " << to_string(state_) << "\n";
+        const std::vector<std::string> sf = shortfalls();
+        for (const std::string& s : sf) o << "shortfall      : " << s << "\n";
+        return o.str();
+    }
+
+    static const char* seam_short(ProbeKind k) noexcept { return to_string(k); }
+
+private:
+    void accrue_(PostureLeg& L, const SeamResult& r, std::uint64_t unix_now) {
+        if (L.clean_run == 0) {
+            L.run_first_unix = unix_now;
+            L.run_height_lo  = r.sample.height;
+            L.run_height_hi  = r.sample.height;
+            L.run_blocks     = 0;
+            L.run_tip_clean  = 0;
+            L.run_tmpl_clean = 0;
+        } else if (r.sample.height > L.run_height_hi) {
+            // Forward progress only; see the header note on what `blocks` counts.
+            ++L.run_blocks;
+            L.run_height_hi = r.sample.height;
+        }
+        if (r.sample.height < L.run_height_lo && r.sample.height != 0)
+            L.run_height_lo = r.sample.height;
+        L.run_last_unix = unix_now;
+        ++L.clean_run;
+        if (r.sample.kind == ProbeKind::Tip)           ++L.run_tip_clean;
+        else if (r.sample.kind == ProbeKind::Template) ++L.run_tmpl_clean;
+
+        if (L.clean_run  > L.best_clean_run) L.best_clean_run = L.clean_run;
+        if (L.run_blocks > L.best_blocks)    L.best_blocks    = L.run_blocks;
+        if (L.run_seconds() > L.best_seconds) L.best_seconds  = L.run_seconds();
+    }
+
+    void reset_(PostureLeg& L, SoakPosture p, std::string why, std::uint64_t unix_now) {
+        const bool had_qualification = L.qualified;
+        L.clean_run = 0;
+        L.run_blocks = 0;
+        L.run_first_unix = 0;
+        L.run_last_unix  = 0;
+        L.run_height_lo  = 0;
+        L.run_height_hi  = 0;
+        L.run_tip_clean  = 0;
+        L.run_tmpl_clean = 0;
+        L.void_run = 0;
+        ++L.resets;
+        L.last_reset_why = why;
+        // Qualification is not a trophy. The M4 criterion is every sample in
+        // the window, so a leg that has just failed no longer has a window.
+        L.qualified = false;
+        L.qualified_unix = 0;
+        if (had_qualification)
+            revocations_.emplace_back(unix_now, "posture " + std::string(posture_tag(p))
+                                              + " lost its qualification: " + why);
+    }
+
+    void evaluate_(std::uint64_t unix_now) {
+        if (state_ == GraduationState::Revoked) return;
+        for (std::size_t i = 0; i < 2; ++i) {
+            PostureLeg& L = legs_[i];
+            if (!L.qualified && L.meets(thr_)) {
+                L.qualified = true;
+                L.qualified_unix = unix_now;
+            }
+        }
+        const bool key_ok = !key_.c2pool_commit.empty() && !key_.net.empty()
+                         && !key_.monerod_version.empty() && key_.monerod_version != "unknown"
+                         && key_.comparator_version == COMPARATOR_VERSION;
+        const bool both = legs_[0].qualified && legs_[1].qualified;
+        if (key_ok && both) {
+            if (state_ != GraduationState::Graduated) graduated_unix_ = unix_now;
+            state_ = GraduationState::Graduated;
+        } else {
+            state_ = (last_unix_ != 0) ? GraduationState::Observing
+                                       : GraduationState::Ungraduated;
+        }
+    }
+
+    static std::string esc(const std::string& s) {
+        std::string o;
+        o.reserve(s.size() + 8);
+        for (char c : s) {
+            if (c == '"' || c == '\\') { o.push_back('\\'); o.push_back(c); }
+            else if (c == '\n') o += "\\n";
+            else if (static_cast<unsigned char>(c) < 0x20) o += ' ';
+            else o.push_back(c);
+        }
+        return o;
+    }
+
+    GraduationKey   key_{};
+    SoakThresholds  thr_{};
+    GraduationState state_ = GraduationState::Ungraduated;
+    PostureLeg      legs_[2]{};
+    std::uint64_t   no_sample_drains_[2]{0, 0};
+    std::vector<std::pair<std::uint64_t, std::string>> revocations_;
+    std::uint64_t   first_unix_     = 0;
+    std::uint64_t   last_unix_      = 0;
+    std::uint64_t   graduated_unix_ = 0;
+};
+
+} // namespace c2pool::xmr::native::parity

--- a/src/impl/xmr/native/parity/xmr_parity_sources.hpp
+++ b/src/impl/xmr/native/parity/xmr_parity_sources.hpp
@@ -42,6 +42,7 @@
 
 #include "impl/xmr/native/chain/xmr_chain_view.hpp"
 #include "impl/xmr/native/parity/xmr_parity_types.hpp"
+#include "impl/xmr/native/parity/xmr_tip_observer.hpp"
 #include "impl/xmr/node/minijson.hpp"
 #include "impl/xmr/node/monerod_transport.hpp"
 
@@ -305,17 +306,12 @@ inline ArmObservation no_observation(const char* arm, std::string why) {
 }
 
 // ---------------------------------------------------------------------------
-// ITipObserver -- what the oracle pulls a tip from.
-//
-// A tip EVENT says something moved; the oracle then asks both sides what they
-// see. That indirection is what lets one side be an RPC round trip and the
-// other a struct read without either knowing about the other.
+// ITipObserver -- what the oracle pulls a tip from -- now lives in
+// xmr_tip_observer.hpp, included above. It moved so that a DECORATOR of the
+// seam (M4's PerturbingTipObserver) does not have to drag this file's chain-view
+// include, and therefore the whole vendored consensus link, behind one pure
+// virtual function. Every name this header exported, it still exports.
 // ---------------------------------------------------------------------------
-class ITipObserver {
-public:
-    virtual ~ITipObserver() = default;
-    virtual ArmObservation observe() = 0;
-};
 
 // The native side. Cheap: it reads the row the verify thread already built.
 class ChainViewTipObserver final : public ITipObserver {

--- a/src/impl/xmr/native/parity/xmr_soak_driver.hpp
+++ b/src/impl/xmr/native/parity/xmr_soak_driver.hpp
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/parity/xmr_soak_driver.hpp
+//
+// M4, the harness: the thing that RUNS the soak, as opposed to the thing that
+// records it.
+//
+// C6 built the judge (compare_seam), the intake (ArmObservation), and the C6
+// ledger. What nothing built is the loop around them -- and the loop is where
+// the M4 claim is either earned or quietly not made:
+//
+//   * SOMETHING HAS TO DRIVE P-TPL. on_tip fires by itself, because the chain
+//     index publishes a tip event at every height. on_serve does not: it is
+//     called by whoever serves a template, and in the node harness nobody did.
+//     A soak that only followed tips would run up a long streak having never
+//     once compared a template -- and "P-TPL CLEAN on every sample" is half of
+//     what M4 says. So the driver PULLS a template from the configured serving
+//     arm on its own cadence and hands it to the oracle as the served artefact.
+//     That is also why the threshold set carries min_template_clean: the cheap
+//     seam must not be allowed to carry the expensive one.
+//
+//   * THE POSTURE HAS TO BE EXACT. ArmResolver::serving() falls back to the
+//     other arm when the configured one is not ready, which is the correct
+//     production behaviour and is fatal to a parity claim: a leg that silently
+//     served monerod for an hour is not evidence about the native arm. So the
+//     driver resolves the posture's arm STRICTLY -- arm(posture), no fallback --
+//     and an unready arm produces no sample, which the ledger counts as a
+//     no-sample drain rather than as calm.
+//
+//   * AND SOMETHING HAS TO BE ABLE TO REFUSE. A soak harness that has never
+//     been seen to say no is not a gate. TipFaultInjection below is the
+//     negative control: a decorator around the native arm's tip observer that
+//     perturbs ONE required EQUALITY field by ONE UNIT, on demand, after a
+//     chosen number of samples. It is the same mutation xmr_native_parity_kat
+//     already pins offline ("perturb each required field, it must FAIL"), but
+//     applied LIVE, through the real observer, the real comparator and the real
+//     ledger, so that "the streak resets and graduation is refused" is a thing
+//     the harness was watched doing rather than a thing the code says it does.
+//     It is DISARMED unless a flag names a field, it lives in the harness path
+//     only, and it stamps every perturbed sample's note so a transcript can
+//     never be mistaken for an honest one.
+//
+// SCOPE FENCE: src/impl/xmr/ only. No consensus digest, no src/sharechain/v37.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <cstdint>
+#include <deque>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "impl/xmr/native/parity/xmr_graduation_ledger.hpp"
+#include "impl/xmr/native/parity/xmr_tip_observer.hpp"
+#include "impl/xmr/native/parity/xmr_parity_types.hpp"
+
+namespace c2pool::xmr::native::parity {
+
+// ---------------------------------------------------------------------------
+// One line of the soak transcript: a verdict WITH the context that makes it
+// readable six hours later. A bare verdict stream is unfalsifiable.
+// ---------------------------------------------------------------------------
+struct SoakEntry {
+    SoakPosture   posture = SoakPosture::ServeMonerodShadowNative;
+    ProbeKind     seam    = ProbeKind::Tip;
+    ParityVerdict verdict = ParityVerdict::Void;
+    std::uint64_t height  = 0;
+    // Named at_unix rather than `unix`: GCC defines `unix` as a macro outside
+    // strict-ANSI mode, and CMake's cxx_std_20 asks for gnu++20 by default.
+    std::uint64_t at_unix = 0;
+    std::uint64_t clean_run_after = 0;   // the streak this sample left behind
+    std::size_t   field_diffs = 0;
+    std::string   note;
+    std::string   first_diff;            // "field served=X shadow=Y", or empty
+
+    std::string render() const {
+        std::ostringstream o;
+        o << "[M4-SOAK] " << posture_tag(posture)
+          << " seam=" << to_string(seam)
+          << " h=" << height
+          << " verdict=" << to_string(verdict)
+          << " streak=" << clean_run_after
+          << " unix=" << at_unix;
+        if (field_diffs) o << " diffs=" << field_diffs;
+        if (!first_diff.empty()) o << " [" << first_diff << "]";
+        if (!note.empty()) o << " note=\"" << note << "\"";
+        return o.str();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// SoakDriver
+//
+// Owns nothing it did not create: the oracle, the arms and the node stay the
+// caller's. It is given batches of SeamResults (whatever ParityOracle::drain()
+// produced) and turns them into ledger movement, a transcript and a verdict.
+// ---------------------------------------------------------------------------
+class SoakDriver {
+public:
+    struct Config {
+        SoakPosture   posture = SoakPosture::ServeMonerodShadowNative;
+        std::string   ledger_path;
+        // Persist after this many recorded samples. 0 = only on demand.
+        std::uint64_t autosave_every = 16;
+        // How much transcript to keep in memory. The interesting part of a soak
+        // is always the tail plus the failures, and both are kept: failures are
+        // held in their own list so a long clean run cannot push them out.
+        std::size_t   transcript_cap = 256;
+        std::size_t   failure_cap    = 64;
+    };
+
+    SoakDriver(M4GraduationLedger& ledger, Config cfg)
+        : ledger_(ledger), cfg_(std::move(cfg)) {}
+
+    const Config&            config() const noexcept { return cfg_; }
+    SoakPosture              posture() const noexcept { return cfg_.posture; }
+    const M4GraduationLedger& ledger() const noexcept { return ledger_; }
+
+    const std::deque<SoakEntry>&  transcript() const noexcept { return tail_; }
+    const std::vector<SoakEntry>& failures()   const noexcept { return failures_; }
+    std::uint64_t recorded() const noexcept { return recorded_; }
+    std::uint64_t drains()   const noexcept { return drains_; }
+
+    // One drain's worth of samples. `unix_now` is the caller's clock: the whole
+    // component is clock-free so a KAT can drive 72 hours in microseconds.
+    //
+    // Returns the lines it produced, so a tool can print them without the
+    // driver owning a log sink.
+    std::vector<std::string> ingest(const std::vector<SeamResult>& batch,
+                                    std::uint64_t unix_now) {
+        std::vector<std::string> lines;
+        ++drains_;
+        if (batch.empty()) {
+            ledger_.note_no_sample(cfg_.posture);
+            return lines;
+        }
+        for (const SeamResult& r : batch) {
+            // P-POOL is M1's seam and has its own tally; it is not part of the
+            // M4 two-posture criterion and must not silently pad a streak.
+            if (r.sample.kind == ProbeKind::Pool) continue;
+            ledger_.record(cfg_.posture, r, unix_now);
+            ++recorded_;
+
+            SoakEntry e;
+            e.posture = cfg_.posture;
+            e.seam    = r.sample.kind;
+            e.verdict = r.sample.verdict;
+            e.height  = r.sample.height;
+            e.at_unix = unix_now;
+            e.clean_run_after = ledger_.leg(cfg_.posture).clean_run;
+            e.field_diffs     = r.sample.fields.size();
+            e.note            = r.sample.note;
+            if (!r.sample.fields.empty()) {
+                const FieldDiff& d = r.sample.fields.front();
+                e.first_diff = d.field + " served=" + d.served + " shadow=" + d.shadow;
+            }
+            lines.push_back(e.render());
+            if (r.sample.verdict == ParityVerdict::Fail ||
+                r.sample.verdict == ParityVerdict::ServedMismatch) {
+                if (failures_.size() < cfg_.failure_cap) failures_.push_back(e);
+            }
+            tail_.push_back(std::move(e));
+            while (tail_.size() > cfg_.transcript_cap) tail_.pop_front();
+        }
+        if (cfg_.autosave_every && recorded_ % cfg_.autosave_every == 0) save();
+        return lines;
+    }
+
+    bool save(std::string* why = nullptr) {
+        if (cfg_.ledger_path.empty()) { if (why) *why = "no ledger path"; return false; }
+        return ledger_.save(cfg_.ledger_path, why);
+    }
+
+    // One line a script can grep, and it says the WHOLE truth: the state, the
+    // posture that was actually run, and a shortfall when there is one.
+    //
+    // The shortfall shown is THIS POSTURE'S wherever one exists. The other
+    // leg's is a fact about a run that has not happened yet, and printing it
+    // beside this run's numbers reads as a comment on them -- which is how a
+    // reader ends up looking for the wrong failure.
+    std::string verdict_line() const {
+        const PostureLeg& L = ledger_.leg(cfg_.posture);
+        const std::vector<std::string> all = ledger_.shortfalls();
+        const std::string mine = std::string(posture_tag(cfg_.posture)) + ":";
+        std::vector<std::string> sf;
+        for (const std::string& s : all)
+            if (s.compare(0, mine.size(), mine) == 0) sf.push_back(s);
+        if (sf.empty()) sf = all;
+        std::ostringstream o;
+        o << "M4-VERDICT: " << (ledger_.graduated() ? "GRADUATED" : "NOT-GRADUATED")
+          << " posture=" << posture_tag(cfg_.posture)
+          << " state=" << to_string(ledger_.state())
+          << " streak=" << L.clean_run
+          << " blocks=" << L.run_blocks
+          << " span=" << L.run_seconds() << "s"
+          << " tip=" << L.run_tip_clean
+          << " tpl=" << L.run_tmpl_clean
+          << " clean=" << L.clean
+          << " fail=" << L.fail
+          << " mismatch=" << L.served_mismatch
+          << " void=" << L.voided
+          << " resets=" << L.resets
+          << " qualified=" << (L.qualified ? 1 : 0)
+          << " legs_qualified="
+          << ((ledger_.leg(SoakPosture::ServeMonerodShadowNative).qualified ? 1 : 0)
+            + (ledger_.leg(SoakPosture::ServeNativeShadowMonerod).qualified ? 1 : 0))
+          << "/2";
+        if (!sf.empty()) o << " shortfall=\"" << sf.front() << "\"";
+        return o.str();
+    }
+
+private:
+    M4GraduationLedger&    ledger_;
+    Config                 cfg_;
+    std::deque<SoakEntry>  tail_;
+    std::vector<SoakEntry> failures_;
+    std::uint64_t          recorded_ = 0;
+    std::uint64_t          drains_   = 0;
+};
+
+// ---------------------------------------------------------------------------
+// THE NEGATIVE CONTROL.
+//
+// A fault injector for the native arm's tip observation. It is HARNESS-ONLY and
+// exists for one reason: to make the refusal path something that was observed
+// rather than something that is asserted. Disarmed unless `field` is set.
+//
+// It perturbs by ONE UNIT (numeric fields) or by flipping the last nibble (hex
+// ids), which is the smallest change that can possibly be wrong -- a large
+// perturbation would also be caught by a sloppier judge and would prove less.
+//
+// `absent` is the OTHER half of the same control: instead of a wrong value, the
+// field simply stops being answered. A comparator that skipped an unanswered
+// required field would read CLEAN on that, which is the exact vacuity C6 was
+// built against, so the harness can drive it live too.
+// ---------------------------------------------------------------------------
+struct TipFaultInjection {
+    std::string   field;              // "" = disarmed
+    std::uint64_t after_samples = 0;  // arm only after this many observations
+    std::uint64_t for_samples   = 0;  // 0 = forever once armed
+    bool          absent        = false;  // remove the field instead of perturbing it
+
+    bool armed() const noexcept { return !field.empty(); }
+};
+
+class PerturbingTipObserver final : public ITipObserver {
+public:
+    PerturbingTipObserver(ITipObserver& inner, TipFaultInjection fault)
+        : inner_(inner), fault_(std::move(fault)) {}
+
+    ArmObservation observe() override {
+        ArmObservation o = inner_.observe();
+        if (!fault_.armed() || !o.have) return o;
+        ++seen_;
+        if (seen_ <= fault_.after_samples) return o;
+        if (fault_.for_samples != 0 && seen_ > fault_.after_samples + fault_.for_samples)
+            return o;
+
+        const Obs& cur = o.fields.get(fault_.field.c_str());
+        if (!cur.present) return o;      // nothing to perturb; say so by doing nothing
+
+        ++injected_;
+        if (fault_.absent) {
+            o.fields.set(fault_.field.c_str(), Obs::absent());
+            o.why = "HARNESS FAULT INJECTION: field '" + fault_.field + "' withheld";
+            return o;
+        }
+        o.fields.set(fault_.field.c_str(), Obs::text(perturb(cur.value)));
+        o.why = "HARNESS FAULT INJECTION: field '" + fault_.field + "' perturbed by one unit";
+        return o;
+    }
+
+    std::uint64_t observations() const noexcept { return seen_; }
+    std::uint64_t injected()     const noexcept { return injected_; }
+
+    // "12345" -> "12346";  "10:5" -> "10:6";  a 64-char hex id -> last nibble
+    // flipped; anything else gets a suffix, which still differs and still fails.
+    static std::string perturb(const std::string& v) {
+        if (v.empty()) return "1";
+        const bool hex_id = v.size() == 64 &&
+            v.find_first_not_of("0123456789abcdef") == std::string::npos;
+        if (hex_id) {
+            std::string out = v;
+            out.back() = (out.back() == '0') ? '1' : '0';
+            return out;
+        }
+        // Decimal, or the "hi:lo" u128 rendering: bump the last run of digits.
+        std::size_t end = v.size();
+        while (end > 0 && (v[end - 1] < '0' || v[end - 1] > '9')) --end;
+        if (end == 0) return v + "-perturbed";
+        std::size_t begin = end;
+        while (begin > 0 && v[begin - 1] >= '0' && v[begin - 1] <= '9') --begin;
+        const std::string digits = v.substr(begin, end - begin);
+        // Increment the decimal string in place; no 64-bit parse, so a 128-bit
+        // rendering perturbs correctly too.
+        std::string bumped = digits;
+        int i = static_cast<int>(bumped.size()) - 1;
+        for (; i >= 0; --i) {
+            if (bumped[static_cast<std::size_t>(i)] != '9') {
+                ++bumped[static_cast<std::size_t>(i)];
+                break;
+            }
+            bumped[static_cast<std::size_t>(i)] = '0';
+        }
+        if (i < 0) bumped.insert(bumped.begin(), '1');
+        return v.substr(0, begin) + bumped + v.substr(end);
+    }
+
+private:
+    ITipObserver&     inner_;
+    TipFaultInjection fault_;
+    std::uint64_t     seen_     = 0;
+    std::uint64_t     injected_ = 0;
+};
+
+} // namespace c2pool::xmr::native::parity

--- a/src/impl/xmr/native/parity/xmr_tip_observer.hpp
+++ b/src/impl/xmr/native/parity/xmr_tip_observer.hpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/parity/xmr_tip_observer.hpp
+//
+// C6: the tip-observer SEAM, on its own.
+//
+// It was declared at the bottom of xmr_parity_sources.hpp, next to its two
+// concrete implementations. That was the right place while both of them were
+// the only callers -- and the wrong one as soon as something else wanted to
+// DECORATE the seam, because xmr_parity_sources.hpp reaches C2c's chain view
+// and therefore drags the whole vendored consensus link (keccak, the difficulty
+// retarget, boost multiprecision) behind one pure virtual function.
+//
+// So the interface moves here and nothing else does. xmr_parity_sources.hpp
+// includes this file and keeps every name it exported, so no consumer changes;
+// what the split buys is that M4's PerturbingTipObserver -- a decorator that
+// needs the seam and nothing under it -- stays STL-only, and so does its KAT.
+//
+// A tip EVENT says something moved; the oracle then ASKS both sides what they
+// see. That indirection is what lets one side be an RPC round trip and the
+// other a struct read without either knowing about the other.
+//
+// SCOPE FENCE: src/impl/xmr/ only.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include "impl/xmr/native/parity/xmr_parity_types.hpp"
+
+namespace c2pool::xmr::native::parity {
+
+class ITipObserver {
+public:
+    virtual ~ITipObserver() = default;
+    virtual ArmObservation observe() = 0;
+};
+
+} // namespace c2pool::xmr::native::parity

--- a/src/impl/xmr/native/test/CMakeLists.txt
+++ b/src/impl/xmr/native/test/CMakeLists.txt
@@ -595,4 +595,35 @@ if (BUILD_TESTING)
     endif()
     add_test(NAME xmr_native_backlog_famine_kat COMMAND xmr_native_backlog_famine_kat)
 
+    # ------------------------------------------------------------------
+    # M4 -- the two-posture parity soak (../parity/xmr_graduation_ledger.hpp and
+    # ../parity/xmr_soak_driver.hpp).
+    #
+    #   xmr_native_m4_soak_kat -- the streak state machine, the ledger and the
+    #   REFUSAL. CLEAN accrues; FAIL and SERVED-MISMATCH reset to zero with no
+    #   budget of allowed failures; VOID neither accrues nor resets, but a RUN
+    #   of VOIDs past the cap resets anyway; a reorg contributes no block; one
+    #   posture is not two; a tip-only stream never satisfies the P-TPL floor;
+    #   a ledger written under the previous comparator version is refused and
+    #   the streak restarts (the M1 lesson, made mechanical); and the negative
+    #   control runs end to end through the REAL comparator -- two agreeing arm
+    #   observations compare CLEAN, one field perturbed by ONE UNIT FAILs, and
+    #   the ledger resets the streak, drops the qualification and refuses to
+    #   graduate.
+    #
+    # STL only: no RandomX, no daemon, no network, no clock of its own (the
+    # ledger takes unix seconds from the caller, so 72 hours pass in
+    # microseconds). It writes and removes one small JSON file in the working
+    # directory; ctest runs it inside the build tree with no arguments.
+    #
+    # DRIFT-GUARD: also listed in BOTH `--target` lists in
+    # .github/workflows/build.yml. A target registered with add_test but never
+    # built reports "***Not Run" and exits 8 -- the #1539 lesson.
+    add_executable(xmr_native_m4_soak_kat xmr_m4_soak_kat.cpp)
+    target_include_directories(xmr_native_m4_soak_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_features(xmr_native_m4_soak_kat PRIVATE cxx_std_20)
+    add_test(NAME xmr_native_m4_soak_kat COMMAND xmr_native_m4_soak_kat)
+
 endif()

--- a/src/impl/xmr/native/test/xmr_m4_soak_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_m4_soak_kat.cpp
@@ -1,0 +1,846 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/test/xmr_m4_soak_kat.cpp
+//
+// M4: THE STREAK STATE MACHINE, THE LEDGER, AND THE REFUSAL.
+//
+// The M4 gate is a claim about a PROCESS, not about a function: two postures,
+// each soaked until a streak of CLEAN samples is long enough, wide enough in
+// blocks and old enough in wall clock, with zero non-CLEAN samples in the
+// window. Every way that claim has gone wrong before is a way of accruing
+// credit that was not earned, so almost every check below is a check that
+// something did NOT count:
+//
+//   SUITE A  the streak machine. CLEAN accrues; FAIL and SERVED-MISMATCH reset
+//            to zero (there is no budget of allowed failures); VOID neither
+//            accrues nor resets, but a RUN of VOIDs past the cap resets anyway,
+//            because a leg that stopped producing judgeable samples is a probe
+//            that stopped firing and not a streak quietly holding; a reorg
+//            walking the tip backwards contributes no block.
+//
+//   SUITE B  graduation. One leg is not two. A tip-only stream never satisfies
+//            a template floor, so the cheap seam cannot carry the expensive one.
+//            A key with no commit, or with a daemon version nobody ever
+//            observed, cannot graduate at all. And a FAIL arriving AFTER
+//            graduation takes the qualification away again, loudly.
+//
+//   SUITE C  persistence, including the M1 LESSON made mechanical: a ledger
+//            written under comparator v2 is REFUSED by a v3 binary, and the
+//            streak restarts from zero. Also refused: another commit, another
+//            daemon, another network. A missing file is not an error.
+//
+//   SUITE D  the negative control itself, end to end through the REAL
+//            comparator: two arm observations that agree on all seven required
+//            P-TIP fields compare CLEAN, the injector perturbs ONE of them by
+//            ONE UNIT, and the same comparator now FAILs -- and the ledger
+//            resets the streak, clears the qualification and refuses to
+//            graduate. That is the mechanism the live regtest mini-soak
+//            exercises; here it is pinned without a daemon.
+//
+//   SUITE E  the driver: batches to ledger movement, a transcript with the
+//            context that makes a verdict readable later, P-POOL samples
+//            skipped (M1's seam is not part of the M4 criterion and must not
+//            pad a streak), and an empty drain counted as silence rather than
+//            as calm.
+//
+// SCOPE FENCE: src/impl/xmr/ only. No consensus digest, no src/sharechain/v37.
+// STL only: no RandomX, no daemon, no network, no clock (the ledger takes unix
+// seconds from the caller, so 72 hours pass in microseconds).
+// ---------------------------------------------------------------------------
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/native/parity/xmr_graduation_ledger.hpp"
+#include "impl/xmr/native/parity/xmr_parity_comparator.hpp"
+#include "impl/xmr/native/parity/xmr_soak_driver.hpp"
+
+using namespace c2pool::xmr::native;
+using namespace c2pool::xmr::native::parity;
+
+// ---------------------------------------------------------------------------
+static int g_checks = 0;
+static int g_fail   = 0;
+
+#define CHECK(cond, ...)                                  \
+    do {                                                  \
+        ++g_checks;                                       \
+        const bool _ok = (cond);                          \
+        if (!_ok) {                                       \
+            ++g_fail;                                     \
+            std::printf("  [FAIL] ");                     \
+            std::printf(__VA_ARGS__);                     \
+            std::printf("\n");                            \
+        }                                                 \
+    } while (0)
+
+static void head(const char* s) { std::printf("\n== %s ==\n", s); }
+
+// ---------------------------------------------------------------------------
+// Fixtures.
+// ---------------------------------------------------------------------------
+static SeamResult sample(ProbeKind kind, ParityVerdict v, std::uint64_t height,
+                         const char* note = "") {
+    SeamResult r;
+    r.sample.kind    = kind;
+    r.sample.verdict = v;
+    r.sample.height  = height;
+    r.sample.note    = note;
+    r.sample.classes.push_back(HeightClass::Steady);
+    return r;
+}
+
+// Small enough that a KAT can satisfy it by hand, structurally identical to the
+// stagenet shape.
+static SoakThresholds tiny() {
+    SoakThresholds t;
+    t.min_clean_samples  = 6;
+    t.min_blocks         = 3;
+    t.min_seconds        = 30;
+    t.min_tip_clean      = 3;
+    t.min_template_clean = 2;
+    t.max_void_run       = 4;
+    return t;
+}
+
+static GraduationKey key_of(const char* commit = "abc1234",
+                            const char* daemon = "0.18.5.1",
+                            const char* net    = "regtest") {
+    GraduationKey k;
+    k.c2pool_commit   = commit;
+    k.monerod_version = daemon;
+    k.net             = net;
+    return k;
+}
+
+// Feed one leg an alternating TIP/TEMPLATE stream of CLEAN samples, one block
+// and `dt` seconds apart, and hand back the unix clock where it stopped.
+static std::uint64_t run_clean(M4GraduationLedger& L, SoakPosture p, int n,
+                               std::uint64_t h0 = 100, std::uint64_t t0 = 1000,
+                               std::uint64_t dt = 10) {
+    std::uint64_t t = t0;
+    for (int i = 0; i < n; ++i) {
+        const ProbeKind k = (i % 2 == 0) ? ProbeKind::Tip : ProbeKind::Template;
+        L.record(p, sample(k, ParityVerdict::Clean, h0 + static_cast<std::uint64_t>(i)), t);
+        t += dt;
+    }
+    return t;
+}
+
+// ---------------------------------------------------------------------------
+// SUITE A -- the streak state machine.
+// ---------------------------------------------------------------------------
+static void suite_streak() {
+    head("A: the streak state machine");
+    const SoakPosture P = SoakPosture::ServeNativeShadowMonerod;
+
+    // A1: CLEAN accrues samples, blocks and wall clock, and splits per seam.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, P, 6, 100, 1000, 10);
+        const PostureLeg& leg = L.leg(P);
+        CHECK(leg.clean_run == 6, "A1 clean_run=%llu want 6", (unsigned long long)leg.clean_run);
+        // Six samples at heights 100..105: five FORWARD STEPS after the first.
+        CHECK(leg.run_blocks == 5, "A1 run_blocks=%llu want 5", (unsigned long long)leg.run_blocks);
+        CHECK(leg.run_seconds() == 50, "A1 span=%llu want 50", (unsigned long long)leg.run_seconds());
+        CHECK(leg.run_tip_clean == 3, "A1 tip=%llu want 3", (unsigned long long)leg.run_tip_clean);
+        CHECK(leg.run_tmpl_clean == 3, "A1 tpl=%llu want 3", (unsigned long long)leg.run_tmpl_clean);
+        CHECK(leg.run_height_lo == 100 && leg.run_height_hi == 105,
+              "A1 heights %llu..%llu", (unsigned long long)leg.run_height_lo,
+              (unsigned long long)leg.run_height_hi);
+        CHECK(leg.fail == 0 && leg.voided == 0, "A1 nothing else moved");
+        CHECK(L.leg(SoakPosture::ServeMonerodShadowNative).clean_run == 0,
+              "A1 the OTHER posture is untouched: two legs, two experiments");
+    }
+
+    // A2: one FAIL resets the whole run. Not a decrement, not an average.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, P, 6, 100, 1000, 10);
+        CHECK(L.leg(P).clean_run == 6, "A2 precondition");
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Fail, 106, "difficulty differed"), 1060);
+        const PostureLeg& leg = L.leg(P);
+        CHECK(leg.clean_run == 0,      "A2 streak reset to 0, got %llu", (unsigned long long)leg.clean_run);
+        CHECK(leg.run_blocks == 0,     "A2 blocks reset");
+        CHECK(leg.run_seconds() == 0,  "A2 wall clock reset");
+        CHECK(leg.run_tip_clean == 0 && leg.run_tmpl_clean == 0, "A2 per-seam reset");
+        CHECK(leg.resets == 1,         "A2 the reset is COUNTED, not silent");
+        CHECK(leg.fail == 1,           "A2 the failure is counted");
+        CHECK(leg.clean == 6,          "A2 lifetime clean survives: the run died, the history did not");
+        CHECK(leg.last_reset_why.find("FAIL") != std::string::npos,
+              "A2 the reason is recorded: '%s'", leg.last_reset_why.c_str());
+        CHECK(!L.graduated(), "A2 and it is not graduated");
+    }
+
+    // A3: SERVED-MISMATCH resets AND revokes -- it is the worse verdict.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, P, 4, 100, 1000, 10);
+        L.record(P, sample(ProbeKind::Template, ParityVerdict::ServedMismatch, 104), 1040);
+        CHECK(L.leg(P).clean_run == 0, "A3 streak reset");
+        CHECK(L.state() == GraduationState::Revoked, "A3 and the KEY is revoked");
+        CHECK(!L.revocations().empty(), "A3 with a recorded reason");
+        // Revocation is terminal for the key: more clean samples do not undo it.
+        run_clean(L, P, 20, 200, 2000, 10);
+        CHECK(L.state() == GraduationState::Revoked, "A3 revocation is terminal for this key");
+        CHECK(!L.graduated(), "A3 and nothing graduates after it");
+    }
+
+    // A4: VOID neither accrues nor resets. It has never been agreement.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, P, 4, 100, 1000, 10);
+        const std::uint64_t before = L.leg(P).clean_run;
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Void, 104, "arms on different tips"), 1040);
+        CHECK(L.leg(P).clean_run == before, "A4 VOID did not accrue and did not reset");
+        CHECK(L.leg(P).voided == 1, "A4 but it IS counted");
+        CHECK(L.leg(P).samples == 4, "A4 and it is not a judged sample");
+    }
+
+    // A5: a RUN of VOIDs past the cap resets. Silence is not a streak.
+    {
+        M4GraduationLedger L(key_of(), tiny());          // max_void_run = 4
+        run_clean(L, P, 4, 100, 1000, 10);
+        std::uint64_t t = 1040;
+        for (int i = 0; i < 4; ++i)
+            L.record(P, sample(ProbeKind::Tip, ParityVerdict::Void, 104), t += 10);
+        CHECK(L.leg(P).clean_run == 4, "A5 four VOIDs is exactly at the cap, streak stands");
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Void, 104), t += 10);
+        CHECK(L.leg(P).clean_run == 0, "A5 the fifth breaks it: the leg went quiet");
+        CHECK(L.leg(P).resets == 1, "A5 counted as a reset");
+        CHECK(L.leg(P).last_reset_why.find("VOID") != std::string::npos,
+              "A5 and named as VOID rather than as a failure: '%s'",
+              L.leg(P).last_reset_why.c_str());
+    }
+    // ...and a CLEAN sample in the middle clears the void run.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, P, 2, 100, 1000, 10);
+        std::uint64_t t = 1020;
+        for (int i = 0; i < 4; ++i)
+            L.record(P, sample(ProbeKind::Tip, ParityVerdict::Void, 102), t += 10);
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Clean, 103), t += 10);
+        for (int i = 0; i < 4; ++i)
+            L.record(P, sample(ProbeKind::Tip, ParityVerdict::Void, 103), t += 10);
+        CHECK(L.leg(P).clean_run == 3, "A5b a judged sample resets the void RUN, got %llu",
+              (unsigned long long)L.leg(P).clean_run);
+        CHECK(L.leg(P).resets == 0, "A5b and nothing was reset");
+    }
+
+    // A6: a reorg walks the tip backwards and contributes no block. Forward
+    // progress only -- the conservative direction.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Clean, 100), 1000);
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Clean, 101), 1010);
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Clean, 100), 1020);  // reorg
+        L.record(P, sample(ProbeKind::Tip, ParityVerdict::Clean, 101), 1030);  // re-adopt
+        CHECK(L.leg(P).clean_run == 4, "A6 four clean samples");
+        CHECK(L.leg(P).run_blocks == 1, "A6 but ONE block of forward progress, got %llu",
+              (unsigned long long)L.leg(P).run_blocks);
+    }
+
+    // A7: no_sample drains are counted and touch nothing.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, P, 3, 100, 1000, 10);
+        for (int i = 0; i < 5; ++i) L.note_no_sample(P);
+        CHECK(L.no_sample_drains(P) == 5, "A7 no-sample drains counted");
+        CHECK(L.leg(P).clean_run == 3, "A7 and the streak is untouched by them");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE B -- what graduation requires.
+// ---------------------------------------------------------------------------
+static void suite_graduation() {
+    head("B: graduation requires BOTH postures, both seams, and a complete key");
+
+    // B1: one leg is not two.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        CHECK(L.leg(SoakPosture::ServeMonerodShadowNative).qualified,
+              "B1 the soaked leg qualified");
+        CHECK(!L.graduated(), "B1 but one posture is not graduation");
+        const std::vector<std::string> sf = L.shortfalls();
+        bool names_other = false;
+        for (const std::string& s : sf)
+            if (s.find("serve-native") != std::string::npos) names_other = true;
+        CHECK(names_other, "B1 and the shortfall names the posture that has not run");
+    }
+
+    // B2: both legs, and the graduation is stamped.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        const std::uint64_t t = run_clean(L, SoakPosture::ServeNativeShadowMonerod,
+                                          8, 200, 5000, 10);
+        CHECK(L.graduated(), "B2 both legs qualified -> GRADUATED");
+        CHECK(L.state() == GraduationState::Graduated, "B2 state");
+        CHECK(L.graduated_unix() != 0 && L.graduated_unix() < t, "B2 stamped with when");
+        CHECK(L.shortfalls().empty(), "B2 and nothing is outstanding");
+    }
+
+    // B3: a tip-only stream never satisfies the template floor. The cheap seam
+    // cannot carry the expensive one, which is the whole reason M4 names P-TPL.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        std::uint64_t t = 1000;
+        for (int i = 0; i < 40; ++i) {
+            L.record(SoakPosture::ServeMonerodShadowNative,
+                     sample(ProbeKind::Tip, ParityVerdict::Clean,
+                            100 + static_cast<std::uint64_t>(i)), t);
+            t += 10;
+        }
+        const PostureLeg& leg = L.leg(SoakPosture::ServeMonerodShadowNative);
+        CHECK(leg.clean_run == 40, "B3 a long clean streak");
+        CHECK(leg.run_tmpl_clean == 0, "B3 with no template sample in it");
+        CHECK(!leg.qualified, "B3 does NOT qualify the leg");
+        bool names_tpl = false;
+        for (const std::string& s : L.shortfalls())
+            if (s.find("P-TPL") != std::string::npos || s.find("TPL") != std::string::npos
+                || s.find("tpl") != std::string::npos) names_tpl = true;
+        CHECK(names_tpl, "B3 and says so");
+    }
+
+    // B4: an incomplete key cannot graduate, however clean the samples are.
+    {
+        GraduationKey k = key_of();
+        k.monerod_version = "unknown";              // the daemon never answered
+        M4GraduationLedger L(k, tiny());
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        run_clean(L, SoakPosture::ServeNativeShadowMonerod, 8, 200, 5000, 10);
+        CHECK(!L.graduated(), "B4 a graduation that cannot name the daemon it beat is not one");
+        bool names_key = false;
+        for (const std::string& s : L.shortfalls())
+            if (s.find("monerod version") != std::string::npos) names_key = true;
+        CHECK(names_key, "B4 and the shortfall says which key is missing");
+
+        // ...and once the daemon answers, the same samples do graduate.
+        L.bind_monerod_version("0.18.5.1", 9000);
+        run_clean(L, SoakPosture::ServeNativeShadowMonerod, 1, 300, 9000, 10);
+        CHECK(L.key().monerod_version == "0.18.5.1", "B4 version bound on first sight");
+        CHECK(L.graduated(), "B4 and the key is now complete");
+    }
+    {
+        GraduationKey k = key_of();
+        k.c2pool_commit = "";
+        M4GraduationLedger L(k, tiny());
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        run_clean(L, SoakPosture::ServeNativeShadowMonerod, 8, 200, 5000, 10);
+        CHECK(!L.graduated(), "B4b a graduation that cannot name the code it judged is not one");
+    }
+
+    // B5: a FAIL AFTER graduation takes the qualification away again.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        run_clean(L, SoakPosture::ServeNativeShadowMonerod, 8, 200, 5000, 10);
+        CHECK(L.graduated(), "B5 precondition: graduated");
+        const std::size_t revs = L.revocations().size();
+        L.record(SoakPosture::ServeNativeShadowMonerod,
+                 sample(ProbeKind::Tip, ParityVerdict::Fail, 210, "seed_hash differed"), 5200);
+        CHECK(!L.graduated(), "B5 one later FAIL and it is no longer graduated");
+        CHECK(!L.leg(SoakPosture::ServeNativeShadowMonerod).qualified,
+              "B5 the leg lost its qualification");
+        CHECK(L.leg(SoakPosture::ServeMonerodShadowNative).qualified,
+              "B5 the OTHER leg keeps its own: postures are judged apart");
+        CHECK(L.revocations().size() > revs,
+              "B5 and losing a qualification is recorded, not silent");
+        CHECK(L.state() == GraduationState::Observing, "B5 back to Observing");
+    }
+
+    // B6: the stagenet numbers are the plan's, unscaled. Guarded here so that a
+    // future edit that "rounds" 72 h has to change a KAT that says why.
+    {
+        const SoakThresholds s = SoakThresholds::stagenet_m4();
+        CHECK(s.min_seconds == 72 * 3600, "B6 72 hours per posture");
+        CHECK(s.min_blocks == 720, "B6 720 blocks per posture");
+        CHECK(s.min_template_clean > 0, "B6 with P-TPL samples inside the window");
+        const SoakThresholds r = SoakThresholds::regtest_mini();
+        CHECK(r.min_clean_samples > 0 && r.min_blocks > 0 && r.min_seconds > 0
+              && r.min_template_clean > 0,
+              "B6 the regtest shape keeps EVERY threshold non-zero: a harness that "
+              "graduates on nothing proves nothing");
+        CHECK(r.min_seconds < s.min_seconds,
+              "B6 and it is the scaled one, not the real gate");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE C -- persistence, and the key that refuses to inherit.
+// ---------------------------------------------------------------------------
+static void suite_persistence() {
+    head("C: persistence, and a key that never inherits");
+    const char* path = "xmr_m4_soak_kat_ledger.json";
+
+    // C1: round trip. Every counter that matters comes back.
+    {
+        M4GraduationLedger A(key_of(), tiny());
+        run_clean(A, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        A.record(SoakPosture::ServeNativeShadowMonerod,
+                 sample(ProbeKind::Tip, ParityVerdict::Fail, 201, "x"), 5000);
+        run_clean(A, SoakPosture::ServeNativeShadowMonerod, 4, 210, 6000, 10);
+        A.note_no_sample(SoakPosture::ServeNativeShadowMonerod);
+
+        std::string why;
+        CHECK(A.save(path, &why), "C1 save: %s", why.c_str());
+
+        M4GraduationLedger B(key_of(), tiny());
+        CHECK(B.load(path, &why), "C1 load: %s", why.c_str());
+        const SoakPosture ps[2] = {SoakPosture::ServeMonerodShadowNative,
+                                   SoakPosture::ServeNativeShadowMonerod};
+        for (SoakPosture p : ps) {
+            const PostureLeg& a = A.leg(p);
+            const PostureLeg& b = B.leg(p);
+            CHECK(a.clean_run == b.clean_run && a.run_blocks == b.run_blocks
+                  && a.run_first_unix == b.run_first_unix && a.run_last_unix == b.run_last_unix
+                  && a.run_tip_clean == b.run_tip_clean && a.run_tmpl_clean == b.run_tmpl_clean
+                  && a.samples == b.samples && a.clean == b.clean && a.fail == b.fail
+                  && a.served_mismatch == b.served_mismatch && a.voided == b.voided
+                  && a.resets == b.resets && a.qualified == b.qualified
+                  && a.best_clean_run == b.best_clean_run
+                  && a.last_reset_why == b.last_reset_why,
+                  "C1 leg %s round-trips", posture_tag(p));
+            CHECK(A.no_sample_drains(p) == B.no_sample_drains(p),
+                  "C1 no-sample drains round-trip for %s", posture_tag(p));
+        }
+        CHECK(A.state() == B.state(), "C1 state round-trips");
+        CHECK(A.first_sample_unix() == B.first_sample_unix()
+              && A.last_sample_unix() == B.last_sample_unix(), "C1 first/last sample");
+        CHECK(A.key().comparator_version == COMPARATOR_VERSION
+              && B.key().comparator_version == COMPARATOR_VERSION,
+              "C1 and both are stamped with the RUNNING comparator version");
+
+        // ...and the resumed ledger keeps accruing on the same streak rather
+        // than starting a second one.
+        run_clean(B, SoakPosture::ServeNativeShadowMonerod, 4, 220, 7000, 10);
+        CHECK(B.leg(SoakPosture::ServeNativeShadowMonerod).clean_run == 8,
+              "C1 a resumed leg continues its streak, got %llu",
+              (unsigned long long)B.leg(SoakPosture::ServeNativeShadowMonerod).clean_run);
+    }
+
+    // C2: THE M1 LESSON. A ledger written under an older comparator is refused.
+    {
+        M4GraduationLedger A(key_of(), tiny());
+        run_clean(A, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        run_clean(A, SoakPosture::ServeNativeShadowMonerod, 8, 200, 5000, 10);
+        CHECK(A.graduated(), "C2 precondition: a GRADUATED ledger on disk");
+        std::string json = A.to_json();
+
+        // Rewrite the version as the one before this one. Nothing else changes:
+        // the same commit, the same daemon, the same network, the same streaks.
+        const std::string want = "\"comparator_version\": "
+                               + std::to_string(COMPARATOR_VERSION);
+        const std::string was  = "\"comparator_version\": "
+                               + std::to_string(COMPARATOR_VERSION - 1);
+        const std::size_t at = json.find(want);
+        CHECK(at != std::string::npos, "C2 the version is in the file");
+        json.replace(at, want.size(), was);
+
+        M4GraduationLedger B(key_of(), tiny());
+        std::string why;
+        CHECK(!B.from_json(json, &why), "C2 a v%u ledger is REFUSED by a v%u binary",
+              (unsigned)(COMPARATOR_VERSION - 1), (unsigned)COMPARATOR_VERSION);
+        CHECK(why.find("key mismatch") != std::string::npos,
+              "C2 and says why: '%s'", why.c_str());
+        CHECK(!B.graduated(), "C2 the graduation did NOT carry across the bump");
+        CHECK(B.leg(SoakPosture::ServeMonerodShadowNative).clean_run == 0
+              && B.leg(SoakPosture::ServeNativeShadowMonerod).clean_run == 0,
+              "C2 and both streaks restart at zero");
+    }
+
+    // C3: the other three keys, each on its own.
+    {
+        M4GraduationLedger A(key_of("abc1234", "0.18.5.1", "regtest"), tiny());
+        run_clean(A, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        const std::string json = A.to_json();
+
+        struct Case { GraduationKey k; const char* what; };
+        const Case cases[3] = {
+            {key_of("def5678", "0.18.5.1", "regtest"),  "a different c2pool commit"},
+            {key_of("abc1234", "0.18.6.0", "regtest"),  "a different monerod"},
+            {key_of("abc1234", "0.18.5.1", "stagenet"), "a different network"},
+        };
+        for (const Case& c : cases) {
+            M4GraduationLedger B(c.k, tiny());
+            std::string why;
+            CHECK(!B.from_json(json, &why), "C3 %s is refused", c.what);
+            CHECK(B.leg(SoakPosture::ServeMonerodShadowNative).clean_run == 0,
+                  "C3 %s: streak restarts", c.what);
+        }
+        // The same key on all four, and it loads.
+        M4GraduationLedger Same(key_of("abc1234", "0.18.5.1", "regtest"), tiny());
+        std::string why;
+        CHECK(Same.from_json(json, &why), "C3 the SAME key loads: %s", why.c_str());
+        CHECK(Same.leg(SoakPosture::ServeMonerodShadowNative).clean_run == 8,
+              "C3 with its streak intact");
+    }
+
+    // C4: a ledger whose daemon version is not yet bound adopts the one on
+    // disk. An un-polled daemon must not make a resume look like a foreign key.
+    {
+        M4GraduationLedger A(key_of("abc1234", "0.18.5.1", "regtest"), tiny());
+        run_clean(A, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        const std::string json = A.to_json();
+
+        GraduationKey unbound = key_of("abc1234", "", "regtest");
+        M4GraduationLedger B(unbound, tiny());
+        std::string why;
+        CHECK(B.from_json(json, &why), "C4 an unbound daemon version resumes: %s", why.c_str());
+        CHECK(B.key().monerod_version == "0.18.5.1", "C4 and adopts what is on disk");
+        CHECK(B.leg(SoakPosture::ServeMonerodShadowNative).clean_run == 8, "C4 streak intact");
+    }
+
+    // C5: a daemon that changes version UNDER the soak revokes rather than
+    // silently re-keying.
+    {
+        M4GraduationLedger L(key_of("abc1234", "0.18.5.1", "regtest"), tiny());
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 4, 100, 1000, 10);
+        L.bind_monerod_version("0.18.5.1", 1100);
+        CHECK(L.state() != GraduationState::Revoked, "C5 the same version is a no-op");
+        L.bind_monerod_version("0.18.6.0", 1200);
+        CHECK(L.state() == GraduationState::Revoked,
+              "C5 a daemon that changed under the soak revokes the key");
+    }
+
+    // C5b: the state on disk is a CACHE, not the decision. A file that claims
+    // Graduated over legs that did not qualify is corrected on load.
+    {
+        M4GraduationLedger A(key_of(), tiny());
+        run_clean(A, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        std::string json = A.to_json();
+        const std::size_t at = json.find("\"state\": \"Observing\"");
+        CHECK(at != std::string::npos, "C5b precondition: the ledger is Observing");
+        json.replace(at, std::string("\"state\": \"Observing\"").size(),
+                     "\"state\": \"Graduated\"");
+        M4GraduationLedger B(key_of(), tiny());
+        std::string why;
+        CHECK(B.from_json(json, &why), "C5b the forged file still loads: %s", why.c_str());
+        CHECK(!B.graduated(),
+              "C5b but the claim is re-derived from the counters and refused");
+        CHECK(!B.leg(SoakPosture::ServeNativeShadowMonerod).qualified,
+              "C5b the second leg never ran and still has not");
+    }
+
+    // C6: a missing file is not an error -- an un-run experiment is ungraduated,
+    // which is already the fail-closed answer. A corrupt one IS reported.
+    {
+        M4GraduationLedger B(key_of(), tiny());
+        std::string why = "sentinel";
+        CHECK(!B.load("xmr_m4_soak_kat_definitely_absent.json", &why), "C6 missing file");
+        CHECK(why.empty(), "C6 and it is not reported as an error, got '%s'", why.c_str());
+        CHECK(!B.from_json("{ this is not json", &why), "C6 corrupt is refused");
+        CHECK(!why.empty(), "C6 and IS reported");
+    }
+
+    std::remove(path);
+}
+
+// ---------------------------------------------------------------------------
+// SUITE D -- the negative control, through the real comparator.
+// ---------------------------------------------------------------------------
+namespace {
+
+// A tip observer that answers a fixed, honest observation.
+class CannedTip final : public ITipObserver {
+public:
+    explicit CannedTip(ArmObservation o) : o_(std::move(o)) {}
+    ArmObservation observe() override { ++calls_; return o_; }
+    std::uint64_t calls() const noexcept { return calls_; }
+private:
+    ArmObservation o_;
+    std::uint64_t  calls_ = 0;
+};
+
+Hash id_of(std::uint8_t b) {
+    Hash h{};
+    for (std::size_t i = 0; i < h.size(); ++i) h[i] = static_cast<std::uint8_t>(b + i);
+    return h;
+}
+
+// One arm's answer for P-TIP with every required EQUALITY field present.
+ArmObservation tip_arm(const char* name, std::uint64_t height) {
+    ArmObservation o;
+    o.arm     = name;
+    o.have    = true;
+    o.height  = height;
+    o.prev_id = id_of(0x10);
+    o.fields.set("id",                    Obs::id(id_of(0x20)));
+    o.fields.set("prev_id",               Obs::id(id_of(0x10)));
+    o.fields.set("cumulative_difficulty", Obs::u128(U128{0, 123456}));
+    o.fields.set("difficulty",            Obs::u128(U128{0, 1000}));
+    o.fields.set("timestamp",             Obs::u64(1700000000));
+    o.fields.set("reward",                Obs::u64(600000000000ull));
+    o.fields.set("block_weight",          Obs::u64(1234));
+    o.fields.set("long_term_weight",      Obs::u64(1234));
+    o.fields.set("major_version",         Obs::u64(16));
+    return o;
+}
+
+} // namespace
+
+static void suite_injection() {
+    head("D: the negative control, end to end through the real comparator");
+
+    // D1: one-unit perturbation semantics, over the three renderings the Obs
+    // layer produces.
+    {
+        CHECK(PerturbingTipObserver::perturb("1234") == "1235", "D1 decimal +1");
+        CHECK(PerturbingTipObserver::perturb("1299") == "1300", "D1 decimal carries");
+        CHECK(PerturbingTipObserver::perturb("999")  == "1000", "D1 decimal grows");
+        CHECK(PerturbingTipObserver::perturb("0")    == "1",    "D1 zero is a real value");
+        // The u128 rendering: only the LOW word moves, so a carry into the high
+        // word can never be manufactured by the injector itself.
+        CHECK(PerturbingTipObserver::perturb("7:42") == "7:43", "D1 u128 hi:lo");
+        const std::string hexid(64, 'a');
+        const std::string bumped = PerturbingTipObserver::perturb(hexid);
+        CHECK(bumped.size() == 64 && bumped != hexid, "D1 a 64-hex id changes and stays an id");
+        CHECK(bumped.compare(0, 63, hexid, 0, 63) == 0, "D1 by exactly one nibble");
+    }
+
+    // D2: the injector is honest until it is armed, and stops when told to.
+    {
+        CannedTip inner(tip_arm("native", 500));
+        TipFaultInjection f;
+        f.field = "difficulty";
+        f.after_samples = 3;
+        f.for_samples   = 2;
+        PerturbingTipObserver inj(inner, f);
+        const std::string honest = tip_arm("native", 500).fields.get("difficulty").value;
+        for (int i = 0; i < 3; ++i)
+            CHECK(inj.observe().fields.get("difficulty").value == honest,
+                  "D2 observation %d is honest", i + 1);
+        CHECK(inj.observe().fields.get("difficulty").value != honest, "D2 observation 4 perturbed");
+        CHECK(inj.observe().fields.get("difficulty").value != honest, "D2 observation 5 perturbed");
+        CHECK(inj.observe().fields.get("difficulty").value == honest,
+              "D2 observation 6 is honest again: for_samples honoured");
+        CHECK(inj.injected() == 2, "D2 and exactly two were injected, got %llu",
+              (unsigned long long)inj.injected());
+    }
+    // ...and the withholding mode removes the field rather than changing it.
+    {
+        CannedTip inner(tip_arm("native", 500));
+        TipFaultInjection f;
+        f.field  = "long_term_weight";
+        f.absent = true;
+        PerturbingTipObserver inj(inner, f);
+        const ArmObservation o = inj.observe();
+        CHECK(!o.fields.get("long_term_weight").present,
+              "D2b the field is ABSENT, not zero -- which is the vacuity C6 exists against");
+        CHECK(o.have, "D2b the arm still answered");
+    }
+    // A disarmed injector is a pass-through.
+    {
+        CannedTip inner(tip_arm("native", 500));
+        PerturbingTipObserver inj(inner, TipFaultInjection{});
+        CHECK(inj.observe().fields.get("difficulty").present, "D2c disarmed: unchanged");
+        CHECK(inj.injected() == 0, "D2c and nothing injected");
+    }
+
+    // D3: THE CONTROL. The same two arms, the same comparator, twice.
+    {
+        const ArmObservation daemon = tip_arm("monerod", 500);
+
+        // (a) honest: CLEAN.
+        {
+            CannedTip inner(tip_arm("native", 500));
+            PerturbingTipObserver inj(inner, TipFaultInjection{});
+            const SeamResult r = compare_seam(TIP_SEAM, inj.observe(), daemon, {});
+            CHECK(r.sample.verdict == ParityVerdict::Clean,
+                  "D3a honest arms compare CLEAN (got %s)", to_string(r.sample.verdict));
+            CHECK(r.equality_compared == r.equality_required,
+                  "D3a and every required field was actually compared");
+        }
+
+        // (b) one field, one unit: FAIL. Nothing else about the sample changed.
+        for (const char* field : {"cumulative_difficulty", "difficulty", "id",
+                                  "timestamp", "reward", "block_weight",
+                                  "long_term_weight", "major_version"}) {
+            CannedTip inner(tip_arm("native", 500));
+            TipFaultInjection f;
+            f.field = field;
+            PerturbingTipObserver inj(inner, f);
+            const SeamResult r = compare_seam(TIP_SEAM, inj.observe(), daemon, {});
+            CHECK(r.sample.verdict == ParityVerdict::Fail,
+                  "D3b perturbing '%s' by one unit FAILS (got %s)", field,
+                  to_string(r.sample.verdict));
+            CHECK(r.equality_differed == 1, "D3b exactly one field differed for '%s'", field);
+        }
+
+        // (c) withholding it FAILS too -- a comparison that did not happen is
+        // not one that passed.
+        {
+            CannedTip inner(tip_arm("native", 500));
+            TipFaultInjection f;
+            f.field  = "reward";
+            f.absent = true;
+            PerturbingTipObserver inj(inner, f);
+            const SeamResult r = compare_seam(TIP_SEAM, inj.observe(), daemon, {});
+            CHECK(r.sample.verdict == ParityVerdict::Fail, "D3c a withheld required field FAILS");
+            CHECK(r.equality_absent == 1, "D3c and is counted as absent, not as equal");
+        }
+
+        // (d) THE WHOLE POINT: an accrued, qualified leg meets an injected
+        // divergence and the ledger refuses.
+        {
+            M4GraduationLedger L(key_of(), tiny());
+            const SoakPosture P = SoakPosture::ServeNativeShadowMonerod;
+            run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+            run_clean(L, P, 8, 200, 5000, 10);
+            CHECK(L.graduated(), "D3d precondition: GRADUATED on both legs");
+
+            CannedTip inner(tip_arm("native", 500));
+            TipFaultInjection f;
+            f.field = "cumulative_difficulty";      // a SENTINEL field
+            PerturbingTipObserver inj(inner, f);
+            const SeamResult bad = compare_seam(TIP_SEAM, inj.observe(), daemon, {});
+            CHECK(bad.sample.verdict == ParityVerdict::Fail, "D3d the injected sample FAILS");
+            CHECK(bad.sentinel_tripped, "D3d on a SENTINEL field");
+
+            L.record(P, bad, 6000);
+            CHECK(L.leg(P).clean_run == 0, "D3d the streak RESET");
+            CHECK(!L.leg(P).qualified, "D3d the leg lost its qualification");
+            CHECK(!L.graduated(), "D3d and the ledger REFUSES to graduate");
+            CHECK(L.state() == GraduationState::Revoked,
+                  "D3d a sentinel revokes the key outright");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE E -- the driver.
+// ---------------------------------------------------------------------------
+static void suite_driver() {
+    head("E: the soak driver");
+
+    // E1: a batch becomes ledger movement AND a readable transcript.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        SoakDriver::Config c;
+        c.posture = SoakPosture::ServeNativeShadowMonerod;
+        c.autosave_every = 0;                      // no file in this check
+        SoakDriver d(L, c);
+
+        std::vector<SeamResult> batch;
+        batch.push_back(sample(ProbeKind::Tip, ParityVerdict::Clean, 100, "9 field(s) equal"));
+        batch.push_back(sample(ProbeKind::Template, ParityVerdict::Clean, 100, "6 field(s) equal"));
+        const std::vector<std::string> lines = d.ingest(batch, 1000);
+
+        CHECK(lines.size() == 2, "E1 one line per sample");
+        CHECK(d.recorded() == 2, "E1 both recorded");
+        CHECK(L.leg(c.posture).clean_run == 2, "E1 and the streak moved");
+        CHECK(!d.transcript().empty(), "E1 a transcript exists");
+        const SoakEntry& e = d.transcript().back();
+        CHECK(e.posture == c.posture && e.seam == ProbeKind::Template
+              && e.verdict == ParityVerdict::Clean && e.height == 100
+              && e.clean_run_after == 2,
+              "E1 and it carries the sample's CONTEXT, not just its verdict");
+        CHECK(e.render().find("serve-native") != std::string::npos,
+              "E1 the rendered line names the posture: '%s'", e.render().c_str());
+    }
+
+    // E2: P-POOL is M1's seam and must not pad an M4 streak.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        SoakDriver::Config c;
+        c.autosave_every = 0;
+        SoakDriver d(L, c);
+        std::vector<SeamResult> batch;
+        for (int i = 0; i < 20; ++i)
+            batch.push_back(sample(ProbeKind::Pool, ParityVerdict::Clean, 100));
+        d.ingest(batch, 1000);
+        CHECK(d.recorded() == 0, "E2 twenty clean P-POOL samples recorded nothing");
+        CHECK(L.leg(c.posture).clean_run == 0, "E2 and moved no M4 streak");
+    }
+
+    // E3: an empty drain is silence, counted as such, and touches no streak.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        SoakDriver::Config c;
+        c.autosave_every = 0;
+        SoakDriver d(L, c);
+        std::vector<SeamResult> one;
+        one.push_back(sample(ProbeKind::Tip, ParityVerdict::Clean, 100));
+        d.ingest(one, 1000);
+        for (int i = 0; i < 5; ++i) d.ingest({}, 1010);
+        CHECK(L.no_sample_drains(c.posture) == 5, "E3 five silent drains counted");
+        CHECK(L.leg(c.posture).clean_run == 1, "E3 and the streak is untouched");
+        CHECK(d.drains() == 6, "E3 six drains in total");
+    }
+
+    // E4: failures are held apart from the tail, so a long clean run cannot
+    // push the one interesting sample out of the transcript.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        SoakDriver::Config c;
+        c.autosave_every = 0;
+        c.transcript_cap = 4;
+        SoakDriver d(L, c);
+        std::vector<SeamResult> bad;
+        bad.push_back(sample(ProbeKind::Tip, ParityVerdict::Fail, 100, "difficulty differed"));
+        d.ingest(bad, 1000);
+        for (int i = 0; i < 20; ++i) {
+            std::vector<SeamResult> ok;
+            ok.push_back(sample(ProbeKind::Tip, ParityVerdict::Clean,
+                                101 + static_cast<std::uint64_t>(i)));
+            d.ingest(ok, 1010 + static_cast<std::uint64_t>(i));
+        }
+        CHECK(d.transcript().size() == 4, "E4 the tail is bounded");
+        CHECK(d.failures().size() == 1, "E4 but the failure is still there");
+        CHECK(d.failures().front().verdict == ParityVerdict::Fail, "E4 and is the right one");
+    }
+
+    // E5: the one line a script greps says the whole truth, both ways.
+    {
+        M4GraduationLedger L(key_of(), tiny());
+        SoakDriver::Config c;
+        c.posture = SoakPosture::ServeNativeShadowMonerod;
+        c.autosave_every = 0;
+        SoakDriver d(L, c);
+        CHECK(d.verdict_line().find("NOT-GRADUATED") != std::string::npos,
+              "E5 fail-closed before any sample: '%s'", d.verdict_line().c_str());
+        CHECK(d.verdict_line().find("shortfall=") != std::string::npos,
+              "E5 and says what is missing");
+        CHECK(d.verdict_line().find("shortfall=\"serve-native:") != std::string::npos,
+              "E5 naming THIS posture's shortfall, not the other leg's: '%s'",
+              d.verdict_line().c_str());
+
+        // The other leg soaked clean: the shortfall shown must still be this
+        // posture's, because the other leg's is a fact about a run that is done.
+        run_clean(L, SoakPosture::ServeMonerodShadowNative, 8, 100, 1000, 10);
+        CHECK(d.verdict_line().find("shortfall=\"serve-native:") != std::string::npos,
+              "E5 still this posture's: '%s'", d.verdict_line().c_str());
+
+        run_clean(L, SoakPosture::ServeNativeShadowMonerod, 8, 200, 5000, 10);
+        const std::string line = d.verdict_line();
+        CHECK(line.find("M4-VERDICT: GRADUATED") != std::string::npos,
+              "E5 and GRADUATED when both legs are in: '%s'", line.c_str());
+        CHECK(line.find("legs_qualified=2/2") != std::string::npos,
+              "E5 naming how many legs earned it");
+    }
+}
+
+// ---------------------------------------------------------------------------
+int main(int argc, char** argv) {
+    (void)argc; (void)argv;
+    std::printf("xmr_native_m4_soak_kat -- the M4 streak machine, ledger and refusal\n");
+    std::printf("comparator version %u\n", static_cast<unsigned>(COMPARATOR_VERSION));
+
+    suite_streak();
+    suite_graduation();
+    suite_persistence();
+    suite_injection();
+    suite_driver();
+
+    std::printf("\n%d checks, %d failures\n", g_checks, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**DO NOT MERGE.** Stacked on `v37/xmr-native-m3` (c2pool#1591). Held DRAFT for review.

## What this is

M4's exit criterion is not a property of a function. It is a property of a
*process*: `serve=monerod/shadow=native` for a sustained window with every
sample CLEAN, then `serve=native/shadow=monerod` for another, and only then is
the daemon demotable. C6 (c2pool#1591's ancestry) built the judge and a
per-seam ledger. This builds the loop around them, and the artefact the gate is
read off.

Two things turned out to be **missing rather than merely unwritten**, and both
would have made a soak on the pre-M4 code report a claim it had not tested:

* **Nothing ever called `on_serve`.** The tip probe fires by itself, because the
  chain index publishes an event at every height. The template probe only fires
  when somebody *serves* a template — and in this harness nobody did. A soak run
  before this change would have accumulated a long P-TIP streak having **never
  once compared a template**, while "P-TPL CLEAN on every sample" is half of
  what M4 asks for. `SoakDriver` is that caller; `SoakThresholds::
  min_template_clean` is what stops the cheap seam carrying the expensive one.
* **The posture had no way to be exact.** `ArmResolver::serving()` falls back to
  the other arm when the configured one is not ready — correct in production,
  fatal to a parity claim, because a leg that quietly served monerod for an hour
  is not evidence about the native arm. `NativeNode::m4_serve_probe()` resolves
  `arm(serve_arm)` strictly; an unready arm yields no sample and says why.

## The ledger

`M4GraduationLedger` records two legs. A leg is a streak, fragile by
construction:

| verdict | effect on the streak |
|---|---|
| CLEAN | accrues: one sample, possibly one block, more wall clock |
| FAIL | **resets to zero** and takes the leg's qualification with it |
| SERVED-MISMATCH | resets **and revokes the key** |
| VOID | neither accrues nor resets… |
| VOID × `max_void_run` | …but a *run* of them resets anyway |

There is no averaging, no "mostly clean", no budget of allowed failures: the
criterion is every sample. The void-run rule is the DASH lesson at its sharpest
— a leg that has stopped producing judgeable samples is a probe that stopped
firing, not a streak quietly holding, and letting it coast would make silence
indistinguishable from agreement.

`blocks` counts **forward height progress only**, so a reorg contributes none
(the conservative direction: it can only make a 720-block claim harder to earn).
The key is C6's four-part `{commit, comparator_version, monerod_version, net}`
and is stamped with the **running** `COMPARATOR_VERSION` — so a streak earned
under an older comparator cannot be inherited across a bump. That is the M1
lesson made mechanical rather than remembered, and the KAT pins it by rewriting
a graduated ledger's version by one and watching a v3 binary refuse it. The
state on disk is treated as a *cache of a decision* and re-derived from the
counters on load, so a file claiming `Graduated` over legs that did not qualify
is corrected rather than believed.

The two postures are **two runs of the binary against the same `--m4-ledger`
file** — the shape a 72 h + 72 h stagenet soak has. Persistence is not an
optimisation here; it is the mechanism by which a leg survives its own posture
flip.

## The negative control

A harness that has never been seen to refuse is not a gate.
`TipFaultInjection` / `PerturbingTipObserver` decorate the native arm's tip
observer, are disarmed unless a field is named, and perturb one required
EQUALITY field by **one unit** (or withhold it) — the same mutation
`xmr_native_parity_kat` pins offline, applied **live**, through the real
observer, the real comparator and the real ledger. `--m4-require refusal`
asserts the opposite claim from a normal run: the ledger must **not** graduate,
and it must have reset a streak on a real FAIL rather than merely failed to
accumulate one.

## Regtest mini-soak — what was actually run

Isolated rig on workstation-191: own datadirs, own ports (48488/48489 and
48588/48589), two `monerod v0.18.5.1-release` in `--regtest --fixed-difficulty
1`, never peered to each other. Nothing shared with the `.40` observer, the
`.44` stagenet daemon, or the CI heavy runners. Every daemon stopped afterwards.

Thresholds for the rehearsal: `clean>=24 blocks>=6 seconds>=40 tip>=6 tpl>=12
void_run<=16`. Build: `g++-15`, `-DXMR_BUILD_RANDOMX=ON`, so the L4 RandomX
verifier is live (`rx: mode=1`, `foreign=0` throughout).

Seven legs, each a separate run of `xmr_native_node` (`--run-seconds 150`, one
block every 6 s, P-TPL cadence 1.5 s). All seven exited `M4-RUN: PASS` — for the
clean legs that means "graduated as required", for the control legs it means
"refused as required".

| leg | posture | streak | blocks | span | P-TIP / P-TPL | fail | resets | ledger |
|---|---|---|---|---|---|---|---|---|
| legA | serve=monerod | 105 | 17 | 147 s | 17 / 88 | 0 | 0 | Observing, `legs_qualified=1/2` |
| legB | serve=native | 114 | 17 | 147 s | 17 / 97 | 0 | 0 | **GRADUATED**, `legs_qualified=2/2` |
| nc1a | serve=monerod | 110 | 17 | 147 s | 17 / 93 | 0 | 0 | Observing, leg qualified |
| **nc1** | serve=native, `reward` +1 unit after 10 observations | 11 | 0 | 14 s | 0 / 11 | **7** | **7** | Observing, **NOT GRADUATED** |
| nc1sa | serve=monerod | 117 | 17 | 146 s | 17 / 100 | 0 | 0 | Observing, leg qualified |
| **nc1s** | serve=native, `cumulative_difficulty` +1 unit (a **sentinel**) | 11 | 0 | 13 s | 0 / 11 | **7** | **7** | **Revoked** |
| **nc2** | serve=native, judge = the **divergent** daemon | 0 | 0 | 0 s | 0 / 0 | 0 | 0 | Observing, `void=115`, **NOT GRADUATED** |

The two postures of the clean run are two processes against one ledger file, and
the second one is what flipped it:

```
M4-VERDICT: GRADUATED posture=serve-native state=Graduated streak=114 blocks=17
            span=147s tip=17 tpl=97 clean=114 fail=0 mismatch=0 void=3 resets=0
            qualified=1 legs_qualified=2/2
```

```json
"key": {"c2pool_commit": "...-m4harness", "comparator_version": 3,
        "monerod_version": "0.18.5.1-release", "net": "regtest"},
"state": "Graduated", "graduated_unix": 1789127901
```

**nc1 is the required negative control and it is not vacuous.** The
`serve-native` leg soaked 110 CLEAN samples and *qualified*; then one required
EQUALITY field of the native tip observation was perturbed by one unit, and the
real comparator failed the sample:

```
last_reset_why: "P-TIP FAIL at height 184: 1 field(s) differed; [P-TIP first=native]"
revocation    : "posture serve-native lost its qualification:
                 P-TIP FAIL at height 178: 1 field(s) differed"
qualified     : false      resets: 7      graduated: NO
```

nc1s shows the sentinel path: `REVOKED: sentinel field 'cumulative_difficulty'
differed: 0:218 vs 0:217` — the one-unit perturbation, visible in the reason.
nc2 is the control with **no injection at all**: the judge is a second regtest
daemon at the same height on a different chain, every sample is VOID on the
prev_id alignment key, the streak never starts, and the ledger refuses.

`randomx: mode=1 foreign=0` throughout — the L4 verifier was live on the verify
thread and never on an io thread.

## What this does NOT prove

**The real M4 thresholds are not met and this is not an M4 milestone.**
72 hours and 720 blocks *per posture* on **stagenet** against a synced daemon is
a host-and-days run; minutes on regtest is a rehearsal of the gate, never the
gate. `SoakThresholds::stagenet_m4()` carries the plan's numbers unscaled and is
the default for any non-regtest network, so a stagenet run cannot silently
inherit the mini-soak's numbers. M1's own floors (≥10 000 relayed txs, the
≥720-block `already_generated_coins`/`median_weight` streak) are a separate
claim this branch does not touch.

Also out of scope here: P-SUB contributes no samples in this rig (no block was
found), and the P-TPL backlog-famine CONSTRAINT is oriented to the **served**
arm, so in `serve=monerod` it reads as a served-arm famine claim rather than a
native-arm one. Both are noted in the code rather than left to be discovered.

## Tests

`xmr_native_m4_soak_kat` — 165 checks, 0 failures. The streak machine (CLEAN
accrues, FAIL/SERVED-MISMATCH reset, VOID neither, a void *run* does, a reorg
contributes no block), both graduation halves (one leg is not two; a tip-only
stream never satisfies the template floor; an incomplete key cannot graduate; a
later FAIL takes a qualification away), persistence (round trip, the
version-bump refusal, the other three key mismatches, an unbound daemon version
resuming, a forged `Graduated` corrected, a missing file not an error), the
injector end to end through `compare_seam` (eight fields, each perturbed by one
unit, each must FAIL; a withheld field must FAIL too), and the driver (P-POOL
skipped, silence counted, failures held apart from the bounded tail).

STL-only and clock-free — 72 hours pass in microseconds. Registered with
`add_test` **and** in BOTH `--target` lists in `.github/workflows/build.yml`
(the c2pool#1539 `***Not Run` lesson).

## Incidental

* `ITipObserver` moves to `parity/xmr_tip_observer.hpp` so a decorator of the
  seam does not drag C2c's chain view — and the whole vendored consensus link —
  behind one pure virtual function. `xmr_parity_sources.hpp` includes it and
  exports every name it did before.
* `xmr_native_node` now links `xmr_node`: driving P-TPL means polling the daemon
  arm, which instantiates the production `get_miner_data` parser. A second
  decode path would make "we match the daemon" a claim about a re-typed struct.

## Scope

`src/impl/xmr/native/**` only, plus the two `--target` lines in
`.github/workflows/build.yml`. **Zero files under `src/sharechain/`.** No
consensus digest, no w4 owed-digest fold.
