### PR TITLE
xmr(native): autonomous reorg-follow after same-height race loss [DO NOT MERGE]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,7 @@ jobs:
                     xmr_levin_codec_kat xmr_epee_storage_kat xmr_levin_messages_kat xmr_levin_fuzz_kat \
                     xmr_native_block_id_kat xmr_native_consensus_state_kat \
                     xmr_native_anchor_self_check_kat xmr_native_chain_index_kat \
+                    xmr_native_reorg_follow_kat \
                     xmr_levin_socket_kat xmr_levin_link_kat \
                     xmr_native_rct_verify_kat xmr_native_txpool_kat \
                     xmr_native_chain_locator_kat xmr_native_peer_store_kat \
@@ -680,6 +681,7 @@ jobs:
                     xmr_levin_codec_kat xmr_epee_storage_kat xmr_levin_messages_kat xmr_levin_fuzz_kat \
                     xmr_native_block_id_kat xmr_native_consensus_state_kat \
                     xmr_native_anchor_self_check_kat xmr_native_chain_index_kat \
+                    xmr_native_reorg_follow_kat \
                     xmr_levin_socket_kat xmr_levin_link_kat \
                     xmr_native_rct_verify_kat xmr_native_txpool_kat \
                     xmr_native_chain_locator_kat xmr_native_peer_store_kat \

--- a/src/impl/xmr/native/chain/xmr_chain_index.hpp
+++ b/src/impl/xmr/native/chain/xmr_chain_index.hpp
@@ -655,10 +655,25 @@ public:
     // plus anything a refused reorg needs before it can be retried. The sync
     // driver reads this; the index never schedules its own network traffic
     // beyond the single hint request above.
+    //
+    // Ids whose BYTES we already hold are filtered out here rather than pruned
+    // from the lists: `wanted_` is replaced wholesale by the next chain entry
+    // and `refetch_` is deliberately a standing want list, so neither is a
+    // record of what is still missing. Without the filter the driver re-asked
+    // for a block it was already holding every refetch_reask_ms, forever --
+    // which is what a parked branch looks like from the outside, and what made
+    // "we are not making progress" indistinguishable from "the peer is not
+    // answering". Membership is not enough: a bodiless fluffy announcement and
+    // a row whose body has been evicted are both "known" and both still need
+    // fetching, so the test is whether we have bytes we could re-apply.
     std::vector<Hash> refetch_wanted() const {
         std::lock_guard<std::mutex> lk(mu_);
-        std::vector<Hash> out = wanted_;
-        out.insert(out.end(), refetch_.begin(), refetch_.end());
+        std::vector<Hash> out;
+        out.reserve(wanted_.size() + refetch_.size());
+        for (const Hash& id : wanted_)
+            if (!have_body_locked_(id)) out.push_back(id);
+        for (const Hash& id : refetch_)
+            if (!have_body_locked_(id) && !contains_hash_(out, id)) out.push_back(id);
         return out;
     }
 
@@ -776,8 +791,42 @@ private:
         // The difficulty this block had to beat, on ITS branch.
         U128 difficulty{};
         if (!branch_difficulty_locked_(prev, parent_height, rules, difficulty, why)) {
-            // We cannot see far enough back to judge it. Not a fault, not a
-            // rejection: park it and say what is missing.
+            // We cannot see far enough back to judge it YET. Not a fault, not a
+            // rejection -- and, until now, not a park either: this path SAID
+            // ParkedOrphan and then returned without storing the block, without
+            // asking for anything, and without a line in the journal. The block
+            // was destroyed. Every re-delivery hit the same return, so the
+            // fork-point child of a rival branch could be handed to this node
+            // forever and never be held once; AltPool::heaviest() never had a
+            // candidate, the fork choice never ran, and the node sat on its own
+            // tip while its peers moved on. Park it for real, so that the moment
+            // the missing piece lands -- the parent resolving, or the chain
+            // growing past the fork point -- resolve_descendants_locked_ picks
+            // it up and the fork choice finally gets to see it.
+            //
+            // Unresolved and un-adoptable, deliberately: it has no cumulative
+            // difficulty on its branch, heaviest() skips it, and the fail-closed
+            // bound in the switch refuses any branch containing it. Holding
+            // bytes is the whole of what happens here.
+            if (const AltBlock* have = alt_.find(r.id); have && have->has_entry) {
+                r.outcome = OfferOutcome::Duplicate;
+                r.why     = "already parked, unjudgeable: " + why;
+                return r;
+            }
+            const bool was_parked = alt_.contains(r.id);
+            AltBlock b;
+            b.id             = r.id;
+            b.prev_id        = prev;
+            b.height         = r.height;
+            b.resolved       = false;
+            b.adoptable      = false;
+            b.own_mined      = own_mined;
+            b.entry          = std::move(entry);
+            b.has_entry      = true;
+            b.first_seen_seq = ++seq_;
+            if (peer) b.source = *peer;
+            alt_.insert(std::move(b));
+            if (!was_parked) ++orphans_;
             r.outcome = OfferOutcome::ParkedOrphan;
             r.why     = why;
             return r;
@@ -843,7 +892,18 @@ private:
                 // parked behind it.
                 resolve_descendants_locked_(r.id);
                 connect_parked_children_locked_();
-                r.outcome = OfferOutcome::Connected;
+                // And then ask the fork choice, because the two calls above can
+                // have RESOLVED a branch that was unjudgeable a moment ago: a
+                // block whose difficulty window only became assemblable once the
+                // chain grew, or whose parent only just landed. The branch path
+                // runs the fork choice on every offer; this one did not, so a
+                // branch that became heavier as a side effect of an ordinary
+                // extend would sit resolved-and-ignored until the next block
+                // happened to arrive on it. maybe_switch_locked_() is a no-op
+                // when nothing outweighs the tip, so the cost is one comparison.
+                const bool switched = maybe_switch_locked_();
+                r.outcome = switched && !rows_.contains(r.id) ? OfferOutcome::StoredAsAlt
+                                                              : OfferOutcome::Connected;
                 return r;
             }
             if (co.status == ConnectStatus::BodiesMissing) {
@@ -975,7 +1035,14 @@ private:
                 return false;
             }
             const std::size_t need = DIFFICULTY_BLOCKS_COUNT - upper.size();
