### PR TITLE
dash(qc): pull hook at qc-plan-underivable refusal — ask, dont just wait (#1203)

### DIFF
--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -879,6 +879,23 @@ public:
         };
     }
 
+    /// #1203 — "ask, don't just wait". When a height fails closed with
+    /// cause=qc-plan-underivable the offending quorum's identity is KNOWN
+    /// (QcPlanGap::slot_known, the SlotUnsatisfied stage). dashd relays
+    /// quorum commitments by inventory ONLY, so a node that missed the inv
+    /// has no path to that commitment and the refusal tail runs to ~10 min
+    /// (issue #1203). This hook is invoked at the refusal site WITH that gap
+    /// so a targeted re-request (a getqrinfo for the named quorum) can be
+    /// issued to shorten the tail. It NEVER mints a null commitment and NEVER
+    /// changes what is served — the refusal is still reward-safe and still
+    /// fails closed to the dashd arm. Fired only when the gap names a single
+    /// quorum; the SlotSetUnderivable / Unreported stages have nothing to ask
+    /// for. UNSET (default) => byte-identical to today: the refusal simply
+    /// waits for the next inventory relay.
+    void set_qc_pull_fn(std::function<void(const QcPlanGap&)> fn) {
+        m_qc_pull_fn = std::move(fn);
+    }
+
     /// PoSe no-op proof for one REAL (non-null) type-6 commitment — the
     /// enforcement of the #1083 landmine comment at the inclusion site
     /// (embedded_gbt.hpp). dashd's verifier PoSe-punishes every member a
