### PR TITLE
web: DOGE payout addresses render with DOGE version bytes (REDO of payout-encoding-doge-case)

### DIFF
--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -2430,6 +2430,16 @@ nlohmann::json MiningInterface::rest_current_payouts()
             uint8_t p2sh  = m_testnet ?  19 : 16;   // Dash: '7'
             return core::script_to_address(s, "", p2pkh, p2sh);
         }
+        if (m_blockchain == Blockchain::DOGECOIN) {
+            // DOGE version bytes: mainnet 0x1e ('D') / 0x16, testnet 0x71 / 0xc4.
+            // Without this arm a primary-DOGE node falls through to the bool
+            // overload's BTC branch (is_ltc==false) and renders DOGE payouts as
+            // Bitcoin '1...' addresses. Display-only, reward-safe (scripts and
+            // amounts are unchanged; only the human-readable address string is).
+            uint8_t p2pkh = m_testnet ? 0x71 : 0x1e;
+            uint8_t p2sh  = m_testnet ? 0xc4 : 0x16;
+            return core::script_to_address(s, "", p2pkh, p2sh);
+        }
         return core::script_to_address(s, is_ltc, m_testnet);
     };
 

--- a/test/test_redistribute_address.cpp
+++ b/test/test_redistribute_address.cpp
@@ -18,6 +18,7 @@
 #include <impl/ltc/redistribute.hpp>
 #include <impl/ltc/share_tracker.hpp>
 #include <core/web_server.hpp>
+#include <core/address_utils.hpp>
 
 using core::MiningInterface;
 
@@ -288,4 +289,48 @@ TEST(AddressConversionCase4, ShortOrMalformedScriptNotExtracted)
                   short_script[1] == 0xa9 &&
                   short_script[2] == 0x14);
     EXPECT_FALSE(valid);
+}
+
+// ============================================================================
+// DOGE payout-address encoding contract (rest_current_payouts resolve_addr)
+//
+// A primary-DOGE node must render coinbase-payout scriptPubKeys as DOGE
+// addresses ('D...', version byte 0x1e) — NOT Bitcoin '1...' addresses. The
+// bool script_to_address(script, is_ltc, testnet) overload only knows LTC
+// (0x30) vs BTC (0x00); with is_ltc==false a DOGE node would silently emit
+// Bitcoin addresses. The web layer must therefore pass DOGE's explicit
+// version bytes via the string overload (as it already does for DASH).
+//
+// These lock the encoding contract the resolve_addr DOGE arm depends on.
+// (Exercising the lambda through a DOGECOIN-configured MiningInterface needs
+// a coin fixture; tracked as a follow-up.) Display-only, reward-safe.
+// ============================================================================
+
+TEST(DogePayoutEncoding, ExplicitVersionBytesYieldDogeAddress)
+{
+    const auto h = make_hash(0x42);
+    auto script = p2pkh_script(h);
+
+    // What the fixed resolve_addr DOGE arm passes: mainnet 0x1e / 0x16.
+    std::string doge = core::script_to_address(script, "", 0x1e, 0x16);
+
+    ASSERT_FALSE(doge.empty());
+    EXPECT_EQ(doge.front(), 'D')  // DOGE mainnet P2PKH always base58-encodes to 'D'
+        << "DOGE payout rendered as '" << doge << "' (expected 'D...')";
+}
+
+TEST(DogePayoutEncoding, BoolOverloadMisrendersDogeAsBitcoin)
+{
+    const auto h = make_hash(0x42);
+    auto script = p2pkh_script(h);
+
+    // The defective path a primary-DOGE node hits without the explicit arm:
+    // is_ltc=false → BTC version byte 0x00 → '1...'. This documents exactly
+    // the mis-encoding the resolve_addr DOGE arm exists to prevent.
+    std::string as_btc = core::script_to_address(script, /*is_ltc=*/false, /*testnet=*/false);
+    std::string as_doge = core::script_to_address(script, "", 0x1e, 0x16);
+
+    ASSERT_FALSE(as_btc.empty());
+    EXPECT_EQ(as_btc.front(), '1');
+    EXPECT_NE(as_btc, as_doge);  // the bug: same script, wrong chain's address
 }


### PR DESCRIPTION
## What

Render DOGE coinbase-payout addresses with DOGE version bytes in the
`/current_payouts` JSON API, instead of Bitcoin `1...` addresses.

## Why (REDO of dashboard/payout-encoding-doge-case)

The old branch `dashboard/payout-encoding-doge-case` (PR #370, merged) is
~1819 commits behind master and cannot open a non-conflicting PR. The
underlying defect it named is still LIVE in today's master:

`MiningInterface::rest_current_payouts()` resolve_addr (src/core/web_server.cpp)
has an explicit DASH arm but every other coin falls through to the bool
overload `script_to_address(s, is_ltc, testnet)`, which only distinguishes
LTC (0x30) from BTC (0x00). On a primary-DOGE node (`m_blockchain == DOGECOIN`)
`is_ltc` is false, so DOGE payouts render as Bitcoin `1...` addresses.

## Fix

Add a DOGE arm passing DOGE's explicit version bytes (mainnet 0x1e/0x16,
testnet 0x71/0xc4) via the string overload, mirroring the existing DASH arm.

- **Display-only, reward-safe:** payout scripts and amounts are unchanged;
  only the human-readable address string in the API response is corrected.
- **Attribution-clean** per fleet law.

## Tests

Two KATs in `test/test_redistribute_address.cpp` lock the DOGE encoding
contract: explicit version bytes yield a `D...` address, and the bool
overload's `is_ltc=false` path mis-renders the same script as `1...`
(documenting the defect the arm prevents).

Scope note (honest): the KATs lock the core encoding contract the arm
depends on. Exercising the lambda end-to-end through a DOGECOIN-configured
`MiningInterface` needs a coin fixture — tracked as a follow-up.

Draft pending designated-reviewer sign-off before CI/merge.
