### PR TITLE
dash(tx-inject): M3 rate-limiting + bounded-work signer sandbox (#157)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -2764,7 +2764,11 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         p2p_node.set_tx_inject_sink(
             [&node_coin_state](const dash::coin::MutableTransaction& tx,
                                uint32_t flags, int32_t expiry_height) {
-                return node_coin_state.submit_inject(tx, flags, expiry_height);
+                // #157 M3: peer-origin — charge the aggregate-PEER rate budget so
+                // a peer flood cannot starve the local operator's own inject.
+                return node_coin_state.submit_inject(
+                    tx, flags, expiry_height,
+                    dash::coin::NodeCoinState::InjectOrigin::Peer);
             });
         std::cout << "[run] embedded-tx-inject ARMED (#157): miner/user tx-injection "
                      "ON — submitted txs ride the block with priority through the "

--- a/src/impl/dash/coin/inject_rate_limiter.hpp
+++ b/src/impl/dash/coin/inject_rate_limiter.hpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// #157 M3 — GLOBAL (node-wide) inject rate limiter: count + volume per window.
+//
+// WHY A SECOND LIMITER
+// --------------------
+// M2 gave each PEER a sliding-window count cap (dash::PeerInjectGuard, in
+// tx_inject_relay.hpp). That bounds ONE peer, but two gaps remain:
+//   * AGGREGATE peer flood — N peers each just under their per-peer cap still
+//     sum to N * cap injects/min hitting the (script-verifying) submit gate.
+//   * LOCAL flood — the --embedded-tx-inject-hex loader and any future local
+//     submit path never pass through a peer guard at all.
+// Both funnel through the SINGLE gate every inject crosses:
+// NodeCoinState::submit_inject. So this limiter lives THERE, node-wide, and
+// bounds the total inject work the node performs per window regardless of
+// origin — the "global cap" half of the per-peer-AND-global requirement.
+//
+// SHAPE: a sliding-window token bucket over TWO budgets at once — a COUNT
+// budget (max injects/window) and a BYTE budget (max serialized bytes/window).
+// A flood of many small txs is bounded by count; a flood of few large txs is
+// bounded by bytes. try_consume() prunes the window to `now`, admits iff BOTH
+// budgets have room, and (only then) records the event — so a refused attempt
+// costs nothing and leaves the window untouched, letting a throttled source
+// recover as its old events age out.
+//
+// CHARGED ON ATTEMPT, NOT ON SUCCESS: the gate consumes a token for every
+// attempt that passes the rate check, BEFORE the validity/script work — so a
+// flood of INVALID injects is throttled too (each still costs the interpreter
+// otherwise). This is the DoS-correct placement.
+//
+// MONEY-SAFETY: a rate ceiling in front of the validity gate. It only REFUSES;
+// it never admits, never loosens a consensus check, and touches no coinbase /
+// subsidy / PPLNS / payee / fee state. It reads a byte count and a clock.
+//
+// PURE + HEADER-ONLY, IO-thread-confined (same discipline as the M2 relay
+// guard / NodeImpl::m_known_txs) — no internal locking. Drivable from a
+// rig-free KAT by passing an explicit `now`.
+
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <deque>
+
+namespace dash {
+namespace coin {
+
+struct InjectRateLimiter {
+    // Node-wide ceilings per window. An inject is a rare operator/miner action;
+    // these are generous for a human-driven or scripted operator batch yet bound
+    // a hostile aggregate to a low steady rate. Sized above the single-peer cap
+    // (PeerInjectGuard::kMaxInjectsPerPeerPerWindow = 30) so a lone well-behaved
+    // peer never trips the global limiter, while an aggregate flood does.
+    static constexpr std::size_t kMaxInjectsPerWindow = 200;
+    // Byte volume ceiling per window. 8 MB/min bounds memory/bandwidth churn
+    // while clearing ~80 max-size (100 KB) injects — far beyond any real batch.
+    static constexpr uint64_t    kMaxBytesPerWindow   = 8u * 1024u * 1024u;
+    static constexpr std::time_t kWindowSeconds       = 60;
+
+    // Named outcome so the caller logs cause/value/threshold in the repo's
+    // convention (DEF3 — no silent drops).
+    enum class Verdict : uint8_t {
+        Ok = 0,
+        CountExceeded,   // count budget full for this window
+        BytesExceeded,   // byte budget would overflow for this window
+    };
+    static const char* verdict_name(Verdict v) {
+        switch (v) {
+            case Verdict::Ok:            return "ok";
+            case Verdict::CountExceeded: return "inject-rate-limited-count";
+            case Verdict::BytesExceeded: return "inject-rate-limited-bytes";
+        }
+        return "inject-rate-limited-unknown";
+    }
+    struct Result {
+        Verdict  verdict{Verdict::Ok};
+        uint64_t value{0};       // observed count-in-window or bytes-in-window
+        uint64_t threshold{0};   // the cap it would breach
+        bool ok() const { return verdict == Verdict::Ok; }
+        const char* name() const { return verdict_name(verdict); }
+    };
+
+    std::deque<std::time_t> ts;      // event timestamps inside the window
+    std::deque<uint64_t>    sz;      // parallel per-event byte sizes
+    uint64_t bytes_in_window{0};     // running sum of sz (kept in step)
+
+    // Drop events older than the window ending at `now`.
+    void prune(std::time_t now) {
+        while (!ts.empty() && ts.front() + kWindowSeconds <= now) {
+            bytes_in_window -= sz.front();
+            ts.pop_front();
+            sz.pop_front();
+        }
+    }
+
+    // Prune to `now`, then admit iff BOTH budgets have room for one more event
+    // of `byte_size`. Records the event only on admit; a refusal mutates nothing
+    // beyond the prune. Count is checked before bytes (cheapest signal first).
+    Result try_consume(uint64_t byte_size, std::time_t now) {
+        prune(now);
+        Result r;
+        if (ts.size() >= kMaxInjectsPerWindow) {
+            r.verdict = Verdict::CountExceeded;
+            r.value = ts.size(); r.threshold = kMaxInjectsPerWindow;
+            return r;
+        }
+        if (bytes_in_window + byte_size > kMaxBytesPerWindow) {
+            r.verdict = Verdict::BytesExceeded;
+            r.value = bytes_in_window + byte_size; r.threshold = kMaxBytesPerWindow;
+            return r;
+        }
+        ts.push_back(now);
+        sz.push_back(byte_size);
+        bytes_in_window += byte_size;
+        return r;  // Ok — token consumed
+    }
+
+    std::size_t count_in_window() const { return ts.size(); }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/inject_rate_limiter.hpp
+++ b/src/impl/dash/coin/inject_rate_limiter.hpp
@@ -57,6 +57,18 @@ struct InjectRateLimiter {
     static constexpr uint64_t    kMaxBytesPerWindow   = 8u * 1024u * 1024u;
     static constexpr std::time_t kWindowSeconds       = 60;
 
+    // #157 M3 — BUDGET SPLIT. A node runs TWO of these: a LOCAL-operator budget
+    // and a SEPARATE aggregate-PEER budget, so a peer flood exhausts only the
+    // peer budget and can NEVER starve the operator's own inject. Both use the
+    // same caps; `scope` only selects the NAMED cause each reports, so a
+    // peer-budget refusal is told apart from a local one in logs/tests. The
+    // accounting is byte-identical between scopes.
+    enum class Scope : uint8_t { Local, Peers };
+    Scope scope{Scope::Local};
+
+    InjectRateLimiter() = default;
+    explicit InjectRateLimiter(Scope s) : scope(s) {}
+
     // Named outcome so the caller logs cause/value/threshold in the repo's
     // convention (DEF3 — no silent drops).
     enum class Verdict : uint8_t {
@@ -64,6 +76,7 @@ struct InjectRateLimiter {
         CountExceeded,   // count budget full for this window
         BytesExceeded,   // byte budget would overflow for this window
     };
+    // Canonical (LOCAL-scope) names.
     static const char* verdict_name(Verdict v) {
         switch (v) {
             case Verdict::Ok:            return "ok";
@@ -72,12 +85,27 @@ struct InjectRateLimiter {
         }
         return "inject-rate-limited-unknown";
     }
+    // Scope-aware name: the LOCAL budget keeps the canonical names; the
+    // aggregate-PEER budget reports DISTINCT names so observability separates a
+    // peer-budget refusal from a local one (DEF3 — every refusal named).
+    const char* scoped_name(Verdict v) const {
+        if (scope == Scope::Peers) {
+            switch (v) {
+                case Verdict::Ok:            return "ok";
+                case Verdict::CountExceeded: return "inject-rate-limited-peers-count";
+                case Verdict::BytesExceeded: return "inject-rate-limited-peers-bytes";
+            }
+            return "inject-rate-limited-peers-unknown";
+        }
+        return verdict_name(v);
+    }
     struct Result {
         Verdict  verdict{Verdict::Ok};
         uint64_t value{0};       // observed count-in-window or bytes-in-window
         uint64_t threshold{0};   // the cap it would breach
+        const char* cause_name{"ok"};  // scope-resolved name, set by try_consume
         bool ok() const { return verdict == Verdict::Ok; }
-        const char* name() const { return verdict_name(verdict); }
+        const char* name() const { return cause_name; }
     };
 
     std::deque<std::time_t> ts;      // event timestamps inside the window
@@ -102,11 +130,13 @@ struct InjectRateLimiter {
         if (ts.size() >= kMaxInjectsPerWindow) {
             r.verdict = Verdict::CountExceeded;
             r.value = ts.size(); r.threshold = kMaxInjectsPerWindow;
+            r.cause_name = scoped_name(r.verdict);
             return r;
         }
         if (bytes_in_window + byte_size > kMaxBytesPerWindow) {
             r.verdict = Verdict::BytesExceeded;
             r.value = bytes_in_window + byte_size; r.threshold = kMaxBytesPerWindow;
+            r.cause_name = scoped_name(r.verdict);
             return r;
         }
         ts.push_back(now);

--- a/src/impl/dash/coin/inject_sandbox.hpp
+++ b/src/impl/dash/coin/inject_sandbox.hpp
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// #157 M3 — SANDBOXED SIGNER / bounded-work guard for injected transactions.
+//
+// WHAT THIS IS
+// ------------
+// The injection runtime never signs (design §9.1 — the "isolated-signer SEAM":
+// tx_bytes arrive already-signed and are never mutated). What it DOES do is
+// re-VALIDATE every injected blob against the consensus-exact script interpreter
+// (dash_scriptcheck.so VerifyScript, wired as Mempool::m_script_check) — once at
+// admission's price-fold and again at EVERY template build for as long as the
+// inject stays in the pool. That script-verify path is the attack surface a
+// malicious inject targets: a single 100 KB blob stuffed with thousands of
+// minimal inputs, or a pathological scriptSig, forces the interpreter to do
+// unbounded work on every build.
+//
+// This header is the runtime-side realization of design §10 ("bound the blast
+// radius of a signing/validation bug to the blob itself"): a pure, cheap,
+// chain-state-INDEPENDENT vetting pass that BOUNDS the work the interpreter can
+// be asked to do, run ONCE at submit_inject BEFORE the tx is ever admitted to
+// the pool. It caps:
+//   * input count       — each vin is one VerifyScript call per build
+//   * output count      — bounds vout iteration / sigop surface
+//   * per-scriptSig size — bounds interpreter stack/alloc for one input
+//   * total scriptSig bytes — bounds aggregate interpreter work / allocation
+//   * legacy sigops     — bounds the CHECKSIG/CHECKMULTISIG work (dashd's own
+//                         MAX_BLOCK_SIGOPS accounting, reused via sigops.hpp)
+//
+// FAIL-CLOSED: any tx that breaches a bound is REFUSED BY NAME here and never
+// reaches the interpreter, the pool, or a template. No unbounded recursion, no
+// unbounded allocation, no partial admission.
+//
+// MONEY-SAFETY: this is a DoS bound placed IN FRONT OF the M1 validity gate
+// (Mempool::add_inject). It only ever REFUSES; it can never admit a tx the gate
+// would refuse, never loosen a consensus check, and touches NO coinbase /
+// subsidy / PPLNS / payee / fee state. The set of txs that reach add_inject is a
+// strict subset of before. Bounds are set generously (see the constants) so any
+// realistic operator/miner inject passes untouched.
+//
+// PURE + HEADER-ONLY: no node.hpp, no NodeCoinState — drivable from a rig-free
+// KAT over a MutableTransaction.
+
+#include <impl/dash/coin/transaction.hpp>   // MutableTransaction, TxIn, TxOut
+#include <impl/dash/coin/sigops.hpp>        // count_script_sigops, DASH_MAX_BLOCK_SIGOPS
+
+#include <cstddef>
+#include <cstdint>
+
+namespace dash {
+namespace coin {
+
+// Bounded-work sandbox for the injected-tx script-verify surface. All caps are
+// DoS ceilings, chosen well above any realistic inject; a normal spend (a
+// handful of inputs, standard scripts) clears every one.
+struct InjectSandbox {
+    // A consensus-valid tx can have many inputs, but an inject is a rare
+    // operator/miner action, not a chain-history sweep. 1000 inputs bounds the
+    // per-build VerifyScript fan-out while clearing any realistic consolidation.
+    static constexpr std::size_t kMaxInputs  = 1000;
+    static constexpr std::size_t kMaxOutputs = 1000;
+    // dashd/dashcore MAX_SCRIPT_SIZE = 10000 bytes: the interpreter refuses a
+    // larger script outright, so a scriptSig above it can never verify — refuse
+    // it here before the interpreter allocates for it.
+    static constexpr std::size_t kMaxScriptSigBytes = 10000;
+    // Aggregate scriptSig budget across all inputs — bounds total interpreter
+    // allocation/work independent of how the bytes split across inputs. Sits at
+    // the pool's per-tx byte cap (Mempool::kMaxInjectTxBytes) so it never binds
+    // before the size gate but caps a size-legal blob that is all-scriptSig.
+    static constexpr std::size_t kMaxTotalScriptSigBytes = 100000;
+    // Legacy sigops for ONE tx. dashd's whole-block ceiling is 40'000
+    // (DASH_MAX_BLOCK_SIGOPS); a single injected tx that alone approached the
+    // block ceiling would crowd out every other tx, so cap one inject at a tenth
+    // of the block budget. Generous for any standard multi-input spend.
+    static constexpr uint32_t kMaxLegacySigOps = 4000;
+
+    // Every breach is NAMED (DEF3 discipline — no silent drops), carrying the
+    // observed value and the threshold at the call site.
+    enum class Verdict : uint8_t {
+        Ok = 0,
+        TooManyInputs,
+        TooManyOutputs,
+        ScriptSigTooLarge,
+        TotalScriptSigTooLarge,
+        TooManySigOps,
+    };
+
+    static const char* verdict_name(Verdict v) {
+        switch (v) {
+            case Verdict::Ok:                     return "ok";
+            case Verdict::TooManyInputs:          return "inject-sandbox-too-many-inputs";
+            case Verdict::TooManyOutputs:         return "inject-sandbox-too-many-outputs";
+            case Verdict::ScriptSigTooLarge:      return "inject-sandbox-scriptsig-too-large";
+            case Verdict::TotalScriptSigTooLarge: return "inject-sandbox-total-scriptsig-too-large";
+            case Verdict::TooManySigOps:          return "inject-sandbox-too-many-sigops";
+        }
+        return "inject-sandbox-unknown";
+    }
+
+    // The observed value and threshold that produced a non-Ok verdict, so the
+    // caller can log cause/value/threshold in the repo's convention.
+    struct Report {
+        Verdict     verdict{Verdict::Ok};
+        uint64_t    value{0};      // the observed quantity that breached
+        uint64_t    threshold{0};  // the cap it breached
+        bool ok() const { return verdict == Verdict::Ok; }
+        const char* name() const { return verdict_name(verdict); }
+    };
+
+    // Vet a tx's script-verify surface. Cheapest checks first; returns on the
+    // FIRST breach (fail-closed). Chain-state-independent — reads only the tx.
+    static Report vet(const MutableTransaction& tx) {
+        Report r;
+
+        if (tx.vin.size() > kMaxInputs) {
+            r.verdict = Verdict::TooManyInputs;
+            r.value = tx.vin.size(); r.threshold = kMaxInputs; return r;
+        }
+        if (tx.vout.size() > kMaxOutputs) {
+            r.verdict = Verdict::TooManyOutputs;
+            r.value = tx.vout.size(); r.threshold = kMaxOutputs; return r;
+        }
+
+        uint64_t total_scriptsig = 0;
+        for (const auto& vin : tx.vin) {
+            const std::size_t n = vin.scriptSig.m_data.size();
+            if (n > kMaxScriptSigBytes) {
+                r.verdict = Verdict::ScriptSigTooLarge;
+                r.value = n; r.threshold = kMaxScriptSigBytes; return r;
+            }
+            total_scriptsig += n;
+            if (total_scriptsig > kMaxTotalScriptSigBytes) {
+                r.verdict = Verdict::TotalScriptSigTooLarge;
+                r.value = total_scriptsig; r.threshold = kMaxTotalScriptSigBytes; return r;
+            }
+        }
+
+        // Legacy sigop bound — reuse dashd's own counting rules (sigops.hpp)
+        // over every scriptSig and every scriptPubKey, fAccurate=false, exactly
+        // as the G2 selector counts. Saturating accumulate so a crafted tx
+        // cannot wrap the counter past the cap.
+        uint64_t sigops = 0;
+        for (const auto& vin : tx.vin) {
+            sigops += count_script_sigops(vin.scriptSig.m_data, /*accurate=*/false);
+            if (sigops > kMaxLegacySigOps) {
+                r.verdict = Verdict::TooManySigOps;
+                r.value = sigops; r.threshold = kMaxLegacySigOps; return r;
+            }
+        }
+        for (const auto& vout : tx.vout) {
+            sigops += count_script_sigops(vout.scriptPubKey.m_data, /*accurate=*/false);
+            if (sigops > kMaxLegacySigOps) {
+                r.verdict = Verdict::TooManySigOps;
+                r.value = sigops; r.threshold = kMaxLegacySigOps; return r;
+            }
+        }
+
+        return r;  // Ok
+    }
+};
+
+} // namespace coin
+} // namespace dash

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -23,6 +23,8 @@
 #include <impl/dash/coin/mn_state_machine.hpp>   // MnStateMachine
 #include <impl/dash/coin/mempool.hpp>            // Mempool
 #include <impl/dash/coin/tx_inject_pool.hpp>     // TxInjectPool (#157 miner/user tx-injection)
+#include <impl/dash/coin/inject_sandbox.hpp>     // #157 M3: InjectSandbox (bounded-work script-verify guard)
+#include <impl/dash/coin/inject_rate_limiter.hpp> // #157 M3: InjectRateLimiter (node-wide count+byte cap)
 #include <impl/dash/coin/rpc_data.hpp>           // DashWorkData
 #include <impl/dash/coin/quorum_manager.hpp>     // QuorumManager (merkleRootQuorums source)
 #include <impl/dash/coin/quorum_root.hpp>        // compute_merkle_root_quorums (pre-emit recompute)
@@ -622,12 +624,43 @@ public:
         if (tx.type != 0 || tx.vin.empty() || tx.vout.empty()) {
             r.cause = "inject-type-unsupported"; return r;
         }
+        const uint32_t byte_size =
+            static_cast<uint32_t>(::pack(tx).get_span().size());
+        // #157 M3 — GLOBAL RATE LIMIT (node-wide count + bytes per window). This
+        // is the SINGLE gate both the local loader and the peer path cross, so a
+        // limiter here bounds the total inject work regardless of origin (the
+        // "global" half of per-peer-AND-global). CHARGED ON ATTEMPT, before any
+        // consensus/script work, so an INVALID-inject flood is throttled too.
+        // Reward-safe: a ceiling in front of the validity gate — only refuses.
+        {
+            const std::time_t now = std::time(nullptr);
+            auto rl = m_inject_rate.try_consume(byte_size, now);
+            if (!rl.ok()) {
+                LOG_WARNING << "[MEMPOOL] inject rate-limited cause=" << rl.name()
+                            << " value=" << rl.value << " threshold=" << rl.threshold
+                            << " txid=" << r.txid.GetHex().substr(0, 16);
+                r.cause = rl.name(); return r;
+            }
+        }
+        // #157 M3 — SANDBOX (bounded-work guard on the script-verify surface).
+        // Cheap, chain-state-independent structural bounds run BEFORE the tx can
+        // enter the pool, so a pathological blob never reaches the consensus-exact
+        // interpreter (at admission or at any later build). FAIL-CLOSED: any
+        // breach refuses by name. Reward-safe: a DoS bound in front of the
+        // validity gate — it only refuses, never loosens a check.
+        {
+            auto sb = dash::coin::InjectSandbox::vet(tx);
+            if (!sb.ok()) {
+                LOG_WARNING << "[MEMPOOL] inject sandbox-refused cause=" << sb.name()
+                            << " value=" << sb.value << " threshold=" << sb.threshold
+                            << " txid=" << r.txid.GetHex().substr(0, 16);
+                r.cause = sb.name(); return r;
+            }
+        }
         // Lazily reconcile the pool with the mempool before admitting: forget
         // any tracked inject no longer in the mempool (confirmed / evicted) and
         // reap expired ones, so the caps reflect what is actually live.
         reconcile_inject_pool();
-        const uint32_t byte_size =
-            static_cast<uint32_t>(::pack(tx).get_span().size());
         // DoS caps FIRST (cheap, no consensus work): a full / over-cap pool
         // refuses before the mempool pays for pricing.
         auto pv = m_inject_pool.would_admit(r.txid, byte_size);
@@ -663,6 +696,10 @@ public:
     }
 
     size_t inject_pool_size() const { return m_inject_pool.size(); }
+
+    // #157 M3: number of injects the node-wide rate limiter still counts inside
+    // its current window (test/observability accessor; no consensus effect).
+    size_t inject_rate_count() const { return m_inject_rate.count_in_window(); }
 
     /// PINNED LOCAL TX (--pin-local-tx-hex, donation-dust consolidation): an
     /// operator-supplied, externally-signed, zero-fee tx that can only reach
@@ -2016,6 +2053,10 @@ private:
     // m_mempool (Mempool::add_inject priority), not this structure.
     bool                         m_tx_inject_enabled{false};
     dash::coin::TxInjectPool     m_inject_pool;
+    // #157 M3: node-wide inject rate limiter (count + bytes per window). The
+    // "global" half of the per-peer-AND-global DoS caps; the per-peer half is
+    // dash::PeerInjectGuard (tx_inject_relay.hpp), consulted on the peer path.
+    dash::coin::InjectRateLimiter m_inject_rate;
     // #107 PHASE 2 (--embedded-accrue-asset-locks): DEFAULT OFF — accrue the
     // pending type-8 asset-lock term into the CbTx creditPoolBalance. See
     // set_accrue_pending_asset_locks. Consumed by make_embedded_work_inputs

--- a/src/impl/dash/coin/node_coin_state.hpp
+++ b/src/impl/dash/coin/node_coin_state.hpp
@@ -605,6 +605,13 @@ public:
         uint256     txid;
     };
 
+    /// #157 M3 — where an inject entered from. Selects which node-wide rate
+    /// budget it draws on: a peer-origin inject charges the aggregate-PEER
+    /// limiter, a local operator inject the LOCAL limiter. Because the budgets
+    /// are separate, a peer flood exhausts only the peer budget and can NEVER
+    /// starve the operator's own inject. Default Local (the hex-loader path).
+    enum class InjectOrigin : uint8_t { Local, Peer };
+
     /// Submit a raw transaction for injection. Cheapest-checks-first gate
     /// (design §4.3): feature-enabled → DoS caps (pool full / total bytes / per-
     /// tx size, TxInjectPool) → mempool admission (Mempool::add_inject: size,
@@ -615,7 +622,8 @@ public:
     /// design's wire fields (carried for M2/M3). io-thread only.
     InjectSubmitResult submit_inject(const MutableTransaction& tx,
                                      uint32_t flags = 0,
-                                     int32_t expiry_height = 0) {
+                                     int32_t expiry_height = 0,
+                                     InjectOrigin origin = InjectOrigin::Local) {
         InjectSubmitResult r;
         r.txid = dash::coin::dash_txid(tx);
         if (!m_tx_inject_enabled) { r.cause = "inject-disabled"; return r; }
@@ -626,18 +634,39 @@ public:
         }
         const uint32_t byte_size =
             static_cast<uint32_t>(::pack(tx).get_span().size());
-        // #157 M3 — GLOBAL RATE LIMIT (node-wide count + bytes per window). This
-        // is the SINGLE gate both the local loader and the peer path cross, so a
-        // limiter here bounds the total inject work regardless of origin (the
-        // "global" half of per-peer-AND-global). CHARGED ON ATTEMPT, before any
-        // consensus/script work, so an INVALID-inject flood is throttled too.
-        // Reward-safe: a ceiling in front of the validity gate — only refuses.
+        // #157 M3 — PER-TX SIZE CAP, CHARGED-FREE. Refuse an oversize blob HERE,
+        // before the rate limiter is charged and before the sandbox runs, so an
+        // oversize-blob flood cannot drain the node-wide byte-window (8 MB/min)
+        // and starve legitimate injects — 3 peers each pushing one ~2.9 MB junk
+        // frame would otherwise empty the shared byte budget on attempts that get
+        // rejected anyway. TxInjectPool::would_admit re-checks this exact cap, so
+        // hoisting it changes NO accept decision: an oversize inject was always
+        // refused; it now refuses EARLIER, by the SAME named cause. Every CHARGED
+        // attempt is therefore <= kMaxInjectTxBytes and the count cap dominates.
+        // Reward-safe: an earlier refusal only — never loosens a check.
+        if (byte_size > dash::coin::TxInjectPool::kMaxInjectTxBytes) {
+            r.cause = dash::coin::TxInjectPool::admit_name(
+                          dash::coin::TxInjectPool::Admit::TooLarge);
+            return r;
+        }
+        // #157 M3 — RATE LIMIT (node-wide count + bytes per window), CHARGED ON
+        // ATTEMPT before any consensus/script work so an INVALID-inject flood is
+        // throttled too. The budget is SPLIT BY ORIGIN: a peer-origin inject
+        // draws on the aggregate-PEER limiter, a local operator inject on the
+        // LOCAL limiter. This is the invariant a single shared limiter could not
+        // give — a peer flood (7 peers @30/min, or a few @3 MB, or a per-peer
+        // guard reset on reconnect) exhausts ONLY the peer budget and can NEVER
+        // starve the operator's own inject. Reward-safe: a ceiling in front of
+        // the validity gate — only refuses.
         {
+            dash::coin::InjectRateLimiter& limiter =
+                (origin == InjectOrigin::Peer) ? m_inject_rate_peer : m_inject_rate;
             const std::time_t now = std::time(nullptr);
-            auto rl = m_inject_rate.try_consume(byte_size, now);
+            auto rl = limiter.try_consume(byte_size, now);
             if (!rl.ok()) {
                 LOG_WARNING << "[MEMPOOL] inject rate-limited cause=" << rl.name()
                             << " value=" << rl.value << " threshold=" << rl.threshold
+                            << " origin=" << (origin == InjectOrigin::Peer ? "peer" : "local")
                             << " txid=" << r.txid.GetHex().substr(0, 16);
                 r.cause = rl.name(); return r;
             }
@@ -697,9 +726,14 @@ public:
 
     size_t inject_pool_size() const { return m_inject_pool.size(); }
 
-    // #157 M3: number of injects the node-wide rate limiter still counts inside
-    // its current window (test/observability accessor; no consensus effect).
+    // #157 M3: number of injects the LOCAL rate limiter still counts inside its
+    // current window (test/observability accessor; no consensus effect).
     size_t inject_rate_count() const { return m_inject_rate.count_in_window(); }
+    // #157 M3: same, for the aggregate-PEER rate limiter.
+    size_t inject_rate_count_peer() const { return m_inject_rate_peer.count_in_window(); }
+    // #157 M3: bytes the LOCAL rate limiter still counts in its window — proves
+    // an oversize blob was refused BEFORE the byte-window was charged.
+    uint64_t inject_rate_bytes() const { return m_inject_rate.bytes_in_window; }
 
     /// PINNED LOCAL TX (--pin-local-tx-hex, donation-dust consolidation): an
     /// operator-supplied, externally-signed, zero-fee tx that can only reach
@@ -2053,10 +2087,15 @@ private:
     // m_mempool (Mempool::add_inject priority), not this structure.
     bool                         m_tx_inject_enabled{false};
     dash::coin::TxInjectPool     m_inject_pool;
-    // #157 M3: node-wide inject rate limiter (count + bytes per window). The
-    // "global" half of the per-peer-AND-global DoS caps; the per-peer half is
-    // dash::PeerInjectGuard (tx_inject_relay.hpp), consulted on the peer path.
+    // #157 M3: LOCAL-operator inject rate limiter (count + bytes per window).
+    // The local half of the origin-split node-wide budget.
     dash::coin::InjectRateLimiter m_inject_rate;
+    // #157 M3: SEPARATE aggregate-PEER inject rate limiter. Same caps as the
+    // local limiter but a distinct budget (Scope::Peers, distinct named causes),
+    // so a peer flood exhausts only THIS budget and never starves a local
+    // inject. The per-peer half remains dash::PeerInjectGuard (tx_inject_relay.hpp).
+    dash::coin::InjectRateLimiter m_inject_rate_peer{
+        dash::coin::InjectRateLimiter::Scope::Peers};
     // #107 PHASE 2 (--embedded-accrue-asset-locks): DEFAULT OFF — accrue the
     // pending type-8 asset-lock term into the CbTx creditPoolBalance. See
     // set_accrue_pending_asset_locks. Consumed by make_embedded_work_inputs

--- a/src/impl/dash/tx_inject_relay.hpp
+++ b/src/impl/dash/tx_inject_relay.hpp
@@ -39,6 +39,7 @@
 #include <functional>
 #include <string>
 #include <map>
+#include <utility>   // #157 M3: std::pair for the per-peer byte window
 
 namespace dash {
 
@@ -85,10 +86,17 @@ struct PeerInjectGuard {
     // still bounds a hostile peer to ~1 script-check attempt every 2 s.
     static constexpr std::size_t kMaxInjectsPerPeerPerWindow = 30;
     static constexpr std::time_t kWindowSeconds = 60;
+    // #157 M3: per-peer VOLUME cap (bytes/window) alongside the count cap above.
+    // A peer sending few but MAX-SIZE injects (kMaxInjectTxBytes = 100 KB each)
+    // is bounded by count, but this bounds the bandwidth/memory churn directly:
+    // 30 * 100 KB = 3 MB/min ceiling, matching the count cap at max tx size.
+    static constexpr uint64_t kMaxInjectBytesPerPeerPerWindow = 3u * 1024u * 1024u;
     // Per-peer txid memory cap (FIFO eviction). Bounds the set a peer can grow.
     static constexpr std::size_t kMaxPeerSeen = 4096;
 
     std::deque<std::time_t> window;   // submit timestamps inside kWindowSeconds
+    std::deque<std::pair<std::time_t, uint64_t>> byte_window;  // (ts, bytes) inside the window
+    uint64_t                bytes_in_window{0};   // running sum of byte_window
     std::deque<uint256>     seen_order;
     std::map<uint256, char> seen;  // txid -> present (this peer only)
 
@@ -97,6 +105,19 @@ struct PeerInjectGuard {
         while (!window.empty() && window.front() + kWindowSeconds <= now)
             window.pop_front();
         return window.size();
+    }
+
+    // #157 M3: drop byte events older than the window; return bytes still inside.
+    uint64_t prune_byte_window(std::time_t now) {
+        while (!byte_window.empty() && byte_window.front().first + kWindowSeconds <= now) {
+            bytes_in_window -= byte_window.front().second;
+            byte_window.pop_front();
+        }
+        return bytes_in_window;
+    }
+    void record_bytes(std::time_t now, uint64_t byte_size) {
+        byte_window.emplace_back(now, byte_size);
+        bytes_in_window += byte_size;
     }
 
     bool peer_has_seen(const uint256& txid) const {
@@ -154,7 +175,7 @@ struct NodeInjectSeen {
 //   node_seen   — node-level decided-txid set (IO-thread-confined)
 //   peer_guard  — this peer's DoS state
 //   txid        — dash_txid(msg.m_tx), self-computed by the caller
-//   byte_size   — informational (reserved; DoS byte caps live in submit_inject)
+//   byte_size   — #157 M3: charged against the per-peer VOLUME cap (bytes/window)
 //   now         — one clock reading for the whole decision
 //   submit_fn   — () -> InjectSubmitOutcome, wrapping NodeCoinState::submit_inject
 template <typename SubmitFn>
@@ -166,7 +187,6 @@ InjectRelayVerdict ingest_peer_inject(bool enabled,
                                       std::time_t now,
                                       SubmitFn&& submit_fn)
 {
-    (void)byte_size;
     InjectRelayVerdict v;
     v.txid = txid;
 
@@ -202,14 +222,26 @@ InjectRelayVerdict ingest_peer_inject(bool enabled,
     // we saw the peer act (window untouched so a slowed peer recovers).
     if (peer_guard.prune_window(now) >= PeerInjectGuard::kMaxInjectsPerPeerPerWindow) {
         v.kind = InjectRelayVerdict::Kind::RateLimited;
-        v.cause = "peer-rate-limited";
+        v.cause = "peer-rate-limited-count";
         v.forward = false;
         return v;
     }
 
-    // Genuinely new + within budget: charge the window, remember the peer saw it,
-    // and route through the M1 gate exactly once.
+    // #157 M3 — per-peer VOLUME cap. A peer under the count cap can still push
+    // bytes with big injects; refuse once this window's bytes would exceed the
+    // ceiling. Pruned to `now`; no submit, window untouched so a peer recovers.
+    if (peer_guard.prune_byte_window(now) + byte_size
+            > PeerInjectGuard::kMaxInjectBytesPerPeerPerWindow) {
+        v.kind = InjectRelayVerdict::Kind::RateLimited;
+        v.cause = "peer-rate-limited-bytes";
+        v.forward = false;
+        return v;
+    }
+
+    // Genuinely new + within budget: charge both windows, remember the peer saw
+    // it, and route through the M1 gate exactly once.
     peer_guard.record_window(now);
+    peer_guard.record_bytes(now, byte_size);
     peer_guard.remember_peer_seen(txid);
 
     InjectSubmitOutcome out = submit_fn();

--- a/test/test_dash_tx_inject.cpp
+++ b/test/test_dash_tx_inject.cpp
@@ -41,6 +41,8 @@
 #include <impl/dash/coin/tx_inject_pool.hpp>
 #include <impl/dash/coin/node_coin_state.hpp>   // #157 M2: submit_inject gate (relay routes through it)
 #include <impl/dash/tx_inject_relay.hpp>        // #157 M2: ingest_peer_inject relay policy
+#include <impl/dash/coin/inject_sandbox.hpp>    // #157 M3: bounded-work script-verify sandbox
+#include <impl/dash/coin/inject_rate_limiter.hpp> // #157 M3: node-wide count+byte rate limiter
 #include <impl/dash/coin/good_citizen_defaults.hpp>
 #include <impl/dash/coin/vendor/dashscript/c2pool_scriptcheck.h>
 
@@ -722,4 +724,244 @@ TEST(DashTxInject, InjectedTxRidesRegisterTemplateTxs)
     EXPECT_EQ(dash_txid(selected[0].tx), txid)
         << "the accepted inject must be in the served body (rides register_template_txs)";
     EXPECT_EQ(fees, 0u) << "a 0-fee inject contributes 0 to total_fees — reward path unchanged";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #157 M3 — RATE-LIMITING + SANDBOXED SIGNER
+//
+// These KATs drive the two M3 additions that sit IN FRONT of the (unchanged) M1
+// validity gate: the node-wide InjectRateLimiter (count + bytes/window), the
+// per-peer VOLUME cap on PeerInjectGuard, and the bounded-work InjectSandbox on
+// the script-verify surface. RED on master by construction (master has none of
+// these types). Every case proves a DoS bound HOLDS and fails CLOSED by a NAMED
+// cause — and the pre-existing M1/M2 acceptance KATs above double as the
+// regression guard that M3 never blocks or loosens a normal inject.
+// ─────────────────────────────────────────────────────────────────────────────
+
+namespace {
+using dash::coin::InjectSandbox;
+using dash::coin::InjectRateLimiter;
+using ::bitcoin_family::coin::TxIn;
+using ::bitcoin_family::coin::TxOut;
+
+// A minimal type-0 tx: 1 input (prevout hash = seed), 1 output, tiny scriptSig.
+// Passes the sandbox (small) and the type check; used to exercise the rate
+// limiter without paying for signing (it is rejected post-rate-charge by the
+// validity gate, which is exactly what a flood looks like).
+MutableTransaction minimal_tx(uint8_t seed) {
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 0;
+    TxIn in; in.prevout.hash = prevhash(seed); in.prevout.index = 0;
+    in.sequence = 0xffffffffu;
+    in.scriptSig = to_script({0x51});   // OP_1 — 1 byte, 0 sigops
+    tx.vin.push_back(in);
+    TxOut out; out.value = 1000; tx.vout.push_back(out);
+    return tx;
+}
+
+// A type-0 tx with `n` inputs (each a distinct tiny prevout, tiny scriptSig).
+MutableTransaction tx_with_inputs(std::size_t n) {
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        TxIn in; in.prevout.hash = prevhash(static_cast<uint8_t>(i & 0xff));
+        in.prevout.index = static_cast<uint32_t>(i);
+        in.sequence = 0xffffffffu;
+        in.scriptSig = to_script({0x51});
+        tx.vin.push_back(in);
+    }
+    TxOut out; out.value = 1000; tx.vout.push_back(out);
+    return tx;
+}
+} // namespace
+
+// (M3-1) SANDBOX accepts a normal signed spend untouched — the DoS bounds never
+//        bind on a realistic inject (money-safety: M3 does not block normal txs).
+TEST(DashTxInject, SandboxAcceptsNormalSpend)
+{
+    Key k(0xc1);
+    auto tx = make_signed_spend(k, prevhash(0x31), 100'000);
+    auto r = InjectSandbox::vet(tx);
+    EXPECT_TRUE(r.ok()) << "a normal 1-in/1-out spend must clear every sandbox bound, got "
+                        << r.name();
+}
+
+// (M3-2) SANDBOX bounds the input fan-out (each input = one VerifyScript call
+//        per build). >kMaxInputs fails CLOSED by name.
+TEST(DashTxInject, SandboxRefusesTooManyInputs)
+{
+    auto ok  = tx_with_inputs(InjectSandbox::kMaxInputs);
+    EXPECT_TRUE(InjectSandbox::vet(ok).ok()) << "exactly the cap must pass";
+
+    auto bad = tx_with_inputs(InjectSandbox::kMaxInputs + 1);
+    auto r = InjectSandbox::vet(bad);
+    EXPECT_EQ(r.verdict, InjectSandbox::Verdict::TooManyInputs);
+    EXPECT_STREQ(r.name(), "inject-sandbox-too-many-inputs");
+    EXPECT_EQ(r.value, InjectSandbox::kMaxInputs + 1);
+    EXPECT_EQ(r.threshold, InjectSandbox::kMaxInputs);
+}
+
+// (M3-3) SANDBOX bounds a single scriptSig (interpreter stack/alloc). A scriptSig
+//        above kMaxScriptSigBytes fails CLOSED before the interpreter sees it.
+TEST(DashTxInject, SandboxRefusesOversizeScriptSig)
+{
+    MutableTransaction tx = minimal_tx(0x40);
+    tx.vin[0].scriptSig = to_script(std::vector<uint8_t>(InjectSandbox::kMaxScriptSigBytes + 1, 0x00));
+    auto r = InjectSandbox::vet(tx);
+    EXPECT_EQ(r.verdict, InjectSandbox::Verdict::ScriptSigTooLarge);
+    EXPECT_STREQ(r.name(), "inject-sandbox-scriptsig-too-large");
+    EXPECT_EQ(r.threshold, InjectSandbox::kMaxScriptSigBytes);
+}
+
+// (M3-4) SANDBOX bounds AGGREGATE scriptSig bytes across inputs (each under the
+//        per-script cap, summing past the total). Fails CLOSED by name.
+TEST(DashTxInject, SandboxRefusesTotalScriptSigOverflow)
+{
+    MutableTransaction tx;
+    tx.version = 1; tx.type = 0; tx.locktime = 0;
+    // 12 inputs * 9000 bytes = 108000 > kMaxTotalScriptSigBytes(100000), each
+    // 9000 < kMaxScriptSigBytes(10000) so the per-script cap never binds first.
+    for (int i = 0; i < 12; ++i) {
+        TxIn in; in.prevout.hash = prevhash(static_cast<uint8_t>(i));
+        in.prevout.index = static_cast<uint32_t>(i); in.sequence = 0xffffffffu;
+        in.scriptSig = to_script(std::vector<uint8_t>(9000, 0x00));  // pushes, 0 sigops
+        tx.vin.push_back(in);
+    }
+    TxOut out; out.value = 1000; tx.vout.push_back(out);
+    auto r = InjectSandbox::vet(tx);
+    EXPECT_EQ(r.verdict, InjectSandbox::Verdict::TotalScriptSigTooLarge);
+    EXPECT_STREQ(r.name(), "inject-sandbox-total-scriptsig-too-large");
+    EXPECT_EQ(r.threshold, InjectSandbox::kMaxTotalScriptSigBytes);
+}
+
+// (M3-5) SANDBOX bounds the CHECKSIG work (dashd's own legacy sigop rules). A
+//        scriptSig stuffed with OP_CHECKSIG past kMaxLegacySigOps fails CLOSED.
+TEST(DashTxInject, SandboxRefusesSigOpFlood)
+{
+    MutableTransaction tx = minimal_tx(0x50);
+    // kMaxLegacySigOps+1 OP_CHECKSIG (0xac) bytes: 4001 bytes < per-script cap
+    // and < total cap, so only the sigop bound can trip.
+    tx.vin[0].scriptSig = to_script(std::vector<uint8_t>(InjectSandbox::kMaxLegacySigOps + 1, 0xac));
+    auto r = InjectSandbox::vet(tx);
+    EXPECT_EQ(r.verdict, InjectSandbox::Verdict::TooManySigOps);
+    EXPECT_STREQ(r.name(), "inject-sandbox-too-many-sigops");
+    EXPECT_GT(r.value, static_cast<uint64_t>(InjectSandbox::kMaxLegacySigOps));
+    EXPECT_EQ(r.threshold, InjectSandbox::kMaxLegacySigOps);
+}
+
+// (M3-6) GLOBAL RATE LIMITER — COUNT cap. The (N+1)th event in a window is the
+//        one refused; a refusal mutates nothing (window untouched).
+TEST(DashTxInject, RateLimiterCountCap)
+{
+    InjectRateLimiter rl;
+    const std::time_t t = 10'000;
+    for (std::size_t i = 0; i < InjectRateLimiter::kMaxInjectsPerWindow; ++i)
+        EXPECT_TRUE(rl.try_consume(100, t).ok()) << "under cap must pass at i=" << i;
+
+    auto over = rl.try_consume(100, t);
+    EXPECT_FALSE(over.ok());
+    EXPECT_EQ(over.verdict, InjectRateLimiter::Verdict::CountExceeded);
+    EXPECT_STREQ(over.name(), "inject-rate-limited-count");
+    EXPECT_EQ(rl.count_in_window(), InjectRateLimiter::kMaxInjectsPerWindow)
+        << "a refused attempt must not be recorded";
+}
+
+// (M3-7) GLOBAL RATE LIMITER — BYTE cap. Few large events exhaust the byte
+//        budget while the count cap is untouched; recovers as the window ages.
+TEST(DashTxInject, RateLimiterByteCap)
+{
+    InjectRateLimiter rl;
+    const std::time_t t = 20'000;
+    const uint64_t big = InjectRateLimiter::kMaxBytesPerWindow / 2;   // 2 fit, 3rd overflows
+    EXPECT_TRUE(rl.try_consume(big, t).ok());
+    EXPECT_TRUE(rl.try_consume(big, t).ok());
+    auto over = rl.try_consume(big, t);
+    EXPECT_FALSE(over.ok());
+    EXPECT_EQ(over.verdict, InjectRateLimiter::Verdict::BytesExceeded);
+    EXPECT_STREQ(over.name(), "inject-rate-limited-bytes");
+
+    // After the window rolls forward, the old bytes age out and it recovers.
+    auto later = rl.try_consume(big, t + InjectRateLimiter::kWindowSeconds);
+    EXPECT_TRUE(later.ok()) << "the window must recover once old events expire";
+}
+
+// (M3-8) GLOBAL RATE LIMITER end-to-end through submit_inject: a flood of
+//        distinct injects is throttled at the node-wide count cap, refused BY
+//        NAME, and the limiter counts every ATTEMPT (charged before validity so
+//        an invalid-inject flood is throttled too). Reward path never touched.
+TEST(DashTxInject, SubmitInjectGlobalRateLimitedByName)
+{
+    UTXOViewCache utxo(nullptr);
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    // The cap is 200 and a uint8 seed only spans 256, but distinct prevout
+    // INDEX keeps each txid unique; drive cap+1 distinct injects in one window.
+    const std::size_t cap = InjectRateLimiter::kMaxInjectsPerWindow;
+    for (std::size_t i = 0; i < cap; ++i) {
+        MutableTransaction tx = minimal_tx(0x01);
+        tx.vin[0].prevout.index = static_cast<uint32_t>(i);   // unique txid
+        auto r = st.submit_inject(tx);
+        // Rejected by the validity gate (no coin), NOT rate-limited — the point
+        // is the attempt was CHARGED against the window without being throttled.
+        EXPECT_NE(r.cause, "inject-rate-limited-count")
+            << "under the cap must not be rate-limited at i=" << i;
+    }
+    EXPECT_EQ(st.inject_rate_count(), cap) << "every attempt is charged before validity";
+
+    MutableTransaction over = minimal_tx(0x01);
+    over.vin[0].prevout.index = static_cast<uint32_t>(cap);
+    auto r = st.submit_inject(over);
+    EXPECT_FALSE(r.ok);
+    EXPECT_EQ(r.cause, "inject-rate-limited-count")
+        << "the (cap+1)th inject in a window is throttled by name";
+}
+
+// (M3-9) SANDBOX end-to-end through submit_inject: a pathological inject is
+//        refused BY NAME and NEVER enters the pool (never reaches the consensus
+//        interpreter or a template). Proves the bound sits in front of the gate.
+TEST(DashTxInject, SubmitInjectSandboxRefusedByName)
+{
+    UTXOViewCache utxo(nullptr);
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    auto bad = tx_with_inputs(InjectSandbox::kMaxInputs + 1);
+    auto r = st.submit_inject(bad);
+    EXPECT_FALSE(r.ok);
+    EXPECT_EQ(r.cause, "inject-sandbox-too-many-inputs");
+    EXPECT_EQ(st.inject_pool_size(), 0u)
+        << "a sandbox-refused inject must never enter the pool";
+}
+
+// (M3-10) PER-PEER VOLUME cap on the relay path: a peer under the per-peer COUNT
+//         cap is still bounded by BYTES/window. Refused as RateLimited by name,
+//         and submit_fn is never called for the throttled frame.
+TEST(DashTxInject, PeerInjectByteVolumeRateLimited)
+{
+    dash::NodeInjectSeen node_seen;
+    dash::PeerInjectGuard peer;
+    const std::uint32_t big =
+        static_cast<std::uint32_t>(dash::PeerInjectGuard::kMaxInjectBytesPerPeerPerWindow / 2);
+
+    int submit_calls = 0;
+    auto stub = [&]() -> dash::InjectSubmitOutcome { ++submit_calls; return {true, "ok"}; };
+
+    // Two big frames (each half the byte budget) fit; the third overflows it —
+    // all well under the 30/window COUNT cap, so only the byte cap can trip.
+    auto v1 = dash::ingest_peer_inject(true, node_seen, peer, prevhash(0x01), big, 7000, stub);
+    EXPECT_EQ(v1.kind, dash::InjectRelayVerdict::Kind::Accepted);
+    auto v2 = dash::ingest_peer_inject(true, node_seen, peer, prevhash(0x02), big, 7000, stub);
+    EXPECT_EQ(v2.kind, dash::InjectRelayVerdict::Kind::Accepted);
+    auto v3 = dash::ingest_peer_inject(true, node_seen, peer, prevhash(0x03), big, 7000, stub);
+    EXPECT_EQ(v3.kind, dash::InjectRelayVerdict::Kind::RateLimited);
+    EXPECT_EQ(v3.cause, "peer-rate-limited-bytes");
+    EXPECT_EQ(submit_calls, 2) << "the byte-throttled frame must not reach submit";
+
+    // The count cap is untouched (only 2 events recorded there).
+    EXPECT_LT(peer.window.size(), dash::PeerInjectGuard::kMaxInjectsPerPeerPerWindow);
+
+    // Recovers once the window rolls past the old byte events.
+    auto later = dash::ingest_peer_inject(true, node_seen, peer, prevhash(0x04), big,
+        7000 + dash::PeerInjectGuard::kWindowSeconds, stub);
+    EXPECT_EQ(later.kind, dash::InjectRelayVerdict::Kind::Accepted)
+        << "the per-peer byte window must recover as old events expire";
 }

--- a/test/test_dash_tx_inject.cpp
+++ b/test/test_dash_tx_inject.cpp
@@ -965,3 +965,81 @@ TEST(DashTxInject, PeerInjectByteVolumeRateLimited)
     EXPECT_EQ(later.kind, dash::InjectRelayVerdict::Kind::Accepted)
         << "the per-peer byte window must recover as old events expire";
 }
+
+// (M3-11) DoS — SIZE CAP BEFORE THE RATE CHARGE. An oversize inject is refused
+//         by the named oversize cause BEFORE the node-wide rate limiter is
+//         charged, so an oversize-blob flood cannot drain the shared byte-window
+//         (8 MB/min) and starve legitimate injects. Regression guard for the
+//         charge-then-reject ordering bug: a big junk frame must cost the window
+//         NOTHING. Reward path never reached.
+TEST(DashTxInject, OversizeInjectRefusedBeforeRateCharge)
+{
+    UTXOViewCache utxo(nullptr);
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    // A serialized tx whose size exceeds the per-tx cap (scriptPubKey alone).
+    MutableTransaction big = minimal_tx(0x60);
+    big.vout[0].scriptPubKey =
+        to_script(std::vector<uint8_t>(TxInjectPool::kMaxInjectTxBytes + 64, 0x51));
+    ASSERT_GT(::pack(big).get_span().size(), TxInjectPool::kMaxInjectTxBytes)
+        << "the crafted tx must actually exceed the per-tx byte cap";
+
+    auto r = st.submit_inject(big);
+    EXPECT_FALSE(r.ok);
+    EXPECT_EQ(r.cause, "inject-pool-oversize")
+        << "an oversize inject must be refused by the named oversize cause";
+
+    // THE FIX: the oversize attempt consumed NEITHER the count NOR the byte
+    // window — it was rejected strictly before the rate limiter was charged.
+    EXPECT_EQ(st.inject_rate_count(), 0u)
+        << "an oversize blob must not be charged to the node-wide count window";
+    EXPECT_EQ(st.inject_rate_bytes(), 0u)
+        << "an oversize blob must not drain the node-wide byte window";
+}
+
+// (M3-12) DoS — LOCAL-vs-PEER BUDGET SPLIT. A peer flood that exhausts the
+//         aggregate-PEER rate budget CANNOT starve the local operator's own
+//         inject: the two origins draw on SEPARATE node-wide budgets. Peer-origin
+//         attempts are throttled by their own named cause, while a local inject
+//         still passes the rate gate. Regression guard for the shared-budget
+//         starvation the split fixes. Reward path never touched.
+TEST(DashTxInject, PeerFloodDoesNotStarveLocalInject)
+{
+    using Origin = NodeCoinState::InjectOrigin;
+    UTXOViewCache utxo(nullptr);           // empty view: injects fail post-charge
+    NodeCoinState st; arm_ncs(st, utxo);
+
+    const std::size_t cap = InjectRateLimiter::kMaxInjectsPerWindow;
+    // Exhaust the PEER count budget with `cap` distinct peer-origin attempts
+    // (each rejected on the empty view AFTER being charged — a flood's shape).
+    for (std::size_t i = 0; i < cap; ++i) {
+        MutableTransaction tx = minimal_tx(0x01);
+        tx.vin[0].prevout.index = static_cast<uint32_t>(i);   // unique txid
+        auto r = st.submit_inject(tx, 0, 0, Origin::Peer);
+        EXPECT_NE(r.cause, "inject-rate-limited-peers-count")
+            << "under the peer cap must not be rate-limited at i=" << i;
+    }
+    EXPECT_EQ(st.inject_rate_count_peer(), cap)
+        << "every peer attempt is charged to the PEER budget";
+
+    // The (cap+1)th PEER inject is throttled on the PEER budget, by its own name.
+    {
+        MutableTransaction over = minimal_tx(0x01);
+        over.vin[0].prevout.index = static_cast<uint32_t>(cap);
+        auto r = st.submit_inject(over, 0, 0, Origin::Peer);
+        EXPECT_FALSE(r.ok);
+        EXPECT_EQ(r.cause, "inject-rate-limited-peers-count")
+            << "the (cap+1)th PEER inject is throttled on the peer budget by name";
+    }
+
+    // INVARIANT: the peer flood did NOT touch the LOCAL budget. A local inject
+    // still passes the rate gate — it fails later on the empty view, NOT on the
+    // rate limiter (never 'inject-rate-limited-*').
+    MutableTransaction local = minimal_tx(0x02);
+    auto rl = st.submit_inject(local, 0, 0, Origin::Local);
+    EXPECT_FALSE(rl.ok) << "empty view: the local inject is unpriceable, not accepted";
+    EXPECT_EQ(rl.cause, "inject-unpriceable")
+        << "a local inject must clear the rate gate despite the peer flood";
+    EXPECT_EQ(st.inject_rate_count(), 1u)
+        << "only the single local attempt is charged to the LOCAL budget";
+}


### PR DESCRIPTION
## #157 M3 — rate-limiting + bounded-work signer sandbox (DASH, flag DEFAULT OFF)

**DRAFT — do not merge.** Independent review + an operator tap are owed before the
`--embedded-tx-inject` flag is armed anywhere: tx-injection is a money-path feature
(it controls what lands in a mined block). This PR neither arms the flag nor changes
its default.

Builds on the merged M1 (#1499, runtime + submit_inject gate) and M2 (#1505, p2p
`tx_inject` transport). Implements the M3 slice from `docs/design/miner-tx-injection.md`
(§4.6 guards, §8/§10 sandbox, §11 code map), DASH-first.

### Design note — how M3 fits the existing gate

Every inject — local (`--embedded-tx-inject-hex`) or peer (`tx_inject` frame) — funnels
through the single M1 gate `NodeCoinState::submit_inject`, which runs the consensus
validity checks (type-0, vin/vout, DoS caps, script-armed, BIP68 fail-closed, MoneyRange,
dedup, already-confirmed) via `Mempool::add_inject`. M3 adds two DoS layers **in front of
that gate**, never inside it:

1. **Rate-limiting** — M2 already gave each peer a sliding-window *count* cap
   (`PeerInjectGuard`). M3 adds the missing halves: a per-peer *byte-volume* window, and a
   node-wide `InjectRateLimiter` (count **and** bytes per window) consulted inside
   `submit_inject` so it bounds the aggregate of all peers **and** the local loader in one
   place. The global limiter is charged on *attempt*, before any script/validity work, so a
   flood of *invalid* injects is throttled too.
2. **Sandboxed signer** — the runtime never signs (design §9.1 seam: bytes arrive
   already-signed and are never mutated). What it does is re-validate each blob against the
   consensus-exact interpreter, once at admission and again at *every* template build. M3
   adds `InjectSandbox::vet()` — a pure, chain-state-independent pass run once in
   `submit_inject` that **bounds the work that interpreter can be asked to do** (input count,
   output count, per-scriptSig size, total scriptSig bytes, legacy sigops) so a pathological
   blob can never enter the pool. This is the runtime-side realization of design §10 ("bound
   the blast radius of a signing/validation bug to the blob itself"); the separate-process
   offline key-bearing builder of §10 remains a non-runtime tool, staged.

### Files changed

- **new** `src/impl/dash/coin/inject_rate_limiter.hpp` — node-wide count+byte token bucket.
- **new** `src/impl/dash/coin/inject_sandbox.hpp` — bounded-work script-verify guard.
- `src/impl/dash/coin/node_coin_state.hpp` — `submit_inject` consults the rate limiter then
  the sandbox before the (unchanged) validity gate; adds `m_inject_rate` + a test accessor.
- `src/impl/dash/tx_inject_relay.hpp` — `PeerInjectGuard` gains a per-peer byte-volume
  window; `ingest_peer_inject` now charges `byte_size` (was reserved).
- `test/test_dash_tx_inject.cpp` — 10 new KATs (folded into `test_dash_mempool`).

Every rejection is NAMED with cause/value/threshold and logged, matching the repo
convention: `inject-rate-limited-count/-bytes`, `peer-rate-limited-count/-bytes`,
`inject-sandbox-too-many-inputs / -too-many-outputs / -scriptsig-too-large /
-total-scriptsig-too-large / -too-many-sigops`.

### Money-safety

- The validity gate `Mempool::add_inject` is **byte-unchanged in what it accepts**; the new
  guards only ADD refusals in front of it (fail-closed), so the accepted set is a strict
  subset — nothing is loosened.
- Reward-safety proof obligation holds: `git diff` over the coinbase / subsidy / PPLNS /
  payee / donation files is **empty**; no `give_author`/`donation`/`payee`/`subsidy` tokens
  in the new files. An injected tx still enters only the block body.
- Flag stays DEFAULT OFF; nothing is armed.

### Build / test

Built `test_dash_mempool` (`-DCOIN_DGB=ON`, Release, gcc13 conan profile) on a build host.

- `DashTxInject.*` — **28/28 pass** (18 pre-existing M1/M2 + 10 new M3). Named
  cause/value/threshold visible in the logs (e.g. `inject rate-limited
  cause=inject-rate-limited-count value=200 threshold=200`).
- Full `test_dash_mempool` binary — **144/144 pass**, no regressions.

The new tests are RED on master by construction (the `InjectSandbox` / `InjectRateLimiter`
types do not exist there, so the test TU does not compile against master).

### Review-gated

Post-cut Tier-3 feature; not a dashd-cut blocker. Marked draft. Independent review + an
operator tap are owed before merge and before the flag is armed anywhere.
