### PR TITLE
control-plane: live money-gated POST /api/config/apply (#157 Slice A)

### DIFF
--- a/src/core/config_endpoint.cpp
+++ b/src/core/config_endpoint.cpp
@@ -6,6 +6,12 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <random>
+
+#include "address_validator.hpp"
 
 namespace c2pool::config_endpoint {
 
@@ -19,6 +25,27 @@ std::shared_ptr<const settings::ResolvedConfig> g_snapshot;
 catalog::CoinBit g_coin = catalog::C_ALL;
 std::string      g_settings_path;
 bool             g_published = false;
+
+// Guards every access to the process-global gate state below (snapshot swap,
+// control token, pending nonces, tripwire). Web threads read the snapshot and
+// the armed apply path swaps it, so the previously lock-free read is now
+// serialized behind this mutex.
+std::mutex g_mu;
+
+// Slice A gate state (all under g_mu).
+std::string                                   g_control_token;   // empty => not armed
+std::map<std::string, std::string>            g_pending_nonces;  // diff-digest -> nonce
+std::map<std::string, int64_t>                g_nonce_issued_at; // diff-digest -> epoch s
+TripwireState                                 g_tripwire;
+ParamApplier                                  g_applier;
+
+// Single-use nonce TTL. Generous; only guards against unbounded staleness.
+constexpr int64_t kNonceTtlSeconds = 600;
+
+int64_t now_epoch_s() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::system_clock::now().time_since_epoch()).count();
+}
 
 const char* coin_name(catalog::CoinBit c) {
     switch (c) {
@@ -76,6 +103,94 @@ const char* pair_partner(const std::string& canon) {
     return nullptr;
 }
 
+// Schema/type validation of a single value against its catalog row. Returns
+// true when the value is well-formed for the row's type + declared validator;
+// on failure `err` names the reason. ADDR_COIN is NOT checked here — address
+// validity is a money-path gate (AddressValidator) applied only after the
+// two-phase nonce confirms, never on the cheap schema pass.
+bool validate_value(const catalog::ParamRow& row, const std::string& value,
+                    std::string& err) {
+    using catalog::PType;
+    using catalog::Validator;
+
+    auto is_int = [](const std::string& s, long long& out) -> bool {
+        if (s.empty()) return false;
+        try { size_t pos = 0; out = std::stoll(s, &pos); return pos == s.size(); }
+        catch (...) { return false; }
+    };
+    auto is_dbl = [](const std::string& s, double& out) -> bool {
+        if (s.empty()) return false;
+        try { size_t pos = 0; out = std::stod(s, &pos); return pos == s.size(); }
+        catch (...) { return false; }
+    };
+    auto is_bool_word = [](const std::string& v) -> bool {
+        std::string s;
+        for (char c : v) s.push_back(static_cast<char>(std::tolower(
+            static_cast<unsigned char>(c))));
+        return s == "true" || s == "false" || s == "1" || s == "0" ||
+               s == "on"   || s == "off"   || s == "yes" || s == "no";
+    };
+    auto is_even_hex = [](const std::string& s) -> bool {
+        if (s.empty() || (s.size() % 2) != 0) return false;
+        for (char c : s) if (!std::isxdigit(static_cast<unsigned char>(c))) return false;
+        return true;
+    };
+
+    long long iv = 0;
+    double dv = 0.0;
+    switch (row.type) {
+        case PType::BOOL:
+        case PType::TRISTATE_BOOL:
+            if (!is_bool_word(value)) { err = "expected a boolean"; return false; }
+            return true;
+        case PType::UINT16:
+            if (!is_int(value, iv) || iv < 0 || iv > 65535) {
+                err = "expected an integer in [0,65535]"; return false; }
+            return true;
+        case PType::INT64:
+            if (!is_int(value, iv)) { err = "expected an integer"; return false; }
+            return true;
+        case PType::DBL:
+            if (!is_dbl(value, dv)) { err = "expected a number"; return false; }
+            break;
+        case PType::HEX:
+            if (!value.empty() && !is_even_hex(value)) {
+                err = "expected even-length hex"; return false; }
+            break;
+        case PType::ENUM_STR:
+            if (value.empty()) { err = "enum value must be non-empty"; return false; }
+            break;
+        default:
+            break;  // STRING/PATH/HOSTPORT/etc: shape checked by the money gate or accepted
+    }
+
+    // Declared per-key validators that are cheap + local (no coin decoder).
+    switch (row.validator) {
+        case Validator::PORT_RANGE:
+            if (!is_int(value, iv) || iv < 0 || iv > 65535) {
+                err = "port must be in [0,65535]"; return false; }
+            break;
+        case Validator::PCT_0_100:
+            if (!is_dbl(value, dv) || dv < 0.0 || dv > 100.0) {
+                err = "percent must be in [0,100]"; return false; }
+            break;
+        case Validator::HEX_EVEN:
+        case Validator::HEX8_MAGIC:
+            if (!value.empty() && !is_even_hex(value)) {
+                err = "expected even-length hex"; return false; }
+            if (row.validator == Validator::HEX8_MAGIC && !value.empty() && value.size() != 8) {
+                err = "magic must be 8 hex chars"; return false; }
+            break;
+        case Validator::HASH256:
+            if (!value.empty() && (value.size() != 64 || !is_even_hex(value))) {
+                err = "expected a 32-byte (64-hex) hash"; return false; }
+            break;
+        default:
+            break;
+    }
+    return true;
+}
+
 // Effective tri value of a tristate key AFTER overlaying the batch on current.
 settings::TriBool effective_tri(const std::string& canon,
                                 const std::map<std::string, std::string>& changes,
@@ -90,25 +205,40 @@ settings::TriBool effective_tri(const std::string& canon,
 void publish_resolved(std::shared_ptr<const settings::ResolvedConfig> snapshot,
                       catalog::CoinBit coin,
                       std::string settings_path) {
+    std::lock_guard<std::mutex> lk(g_mu);
     g_snapshot       = std::move(snapshot);
     g_coin           = coin;
     g_settings_path  = std::move(settings_path);
     g_published      = (g_snapshot != nullptr);
 }
 
-bool is_published() { return g_published && g_snapshot != nullptr; }
+bool is_published() {
+    std::lock_guard<std::mutex> lk(g_mu);
+    return g_published && g_snapshot != nullptr;
+}
 
 nlohmann::json resolved_config_json() {
-    if (!is_published()) {
+    // Capture the snapshot under the lock so a concurrent armed apply that
+    // swaps g_snapshot cannot free the object out from under this reader.
+    std::shared_ptr<const settings::ResolvedConfig> snap;
+    catalog::CoinBit coin;
+    std::string      settings_path;
+    {
+        std::lock_guard<std::mutex> lk(g_mu);
+        snap = g_snapshot;
+        coin = g_coin;
+        settings_path = g_settings_path;
+    }
+    if (!snap) {
         return nlohmann::json{
             {"error", "config not published"},
             {"schema_version", kSchemaVersion}};
     }
-    const settings::ResolvedConfig& rc = *g_snapshot;
+    const settings::ResolvedConfig& rc = *snap;
 
     nlohmann::json keys = nlohmann::json::object();
     for (const auto& row : catalog::all_params()) {
-        if (!row.applies_to(g_coin)) continue;
+        if (!row.applies_to(coin)) continue;
 
         nlohmann::json entry = nlohmann::json::object();
         entry["type"]        = catalog::ptype_name(row.type);
@@ -136,12 +266,14 @@ nlohmann::json resolved_config_json() {
     }
 
     return nlohmann::json{
-        {"coin",           coin_name(g_coin)},
+        {"coin",           coin_name(coin)},
         {"schema_version", kSchemaVersion},
-        {"settings_path",  g_settings_path},
+        {"settings_path",  settings_path},
         // The endpoint reports the resolved LAUNCH config, not live node state.
         {"scope",          "resolved launch config"},
-        {"apply_armed",    false},   // POST /api/config/apply is inert (503).
+        // apply_armed reflects whether an operator has registered the control
+        // token: false (dormant, 503) until arming, true once armed (Slice A).
+        {"apply_armed",    has_control_token()},
         {"keys",           std::move(keys)},
     };
 }
@@ -227,6 +359,10 @@ BatchResult validate_apply_batch(const std::map<std::string, std::string>& chang
             return reject(BatchVerdict::RejectReadonly, canon,
                           "compile-time read-only key cannot be written");
 
+        std::string verr;
+        if (!validate_value(*row, value, verr))
+            return reject(BatchVerdict::RejectValidator, canon, verr);
+
         if (row->is_money())               r.money_keys.push_back(canon);
         else if (row->mutability == catalog::Mut::RESTART)
                                            r.restart_keys.push_back(canon);
@@ -271,6 +407,312 @@ void ParamApplier::register_setter(const std::string& canon, Setter fn) {
 }
 bool ParamApplier::has(const std::string& canon) const {
     return setters_.count(canon) != 0;
+}
+bool ParamApplier::invoke(const std::string& canon, const std::string& value) const {
+    auto it = setters_.find(canon);
+    if (it == setters_.end() || !it->second) return false;
+    return it->second(value);
+}
+
+// ---------------------------------------------------------------------------
+// Slice A (#157): control token, two-phase money nonce, tripwire, armed apply.
+// ---------------------------------------------------------------------------
+namespace {
+
+// A random 128-bit hex token/nonce from a per-thread PRNG seeded off the OS
+// entropy source. Not a secret store — a loopback-only unguessable handle.
+std::string random_hex_128() {
+    static thread_local std::mt19937_64 rng(std::random_device{}());
+    uint64_t a = rng(), b = rng();
+    char buf[33];
+    std::snprintf(buf, sizeof(buf), "%016llx%016llx",
+                  static_cast<unsigned long long>(a),
+                  static_cast<unsigned long long>(b));
+    return std::string(buf, 32);
+}
+
+// Constant-time-ish string compare (avoids trivial early-out timing on the
+// loopback token; defense in depth, the endpoint is loopback-only anyway).
+bool ct_equal(const std::string& a, const std::string& b) {
+    if (a.size() != b.size()) return false;
+    unsigned char acc = 0;
+    for (size_t i = 0; i < a.size(); ++i)
+        acc |= static_cast<unsigned char>(a[i]) ^ static_cast<unsigned char>(b[i]);
+    return acc == 0;
+}
+
+} // namespace
+
+void set_control_token(std::string token) {
+    std::lock_guard<std::mutex> lk(g_mu);
+    g_control_token = std::move(token);
+}
+bool has_control_token() {
+    std::lock_guard<std::mutex> lk(g_mu);
+    return !g_control_token.empty();
+}
+bool check_control_token(const std::string& presented) {
+    std::lock_guard<std::mutex> lk(g_mu);
+    if (g_control_token.empty()) return false;
+    return ct_equal(presented, g_control_token);
+}
+void clear_control_token() {
+    std::lock_guard<std::mutex> lk(g_mu);
+    g_control_token.clear();
+}
+
+TripwireState tripwire_state() {
+    std::lock_guard<std::mutex> lk(g_mu);
+    return g_tripwire;
+}
+void reset_tripwire() {
+    std::lock_guard<std::mutex> lk(g_mu);
+    g_tripwire = TripwireState{};
+}
+// Internal: record a tripwire fire. Assumes g_mu is NOT held by the caller.
+namespace {
+void trip_money_wire(const std::string& key, const std::string& reason) {
+    std::lock_guard<std::mutex> lk(g_mu);
+    ++g_tripwire.count;
+    g_tripwire.last_key    = key;
+    g_tripwire.last_reason = reason;
+}
+} // namespace
+
+ParamApplier& applier() { return g_applier; }
+
+std::string money_diff_digest(const std::map<std::string, std::string>& money_changes) {
+    std::vector<std::pair<std::string, std::string>> kv(
+        money_changes.begin(), money_changes.end());
+    return settings::SettingsFile::money_digest(kv);
+}
+
+std::string issue_money_nonce(const std::map<std::string, std::string>& money_changes) {
+    const std::string digest = money_diff_digest(money_changes);
+    std::string nonce = random_hex_128();
+    std::lock_guard<std::mutex> lk(g_mu);
+    g_pending_nonces[digest]  = nonce;
+    g_nonce_issued_at[digest] = now_epoch_s();
+    return nonce;
+}
+
+bool verify_money_nonce(const std::map<std::string, std::string>& money_changes,
+                        const std::string& presented) {
+    if (presented.empty()) return false;
+    const std::string digest = money_diff_digest(money_changes);
+    std::lock_guard<std::mutex> lk(g_mu);
+    auto it = g_pending_nonces.find(digest);
+    if (it == g_pending_nonces.end()) return false;
+    // TTL: a stale nonce is refused (and swept).
+    auto ta = g_nonce_issued_at.find(digest);
+    if (ta != g_nonce_issued_at.end() &&
+        now_epoch_s() - ta->second > kNonceTtlSeconds) {
+        g_pending_nonces.erase(it);
+        g_nonce_issued_at.erase(ta);
+        return false;
+    }
+    const bool match = ct_equal(presented, it->second);
+    if (match) {                       // single-use: consume on success
+        g_pending_nonces.erase(it);
+        g_nonce_issued_at.erase(digest);
+    }
+    return match;
+}
+
+void clear_money_nonces() {
+    std::lock_guard<std::mutex> lk(g_mu);
+    g_pending_nonces.clear();
+    g_nonce_issued_at.clear();
+}
+
+const char* apply_status_name(ApplyStatus s) {
+    switch (s) {
+        case ApplyStatus::NotArmed:         return "not_armed";
+        case ApplyStatus::NotPublished:     return "not_published";
+        case ApplyStatus::RejectNoToken:    return "no_token";
+        case ApplyStatus::RejectValidation: return "validation";
+        case ApplyStatus::NeedConfirm:      return "need_confirm";
+        case ApplyStatus::RejectMoneyGate:  return "money_gate";
+        case ApplyStatus::Applied:          return "applied";
+    }
+    return "?";
+}
+
+nlohmann::json ApplyResponse::to_json() const {
+    nlohmann::json j{
+        {"schema_version", kSchemaVersion},
+        {"status",         apply_status_name(status)},
+        {"applied",        status == ApplyStatus::Applied},
+        {"armed",          status != ApplyStatus::NotArmed},
+    };
+    if (!message.empty())       j["error"]         = message;   // human cause
+    if (!offending_key.empty()) j["offending_key"] = offending_key;
+    if (status == ApplyStatus::NeedConfirm) {
+        j["need_confirm"] = true;
+        j["money_nonce"]  = money_nonce;
+        j["money_keys"]   = money_keys;
+    }
+    if (status == ApplyStatus::Applied)
+        j["applied_keys"] = applied_keys;
+    return j;
+}
+
+ApplyRequest parse_apply_request(const std::string& body) {
+    ApplyRequest req;
+    nlohmann::json j = nlohmann::json::parse(body, nullptr, /*allow_exceptions=*/false);
+    if (!j.is_object()) return req;
+    if (j.contains("control_token") && j["control_token"].is_string())
+        req.control_token = j["control_token"].get<std::string>();
+    if (j.contains("money_nonce") && j["money_nonce"].is_string())
+        req.money_nonce = j["money_nonce"].get<std::string>();
+    if (j.contains("changes") && j["changes"].is_object()) {
+        for (auto it = j["changes"].begin(); it != j["changes"].end(); ++it) {
+            if (it.value().is_string())
+                req.changes[it.key()] = it.value().get<std::string>();
+            else if (it.value().is_boolean())
+                req.changes[it.key()] = it.value().get<bool>() ? "true" : "false";
+            else if (it.value().is_number())
+                req.changes[it.key()] = it.value().dump();
+        }
+    }
+    return req;
+}
+
+ApplyResponse apply_config(const ApplyRequest& req) {
+    ApplyResponse out;
+
+    // 0) Armed? No control token registered => stay dormant (503 armed:false).
+    //    This is the KAT pivot: the endpoint is INERT until an operator arms it
+    //    by registering the loopback control token — never a silent default.
+    if (!has_control_token()) {
+        out.status = ApplyStatus::NotArmed;
+        out.http_status = 503;
+        out.message = "config-apply not armed; runtime mutation is operator-gated";
+        return out;
+    }
+
+    // 1) A published snapshot is the apply base + reporting mirror.
+    if (!is_published()) {
+        out.status = ApplyStatus::NotPublished;
+        out.http_status = 503;
+        out.message = "config not published";
+        return out;
+    }
+
+    // 2) Control token (loopback defense-in-depth; the HTTP layer also gates).
+    if (!check_control_token(req.control_token)) {
+        out.status = ApplyStatus::RejectNoToken;
+        out.http_status = 403;
+        out.message = "missing or invalid control token";
+        return out;
+    }
+
+    if (req.changes.empty()) {
+        out.status = ApplyStatus::RejectValidation;
+        out.http_status = 400;
+        out.message = "no changes requested";
+        return out;
+    }
+
+    // Capture the base snapshot + coin under the lock.
+    std::shared_ptr<const settings::ResolvedConfig> base;
+    catalog::CoinBit coin;
+    {
+        std::lock_guard<std::mutex> lk(g_mu);
+        base = g_snapshot;
+        coin = g_coin;
+    }
+
+    // 3) Schema + batch + referee validation (pure oracle, atomic — one bad
+    //    key rejects the WHOLE batch, so nothing is applied partially).
+    BatchResult batch = validate_apply_batch(req.changes, coin, *base);
+    if (!batch.ok()) {
+        out.status = ApplyStatus::RejectValidation;
+        out.http_status = 400;
+        out.message = batch.message;
+        out.offending_key = batch.offending_key;
+        return out;
+    }
+
+    // 4) MONEY-PATH GATE (two-phase nonce + AddressValidator + tripwire).
+    if (!batch.money_keys.empty()) {
+        std::map<std::string, std::string> money_diff;
+        for (const auto& k : batch.money_keys) money_diff[k] = req.changes.at(k);
+
+        // Phase 1 (no nonce): issue a nonce bound to THIS exact diff and apply
+        // NOTHING. This is the sanctioned confirmation request — the tripwire
+        // does NOT fire here (it is not an attempt to write without a nonce).
+        if (req.money_nonce.empty()) {
+            out.status = ApplyStatus::NeedConfirm;
+            out.http_status = 200;
+            out.money_nonce = issue_money_nonce(money_diff);
+            out.money_keys = batch.money_keys;
+            out.message = "money-path change requires confirmation; re-POST the "
+                          "same diff with this money_nonce";
+            return out;
+        }
+
+        // Phase 2: the presented nonce MUST match the one issued for THIS exact
+        // diff. A miss (wrong/expired nonce, or a different diff) trips the
+        // wire and refuses — no partial apply.
+        if (!verify_money_nonce(money_diff, req.money_nonce)) {
+            trip_money_wire(batch.money_keys.front(),
+                            "money-path write without a valid confirmed nonce");
+            out.status = ApplyStatus::RejectMoneyGate;
+            out.http_status = 409;
+            out.offending_key = batch.money_keys.front();
+            out.message = "money nonce missing or mismatched for this diff; refused";
+            return out;
+        }
+
+        // Server-side AddressValidator on any address-typed money value
+        // (fail-closed: an unparseable address refuses + trips the wire).
+        for (const auto& k : batch.money_keys) {
+            const catalog::ParamRow* row = catalog::find_by_canon(k);
+            if (!row || row->validator != catalog::Validator::ADDR_COIN) continue;
+            const std::string& addr = money_diff.at(k);
+            if (addr.empty()) continue;  // clearing an address is not an address
+            c2pool::address::BlockchainAddressValidator av;
+            auto res = av.validate_address_multi(addr);
+            if (!res.is_valid) {
+                trip_money_wire(k, "money-path address failed server-side validation");
+                out.status = ApplyStatus::RejectMoneyGate;
+                out.http_status = 409;
+                out.offending_key = k;
+                out.message = "address failed server-side validation: " +
+                              res.error_message;
+                return out;
+            }
+        }
+    }
+
+    // 5) APPLY. Atomic snapshot swap (never mutate the published snapshot in
+    //    place — a web reader may hold the old pointer) + registered setters.
+    //    This swaps the reporting mirror behind GET /api/config and calls any
+    //    registered ParamApplier setter; it NEVER touches coinbase/subsidy/
+    //    PPLNS/payee computation and never arms --embedded-tx-inject (Slice B).
+    {
+        std::lock_guard<std::mutex> lk(g_mu);
+        auto next = std::make_shared<settings::ResolvedConfig>(*g_snapshot);
+        for (const auto& [canon, value] : req.changes) {
+            const catalog::ParamRow* row = catalog::find_by_canon(canon);
+            if (row && row->type == catalog::PType::TRISTATE_BOOL)
+                next->set_tri(canon, parse_tri(value), settings::Source::Runtime);
+            else
+                next->set(canon, value, settings::Source::Runtime);
+        }
+        g_snapshot = std::move(next);
+    }
+    // Invoke live setters OUTSIDE the lock (a setter must never re-enter the
+    // gate). Empty by default => a bare apply is a mirror swap only.
+    for (const auto& [canon, value] : req.changes)
+        (void)g_applier.invoke(canon, value);
+
+    for (const auto& [canon, value] : req.changes) { out.applied_keys.push_back(canon); (void)value; }
+    out.status = ApplyStatus::Applied;
+    out.http_status = 200;
+    out.message.clear();
+    return out;
 }
 
 } // namespace c2pool::config_endpoint

--- a/src/core/config_endpoint.hpp
+++ b/src/core/config_endpoint.hpp
@@ -143,9 +143,103 @@ public:
     // Register a live setter for a canonical key. (Unused this pass.)
     void register_setter(const std::string& canon, Setter fn);
     bool has(const std::string& canon) const;
+    // Invoke a registered setter; returns false when none is registered.
+    bool invoke(const std::string& canon, const std::string& value) const;
 private:
     std::map<std::string, Setter> setters_;
 };
+
+// ---------------------------------------------------------------------------
+// Slice A (#157): LIVE control-plane apply — dormant -> money-gated.
+//
+// The endpoint stays fail-closed by default: apply_config() answers an
+// unconditional 503 {"armed":false} until an operator registers a per-process
+// control token (set_control_token, surfaced only on loopback at launch). No
+// token => not armed => the M1 dormancy is preserved. Registering the token is
+// the reviewed/operator-tap arming step (NOT done by default anywhere).
+//
+// Two-tier apply (design note §"Slice A"):
+//   * non-money keys  -> control token + schema validation -> applied.
+//   * money-path keys (Mut::MONEY_*) -> the FULL gate: a two-phase money nonce
+//     BOUND TO THE EXACT diff (issue -> confirm), server-side AddressValidator
+//     on any address value, and the M0 tripwire. Any miss => refuse, and the
+//     tripwire fires. Nothing is applied partially (batch atomicity).
+//
+// "Apply" here swaps the process-global published ResolvedConfig snapshot
+// (the reporting mirror behind GET /api/config) atomically and invokes any
+// registered ParamApplier setter. It NEVER touches coinbase/subsidy/PPLNS/
+// payee computation, and it never arms --embedded-tx-inject (Slice B).
+
+// Control token (process-global). Empty until an operator registers one; while
+// empty the apply endpoint is NOT armed and answers 503 {"armed":false}.
+void set_control_token(std::string token);
+bool has_control_token();
+bool check_control_token(const std::string& presented);
+void clear_control_token();  // test helper
+
+// M0 tripwire: fires on any attempt to write a money-path key without a valid
+// confirmed nonce (or with an address that fails validation). Process-global,
+// observable; a KAT pins "money key without confirmed nonce => tripwire".
+struct TripwireState {
+    uint64_t    count = 0;
+    std::string last_reason;
+    std::string last_key;
+};
+TripwireState tripwire_state();
+void reset_tripwire();  // test helper
+
+// Canonical digest of a money-key diff (sorted canon=value; reuses the
+// settings money_digest serialization). The two-phase nonce is bound to THIS.
+std::string money_diff_digest(const std::map<std::string, std::string>& money_changes);
+
+// Phase 1: issue a fresh single-use nonce bound to an exact money diff.
+std::string issue_money_nonce(const std::map<std::string, std::string>& money_changes);
+// Phase 2: the presented nonce must match the one issued for THIS EXACT diff.
+// Consumes the pending nonce on success (single-use). A mismatched diff yields
+// a different digest and therefore never matches.
+bool verify_money_nonce(const std::map<std::string, std::string>& money_changes,
+                        const std::string& presented);
+void clear_money_nonces();  // test helper
+
+// Registry of live setters used by apply (seeded by a main; empty by default,
+// so a bare apply is a snapshot-mirror swap with no runtime money mutation).
+ParamApplier& applier();
+
+// ---- The armed apply entry point -------------------------------------------
+struct ApplyRequest {
+    std::string                        control_token;
+    std::map<std::string, std::string> changes;
+    std::string                        money_nonce;   // empty => issue phase
+};
+
+enum class ApplyStatus {
+    NotArmed,          // no control token registered -> 503 {"armed":false}
+    NotPublished,      // no snapshot published yet
+    RejectNoToken,     // token missing or wrong
+    RejectValidation,  // schema/batch/referee validation failed
+    NeedConfirm,       // money keys present, nonce issued, NOTHING applied
+    RejectMoneyGate,   // nonce miss/mismatch or bad address -> TRIPWIRE fired
+    Applied,           // token ok, validated, (money confirmed) -> applied
+};
+
+const char* apply_status_name(ApplyStatus s);
+
+struct ApplyResponse {
+    ApplyStatus              status = ApplyStatus::NotArmed;
+    int                      http_status = 503;
+    std::string              message;
+    std::string              offending_key;
+    std::string              money_nonce;    // set on NeedConfirm
+    std::vector<std::string> applied_keys;
+    std::vector<std::string> money_keys;     // echoed on NeedConfirm
+    nlohmann::json to_json() const;
+};
+
+// Validate + gate + (on success) apply a batch. Fail-closed at every step.
+ApplyResponse apply_config(const ApplyRequest& req);
+
+// Parse the POST body JSON into an ApplyRequest (tolerant of missing fields).
+ApplyRequest parse_apply_request(const std::string& body);
 
 } // namespace c2pool::config_endpoint
 

--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -1032,15 +1032,40 @@ void HttpSession::process_request()
             }
         }
         else if (request_.method() == http::verb::post) {
-            // ── Control-plane M1: POST /api/config/apply is INERT this pass.
-            // Runtime mutation is operator-gated: the write path (control-token
-            // + two-phase money nonce + server-side AddressValidator) is NOT
-            // armed, so the only answer is an unconditional 503. Arming this
-            // requires flipping the KAT that pins the 503 — a reviewed change.
-            // (Plan: "the endpoint is never live without the gate.")
+            // ── Control-plane Slice A (#157): POST /api/config/apply is the
+            // LIVE, money-gated write path — but fail-closed by default. It is
+            // loopback-only (same posture as the GET config endpoints), and it
+            // stays an unconditional 503 {"armed":false} UNTIL a main installs
+            // the apply fn AND an operator registers the loopback control token
+            // (config_endpoint::apply_config re-checks the token and answers
+            // 503 {"armed":false} while unset). No main wires it by default, so
+            // production stays dormant; a reviewed operator-tap arming is what
+            // makes it live. The apply fn itself enforces the control token +
+            // two-phase money nonce (bound to the exact diff) + AddressValidator
+            // + M0 tripwire for money-path keys — never a silent default.
             if (std::string(request_.target()) == "/api/config/apply") {
-                response.result(http::status::service_unavailable);
-                response.body() = R"({"armed":false,"error":"config-apply not armed; runtime mutation is operator-gated"})";
+                auto remote_addr = socket_.remote_endpoint().address();
+                if (!remote_addr.is_loopback()) {
+                    response.result(http::status::forbidden);
+                    response.body() = R"({"error":"Config API is local-only"})";
+                    response.prepare_payload();
+                    send_response(std::move(response));
+                    return;
+                }
+                if (!mining_interface_->has_config_apply_fn()) {
+                    // Dormant: no apply fn installed => preserve the M1 posture.
+                    response.result(http::status::service_unavailable);
+                    response.body() = R"({"armed":false,"error":"config-apply not armed; runtime mutation is operator-gated"})";
+                    response.prepare_payload();
+                    send_response(std::move(response));
+                    return;
+                }
+                auto j = mining_interface_->rest_config_apply(request_.body());
+                int st = j.is_object() ? j.value("http_status", 200) : 200;
+                if (st < 100 || st > 599) st = 200;
+                if (j.is_object()) j.erase("http_status");
+                response.result(static_cast<http::status>(st));
+                response.body() = j.dump();
                 response.prepare_payload();
                 send_response(std::move(response));
                 return;

--- a/src/core/test/web_server_config_endpoint_test.cpp
+++ b/src/core/test/web_server_config_endpoint_test.cpp
@@ -42,9 +42,10 @@ using tcp = boost::asio::ip::tcp;
 namespace ce = c2pool::config_endpoint;
 using namespace c2pool::settings;
 
-// One synchronous loopback HTTP request through the real server.
+// One synchronous loopback HTTP request through the real server. `post_body`
+// is used only for POST (defaults to an empty JSON object).
 std::string do_request(uint16_t port, http::verb method, const std::string& target,
-                       int& status_out) {
+                       int& status_out, const std::string& post_body = "{}") {
     net::io_context ioc;
     tcp::socket sock(ioc);
     sock.connect(tcp::endpoint(net::ip::make_address("127.0.0.1"), port));
@@ -53,7 +54,8 @@ std::string do_request(uint16_t port, http::verb method, const std::string& targ
     req.set(http::field::host, "127.0.0.1");
     req.set(http::field::user_agent, "m1-present-check");
     if (method == http::verb::post) {
-        req.body() = "{}";
+        req.set(http::field::content_type, "application/json");
+        req.body() = post_body;
         req.prepare_payload();
     }
     http::write(sock, req);
@@ -85,6 +87,34 @@ std::shared_ptr<ResolvedConfig> dash_snapshot() {
     rc->seed_compiled_defaults(c2pool::catalog::C_DASH);
     rc->set("web.port", "8080", Source::Cli);
     return rc;
+}
+
+// Slice A (#157): stand up a server whose POST /api/config/apply is WIRED to the
+// live gated-apply path. The caller must still arm it by registering a control
+// token (ce::set_control_token) — an unarmed wired server stays 503.
+std::unique_ptr<core::WebServer> make_apply_server(net::io_context& ioc) {
+    auto ws = std::make_unique<core::WebServer>(ioc, "127.0.0.1", 0, false);
+    ws->set_stratum_port(0);
+    auto* mi = ws->get_mining_interface();
+    mi->set_config_fns(
+        []() { return ce::resolved_config_json(); },
+        []() { return ce::catalog_schema_json(); });
+    mi->set_config_apply_fn([](const std::string& body) {
+        auto req  = ce::parse_apply_request(body);
+        auto resp = ce::apply_config(req);
+        auto j    = resp.to_json();
+        j["http_status"] = resp.http_status;
+        return j;
+    });
+    ws->start();
+    return ws;
+}
+
+// Reset all process-global Slice A gate state so each armed test is isolated.
+void reset_apply_state() {
+    ce::clear_control_token();
+    ce::clear_money_nonces();
+    ce::reset_tripwire();
 }
 
 } // namespace
@@ -129,16 +159,174 @@ TEST(ConfigEndpointHttp, GetSchemaReturnsCatalog) {
     EXPECT_TRUE(found_tri) << "schema must carry embedded.serve_mempool_txs as tristate_bool";
 }
 
-TEST(ConfigEndpointHttp, PostApplyIsInert503) {
+// DORMANT posture (Slice A): with NO apply fn installed, POST stays 503
+// {"armed":false} — the M1 inert behavior is preserved for every production
+// main (none wire the apply fn).
+TEST(ConfigEndpointHttp, PostApplyDormantWhenUnwired) {
     ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
     net::io_context ioc;
-    auto ws = make_wired_server(ioc);
+    auto ws = make_wired_server(ioc);   // read fns only; no apply fn
 
     int status = 0;
     auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply", status);
-    EXPECT_EQ(status, 503) << "runtime mutation must be inert (operator-gated)";
+    EXPECT_EQ(status, 503) << "unwired apply must be inert (operator-gated)";
     auto j = nlohmann::json::parse(body);
     EXPECT_FALSE(j.value("armed", true)) << "apply endpoint must report armed:false";
+}
+
+// DORMANT posture (Slice A): even with the apply fn WIRED, the endpoint stays
+// 503 {"armed":false} until an operator registers the loopback control token.
+TEST(ConfigEndpointHttp, PostApplyWiredButUnarmedStays503) {
+    reset_apply_state();  // no control token
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    int status = 0;
+    nlohmann::json changes = {{"changes", {{"web.port", "9091"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, changes.dump());
+    EXPECT_EQ(status, 503) << "wired-but-unarmed apply must report 503";
+    auto j = nlohmann::json::parse(body);
+    EXPECT_FALSE(j.value("armed", true));
+}
+
+// A non-money write applies behind a valid control token + schema validation,
+// and the resolved-config mirror reflects it.
+TEST(ConfigEndpointHttp, PostApplyNonMoneyAppliesWithToken) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-abc");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    int status = 0;
+    nlohmann::json req = {{"control_token", "tok-abc"},
+                          {"changes", {{"web.port", "9091"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, req.dump());
+    EXPECT_EQ(status, 200) << body;
+    auto j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("applied", false)) << body;
+
+    // The mirror behind GET /api/config now reports the applied value.
+    auto cfg = nlohmann::json::parse(
+        do_request(ws->bound_port(), http::verb::get, "/api/config", status));
+    EXPECT_EQ(cfg["keys"]["web.port"].value("value", std::string()), "9091");
+    // apply_armed flips true once the token is registered.
+    EXPECT_TRUE(cfg.value("apply_armed", false));
+}
+
+// A valid token is REQUIRED: an armed endpoint refuses a request that omits it.
+TEST(ConfigEndpointHttp, PostApplyRefusesWithoutToken) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-abc");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    int status = 0;
+    nlohmann::json req = {{"changes", {{"web.port", "9091"}}}};  // no token
+    do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+               status, req.dump());
+    EXPECT_EQ(status, 403) << "missing control token must be refused";
+}
+
+// An unknown / not-applicable key is rejected with a named cause; nothing applies.
+TEST(ConfigEndpointHttp, PostApplyRejectsUnknownKey) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-abc");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    int status = 0;
+    nlohmann::json req = {{"control_token", "tok-abc"},
+                          {"changes", {{"no.such.key", "1"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, req.dump());
+    EXPECT_EQ(status, 400) << body;
+    auto j = nlohmann::json::parse(body);
+    EXPECT_EQ(j.value("status", std::string()), "validation");
+    EXPECT_EQ(j.value("offending_key", std::string()), "no.such.key");
+}
+
+// A money-path write WITHOUT a nonce does NOT apply: it issues a confirm nonce
+// and leaves the config untouched (the tripwire does NOT fire — this is the
+// sanctioned confirmation request).
+TEST(ConfigEndpointHttp, PostApplyMoneyWithoutNonceIssuesConfirmAndAppliesNothing) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-abc");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    int status = 0;
+    nlohmann::json req = {{"control_token", "tok-abc"},
+                          {"changes", {{"money.node_owner_fee_pct", "0.5"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, req.dump());
+    EXPECT_EQ(status, 200) << body;
+    auto j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("need_confirm", false)) << body;
+    EXPECT_FALSE(j.value("applied", true));
+    EXPECT_FALSE(j.value("money_nonce", std::string()).empty());
+    EXPECT_EQ(ce::tripwire_state().count, 0u)
+        << "a phase-1 confirmation request must not trip the money wire";
+
+    // The mirror is unchanged (the money key was never applied: a seeded-but-
+    // unset compiled default reports an empty value).
+    auto cfg = nlohmann::json::parse(
+        do_request(ws->bound_port(), http::verb::get, "/api/config", status));
+    EXPECT_EQ(cfg["keys"]["money.node_owner_fee_pct"].value("value", std::string()), "");
+}
+
+// The two-phase nonce is BOUND TO THE EXACT diff: a nonce issued for one diff
+// must not confirm a different diff (that trips the wire + refuses), and it
+// applies only when the confirmed diff matches.
+TEST(ConfigEndpointHttp, PostApplyMoneyTwoPhaseNonceMustMatchDiff) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-abc");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    // Phase 1: issue a nonce bound to fee=0.5.
+    int status = 0;
+    nlohmann::json issue = {{"control_token", "tok-abc"},
+                            {"changes", {{"money.node_owner_fee_pct", "0.5"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, issue.dump());
+    auto j = nlohmann::json::parse(body);
+    const std::string nonce = j.value("money_nonce", std::string());
+    ASSERT_FALSE(nonce.empty());
+
+    // Phase 2a: present the nonce against a DIFFERENT diff (fee=0.7) -> refuse
+    // + tripwire fires. No apply.
+    nlohmann::json wrong = {{"control_token", "tok-abc"},
+                            {"money_nonce", nonce},
+                            {"changes", {{"money.node_owner_fee_pct", "0.7"}}}};
+    body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                      status, wrong.dump());
+    EXPECT_EQ(status, 409) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_EQ(j.value("status", std::string()), "money_gate");
+    EXPECT_GE(ce::tripwire_state().count, 1u)
+        << "a diff-mismatched nonce must trip the money wire";
+
+    // Phase 2b: present the nonce against the ORIGINAL diff (fee=0.5) -> applied.
+    nlohmann::json confirm = {{"control_token", "tok-abc"},
+                              {"money_nonce", nonce},
+                              {"changes", {{"money.node_owner_fee_pct", "0.5"}}}};
+    body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                      status, confirm.dump());
+    EXPECT_EQ(status, 200) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("applied", false)) << body;
+
+    auto cfg = nlohmann::json::parse(
+        do_request(ws->bound_port(), http::verb::get, "/api/config", status));
+    EXPECT_EQ(cfg["keys"]["money.node_owner_fee_pct"].value("value", std::string()), "0.5");
 }
 
 TEST(ConfigEndpointHttp, UnwiredInterfaceReturns404) {

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5686,6 +5686,21 @@ nlohmann::json MiningInterface::rest_config_schema()
     return nlohmann::json{{"error", "config schema endpoint not wired"}};
 }
 
+nlohmann::json MiningInterface::rest_config_apply(const std::string& body)
+{
+    // Slice A (#157): route the POST body through the installed gated-apply fn
+    // (control token + two-phase money nonce + AddressValidator + tripwire).
+    // Unwired => the caller (http_session) never reaches here; it answers 503.
+    if (m_config_apply_fn) {
+        auto j = m_config_apply_fn(body);
+        if (!j.is_null())
+            return j;
+    }
+    return nlohmann::json{{"armed", false},
+        {"error", "config-apply not armed; runtime mutation is operator-gated"},
+        {"http_status", 503}};
+}
+
 nlohmann::json MiningInterface::rest_node_topology()
 {
     // D0.3 seam: prefer the per-coin StatsProvider hook when the wiring layer

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -599,6 +599,19 @@ public:
     nlohmann::json rest_config();          // GET /api/config
     nlohmann::json rest_config_schema();   // GET /api/config/schema
 
+    // Slice A (#157): the LIVE apply path for POST /api/config/apply. Takes the
+    // raw request body and returns a JSON response that carries an
+    // "http_status" hint the HTTP layer maps to the wire status. UNWIRED by
+    // default: no main installs it, so the POST route stays 503 {"armed":false}
+    // (dormant). A main/test that wants the live gated apply installs a fn that
+    // routes through config_endpoint::apply_config (control token + two-phase
+    // money nonce + AddressValidator + tripwire). Never wired in production
+    // without an operator arming the control token.
+    using config_apply_fn_t = std::function<nlohmann::json(const std::string& body)>;
+    void set_config_apply_fn(config_apply_fn_t fn) { m_config_apply_fn = thread_safe_wrap(std::move(fn)); }
+    bool has_config_apply_fn() const { return static_cast<bool>(m_config_apply_fn); }
+    nlohmann::json rest_config_apply(const std::string& body);  // POST /api/config/apply
+
     // Sharechain stats callback — returns live tracker data for the /sharechain/stats endpoint
     using sharechain_stats_fn_t = std::function<nlohmann::json()>;
     void set_sharechain_stats_fn(sharechain_stats_fn_t fn) { m_sharechain_stats_fn = thread_safe_wrap(std::move(fn)); }
@@ -1345,6 +1358,7 @@ private:
     embedded_template_fn_t m_embedded_template_fn;  // /embedded_template last-served snapshot (optional)
     config_json_fn_t m_config_fn;         // GET /api/config — resolved launch config (optional)
     config_json_fn_t m_config_schema_fn;  // GET /api/config/schema — catalog schema (optional)
+    config_apply_fn_t m_config_apply_fn;  // POST /api/config/apply — Slice A gated apply (optional; unwired => 503)
     // Rate limiter for /api/coin_peers: IP → last request time
     std::map<std::string, std::chrono::steady_clock::time_point> m_coin_peers_rate_limit;
     sharechain_window_fn_t m_sharechain_window_fn;


### PR DESCRIPTION
## Slice A (#157) — control-plane apply, dormant → live (money-gated)

Implements **Slice A only** of `docs/design/tx_inject_qt_control.md`. DRAFT — pending independent review + operator tap. Slice B (arm/disarm + submit-raw-tx) is a separate follow-up and is **not** built here.

### What changed
Turns the previously **inert** `POST /api/config/apply` (unconditional 503, pinned by a KAT) into a **fail-closed live write path**.

Fail-closed posture, in layers:
- **Loopback only** (same posture as the GET config endpoints).
- **Dormant by default.** No main installs the apply fn, so production stays `503 {"armed":false}`. Even a wired endpoint stays 503 until an operator registers a per-process **control token** — arming is a reviewed operator-tap step, never a silent default.

Two-tier apply, **atomic** (one bad key rejects the whole batch — nothing applies partially):
1. **Non-money keys** → loopback control token + schema/type/range validation. Unknown / not-applicable / read-only / out-of-range keys are refused with a named cause.
2. **Money-path keys** (any `Mut::MONEY_*` catalog row) → the FULL gate:
   - a **two-phase money nonce bound to the EXACT requested diff** (phase 1 issues a nonce for a specific diff and applies nothing; phase 2 must present the same diff + that nonce — a nonce issued for one diff never confirms another);
   - the server-side **`AddressValidator`** on any address-typed money value (fail-closed on an unparseable address);
   - the **M0 tripwire**, which fires on any attempt to write a money key without a valid confirmed nonce (or with an invalid address).

"Apply" swaps the process-global published `ResolvedConfig` snapshot atomically (the reporting mirror behind `GET /api/config`) and invokes any registered `ParamApplier` setter. It **never touches coinbase/subsidy/PPLNS/payee computation** and **never arms `--embedded-tx-inject`** (that is Slice B, and the catalog marks that flag `RESTART`, not money-path, so this slice does not treat it as money).

### Files
- `src/core/config_endpoint.{hpp,cpp}` — control token, two-phase money nonce (diff-bound, single-use, TTL), tripwire, per-value schema validation, and the armed `apply_config` entry point + JSON request parser.
- `src/core/web_server.{hpp,cpp}` — optional `set_config_apply_fn` seam + `rest_config_apply(body)` (unwired by default → 503).
- `src/core/http_session.cpp` — the `POST /api/config/apply` route: loopback gate → 503 when unwired → otherwise route through the gated apply fn.
- `src/core/test/web_server_config_endpoint_test.cpp` — flips the inert-503 KAT and adds the gated-apply cases.

### Tests (`core_test`, folded into the existing target — no new executable)
Built + run on a build host; **11/11 `ConfigEndpointHttp` pass**. New cases: dormant when unwired; dormant wired-but-unarmed; non-money applies with a valid token (mirror reflects it, `apply_armed` flips true); refuse without token (403); reject unknown key (400, named cause); money write without a nonce issues a confirm and applies nothing (tripwire does not fire on the sanctioned phase-1 request); two-phase nonce must match the diff (a mismatched diff → 409 + tripwire; the matching diff → applied).

### Not done / to polish
- Enum-member and hostport validators fall back to non-empty / shape checks (no per-enum member table exists yet).
- BCH/NMC/BIP110 have no `AddressValidator` blockchain enum, so their addresses fall through the multi-validator (garbage still refused).
- Conflicts textually with #1606 / #1611 in shared files (`http_session.cpp`); rebase later.

DRAFT — do not merge. Requires independent review + operator tap on the money path.



---
_Supersedes #1615 (identical tree `903b70c9`; reopened on a footer-free commit `894a0b7` to clear the attribution-gate — the sanctioned new-branch fix, not a force-push)._
