### PR TITLE
ci(build): materialize full tree before Web-static verify cache step (fix opaque cache-path red)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1117,8 +1117,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       # For an observability defect the check IS the fix: fail closed if the
-      # checked-out HEAD is ever not the head we asked for.
-      - name: Assert checkout matches expected head SHA (fail closed)
+      # checked-out HEAD is ever not the head we asked for, and force the full
+      # working tree back onto disk before any consumer reads it.
+      - name: Assert head + materialize tree + guard cache path (fail closed)
         working-directory: ${{ github.workspace }}
         run: |
           expected='${{ github.event.pull_request.head.sha || github.sha }}'
@@ -1127,7 +1128,26 @@ jobs:
             echo "::error title=Checkout integrity::checked-out HEAD ${actual} != expected head ${expected} — broken/stale merge-ref, not a code defect." >&2
             exit 1
           fi
-          echo "checkout verified: HEAD=${actual} matches expected head"
+          # The self-hosted workspace is REUSED: prune-runner-workspace strips the
+          # checkout to .git/.github at the prior job's end. actions/checkout then
+          # runs `checkout -f <sha>`, which only rewrites files that DIFFER between
+          # the previously-checked-out commit and this head — so files unchanged
+          # across the two commits (e.g. package-lock.json on a non-web PR) are
+          # left physically absent even though HEAD is correct. setup-node's
+          # cache-dependency-path glob then resolves nothing and dies with an
+          # opaque "Some specified paths were not resolved". reset --hard writes
+          # the ENTIRE target tree to disk, closing that gap deterministically.
+          git reset --hard "$expected"
+          # Regression guard (standing rule: assertion ships in the fixing PR):
+          # the cache-dependency-path MUST exist on disk before setup-node, else
+          # a genuinely moved/removed lockfile turns into the same opaque red.
+          # Fail loudly and legibly instead, and point at the real cause.
+          lock="web-static/sharechain-explorer/package-lock.json"
+          if [ ! -f "$lock" ]; then
+            echo "::error title=cache-dependency-path unresolved::${lock} absent on disk after checkout of ${expected}. The lockfile moved/was removed, or the tree failed to materialize — fix the path or the checkout, NOT the cache step." >&2
+            exit 1
+          fi
+          echo "checkout verified: HEAD=${actual}; ${lock} present on disk"
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Root cause (verified from job 103473067132, PR #1613 head 58eeaae5)

Web-static verify fails on exactly one line:

    ##[error]Some specified paths were not resolved, unable to cache dependencies.

It is **not** a static-asset regression and **not** a moved/missing lockfile:
`web-static/sharechain-explorer/package-lock.json` is committed at that exact
`cache-dependency-path` on **both master and PR #1613 head**, and the PRs
web-static diff vs master is empty.

The self-hosted runner reuses its workspace. `prune-runner-workspace` strips the
checkout to `.git`/`.github` at the prior jobs end. `actions/checkout@v6` then does
`fetch --depth=1 <head.sha>` + `git checkout --force <head.sha>`, which only rewrites
files that **differ** between the previously-checked-out commit and this head. Files
unchanged across the two commits (here package-lock.json, untouched by this PR) are
left **physically absent** — even though HEAD is correct and the existing SHA-assert
guard passes (it only reads `.git`). setup-nodes cache glob resolves nothing and the
job dies before verifying anything. Classic hollow-green: the guard is green, the tree
is incomplete.

## Fix
In the existing fail-closed guard step, after asserting HEAD == expected head:
- `git reset --hard "$expected"` — writes the **entire** target tree to disk
  deterministically, closing the reused-workspace gap.
- **Regression assertion (ships in the fixing PR):** fail closed with a labeled
  `::error` if the lockfile is still absent, so a genuinely moved/removed
  cache-dependency-path surfaces legibly instead of as an opaque red.

Cache step and path filter untouched; per-coin source-presence guards (#47) untouched.

## Evidence
The `web` path filter includes `.github/workflows/build.yml`, so this workflow-only PR
fires Web-static verify on a web-touching diff — watch this PRs run for the green.

Do not merge — surfacing for integrators tap.