### PR TITLE
xmr(p2pool): all-in-one 3-sidechain monitor + fullscreen TUI [DO NOT MERGE]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,7 @@ jobs:
                     v37_xmr_m2_native_settlement_kat \
                     v37_xmr_m3_arm_order_kat \
                     xmr_p2pool_parse_kat xmr_p2pool_observer \
+                    xmr_p2pool_monitor_kat xmr_p2pool_monitor \
             -j"${BUILD_J:-8}" 2>&1 | tee "${GITHUB_WORKSPACE}/ci-logs/build-tests.log"
 
       - name: Run tests
@@ -693,6 +694,7 @@ jobs:
                     v37_xmr_m2_native_settlement_kat \
                     v37_xmr_m3_arm_order_kat \
                     xmr_p2pool_parse_kat xmr_p2pool_observer \
+                    xmr_p2pool_monitor_kat xmr_p2pool_monitor \
             -j4  # ASan+UBSan: cc1plus RSS ~2-3GB each; -j8 wedged runner cgroup memory.high (throttle-hang). -j4 caps peak <12G.
                  # xmr_provenance_gate: previously omitted here because
                  # -fsanitize=undefined rejected its constexpr pointer comparison

--- a/src/impl/xmr/p2pool/CMakeLists.txt
+++ b/src/impl/xmr/p2pool/CMakeLists.txt
@@ -21,19 +21,35 @@
 # a sidechain blob is handed to THOSE parsers rather than to a second copy
 # written here -- which is the whole reason this component is stacked on M3.
 #
-# Two targets, both under BUILD_TESTING:
+# Four targets, all under BUILD_TESTING:
 #
-#   xmr_p2pool_parse_kat   the deterministic parser KAT over two real captured
-#                          frames. REGISTERED with add_test and run in both CI
-#                          legs. Offline: the goldens are in the header.
-#   xmr_p2pool_observer    the live harness. BUILT by CI so it cannot bit-rot,
-#                          RUN by nobody in CI, because running it dials a
-#                          public network. Registers no ctest test, so the
-#                          #1539 Not-Run rule does not apply to it.
+#   xmr_p2pool_parse_kat    the deterministic parser KAT over two real captured
+#                           frames. REGISTERED with add_test and run in both CI
+#                           legs. Offline: the goldens are in the header.
+#   xmr_p2pool_monitor_kat  the deterministic RENDER KAT: three fixed read
+#                           models drawn to a golden frame, plus the emitted
+#                           message-id pin re-asserted for the monitor. Also
+#                           REGISTERED, also offline -- it includes no socket
+#                           header and needs no terminal.
+#   xmr_p2pool_observer     the live single-chain harness. BUILT by CI so it
+#                           cannot bit-rot, RUN by nobody in CI, because running
+#                           it dials a public network. Registers no ctest test,
+#                           so the #1539 Not-Run rule does not apply to it.
+#   xmr_p2pool_monitor      the live all-in-one monitor: all three sidechains in
+#                           ONE poll() loop behind a fullscreen ANSI/termios
+#                           TUI. Same rule as the observer -- BUILT by CI, never
+#                           RUN by it (it dials three public networks and the
+#                           fullscreen mode wants a tty), and it registers no
+#                           ctest test either. What CI runs is the render KAT.
+#
+# THE TUI HAS NO DEPENDENCIES. It is ANSI escapes plus POSIX termios: no
+# ncurses, no boost, no asio, no threads. The renderer itself
+# (p2pool_tui.hpp) is pure STL and deliberately POSIX-free, which is what lets
+# the KAT pin a whole frame without linking a socket layer.
 #
 # DRIFT-GUARD: tools/ci/check_test_target_allowlist.py audits
 # src/impl/<coin>/test/CMakeLists.txt; this tree sits one level deeper
-# (src/impl/xmr/p2pool/test/) and is outside that glob, so BOTH targets are
+# (src/impl/xmr/p2pool/test/) and is outside that glob, so ALL FOUR targets are
 # added to BOTH `--target` lists in .github/workflows/build.yml by hand. A
 # target registered with add_test but never built reports "***Not Run" and
 # exits non-zero -- the #1539 lesson.
@@ -42,11 +58,17 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 if (BUILD_TESTING AND UNIX)
-    # The live harness. POSIX sockets only: no asio, no threads, no boost.
+    # The live harnesses. POSIX sockets only: no asio, no threads, no boost,
+    # and for the monitor's full-screen mode, no ncurses either.
     add_executable(xmr_p2pool_observer tools/p2pool_observer_main.cpp)
     target_include_directories(xmr_p2pool_observer PRIVATE ${CMAKE_SOURCE_DIR}/src)
     target_link_libraries(xmr_p2pool_observer PRIVATE xmr_coin)
     target_compile_features(xmr_p2pool_observer PRIVATE cxx_std_20)
+
+    add_executable(xmr_p2pool_monitor tools/p2pool_monitor_main.cpp)
+    target_include_directories(xmr_p2pool_monitor PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(xmr_p2pool_monitor PRIVATE xmr_coin)
+    target_compile_features(xmr_p2pool_monitor PRIVATE cxx_std_20)
 endif()
 
 if (BUILD_TESTING)

--- a/src/impl/xmr/p2pool/README.md
+++ b/src/impl/xmr/p2pool/README.md
@@ -73,14 +73,20 @@ peer at once.
 | `p2pool_handshake.hpp` | challenge/solution keccak and the dial-side proof of work |
 | `p2pool_block.hpp` | the `PoolBlock` parse: Monero template + sidechain record + share set |
 | `p2pool_read_model.hpp` | the accumulator: tip, difficulty, cadence, same-height contests |
-| `p2pool_observer.hpp` | sessions and the poll loop |
-| `tools/p2pool_observer_main.cpp` | the live harness |
-| `test/p2pool_parse_kat.cpp` | the KAT, over two real captured frames |
+| `p2pool_observer.hpp` | sessions and the poll loop, in three drivable phases |
+| `p2pool_multiwatch.hpp` | three observers through **one** `poll()`, plus the terminal |
+| `p2pool_tui.hpp` | the frame: a pure function from three read models to text |
+| `tools/p2pool_observer_main.cpp` | the live single-chain harness |
+| `tools/p2pool_monitor_main.cpp` | the live all-in-one monitor: fullscreen TUI and `--snapshot` |
+| `test/p2pool_parse_kat.cpp` | the parser KAT, over two real captured frames |
+| `test/p2pool_monitor_kat.cpp` | the render KAT: a golden frame and the emit-set pin |
+| `test/p2pool_monitor_golden.inc` | that golden frame, one C string per line — readable as a picture |
 | `test/gen_p2pool_golden.py` | independent Python reading that generates the golden's expected values |
 
 Everything is header-only STL over two things the repository already has:
 `xmr_coin` (the vendored Monero keccak and tree hash) and the native lane's
-consensus headers.
+consensus headers. The TUI adds nothing to that: ANSI escapes and POSIX
+`termios`, no ncurses, no boost, no asio, no threads.
 
 ---
 
@@ -171,6 +177,130 @@ CI **builds** this binary so it cannot bit-rot and **never runs** it, because
 running it dials a public network. It registers no ctest test, so the #1539
 Not-Run rule does not apply to it. What CI runs is `xmr_p2pool_parse_kat`,
 which is offline: both goldens are embedded in the header.
+
+---
+
+## All three sidechains at once
+
+`xmr_p2pool_monitor` watches **main, mini and nano together** in one read-only
+process, on one screen.
+
+```
+xmr_p2pool_monitor                          fullscreen, all three chains
+xmr_p2pool_monitor --chains mini,nano       two of them
+xmr_p2pool_monitor --snapshot --seconds 90  one plain-text frame to stdout
+```
+
+### One `poll()`, three chains, no threads
+
+An `Observer` **is** one sidechain — one consensus id, one peer set, one read
+model, one byte ledger — and that shape is not changed to make three of them
+fit. What cannot be had three times is the event loop: three `::poll()` calls in
+sequence means each blocks the other two for its timeout, and the five-second
+tip-poll rule above starts to slip. Threads would fix the stall and bring a
+mutex around every read model for three sockets' worth of traffic.
+
+So the observer's loop was split into the three phases it already contained, and
+the monitor drives all three chains through **one** `poll()`:
+
+```
+for each chain:  begin_tick()                        dial, reap
+for each chain:  begins[i] = pfds.size(); collect()  append its sockets
+append the tty                                       a keypress wakes the loop
+::poll(pfds, timeout)                                the only blocking call
+for each chain:  dispatch(pfds + begins[i], n_i)     its own slice, only
+```
+
+**The range is the tag.** A chain's sockets occupy a contiguous slice of the
+shared array, so there is no per-fd chain map to build, look up or leave stale,
+and a chain cannot be handed another chain's `revents` — it is handed a pointer
+and a length. `run()` is written in terms of the same three calls, so the
+single-chain harness and the monitor cannot drift apart.
+
+Per-connection timers needed nothing: `next_tip_poll_ms_` already lives inside
+`PeerSession`, so the "< 10 s" rule holds independently on every socket of every
+chain.
+
+One thing did have to change. The observer never re-dials an endpoint, which is
+right for a 300-second harness and wrong for a monitor left running for hours:
+every peer that ever hung up would be excluded permanently, the dial queue would
+drain, and a panel would go quiet while the chain was fine. `redial_after_ms`
+(0 = never, the harness default) and an idle-chain reseed fix that, and the
+queue is capped so gossip cannot grow it without bound overnight.
+
+### The TUI has no dependencies
+
+ANSI escapes and POSIX `termios`: raw mode is four flags, the alternate screen
+and the cursor are two escapes each, the size is `TIOCGWINSZ`, `SIGWINCH` sets a
+flag. No ncurses, no boost, no asio, no threads.
+
+The restore path is installed three ways over, because a monitor that dies in
+raw mode leaves someone with a shell that does not echo: the loop exits on a
+quit flag set by `SIGINT`/`SIGTERM`, the `TerminalUi` destructor restores, and an
+`atexit` hook restores whatever the exit path was.
+
+Everything drawn is printable ASCII — the pulse ramp is `_.-=+*#`, the bars are
+`#`/`-`. The moment a frame holds a multi-byte character, `size()` stops being
+the column count and every alignment becomes a guess.
+
+### The frame is a pure function, so it is pinned
+
+`p2pool_tui.hpp` is deliberately POSIX-free: no socket, no terminal, no clock.
+Ages and uptime are resolved at one instant handed in by the caller. That is
+what lets `xmr_p2pool_monitor_kat` fill three read models with fixed synthetic
+observations at fixed timestamps and compare the **whole frame** against
+`p2pool_monitor_golden.inc`, byte for byte, on every machine and forever. A
+dashboard is the easiest place in a codebase to hide a wrong number, because the
+only thing that would catch it is somebody looking at it.
+
+Colour is additive and nothing else: `strip_ansi(render(color))` equals
+`render(plain)` line for line, which the KAT asserts — so `--snapshot` is the
+same renderer with the escapes off, not a second one that could disagree with
+the screen. The KAT also re-asserts the emitted id set `{0, 1, 3, 6}` for this
+second binary, and the footer of every frame prints that set **as computed from
+the encoder**, so a fifth encoder would start announcing itself on screen in the
+same breath as it failed the test.
+
+The panels inherit the read model's refusals rather than softening them for
+looks: below two live samples the cadence line says `warming` instead of
+printing a number, the pulse shows the individual gaps because a mean hides the
+difference between a steady beat and a stall between bursts, and `monero tpl` is
+labelled a template height — deciding that a sidechain block cleared Monero's
+target needs a Monero PoW target this observer does not hold.
+
+### What the live runs found
+
+**A whole sidechain went dark, and the panel is how it was caught.** On the
+second live run the main chain reported `DARK — 0 up / 0 sock / 0 known / 0
+queued / 0 B sent` for four minutes while mini and nano were fine. That is a
+real bug with three parts, all now fixed:
+
+* both of main's DNS seeds failed inside `start()` in the first second of the
+  run — and `fail()` only logged when the session had already left
+  `State::Closed`, which a session that never connected never does, so the
+  failure was **silent**. It logs now;
+* the failed dial then took the full five-minute cool-off, the same as a peer
+  that had talked and hung up. A dial that never reached a socket is a different
+  fact and now earns a 15-second retry instead;
+* with no peer connected there is no peer-list gossip, so the seeds were the
+  only way back and the chain could not recover on its own. `reseed()` now
+  clears the cool-off on the seed endpoints of a chain that has nothing, and the
+  monitor reseeds a dark chain every 20 seconds.
+
+Two display defects too, both invisible until three real chains were on screen:
+the final snapshot was taken *after* the sockets were closed and so reported
+`4 up / 0 sockets`, and the `net` line overflowed 100 columns once peer counts
+reached three digits, truncating `bcast` mid-word. Both fixed; the golden frame
+pins the layout that replaced them.
+
+The first of those is the argument for the dashboard existing at all: `DARK` next
+to `0 queued` said, on sight, that the chain had nothing left to dial — which is
+a different failure from "peers are refusing us", and the two look identical in
+a log.
+
+CI **builds** the monitor and never runs it — it dials three public networks and
+the fullscreen mode wants a tty — and it registers no ctest test either. What CI
+runs is the render KAT, which is offline.
 
 ---
 

--- a/src/impl/xmr/p2pool/p2pool_multiwatch.hpp
+++ b/src/impl/xmr/p2pool/p2pool_multiwatch.hpp
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/p2pool/p2pool_multiwatch.hpp
+//
+// THREE SIDECHAINS, ONE poll(). And the terminal, which is the other half of
+// "all-in-one" and the half that is easy to get wrong.
+//
+// ---------------------------------------------------------------------------
+// WHY NOT THREE OBSERVERS, THREE LOOPS
+// ---------------------------------------------------------------------------
+// An Observer is one sidechain by construction: one consensus id, one peer set,
+// one read model, one byte ledger. That is the right shape and it is not
+// changed here -- the monitor holds THREE of them. What cannot be had three
+// times is the event loop: three ::poll() calls in sequence means each one
+// blocks the other two for its timeout, so a quiet main chain would stall the
+// mini panel for half a second at a time, and the 5-second tip-poll rule (which
+// is what keeps a pulling observer from being banned) would start to slip under
+// load. Threads would fix the stall and bring a mutex around every read model
+// for a workload that is three sockets' worth of traffic.
+//
+// So the observer's loop was split into three phases it already contained
+// (begin_tick / collect / dispatch, see p2pool_observer.hpp) and this file
+// drives all three chains through ONE ::poll():
+//
+//     for each chain: begin_tick()                      dial, reap
+//     for each chain: begins[i] = pfds.size(); collect() append its sockets
+//     append the tty                                    so a keypress wakes us
+//     ::poll(pfds, timeout)                             the only blocking call
+//     for each chain: dispatch(pfds+begins[i], n_i)     its own slice, only
+//
+// THE RANGE IS THE TAG. A chain's sockets occupy a contiguous slice of the
+// shared array, so there is no per-fd chain map to be built, looked up or left
+// stale -- and a chain can never be handed another chain's revents, because it
+// is handed a pointer and a length and nothing else.
+//
+// Per-connection timers need no change for this: next_tip_poll_ms_ lives inside
+// PeerSession and is already per connection, so the "< 10 s" rule holds
+// independently on each socket of each chain.
+//
+// ---------------------------------------------------------------------------
+// THE RE-DIAL PROBLEM, which only appears when a run is long
+// ---------------------------------------------------------------------------
+// The observer never re-dials an endpoint: for a 300-second harness that is
+// exactly right. Run the same code for six hours and every peer that ever hung
+// up is permanently excluded, the dial queue drains, and the panel goes quiet
+// while the chain is fine. The monitor therefore sets ObserverConfig's
+// redial_after_ms, and reseeds a chain that has gone completely idle. Both are
+// the caller's choice; run() still defaults to the harness behaviour.
+//
+// ---------------------------------------------------------------------------
+// THE TERMINAL, AND PUTTING IT BACK
+// ---------------------------------------------------------------------------
+// No ncurses. Raw mode is four termios flags, the alternate screen and the
+// cursor are two escapes each, and the size comes from TIOCGWINSZ -- that is
+// the entire dependency, and it is POSIX.
+//
+// What actually matters is the restore path, because a monitor that dies in raw
+// mode leaves the user with a shell that does not echo. So the restore is
+// installed three ways over: the loop checks a quit flag set by SIGINT/SIGTERM
+// and exits normally, TerminalUi's destructor restores, and an atexit hook
+// restores whatever the exit path was. Restoring twice is harmless; restoring
+// zero times costs someone a `reset`.
+//
+// SIGWINCH sets a flag and nothing else. Re-measuring the window inside a
+// signal handler would mean calling ioctl() from one, and the frame is redrawn
+// within the refresh interval anyway.
+//
+// POSIX + STL. No ncurses, no boost, no asio, no threads.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <poll.h>
+#include <signal.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+
+#include <csignal>
+#include <cstdlib>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/p2pool/p2pool_observer.hpp"
+#include "impl/xmr/p2pool/p2pool_tui.hpp"
+
+namespace c2pool::xmr::p2pool {
+
+// ---------------------------------------------------------------------------
+// Signal flags. Written by handlers, read by the loop; nothing else.
+// ---------------------------------------------------------------------------
+inline volatile std::sig_atomic_t g_tui_quit    = 0;
+inline volatile std::sig_atomic_t g_tui_resized = 1;   // measure once at start
+
+inline void tui_on_quit(int)   { g_tui_quit = 1; }
+inline void tui_on_winch(int)  { g_tui_resized = 1; }
+
+// ---------------------------------------------------------------------------
+// The multiplexer.
+// ---------------------------------------------------------------------------
+struct MonitorConfig {
+    std::vector<Sidechain> chains{Sidechain::Main, Sidechain::Mini, Sidechain::Nano};
+    std::size_t   peers_per_chain  = 4;
+    std::uint64_t run_ms           = 0;         // 0 = until the user quits
+    std::uint64_t refresh_ms       = 1000;
+    std::uint64_t redial_after_ms  = 300000;    // 5 minutes; see the header note
+    // How often a chain with no peers AND nothing queued retries its DNS seeds.
+    // Short on purpose: a dark chain has no gossip, so the seeds are its only
+    // way back, and a live run has already shown a chain losing four minutes to
+    // two seed lookups that failed in the first second.
+    std::uint64_t reseed_idle_ms   = 20000;
+    std::uint64_t seed             = 0;
+    bool          verbose          = false;
+};
+
+class MultiWatch {
+public:
+    explicit MultiWatch(const MonitorConfig& mc) : cfg_(mc) {
+        for (std::size_t i = 0; i < cfg_.chains.size(); ++i) {
+            ObserverConfig oc;
+            oc.chain           = cfg_.chains[i];
+            oc.max_peers       = cfg_.peers_per_chain;
+            oc.redial_after_ms = cfg_.redial_after_ms;
+            oc.verbose         = cfg_.verbose;
+            // Each chain gets its own deterministic sub-seed when a seed was
+            // given, so a seeded run is reproducible per chain rather than
+            // depending on the order three observers happened to draw from one
+            // generator.
+            oc.seed = cfg_.seed ? (cfg_.seed + 1013904223ull * (i + 1)) : 0;
+            oc.run_ms = 0;                      // this class owns the loop
+            slots_.push_back(Slot{std::make_unique<Observer>(oc), 0});
+        }
+    }
+
+    std::size_t size() const noexcept { return slots_.size(); }
+    Observer&       observer(std::size_t i)       { return *slots_[i].obs; }
+    const Observer& observer(std::size_t i) const { return *slots_[i].obs; }
+    Sidechain chain(std::size_t i) const noexcept { return cfg_.chains[i]; }
+
+    void set_log(LogSink s) { for (Slot& sl : slots_) sl.obs->set_log(s); }
+
+    void seed_all() { for (Slot& sl : slots_) sl.obs->add_default_seeds(); }
+
+    // Dial this endpoint first on the named chain; the DNS seeds still follow.
+    void add_peer(Sidechain c, const std::string& host, std::uint16_t port) {
+        for (std::size_t i = 0; i < slots_.size(); ++i)
+            if (cfg_.chains[i] == c) slots_[i].obs->add_seed(host, port);
+    }
+
+    // ONE turn of the shared loop. `extra_fd` (the tty, or -1) is polled beside
+    // the sockets and its revents are returned, so a keypress wakes the loop
+    // without a second poll and without a timeout race.
+    short poll_once(int extra_fd, short extra_events, int timeout_ms) {
+        const std::uint64_t t = now_ms();
+
+        for (Slot& sl : slots_) {
+            sl.obs->begin_tick();
+            if (sl.obs->idle() && t >= sl.next_reseed_ms) {
+                sl.obs->reseed();
+                sl.next_reseed_ms = t + cfg_.reseed_idle_ms;
+            }
+        }
+
+        pfds_.clear();
+        live_.clear();
+        begins_.clear();
+        begins_.reserve(slots_.size() + 1);
+        for (Slot& sl : slots_) {
+            begins_.push_back(pfds_.size());
+            sl.obs->collect(pfds_, live_);
+        }
+        begins_.push_back(pfds_.size());        // end of the last chain's slice
+
+        const std::size_t sockets = pfds_.size();
+        if (extra_fd >= 0) {
+            pollfd p{};
+            p.fd     = extra_fd;
+            p.events = extra_events;
+            pfds_.push_back(p);
+        }
+
+        short extra_revents = 0;
+        if (pfds_.empty()) {
+            ::poll(nullptr, 0, timeout_ms);     // nothing open yet: just wait
+            return 0;
+        }
+        const int rc = ::poll(pfds_.data(), pfds_.size(), timeout_ms);
+        if (rc < 0) {
+            if (errno != EINTR) return 0;       // EINTR: a signal, handled by the caller
+        } else if (extra_fd >= 0) {
+            extra_revents = pfds_[sockets].revents;
+        }
+
+        // Each chain sees ITS OWN slice and nothing else.
+        for (std::size_t i = 0; i < slots_.size(); ++i) {
+            const std::size_t b = begins_[i];
+            const std::size_t n = begins_[i + 1] - b;
+            slots_[i].obs->dispatch(pfds_.data() + b, live_.data() + b, n);
+        }
+        return extra_revents;
+    }
+
+    void close_all() { for (Slot& sl : slots_) sl.obs->close_all("monitor stopped"); }
+
+    // The frame, taken at one instant across all three chains.
+    tui::MonitorFrame frame(std::uint64_t elapsed_ms, bool interactive) const {
+        tui::MonitorFrame f;
+        f.elapsed_ms  = elapsed_ms;
+        f.interactive = interactive;
+        const std::uint64_t t = now_ms();
+        for (const Slot& sl : slots_) {
+            tui::EmitCounts ec;
+            const OutboundLedger& led = sl.obs->ledger();
+            for (std::size_t i = 0; i < kControlMessageCount; ++i) {
+                ec.messages[i] = led.messages[i];
+                ec.bytes[i]    = led.bytes[i];
+            }
+            f.chains.push_back(tui::view_of(sl.obs->model(), ec, sl.obs->live_sessions(),
+                                            sl.obs->pending_dials(), t));
+        }
+        return f;
+    }
+
+private:
+    struct Slot {
+        std::unique_ptr<Observer> obs;
+        std::uint64_t             next_reseed_ms = 0;
+    };
+
+    MonitorConfig            cfg_;
+    std::vector<Slot>        slots_;
+    std::vector<pollfd>      pfds_;
+    std::vector<PeerSession*> live_;
+    std::vector<std::size_t> begins_;
+};
+
+// ---------------------------------------------------------------------------
+// The terminal.
+// ---------------------------------------------------------------------------
+class TerminalUi;
+inline TerminalUi* g_tui_active = nullptr;
+inline void tui_atexit_restore();
+
+class TerminalUi {
+public:
+    ~TerminalUi() { end(); }
+
+    bool is_tty() const { return ::isatty(STDIN_FILENO) && ::isatty(STDOUT_FILENO); }
+
+    // Raw mode, alternate screen, cursor hidden, signal handlers installed.
+    // Returns false (changing nothing) when stdout is not a terminal.
+    bool begin() {
+        if (active_) return true;
+        if (!is_tty()) return false;
+        if (::tcgetattr(STDIN_FILENO, &saved_) != 0) return false;
+
+        termios raw = saved_;
+        // Canonical mode and echo off: keys arrive one at a time and are not
+        // printed over the frame. ISIG is left ON so Ctrl-C still raises
+        // SIGINT, which is what the quit handler below is for.
+        raw.c_lflag &= static_cast<tcflag_t>(~(ICANON | ECHO));
+        raw.c_iflag &= static_cast<tcflag_t>(~(IXON));
+        raw.c_cc[VMIN]  = 0;
+        raw.c_cc[VTIME] = 0;
+        if (::tcsetattr(STDIN_FILENO, TCSAFLUSH, &raw) != 0) return false;
+
+        active_ = true;
+        g_tui_active = this;
+        std::atexit(&tui_atexit_restore);
+
+        install(SIGINT,  &tui_on_quit);
+        install(SIGTERM, &tui_on_quit);
+        install(SIGHUP,  &tui_on_quit);
+        install(SIGWINCH, &tui_on_winch);
+
+        write_all("\x1b[?1049h");     // alternate screen
+        write_all("\x1b[?25l");       // hide cursor
+        write_all("\x1b[2J");         // clear it once; frames repaint in place
+        return true;
+    }
+
+    // Put everything back. Safe to call twice, safe from atexit.
+    void end() {
+        if (!active_) return;
+        active_ = false;
+        write_all("\x1b[?25h");       // show cursor
+        write_all("\x1b[?1049l");     // leave alternate screen
+        ::tcsetattr(STDIN_FILENO, TCSAFLUSH, &saved_);
+        if (g_tui_active == this) g_tui_active = nullptr;
+    }
+
+    bool size(std::size_t& cols, std::size_t& rows) const {
+        winsize ws{};
+        if (::ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws) != 0 || ws.ws_col == 0 || ws.ws_row == 0)
+            return false;
+        cols = ws.ws_col;
+        rows = ws.ws_row;
+        return true;
+    }
+
+    // Home the cursor, write every line, erase anything below. No clear-screen
+    // per frame: clearing first is what makes a hand-rolled TUI flicker.
+    void paint(const std::vector<std::string>& lines) {
+        std::string out = "\x1b[H";
+        for (std::size_t i = 0; i < lines.size(); ++i) {
+            out += lines[i];
+            if (i + 1 < lines.size()) out += "\r\n";
+        }
+        out += "\x1b[J";
+        write_all(out);
+    }
+
+private:
+    static void install(int sig, void (*fn)(int)) {
+        struct sigaction sa{};
+        sa.sa_handler = fn;
+        ::sigemptyset(&sa.sa_mask);
+        sa.sa_flags = 0;              // no SA_RESTART: poll() must return EINTR
+        ::sigaction(sig, &sa, nullptr);
+    }
+
+    static void write_all(const std::string& s) {
+        std::size_t off = 0;
+        while (off < s.size()) {
+            const ssize_t n = ::write(STDOUT_FILENO, s.data() + off, s.size() - off);
+            if (n <= 0) break;
+            off += static_cast<std::size_t>(n);
+        }
+    }
+
+    termios saved_{};
+    bool    active_ = false;
+};
+
+inline void tui_atexit_restore() {
+    if (g_tui_active) g_tui_active->end();
+}
+
+} // namespace c2pool::xmr::p2pool

