### PR TITLE
qt/tx-inject: money-gated runtime arm + loopback submit endpoint (#157 Slice B)

### DIFF
--- a/src/c2pool/main_dash.cpp
+++ b/src/c2pool/main_dash.cpp
@@ -1379,11 +1379,32 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
         // ── Control-plane M1 (SAFE): install the READ-ONLY config endpoints.
         // The lambdas read the immutable snapshot published in main() (before
         // run_node) at request time, so install order is irrelevant. No node
-        // state is touched. POST /api/config/apply stays inert (503) in
-        // http_session.cpp — runtime mutation is operator-gated, not armed.
+        // state is touched. POST /api/config/apply is WIRED just below (Slice
+        // A/B) but stays fail-closed: it answers 503 {"armed":false} until an
+        // operator registers a loopback control token (none is registered here),
+        // and money-path keys additionally require the two-phase money nonce.
         mi->set_config_fns(
             []() { return c2pool::config_endpoint::resolved_config_json(); },
             []() { return c2pool::config_endpoint::catalog_schema_json(); });
+
+        // #157 Slice A/B: wire the LIVE gated-apply path for POST
+        // /api/config/apply. This installs the plumbing ONLY -- the endpoint
+        // stays fail-closed: config_endpoint::apply_config() answers 503
+        // {"armed":false} until an operator registers a loopback control token
+        // (nothing here registers one). Money-path keys (Mut::MONEY_*, which now
+        // includes embedded.tx_inject -- the tx-injection arm) additionally
+        // require the two-phase money nonce bound to the exact diff + the M0
+        // tripwire. The lambda is capture-free (apply_config is process-global);
+        // the runtime setter that actually flips node state is registered on the
+        // ParamApplier next to the node_coin_state arm (Slice B, below).
+        mi->set_config_apply_fn(
+            [](const std::string& body) -> nlohmann::json {
+                auto req  = c2pool::config_endpoint::parse_apply_request(body);
+                auto resp = c2pool::config_endpoint::apply_config(req);
+                auto j    = resp.to_json();
+                j["http_status"] = resp.http_status;   // http_session maps to wire status
+                return j;
+            });
 
         // ── Peer-info liveness: serialize the HTTP-cache rebuild onto the
         // io_context thread (main_ltc.cpp parity). Once the io_context is wired,
@@ -2748,32 +2769,110 @@ int run_node(bool testnet, const std::string& rpc_endpoint,
     // transaction, which is exactly the case that costs a whole block.
     node_coin_state.set_serve_mempool_txs(embedded_serve_mempool_txs);
     // #157 (--embedded-tx-inject): arm the opt-in miner/user tx-injection lane.
-    // Default OFF; the actual local submits happen after the mempool + the
-    // consensus-exact script check are wired (see --embedded-tx-inject-hex).
-    node_coin_state.set_tx_inject_enabled(embedded_tx_inject);
-    // #157 M2 (peer tx-injection over the sharechain p2p): install the sink the
-    // tx_inject HANDLER routes a peer's tx through. It MUST target THIS
-    // node_coin_state (the armed one) — NodeImpl::m_coin_state is a different
-    // object that main_dash never arms, so a handler calling m_coin_state would
-    // fail-closed forever. Flag OFF ⇒ a NULL sink ⇒ the handler ignores every
-    // tx_inject (belt), and submit_inject would refuse anyway (suspenders).
+    // Slice B routes the ARM through TWO places that MUST move together, so a
+    // runtime arm (via POST /api/config/apply -> the ParamApplier setter below)
+    // behaves exactly like a startup arm:
+    //   (1) node_coin_state.set_tx_inject_enabled() -- the M1 submit gate; and
+    //   (2) p2p_node.set_tx_inject_sink() -- the sink the peer tx_inject HANDLER
+    //       routes a peer tx through. It MUST target THIS node_coin_state (the
+    //       armed one); NodeImpl::m_coin_state is a different object main_dash
+    //       never arms, so a handler calling it would fail-closed forever. If a
+    //       runtime arm flipped only (1) and not (2), peer tx_inject frames
+    //       would be SILENTLY ignored (Fable review, Edit 1). So arm/disarm is a
+    //       single closure that always moves both, and disarm clears the sink.
     // node_coin_state and p2p_node both live in run_node scope; node_coin_state
     // (declared later) is destroyed first, but only AFTER ioc.run() returns, so
     // no dispatch can reach a dangling ref. Reward-safe: transport only.
+    auto arm_tx_inject = [&node_coin_state, &p2p_node](bool on) {
+        node_coin_state.set_tx_inject_enabled(on);
+        if (on) {
+            p2p_node.set_tx_inject_sink(
+                [&node_coin_state](const dash::coin::MutableTransaction& tx,
+                                   uint32_t flags, int32_t expiry_height) {
+                    return node_coin_state.submit_inject(tx, flags, expiry_height);
+                });
+        } else {
+            p2p_node.set_tx_inject_sink(nullptr);   // disarm clears the sink too
+        }
+    };
+    arm_tx_inject(embedded_tx_inject);
     if (embedded_tx_inject) {
-        p2p_node.set_tx_inject_sink(
-            [&node_coin_state](const dash::coin::MutableTransaction& tx,
-                               uint32_t flags, int32_t expiry_height) {
-                return node_coin_state.submit_inject(tx, flags, expiry_height);
-            });
         std::cout << "[run] embedded-tx-inject ARMED (#157): miner/user tx-injection "
-                     "ON — submitted txs ride the block with priority through the "
+                     "ON -- submitted txs ride the block with priority through the "
                      "SAME validity gate; reward path byte-unchanged. Requires "
                      "--embedded-fold-checkscripts + the served-body posture. M2 "
                      "peer tx_inject transport is live (first-see fan-out, "
                      "per-peer DoS guard).\n";
-    } else {
-        p2p_node.set_tx_inject_sink(nullptr);   // explicit: feature dormant
+    }
+
+    // #157 Slice B: register the runtime ARM setter on the process-global
+    // ParamApplier. embedded.tx_inject is a MONEY-path key (param_catalog.inc),
+    // so apply_config admits a change to it ONLY behind the loopback control
+    // token + the two-phase money nonce (bound to the exact diff) + the M0
+    // tripwire, then invokes THIS setter to flip the runtime arm (both the M1
+    // gate AND the p2p sink, via arm_tx_inject). The setter runs on the node
+    // io_context (apply_config is dispatched there by thread_safe_wrap), so the
+    // IO-confined arm/sink state is mutated only on the strand the node runs on.
+    // Reward path untouched: arming only changes WHICH consensus-valid body txs
+    // may be offered, never the coinbase/subsidy/PPLNS/payee computation.
+    c2pool::config_endpoint::applier().register_setter(
+        "embedded.tx_inject",
+        [arm_tx_inject](const std::string& value) -> bool {
+            std::string v;
+            for (char c : value) v.push_back(static_cast<char>(std::tolower(
+                static_cast<unsigned char>(c))));
+            const bool on = (v == "true" || v == "1" || v == "on" || v == "yes");
+            arm_tx_inject(on);
+            return true;
+        });
+
+    // #157 Slice B: POST /api/tx-inject/submit -- loopback-only raw-tx submit to
+    // the armed M1 gate. thread_safe_wrap posts this onto the node io_context
+    // (Fable review, Edit 2: submit_inject / m_inject_pool are IO-thread-confined
+    // and lock-free, so the submit MUST NOT run on the WEB thread). submit_inject
+    // itself refuses ("inject-disabled") while the arm is OFF, so a disarmed node
+    // never injects. It does NOT modify the submit_inject validity gate -- it
+    // only calls it. Reward-safe: an inject is an ordinary block-body tx.
+    if (web_server) {
+        web_server->get_mining_interface()->set_tx_inject_submit_fn(
+            [&node_coin_state](const std::string& body) -> nlohmann::json {
+                nlohmann::json req = nlohmann::json::parse(body, nullptr, /*allow_exceptions=*/false);
+                if (!req.is_object() || !req.contains("raw_tx") || !req["raw_tx"].is_string())
+                    return nlohmann::json{{"ok", false}, {"cause", "missing raw_tx hex"},
+                                          {"http_status", 400}};
+                std::string hex = req["raw_tx"].get<std::string>();
+                hex.erase(std::remove_if(hex.begin(), hex.end(),
+                              [](unsigned char c) { return std::isspace(c); }), hex.end());
+                if (hex.empty() || hex.size() % 2 != 0)
+                    return nlohmann::json{{"ok", false}, {"cause", "raw_tx must be even-length hex"},
+                                          {"http_status", 400}};
+                uint32_t flags  = 0;
+                int32_t  expiry = 0;
+                if (req.contains("flags") && req["flags"].is_number_unsigned())
+                    flags = req["flags"].get<uint32_t>();
+                if (req.contains("expiry_height") && req["expiry_height"].is_number_integer())
+                    expiry = req["expiry_height"].get<int32_t>();
+                dash::coin::MutableTransaction tx;
+                try {
+                    auto raw = ParseHex(hex);
+                    PackStream ps(raw);
+                    ps >> tx;
+                } catch (const std::exception& e) {
+                    return nlohmann::json{{"ok", false},
+                                          {"cause", std::string("tx parse failed: ") + e.what()},
+                                          {"http_status", 400}};
+                }
+                auto r = node_coin_state.submit_inject(tx, flags, expiry);
+                // inject-disabled (arm OFF) -> 409; other named refusals -> 422.
+                const int http = r.ok ? 200 : (r.cause == "inject-disabled" ? 409 : 422);
+                return nlohmann::json{
+                    {"ok",          r.ok},
+                    {"cause",       r.cause},
+                    {"txid",        r.txid.GetHex()},
+                    {"armed",       node_coin_state.tx_inject_enabled()},
+                    {"http_status", http},
+                };
+            });
     }
     // ── IS/CL MINING-SAFETY HOLD arming (dashd TestPackageTransactions) ─────
     // dashd's miner refuses any not-yet-islocked tx with vins younger than 10

--- a/src/core/http_session.cpp
+++ b/src/core/http_session.cpp
@@ -1070,6 +1070,43 @@ void HttpSession::process_request()
                 send_response(std::move(response));
                 return;
             }
+
+            // ── Control-plane Slice B (#157): POST /api/tx-inject/submit ──────
+            // Hand a raw consensus tx to the armed M1 inject gate. Loopback-only
+            // (same posture as /api/config/apply). Fail-closed: a 503
+            // {"armed":false} until a main installs the submit fn, and even then
+            // NodeCoinState::submit_inject refuses ("inject-disabled") while the
+            // --embedded-tx-inject arm is OFF. The submit fn marshals onto the
+            // node io_context (thread_safe_wrap) so the IO-confined inject state
+            // is never touched from the WEB thread. Reward path untouched: an
+            // inject is an ordinary block-body tx.
+            if (std::string(request_.target()) == "/api/tx-inject/submit") {
+                auto remote_addr = socket_.remote_endpoint().address();
+                if (!remote_addr.is_loopback()) {
+                    response.result(http::status::forbidden);
+                    response.body() = R"({"error":"tx-inject API is local-only"})";
+                    response.prepare_payload();
+                    send_response(std::move(response));
+                    return;
+                }
+                if (!mining_interface_->has_tx_inject_submit_fn()) {
+                    // Dormant: no submit fn installed => feature not wired.
+                    response.result(http::status::service_unavailable);
+                    response.body() = R"({"armed":false,"error":"tx-inject submit not wired"})";
+                    response.prepare_payload();
+                    send_response(std::move(response));
+                    return;
+                }
+                auto j = mining_interface_->rest_tx_inject_submit(request_.body());
+                int st = j.is_object() ? j.value("http_status", 200) : 200;
+                if (st < 100 || st > 599) st = 200;
+                if (j.is_object()) j.erase("http_status");
+                response.result(static_cast<http::status>(st));
+                response.body() = j.dump();
+                response.prepare_payload();
+                send_response(std::move(response));
+                return;
+            }
             // Handle JSON-RPC POST request.
             // Accept both 1.0 and 2.0 — upgrade 1.0 to 2.0 for the library.
             std::string request_body = request_.body();

--- a/src/core/param_catalog.inc
+++ b/src/core/param_catalog.inc
@@ -548,7 +548,7 @@ C2P_PARAM("embedded.fold_live_expect", Embedded, HEX, RESTART, C_DASH, LIT, "", 
 C2P_PARAM("embedded.fold_checkscripts", Embedded, BOOL, RESTART, C_DASH, LIT, "false", NONE, "consensus-exact input-script check")
   C2P_ALIAS("embedded.fold_checkscripts", BIN_DASH, "--embedded-fold-checkscripts", FLAG)
 
-C2P_PARAM("embedded.tx_inject", Embedded, BOOL, RESTART, C_DASH, LIT, "false", NONE, "#157 miner/user tx-injection (opt-in, default OFF, reward-neutral)")
+C2P_PARAM("embedded.tx_inject", Embedded, BOOL, MONEY_LIVE, C_DASH, LIT, "false", NONE, "#157 miner/user tx-injection arm (opt-in, default OFF, reward-neutral; MONEY-path: arming changes mined-block body -> the full two-phase money-nonce + M0 tripwire gate, Slice B)")
   C2P_ALIAS("embedded.tx_inject", BIN_DASH, "--embedded-tx-inject", FLAG)
 
 C2P_PARAM("embedded.tx_inject_hex", Embedded, PATH, RESTART, C_DASH, LIT, "", NONE, "#157 local tx-inject submit file (raw tx hex per line)")

--- a/src/core/test/web_server_config_endpoint_test.cpp
+++ b/src/core/test/web_server_config_endpoint_test.cpp
@@ -359,3 +359,83 @@ TEST(ConfigEndpointHttp, CoinGenericDgb) {
     EXPECT_FALSE(j["keys"].contains("embedded.tx_serve_own_set"))
         << "DGB config must not carry DASH-only embedded keys";
 }
+
+// ── Slice B (#157): tx-injection ARM is a MONEY-path config write ──────────
+// Observed by a static so the process-global ParamApplier setter never holds a
+// dangling stack reference after the test returns.
+static bool s_tx_inject_setter_saw = false;
+
+// Reclassification present-check: embedded.tx_inject must now report as a
+// money-path key (Mut::MONEY_LIVE) over GET /api/config, so a qt/operator sees
+// that arming it demands the full money gate — not a plain RESTART write.
+TEST(ConfigEndpointHttp, SliceBTxInjectIsMoneyClassified) {
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    net::io_context ioc;
+    auto ws = make_wired_server(ioc);
+
+    int status = 0;
+    auto body = do_request(ws->bound_port(), http::verb::get, "/api/config", status);
+    EXPECT_EQ(status, 200) << body;
+    auto j = nlohmann::json::parse(body);
+    ASSERT_TRUE(j["keys"].contains("embedded.tx_inject")) << body;
+    EXPECT_TRUE(j["keys"]["embedded.tx_inject"].value("money", false))
+        << "the tx-injection arm must be money-classified (Slice B)";
+    EXPECT_EQ(j["keys"]["embedded.tx_inject"].value("mutability", std::string()),
+              "money_live");
+}
+
+// The arm routed THROUGH apply_config: a change to embedded.tx_inject without a
+// nonce issues a confirm (money gate, nothing applied, no tripwire); presenting
+// the matching nonce applies it AND invokes the registered runtime arm setter.
+// This is exactly the path the QT arm/disarm uses (Slice A gate reused, no
+// second write path).
+TEST(ConfigEndpointHttp, SliceBTxInjectArmGoesThroughMoneyGateAndFiresSetter) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-arm");
+    // Register the runtime arm setter (main_dash registers the real one that
+    // flips node_coin_state + the p2p sink; here we prove apply invokes it).
+    s_tx_inject_setter_saw = false;
+    ce::applier().register_setter(
+        "embedded.tx_inject",
+        [](const std::string& v) {
+            s_tx_inject_setter_saw = (v == "true" || v == "1" || v == "on");
+            return true;
+        });
+
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    // Phase 1: no nonce -> confirm issued, nothing applied, wire not tripped.
+    int status = 0;
+    nlohmann::json issue = {{"control_token", "tok-arm"},
+                            {"changes", {{"embedded.tx_inject", "true"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, issue.dump());
+    EXPECT_EQ(status, 200) << body;
+    auto j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("need_confirm", false)) << body;
+    EXPECT_FALSE(j.value("applied", true));
+    const std::string nonce = j.value("money_nonce", std::string());
+    ASSERT_FALSE(nonce.empty());
+    EXPECT_EQ(ce::tripwire_state().count, 0u);
+    EXPECT_FALSE(s_tx_inject_setter_saw)
+        << "a phase-1 confirmation request must not fire the arm setter";
+
+    // Phase 2: matching nonce -> applied + setter fired.
+    nlohmann::json confirm = {{"control_token", "tok-arm"},
+                              {"money_nonce", nonce},
+                              {"changes", {{"embedded.tx_inject", "true"}}}};
+    body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                      status, confirm.dump());
+    EXPECT_EQ(status, 200) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("applied", false)) << body;
+    EXPECT_TRUE(s_tx_inject_setter_saw)
+        << "a confirmed money-gated apply must fire the runtime arm setter";
+
+    // The reporting mirror now shows the arm ON.
+    auto cfg = nlohmann::json::parse(
+        do_request(ws->bound_port(), http::verb::get, "/api/config", status));
+    EXPECT_EQ(cfg["keys"]["embedded.tx_inject"].value("value", std::string()), "true");
+}

--- a/src/core/test/web_server_config_endpoint_test.cpp
+++ b/src/core/test/web_server_config_endpoint_test.cpp
@@ -15,6 +15,8 @@
 // the coin field + mask-applicable keys track the published coin.
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -106,6 +108,24 @@ std::unique_ptr<core::WebServer> make_apply_server(net::io_context& ioc) {
         j["http_status"] = resp.http_status;
         return j;
     });
