### PR TITLE
release.yml: force-github-hosted dispatch input (REDO of stale release-github-hosted)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,10 @@ on:
         description: "JSON array of coins to build (e.g. [\"ltc\"]). Blank = all six."
         required: false
         default: ""
+      force-github-hosted:
+        description: "Route every lane to GitHub-hosted runners (fresh default-boost per run). Set true for release builds that must dodge the self-hosted cppstd=20 spirit::x3 boost issue."
+        required: false
+        default: ""
 
 concurrency:
   group: release-${{ github.ref }}
@@ -64,7 +68,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   linux:
     name: ${{ matrix.coin }} package (Linux x86_64)
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.force-github-hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -297,9 +301,9 @@ jobs:
         arch: [arm64, x86_64]
         include:
           - arch: arm64
-            runner: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14' }}
+            runner: ${{ inputs.force-github-hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14' }}
           - arch: x86_64
-            runner: [self-hosted, macOS, X64, c2pool-mac-intel]
+            runner: ${{ inputs.force-github-hosted != 'true' && fromJSON('["self-hosted","macOS","X64","c2pool-mac-intel"]') || 'macos-13' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -406,7 +410,7 @@ jobs:
     name: ${{ matrix.coin }} package (macOS universal)
     needs: macos
     if: always()
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14' }}
+    runs-on: ${{ inputs.force-github-hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","macOS","ARM64","c2pool-mac-arm"]') || 'macos-14' }}
     strategy:
       fail-fast: false
       matrix:
@@ -510,7 +514,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   windows:
     name: ${{ matrix.coin }} package (Windows x86_64)
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Windows","X64","c2pool-build"]') || 'windows-2022' }}
+    runs-on: ${{ inputs.force-github-hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Windows","X64","c2pool-build"]') || 'windows-2022' }}
     defaults:
       run:
         # VM217 Windows PowerShell runs at ExecutionPolicy=Restricted and has no
@@ -747,7 +751,7 @@ jobs:
   # ════════════════════════════════════════════════════════════════════════════
   checksums:
     name: SHA256SUMS + draft release
-    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.force-github-hosted != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","c2pool-build"]') || 'ubuntu-24.04' }}
     needs: [linux, macos-universal, windows]
     if: always()
     permissions:


### PR DESCRIPTION
Fresh REDO off today's master (9063ec70) of the stale `ci-steward/release-github-hosted` branch (~1050 behind, ran zero CI).

## What
Adds a `workflow_dispatch` input `force-github-hosted`. When set `true`, every lane's `runs-on` is prefixed with `inputs.force-github-hosted != 'true' &&` so a release dispatch routes all six lanes to GitHub-hosted runners — dodging the self-hosted cppstd=20 spirit::x3 boost issue on a fresh default-boost VM. Default blank preserves existing self-hosted routing (with fork fallback).

## Why this is a REDO, not a reopen
The original branch carried two commits. The Conan cache-scoping-by-`runner.environment` half already landed on master (gating at the Linux/Windows provision steps). Only the force-github-hosted input survived as novel — reconstructed here on a clean base so it lands non-conflicting and runs CI.

## Scope / safety
- Single file: `.github/workflows/release.yml`. Six `runs-on` lanes + one new input.
- Per-coin source-presence guards untouched (isolation invariant preserved).
- mac-intel x86_64 bare-array runner converted to the same toggle ternary (macos-13 fallback).
- Draft: opened as draft so CI validates the workflow parse without implying merge-ready.

Held behind push-approval for merge per standing rule.