--- a/src/impl/xmr/p2pool/p2pool_observer.hpp
+++ b/src/impl/xmr/p2pool/p2pool_observer.hpp
@@ -59,6 +59,14 @@
 // POSIX sockets, no asio, no threads: one blocking-free poll() loop. That is
 // deliberate -- this is a telemetry harness, and keeping it dependency-free
 // keeps it honest about what observing actually requires.
+//
+// An Observer is exactly one sidechain: one consensus id, one peer set, one
+// read model, one byte ledger. Watching three sidechains is therefore three
+// Observers rather than one Observer that grew a chain field -- and because
+// three poll() loops would each block the other two, the loop is also offered
+// as three phases (begin_tick / collect / dispatch) a caller can drive from a
+// single poll() over all three chains' sockets. run() is written in terms of
+// those same three calls, so there is one implementation, not two.
 // ---------------------------------------------------------------------------
 #pragma once
 
@@ -138,6 +146,19 @@ struct ObserverConfig {
     std::uint64_t run_ms           = 300000;
     std::uint64_t seed             = 0;       // 0 => clock-seeded
     bool          verbose          = false;
+    // How long a dialled endpoint stays on the do-not-redial list. 0 means
+    // "never re-dial", which is right for a bounded harness run: inside five
+    // minutes a peer that hung up is unlikely to have become useful again, and
+    // never re-dialling keeps the run's peer set trivially auditable. It is
+    // WRONG for a monitor that runs for hours: peer churn then drains the dial
+    // queue permanently and a live chain's panel goes quiet with no peers left
+    // to try. The monitor sets a few minutes; run() leaves it at 0, so the
+    // harness behaves exactly as before.
+    std::uint64_t redial_after_ms  = 0;
+    // Hard ceiling on the pending dial queue. Gossip supplies addresses far
+    // faster than a handful of sockets can consume them, and with re-dialling
+    // enabled the queue would otherwise grow without bound overnight.
+    std::size_t   max_dial_queue   = 1024;
     // Directory to write any blob that failed to parse. A parser that cannot
     // be shown its own counter-example is a parser nobody can fix, and these
     // bytes came off a live network that will not reproduce them on request.
@@ -286,13 +307,20 @@ private:
 
     void close_fd() { if (fd_ >= 0) { ::close(fd_); fd_ = -1; } }
 
+    // Report once, close idempotently. The report is NOT conditioned on the
+    // session having left State::Closed, because a session starts there: dial
+    // failures inside start() -- a DNS answer with no route, a refused connect
+    // -- used to close silently, which is exactly the failure that is hardest
+    // to diagnose later. A monitor run found a whole sidechain dark with no
+    // line in the log to say why.
     bool fail(const std::string& why, const LogSink& log) {
-        if (state_ != State::Closed) {
+        if (!reported_) {
+            reported_     = true;
             close_reason_ = why;
-            state_ = State::Closed;
-            close_fd();
             if (log) log("peer " + endpoint_ + " closed: " + why);
         }
+        state_ = State::Closed;
+        close_fd();
         return false;
     }
 
@@ -550,6 +578,7 @@ private:
 
     int    fd_ = -1;
     State  state_ = State::Closed;
+    bool   reported_ = false;
     std::string close_reason_;
 
     std::vector<std::uint8_t> rxbuf_;
@@ -609,24 +638,86 @@ public:
         for (const std::string& h : seed_hosts(cfg_.chain)) queue_.push_back({h, port});
     }
 
+    // -----------------------------------------------------------------------
+    // THE LOOP, IN THREE PIECES
+    // -----------------------------------------------------------------------
+    // run() below is the whole event loop for ONE sidechain and is what the
+    // observer harness calls. The monitor watches three sidechains at once and
+    // must not own three event loops -- three poll() calls would each block the
+    // other two for their timeout, and threads are not on the menu. So the loop
+    // is expressed as three phases the CALLER may drive instead:
+    //
+    //     begin_tick()  dial, reap                    (before the poll)
+    //     collect()     append this chain's pollfds    (build the shared set)
+    //     dispatch()    step those sessions, harvest   (after the poll)
+    //
+    // A caller with three Observers appends each one's pollfds to a single
+    // vector, remembers where each chain's range started, calls ::poll() once
+    // and hands each Observer back exactly its own slice. The RANGE IS THE TAG:
+    // no per-fd chain bookkeeping exists, and none can go stale.
+    //
+    // run() is written in terms of the same three calls, so the harness and the
+    // monitor cannot drift apart: there is one implementation of each phase.
+    // -----------------------------------------------------------------------
+
+    // Dial up to max_peers and reap closed sessions. Call before collect().
+    void begin_tick() { open_sessions(); }
+
+    // Append one pollfd per live session, and the matching session pointer.
+    // Both vectors grow by the same count, which is this chain's slice width.
+    void collect(std::vector<pollfd>& pfds, std::vector<PeerSession*>& live) {
+        for (auto& s : sessions_) {
+            if (s->closed()) continue;
+            pollfd p{};
+            p.fd     = s->fd();
+            p.events = s->poll_events();
+            pfds.push_back(p);
+            live.push_back(s.get());
+        }
+    }
+
+    // Step the `n` sessions this chain contributed, then take in any gossiped
+    // addresses. `pfds` and `live` point at THIS chain's slice of the shared
+    // arrays, in the order collect() produced them.
+    void dispatch(const pollfd* pfds, PeerSession* const* live, std::size_t n) {
+        for (std::size_t i = 0; i < n; ++i)
+            live[i]->step(pfds[i].revents, ledger_, sink(), log_, model_);
+        harvest();
+    }
+
+    // Nothing connected and nothing left to dial: this chain has run dry and a
+    // long-lived caller should reseed it rather than watch a dead panel.
+    bool idle() const { return live_sessions() == 0 && queue_.empty(); }
+
+    // Put the DNS seeds back on the dial queue, and CLEAR their cool-off while
+    // doing it. This is only ever called on a chain with no peers and nothing
+    // queued, and such a chain has nothing to lose by trying its bootstrap
+    // again: with no connection there is no peer-list gossip, so the seeds are
+    // the only way back. A chain that is connected keeps the ordinary cool-off.
+    void reseed() {
+        const std::uint16_t port = default_port(cfg_.chain);
+        for (const std::string& h : seed_hosts(cfg_.chain)) {
+            dialled_.erase(h + ":" + std::to_string(port));
+            queue_.push_back({h, port});
+        }
+    }
+
+    void close_all(const char* why) {
+        for (auto& s : sessions_) if (!s->closed()) s->close_now(why, log_);
+    }
+
     // Blocking run for cfg_.run_ms. Returns the number of poll iterations.
     std::uint64_t run() {
         const std::uint64_t t_end = now_ms() + cfg_.run_ms;
         std::uint64_t iterations = 0;
+        std::vector<pollfd> pfds;
+        std::vector<PeerSession*> live;
         while (now_ms() < t_end) {
             ++iterations;
-            open_sessions();
-            std::vector<pollfd> pfds;
-            std::vector<PeerSession*> live;
-            pfds.reserve(sessions_.size());
-            for (auto& s : sessions_) {
-                if (s->closed()) continue;
-                pollfd p{};
-                p.fd = s->fd();
-                p.events = s->poll_events();
-                pfds.push_back(p);
-                live.push_back(s.get());
-            }
+            begin_tick();
+            pfds.clear();
+            live.clear();
+            collect(pfds, live);
             if (pfds.empty()) {
                 if (queue_.empty()) break;          // nothing left to dial
                 ::poll(nullptr, 0, 200);
@@ -634,11 +725,9 @@ public:
             }
             const int rc = ::poll(pfds.data(), pfds.size(), 500);
             if (rc < 0 && errno != EINTR) break;
-            for (std::size_t i = 0; i < live.size(); ++i)
-                live[i]->step(pfds[i].revents, ledger_, sink(), log_, model_);
-            harvest();
+            dispatch(pfds.data(), live.data(), live.size());
         }
-        for (auto& s : sessions_) if (!s->closed()) s->close_now("run finished", log_);
+        close_all("run finished");
         return iterations;
     }
 
@@ -647,6 +736,11 @@ public:
         for (const auto& s : sessions_) if (!s->closed()) ++n;
         return n;
     }