+    ws->start();
+    return ws;
+}
+
+// Slice B (#157): stand up a server whose POST /api/tx-inject/submit is WIRED to
+// a caller-supplied submit fn (the same seam main_dash uses via
+// set_tx_inject_submit_fn). An UNWIRED server (make_wired_server) stays 503
+// {"armed":false} on this route — the fail-closed dormant posture.
+std::unique_ptr<core::WebServer> make_submit_server(
+        net::io_context& ioc,
+        std::function<nlohmann::json(const std::string&)> submit_fn) {
+    auto ws = std::make_unique<core::WebServer>(ioc, "127.0.0.1", 0, false);
+    ws->set_stratum_port(0);
+    auto* mi = ws->get_mining_interface();
+    mi->set_config_fns(
+        []() { return ce::resolved_config_json(); },
+        []() { return ce::catalog_schema_json(); });
+    mi->set_tx_inject_submit_fn(std::move(submit_fn));
     ws->start();
     return ws;
 }
@@ -438,4 +458,177 @@ TEST(ConfigEndpointHttp, SliceBTxInjectArmGoesThroughMoneyGateAndFiresSetter) {
     auto cfg = nlohmann::json::parse(
         do_request(ws->bound_port(), http::verb::get, "/api/config", status));
     EXPECT_EQ(cfg["keys"]["embedded.tx_inject"].value("value", std::string()), "true");
+}
+
+// ── Slice B (#157): POST /api/tx-inject/submit — raw-tx submit route ────────
+// A main that never installs the submit fn keeps the route INERT: http_session
+// answers 503 {"armed":false} (has_tx_inject_submit_fn() gate). This is the
+// fail-closed dormant posture every production main starts in.
+TEST(ConfigEndpointHttp, SliceBTxInjectSubmitDormantWhenUnwired) {
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    net::io_context ioc;
+    auto ws = make_wired_server(ioc);   // config read fns only; NO submit fn
+
+    int status = 0;
+    nlohmann::json body_j = {{"raw_tx", "00"}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/tx-inject/submit",
+                           status, body_j.dump());
+    EXPECT_EQ(status, 503) << "an unwired submit endpoint must be inert";
+    auto j = nlohmann::json::parse(body);
+    EXPECT_FALSE(j.value("armed", true)) << "the submit route must report armed:false";
+    EXPECT_NE(j.value("error", std::string()).find("not wired"), std::string::npos) << body;
+}
+
+// The wired submit route, end to end through the REAL http_session dispatch.
+//
+// NOTE ON SCOPE: core_test does not link the dash node library, so a real
+// NodeCoinState / submit_inject cannot be constructed here — the arm gate
+// itself (submit_inject returns "inject-disabled" whenever embedded.tx_inject
+// is OFF, which is the default) is pinned at the node layer. This test double
+// mirrors main_dash's submit-fn HTTP contract so the CORE-owned pieces are
+// exercised for real: the /api/tx-inject/submit route match, verbatim body
+// pass-through into rest_tx_inject_submit, and http_session's http_status
+// mapping (+ erase from the emitted body) for the two money-safety causes —
+// a malformed/non-hex raw-tx (400, not a crash, not a silent accept) and a
+// well-formed tx on a DISARMED node (409 inject-disabled, fail-closed).
+TEST(ConfigEndpointHttp, SliceBTxInjectSubmitRouteMapsDisarmedAndBadHex) {
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+
+    std::string seen_body;
+    auto submit_double = [&seen_body](const std::string& body) -> nlohmann::json {
+        seen_body = body;
+        auto req = nlohmann::json::parse(body, nullptr, /*allow_exceptions=*/false);
+        if (!req.is_object() || !req.contains("raw_tx") || !req["raw_tx"].is_string())
+            return nlohmann::json{{"ok", false}, {"cause", "missing raw_tx hex"},
+                                  {"http_status", 400}};
+        const std::string hex = req["raw_tx"].get<std::string>();
+        const bool even_hex = !hex.empty() && (hex.size() % 2 == 0) &&
+            std::all_of(hex.begin(), hex.end(),
+                        [](unsigned char c) { return std::isxdigit(c) != 0; });
+        if (!even_hex)
+            return nlohmann::json{{"ok", false}, {"cause", "raw_tx must be even-length hex"},
+                                  {"http_status", 400}};
+        // Well-formed hex, but the tx-inject arm is OFF by default
+        // (embedded.tx_inject default false) => submit_inject refuses.
+        return nlohmann::json{{"ok", false}, {"cause", "inject-disabled"},
+                              {"armed", false}, {"http_status", 409}};
+    };
+
+    net::io_context ioc;
+    auto ws = make_submit_server(ioc, submit_double);
+
+    // (a) malformed / non-hex raw_tx => 400 (bad request), never a silent accept.
+    int status = 0;
+    nlohmann::json bad = {{"raw_tx", "zz"}};  // non-hex chars
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/tx-inject/submit",
+                           status, bad.dump());
+    EXPECT_EQ(status, 400) << body;
+    auto j = nlohmann::json::parse(body);
+    EXPECT_FALSE(j.value("ok", true));
+    EXPECT_FALSE(j.contains("http_status"))
+        << "http_session must strip the transport http_status from the body";
+    EXPECT_EQ(seen_body, bad.dump())
+        << "the raw POST body must reach the submit fn verbatim";
+
+    // (b) well-formed hex on a DISARMED node => 409 inject-disabled (fail-closed).
+    nlohmann::json ok_hex = {{"raw_tx", "0100000000"}};
+    body = do_request(ws->bound_port(), http::verb::post, "/api/tx-inject/submit",
+                      status, ok_hex.dump());
+    EXPECT_EQ(status, 409) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_EQ(j.value("cause", std::string()), "inject-disabled");
+    EXPECT_FALSE(j.value("armed", true)) << "a disarmed submit must not report armed";
+}
+
+// Money gate, ADDRESS-key branch (config_endpoint.cpp:668-686). The existing
+// money KATs only ever drive a PCT key; an ADDR_COIN money key with an INVALID
+// address must, once the two-phase nonce confirms, be rejected by the
+// server-side AddressValidator with RejectMoneyGate (409) and the M0 tripwire
+// must fire — proving a bad payout/owner address can never be applied.
+TEST(ConfigEndpointHttp, SliceBMoneyGateRejectsInvalidAddressAndTripsWire) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-addr");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    const std::string bad_addr = "not-a-valid-dash-address";
+
+    // Phase 1: no nonce -> confirm issued, nothing applied, wire NOT tripped
+    // (a bad address passes the cheap schema pass; validity is a money-gate
+    // check applied only AFTER the nonce confirms).
+    int status = 0;
+    nlohmann::json issue = {{"control_token", "tok-addr"},
+                            {"changes", {{"money.node_owner_address", bad_addr}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, issue.dump());
+    EXPECT_EQ(status, 200) << body;
+    auto j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("need_confirm", false)) << body;
+    const std::string nonce = j.value("money_nonce", std::string());
+    ASSERT_FALSE(nonce.empty());
+    EXPECT_EQ(ce::tripwire_state().count, 0u);
+
+    // Phase 2: matching nonce -> the AddressValidator rejects the bad address.
+    nlohmann::json confirm = {{"control_token", "tok-addr"},
+                              {"money_nonce", nonce},
+                              {"changes", {{"money.node_owner_address", bad_addr}}}};
+    body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                      status, confirm.dump());
+    EXPECT_EQ(status, 409) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_EQ(j.value("status", std::string()), "money_gate");
+    EXPECT_EQ(j.value("offending_key", std::string()), "money.node_owner_address");
+    EXPECT_GE(ce::tripwire_state().count, 1u)
+        << "an invalid money-path address must trip the M0 wire";
+    EXPECT_EQ(ce::tripwire_state().last_key, "money.node_owner_address");
+
+    // Nothing applied: the address key stays empty in the reporting mirror.
+    auto cfg = nlohmann::json::parse(
+        do_request(ws->bound_port(), http::verb::get, "/api/config", status));
+    EXPECT_EQ(cfg["keys"]["money.node_owner_address"].value("value", std::string()), "");
+}
+
+// Nonce single-use / replay: a confirmed money nonce is CONSUMED on a
+// successful apply. Re-presenting the SAME nonce for the SAME diff a second
+// time must be REFUSED (the pending nonce is gone) with money_gate (409) + a
+// tripwire fire — proving the two-phase nonce cannot be replayed.
+TEST(ConfigEndpointHttp, SliceBMoneyNonceIsSingleUseReplayRefused) {
+    reset_apply_state();
+    ce::publish_resolved(dash_snapshot(), c2pool::catalog::C_DASH, "/tmp/x.toml");
+    ce::set_control_token("tok-replay");
+    net::io_context ioc;
+    auto ws = make_apply_server(ioc);
+
+    // Phase 1: issue a nonce bound to fee=0.5.
+    int status = 0;
+    nlohmann::json issue = {{"control_token", "tok-replay"},
+                            {"changes", {{"money.node_owner_fee_pct", "0.5"}}}};
+    auto body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                           status, issue.dump());
+    auto j = nlohmann::json::parse(body);
+    const std::string nonce = j.value("money_nonce", std::string());
+    ASSERT_FALSE(nonce.empty());
+
+    // Phase 2: confirm -> applied. This CONSUMES the nonce (single-use).
+    nlohmann::json confirm = {{"control_token", "tok-replay"},
+                              {"money_nonce", nonce},
+                              {"changes", {{"money.node_owner_fee_pct", "0.5"}}}};
+    body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                      status, confirm.dump());
+    EXPECT_EQ(status, 200) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_TRUE(j.value("applied", false)) << body;
+    const uint64_t trip_after_apply = ce::tripwire_state().count;
+    EXPECT_EQ(trip_after_apply, 0u) << "a sanctioned confirm must not trip the wire";
+
+    // Phase 3 (REPLAY): re-present the SAME now-consumed nonce for the SAME
+    // diff -> refused, since the pending nonce was erased on first use.
+    body = do_request(ws->bound_port(), http::verb::post, "/api/config/apply",
+                      status, confirm.dump());
+    EXPECT_EQ(status, 409) << body;
+    j = nlohmann::json::parse(body);
+    EXPECT_EQ(j.value("status", std::string()), "money_gate");
+    EXPECT_GT(ce::tripwire_state().count, trip_after_apply)
+        << "a consumed nonce must not confirm a second time (single-use)";
 }