@@ -1151,9 +1168,13 @@ public:
         if (m_qc_plan_fn) {
             QcPlanGap qc_gap;
             qc_plan = m_qc_plan_fn(next_h, &qc_gap);
-            if (!qc_plan)   // underivable — fail closed, NAMING what was missing
+            if (!qc_plan) {  // underivable — fail closed, NAMING what was missing
+                // #1203: ASK for the named quorum rather than only waiting for
+                // the next inventory relay (unset hook => unchanged wait).
+                if (m_qc_pull_fn && qc_gap.slot_known) m_qc_pull_fn(qc_gap);
                 return reject("emit-qc-plan-underivable", qc_gap.describe(),
                               "derivable-qc-plan@h=" + std::to_string(next_h));
+            }
             // Collect the type-6 payloads actually in the template.
             std::vector<std::vector<unsigned char>> got;
             for (const auto& tx : w.m_txs)
@@ -1470,6 +1491,9 @@ public:
         if (m_qc_plan_fn && m_populated) {
             qc_plan = m_qc_plan_fn(m_prev_height + 1, &qc_gap);
             qc_ok = qc_plan.has_value();
+            // #1203: ASK for the named quorum on the underivable refusal
+            // instead of only waiting for the next inventory relay.
+            if (!qc_ok && m_qc_pull_fn && qc_gap.slot_known) m_qc_pull_fn(qc_gap);
         }
         // Resolve the superblock disposition ONCE (fail-closed unless the
         // daemonless provider is trigger-confident) and thread the schedule.
@@ -2049,6 +2073,12 @@ private:
     // E1: serve DKG windows daemonlessly. The QcPlanGap out-param is how a
     // refusal learns WHICH quorum it lacked (see set_qc_plan_fn).
     std::function<std::optional<QcBlockPlan>(uint32_t, QcPlanGap*)> m_qc_plan_fn;
+    // #1203: "ask, don't just wait". Invoked at a qc-plan-underivable refusal
+    // with the named-quorum gap so a targeted re-request (getqrinfo for the
+    // quorum the refusal named) can shorten the ~10-min inventory-only tail.
+    // Fired only when the gap names a single quorum (slot_known); UNSET
+    // (default) => the refusal simply waits for the next relay, byte-identical.
+    std::function<void(const QcPlanGap&)> m_qc_pull_fn;
     // PoSe no-op proof for a REAL commitment (emit-qc-real-pose-unfolded gate);
     // unset => capability absent => every non-null commitment refused.
     std::function<std::optional<bool>(const vendor::CFinalCommitment&)> m_qc_pose_noop_fn;

--- a/test/test_dash_node_coin_state.cpp
+++ b/test/test_dash_node_coin_state.cpp
@@ -589,6 +589,71 @@ TEST(DashNodeCoinState, QcPlanServesDkgWindowHeightAndEmitGateEnforcesIt) {
     EXPECT_FALSE(st.make_embedded_work_inputs().viable());
 }
 
+TEST(DashNodeCoinState, QcPullHookFiresWithNamedQuorumOnUnderivableRefusal) {
+    // #1203: on a qc-plan-underivable refusal the offending quorum IS known
+    // (QcPlanGap::slot_known). This proves the "ask, don't just wait" seam:
+    // the pull hook fires exactly once, targeting the quorum the refusal
+    // named, WITHOUT changing the reward-safe fail-closed outcome; and it
+    // does NOT fire when the gap names no single quorum or when it is unset.
+    NodeCoinState st;
+    seed_single_mn(st, p2pkh_script(0x30));
+    seed_sml(st);
+    st.set_require_sml(true);
+    st.set_commitment_window_fn(
+        [](uint32_t next_h) { return dash::coin::is_dkg_commitment_window(next_h); });
+    st.set_sml_current_hash(raw256(0xAB));
+    st.set_tip(1518417, raw256(0xAB), 0x1b104be3u, 1'700'000'000u,
+               DASH_PUBKEY_VER, DASH_P2SH_VER, 1'700'000'123u, 0x20000000u);
+
+    const uint256 want_q = raw256(0x7E);
+    auto naming_plan_fn =
+        [want_q](uint32_t, dash::coin::QcPlanGap* gap)
+            -> std::optional<dash::coin::QcBlockPlan> {
+            if (gap) {
+                *gap = dash::coin::QcPlanGap{};
+                gap->stage = dash::coin::QcPlanStage::SlotUnsatisfied;
+                gap->slot_known = true;
+                gap->llmq_type = 4;
+                gap->quorum_index = 0;
+                gap->quorum_hash = want_q;
+                gap->slot_gap = dash::coin::QcSlotGap::NoCommitmentCached;
+            }
+            return std::nullopt;
+        };
+
+    // Hook UNSET (default): the refusal still fails closed, nothing fires.
+    st.set_qc_plan_fn(naming_plan_fn);
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable());
+
+    // Hook SET: fires exactly once, targeting the named quorum, and does NOT
+    // change the reward-safe refusal.
+    int pulls = 0;
+    uint256 pulled_q;
+    st.set_qc_pull_fn([&](const dash::coin::QcPlanGap& g) {
+        ++pulls;
+        pulled_q = g.quorum_hash;
+    });
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable())
+        << "the pull hook must not change the fail-closed outcome";
+    EXPECT_EQ(pulls, 1);
+    EXPECT_EQ(pulled_q, want_q)
+        << "the pull must target the quorum the refusal named";
+
+    // A gap with NO single quorum (SlotSetUnderivable) must NOT fire — there
+    // is nothing to ask for.
+    st.set_qc_plan_fn([](uint32_t, dash::coin::QcPlanGap* gap)
+                          -> std::optional<dash::coin::QcBlockPlan> {
+        if (gap) {
+            *gap = dash::coin::QcPlanGap{};
+            gap->stage = dash::coin::QcPlanStage::SlotSetUnderivable;
+        }
+        return std::nullopt;
+    });
+    pulls = 0;
+    EXPECT_FALSE(st.make_embedded_work_inputs().viable());
+    EXPECT_EQ(pulls, 0) << "no named quorum => nothing to pull";
+}
+
 // BLOCKER-2 viability: a stale/absent bestCL fails closed; a fresh one serves.
 TEST(DashNodeCoinState, StaleBestClRefusesEmbedded) {
     NodeCoinState st;


### PR DESCRIPTION
Fixes #1203

## What #1203 concluded, and what this does

`qc-plan-underivable` is a **propagation wait, not a missing mechanism** — the analysis in the issue is right, and every production episode ends `terminal=real-arrived`. The remaining work is **latency**: dashd relays quorum commitments **by inventory only**, so a node that missed the `inv` has no path to that commitment and the refusal tail runs to ~10 min. The fix direction the issue names is to *ask* for the commitment at the refusal site, where the exact quorum is already known.

This PR lands the **seam** for that, SAFE-ADDITIVE:

- `NodeCoinState::set_qc_pull_fn(std::function<void(const QcPlanGap&)>)` — invoked at BOTH underivable refusal sites (`make_embedded_work_inputs` viability + `embedded_template_emit_ok`) **only when the gap names a single quorum** (`QcPlanGap::slot_known`, the `SlotUnsatisfied` stage). The `SlotSetUnderivable` / `Unreported` stages have nothing to ask for and do not fire.
- It **never** mints a null commitment and **never** changes what is served. The refusal stays reward-safe and still fails closed to the dashd fallback.
- **Hook UNSET (default) => byte-identical to master.** The pre-existing 109 tests are unchanged.

## Verification (this PR)

- KAT added to `test_dash_node_coin_state` (already CI-allowlisted in build.yml): proves the hook fires **exactly once** with the quorum the refusal named, does **not** alter the fail-closed outcome, and does **not** fire for `SlotSetUnderivable` or when unset.
- Full suite: **110/110 green**, linux gcc13 Release (109 -> 110, my +1).

## Why draft — the next slice

The on-wire pull is a `getqrinfo` for the named quorum issued across the coin/p2p boundary (bounded + expiring to avoid a retry-storm), which is exactly the kind of change whose acceptance is a **soak, not a unit green**. Per the issue: the `dur=` distribution before/after over a 12h soak, quoted with its denominator — the claim is a **shorter tail, never zero episodes and never a null commitment**. Kept draft until that soak evidence lands and integrator verifies.