-            if (!rows_.difficulty_window_ending_at(anchor_row->row.height, need, window)) {
+            // allow_young_chain: a chain shorter than the window is not a chain
+            // we cannot see far enough back on -- it is a chain with nothing
+            // more to see. The tip fast path above already answers from a short
+            // window (the state's own), so refusing here is the branch path
+            // disagreeing with the tip path about the same rows. The store
+            // grants it only when it holds the chain from height 0.
+            if (!rows_.difficulty_window_ending_at(anchor_row->row.height, need, window,
+                                                   /*allow_young_chain=*/true)) {
                 why = "the retained window does not reach the fork point";
                 return false;
             }
@@ -1512,6 +1579,17 @@ private:
     static bool contains_hash_(const std::vector<Hash>& v, const Hash& h) {
         for (const Hash& x : v) if (x == h) return true;
         return false;
+    }
+
+    // Do we hold bytes we could re-apply for this id? Deliberately NOT "do we
+    // know it": a fluffy announcement parked without its transactions, and a
+    // best-chain row whose body has aged out of the entry cache, are both known
+    // and both still need fetching -- and a reorg that needs either of them is
+    // refused with MissingBodies and asks for exactly this id back.
+    bool have_body_locked_(const Hash& id) const {
+        if (entries_.find(key_(id)) != entries_.end()) return true;
+        const AltBlock* b = alt_.find(id);
+        return b && b->has_entry;
     }
 
     void penalize_locked_(const PeerRef* p, PeerFault f, const std::string& why) {

--- a/src/impl/xmr/native/chain/xmr_row_store.hpp
+++ b/src/impl/xmr/native/chain/xmr_row_store.hpp
@@ -190,19 +190,48 @@ public:
         pre_begin_  = rows.size() ? end_height + 1 - rows.size() : end_height + 1;
     }
 
+    // The height of the first block this store can speak for: the start of the
+    // seeded pre-window when there is one, and otherwise the oldest row it
+    // retains. Zero means we hold the chain from its very first block, so there
+    // is nothing missing BELOW us -- only, possibly, nothing there at all yet.
+    std::uint64_t base_height() const noexcept {
+        if (!pre_window_.empty()) return pre_begin_;
+        return rows_.empty() ? 0 : rows_.front().row.height;
+    }
+
     // The (timestamp, cumulative difficulty) window ending at `height`, oldest
     // first, as the difficulty retarget wants it. Returns false when the store
     // cannot reach far enough back -- which is exactly the condition that makes
     // a deep fork unjudgeable and therefore refusable, rather than guessed at.
+    //
+    // `allow_young_chain` is the one case where a window SHORTER than `count` is
+    // the right answer rather than a refusal: the chain itself is younger than
+    // the window. monerod does not refuse there --
+    // Blockchain::get_difficulty_for_next_block collects min(height, 735) rows --
+    // and neither does this index's own tip fast path, which reads the consensus
+    // state's rolling window and therefore gets exactly the rows that exist.
+    // Only the BRANCH path came through here, so only the branch path refused,
+    // and a from-genesis node could not weigh ANY fork below its own tip until
+    // the chain was 735 blocks long: every regtest rig, always, and the first
+    // day of any from-genesis sync.
+    //
+    // The relaxation is granted only when base_height() == 0 -- we genuinely
+    // hold the chain from its first block. A store that merely STARTS high
+    // (trimmed rows, or an anchored boot whose pre-window does not reach the
+    // fork point) still cannot see far enough back, and that refusal must stay
+    // a refusal: a guessed window would put a wrong difficulty on a branch and
+    // the apply path would then disagree with itself.
     bool difficulty_window_ending_at(std::uint64_t height, std::size_t count,
-                                     std::vector<DifficultyRow>& out) const {
+                                     std::vector<DifficultyRow>& out,
+                                     bool allow_young_chain = false) const {
         out.clear();
         if (rows_.empty() || height > rows_.back().row.height) return false;
         if (height < rows_.front().row.height) return false;
 
         const std::uint64_t span = static_cast<std::uint64_t>(count);
-        if (height + 1 < span) return false;              // no such window exists
-        const std::uint64_t lo = height + 1 - span;
+        const bool young = allow_young_chain && base_height() == 0;
+        if (height + 1 < span && !young) return false;    // no such window exists
+        const std::uint64_t lo = height + 1 >= span ? height + 1 - span : 0;
 
         const std::uint64_t rows_lo = rows_.front().row.height;
         out.reserve(static_cast<std::size_t>(span));

--- a/src/impl/xmr/native/p2p/xmr_peer_pool.hpp
+++ b/src/impl/xmr/native/p2p/xmr_peer_pool.hpp
@@ -706,10 +706,34 @@ private:
                                : levinns::decode_new_block(body, n, m, err);
         if (!ok) { raise_fault(key, DosFault::MalformedBody, "block push body"); return; }
 
-        if (Peer* p = find(key)) p->last_relay_ms = now_ms();
+        if (Peer* p = find(key)) {
+            p->last_relay_ms = now_ms();
+            if (note_peer_height(*p, m.current_blockchain_height)) publish_snapshot();
+        }
         ++tel_.blocks_in;
         if (deps_.index)
             deps_.index->on_new_block(ref, std::move(m.b), m.current_blockchain_height, fluffy);
+    }
+
+    // A block push and an objects response both carry the sender's
+    // current_blockchain_height, and neither was folded into the peer's sync
+    // snapshot: only TIMED_SYNC was, on a 60 s beat. The sync driver decides
+    // whether to ask a peer for a chain by comparing that snapshot against our
+    // own tip, so for up to a minute after a peer moved onto a heavier branch we
+    // believed it was still level with us and asked it nothing -- while it
+    // relayed blocks whose parents we did not have. Folding the height in here
+    // makes the FIRST frame after the peer moves the thing that starts the
+    // catch-up, instead of the next beat.
+    //
+    // The HEIGHT only. cumulative_difficulty stays whatever the peer last put in
+    // a sync payload: it is the number the peer ranking and the fork choice are
+    // priced in, and deriving one from a height would be the claim-instead-of-
+    // work this whole layer refuses. Monotone, so a late frame from a peer that
+    // has since been rolled back cannot walk the snapshot backwards.
+    static bool note_peer_height(Peer& p, std::uint64_t current_blockchain_height) {
+        if (current_blockchain_height <= p.sync.current_height) return false;
+        p.sync.current_height = current_blockchain_height;
+        return true;
     }
 
     void handle_transactions(const std::string& key, const PeerRef& ref,
@@ -764,6 +788,7 @@ private:
         if (!p) return;
         ++tel_.objects_in;
         p->wire_busy = false;
+        note_peer_height(*p, m.current_blockchain_height);
 
         const std::uint64_t span_id = p->in_flight_span;
         p->in_flight_span = kNoSpan;

--- a/src/impl/xmr/native/test/CMakeLists.txt
+++ b/src/impl/xmr/native/test/CMakeLists.txt
@@ -282,6 +282,39 @@ if (BUILD_TESTING)
     add_test(NAME xmr_native_chain_index_kat COMMAND xmr_native_chain_index_kat)
 
     # ─────────────────────────────────────────────────────────────────────────
+    # REORG-FOLLOW: the same index, booted the way a regtest node boots -- ONE
+    # row at height 0 and nothing below it -- following a heavier branch that
+    # forked below its tip, while running.
+    #
+    # A SEPARATE TARGET RATHER THAN MORE CASES IN THE FILE ABOVE, on purpose.
+    # That fixture seeds a full 735-row difficulty window because it replays
+    # stagenet from an anchor, so every fork point it reaches is already
+    # covered and its reorg suite passed while a from-genesis node could not
+    # reorganise at all. The young-chain state is not reachable from that
+    # fixture; it needs its own boot, and keeping the two apart is what stops
+    # the next person from "simplifying" this one onto the anchored seed and
+    # quietly deleting the coverage.
+    #
+    # Same light link (xmr_coin + header-only boost, no RandomX, no daemon) and
+    # the same drift-guard rule: added to BOTH --target lists in
+    # .github/workflows/build.yml by the change that adds it here (#1539).
+    # ─────────────────────────────────────────────────────────────────────────
+    add_executable(xmr_native_reorg_follow_kat xmr_reorg_follow_kat.cpp)
+    target_include_directories(xmr_native_reorg_follow_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(xmr_native_reorg_follow_kat PRIVATE xmr_coin)
+    target_compile_features(xmr_native_reorg_follow_kat PRIVATE cxx_std_20)
+    if (TARGET Boost::headers)
+        target_link_libraries(xmr_native_reorg_follow_kat PRIVATE Boost::headers)
+    elseif (TARGET Boost::boost)
+        target_link_libraries(xmr_native_reorg_follow_kat PRIVATE Boost::boost)
+    elseif (DEFINED Boost_INCLUDE_DIRS)
+        target_include_directories(xmr_native_reorg_follow_kat PRIVATE ${Boost_INCLUDE_DIRS})
+    endif()
+    add_test(NAME xmr_native_reorg_follow_kat COMMAND xmr_native_reorg_follow_kat)
+
+    # ─────────────────────────────────────────────────────────────────────────
     # Wave 1 / C1c: the peer manager and DoS (../p2p/chain_seeds.hpp,
     # chain_locator.hpp, xmr_peer_store.hpp, xmr_dial_plan.hpp, xmr_p2p_dos.hpp,
     # xmr_peer_pool.hpp). Four targets: three STL-only, one on boost::asio.

--- a/src/impl/xmr/native/test/xmr_reorg_follow_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_reorg_follow_kat.cpp
@@ -1,0 +1,697 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/test/xmr_reorg_follow_kat.cpp
+//
+// REORG-FOLLOW: the node adopts a heavier branch that forked BELOW its tip,
+// while it is running, without being restarted.
+//
+// WHY THIS FILE EXISTS NEXT TO xmr_chain_index_kat.cpp, WHICH ALREADY TESTS
+// REORGS. That file's fixture seeds a full 735-row difficulty window before it
+// connects anything, because it is replaying stagenet from an anchor. Every
+// reorg in it therefore reaches a fork point the window already covers, and it
+// passes -- 1717 checks, 0 failures -- while a from-genesis node could not
+// reorganise at all. The gate was `RowStore::difficulty_window_ending_at`,
+// which refused any window whose span reached below height 0, so
+// `branch_difficulty_locked_` could not price a single block that attached
+// anywhere but the tip until the chain was 735 blocks long. That is every
+// regtest rig, always, and the first day of any from-genesis sync. The offer
+// path then made it invisible: it answered ParkedOrphan and returned WITHOUT
+// storing the block, so the fork-point child of a rival branch was destroyed on
+// every delivery, the alt pool never held a candidate, and the fork choice
+// never ran. A node that lost a same-height race sat on its own tip forever and
+// only a restart -- which re-syncs through the TIP path, where the window is
+// whatever the consensus state holds -- appeared to "fix" it.
+//
+// So this file boots the way a regtest node boots: ONE seeded row at height 0,
+// one difficulty row, nothing below. Everything it asserts was impossible
+// before the fix, and none of it is reachable from an anchored fixture.
+//
+//   A  ROWS      -- the young-chain window at RowStore level: granted only when
+//                   the store holds the chain from height 0, refused when it
+//                   merely starts high, and the "do not invent a window past
+//                   the pre-window" refusal survives the relaxation.
+//   B  FOLLOW    -- a genesis-booted index at height 8 is handed the rival
+//                   branch of a same-height race and then its extension: it
+//                   holds, judges, and ADOPTS, in one live object, with no
+//                   re-seed and no snapshot reload between the two offers.
+//   C  WALK      -- delivery bottom-up, with a hole. A block whose parent is a
+//                   parked UNRESOLVED alt used to be dropped by the same
+//                   return; now it is held, the missing parent is named in
+//                   refetch_wanted(), and filling the hole resolves the whole
+//                   branch and switches. Also: refetch_wanted() stops naming
+//                   ids we are already holding the bytes for, which is what
+//                   made the driver re-ask forever.
+//   D  BOUNDS    -- the relaxation buys no new powers. Deeper than
+//                   max_reorg_depth is refused and journaled; equal work
+//                   against our own block is KEPT (D-14) and the rival is held
+//                   so the accounting can see the race; a lighter branch never
+//                   switches.
+//
+// No sockets, no RandomX, no daemon: a model verifier stands in for the PoW
+// source exactly as the C2c KAT's does. Registered in BOTH build.yml --target
+// lists -- a registered-but-unbuilt target reads as "***Not Run" and fails
+// ctest with exit 8 (the #1539 lesson).
+// ---------------------------------------------------------------------------
+
+#include <cstdarg>
+#include <cstdio>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/native/chain/xmr_chain_index.hpp"
+#include "impl/xmr/native/chain/xmr_fork_choice.hpp"
+#include "impl/xmr/native/chain/xmr_pow_gate.hpp"
+#include "impl/xmr/native/chain/xmr_row_store.hpp"
+#include "impl/xmr/native/consensus/xmr_reward.hpp"
+#include "impl/xmr/native/contracts/fakes/fake_fetcher.hpp"
+
+using namespace c2pool::xmr::native;
+
+static int g_checks = 0;
+static int g_fail   = 0;
+
+static void checkf(bool cond, const char* fmt, ...) {
+    ++g_checks;
+    if (!cond) {
+        ++g_fail;
+        if (g_fail <= 25) {
+            va_list ap;
+            va_start(ap, fmt);
+            std::vfprintf(stderr, fmt, ap);
+            va_end(ap);
+            std::fputc('\n', stderr);
+        }
+    }
+}
+
+static U128 u128_of(std::uint64_t lo, std::uint64_t hi) { U128 d; d.lo = lo; d.hi = hi; return d; }
+static bool u128_eq(const U128& a, const U128& b) { return a.lo == b.lo && a.hi == b.hi; }
+
+static Hash tag_id(std::uint64_t tag) {
+    Hash h{};
+    for (std::size_t i = 0; i < 8; ++i) h[i] = static_cast<std::uint8_t>((tag >> (8 * i)) & 0xff);
+    h[31] = 0x5a;
+    return h;
+}
+
+static PeerRef peer(std::uint64_t id) {
+    PeerRef p;
+    p.peer_id = id;
+    p.addr    = "10.9.0." + std::to_string(id) + ":18080";
+    return p;
+}
+
+// =============================================================================
+// building a block (the C2c KAT's shape: a structurally real Monero block with
+// one coinbase output and no transactions)
+// =============================================================================
+static void put_varint(std::vector<std::uint8_t>& o, std::uint64_t v) { blob_write_varint(o, v); }
+
+static BlockEntry make_block(std::uint8_t major, std::uint8_t minor, std::uint64_t timestamp,
+                             const Hash& prev, std::uint32_t nonce, std::uint64_t height,
+                             std::uint64_t reward, std::uint8_t salt = 0) {
+    std::vector<std::uint8_t> b;
+    put_varint(b, major);
+    put_varint(b, minor);
+    put_varint(b, timestamp);
+    b.insert(b.end(), prev.begin(), prev.end());
+    for (int i = 0; i < 4; ++i) b.push_back(static_cast<std::uint8_t>((nonce >> (8 * i)) & 0xff));
+
+    put_varint(b, 2);                       // miner_tx version
+    put_varint(b, height + 60);             // unlock_time
+    put_varint(b, 1);                       // one input
+    b.push_back(0xFF);                      // TX_IN_GEN
+    put_varint(b, height);
+    put_varint(b, 1);                       // one output
+    put_varint(b, reward);
+    b.push_back(0x03);                      // TX_OUT_TO_TAGGED_KEY
+    for (int i = 0; i < 32; ++i) b.push_back(static_cast<std::uint8_t>(0x10 + i));
+    b.push_back(salt);                      // view tag doubles as the sibling salt
+    put_varint(b, 33);                      // tx_extra length
+    b.push_back(0x01);                      // TX_EXTRA_TAG_PUBKEY
+    for (int i = 0; i < 32; ++i) b.push_back(static_cast<std::uint8_t>(0x40 + i));
+    b.push_back(0x00);                      // rct type NULL
+
+    put_varint(b, 0);                       // no transaction hashes
+
+    BlockEntry e;
+    e.block_blob = std::move(b);
+    return e;
+}
+
+static Hash id_of(const BlockEntry& e) {
+    EvaluatedBlock ev;
+    std::string    why;
+    if (evaluate_block(e, ev, why) != EvalStatus::Ok) return Hash{};
+    return ev.input.identity.id;
+}
+
+// =============================================================================
+// a model RandomX verifier, shaped exactly like c2pool::xmr::LightVerifier
+// =============================================================================
+class ModelVerifier {
+public:
+    enum class VerifyStatus { Accept, BelowTarget, SeedNotResident, NotInitialized };
+
+    bool prefetch_epoch(const Hash& current, const std::optional<Hash>& next) {
+        ++rekeys;
+        cur_ = current;
+        nxt_ = next;
+        return true;
+    }
+
+    bool seed_resident(const Hash& s) const {
+        if (cur_ && *cur_ == s) return true;
+        return nxt_ && *nxt_ == s;
+    }
+
+    VerifyStatus verify(const std::uint8_t*, std::size_t, const Hash& seed,
+                        std::uint64_t, std::uint64_t, std::uint8_t out[32]) {
+        if (!seed_resident(seed)) return VerifyStatus::SeedNotResident;
+        ++hashes;
+        for (int i = 0; i < 32; ++i) out[i] = static_cast<std::uint8_t>(i);
+        return VerifyStatus::Accept;
+    }
+
+    std::uint64_t rekeys = 0;
+    std::uint64_t hashes = 0;
+
+private:
+    std::optional<Hash> cur_, nxt_;
+};
+
+struct EventLog {
+    std::vector<node::MainchainEvent> events;
+    void attach(ChainIndex& idx) {
+        idx.subscribe([this](const node::MainchainEvent& e) { events.push_back(e); });
+    }
+    std::size_t count(node::MainchainEventKind k) const {
+        std::size_t n = 0;
+        for (const auto& e : events) if (e.kind == k) ++n;
+        return n;
+    }
+    void clear() { events.clear(); }
+};
+
+// =============================================================================
+// the regtest boot: ONE row at height 0, ONE difficulty row, nothing below
+// =============================================================================
+// This is xmr_chain_boot.hpp's try_seed_() reproduced with a synthetic genesis:
+// a private chain starts at the newest implemented fork version from height 1
+// (REGTEST_HARD_FORKS), so every block below carries that major version, and the
+// index is left with base_height() == 0 -- the state the whole fix is about.
+static constexpr std::uint8_t  REG_MAJOR = MAX_IMPLEMENTED_HF_VERSION;
+static constexpr std::uint64_t GENESIS_TS = 1'700'000'000ull;
+
+static ChainRow genesis_row() {
+    ChainRow row;
+    row.height                  = 0;
+    row.id                      = tag_id(0);
+    row.prev_id                 = Hash{};
+    row.timestamp               = GENESIS_TS;
+    row.major_version           = 1;
+    row.minor_version           = 0;
+    row.block_weight            = 80;
+    row.long_term_weight        = 80;
+    row.difficulty              = u128_of(1, 0);
+    row.cumulative_difficulty   = u128_of(1, 0);
+    row.already_generated_coins = 0;
+    row.pow_verified            = true;
+    return row;
+}
+
+static void seed_genesis(ChainIndex& idx) {
+    const ChainRow g = genesis_row();
+    idx.seed_direct(g,
+                    /*difficulty_window=*/{DifficultyRow{g.timestamp, g.cumulative_difficulty}},
+                    /*short_term_weights=*/{g.block_weight},
+                    /*long_term_weights=*/{g.long_term_weight},
+                    /*timestamps_60=*/{g.timestamp},
+                    /*seed_ids=*/{{0, g.id}});
+}
+
+// The un-penalised base reward for a block of negligible weight at a given
+// already_generated_coins, straight out of the consensus reward code. Needed
+// because a young chain is NOT in tail emission: the reward changes every block,
+// so a branch's coinbase has to be priced at the branch's own emission, which is
+// the main chain's up to the fork point and its own above it.
+static std::uint64_t base_at(std::uint64_t agc) {
+    std::uint64_t base = 0;
+    (void)get_block_reward(/*penalty_median=*/300'000, /*block_weight=*/300, agc,
+                           hf_rules_version(REG_MAJOR), base);
+    return base;
+}
+
+// The consensus row at a height. The IChainView reads hand back a
+// ChainMainBlock, which deliberately carries no cumulative difficulty and no
+// emission; both of those live on the state's own row.
+static const ChainRow* row_at(const ChainIndex& idx, std::uint64_t height) {
+    for (const ChainRow& r : idx.view().state().rows())
+        if (r.height == height) return &r;
+    return nullptr;
+}
+
+// The already_generated_coins standing at a height on the best chain.
+static std::uint64_t agc_at(const ChainIndex& idx, std::uint64_t height) {
+    const ChainRow* r = row_at(idx, height);
+    return r ? r->already_generated_coins : 0;
+}
+
+// A from-genesis index driven to `n` blocks, every one of them ours.
+struct Rig {
+    ModelVerifier                         mv;
+    LightVerifierPowSource<ModelVerifier> src{mv};
+    ChainIndexOptions                     opts;
+    ChainIndex*                           idx = nullptr;
+    EventLog                              log;
+    fakes::FakeFetcher                    fetcher;
+    std::vector<Hash>                     main_ids;   // index 0 == height 1
+    PeerRef                               them = peer(3);
+
+    explicit Rig(std::uint64_t n_main = 8, std::uint64_t max_reorg = 720) {
+        opts.net             = XmrNet::Regtest;
+        opts.max_reorg_depth = max_reorg;
+        opts.require_pow     = true;
+        opts.tie             = TieBreak::PreferOwn;
+        idx = new ChainIndex(opts, src);
+        seed_genesis(*idx);
+        idx->set_fetcher(&fetcher);
+        log.attach(*idx);
+
+        Hash prev = genesis_row().id;
+        for (std::uint64_t h = 1; h <= n_main; ++h) {
+            BlockEntry e = block_for(prev, h, agc_at(*idx, h - 1), /*salt=*/0, /*ts_shift=*/0);
+            const OfferResult r = idx->offer_block(nullptr, e, /*own_mined=*/true);
+            checkf(r.outcome == OfferOutcome::Connected,
+                   "rig: main block %llu became %s (%s)",
+                   static_cast<unsigned long long>(h), to_string(r.outcome), r.why.c_str());
+            prev = r.id;
+            main_ids.push_back(prev);
+        }
+        log.clear();
+    }
+
+    ~Rig() { delete idx; }
+
+    // A block at `height` on top of `prev`, priced at the emission standing at
+    // `agc` (the branch's own), with `salt` separating siblings.
+    static BlockEntry block_for(const Hash& prev, std::uint64_t height, std::uint64_t agc,
+                                std::uint8_t salt, std::int64_t ts_shift) {
+        const std::uint64_t ts =
+            static_cast<std::uint64_t>(static_cast<std::int64_t>(GENESIS_TS + 120 * height)
+                                       + ts_shift);
+        return make_block(REG_MAJOR, REG_MAJOR, ts, prev,
+                          static_cast<std::uint32_t>(height * 31 + salt), height, base_at(agc),
+                          salt);
+    }
+
+    Hash tip_id() const {
+        const auto t = idx->tip();
+        return t ? t->id : Hash{};
+    }
+    std::uint64_t tip_height() const {
+        const auto t = idx->tip();
+        return t ? t->height : 0;
+    }
+};
+
+// A branch of `count` blocks hanging off `fork_id` at `fork_height`, priced at
+// the emission standing at the fork point and rolled forward on its own.
+// Returned newest-last; NOT offered.
+static std::vector<BlockEntry> build_branch(const ChainIndex& idx, const Hash& fork_id,
+                                            std::uint64_t fork_height, std::size_t count,
+                                            std::uint8_t salt_base, std::int64_t ts_shift = 0) {
+    std::vector<BlockEntry> out;
+    Hash          prev = fork_id;
+    std::uint64_t agc  = agc_at(idx, fork_height);
+    for (std::size_t i = 0; i < count; ++i) {
+        const std::uint64_t h = fork_height + 1 + i;
+        BlockEntry e = Rig::block_for(prev, h, agc,
+                                      static_cast<std::uint8_t>(salt_base + i), ts_shift);
+        agc  = accumulate_generated_coins(agc, base_at(agc));
+        prev = id_of(e);
+        out.push_back(std::move(e));
+    }
+    return out;
+}
+
+// =============================================================================
+// A. the young-chain window, at RowStore level
+// =============================================================================
+static void push_row(RowStore& s, std::uint64_t h, std::uint64_t ts, std::uint64_t cd) {
+    ChainRow r;
+    r.height                = h;
+    r.id                    = tag_id(h);
+    r.timestamp             = ts;
+    r.cumulative_difficulty = u128_of(cd, 0);
+    s.push(r, false, Hash{});
+}
+
+static void test_young_window() {
+    // A store that holds the chain from its first block.
+    RowStore young;
+    for (std::uint64_t h = 0; h <= 20; ++h) push_row(young, h, 5000 + 60 * h, 1 + h);
+
+    checkf(young.base_height() == 0, "rows: a from-genesis store reports base_height %llu",
+           static_cast<unsigned long long>(young.base_height()));
+
+    std::vector<DifficultyRow> out;
+    checkf(!young.difficulty_window_ending_at(20, DIFFICULTY_BLOCKS_COUNT, out),
+           "rows: the young-chain window was granted WITHOUT the opt-in");
+    checkf(out.empty(), "rows: a refused window left rows behind");
+
+    checkf(young.difficulty_window_ending_at(20, DIFFICULTY_BLOCKS_COUNT, out,
+                                             /*allow_young_chain=*/true),
+           "rows: the young-chain window was refused to a store holding height 0");
+    checkf(out.size() == 21, "rows: young window has %zu rows, expected 21", out.size());
+    checkf(!out.empty() && out.front().timestamp == 5000,
+           "rows: young window does not start at height 0");
+    checkf(!out.empty() && out.back().timestamp == 5000 + 60 * 20,
+           "rows: young window does not end at the height asked for");
+
+    // A store that merely STARTS high: the chain may be long, we just cannot see
+    // it, and that refusal has to stay a refusal.
+    RowStore high;
+    for (std::uint64_t h = 1000; h <= 1010; ++h) push_row(high, h, 9000 + h, 10'000 + h);
+    checkf(high.base_height() == 1000, "rows: a trimmed store reports base_height %llu",
+           static_cast<unsigned long long>(high.base_height()));
+    checkf(!high.difficulty_window_ending_at(1005, DIFFICULTY_BLOCKS_COUNT, out, true),
+           "rows: a window was invented for a store that starts above height 0");
+
+    // The pre-windowed (anchored) store: the relaxation must not reach it, and
+    // the "do not invent a window past the pre-window" refusal must survive.
+    RowStore anchored;
+    std::vector<DifficultyRow> pre;
+    for (std::uint64_t i = 0; i < DIFFICULTY_BLOCKS_COUNT; ++i)
+        pre.push_back(DifficultyRow{5000 + i, u128_of(i, 0)});
+    anchored.seed_pre_window(1000, pre);                 // heights 266..1000
+    for (std::uint64_t h = 1001; h <= 1010; ++h) push_row(anchored, h, 9000 + h, 10'000 + h);
+    checkf(anchored.base_height() == 1000 + 1 - DIFFICULTY_BLOCKS_COUNT,
+           "rows: an anchored store reports base_height %llu",
+           static_cast<unsigned long long>(anchored.base_height()));
+    checkf(anchored.difficulty_window_ending_at(1005, DIFFICULTY_BLOCKS_COUNT, out, true),
+           "rows: the anchored window spanning the pre-window was not assembled");
+    checkf(out.size() == DIFFICULTY_BLOCKS_COUNT, "rows: anchored window is the wrong length");
+    checkf(!anchored.difficulty_window_ending_at(1005, DIFFICULTY_BLOCKS_COUNT + 400, out, true),
+           "rows: a window reaching past the pre-window was invented under the opt-in");
+}
+
+// =============================================================================
+// B. a genesis-booted index follows a heavier branch below its tip
+// =============================================================================
+static void test_follow_after_race_loss() {
+    Rig f(8);
+    ChainIndex& idx = *f.idx;
+
+    const std::uint64_t fork_height = 7;
+    const Hash          fork_id     = f.main_ids[6];         // height 7
+    const Hash          our_tip     = f.main_ids[7];         // height 8, ours
+
+    checkf(f.tip_height() == 8, "follow: the rig did not reach height 8 (at %llu)",
+           static_cast<unsigned long long>(f.tip_height()));
+
+    // The rival at the SAME height, from a peer. ts_shift keeps it a distinct
+    // block; the difficulty window below the fork is identical, so the work is
+    // equal and D-14 keeps ours.
+    std::vector<BlockEntry> rival = build_branch(idx, fork_id, fork_height, 2, /*salt_base=*/11);
+
+    const OfferResult r8 = idx.offer_block(&f.them, rival[0], /*own_mined=*/false);
+    checkf(r8.outcome == OfferOutcome::StoredAsAlt,
+           "follow: the rival at the contested height became %s (%s) -- before the fix this "
+           "path DROPPED it and answered ParkedOrphan",
+           to_string(r8.outcome), r8.why.c_str());
+    checkf(idx.have_block(id_of(rival[0])),
+           "follow: the index does not hold the rival it said it stored");
+    checkf(idx.alt_size() == 1, "follow: alt pool holds %zu candidates, expected 1",
+           idx.alt_size());
+
+    // It was JUDGED, not merely kept: a young chain used to make this
+    // impossible, and an unresolved candidate can never win a fork choice.
+    const std::vector<ChainIndex::AltTip> tips = idx.alt_tips();
+    checkf(tips.size() == 1 && tips[0].resolved,
+           "follow: the rival is parked UNRESOLVED -- its branch difficulty was not computable");
+
+    // Equal work: we keep our own block (D-14), and we are still at our tip.
+    checkf(f.tip_id() == our_tip, "follow: equal work did not keep our own block");
+    checkf(f.log.count(node::MainchainEventKind::Reorg) == 0,
+           "follow: an equal-work rival caused a reorg");
+
+    // Monero buries the rival branch: it gets the next block. Now it is
+    // strictly heavier, and the node must follow it WITHOUT being restarted --
+    // same object, same seeded state, no reload between these two offers.
+    const OfferResult r9 = idx.offer_block(&f.them, rival[1], /*own_mined=*/false);
+    checkf(r9.outcome == OfferOutcome::Reorged,
+           "follow: the heavier branch became %s (%s), expected Reorged",
+           to_string(r9.outcome), r9.why.c_str());
+
+    checkf(f.tip_height() == 9, "follow: tip is at %llu after the switch, expected 9",
+           static_cast<unsigned long long>(f.tip_height()));
+    checkf(f.tip_id() == id_of(rival[1]), "follow: the adopted tip is not the rival branch tip");
+    checkf(idx.is_on_best_chain(id_of(rival[0])),
+           "follow: the fork-point child of the adopted branch is not on the best chain");
+
+    // Exactly one Reorg, of depth 1, and the block it displaced is Orphaned --
+    // which is what the settlement clock reads to refuse crediting it.
+    checkf(f.log.count(node::MainchainEventKind::Reorg) == 1,
+           "follow: %zu Reorg events, expected 1", f.log.count(node::MainchainEventKind::Reorg));
+    for (const auto& e : f.log.events)
+        if (e.kind == node::MainchainEventKind::Reorg)
+            checkf(e.depth == 1, "follow: Reorg reported depth %llu, expected 1",
+                   static_cast<unsigned long long>(e.depth));
+    checkf(f.log.count(node::MainchainEventKind::Orphan) == 1,
+           "follow: %zu Orphan events, expected 1", f.log.count(node::MainchainEventKind::Orphan));
+
+    checkf(!idx.is_on_best_chain(our_tip), "follow: our displaced block is still best-chain");
+    const Burial b = idx.burial_of(our_tip);
+    checkf(b.status == BurialStatus::Orphaned,
+           "follow: our displaced block reads as %s, expected Orphaned", to_string(b.status));
+
+    // The journal says what happened, once, and it committed.
+    checkf(idx.journal().committed() == 1, "follow: the journal committed %llu reorgs, expected 1",
+           static_cast<unsigned long long>(idx.journal().committed()));
+
+    // The chain is still a chain: heights 1..9 contiguous, every parent linking.
+    for (std::uint64_t h = 2; h <= 9; ++h) {
+        const auto cur  = idx.by_height(h);
+        const auto prev = idx.by_height(h - 1);
+        checkf(cur && prev && cur->prev_id == prev->id,
+               "follow: height %llu does not link to its parent after the switch",
+               static_cast<unsigned long long>(h));
+    }
+}
+
+// =============================================================================
+// C. bottom-up delivery with a hole -- the walk to the fork point
+// =============================================================================
+static void test_walk_to_fork() {
+    Rig f(8);
+    ChainIndex& idx = *f.idx;
+
+    const std::uint64_t fork_height = 5;
+    const Hash          fork_id     = f.main_ids[4];    // height 5
+    const Hash          our_tip     = f.main_ids[7];    // height 8, ours
+
+    // A branch of five off height 5: heights 6..10, two blocks longer than the
+    // three above the fork point, so strictly more work.
+    std::vector<BlockEntry> br = build_branch(idx, fork_id, fork_height, 5, /*salt_base=*/21);
+
+    // Deliver it TOP DOWN, which is what a push followed by refetches does: the
+    // tip first, then its parent, then its parent...
+    const OfferResult top = idx.offer_block(&f.them, br[4], /*own_mined=*/false);
+    checkf(top.outcome == OfferOutcome::ParkedOrphan,
+           "walk: the pushed branch tip became %s, expected ParkedOrphan", to_string(top.outcome));
+    checkf(idx.have_block(id_of(br[4])), "walk: the parked branch tip was not kept");
+
+    // Its parent is named for the fetcher.
+    std::vector<Hash> want = idx.refetch_wanted();
+    bool names_parent = false;
+    for (const Hash& h : want) if (h == id_of(br[3])) names_parent = true;
+    checkf(names_parent, "walk: the parked tip's parent is not in refetch_wanted()");
+
+    // And the id we ALREADY hold is not asked for again. This is the loop that
+    // made a stuck node look like a slow peer: the want list is standing, so
+    // without the filter the driver re-asked for a block sitting in its own alt
+    // pool every refetch_reask_ms, forever.
+    for (const Hash& h : want)
+        checkf(!(h == id_of(br[4])), "walk: refetch_wanted() names a block we are holding");
+
+    // The next one down. Its parent is the block we just parked, which is
+    // UNRESOLVED -- "branch difficulty is unknown until the parent resolves".
+    // That is the exact return that used to destroy the block: it answered
+    // ParkedOrphan and stored nothing.
+    const OfferResult mid = idx.offer_block(&f.them, br[3], /*own_mined=*/false);
+    checkf(mid.outcome == OfferOutcome::ParkedOrphan,
+           "walk: a block above an unresolved parent became %s", to_string(mid.outcome));
+    checkf(idx.have_block(id_of(br[3])),
+           "walk: a block above an unresolved parent was DROPPED, not parked");
+
+    for (std::size_t i = 3; i-- > 1; ) {
+        const OfferResult r = idx.offer_block(&f.them, br[i], /*own_mined=*/false);
+        checkf(r.outcome == OfferOutcome::ParkedOrphan,
+               "walk: branch block %zu became %s", i, to_string(r.outcome));
+        checkf(idx.have_block(id_of(br[i])), "walk: branch block %zu was dropped", i);
+    }
+    checkf(idx.alt_size() == 4, "walk: alt pool holds %zu of the 4 parked blocks", idx.alt_size());
+    checkf(f.tip_id() == our_tip, "walk: the tip moved while the branch was still unjudgeable");
+
+    // Now the fork-point child lands. Its parent IS on the best chain, so it is
+    // judgeable; resolving it cascades up the branch and the switch follows in
+    // the same call -- no restart, no second delivery of anything.
+    const OfferResult bottom = idx.offer_block(&f.them, br[0], /*own_mined=*/false);
+    checkf(bottom.outcome == OfferOutcome::Reorged,
+           "walk: the fork-point child became %s (%s), expected Reorged",
+           to_string(bottom.outcome), bottom.why.c_str());
+
+    checkf(f.tip_height() == 10, "walk: tip is at %llu after the switch, expected 10",
+           static_cast<unsigned long long>(f.tip_height()));
+    checkf(f.tip_id() == id_of(br[4]), "walk: the adopted tip is not the branch tip");
+    for (std::size_t i = 0; i < br.size(); ++i)
+        checkf(idx.is_on_best_chain(id_of(br[i])),
+               "walk: branch block %zu is not on the best chain after the switch", i);
+
+    checkf(f.log.count(node::MainchainEventKind::Reorg) == 1,
+           "walk: %zu Reorg events, expected 1", f.log.count(node::MainchainEventKind::Reorg));
+    checkf(f.log.count(node::MainchainEventKind::Orphan) == 3,
+           "walk: %zu Orphan events, expected 3 (heights 6,7,8)",
+           f.log.count(node::MainchainEventKind::Orphan));
+    for (const auto& e : f.log.events)
+        if (e.kind == node::MainchainEventKind::Reorg)
+            checkf(e.depth == 3, "walk: Reorg reported depth %llu, expected 3",
+                   static_cast<unsigned long long>(e.depth));
+
+    // Nothing we now hold on the best chain is still being asked for.
+    want = idx.refetch_wanted();
+    for (const Hash& h : want)
+        for (std::size_t i = 0; i < br.size(); ++i)
+            checkf(!(h == id_of(br[i])),
+                   "walk: refetch_wanted() still names adopted branch block %zu", i);
+}
+
+// =============================================================================
+// D. the bounds the relaxation must not move
+// =============================================================================
+static void test_bounds() {
+    // --- deeper than the horizon: refused and journaled ----------------------
+    {
+        Rig f(8, /*max_reorg=*/2);
+        ChainIndex& idx = *f.idx;
+        const std::uint64_t fork_height = 4;
+        const Hash          fork_id     = f.main_ids[3];
+        const Hash          our_tip     = f.main_ids[7];
+
+        std::vector<BlockEntry> br = build_branch(idx, fork_id, fork_height, 6, /*salt_base=*/31);
+        for (std::size_t i = 0; i < br.size(); ++i)
+            (void)idx.offer_block(&f.them, br[i], /*own_mined=*/false);
+
+        checkf(f.tip_id() == our_tip,
+               "bounds: a branch 4 below the tip was adopted with max_reorg_depth 2");
+        checkf(f.log.count(node::MainchainEventKind::Reorg) == 0,
+               "bounds: a too-deep branch produced a Reorg event");
+        checkf(idx.journal().committed() == 0, "bounds: a too-deep branch committed a reorg");
+        checkf(idx.journal().refused() > 0,
+               "bounds: a too-deep branch was refused SILENTLY -- nothing in the journal");
+    }
+
+    // --- equal work against our own block: kept, and the rival is HELD -------
+    {
+        Rig f(8);
+        ChainIndex& idx = *f.idx;
+        const Hash our_tip = f.main_ids[7];
+        std::vector<BlockEntry> rival =
+            build_branch(idx, f.main_ids[6], 7, 1, /*salt_base=*/41, /*ts_shift=*/0);
+
+        const OfferResult r = idx.offer_block(&f.them, rival[0], /*own_mined=*/false);
+        checkf(r.outcome == OfferOutcome::StoredAsAlt,
+               "bounds: the equal-work rival became %s", to_string(r.outcome));
+        checkf(f.tip_id() == our_tip, "bounds: equal work did not keep our own block (D-14)");
+        // Held, so the accounting layer can see the race at all: in this branch
+        // the rival never becomes a mainchain event.
+        const std::vector<ChainIndex::AltTip> tips = idx.alt_tips();
+        checkf(tips.size() == 1 && tips[0].height == 8 && !tips[0].own_mined,
+               "bounds: the equal-work rival is not visible as an alt tip");
+        checkf(f.log.count(node::MainchainEventKind::Reorg) == 0,
+               "bounds: equal work produced a reorg");
+    }
+
+    // --- a lighter branch never switches -------------------------------------
+    {
+        Rig f(8);
+        ChainIndex& idx = *f.idx;
+        const Hash our_tip = f.main_ids[7];
+        // Two blocks off height 4: heights 5 and 6, four blocks short of our
+        // tip, so strictly less work.
+        std::vector<BlockEntry> br = build_branch(idx, f.main_ids[3], 4, 2, /*salt_base=*/51);
+        for (std::size_t i = 0; i < br.size(); ++i) {
+            const OfferResult r = idx.offer_block(&f.them, br[i], /*own_mined=*/false);
+            checkf(r.outcome == OfferOutcome::StoredAsAlt,
+                   "bounds: a lighter branch block became %s (%s)",
+                   to_string(r.outcome), r.why.c_str());
+        }
+        checkf(f.tip_id() == our_tip, "bounds: a lighter branch was adopted");
+        checkf(f.log.count(node::MainchainEventKind::Reorg) == 0,
+               "bounds: a lighter branch produced a reorg");
+    }
+}
+
+// =============================================================================
+// E. the young-chain relaxation does not change what the chain COMPUTES
+// =============================================================================
+// The branch walk and the apply path must arrive at the same difficulty for the
+// same block, or the switch refuses itself ("branch difficulty disagreed with
+// the connected difficulty"). On a young chain those two are the relaxed
+// RowStore window and the consensus state's own rolling window, so this is the
+// check that they hold the same rows.
+static void test_branch_and_apply_agree() {
+    Rig f(8);
+    ChainIndex& idx = *f.idx;
+
+    const ChainRow* before = row_at(idx, 8);
+    checkf(before != nullptr, "agree: no row at the tip before the branch arrives");
+    const U128 our_tip_cd = before ? before->cumulative_difficulty : U128{};
+
+    std::vector<BlockEntry> br = build_branch(idx, f.main_ids[5], 6, 3, /*salt_base=*/61);
+    for (std::size_t i = 0; i < br.size(); ++i)
+        (void)idx.offer_block(&f.them, br[i], /*own_mined=*/false);
+
+    checkf(f.tip_height() == 9, "agree: the heavier branch did not become the tip");
+    // Had the two windows disagreed, the switch would have rolled itself back
+    // and the journal would say ValidationFailed instead of committing.
+    checkf(idx.journal().committed() == 1,
+           "agree: the branch difficulty disagreed with the connected difficulty");
+
+    const ChainRow* adopted = row_at(idx, 9);
+    checkf(adopted != nullptr, "agree: no row at the adopted tip height");
+    checkf(adopted && u128_greater(adopted->cumulative_difficulty, our_tip_cd),
+           "agree: the adopted tip does not carry strictly more work than the one it replaced");
+
+    // Every row the switch re-applied carries a difficulty the state computed,
+    // and the chain's cumulative difficulty is still the running sum of them.
+    U128 sum = genesis_row().cumulative_difficulty;
+    for (std::uint64_t h = 1; h <= 9; ++h) {
+        const ChainRow* row = row_at(idx, h);
+        if (!row) { checkf(false, "agree: height %llu missing", (unsigned long long)h); break; }
+        sum = u128_add(sum, row->difficulty);
+        checkf(u128_eq(sum, row->cumulative_difficulty),
+               "agree: cumulative difficulty at height %llu is not the running sum",
+               static_cast<unsigned long long>(h));
+    }
+}
+
+// =============================================================================
+int main() {
+    test_young_window();
+    test_follow_after_race_loss();
+    test_walk_to_fork();
+    test_bounds();
+    test_branch_and_apply_agree();
+
+    std::printf("xmr_native_reorg_follow_kat: %d checks, %d failures\n", g_checks, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**DRAFT — DO NOT MERGE.** Stacked on `v37/xmr-native-multinode` (c2pool#1592, the multi-node prefer-own same-height tiebreak). Node behaviour only; no consensus rule changes, nothing under `src/sharechain/`.

## The bug

A native node that lost a same-height race **sat on its own tip forever**. Its daemon reorganised onto the winning branch and relayed the blocks; the node dropped every single one of them. Only a process restart appeared to fix it — because a restart re-syncs through the TIP path, where the branch path never runs.

## Cause: a third gate, in the chain index, specific to a young chain

`RowStore::difficulty_window_ending_at` refused any 735-row window whose span reached below height 0. A genesis-booted index (`ChainBoot::try_seed_`) seeds **one** difficulty row, at height 0 — so `branch_difficulty_locked_` could not price a single block that attached anywhere but the tip until the chain was 735 blocks long. That is **every regtest rig, always**, and the first day of any from-genesis sync.

The tip fast path was never affected: it reads the consensus state's own rolling window and gets whatever rows exist, which is exactly what monerod's `get_difficulty_for_next_block` does with its `min(height, 735)`. So the branch path was refusing a window the tip path was happily computing over, for the same rows.

Anchored boots (stagenet, mainnet) seed a full 735-row pre-window — and so does the C2c KAT fixture. That is why `xmr_native_chain_index_kat` passes 1717/0 **with a reorg suite in it** while a from-genesis node could not reorganise at all.

**A second defect made it silent.** On that refusal `offer_locked_` answered `ParkedOrphan` and returned *without inserting the block*, without naming anything for the fetcher and without a journal line — the block was destroyed. Every re-delivery hit the same return, so `AltPool::heaviest()` never had a candidate, `maybe_switch_locked_` never opened a record, and nothing anywhere reported that a block had been thrown away.

## The fix

| file | change |
|---|---|
| `chain/xmr_row_store.hpp` | `difficulty_window_ending_at(..., allow_young_chain)`, granted **only** when `base_height() == 0` — we hold the chain from its first block. A store that merely *starts* high still refuses: that is a real refusal and stays one. |
| `chain/xmr_chain_index.hpp` | `branch_difficulty_locked_` is the only caller that opts in. `offer_locked_` **parks** the unjudgeable block for real (unresolved, un-adoptable — `heaviest()` skips it, the fail-closed bound still refuses any branch containing it) so `resolve_descendants_locked_` can pick it up when the parent resolves. `refetch_wanted()` stops naming ids whose bodies we already hold. The tip fast path runs the fork choice after draining parked children. |
| `p2p/xmr_peer_pool.hpp` | Folds `current_blockchain_height` from block pushes and objects responses into the peer's sync snapshot. Only TIMED_SYNC did, on a 60 s beat, so for up to a minute after a peer moved we asked it nothing. The **height** only — `cumulative_difficulty` stays what the peer actually signed for. |

## KAT — `xmr_native_reorg_follow_kat`, 135 checks

Boots the way a regtest node boots (one row at height 0) — a state the anchored C2c fixture cannot reach, which is why it is a separate target rather than more cases in `xmr_chain_index_kat.cpp`.

* **A** the young-chain window at `RowStore` level: granted at `base_height()==0`, refused for a store that starts high, and the "do not invent a window past the pre-window" refusal survives the opt-in
* **B** genesis-booted index at height 8 is handed the rival of a same-height race and then its extension: it holds, judges, and **adopts** — one live object, no re-seed, no snapshot reload
* **C** delivery bottom-up with a hole: a block above a parked UNRESOLVED parent is held (not dropped), the missing parent is named in `refetch_wanted()`, filling the hole resolves the branch and switches; ids we hold are no longer re-asked
* **D** bounds unmoved: deeper than `max_reorg_depth` is refused **and journaled**; equal work against our own block is KEPT (D-14) with the rival held so the accounting can see the race; a lighter branch never switches
* **E** the relaxed `RowStore` window and the consensus state's rolling window agree on the difficulty, or the switch would roll itself back

Built against `613d7cc1` the same file **fails 42 checks** with `the retained window does not reach the fork point` and an alt pool holding nothing. Registered with `add_test` **and in both `build.yml` `--target` lists** (the c2pool#1539 Not-Run lesson).

Green on workstation-191, g++-15, `XMR_BUILD_RANDOMX=ON`:
`xmr_native_reorg_follow_kat` 135/0 · `xmr_native_chain_index_kat` 1717/0 · `xmr_native_peer_pool_kat` 64/0 · `xmr_native_node_kat` 88/0 · `xmr_native_block_relay_kat` 98/0 · `xmr_native_parity_kat` 833/0 · `v37_xmr_prefer_own_race_kat` 95/0 · `v37_xmr_m3_arm_order_kat` 40/0 · `v37_xmr_m2_native_settlement_kat` 85/0

## Live proof — isolated regtest rig, before and after

Two partitioned regtest monerods (A, B) plus a control hub C, two daemonless native nodes (`--arm-order p2p-first`, `--no-daemon-rpc`, `D_conf=3`, distinct payees, `--randomx`), own ports and datadirs, all torn down afterwards. Shared 20-block prefix, partition, each node mines its own block at **h=21**, A's branch is extended by two, the partition heals, and Monero itself buries B's branch (`REORGANIZE SUCCESS! on height: 21`).

**BEFORE** (binary at `613d7cc1`) — loser frozen, 2+ minutes after the heal, daemon at h=24:

```
node2  status: hw=21 cursor=18 tip=21 | found registered=20 settled=0 orphaned=0 pending=20
       native tip feed: events=21 (extend=21 reorg=0 orphan=0) best=21
       same-height: credited=0 refused[orphaned=0 other-only=0] deferred=1 | R-7 violations=0
```

**AFTER** (this branch) — loser follows on its own:

```
node2  status: hw=25 cursor=22 tip=25 | found registered=10 settled=0 orphaned=10 pending=0
       native tip feed: events=26 (extend=24 reorg=1 orphan=1) best=25
       same-height: credited=0 refused[orphaned=1 other-only=0] | R-7 violations=0
       wire RPC to monerod: TOTAL=0    arm-order=p2p-first rpc_on_find_path=0

node1  native tip feed: events=25 (extend=25 reorg=0 orphan=0) best=25
       same-height: credited=1 refused[orphaned=0 other-only=0] | R-7 violations=0
```

Tip trace (status every ~10 s): `tip=21 refresh=222` → `tip=23 refresh=242` — the switch landed inside one status window of monerod B's own REORGANIZE, roughly 10-20 s after the heal. **No restart**: same process, same pid, from the race through the reorg to the credit.

Settlement journals, the whole ledger at the contested height:

```
node1  h=21 verdict=already-credited  credit=12e7118d34f1...   (its own, canonical)
node2  h=21 verdict=refuse-orphaned   credit=-                 (its own, orphaned)
```

One credited entry fleet-wide at h=21, the loser fabricates nothing, `R-7 violations=0` on both.

## Scope, stated plainly

**Regtest and minutes is not a stagenet milestone.** What is proven here is a depth-1 reorg on a private chain of 26 blocks at difficulty 1, in one live run, on one host. Untouched by this work: reorgs deeper than the fork points a young chain produces, a real stagenet/mainnet anchored boot (which never hit the young-chain gate and is unchanged by the opt-in), RandomX seed rollover across an epoch edge during a switch, and the snapshot base path — which still declines to go below the tip on a young chain, deliberately left alone rather than widened on the same change.
