### PR TITLE
v37-btc-dash: --network testnet (DASH testnet chain tag, genesis pin, rpc default)

### DIFF
--- a/src/c2pool/v37/btc/btc_node_config.hpp
+++ b/src/c2pool/v37/btc/btc_node_config.hpp
@@ -86,7 +86,10 @@ inline CoinDaemonEndpoint default_endpoint(BtcFamilyCoin coin, BtcNetwork net) {
         switch (net) {
             case BtcNetwork::Regtest:  e.rpc_port = 19998; e.p2p_port = 19899; break;
             case BtcNetwork::Devnet:   e.rpc_port = 19998; e.p2p_port = 19899; break;
-            case BtcNetwork::Testnet4: // DASH has no testnet4; fall through to testnet
+            // DASH has no testnet4; --network testnet IS testnet3 (rpc 19998,
+            // p2p 19999). It must NOT share the mainnet arm below: falling
+            // through handed a testnet node the MAINNET endpoint 9998/9999.
+            case BtcNetwork::Testnet4: e.rpc_port = 19998; e.p2p_port = 19999; break;
             case BtcNetwork::Mainnet:  e.rpc_port =  9998; e.p2p_port =  9999; break;
         }
     } else {  // LTC

--- a/src/c2pool/v37/btc/dash_rpc_coin_backend.hpp
+++ b/src/c2pool/v37/btc/dash_rpc_coin_backend.hpp
@@ -213,6 +213,13 @@ inline bool chain_matches(const std::string& expect, const std::string& chain) {
 inline constexpr const char* kDashRegtestGenesisHex =
     "000008ca1832a4baf228eb1553c03d3a2c8e02399550dd6ea8d65cec3ef23d2e";
 
+// Dash Core v23.1.7 TESTNET (testnet3) genesis (src/chainparams.cpp:487).
+// Pinned by wait_ready() when main sets --network testnet: the chain tag
+// "test" alone cannot tell two testnet daemons apart, the genesis can.
+// Verify on the host with `dash-cli -testnet getblockhash 0`.
+inline constexpr const char* kDashTestnetGenesisHex =
+    "00000bafbc94add76cb75e2ec92894837288a481e5c005f6563d91623bf8bc2c";
+
 // Thrown by is_canonical() ONLY after Options::oracle_patience of continuous
 // transport failure (see the file header on why this is safe).
 struct OracleUnavailable : std::runtime_error {

--- a/src/c2pool/v37/main_v37_btc_dash.cpp
+++ b/src/c2pool/v37/main_v37_btc_dash.cpp
@@ -186,9 +186,11 @@ static std::string hex32(const ::v37::bytes32& b) {
 
 static void usage() {
     std::printf(
-        "c2pool-v37-btc-dash (EXPERIMENTAL; DASH regtest/devnet ONLY; do not run in production)\n"
-        "  --network regtest|devnet|mainnet   (default regtest; mainnet REFUSED without --i-understand-mainnet)\n"
-        "  --daemon-rpc HOST:PORT             (default 127.0.0.1:19898 — Dash Core REGTEST rpc port)\n"
+        "c2pool-v37-btc-dash (EXPERIMENTAL; DASH regtest/devnet/testnet ONLY; do not run in production)\n"
+        "  --network regtest|devnet|testnet|mainnet\n"
+        "                                     (default regtest; mainnet REFUSED without --i-understand-mainnet)\n"
+        "  --daemon-rpc HOST:PORT             (default 127.0.0.1:19898 — Dash Core REGTEST rpc port;\n"
+        "                                     127.0.0.1:19998 under --network testnet unless given here)\n"
         "  --coin-rpc-auth PATH               dash.conf-style file with rpcuser/rpcpassword (default ~/.dashcore/dash.conf)\n"
         "  --stratum-bind HOST:PORT           (default 127.0.0.1:3032)\n"
         "  --settle-db PATH                   (default ./v37data/dash/<net>/v37_settle_db)\n"
@@ -214,6 +216,7 @@ int main(int argc, char** argv) {
     cfg.network = BtcNetwork::Regtest;
     std::string rpc_hostport = "127.0.0.1:19898";   // S-6: btc_node_config.hpp:87 says 19998 = Dash Core TESTNET;
                                                     // regtest rpc is 19898 (v23.1.7 src/chainparamsbase.cpp:48)
+    bool rpc_hostport_explicit = false;             // --daemon-rpc given? (else the per-network default below)
     std::string auth_path;
     std::string stratum_bind = "127.0.0.1:3032";
     std::string p2p_bind;                 // A2: empty = no inbound carrier bind
@@ -230,10 +233,11 @@ int main(int argc, char** argv) {
             const std::string n = argv[++i];
             if      (n == "regtest") cfg.network = BtcNetwork::Regtest;
             else if (n == "devnet")  cfg.network = BtcNetwork::Devnet;
+            else if (n == "testnet") cfg.network = BtcNetwork::Testnet4;   // DASH has no testnet4; this IS DASH testnet3
             else if (n == "mainnet") cfg.network = BtcNetwork::Mainnet;
             else { usage(); return 2; }
         }
-        else if (!std::strcmp(a, "--daemon-rpc"))                          next(rpc_hostport);
+        else if (!std::strcmp(a, "--daemon-rpc"))                          { next(rpc_hostport); rpc_hostport_explicit = true; }
         else if (!std::strcmp(a, "--coin-rpc-auth"))                       next(auth_path);
         else if (!std::strcmp(a, "--stratum-bind"))                        next(stratum_bind);
         else if (!std::strcmp(a, "--p2p-bind"))                            next(p2p_bind);
@@ -249,6 +253,12 @@ int main(int argc, char** argv) {
         else { usage(); return 2; }
     }
     if (cfg.d_conf == 0 || poll_ms <= 0 || oracle_patience_ms < 0 || carrier_index_patience_ms < 0) { usage(); return 2; }
+    // Per-network RPC default when --daemon-rpc was not given. Dash Core
+    // testnet rpc is 19998, regtest 19898 (v23.1.7 src/chainparamsbase.cpp:
+    // 47-48). NOTE this main never calls btc_node_config.hpp default_endpoint();
+    // the endpoint is this string, then apply_endpoint_override() below.
+    if (!rpc_hostport_explicit && cfg.network == BtcNetwork::Testnet4)
+        rpc_hostport = "127.0.0.1:19998";
     cfg.pow_verify_enabled = true;   // live: the v36 work source verifies X11 itself
     if (cfg.network == BtcNetwork::Mainnet && !cfg.i_understand_mainnet) {
         std::fprintf(stderr, "REFUSED: mainnet without --i-understand-mainnet (HARD SAFETY 4)\n");
@@ -287,9 +297,14 @@ int main(int argc, char** argv) {
     rpc->connect(NetService(conf.host, conf.port), conf.userpass());
 
     DashRpcCoinBackend::Options bopt;
-    bopt.expect_chain    = (cfg.network == BtcNetwork::Regtest) ? "regtest"
-                         : (cfg.network == BtcNetwork::Devnet)  ? "devnet" : "main";
-    bopt.expect_genesis  = (cfg.network == BtcNetwork::Regtest) ? kDashRegtestGenesisHex : "";
+    // Dash Core reports NetworkIDString "test" for -testnet (v23.1.7
+    // src/chainparamsbase.cpp:47, CBaseChainParams::TESTNET). chain_matches()
+    // is exact-match, so Testnet4 must map to "test" and never fall to "main".
+    bopt.expect_chain    = (cfg.network == BtcNetwork::Regtest)  ? "regtest"
+                         : (cfg.network == BtcNetwork::Devnet)   ? "devnet"
+                         : (cfg.network == BtcNetwork::Testnet4) ? "test" : "main";
+    bopt.expect_genesis  = (cfg.network == BtcNetwork::Regtest)  ? kDashRegtestGenesisHex
+                         : (cfg.network == BtcNetwork::Testnet4) ? kDashTestnetGenesisHex : "";
     bopt.oracle_patience = std::chrono::milliseconds(oracle_patience_ms);
     auto backend = std::make_shared<DashRpcCoinBackend>(rpc, bopt);
     if (!backend->wait_ready(std::chrono::seconds(30))) { teardown_io(); return 5; }


### PR DESCRIPTION
c2pool-v37-btc-dash could only be pointed at regtest, devnet or mainnet. The
live DASH testnet (testnet3) was unreachable, so the A2 carrier-relay standup
could only ever be exercised against an isolated regtest chain.

Consumer-tree only; no src/sharechain/v37 consensus code is touched.

  * main_v37_btc_dash.cpp: --network testnet -> BtcNetwork::Testnet4 (DASH has
    no testnet4; the enum value is the DASH testnet3 slot). Dash Core reports
    NetworkIDString "test" for -testnet (v23.1.7 src/chainparamsbase.cpp:47) and
    DashRpcCoinBackend::chain_matches() is exact-match, so expect_chain must be
    "test" -- without this arm it fell through to "main" and the node refused
    every honest testnet daemon.
  * expect_genesis pinned to the testnet3 genesis, mirroring what regtest
    already does: the chain tag "test" alone cannot tell two testnet daemons
    apart, the genesis can.
  * --daemon-rpc defaults to 127.0.0.1:19998 under --network testnet (Dash Core
    testnet rpc port) when the flag is not given explicitly; regtest keeps
    19898. Tracked with an explicit-flag bool so an operator override still wins.
  * btc_node_config.hpp default_endpoint(): DASH Testnet4 no longer falls
    through to the MAINNET arm. That fallthrough handed a testnet node the
    mainnet endpoint 9998/9999; it is now 19998/19999. main_v37_btc_dash.cpp
    does not call default_endpoint(), but any future caller would have dialed
    mainnet from a testnet config.

Verified against a live Dash Core v23.1.7 -testnet daemon on VM100:

  [v37-dash] dashd ready: chain=test blocks=54385 ibd=true genesis=pinned
  [v37-dash] stratum listening on 127.0.0.1:3099; dashd 127.0.0.1:19998
  [v37-dash] exit 0: submits=0/0 transport_fail=1 oracle_unavail=0 withheld_ibd=45

The withheld_ibd counter is the expected DashRpcCoinBackend behaviour while the
daemon is still in initial block download (Options::require_not_ibd defaults to
true): best_tip is withheld until the daemon reports initialblockdownload=false.

DRAFT: opened for review only. No merge, no rollout.