### PR TITLE
xmr(native): the trust anchor counted fees as emission

### DIFF
--- a/src/impl/xmr/native/anchor/xmr_chain_anchor_stagenet.inc
+++ b/src/impl/xmr/native/anchor/xmr_chain_anchor_stagenet.inc
@@ -5,8 +5,10 @@ R"ANCHOR(
 # captured  2026-09-10 19:01Z, daemon tip 2204848, anchor buried 848
 # windows   735 difficulty / 100 short-term / 100000 long-term
 # coins     already_generated_coins from get_miner_data at 2204848 minus the
-#           coinbase of every block above H_a; cross-checked against
-#           get_coinbase_tx_sum over the same range.
+#           BASE EMISSION of every block above H_a -- get_coinbase_tx_sum's
+#           emission_amount, NOT the header `reward`. monerod accumulates
+#           base_reward into already_generated_coins; fees are recycled from
+#           the existing supply and are never added to it.
 # note      monerod publishes no RPC for its compiled-in checkpoints;
 #           `checkpoint` rows are copied by hand at release time and
 #           this capture carries 0 of them.
@@ -18,7 +20,7 @@ prev_id 08034ed1a2196cb678ccb828d88448700a4cb5230d1a00c1e00ef65b9e314e79
 timestamp 1788965550
 major_version 16
 cumulative_difficulty 0 c3772e00db
-already_generated_coins 18163913490712907281
+already_generated_coins 18163913501536847281
 seed 2203648 5bd07b3c898f74aa3923d10f2749c9d4ee7b36461a55948f389e6044acacb321
 diff 1788876380 0 c2cb6d9d38
 diff 1788876664 0 c2cba869a1
@@ -798,5 +800,5 @@ ltw 216879
 ltw 6833x176470
 ltw 300781 298639 298687
 ltw 9327x176470
-digest 6ef031fc7ce4be63aebef4e79d1f270c694edb20c89ebf04a8e8bcda0dc669a8
+digest e159b23d65929cd1642e398448f09ca83e34a8312a98de6fb504647c2ede707c
 )ANCHOR"

--- a/tools/xmr-anchor-gen/xmr_anchor_gen.py
+++ b/tools/xmr-anchor-gen/xmr_anchor_gen.py
@@ -303,29 +303,58 @@ def main():
     assert at["height"] == h_a
 
     # already_generated_coins at H_a: the tip value from get_miner_data, minus
-    # the coinbase amount of every block above H_a. `reward` in a block header
-    # IS the coinbase amount (base emission plus fees), which is exactly what
-    # monerod adds into already_generated_coins per block.
+    # the BASE EMISSION of every block above H_a.
+    #
+    # NOT the header `reward`, which is the coinbase amount -- base emission
+    # PLUS the fees the miner swept. monerod does not add that. It does
+    #
+    #     already_generated_coins = base_reward + already_generated_coins;
+    #
+    # (Blockchain::handle_block_to_main_chain), because a fee is existing
+    # supply changing hands, not supply being created; counting it as emission
+    # would inflate the number the tail-emission curve and the template's own
+    # reward calculation are both read off.
+    #
+    # Backing the tip value out with `reward` therefore removes base+fee per
+    # block where only base was ever added, and leaves the anchor SHORT BY THE
+    # FEE TOTAL over the range. That is what shipped in the stagenet bundle,
+    # and the M4 parity soak caught it on its first template sample: every
+    # P-TPL compare differed on already_generated_coins by exactly the daemon's
+    # own fee_amount for those blocks, which -- the field being a sentinel --
+    # revoked the graduation key outright.
     md = rpc.json_rpc("get_miner_data")
     md_tip = int(md["height"]) - 1
     coins_at_md_tip = int(md["already_generated_coins"])
     above = fetch_headers(rpc, h_a + 1, md_tip) if md_tip > h_a else []
-    coins = coins_at_md_tip - sum(x["reward"] for x in above)
-    if coins <= 0:
-        raise SystemExit("already_generated_coins came out non-positive")
 
-    # Independent cross-check of the same subtraction against the daemon's own
-    # coinbase sum over the identical range.
+    emission_above = 0
     if above:
         cs = rpc.json_rpc("get_coinbase_tx_sum",
                           {"height": h_a + 1, "count": md_tip - h_a})