+
+    // How many addresses are waiting to be dialled. A monitor panel shows this
+    // because "no peers and nothing queued" and "no peers but plenty queued"
+    // are different situations and look identical without it.
+    std::size_t pending_dials() const noexcept { return queue_.size(); }
 
 private:
     struct Dial { std::string host; std::uint16_t port; };
@@ -662,16 +756,42 @@ private:
     void ingest(const PoolBlock& pb, const std::vector<std::uint8_t>& blob,
                 const std::string& endpoint);
 
+    // `dialled_` maps an endpoint to the time it may be dialled AGAIN. With
+    // redial_after_ms == 0 that time is never, which is the harness rule.
+    bool may_dial(const std::string& ep, std::uint64_t t) const {
+        const auto it = dialled_.find(ep);
+        return it == dialled_.end() || t >= it->second;
+    }
+
+    // A dial that never got as far as a socket is a different fact from a peer
+    // that talked and then hung up, and it earns a much shorter cool-off. A
+    // live run found the difference the hard way: both of the main sidechain's
+    // DNS seeds failed to resolve in the first second of a monitor run, the
+    // full five-minute cool-off applied, and -- with no peer connected there is
+    // no gossip to supply anything else -- that chain stayed dark for the whole
+    // run while mini and nano were fine.
+    static constexpr std::uint64_t kFailedDialRetryMs = 15000;
+
+    std::uint64_t cool_off_until(std::uint64_t t, bool started) const {
+        if (cfg_.redial_after_ms == 0) return ~0ull;      // never: the harness rule
+        const std::uint64_t d = started
+                ? cfg_.redial_after_ms
+                : std::min<std::uint64_t>(cfg_.redial_after_ms, kFailedDialRetryMs);
+        return t + d;
+    }
+
     void open_sessions() {
+        const std::uint64_t t = now_ms();
         while (live_sessions() < cfg_.max_peers && !queue_.empty()) {
             const Dial d = queue_.front();
             queue_.pop_front();
             const std::string ep = d.host + ":" + std::to_string(d.port);
-            if (dialled_.count(ep)) continue;
-            dialled_.insert(ep);
+            if (!may_dial(ep, t)) continue;
             auto s = std::make_unique<PeerSession>(d.host, d.port, cfg_, consensus_,
                                                    static_cast<std::uint64_t>(rng_()));
-            if (s->start(ledger_, log_)) sessions_.push_back(std::move(s));
+            const bool started = s->start(ledger_, log_);
+            dialled_[ep] = cool_off_until(t, started);
+            if (started) sessions_.push_back(std::move(s));
         }
         // Reap closed sessions so the vector cannot grow without bound on a
         // long run against a churning network.
@@ -685,6 +805,7 @@ private:
     }
 
     void harvest() {
+        const std::uint64_t t = now_ms();
         for (auto& s : sessions_) {
             for (const PeerEntry& p : s->take_discovered()) {
                 if (p.port == 0 || p.port == 0xFFFF) continue;
@@ -692,7 +813,8 @@ private:
                 char buf[INET6_ADDRSTRLEN] = {0};
                 ::inet_ntop(AF_INET, p.addr.data() + 12, buf, sizeof(buf));
                 const std::string ep = std::string(buf) + ":" + std::to_string(p.port);
-                if (dialled_.count(ep)) continue;
+                if (!may_dial(ep, t)) continue;
+                if (queue_.size() >= cfg_.max_dial_queue) continue;
                 queue_.push_back({std::string(buf), p.port});
             }
         }
@@ -708,7 +830,8 @@ private:
 
     std::vector<std::unique_ptr<PeerSession>> sessions_;
     std::deque<Dial>      queue_;
-    std::set<std::string> dialled_;
+    // endpoint -> the time it was last dialled; see may_dial().
+    std::map<std::string, std::uint64_t> dialled_;
 };
 
 // ---------------------------------------------------------------------------

--- a/src/impl/xmr/p2pool/p2pool_read_model.hpp
+++ b/src/impl/xmr/p2pool/p2pool_read_model.hpp
@@ -248,6 +248,36 @@ public:
     const std::map<Hash, ObservedBlock>& blocks() const noexcept { return by_id_; }
     const std::vector<Hash>& arrival_order() const noexcept { return order_; }
 