--- a/src/core/web_server.cpp
+++ b/src/core/web_server.cpp
@@ -5701,6 +5701,23 @@ nlohmann::json MiningInterface::rest_config_apply(const std::string& body)
         {"http_status", 503}};
 }
 
+nlohmann::json MiningInterface::rest_tx_inject_submit(const std::string& body)
+{
+    // Slice B (#157): route the POST body through the installed submit fn, which
+    // (in main_dash) deserializes the raw tx and calls the armed
+    // NodeCoinState::submit_inject on the node io_context (via thread_safe_wrap,
+    // so the IO-confined inject state is never touched from the WEB thread).
+    // Unwired => the caller (http_session) answers 503 before reaching here.
+    if (m_tx_inject_submit_fn) {
+        auto j = m_tx_inject_submit_fn(body);
+        if (!j.is_null())
+            return j;
+    }
+    return nlohmann::json{{"armed", false},
+        {"error", "tx-inject submit not wired"},
+        {"http_status", 503}};
+}
+
 nlohmann::json MiningInterface::rest_node_topology()
 {
     // D0.3 seam: prefer the per-coin StatsProvider hook when the wiring layer

--- a/src/core/web_server.hpp
+++ b/src/core/web_server.hpp
@@ -612,6 +612,21 @@ public:
     bool has_config_apply_fn() const { return static_cast<bool>(m_config_apply_fn); }
     nlohmann::json rest_config_apply(const std::string& body);  // POST /api/config/apply
 
+    // Slice B (#157): POST /api/tx-inject/submit -- hand a raw consensus tx to
+    // the armed M1 inject gate (NodeCoinState::submit_inject). Wrapped in
+    // thread_safe_wrap so the submit runs on the node io_context (the same
+    // strand the node runs on), never on the WEB thread -- submit_inject /
+    // m_inject_pool are IO-thread-confined (no locks). UNWIRED by default: no
+    // main installs it, so the POST route stays 503 {"armed":false}. When
+    // wired, submit_inject itself refuses ("inject-disabled") while the
+    // --embedded-tx-inject arm is OFF, so a disarmed node never injects. It
+    // NEVER touches coinbase/subsidy/PPLNS/payee -- an inject is an ordinary
+    // block-body tx (a 0-fee inject adds 0 to fees).
+    using tx_inject_submit_fn_t = std::function<nlohmann::json(const std::string& body)>;
+    void set_tx_inject_submit_fn(tx_inject_submit_fn_t fn) { m_tx_inject_submit_fn = thread_safe_wrap(std::move(fn)); }
+    bool has_tx_inject_submit_fn() const { return static_cast<bool>(m_tx_inject_submit_fn); }
+    nlohmann::json rest_tx_inject_submit(const std::string& body);  // POST /api/tx-inject/submit
+
     // Sharechain stats callback — returns live tracker data for the /sharechain/stats endpoint
     using sharechain_stats_fn_t = std::function<nlohmann::json()>;
     void set_sharechain_stats_fn(sharechain_stats_fn_t fn) { m_sharechain_stats_fn = thread_safe_wrap(std::move(fn)); }
@@ -1359,6 +1374,7 @@ private:
     config_json_fn_t m_config_fn;         // GET /api/config — resolved launch config (optional)
     config_json_fn_t m_config_schema_fn;  // GET /api/config/schema — catalog schema (optional)
     config_apply_fn_t m_config_apply_fn;  // POST /api/config/apply — Slice A gated apply (optional; unwired => 503)
+    tx_inject_submit_fn_t m_tx_inject_submit_fn;  // POST /api/tx-inject/submit — Slice B raw-tx submit (optional; unwired => 503)
     // Rate limiter for /api/coin_peers: IP → last request time
     std::map<std::string, std::chrono::steady_clock::time_point> m_coin_peers_rate_limit;
     sharechain_window_fn_t m_sharechain_window_fn;


### PR DESCRIPTION
## Slice B (#157): QT tx-injection control plane -- money-gated arm + loopback submit

Builds on **Slice A** (PR #1616, branch `qt/control-plane-apply-clean`), which added the money-gated `POST /api/config/apply` mechanism. The base of this PR is that branch, not master.

### Part 1 -- runtime arm/disarm of `--embedded-tx-inject` through Slice A
- Reclassify `embedded.tx_inject` in `param_catalog.inc` from `RESTART` to **`MONEY_LIVE`**. Arming changes what lands in mined blocks, so it must go through the full money gate: loopback control token + two-phase money nonce bound to the exact diff + M0 tripwire. No second write path is introduced -- the Slice A `apply_config` is reused.
- A `ParamApplier` setter registered from `main_dash` flips the runtime arm. It sets **both** the M1 submit gate (`set_tx_inject_enabled`) **and** the p2p `tx_inject` sink (`set_tx_inject_sink`) together.
- The Slice A config-apply fn is wired in `main_dash`, but stays fail-closed: `503 {"armed":false}` until an operator registers a loopback control token -- none is registered by default.

### Part 2 -- `POST /api/tx-inject/submit` (loopback-only)
- Hands a raw consensus tx to the **existing** `NodeCoinState::submit_inject` gate (M1). The validity gate is byte-unchanged -- only called.
- Refuses when the flag is disarmed (`submit_inject` returns `inject-disabled`).
- Fail-closed and dormant until the submit fn is installed; loopback-only, same posture as the other admin endpoints.

### Two mandatory review edits (from the design-note review)
- **Edit 1 -- runtime arm also sets the p2p sink.** At startup the sink was installed only under `if(embedded_tx_inject)` in `main_dash`. A runtime arm that flipped only the enable flag would leave the sink null and peer `tx_inject` frames silently ignored. Arm/disarm is now a single closure that always moves both (and disarm clears the sink).
- **Edit 2 -- IO-strand safety.** `submit_inject` and the inject pool are IO-thread-confined and lock-free. The submit fn (and the whole apply path, including the arm setter) is dispatched onto the node `io_context` via the existing `thread_safe_wrap`, so node state is never touched from the web thread.

### Safety
- Reward path untouched: no `coinbase_builder` / `subsidy` / `pplns` / `payee` / `donation` files changed; `submit_inject` byte-unchanged.
- Flag stays **default OFF**. Endpoints fail-closed (503) until an operator arms them. Nothing is armed live here.

### Tests
- `core_test` (`web_server_config_endpoint_test`): full `ConfigEndpointHttp` suite green (13/13), including two new Slice B KATs -- `embedded.tx_inject` reports money-classified over `GET /api/config`, and an arm routed through `apply_config` requires the two-phase nonce and fires the runtime arm setter.

### Not done / follow-ups
- The #1606 per-peer inject rate-limiter / sandbox (`inject_rate_limiter` / `inject_sandbox`) is **not present on this base branch**, so the submit endpoint routes through `submit_inject` (which already enforces the M1 DoS caps + validity gate). Wiring an additional M3 limiter is a follow-up once #1606 lands.
- The full `c2pool-dash` binary was compile-verified at the object level (`main_dash.cpp.o`) but not fully linked, per the build-scope guidance. Client-side QT arm/disarm UI is out of scope for this node-side slice.

**DRAFT** -- money-adjacent; do not merge/undraft/arm live.