-        s = wide_to_int(cs, "wide_emission_amount", "emission_amount",
-                        "emission_amount_top64") \
-            + wide_to_int(cs, "wide_fee_amount", "fee_amount", "fee_amount_top64")
-        if s != sum(x["reward"] for x in above):
-            raise SystemExit("coinbase cross-check disagrees: %d vs %d"
-                             % (s, sum(x["reward"] for x in above)))
-        print("coinbase cross-check OK over %d blocks" % len(above), file=sys.stderr)
+        emission_above = wide_to_int(cs, "wide_emission_amount", "emission_amount",
+                                     "emission_amount_top64")
+        fees_above = wide_to_int(cs, "wide_fee_amount", "fee_amount",
+                                 "fee_amount_top64")
+
+        # THE CROSS-CHECK THAT CATCHES THIS CLASS, rather than the one that
+        # missed it. The old check asserted emission+fee == sum(reward), which
+        # is a true identity about the two RPCs and says nothing about which of
+        # them belongs in the subtraction -- so it confirmed the wrong quantity
+        # and printed OK. What is actually claimed here is that the headers'
+        # rewards decompose into the daemon's emission and fee totals, and the
+        # quantity used is the emission half, named as such.
+        reward_above = sum(x["reward"] for x in above)
+        if emission_above + fees_above != reward_above:
+            raise SystemExit("coinbase decomposition disagrees: emission %d + fee %d "
+                             "!= sum(reward) %d"
+                             % (emission_above, fees_above, reward_above))
+        print("coinbase decomposition OK over %d blocks: emission=%d fee=%d "
+              "(fee is NOT emitted and is NOT subtracted)"
+              % (len(above), emission_above, fees_above), file=sys.stderr)
+
+    coins = coins_at_md_tip - emission_above
+    if coins <= 0:
+        raise SystemExit("already_generated_coins came out non-positive")
 
     by_height = {x["height"]: x for x in win}
     seeds = []
@@ -372,8 +401,10 @@ def main():
            ANCHOR_LONG_TERM_WEIGHTS),
         "coins     already_generated_coins from get_miner_data at %d minus the"
         % md_tip,
-        "          coinbase of every block above H_a; cross-checked against",
-        "          get_coinbase_tx_sum over the same range.",
+        "          BASE EMISSION of every block above H_a -- get_coinbase_tx_sum's",
+        "          emission_amount, NOT the header `reward`. monerod accumulates",
+        "          base_reward into already_generated_coins; fees are recycled from",
+        "          the existing supply and are never added to it.",
         "note      monerod publishes no RPC for its compiled-in checkpoints;",
         "          `checkpoint` rows are copied by hand at release time and",
         "          this capture carries %d of them." % len(checkpoints),


### PR DESCRIPTION
**DRAFT — stacked on #1608, which is stacked on #1594 (`v37/xmr-native-m4harness`). Do not merge ahead of them.**

The M4 parity soak was pointed at the synced stagenet daemon on VM500 for the first time. It went to `Revoked` on its first template sample.

## What it saw

Every P-TPL compare differed on `already_generated_coins`, by the same amount, at every height:

```
served (monerod) 18164847101536847281
shadow (native)  18164847090712907281
               =       10823940000
```

`already_generated_coins` is a **sentinel** field, so this did not merely reset the streak — it revoked the graduation key outright. P-TIP, meanwhile, was CLEAN on all nine fields, including cumulative difficulty: the native index had walked the same chain and done the same arithmetic.

## Where the number comes from

It is not arbitrary. It is exactly the daemon's own `fee_amount` for the 848 blocks the anchor generator subtracted when it backed the anchor's `already_generated_coins` out of a later `get_miner_data` reading:

```
get_coinbase_tx_sum(height=2204001, count=848)
  emission_amount 508800000000000     (= 848 × 0.6 XMR, base only)
  fee_amount          10823940000     ← the entire divergence
```

## The premise, and it was written down

```python
# `reward` in a block header IS the coinbase amount (base emission plus fees),
# which is exactly what monerod adds into already_generated_coins per block.
coins = coins_at_md_tip - sum(x["reward"] for x in above)
```

The first half is true. The second is not — `Blockchain::handle_block_to_main_chain` does

```cpp
already_generated_coins = base_reward + already_generated_coins;
```

A fee is existing supply changing hands, not supply being created, and monerod never adds it. Subtracting `reward` removes base+fee per block where only base went in, leaving the anchor short by the fee total — a **constant offset** the native index then carries forward forever, because its own forward accumulation is correct (1556 blocks × 0.6 XMR, to the atomic unit, over the probe run).

## And the cross-check confirmed it

```python
s = emission_amount + fee_amount
if s != sum(x["reward"] for x in above): raise SystemExit(...)
print("coinbase cross-check OK")
```

That is a true identity about two RPCs, and it says nothing about **which of them belongs in the subtraction**. It validated the arithmetic around the wrong quantity and printed OK. It now asserts the decomposition and *uses the emission half*, named as such — a check that would have caught this class rather than blessing it.

## The change

* `xmr_chain_anchor_stagenet.inc`: `already_generated_coins` → `18163913501536847281`, digest recomputed over the corrected body (`e159b23d…`). No format bump, no new field, every other row byte-identical.
* `xmr_anchor_gen.py`: subtract `emission_amount`; the cross-check becomes a decomposition assertion; both provenance comments state the rule instead of the mistake.

## Verification on VM500, against the live synced stagenet daemon

* `xmr_native_anchor_self_check_kat` — **153 checks, 0 failures** (its model bundle is built in-test and is untouched by the value; the embedded case re-derives the digest from the corrected body).
* `xmr_native_m4_soak_kat` — **165 checks, 0 failures**.
* The same soak run, re-run with the corrected anchor: P-TPL CLEAN on all six fields, and the ledger accrues instead of revoking.

This is the first defect the M4 harness found *by being run*, which is the argument for running it against a real chain rather than a fixture.