+    // Per-height arrival record, ordered by height. Exposed for the reason
+    // cadence_seconds() exists at all: one averaged cadence cannot say whether
+    // the chain is beating steadily or arriving in bursts, and a display that
+    // shows the individual gaps says more than the mean does. Callers inherit
+    // the frontier caveat -- a height at or below frontier_height() carries a
+    // FETCH time, not an arrival time.
+    const std::map<std::uint64_t, HeightContest>& heights() const noexcept { return by_height_; }
+
+    // The gaps between consecutive LIVE height arrivals, oldest first, at most
+    // `max` of them (0 = all). Same live-window rule as cadence_seconds():
+    // everything at or below the frontier is excluded, because those heights
+    // were backfilled by our own parent walk and their spacing measures our
+    // fetch rate rather than the chain's block rate.
+    std::vector<std::uint64_t> live_arrival_gaps_ms(std::size_t max) const {
+        std::vector<std::uint64_t> t;
+        if (have_frontier_)
+            for (const auto& kv : by_height_)
+                if (kv.first > frontier_height_) t.push_back(kv.second.first_seen_ms);
+        std::vector<std::uint64_t> gaps;
+        for (std::size_t i = 1; i < t.size(); ++i)
+            gaps.push_back(t[i] >= t[i - 1] ? t[i] - t[i - 1] : 0);
+        if (max && gaps.size() > max)
+            gaps.erase(gaps.begin(), gaps.end() - static_cast<std::ptrdiff_t>(max));
+        return gaps;
+    }
+
+    // The chain's own parameters, so a display can put an observed number next
+    // to the target it is supposed to approach.
+    SidechainParams params() const noexcept { return params_; }
+
     const ObservedBlock* find(const Hash& id) const {
         const auto it = by_id_.find(id);
         return it == by_id_.end() ? nullptr : &it->second;

--- a/src/impl/xmr/p2pool/p2pool_tui.hpp
+++ b/src/impl/xmr/p2pool/p2pool_tui.hpp
@@ -1,0 +1,758 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/p2pool/p2pool_tui.hpp
+//
+// THE FRAME: three sidechain panels drawn as a pure function of three read
+// models. No sockets, no terminal, no clock.
+//
+// ---------------------------------------------------------------------------
+// WHY THE RENDERER HOLDS NOTHING
+// ---------------------------------------------------------------------------
+// A live dashboard is the easiest place in a codebase to hide an untested
+// number, because the thing that would catch it -- looking at it -- is exactly
+// what nobody does at three in the morning. So the rendering here is a total
+// function
+//
+//     render(frame, cols, rows, color) -> exactly `rows` lines of `cols` columns
+//
+// over a `MonitorFrame` that is plain data: no pointer into a live model, no
+// call to the clock, no access to a socket. Everything time-dependent -- ages,
+// uptime -- is resolved by view_of() at ONE instant passed in by the caller.
+// That is what lets a KAT pin the whole frame against a golden: feed a fixed
+// read model and a fixed `now`, and the bytes are the same on every machine, on
+// every run, forever. A renderer that reads the clock itself cannot be pinned,
+// and a dashboard that cannot be pinned drifts silently.
+//
+// ---------------------------------------------------------------------------
+// ONE BYTE IS ONE COLUMN
+// ---------------------------------------------------------------------------
+// Everything drawn is printable ASCII. The sparkline is `_.-=+*#`, the bars are
+// `#` and `-`, the rules are `-`. That is not nostalgia: the moment a frame
+// contains a multi-byte character, `std::string::size()` stops being the column
+// count and every alignment in the file becomes a guess. The Line builder below
+// tracks visible width as it appends, counts SGR escapes as zero-width, and
+// clamps at `cols`, so a narrow terminal truncates instead of wrapping and
+// shearing the layout.
+//
+// Colour is optional and strictly additive: render(color=false) and
+// strip_ansi(render(color=true)) are the same bytes, which the KAT asserts.
+// Snapshot mode is therefore not a second renderer, it is the same one with the
+// escapes turned off.
+//
+// ---------------------------------------------------------------------------
+// WHAT THE PANELS SAY, AND WHAT THEY REFUSE TO SAY
+// ---------------------------------------------------------------------------
+// The read model's rules carry through to the display rather than being
+// softened for looks:
+//
+//   * Cadence is the LIVE-WINDOW figure only. Heights at or below the frontier
+//     were backfilled by our own parent walk, and their spacing measures our
+//     fetch rate. Below the two-sample threshold the panel prints "warming",
+//     never a number with one sample behind it.
+//   * The pulse line is the individual live gaps, newest on the right, because
+//     an average of 10 s hides the difference between a steady beat and two
+//     bursts around a stall.
+//   * `monero tpl` is the highest Monero template height seen in a sidechain
+//     coinbase. It is not a claim that P2Pool found a Monero block: deciding
+//     that needs the Monero PoW target, which an observer holding no Monero
+//     chain does not have.
+//   * The `out` line is the byte ledger, and the footer prints the emitted
+//     message-id set COMPUTED from the encoder (emitted_id_set(), which encodes
+//     every ControlMessage and reads back the id byte) rather than a typed-in
+//     list. If a fifth encoder ever appeared, the footer would start saying so
+//     on screen and the KAT would fail in the same breath.
+//
+// Header-only, STL only. Deliberately free of POSIX: this file is what the KAT
+// compiles, and the KAT must not need a socket layer to check a layout.
+// ---------------------------------------------------------------------------
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/p2pool/p2pool_block.hpp"
+#include "impl/xmr/p2pool/p2pool_consensus.hpp"
+#include "impl/xmr/p2pool/p2pool_read_model.hpp"
+#include "impl/xmr/p2pool/p2pool_wire.hpp"
+
+namespace c2pool::xmr::p2pool::tui {
+
+// ---------------------------------------------------------------------------
+// SGR codes. Every one of them is zero-width by construction; nothing else in
+// this file emits an escape.
+// ---------------------------------------------------------------------------
+inline constexpr const char* kReset   = "\x1b[0m";
+inline constexpr const char* kBold    = "\x1b[1m";
+inline constexpr const char* kDim     = "\x1b[2m";
+inline constexpr const char* kRed     = "\x1b[31m";
+inline constexpr const char* kGreen   = "\x1b[32m";
+inline constexpr const char* kYellow  = "\x1b[33m";
+inline constexpr const char* kBlue    = "\x1b[34m";
+inline constexpr const char* kMagenta = "\x1b[35m";
+inline constexpr const char* kCyan    = "\x1b[36m";
+inline constexpr const char* kWhite   = "\x1b[37m";
+
+// Remove every CSI sequence. Used by the KAT to prove the colour build and the
+// plain build differ by escapes alone.
+inline std::string strip_ansi(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (std::size_t i = 0; i < s.size(); ++i) {
+        if (s[i] == '\x1b' && i + 1 < s.size() && s[i + 1] == '[') {
+            i += 2;
+            while (i < s.size() && !((s[i] >= 'A' && s[i] <= 'Z') || (s[i] >= 'a' && s[i] <= 'z'))) ++i;
+            continue;   // the final letter is consumed by the loop increment
+        }
+        out.push_back(s[i]);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// One line, built left to right, clamped at `cols` visible columns.
+// ---------------------------------------------------------------------------
+class Line {
+public:
+    Line(std::size_t cols, bool color) : cols_(cols), color_(color) {}
+
+    Line& put(const std::string& s) {
+        for (const char c : s) {
+            if (vis_ >= cols_) break;
+            buf_.push_back(c);
+            ++vis_;
+        }
+        return *this;
+    }
+    Line& put(const char* s) { return put(std::string(s)); }
+    Line& put(char c) { if (vis_ < cols_) { buf_.push_back(c); ++vis_; } return *this; }
+    Line& sgr(const char* code) { if (color_) buf_ += code; return *this; }
+    Line& pad_to(std::size_t col) {
+        while (vis_ < col && vis_ < cols_) { buf_.push_back(' '); ++vis_; }
+        return *this;
+    }
+    Line& repeat(char c, std::size_t n) { for (std::size_t i = 0; i < n; ++i) put(c); return *this; }
+    std::size_t visible() const noexcept { return vis_; }
+    std::size_t room() const noexcept { return cols_ > vis_ ? cols_ - vis_ : 0; }
+
+    // Close any colour and pad the rest of the row with plain spaces, so a
+    // full-screen repaint overwrites whatever the previous frame left there.
+    std::string take() {
+        sgr(kReset);
+        pad_to(cols_);
+        return buf_;
+    }
+
+private:
+    std::string buf_;
+    std::size_t cols_;
+    std::size_t vis_ = 0;
+    bool        color_;
+};
+
+// ---------------------------------------------------------------------------
+// Formatting. Integer maths wherever a rounding difference could show up in a
+// golden; snprintf with an explicit precision everywhere else.
+// ---------------------------------------------------------------------------
+inline std::string fmt_fixed(long double v, int decimals) {
+    char b[64];
+    std::snprintf(b, sizeof(b), "%.*Lf", decimals, v);
+    return std::string(b);
+}
+
+// 436060000 -> "436.06 M". Suffix appended by the caller ("H/s", "", ...).
+inline std::string fmt_si(long double v, int decimals = 2) {
+    static const char* kUnit[] = {"", "k", "M", "G", "T", "P", "E"};
+    int u = 0;
+    long double x = v < 0 ? -v : v;
+    while (x >= 1000.0L && u < 6) { x /= 1000.0L; ++u; }
+    return fmt_fixed(v < 0 ? -x : x, decimals) + " " + kUnit[u];
+}
+
+inline std::string fmt_bytes(std::uint64_t n) {
+    static const char* kUnit[] = {"B", "KiB", "MiB", "GiB"};
+    int u = 0;
+    long double x = static_cast<long double>(n);
+    while (x >= 1024.0L && u < 3) { x /= 1024.0L; ++u; }
+    return fmt_fixed(x, u == 0 ? 0 : 1) + " " + kUnit[u];
+}
+
+inline std::string fmt_hms(std::uint64_t ms) {
+    const std::uint64_t s = ms / 1000;
+    char b[32];
+    std::snprintf(b, sizeof(b), "%02llu:%02llu:%02llu",
+                  static_cast<unsigned long long>(s / 3600),
+                  static_cast<unsigned long long>((s / 60) % 60),
+                  static_cast<unsigned long long>(s % 60));
+    return std::string(b);
+}
+
+// Compact age: 7s, 2m11s, 1h04m, 3d.
+inline std::string fmt_age(std::uint64_t ms) {
+    const std::uint64_t s = ms / 1000;
+    char b[32];
+    if (s < 60)        std::snprintf(b, sizeof(b), "%llus", static_cast<unsigned long long>(s));
+    else if (s < 3600) std::snprintf(b, sizeof(b), "%llum%02llus",
+                                     static_cast<unsigned long long>(s / 60),
+                                     static_cast<unsigned long long>(s % 60));
+    else if (s < 86400) std::snprintf(b, sizeof(b), "%lluh%02llum",
+                                      static_cast<unsigned long long>(s / 3600),
+                                      static_cast<unsigned long long>((s / 60) % 60));
+    else std::snprintf(b, sizeof(b), "%llud", static_cast<unsigned long long>(s / 86400));
+    return std::string(b);
+}
+
+// The cadence bar. The scale runs 0 .. 2x target, so a chain exactly on target
+// fills exactly half and stops at the `:` mark; slower chains overrun it,
+// faster chains fall short of it. All integer maths -- a bar that rounds
+// differently on another compiler would break the golden for no reason.
+inline std::string cadence_bar(std::uint64_t observed_ms, std::uint64_t target_ms,
+                               std::size_t width) {
+    if (width < 3) width = 3;
+    const std::size_t mark = width / 2;
+    std::size_t n = 0;
+    if (target_ms) {
+        const std::uint64_t span = 2ull * target_ms;
+        const std::uint64_t o = observed_ms > span ? span : observed_ms;
+        n = static_cast<std::size_t>((o * width) / span);
+    }
+    std::string s(1, '[');
+    for (std::size_t i = 0; i < width; ++i)
+        s.push_back(i < n ? '#' : (i == mark ? ':' : '-'));
+    s.push_back(']');
+    return s;
+}
+
+// The pulse. One character per live inter-arrival gap, oldest left, newest
+// right, scaled against 2x target so the target gap sits mid-ramp.
+inline std::string sparkline(const std::vector<std::uint64_t>& gaps_ms,
+                             std::uint64_t target_ms, std::size_t width) {
+    static const char kRamp[] = "_.-=+*#";
+    const std::size_t levels = sizeof(kRamp) - 2;      // 6 -> indices 0..6
+    std::string s;
+    if (gaps_ms.empty() || width == 0) return s;
+    std::size_t begin = 0;
+    if (gaps_ms.size() > width) begin = gaps_ms.size() - width;
+    const std::uint64_t span = target_ms ? 2ull * target_ms : 1;
+    for (std::size_t i = begin; i < gaps_ms.size(); ++i) {
+        std::uint64_t g = gaps_ms[i];
+        if (g > span) g = span;
+        std::size_t lv = static_cast<std::size_t>((g * levels) / span);
+        if (lv > levels) lv = levels;
+        s.push_back(kRamp[lv]);
+    }
+    return s;
+}
+
+inline std::string upper(const std::string& s) {
+    std::string o = s;
+    for (char& c : o) if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+    return o;
+}
+
+// ---------------------------------------------------------------------------
+// THE EMITTED ID SET, computed rather than typed.
+//
+// Encodes every ControlMessage that exists and reads back the id byte. The
+// footer prints what this returns, so the read-only claim on screen is derived
+// from the encoder at run time; the KAT asserts it equals {0, 1, 3, 6}.
+// ---------------------------------------------------------------------------
+inline std::vector<int> emitted_id_set() {
+    std::vector<int> ids;
+    ControlArgs a{};
+    for (std::size_t i = 0; i < kControlMessageCount; ++i) {
+        const std::vector<std::uint8_t> bytes = encode(static_cast<ControlMessage>(i), a);
+        if (bytes.empty()) continue;
+        const int id = static_cast<int>(bytes[0]);
+        if (std::find(ids.begin(), ids.end(), id) == ids.end()) ids.push_back(id);
+    }
+    std::sort(ids.begin(), ids.end());
+    return ids;
+}
+
+inline std::string emitted_id_set_string() {
+    const std::vector<int> ids = emitted_id_set();
+    std::string s = "{";
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        if (i) s += ",";
+        s += std::to_string(ids[i]);
+    }
+    return s + "}";
+}
+
+// ---------------------------------------------------------------------------
+// THE FRAME'S INPUT. Plain data, one snapshot in time.
+// ---------------------------------------------------------------------------
+
+// The outbound byte ledger, copied out of the observer's. Copied rather than
+// referenced so this header needs nothing from the socket layer.
+struct EmitCounts {
+    std::uint64_t messages[kControlMessageCount] = {0, 0, 0, 0};
+    std::uint64_t bytes[kControlMessageCount]    = {0, 0, 0, 0};
+
+    std::uint64_t total_messages() const noexcept {
+        std::uint64_t t = 0;
+        for (std::size_t i = 0; i < kControlMessageCount; ++i) t += messages[i];
+        return t;
+    }
+    std::uint64_t total_bytes() const noexcept {
+        std::uint64_t t = 0;
+        for (std::size_t i = 0; i < kControlMessageCount; ++i) t += bytes[i];
+        return t;
+    }
+};
+
+struct FeedRow {
+    std::uint64_t height   = 0;
+    std::string   id8;                  // first 8 hex characters of the sidechain id
+    std::uint64_t age_ms   = 0;
+    std::size_t   shares   = 0;         // PPLNS payout lines in the coinbase
+    std::size_t   uncles   = 0;
+    bool          contested = false;    // another block already sits at this height
+    bool          verified  = false;    // sidechain id recomputed and matched
+};
+
+enum class ChainStatus : std::uint8_t {
+    Dark = 0,     // no peers, nothing seen
+    Dialling,     // sockets in flight, no handshake yet
+    Warming,      // handshaken, blocks arriving, not enough live heights to time
+    Live,         // handshaken and timing the chain
+};
+
+inline const char* to_string(ChainStatus s) noexcept {
+    switch (s) {
+        case ChainStatus::Dark:     return "DARK";
+        case ChainStatus::Dialling: return "DIAL";
+        case ChainStatus::Warming:  return "WARM";
+        case ChainStatus::Live:     return "LIVE";
+    }
+    return "?";
+}
+
+struct ChainView {
+    Sidechain     chain     = Sidechain::Main;
+    std::uint16_t port      = 0;
+    std::uint64_t target_s  = 0;
+    ChainStatus   status    = ChainStatus::Dark;
+
+    std::uint64_t tip_height = 0;
+    std::string   tip_id8;
+    std::string   difficulty;            // exact decimal
+    long double   difficulty_d = 0.0L;
+    long double   cumulative_d = 0.0L;
+    long double   hashrate     = 0.0L;   // H/s, implied by difficulty / target
+
+    bool          cadence_ok = false;
+    double        cadence_s  = 0.0;
+    std::size_t   cadence_n  = 0;
+    std::uint64_t frontier   = 0;
+    std::vector<std::uint64_t> gaps_ms;  // live inter-arrival gaps, oldest first
+
+    std::size_t   contested = 0;
+    std::size_t   uncles_named = 0;
+    std::size_t   uncles_resolved = 0;
+
+    std::uint64_t monero_high = 0;
+    std::size_t   monero_heights = 0;
+
+    std::size_t   peers_up = 0;          // handshaken
+    std::size_t   sockets  = 0;          // sockets alive, handshaken or not
+    std::size_t   peers_known = 0;
+    std::size_t   gossiped = 0;
+    std::size_t   queued = 0;            // addresses waiting to be dialled
+
+    std::size_t   distinct = 0;
+    std::size_t   dupes = 0;
+    std::size_t   parse_failures = 0;
+    std::size_t   broadcasts = 0;
+
+    std::vector<FeedRow> feed;           // newest first
+    EmitCounts    out;
+};
+
+struct MonitorFrame {
+    std::uint64_t          elapsed_ms = 0;
+    bool                   interactive = false;   // draws the key hints
+    std::vector<ChainView> chains;
+};
+
+struct MonitorTotals {
+    std::size_t   chains = 0;
+    std::size_t   chains_live = 0;
+    std::size_t   peers_up = 0;
+    std::size_t   peers_known = 0;
+    std::size_t   blocks = 0;
+    std::size_t   contested = 0;
+    std::size_t   parse_failures = 0;
+    std::uint64_t messages_out = 0;
+    std::uint64_t bytes_out = 0;
+};
+
+// The three-chain aggregation, in one place so the KAT can check it against the
+// per-chain numbers rather than against the renderer's arithmetic.
+inline MonitorTotals totals_of(const std::vector<ChainView>& chains) {
+    MonitorTotals t;
+    t.chains = chains.size();
+    for (const ChainView& c : chains) {
+        if (c.status == ChainStatus::Live || c.status == ChainStatus::Warming) ++t.chains_live;
+        t.peers_up       += c.peers_up;
+        t.peers_known    += c.peers_known;
+        t.blocks         += c.distinct;
+        t.contested      += c.contested;
+        t.parse_failures += c.parse_failures;
+        t.messages_out   += c.out.total_messages();
+        t.bytes_out      += c.out.total_bytes();
+    }
+    return t;
+}
+
+// ---------------------------------------------------------------------------
+// Turning one read model into one panel's worth of data, at one instant.
+//
+// `now_ms` is passed in rather than read, which is the whole reason a golden
+// frame is possible. Everything else is a straight read of the model.
+// ---------------------------------------------------------------------------
+inline ChainView view_of(const ReadModel& m, const EmitCounts& out, std::size_t sockets,
+                         std::size_t queued, std::uint64_t now_ms, std::size_t feed_rows = 8,
+                         std::size_t pulse_width = 24) {
+    ChainView v;
+    v.chain    = m.chain();
+    v.port     = default_port(m.chain());
+    v.target_s = m.params().target_block_time;
+
+    v.tip_height   = m.tip_height();
+    v.tip_id8      = m.tip_height() ? hex(m.tip_id()).substr(0, 8) : std::string("-");
+    v.difficulty   = m.tip_difficulty().to_string();
+    v.difficulty_d = m.tip_difficulty().as_double();
+    v.cumulative_d = m.tip_cumulative_difficulty().as_double();
+    v.hashrate     = m.implied_hashrate();
+
+    double cad = 0.0;
+    std::size_t n = 0;
+    v.cadence_ok = m.cadence_seconds(cad, n);
+    v.cadence_s  = cad;
+    v.cadence_n  = n;
+    v.frontier   = m.frontier_height();
+    v.gaps_ms    = m.live_arrival_gaps_ms(pulse_width);
+
+    v.contested        = m.contested_heights();
+    v.uncles_named     = m.uncles_seen();
+    v.uncles_resolved  = m.uncles_resolved();
+    v.monero_high      = m.monero_height_high();
+    v.monero_heights   = m.monero_heights_crossed();
+
+    v.peers_up    = m.connected_peers();
+    v.sockets     = sockets;
+    v.peers_known = m.known_peers();
+    v.gossiped    = m.gossiped_addresses();
+    v.queued      = queued;
+
+    v.distinct       = m.distinct_blocks();
+    v.dupes          = m.duplicate_receives();
+    v.parse_failures = m.parse_failures();
+    v.broadcasts     = m.broadcasts_seen();
+    v.out            = out;
+
+    if (v.cadence_ok)                     v.status = ChainStatus::Live;
+    else if (v.peers_up > 0)              v.status = ChainStatus::Warming;
+    else if (v.sockets > 0 || v.queued)   v.status = ChainStatus::Dialling;
+    else                                  v.status = ChainStatus::Dark;
+
+    // The feed is arrival order, newest first, deduplicated by construction:
+    // arrival_order() holds one entry per DISTINCT id.
+    const std::vector<Hash>& order = m.arrival_order();
+    for (std::size_t i = order.size(); i-- > 0 && v.feed.size() < feed_rows;) {
+        const ObservedBlock* b = m.find(order[i]);
+        if (!b) continue;
+        FeedRow r;
+        r.height   = b->sidechain_height;
+        r.id8      = hex(b->sidechain_id).substr(0, 8);
+        r.age_ms   = now_ms >= b->first_seen_ms ? now_ms - b->first_seen_ms : 0;
+        r.shares   = b->share_outputs;
+        r.uncles   = b->uncles.size();
+        r.verified = b->id_verified;
+        const auto it = m.heights().find(b->sidechain_height);
+        r.contested = (it != m.heights().end() && it->second.ids.size() > 1);
+        v.feed.push_back(r);
+    }
+    return v;
+}
+
+// ---------------------------------------------------------------------------
+// THE RENDERER
+// ---------------------------------------------------------------------------
+namespace detail {
+
+// Line priority. Everything at kAlways is drawn whatever the terminal size;
+// the rest is shed from the bottom of the list when the window is short, so a
+// small terminal loses detail rather than losing a chain.
+enum Level : int { kAlways = 0, kDetail = 2, kNetwork = 3, kFeed = 4 };
+
+using Row = std::pair<int, std::string>;
+
+inline const char* chain_color(Sidechain s) {
+    switch (s) {
+        case Sidechain::Main: return kCyan;
+        case Sidechain::Mini: return kMagenta;
+        case Sidechain::Nano: return kYellow;
+    }
+    return kWhite;
+}
+
+inline const char* status_color(ChainStatus s) {
+    switch (s) {
+        case ChainStatus::Live:     return kGreen;
+        case ChainStatus::Warming:  return kYellow;
+        case ChainStatus::Dialling: return kBlue;
+        case ChainStatus::Dark:     return kRed;
+    }
+    return kWhite;
+}
+
+// Green inside 25% of target, yellow inside 60%, red outside. The chain's own
+// variance is large, so the bands are wide on purpose: this flags "something is
+// wrong with our view of the chain", not "a block was late".
+inline const char* cadence_color(double observed_s, std::uint64_t target_s) {
+    if (!target_s) return kWhite;
+    const double r = observed_s / static_cast<double>(target_s);
+    if (r >= 0.75 && r <= 1.25) return kGreen;
+    if (r >= 0.40 && r <= 1.60) return kYellow;
+    return kRed;
+}
+
+inline void label(Line& l, const char* text) {
+    l.put("   ").sgr(kDim).put(text).sgr(kReset).pad_to(12);
+}
+
+inline void panel(const ChainView& v, std::size_t cols, bool color, std::vector<Row>& rows) {
+    {   // title
+        Line l(cols, color);
+        l.put(" ").sgr(kBold).sgr(chain_color(v.chain)).put(upper(to_string(v.chain)));
+        l.sgr(kReset).put("  port ").put(std::to_string(v.port));
+        l.put("  ").sgr(status_color(v.status)).put(to_string(v.status)).sgr(kReset);
+        l.put("  ").sgr(kDim).put("target ").sgr(kReset).put(std::to_string(v.target_s)).put("s");
+        l.put(" ").sgr(kDim).repeat('-', l.room()).sgr(kReset);
+        rows.emplace_back(kAlways, l.take());
+    }
+    {   // tip
+        Line l(cols, color);
+        label(l, "tip");
+        l.sgr(kBold).put(std::to_string(v.tip_height)).sgr(kReset);
+        l.put(" ").put(v.tip_id8);
+        l.put("  ").sgr(kDim).put("diff ").sgr(kReset).put(fmt_si(v.difficulty_d));
+        l.put("  ").sgr(kDim).put("hash ").sgr(kReset).put(fmt_si(v.hashrate)).put("H/s");
+        l.put("  ").sgr(kDim).put("cum ").sgr(kReset).put(fmt_si(v.cumulative_d));
+        rows.emplace_back(kAlways, l.take());
+    }
+    {   // cadence
+        Line l(cols, color);
+        label(l, "cadence");
+        if (v.cadence_ok) {
+            const std::uint64_t obs_ms = static_cast<std::uint64_t>(v.cadence_s * 1000.0 + 0.5);
+            l.sgr(cadence_color(v.cadence_s, v.target_s));
+            l.put(fmt_fixed(static_cast<long double>(v.cadence_s), 2)).put(" s");
+            l.sgr(kReset).sgr(kDim).put(" / ").sgr(kReset).put(std::to_string(v.target_s)).put(" s  ");
+            l.sgr(cadence_color(v.cadence_s, v.target_s));
+            l.put(cadence_bar(obs_ms, v.target_s * 1000ull, 16));
+            l.sgr(kReset);
+            l.put("  ").sgr(kDim).put("over ").sgr(kReset).put(std::to_string(v.cadence_n));
+            l.sgr(kDim).put(" live heights above ").sgr(kReset).put(std::to_string(v.frontier));
+        } else {
+            l.sgr(kDim).put("warming -- ").sgr(kReset).put(std::to_string(v.cadence_n));
+            l.sgr(kDim).put(" live height(s) above frontier ").sgr(kReset)
+             .put(std::to_string(v.frontier)).sgr(kDim).put("; two are needed to time the chain");
+        }
+        rows.emplace_back(kAlways, l.take());
+    }
+    {   // pulse
+        Line l(cols, color);
+        label(l, "pulse");
+        const std::string sp = sparkline(v.gaps_ms, v.target_s * 1000ull, 24);
+        if (sp.empty()) l.sgr(kDim).put("(no live gaps yet)");
+        else {
+            l.sgr(cadence_color(v.cadence_ok ? v.cadence_s : static_cast<double>(v.target_s),
+                                v.target_s)).put(sp).sgr(kReset);
+            l.put("  ").sgr(kDim).put("gaps, newest right (").sgr(kReset)
+             .put(std::to_string(v.gaps_ms.size())).sgr(kDim).put(")");
+        }
+        rows.emplace_back(kDetail, l.take());
+    }
+    {   // races
+        Line l(cols, color);
+        label(l, "races");
+        l.sgr(kDim).put("contested ").sgr(kReset).put(std::to_string(v.contested));
+        l.sgr(kDim).put("  uncles named ").sgr(kReset).put(std::to_string(v.uncles_named));
+        l.sgr(kDim).put(" resolved ").sgr(kReset).put(std::to_string(v.uncles_resolved));
+        l.sgr(kDim).put("  monero tpl ").sgr(kReset).put(std::to_string(v.monero_high));
+        l.sgr(kDim).put(" over ").sgr(kReset).put(std::to_string(v.monero_heights));
+        l.sgr(kDim).put(" heights");
+        rows.emplace_back(kDetail, l.take());
+    }
+    {   // net
+        Line l(cols, color);
+        label(l, "net");
+        l.sgr(v.peers_up ? kGreen : kRed).put(std::to_string(v.peers_up)).sgr(kReset);
+        l.sgr(kDim).put(" up / ").sgr(kReset).put(std::to_string(v.sockets));
+        l.sgr(kDim).put(" sock / ").sgr(kReset).put(std::to_string(v.peers_known));
+        l.sgr(kDim).put(" known / ").sgr(kReset).put(std::to_string(v.gossiped));
+        l.sgr(kDim).put(" gossip / ").sgr(kReset).put(std::to_string(v.queued));
+        l.sgr(kDim).put(" queued");
+        l.sgr(kDim).put("  blocks ").sgr(kReset).put(std::to_string(v.distinct));
+        l.sgr(kDim).put(" (dup ").sgr(kReset).put(std::to_string(v.dupes));
+        l.sgr(kDim).put(", bad ").sgr(kReset).put(std::to_string(v.parse_failures));
+        l.sgr(kDim).put(", bc ").sgr(kReset).put(std::to_string(v.broadcasts));
+        l.sgr(kDim).put(")");
+        rows.emplace_back(kNetwork, l.take());
+    }
+    {   // out
+        Line l(cols, color);
+        label(l, "out");
+        l.sgr(kDim).put("chal ").sgr(kReset).put(std::to_string(v.out.messages[0]));
+        l.sgr(kDim).put("  sol ").sgr(kReset).put(std::to_string(v.out.messages[1]));
+        l.sgr(kDim).put("  block_req ").sgr(kReset).put(std::to_string(v.out.messages[2]));
+        l.sgr(kDim).put("  peer_req ").sgr(kReset).put(std::to_string(v.out.messages[3]));
+        l.sgr(kDim).put("  = ").sgr(kReset).put(fmt_bytes(v.out.total_bytes()));
+        l.sgr(kDim).put(" sent");
+        rows.emplace_back(kNetwork, l.take());
+    }
+    {   // feed
+        Line l(cols, color);
+        label(l, "feed");
+        // ARRIVAL order, newest first -- not height order. A backfilled parent
+        // arrives after the tip that named it, and showing the order things
+        // actually reached us is the point of a feed.
+        if (v.feed.empty()) l.sgr(kDim).put("(nothing received yet)");
+        for (const FeedRow& r : v.feed) {
+            // Only start an entry that fits whole: a feed row cut in half looks
+            // like a truncated block id, which is exactly the wrong thing for a
+            // reader to wonder about.
+            if (l.room() < 32) break;
+            l.put(std::to_string(r.height)).put(" ");
+            l.sgr(kDim).put(r.id8).sgr(kReset);
+            l.sgr(kYellow).put(r.contested ? '*' : ' ').sgr(kReset);
+            l.put(" ").put(fmt_age(r.age_ms));
+            l.put(" ").put(std::to_string(r.shares)).sgr(kDim).put("sh").sgr(kReset);
+            if (r.uncles) { l.sgr(kDim).put(" u").sgr(kReset).put(std::to_string(r.uncles)); }
+            l.put("   ");
+        }
+        rows.emplace_back(kFeed, l.take());
+    }
+    rows.emplace_back(kFeed, Line(cols, color).take());   // breathing room
+}
+
+inline void header(const MonitorFrame& f, const MonitorTotals& t, std::size_t cols, bool color,
+                   std::vector<Row>& rows) {
+    {
+        Line l(cols, color);
+        l.put(" ").sgr(kBold).put("p2pool monitor").sgr(kReset);
+        l.put("  ").sgr(kBold).sgr(kGreen).put("READ-ONLY").sgr(kReset);
+        l.put("  ").sgr(kDim).put("chains ").sgr(kReset)
+         .put(std::to_string(t.chains_live)).put("/").put(std::to_string(t.chains));
+        l.put("  ").sgr(kDim).put("up ").sgr(kReset).put(fmt_hms(f.elapsed_ms));
+        l.put("  ").sgr(kDim).put("peers ").sgr(kReset).put(std::to_string(t.peers_up))
+         .put("/").put(std::to_string(t.peers_known));
+        l.put("  ").sgr(kDim).put("blocks ").sgr(kReset).put(std::to_string(t.blocks));
+        l.put("  ").sgr(kDim).put("races ").sgr(kReset).put(std::to_string(t.contested));
+        l.put("  ").sgr(kReset).put(fmt_bytes(t.bytes_out)).sgr(kDim).put(" out");
+        rows.emplace_back(kAlways, l.take());
+    }
+    {
+        Line l(cols, color);
+        l.sgr(kDim).repeat('-', cols).sgr(kReset);
+        rows.emplace_back(kAlways, l.take());
+    }
+}
+
+inline void footer(const MonitorFrame& f, std::size_t cols, bool color, std::vector<Row>& rows) {
+    {
+        Line l(cols, color);
+        l.sgr(kDim).repeat('-', cols).sgr(kReset);
+        rows.emplace_back(kAlways, l.take());
+    }
+    {
+        Line l(cols, color);
+        l.put(" ").sgr(kDim).put("emitted ids ").sgr(kGreen).put(emitted_id_set_string())
+         .sgr(kReset).sgr(kDim)
+         .put("  CHALLENGE  SOLUTION  BLOCK_REQUEST  PEER_LIST_REQUEST");
+        rows.emplace_back(kAlways, l.take());
+    }
+    {
+        Line l(cols, color);
+        l.put(" ").sgr(kDim).put("never emitted: LISTEN_PORT, BLOCK_RESPONSE, BLOCK_BROADCAST,"
+                                 " BLOCK_NOTIFY -- no encoder exists");
+        rows.emplace_back(kAlways, l.take());
+    }
+    if (f.interactive) {
+        Line l(cols, color);
+        l.put(" ").sgr(kBold).put("q").sgr(kReset).sgr(kDim).put(" quit   ").sgr(kReset);
+        l.sgr(kBold).put("r").sgr(kReset).sgr(kDim).put(" redraw");
+        rows.emplace_back(kAlways, l.take());
+    }
+}
+
+inline std::vector<Row> build(const MonitorFrame& f, std::size_t cols, bool color) {
+    std::vector<Row> rows;
+    const MonitorTotals t = totals_of(f.chains);
+    header(f, t, cols, color, rows);
+    for (const ChainView& v : f.chains) panel(v, cols, color, rows);
+    footer(f, cols, color, rows);
+    return rows;
+}
+
+} // namespace detail
+
+// Every line the frame wants, at this width.
+inline std::size_t natural_rows(const MonitorFrame& f, std::size_t cols = 100) {
+    return detail::build(f, cols, false).size();
+}
+
+// EXACTLY `rows` lines, each EXACTLY `cols` visible columns. Detail is shed
+// from the bottom of the priority list when the window is short; a window
+// shorter than the always-lines is truncated, never wrapped.
+inline std::vector<std::string> render(const MonitorFrame& f, std::size_t cols, std::size_t rows,
+                                       bool color) {
+    if (cols < 40) cols = 40;
+    std::vector<detail::Row> all = detail::build(f, cols, color);
+
+    int cut = 5;                       // nothing shed
+    for (;;) {
+        std::size_t n = 0;
+        for (const detail::Row& r : all) if (r.first < cut) ++n;
+        if (n <= rows || cut <= detail::kAlways + 1) break;
+        --cut;
+    }
+
+    std::vector<std::string> out;
+    for (const detail::Row& r : all) {
+        if (r.first >= cut) continue;
+        if (out.size() >= rows) break;
+        out.push_back(r.second);
+    }
+    const std::string blank = Line(cols, false).take();
+    while (out.size() < rows) out.push_back(blank);
+    return out;
+}
+
+// One plain-text frame: no escapes, no trailing blanks, one trailing newline.
+// This is what --snapshot writes and what the KAT pins.
+inline std::string snapshot_text(const MonitorFrame& f, std::size_t cols = 100) {
+    const std::vector<std::string> lines = render(f, cols, natural_rows(f, cols), false);
+    std::string s;
+    for (const std::string& l : lines) {
+        std::size_t end = l.size();
+        while (end > 0 && l[end - 1] == ' ') --end;
+        s.append(l, 0, end);
+        s.push_back('\n');
+    }
+    return s;
+}
+
+} // namespace c2pool::xmr::p2pool::tui

--- a/src/impl/xmr/p2pool/test/CMakeLists.txt
+++ b/src/impl/xmr/p2pool/test/CMakeLists.txt
@@ -1,21 +1,31 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# The P2Pool observer KAT.
+# The P2Pool KATs. Two registered targets, split along the only line that
+# matters here: what the PARSER does with bytes off a hostile wire, and what the
+# DISPLAY does with numbers out of the read model.
 #
-# ONE registered target, deliberately: the component's whole risk surface is a
-# parser fed by an unauthenticated peer, and a single translation unit that
-# compiles every header together is also the collision fence.
+#   xmr_p2pool_parse_kat    the component's risk surface -- a parser fed by an
+#                           unauthenticated peer -- pinned against two real
+#                           captured frames. One translation unit that compiles
+#                           every header together, which is also the collision
+#                           fence.
+#   xmr_p2pool_monitor_kat  the monitor's frame, pinned against a golden
+#                           rendered from three fixed read models, plus the
+#                           emitted message-id set re-asserted for the second
+#                           live binary. It includes NO socket header, so the
+#                           layout is checked without a network stack -- and
+#                           nothing about a dashboard can drift unseen.
 #
-# It is OFFLINE. The two goldens are real frames captured from a live mini
-# sidechain session and embedded as hex in p2pool_golden_frames.hpp, so the KAT
-# needs no network, no daemon and no fixture file -- it runs identically on a
-# laptop, on the sanitizer leg and on a machine with no route to the internet.
+# BOTH ARE OFFLINE. The parser goldens are real frames captured from a live mini
+# session and embedded as hex; the monitor golden is the frame its own fixture
+# produces (regenerate with `xmr_p2pool_monitor_kat --emit-golden`). Neither
+# needs a network, a daemon, a fixture file or a terminal: they run identically
+# on a laptop, on the sanitizer leg and on a machine with no route out.
 #
-# Links xmr_coin for keccak and the tree hash (through both the sidechain id
-# recomputation and the native lane's Monero block identity). No RandomX, no
-# boost, no libsodium: a LIGHT link, same tier as the C2a KATs.
+# Both link xmr_coin for keccak and the tree hash. No RandomX, no boost, no
+# libsodium, no ncurses: a LIGHT link, same tier as the C2a KATs.
 #
-# DRIFT-GUARD: this directory is outside the coin-test allowlist glob, so the
-# target below is also in BOTH `--target` lists in .github/workflows/build.yml.
+# DRIFT-GUARD: this directory is outside the coin-test allowlist glob, so both
+# targets below are also in BOTH `--target` lists in .github/workflows/build.yml.
 # ─────────────────────────────────────────────────────────────────────────────
 
 if (BUILD_TESTING)
@@ -24,4 +34,10 @@ if (BUILD_TESTING)
     target_link_libraries(xmr_p2pool_parse_kat PRIVATE xmr_coin)
     target_compile_features(xmr_p2pool_parse_kat PRIVATE cxx_std_20)
     add_test(NAME xmr_p2pool_parse_kat COMMAND xmr_p2pool_parse_kat)
+
+    add_executable(xmr_p2pool_monitor_kat p2pool_monitor_kat.cpp)
+    target_include_directories(xmr_p2pool_monitor_kat PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    target_link_libraries(xmr_p2pool_monitor_kat PRIVATE xmr_coin)
+    target_compile_features(xmr_p2pool_monitor_kat PRIVATE cxx_std_20)
+    add_test(NAME xmr_p2pool_monitor_kat COMMAND xmr_p2pool_monitor_kat)
 endif()

--- a/src/impl/xmr/p2pool/test/p2pool_monitor_golden.inc
+++ b/src/impl/xmr/p2pool/test/p2pool_monitor_golden.inc
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/p2pool/test/p2pool_monitor_golden.inc
+//
+// THE GOLDEN FRAME: exactly what the monitor's fixture renders at 100 columns,
+// one C string per line, included inside an array initialiser in
+// p2pool_monitor_kat.cpp.
+//
+// It is kept in its own file rather than inline because it is meant to be READ
+// as a picture. A reviewer can open this and see the dashboard -- the labels,
+// the units, the cadence bar, the pulse ramp, the emitted-id footer -- without
+// building anything, and a diff on this file is a diff of what an operator will
+// be looking at.
+//
+// Regenerate deliberately, never casually:
+//
+//     xmr_p2pool_monitor_kat --emit-golden > p2pool_monitor_golden.inc
+//
+// (then put this header back). If a change to the renderer was not intended to
+// change what is on screen, this file changing is the bug report.
+// ---------------------------------------------------------------------------
+" p2pool monitor  READ-ONLY  chains 3/3  up 00:03:05  peers 9/99  blocks 17  races 1  11.2 KiB out",
+"----------------------------------------------------------------------------------------------------",
+" MAIN  port 37889  LIVE  target 10s ----------------------------------------------------------------",
+"   tip      15200104 2b323940  diff 4.36 G  hash 436.00 MH/s  cum 4.36 T",
+"   cadence  9.33 s / 10 s  [#######-:-------]  over 4 live heights above 15200100",
+"   pulse    ---  gaps, newest right (3)",
+"   races    contested 1  uncles named 1 resolved 1  monero tpl 3512003 over 5 heights",
+"   net      4 up / 4 sock / 57 known / 48 gossip / 12 queued  blocks 8 (dup 0, bad 0, bc 1)",
+"   out      chal 6  sol 6  block_req 141  peer_req 6  = 4.9 KiB sent",
+"   feed     15200104 2b323940  2s 122sh u1   15200103 d0d7dee5* 10s 120sh",
+"",
+" MINI  port 37888  LIVE  target 10s ----------------------------------------------------------------",
+"   tip      14757144 686f767d  diff 218.00 M  hash 21.80 MH/s  cum 218.00 G",
+"   cadence  11.17 s / 10 s  [########:-------]  over 4 live heights above 14757140",
+"   pulse    .*-  gaps, newest right (3)",
+"   races    contested 0  uncles named 0 resolved 0  monero tpl 3512003 over 4 heights",
+"   net      3 up / 3 sock / 31 known / 22 gossip / 7 queued  blocks 6 (dup 0, bad 1, bc 0)",
+"   out      chal 5  sol 5  block_req 118  peer_req 5  = 4.1 KiB sent",
+"   feed     14757144 686f767d  0s 46sh   14757143 575e656c  9s 46sh",
+"",
+" NANO  port 37890  WARM  target 30s ----------------------------------------------------------------",
+"   tip      2301885 72798087  diff 9.40 M  hash 313.33 kH/s  cum 9.40 G",
+"   cadence  warming -- 1 live height(s) above frontier 2301884; two are needed to time the chain",
+"   pulse    (no live gaps yet)",
+"   races    contested 0  uncles named 0 resolved 0  monero tpl 3512003 over 3 heights",
+"   net      2 up / 2 sock / 11 known / 6 gossip / 3 queued  blocks 3 (dup 0, bad 0, bc 0)",
+"   out      chal 3  sol 3  block_req 64  peer_req 3  = 2.2 KiB sent",
+"   feed     2301885 72798087  4s 10sh   2301883 50575e65  34s 9sh   2301884 61686f76  35s 9sh",
+"",
+"----------------------------------------------------------------------------------------------------",
+" emitted ids {0,1,3,6}  CHALLENGE  SOLUTION  BLOCK_REQUEST  PEER_LIST_REQUEST",
+" never emitted: LISTEN_PORT, BLOCK_RESPONSE, BLOCK_BROADCAST, BLOCK_NOTIFY -- no encoder exists",

--- a/src/impl/xmr/p2pool/test/p2pool_monitor_kat.cpp
+++ b/src/impl/xmr/p2pool/test/p2pool_monitor_kat.cpp
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/p2pool/test/p2pool_monitor_kat.cpp
+//
+// THE MONITOR KAT. Offline, deterministic, no socket, no terminal.
+//
+// A dashboard is the easiest place in a codebase to hide a wrong number,
+// because the only thing that would catch it is somebody looking at it. So this
+// KAT pins the WHOLE FRAME: three read models are filled with fixed synthetic
+// observations at fixed millisecond timestamps, rendered at a fixed width with
+// a fixed `now`, and the resulting plain text is compared line by line against
+// a golden embedded below. Any change to a label, a column, a unit or a
+// rounding rule is a diff a reviewer must look at on purpose.
+//
+// Four things are checked, in the order they matter:
+//
+//   1. THE EMIT SET IS STILL {0, 1, 3, 6}. Re-asserted here, independently of
+//      the parser KAT, because this component adds a second binary that dials
+//      three networks at once and the read-only claim has to hold for it too.
+//      The check is over the encoder itself (encode every ControlMessage, read
+//      the id byte back), so a fifth encoder fails it rather than escaping it.
+//   2. THE FRAME IS DETERMINISTIC and matches the golden byte for byte; colour
+//      is additive only, so strip_ansi(coloured) == plain, line by line.
+//   3. THE THREE-CHAIN AGGREGATION IS RIGHT: the header totals are the sums of
+//      the panels, computed from the ChainViews rather than from the renderer.
+//   4. THE HONESTY RULES SURVIVE THE DISPLAY: a model holding only backfilled
+//      heights renders "warming", never a cadence figure -- the display must
+//      not launder the artefact the read model refuses to report.
+//
+// Run with `--emit-golden` to print the frame the fixture produces; that is how
+// the golden below was generated, and how it is regenerated on purpose.
+//
+// Offline, STL only: it includes no socket header, exactly like the parser KAT.
+// ---------------------------------------------------------------------------
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/p2pool/p2pool_consensus.hpp"
+#include "impl/xmr/p2pool/p2pool_read_model.hpp"
+#include "impl/xmr/p2pool/p2pool_tui.hpp"
+#include "impl/xmr/p2pool/p2pool_wire.hpp"
+
+namespace p2p = c2pool::xmr::p2pool;
+namespace tui = c2pool::xmr::p2pool::tui;
+
+namespace {
+
+int g_checks = 0;
+int g_fail   = 0;
+
+void check(bool ok, const char* what) {
+    ++g_checks;
+    if (!ok) { std::printf("FAIL: %s\n", what); ++g_fail; }
+}
+
+template <typename A, typename B>
+void check_eq(const A& got, const B& want, const char* what) {
+    ++g_checks;
+    if (!(got == static_cast<A>(want))) {
+        std::printf("FAIL: %s\n", what);
+        ++g_fail;
+    }
+}
+
+void check_str(const std::string& got, const std::string& want, const char* what) {
+    ++g_checks;
+    if (got != want) {
+        std::printf("FAIL: %s\n  got  |%s|\n  want |%s|\n", what, got.c_str(), want.c_str());
+        ++g_fail;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// THE FIXTURE
+//
+// Three read models filled by hand. Every timestamp is explicit, so the frame
+// is a pure function of the numbers below and of the `now` passed to view_of().
+// The shape of each chain is chosen to exercise a different branch:
+//
+//   main  a live chain past the frontier, with a contested height whose loser
+//         is carried as an uncle by the next block
+//   mini  a live chain with a slow gap, to move the cadence bar off centre
+//   nano  a chain that has handshaken and received its first blocks but has not
+//         yet seen two live heights -- the "warming" branch, and the one that
+//         must NOT print a cadence number
+// ---------------------------------------------------------------------------
+
+p2p::Hash mk_hash(std::uint8_t tag, std::uint8_t n) {
+    p2p::Hash h{};
+    for (std::size_t i = 0; i < h.size(); ++i)
+        h[i] = static_cast<std::uint8_t>((tag * 61u + n * 17u + i * 7u) & 0xFFu);
+    return h;
+}
+
+p2p::ObservedBlock mk_block(std::uint8_t tag, std::uint8_t n, std::uint64_t height,
+                            std::uint64_t seen_ms, std::uint64_t diff_lo,
+                            std::uint64_t monero_height, std::size_t shares) {
+    p2p::ObservedBlock b;
+    b.sidechain_id          = mk_hash(tag, n);
+    b.sidechain_height      = height;
+    b.difficulty.lo         = diff_lo;
+    b.cumulative_difficulty.lo = diff_lo * 1000ull;
+    b.parent                = mk_hash(tag, static_cast<std::uint8_t>(n - 1));
+    b.monero_height         = monero_height;
+    b.monero_timestamp      = 1757600000ull;
+    b.share_outputs         = shares;
+    b.total_reward          = 600000000000ull;
+    b.tx_count              = 12;
+    b.shape                 = p2p::BlobShape::Full;
+    b.id_verified           = true;
+    b.first_seen_ms         = seen_ms;
+    b.from_peer             = "203.0.113.7:37889";
+    return b;
+}
+
+// main: frontier 15200100, then four live heights, one of them contested.
+p2p::ReadModel build_main() {
+    p2p::ReadModel m(p2p::Sidechain::Main);
+    const std::uint64_t d = 4360000000ull;
+
+    m.observe(mk_block(1, 10, 15200100, 1000000, d, 3512000, 118));   // the frontier
+    m.observe(mk_block(1,  9, 15200099, 1000100, d, 3512000, 117));   // backfilled parent
+    m.observe(mk_block(1,  8, 15200098, 1000200, d, 3511999, 119));   // backfilled parent
+
+    m.observe(mk_block(1, 11, 15200101, 1010000, d, 3512001, 120));
+    m.observe(mk_block(1, 12, 15200102, 1019500, d, 3512001, 121));
+    m.observe(mk_block(1, 13, 15200103, 1029000, d, 3512002, 121));
+    m.observe(mk_block(1, 99, 15200103, 1029400, d, 3512002, 120));   // the race
+
+    p2p::ObservedBlock win = mk_block(1, 14, 15200104, 1038000, d, 3512003, 122);
+    win.uncles.push_back(mk_hash(1, 99));                             // loser carried
+    m.observe(win);
+
+    for (int i = 0; i < 4; ++i) m.note_connected("198.51.100." + std::to_string(i) + ":37889");
+    for (int i = 0; i < 57; ++i) m.note_peer("198.51.100." + std::to_string(i) + ":37889");
+    m.note_peer_gossip(48);
+    m.note_broadcast_seen();
+    return m;
+}
+
+// mini: live, with one long gap so the bar and the pulse are not flat.
+p2p::ReadModel build_mini() {
+    p2p::ReadModel m(p2p::Sidechain::Mini);
+    const std::uint64_t d = 218000000ull;
+
+    m.observe(mk_block(2, 10, 14757140, 1000000, d, 3512000, 44));    // frontier
+    m.observe(mk_block(2,  9, 14757139, 1000300, d, 3512000, 43));    // backfilled
+
+    m.observe(mk_block(2, 11, 14757141, 1006000, d, 3512001, 45));
+    m.observe(mk_block(2, 12, 14757142, 1012500, d, 3512001, 45));
+    m.observe(mk_block(2, 13, 14757143, 1031000, d, 3512002, 46));    // 18.5 s gap
+    m.observe(mk_block(2, 14, 14757144, 1039500, d, 3512003, 46));
+
+    for (int i = 0; i < 3; ++i) m.note_connected("198.51.100." + std::to_string(i) + ":37888");
+    for (int i = 0; i < 31; ++i) m.note_peer("198.51.100." + std::to_string(i) + ":37888");
+    m.note_peer_gossip(22);
+    m.note_parse_failure();
+    return m;
+}
+
+// nano: handshaken, one live height only -- the warming branch.
+p2p::ReadModel build_nano() {
+    p2p::ReadModel m(p2p::Sidechain::Nano);
+    const std::uint64_t d = 9400000ull;
+
+    m.observe(mk_block(3, 10, 2301884, 1005000, d, 3512001, 9));      // frontier
+    m.observe(mk_block(3,  9, 2301883, 1005400, d, 3512000, 9));      // backfilled
+    m.observe(mk_block(3, 11, 2301885, 1036000, d, 3512003, 10));     // one live height
+
+    for (int i = 0; i < 2; ++i) m.note_connected("198.51.100." + std::to_string(i) + ":37890");
+    for (int i = 0; i < 11; ++i) m.note_peer("198.51.100." + std::to_string(i) + ":37890");
+    m.note_peer_gossip(6);
+    return m;
+}
+
+tui::EmitCounts mk_emit(std::uint64_t chal, std::uint64_t sol, std::uint64_t breq,
+                        std::uint64_t plreq) {
+    tui::EmitCounts e;
+    e.messages[0] = chal;  e.bytes[0] = chal  * 17;
+    e.messages[1] = sol;   e.bytes[1] = sol   * 41;
+    e.messages[2] = breq;  e.bytes[2] = breq  * 33;
+    e.messages[3] = plreq; e.bytes[3] = plreq * 1;
+    return e;
+}
+
+constexpr std::uint64_t kNow  = 1040000;   // the instant every view is taken at
+constexpr std::size_t   kCols = 100;
+
+tui::MonitorFrame build_frame() {
+    static const p2p::ReadModel main_m = build_main();
+    static const p2p::ReadModel mini_m = build_mini();
+    static const p2p::ReadModel nano_m = build_nano();
+
+    tui::MonitorFrame f;
+    f.elapsed_ms  = 185000;      // 00:03:05
+    f.interactive = false;
+    f.chains.push_back(tui::view_of(main_m, mk_emit(6, 6, 141, 6), 4, 12, kNow));
+    f.chains.push_back(tui::view_of(mini_m, mk_emit(5, 5, 118, 5), 3,  7, kNow));
+    f.chains.push_back(tui::view_of(nano_m, mk_emit(3, 3,  64, 3), 2,  3, kNow));
+    return f;
+}
+
+// ---------------------------------------------------------------------------
+// THE GOLDEN FRAME. Regenerate with `xmr_p2pool_monitor_kat --emit-golden`.
+// ---------------------------------------------------------------------------
+const char* const kGolden[] = {
+#include "p2pool_monitor_golden.inc"
+};
+
+// ---------------------------------------------------------------------------
+// 1) The emit set, re-asserted for this binary.
+// ---------------------------------------------------------------------------
+void check_emit_set() {
+    check_eq(p2p::kControlMessageCount, std::size_t(4), "exactly four control messages exist");
+
+    const std::vector<int> ids = tui::emitted_id_set();
+    check_eq(ids.size(), std::size_t(4), "four distinct outbound message ids");
+    const int want[4] = {0, 1, 3, 6};
+    for (std::size_t i = 0; i < ids.size() && i < 4; ++i)
+        check_eq(ids[i], want[i], "outbound id set is exactly {0,1,3,6}");
+    check_str(tui::emitted_id_set_string(), "{0,1,3,6}", "emit set prints as {0,1,3,6}");
+
+    // Belt: the same statement made positionally over all twelve p2pool ids, so
+    // a NEW encoder for LISTEN_PORT (2), BLOCK_RESPONSE (4), BLOCK_BROADCAST
+    // (5), BLOCK_BROADCAST_COMPACT (8), BLOCK_NOTIFY (9), AUX_JOB_DONATION (10)
+    // or MONERO_BLOCK_BROADCAST (11) fails here and not in review.
+    bool emitted[12] = {false};
+    p2p::ControlArgs a{};
+    for (std::size_t i = 0; i < p2p::kControlMessageCount; ++i) {
+        const std::vector<std::uint8_t> b = p2p::encode(static_cast<p2p::ControlMessage>(i), a);
+        check(!b.empty(), "every control message encodes to bytes");
+        if (!b.empty() && b[0] < 12) emitted[b[0]] = true;
+        std::size_t framed = 0;
+        check(p2p::frame_size(b.data(), b.size(), framed) == p2p::FrameStatus::Complete,
+              "an encoded control message is a whole frame");
+        check_eq(b.size(), framed, "encoded length is the wire length for its id");
+    }
+    const bool want_emitted[12] = {true, true, false, true, false, false,
+                                   true, false, false, false, false, false};
+    for (int i = 0; i < 12; ++i) {
+        ++g_checks;
+        if (emitted[i] != want_emitted[i]) {
+            std::printf("FAIL: outbound id %d (%s) emitted=%d expected=%d\n", i,
+                        p2p::to_string(static_cast<p2p::MessageId>(i)),
+                        emitted[i] ? 1 : 0, want_emitted[i] ? 1 : 0);
+            ++g_fail;
+        }
+    }
+
+    // The monitor adds no encoder, so the lengths upstream reads are unchanged.
+    check_eq(p2p::encode(p2p::ControlMessage::HandshakeChallenge, a).size(), std::size_t(17),
+             "HANDSHAKE_CHALLENGE is 17 bytes");
+    check_eq(p2p::encode(p2p::ControlMessage::HandshakeSolution, a).size(), std::size_t(41),
+             "HANDSHAKE_SOLUTION is 41 bytes");
+    check_eq(p2p::encode(p2p::ControlMessage::BlockRequest, a).size(), std::size_t(33),
+             "BLOCK_REQUEST is 33 bytes");
+    check_eq(p2p::encode(p2p::ControlMessage::PeerListRequest, a).size(), std::size_t(1),
+             "PEER_LIST_REQUEST is 1 byte");
+
+    // The footer states the set on screen; it must state THIS set.
+    const std::string frame = tui::snapshot_text(build_frame(), kCols);
+    check(frame.find("emitted ids {0,1,3,6}") != std::string::npos,
+          "the frame footer prints the emitted id set");
+    check(frame.find("LISTEN_PORT") != std::string::npos,
+          "the frame footer names what is not emitted");
+}
+
+// ---------------------------------------------------------------------------
+// 2) The frame: deterministic, golden-pinned, colour-additive.
+// ---------------------------------------------------------------------------
+void check_render() {
+    const tui::MonitorFrame f = build_frame();
+
+    const std::string a = tui::snapshot_text(f, kCols);
+    const std::string b = tui::snapshot_text(build_frame(), kCols);
+    check(a == b, "the same frame renders to the same bytes twice");
+
+    // Against the golden, line by line so a failure names the line.
+    std::vector<std::string> got;
+    {
+        std::string cur;
+        for (const char c : a) {
+            if (c == '\n') { got.push_back(cur); cur.clear(); }
+            else cur.push_back(c);
+        }
+        if (!cur.empty()) got.push_back(cur);
+    }
+    const std::size_t want_n = sizeof(kGolden) / sizeof(kGolden[0]);
+    check_eq(got.size(), want_n, "the frame has the golden number of lines");
+    for (std::size_t i = 0; i < got.size() && i < want_n; ++i) {
+        ++g_checks;
+        if (got[i] != kGolden[i]) {
+            std::printf("FAIL: frame line %zu\n  got  |%s|\n  want |%s|\n",
+                        i, got[i].c_str(), kGolden[i]);
+            ++g_fail;
+        }
+    }
+
+    // Geometry: render() is total -- exactly `rows` lines of exactly `cols`
+    // visible columns, at any size, padded so a repaint overwrites the last
+    // frame rather than leaving its tail behind.
+    for (std::size_t cols : {60u, 100u, 140u}) {
+        for (std::size_t rows : {12u, 24u, 40u, 60u}) {
+            const std::vector<std::string> plain = tui::render(f, cols, rows, false);
+            check_eq(plain.size(), rows, "render returns exactly the rows asked for");
+            bool width_ok = true;
+            for (const std::string& l : plain) if (l.size() != cols) width_ok = false;
+            check(width_ok, "every plain line is exactly cols wide");
+
+            // Colour is additive and nothing else.
+            const std::vector<std::string> col = tui::render(f, cols, rows, true);
+            check_eq(col.size(), rows, "the coloured frame has the same row count");
+            bool same = true;
+            for (std::size_t i = 0; i < col.size(); ++i)
+                if (tui::strip_ansi(col[i]) != plain[i]) same = false;
+            check(same, "strip_ansi(coloured) == plain, line by line");
+        }
+    }
+
+    // Shedding: a short window drops detail, never a chain.
+    const std::vector<std::string> tight = tui::render(f, 100, 12, false);
+    int titles = 0;
+    for (const std::string& l : tight) {
+        if (l.rfind(" MAIN ", 0) == 0 || l.rfind(" MINI ", 0) == 0 || l.rfind(" NANO ", 0) == 0)
+            ++titles;
+    }
+    check_eq(titles, 3, "all three chains keep their panel in a 12-row window");
+
+    // A narrow window truncates rather than wrapping and shearing the layout.
+    const std::vector<std::string> narrow = tui::render(f, 60, 30, false);
+    bool no_overflow = true;
+    for (const std::string& l : narrow) if (l.size() != 60) no_overflow = false;
+    check(no_overflow, "a 60-column window produces 60-column lines");
+}
+
+// ---------------------------------------------------------------------------
+// 3) The three-chain aggregation.
+// ---------------------------------------------------------------------------
+void check_aggregation() {
+    const tui::MonitorFrame f = build_frame();
+    check_eq(f.chains.size(), std::size_t(3), "three chains in one frame");
+
+    // Each panel is the chain it says it is: consensus port and target cadence
+    // come from p2pool_consensus.hpp, not from the display.
+    check_eq(f.chains[0].port, std::uint16_t(37889), "main panel is port 37889");
+    check_eq(f.chains[1].port, std::uint16_t(37888), "mini panel is port 37888");
+    check_eq(f.chains[2].port, std::uint16_t(37890), "nano panel is port 37890");
+    check_eq(f.chains[0].target_s, std::uint64_t(10), "main targets 10 s");
+    check_eq(f.chains[1].target_s, std::uint64_t(10), "mini targets 10 s");
+    check_eq(f.chains[2].target_s, std::uint64_t(30), "nano targets 30 s");
+
+    const tui::MonitorTotals t = tui::totals_of(f.chains);
+    std::size_t peers_up = 0, known = 0, blocks = 0, contested = 0, bad = 0;
+    std::uint64_t msgs = 0, bytes = 0;
+    for (const tui::ChainView& c : f.chains) {
+        peers_up  += c.peers_up;
+        known     += c.peers_known;
+        blocks    += c.distinct;
+        contested += c.contested;
+        bad       += c.parse_failures;
+        msgs      += c.out.total_messages();
+        bytes     += c.out.total_bytes();
+    }
+    check_eq(t.peers_up, peers_up, "header peers is the sum of the panels");
+    check_eq(t.peers_known, known, "header known peers is the sum of the panels");
+    check_eq(t.blocks, blocks, "header blocks is the sum of the panels");
+    check_eq(t.contested, contested, "header races is the sum of the panels");
+    check_eq(t.parse_failures, bad, "header parse failures is the sum of the panels");
+    check_eq(t.messages_out, msgs, "header messages is the sum of the panels");
+    check_eq(t.bytes_out, bytes, "header bytes is the sum of the panels");
+
+    // The fixture's own arithmetic, so a silent change to it is visible.
+    check_eq(peers_up, std::size_t(9), "fixture has 9 handshaken peers across three chains");
+    check_eq(blocks, std::size_t(17), "fixture holds 17 distinct blocks across three chains");
+    check_eq(t.chains_live, std::size_t(3), "all three fixture chains count as live-or-warming");
+    check_eq(bytes, std::uint64_t(6 * 17 + 6 * 41 + 141 * 33 + 6
+                                 + 5 * 17 + 5 * 41 + 118 * 33 + 5
+                                 + 3 * 17 + 3 * 41 + 64 * 33 + 3),
+             "header byte total is the three ledgers summed");
+
+    // Chains are independent accumulators: mini's parse failure is mini's.
+    check_eq(f.chains[0].parse_failures, std::size_t(0), "main saw no parse failure");
+    check_eq(f.chains[1].parse_failures, std::size_t(1), "mini's parse failure stayed on mini");
+    check_eq(f.chains[2].parse_failures, std::size_t(0), "nano saw no parse failure");
+    check_eq(f.chains[0].contested, std::size_t(1), "main's contested height stayed on main");
+    check_eq(f.chains[1].contested, std::size_t(0), "mini saw no contested height");
+}
+
+// ---------------------------------------------------------------------------
+// 4) The honesty rules, checked through the display.
+// ---------------------------------------------------------------------------
+void check_honesty() {
+    const tui::MonitorFrame f = build_frame();
+
+    // main: cadence over the LIVE window only. Four live heights at
+    // 1010.0, 1019.5, 1029.0, 1038.0 s -> 28.0 s / 3 = 9.33 s. The three
+    // backfilled heights below the frontier (received 100 ms apart) are
+    // excluded; including them would report about 5 s on a 10 s chain.
+    check(f.chains[0].cadence_ok, "main reports a cadence");
+    check_eq(f.chains[0].cadence_n, std::size_t(4), "main times four live heights");
+    check_eq(f.chains[0].frontier, std::uint64_t(15200100), "main's frontier is the first tip seen");
+    check_str(tui::fmt_fixed(static_cast<long double>(f.chains[0].cadence_s), 2), "9.33",
+              "main's cadence is the live-window figure");
+    check_eq(f.chains[0].distinct, std::size_t(8), "main holds eight distinct blocks");
+
+    // nano: one live height. The model refuses to time it and so must the panel.
+    check(!f.chains[2].cadence_ok, "nano refuses to report a cadence from one sample");
+    check_eq(f.chains[2].status, tui::ChainStatus::Warming, "nano shows as warming");
+    const std::string frame = tui::snapshot_text(f, kCols);
+    const std::size_t nano_at = frame.find(" NANO ");
+    check(nano_at != std::string::npos, "the nano panel is drawn");
+    const std::size_t nano_end = frame.find(" MAIN ", nano_at) == std::string::npos
+                               ? frame.size() : frame.find(" MAIN ", nano_at);
+    const std::string nano_panel = frame.substr(nano_at, nano_end - nano_at);
+    check(nano_panel.find("warming") != std::string::npos,
+          "the nano panel says warming instead of printing a cadence");
+
+    // A block whose height is contested is flagged in the feed, and the uncle
+    // that carried the loser is counted as resolved.
+    check_eq(f.chains[0].uncles_named, std::size_t(1), "main names one uncle");
+    check_eq(f.chains[0].uncles_resolved, std::size_t(1), "main's uncle resolves to a block we hold");
+    bool flagged = false;
+    for (const tui::FeedRow& r : f.chains[0].feed)
+        if (r.height == 15200103 && r.contested) flagged = true;
+    check(flagged, "the contested height is flagged in the feed");
+
+    // The Monero line is a template height, never a found-block claim.
+    check_eq(f.chains[0].monero_high, std::uint64_t(3512003), "main's highest monero template");
+    check(frame.find("monero tpl") != std::string::npos, "the monero template height is shown");
+    check(frame.find("found") == std::string::npos,
+          "the frame never claims a monero block was found");
+
+    // An empty chain is DARK and says nothing it cannot support.
+    p2p::ReadModel empty(p2p::Sidechain::Nano);
+    const tui::ChainView dark = tui::view_of(empty, tui::EmitCounts{}, 0, 0, kNow);
+    check_eq(dark.status, tui::ChainStatus::Dark, "a chain with nothing on it is dark");
+    check_eq(dark.tip_id8, std::string("-"), "a dark chain shows no tip id");
+    tui::MonitorFrame df;
+    df.chains.push_back(dark);
+    const std::string dark_frame = tui::snapshot_text(df, kCols);
+    check(dark_frame.find("(nothing received yet)") != std::string::npos,
+          "a dark chain says it has received nothing");
+    check(dark_frame.find("(no live gaps yet)") != std::string::npos,
+          "a dark chain draws no pulse it does not have");
+}
+
+// ---------------------------------------------------------------------------
+// 5) The formatting primitives, pinned on their own so a golden diff is short.
+// ---------------------------------------------------------------------------
+void check_formatting() {
+    check_str(tui::fmt_si(4360000000.0L), "4.36 G", "si: 4.36 G");
+    check_str(tui::fmt_si(436000000.0L),  "436.00 M", "si: 436.00 M");
+    check_str(tui::fmt_si(0.0L),          "0.00 ", "si: zero has no unit prefix");
+    check_str(tui::fmt_bytes(0),          "0 B", "bytes: zero");
+    check_str(tui::fmt_bytes(5222),       "5.1 KiB", "bytes: KiB");
+    check_str(tui::fmt_hms(185000),       "00:03:05", "hms: 3m05s");
+    check_str(tui::fmt_hms(3723000),      "01:02:03", "hms: 1h02m03s");
+    check_str(tui::fmt_age(2000),         "2s", "age: seconds");
+    check_str(tui::fmt_age(131000),       "2m11s", "age: minutes");
+    check_str(tui::fmt_age(3900000),      "1h05m", "age: hours");
+
+    // The bar's scale is 0..2x target, so on target is exactly half full and
+    // stops at the `:` mark.
+    check_str(tui::cadence_bar(10000, 10000, 16), "[########:-------]", "bar: on target");
+    check_str(tui::cadence_bar(0, 10000, 16),     "[--------:-------]", "bar: no data");
+    check_str(tui::cadence_bar(40000, 10000, 16), "[################]", "bar: clamped at 2x");
+    check_str(tui::cadence_bar(5000, 10000, 16),  "[####----:-------]", "bar: twice as fast");
+
+    // The pulse ramps over the same 0..2x scale; the newest gap is on the right.
+    const std::vector<std::uint64_t> gaps = {0, 3400, 6700, 10000, 13400, 16700, 20000, 40000};
+    check_str(tui::sparkline(gaps, 10000, 24), "_.-=+*##", "pulse: the full ramp");
+    check_str(tui::sparkline(gaps, 10000, 3), "*##", "pulse: keeps the newest when it is narrow");
+    check_str(tui::sparkline({}, 10000, 24), "", "pulse: empty when there is nothing live");
+
+    // strip_ansi is the inverse of colouring, including adjacent escapes.
+    check_str(tui::strip_ansi("\x1b[2mlabel\x1b[0m\x1b[1mvalue\x1b[0m"), "labelvalue",
+              "strip_ansi removes every CSI sequence");
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc > 1 && std::strcmp(argv[1], "--emit-golden") == 0) {
+        // Prints the golden in the form p2pool_monitor_golden.inc holds it.
+        const std::string frame = tui::snapshot_text(build_frame(), kCols);
+        std::string cur;
+        for (const char c : frame) {
+            if (c == '\n') {
+                std::string esc;
+                for (const char k : cur) {
+                    if (k == '\\' || k == '"') esc.push_back('\\');
+                    esc.push_back(k);
+                }
+                std::printf("\"%s\",\n", esc.c_str());
+                cur.clear();
+            } else cur.push_back(c);
+        }
+        return 0;
+    }
+    if (argc > 1 && std::strcmp(argv[1], "--show") == 0) {
+        std::printf("%s", tui::snapshot_text(build_frame(), kCols).c_str());
+        return 0;
+    }
+
+    check_emit_set();
+    check_render();
+    check_aggregation();
+    check_honesty();
+    check_formatting();
+
+    std::printf("checks=%d failures=%d\n", g_checks, g_fail);
+    if (g_fail) { std::printf("KAT FAILED\n"); return 1; }
+    std::printf("KAT OK\n");
+    return 0;
+}

--- a/src/impl/xmr/p2pool/tools/p2pool_monitor_main.cpp
+++ b/src/impl/xmr/p2pool/tools/p2pool_monitor_main.cpp
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/p2pool/tools/p2pool_monitor_main.cpp
+//
+// `xmr_p2pool_monitor` -- watch all three P2Pool sidechains at once, read-only,
+// in one process, on one screen.
+//
+//   xmr_p2pool_monitor                          full screen, all three chains
+//   xmr_p2pool_monitor --chains mini,nano       two of them
+//   xmr_p2pool_monitor --snapshot --seconds 90  one plain-text frame to stdout
+//
+// TWO MODES, ONE RENDERER. The fullscreen mode paints the frame from
+// p2pool_tui.hpp into an alternate screen at about 1 Hz; `--snapshot` runs the
+// same loop for a fixed window and prints ONE frame of the same layout as plain
+// text with the escapes turned off. That is what makes the display reviewable:
+// a snapshot can be pasted into a PR, diffed, or checked by a KAT, and it is
+// not a second rendering path that could disagree with what the screen shows.
+//
+// It is a HARNESS, like xmr_p2pool_observer. CI BUILDS it so it cannot bit-rot
+// and never RUNS it: running it dials three public networks and the fullscreen
+// mode wants a tty. It registers no ctest test, so the #1539 Not-Run rule does
+// not apply to it. What CI runs is xmr_p2pool_monitor_kat, which is offline and
+// pins the renderer against a golden frame.
+//
+// READ-ONLY, unchanged and unchangeable here: this tool adds no encoder. Every
+// byte it can put on a socket comes from the four-value ControlMessage enum in
+// p2pool_wire.hpp, and the footer of every frame prints that set as computed
+// from the encoder itself.
+//
+// SCOPE FENCE: everything under src/impl/xmr/. UNIX only.
+// ---------------------------------------------------------------------------
+
+#include <poll.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/p2pool/p2pool_multiwatch.hpp"
+
+namespace p2p = c2pool::xmr::p2pool;
+namespace tui = c2pool::xmr::p2pool::tui;
+
+namespace {
+
+bool parse_chain(const std::string& s, p2p::Sidechain& out) {
+    if (s == "main") { out = p2p::Sidechain::Main; return true; }
+    if (s == "mini") { out = p2p::Sidechain::Mini; return true; }
+    if (s == "nano") { out = p2p::Sidechain::Nano; return true; }
+    return false;
+}
+
+std::vector<std::string> split(const std::string& s, char sep) {
+    std::vector<std::string> out;
+    std::string cur;
+    for (const char c : s) {
+        if (c == sep) { out.push_back(cur); cur.clear(); }
+        else cur.push_back(c);
+    }
+    out.push_back(cur);
+    return out;
+}
+
+void usage() {
+    std::cout <<
+        "xmr_p2pool_monitor -- read-only monitor for all three P2Pool sidechains\n"
+        "  --chains LIST        comma list of main,mini,nano (default all three)\n"
+        "  --peers N            connections PER CHAIN (default 4)\n"
+        "  --seconds N          run window; 0 = until q (default 0, or 60 with --snapshot)\n"
+        "  --snapshot           headless: run the window, print ONE plain frame, exit\n"
+        "  --width N            snapshot width in columns (default 100)\n"
+        "  --refresh-ms N       fullscreen repaint interval (default 1000)\n"
+        "  --peer CHAIN:HOST:PORT   dial this peer first on that chain (repeatable)\n"
+        "  --redial-ms N        re-dial cool-off per endpoint (default 300000)\n"
+        "  --seed N             deterministic rng seed\n"
+        "  --no-color           never emit colour, even on a tty\n"
+        "  --log PATH           write the per-peer log there (never to the screen)\n"
+        "\n"
+        "Keys in fullscreen mode: q quit, r redraw.\n";
+}
+
+struct Options {
+    p2p::MonitorConfig mc;
+    bool        snapshot = false;
+    bool        no_color = false;
+    std::size_t width    = 100;
+    std::string log_path;
+    bool        seconds_set = false;
+    std::vector<std::pair<p2p::Sidechain, std::pair<std::string, std::uint16_t>>> peers;
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    Options o;
+    o.mc.run_ms = 0;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        auto next = [&](const char* what) -> std::string {
+            if (i + 1 >= argc) { std::cerr << "missing value for " << what << "\n"; std::exit(2); }
+            return argv[++i];
+        };
+        if (a == "--chains") {
+            o.mc.chains.clear();
+            for (const std::string& piece : split(next("--chains"), ',')) {
+                p2p::Sidechain c{};
+                if (!parse_chain(piece, c)) { std::cerr << "unknown chain " << piece << "\n"; return 2; }
+                o.mc.chains.push_back(c);
+            }
+            if (o.mc.chains.empty()) { std::cerr << "--chains needs at least one chain\n"; return 2; }
+        } else if (a == "--peers")      o.mc.peers_per_chain = static_cast<std::size_t>(std::stoul(next("--peers")));
+        else if (a == "--seconds")      { o.mc.run_ms = std::stoull(next("--seconds")) * 1000ull; o.seconds_set = true; }
+        else if (a == "--snapshot")     o.snapshot = true;
+        else if (a == "--width")        o.width = static_cast<std::size_t>(std::stoul(next("--width")));
+        else if (a == "--refresh-ms")   o.mc.refresh_ms = std::stoull(next("--refresh-ms"));
+        else if (a == "--redial-ms")    o.mc.redial_after_ms = std::stoull(next("--redial-ms"));
+        else if (a == "--seed")         o.mc.seed = std::stoull(next("--seed"));
+        else if (a == "--no-color")     o.no_color = true;
+        else if (a == "--verbose")      o.mc.verbose = true;
+        else if (a == "--log")          o.log_path = next("--log");
+        else if (a == "--peer") {
+            const std::vector<std::string> parts = split(next("--peer"), ':');
+            p2p::Sidechain c{};
+            if (parts.size() != 3 || !parse_chain(parts[0], c)) {
+                std::cerr << "--peer wants CHAIN:HOST:PORT\n";
+                return 2;
+            }
+            o.peers.push_back({c, {parts[1], static_cast<std::uint16_t>(std::stoul(parts[2]))}});
+        } else if (a == "--help" || a == "-h") { usage(); return 0; }
+        else { std::cerr << "unknown argument " << a << "\n"; usage(); return 2; }
+    }
+
+    // A snapshot is a fixed window by definition; the fullscreen mode runs
+    // until the user says otherwise.
+    if (o.snapshot && !o.seconds_set) o.mc.run_ms = 60000;
+
+    p2p::MultiWatch watch(o.mc);
+
+    // Logging never goes to the screen: in fullscreen mode stdout belongs to
+    // the frame, and a stray log line would shear the layout.
+    FILE* logf = nullptr;
+    if (!o.log_path.empty()) {
+        logf = std::fopen(o.log_path.c_str(), "we");
+        if (!logf) { std::cerr << "cannot open " << o.log_path << "\n"; return 2; }
+        watch.set_log([logf](const std::string& m) {
+            std::fprintf(logf, "%s\n", m.c_str());
+            std::fflush(logf);
+        });
+    }
+
+    for (const auto& p : o.peers) watch.add_peer(p.first, p.second.first, p.second.second);
+    watch.seed_all();
+
+    const std::uint64_t t0    = p2p::now_ms();
+    const std::uint64_t t_end = o.mc.run_ms ? t0 + o.mc.run_ms : 0;
+
+    // -----------------------------------------------------------------------
+    // HEADLESS: run the window, print one frame.
+    // -----------------------------------------------------------------------
+    if (o.snapshot) {
+        std::uint64_t next_note = t0 + 15000;
+        while (!p2p::g_tui_quit && (!t_end || p2p::now_ms() < t_end)) {
+            watch.poll_once(-1, 0, 250);
+            const std::uint64_t t = p2p::now_ms();
+            if (t >= next_note) {                     // a long window should not look hung
+                next_note = t + 15000;
+                const tui::MonitorFrame f = watch.frame(t - t0, false);
+                const tui::MonitorTotals tot = tui::totals_of(f.chains);
+                std::fprintf(stderr, "  .. %llus  peers %zu  blocks %zu\n",
+                             static_cast<unsigned long long>((t - t0) / 1000),
+                             tot.peers_up, tot.blocks);
+            }
+        }
+        // The frame is taken BEFORE the sockets are closed. Closing first would
+        // print "4 peers up / 0 sockets", which is true of a process on its way
+        // out and false of the window the frame is reporting on.
+        const std::uint64_t elapsed = p2p::now_ms() - t0;
+        const tui::MonitorFrame f = watch.frame(elapsed, false);
+        watch.close_all();
+        std::cout << tui::snapshot_text(f, o.width) << std::flush;
+        if (logf) std::fclose(logf);
+        // Non-vacuity, the same rule the observer harness applies: a run that
+        // connected to nothing and parsed nothing is a failed run, and must not
+        // green a pipeline by printing an empty frame.
+        return tui::totals_of(f.chains).blocks ? 0 : 1;
+    }
+
+    // -----------------------------------------------------------------------
+    // FULLSCREEN.
+    // -----------------------------------------------------------------------
+    p2p::TerminalUi term;
+    const bool tty = term.begin();
+    if (!tty) {
+        std::cerr << "stdout is not a terminal -- use --snapshot for a headless frame\n";
+        if (logf) std::fclose(logf);
+        return 2;
+    }
+    const bool color = !o.no_color;
+
+    std::size_t cols = 100, rows = 30;
+    std::uint64_t next_paint = 0;
+    bool quit = false;
+
+    while (!quit && !p2p::g_tui_quit && (!t_end || p2p::now_ms() < t_end)) {
+        const short rev = watch.poll_once(STDIN_FILENO, POLLIN, 200);
+        if (rev & POLLIN) {
+            char keys[32];
+            const ssize_t n = ::read(STDIN_FILENO, keys, sizeof(keys));
+            for (ssize_t k = 0; k < n; ++k) {
+                if (keys[k] == 'q' || keys[k] == 'Q' || keys[k] == 3 /* ^C */) quit = true;
+                if (keys[k] == 'r' || keys[k] == 'R') next_paint = 0;
+            }
+        }
+        const std::uint64_t t = p2p::now_ms();
+        if (p2p::g_tui_resized) { p2p::g_tui_resized = 0; term.size(cols, rows); next_paint = 0; }
+        if (t >= next_paint) {
+            next_paint = t + o.mc.refresh_ms;
+            const tui::MonitorFrame f = watch.frame(t - t0, true);
+            term.paint(tui::render(f, cols, rows, color));
+        }
+    }
+
+    const std::uint64_t elapsed = p2p::now_ms() - t0;
+    const tui::MonitorFrame f = watch.frame(elapsed, false);   // before the sockets go
+    watch.close_all();
+    term.end();                       // back to the normal screen BEFORE printing
+    if (logf) std::fclose(logf);
+
+    // The alternate screen takes the frame with it when it goes, so the last
+    // one is reprinted on the normal screen: a session that ends should leave
+    // its numbers behind, not a blank prompt.
+    std::cout << tui::snapshot_text(f, cols) << std::flush;
+    return 0;
+}


### PR DESCRIPTION
## What this is

One **read-only** process watching **all three P2Pool sidechains at once** — main
(37889), mini (37888), nano (37890) — three consensus contexts multiplexed through
**one `poll()`**, behind a fullscreen ANSI/termios TUI. Stacked on c2pool#1593
(`v37/xmr-p2pool-observer`): same wire, same parser, same read model, **no new
encoder**.

```
xmr_p2pool_monitor                          fullscreen, all three chains
xmr_p2pool_monitor --chains mini,nano       two of them
xmr_p2pool_monitor --snapshot --seconds 90  one plain-text frame to stdout
```

## Proven live

A four-minute `--snapshot` run against the real networks on workstation-191, one
process, all three chains populated:

```
 p2pool monitor  READ-ONLY  chains 3/3  up 00:04:00  peers 9/279  blocks 237  races 3  19.7 KiB out
----------------------------------------------------------------------------------------------------
 MAIN  port 37889  LIVE  target 10s ----------------------------------------------------------------
   tip      15200706 0688ec8a  diff 4.35 G  hash 434.79 MH/s  cum 30.91 P
   cadence  13.25 s / 10 s  [##########------]  over 16 live heights above 15200688
   pulse    ._*_+_##-.__+..  gaps, newest right (15)
   races    contested 2  uncles named 3 resolved 2  monero tpl 3760156 over 6 heights
   net      4 up / 4 sock / 124 known / 173 gossip / 164 queued  blocks 81 (dup 165, bad 0, bc 0)
   out      chal 5  sol 4  block_req 246  peer_req 12  = 8.2 KiB sent
   feed     15200706 0688ec8a  30s 39sh u1   15200705 42be9aa4  35s 39sh

 MINI  port 37888  LIVE  target 10s ----------------------------------------------------------------
   tip      14758158 68937209  diff 235.72 M  hash 23.57 MH/s  cum 2.44 P
   cadence  13.55 s / 10 s  [##########------]  over 18 live heights above 14758136
   pulse    ==+#.===##+==..#+  gaps, newest right (17)
   races    contested 1  uncles named 2 resolved 1  monero tpl 3760156 over 7 heights
   net      1 up / 3 sock / 41 known / 47 gossip / 0 queued  blocks 83 (dup 28, bad 0, bc 0)
   out      chal 1  sol 1  block_req 111  peer_req 3  = 3.6 KiB sent
   feed     14758158 68937209  3s 702sh   14758157 f5fd39c8  18s 703sh

 NANO  port 37890  LIVE  target 30s ----------------------------------------------------------------
   tip      1392499 4f099523  diff 128.90 M  hash 4.30 MH/s  cum 136.54 T
   cadence  31.61 s / 30 s  [########:-------]  over 8 live heights above 1392490
   pulse    ._.*+_#  gaps, newest right (7)
   races    contested 0  uncles named 0 resolved 0  monero tpl 3760156 over 14 heights
   net      4 up / 4 sock / 114 known / 164 gossip / 144 queued  blocks 73 (dup 164, bad 0, bc 0)
   out      chal 5  sol 4  block_req 237  peer_req 12  = 7.9 KiB sent
   feed     1392499 4f099523  12s 404sh   1392498 b9e4ea7f  1m26s 404sh

----------------------------------------------------------------------------------------------------
 emitted ids {0,1,3,6}  CHALLENGE  SOLUTION  BLOCK_REQUEST  PEER_LIST_REQUEST
 never emitted: LISTEN_PORT, BLOCK_RESPONSE, BLOCK_BROADCAST, BLOCK_NOTIFY -- no encoder exists
```

`main` 13.25 s over 16 live heights, `mini` 13.55 s over 18, `nano` 31.61 s over 8;
9 handshaken peers; 237 distinct blocks; 3 same-height races with 3 uncles resolved;
19.7 KiB sent, all of it handshakes, block requests and peer-list requests. All three
panels carry the **same Monero template height (3760156)** — the cross-chain sanity
check that these are three views of one network rather than three copies of one chain.

## One poll(), three chains, no threads

An `Observer` **is** one sidechain (one consensus id, one peer set, one read model,
one byte ledger) and that shape is kept — the monitor holds three of them. What
cannot be had three times is the event loop: three `::poll()` calls in sequence means
each blocks the other two for its timeout, and the five-second tip-poll rule that
keeps a pulling observer from being banned starts to slip. Threads would fix the
stall and bring a mutex around every read model for three sockets' worth of traffic.

So the observer's loop is split into the three phases it already contained:

```
for each chain: begin_tick()                       dial, reap
for each chain: begins[i] = pfds.size(); collect() append its sockets
append the tty                                     a keypress wakes the loop
::poll(pfds, timeout)                              the only blocking call
for each chain: dispatch(pfds + begins[i], n_i)    its own slice, only
```

**The range is the tag.** A chain's sockets occupy a contiguous slice of the shared
array, so there is no per-fd chain map to build, look up or leave stale, and a chain
cannot be handed another chain's `revents` — it is handed a pointer and a length.
`run()` is rewritten in terms of the same three calls, so the single-chain harness
and the monitor cannot drift apart. Per-connection timers needed nothing:
`next_tip_poll_ms_` already lives inside `PeerSession`.

## Still read-only, and the frame says so from the encoder

No new encoder, no `PoolBlock` serialiser, no `LISTEN_PORT`, no `bind`/`listen`/
`accept`. The emitted id set is still exactly **{0, 1, 3, 6}**, the new KAT
re-asserts it for this second binary, and the footer of every frame prints that set
**as computed from the encoder** — encode each `ControlMessage`, read the id byte
back — rather than as a typed-in list. A fifth encoder would start announcing itself
on screen in the same breath as it failed the test.

## The TUI has no dependencies

ANSI escapes and POSIX `termios`. Raw mode is four flags, the alternate screen and
the cursor are two escapes each, the size is `TIOCGWINSZ`, `SIGWINCH` sets a flag.
**No ncurses, no boost, no asio, no threads.** The restore path is installed three
ways over — a quit flag on `SIGINT`/`SIGTERM`, the `TerminalUi` destructor, an
`atexit` hook — because a monitor that dies in raw mode leaves someone with a shell
that does not echo. Everything drawn is printable ASCII, so one byte is one column
and the alignments are not guesses.

## A pure renderer, pinned against a golden frame

`p2pool_tui.hpp` is deliberately POSIX-free: no socket, no terminal, no clock — ages
and uptime resolve at one instant handed in by the caller. That is what lets
`xmr_p2pool_monitor_kat` fill three read models with fixed synthetic observations at
fixed timestamps and compare the **whole frame**, byte for byte, against
`test/p2pool_monitor_golden.inc` (kept in its own file so a reviewer can read it as a
picture). A dashboard is the easiest place in a codebase to hide a wrong number,
because the only thing that would catch it is somebody looking at it.

Colour is additive and nothing else: `strip_ansi(render(colour))` equals
`render(plain)` line for line, which the KAT asserts — so `--snapshot` is the same
renderer with the escapes off, not a second one that could disagree with the screen.

The panels inherit the read model's refusals rather than softening them for looks:
below two live samples the cadence line says `warming` instead of printing a number,
the pulse shows the individual live gaps because a mean hides the difference between
a steady beat and a stall between bursts, and `monero tpl` is labelled a template
height — deciding that a sidechain block cleared Monero's target needs a PoW target
this observer does not hold.

## What the live runs found

**A whole sidechain went dark, and the panel is how it was caught.** On the second
live run main reported `DARK — 0 up / 0 sock / 0 known / 0 queued / 0 B sent` for
four minutes while mini and nano were fine. Three real bugs behind it, all fixed:

* both of main's DNS seeds failed inside `start()`, and `fail()` only logged when the
  session had already left `State::Closed` — which a session that never connected
  never does. The failure was **silent**. It logs now, and the very next run printed
  `peer main.p2poolpeers.net:37889 closed: dns`, naming a seed host that does not
  resolve;
* a failed dial then took the same five-minute cool-off as a peer that had talked and
  hung up. A dial that never reached a socket is a different fact and now earns a
  15-second retry;
* with no peer connected there is no peer-list gossip, so the seeds were the only way
  back. `reseed()` now clears the cool-off on the seed endpoints of a chain that has
  nothing, and the monitor reseeds a dark chain every 20 seconds.

Two display defects as well, invisible until three real chains were on screen at
once: the final snapshot was taken *after* the sockets were closed and so reported
`4 up / 0 sockets`, and the `net` line overflowed 100 columns once peer counts reached
three digits, truncating `bcast` mid-word.

`DARK` next to `0 queued` said on sight that the chain had nothing left to dial —
a different failure from "peers are refusing us", and the two look identical in a log.

## Tests

| | |
|---|---|
| `xmr_p2pool_monitor_kat` | **181 checks, 0 failures** — emit-set `{0,1,3,6}`, golden frame, geometry at 12 sizes, colour-is-additive, 3-chain aggregation, the honesty rules |
| `xmr_p2pool_parse_kat` | **253 checks, 0 failures** — unchanged, still green |

Both are offline: no network, no daemon, no tty. Both registered with `add_test` and
in **both** `--target` lists in `build.yml`, along with both live binaries, because
this directory sits outside the coin-test allowlist glob (c2pool#1539: a target
registered with `add_test` but never built reports `***Not Run` and exits non-zero).

`xmr_p2pool_monitor` dials three public networks and its fullscreen mode wants a tty,
so — exactly like `xmr_p2pool_observer` — CI **builds** it and **never runs** it, and
it registers no ctest test.

## One behaviour change to the observer

Re-dialling. Never re-dialling is right for a 300-second harness and wrong for a
process left running for hours, where every peer that ever hung up would be excluded
permanently and the dial queue would drain. `redial_after_ms` defaults to **0
(never)**, so `run()` behaves exactly as before; the monitor sets five minutes, and
the queue is capped so gossip cannot grow it without bound overnight.

## Scope

Everything under `src/impl/xmr/p2pool/` plus its two `CMakeLists.txt` and the two
`build.yml` target lists. **Zero files under `src/sharechain/`, no consensus edit.**

DRAFT, stacked on c2pool#1593 — do not merge ahead of it.
