### PR TITLE
[DO NOT MERGE] xmr(native): judge the P-TPL famine constraint by arm identity, not by seat (M4 leg-1 stall)

### DIFF
--- a/src/impl/xmr/native/parity/README.md
+++ b/src/impl/xmr/native/parity/README.md
@@ -84,6 +84,30 @@ the backlog moved in between, and `SERVED_MISMATCH` — the verdict that catches
 serving something *neither* arm would have produced — would become unprovable.
 The serving arm is still cross-checked, but only while its epoch has not moved.
 
+## The P-TPL backlog: a measurement and a constraint, judged by arm
+
+`tx_backlog_count` is a **measurement** and never scores: the two arms hold two
+different transaction sets by construction. The daemon's number is its own
+mempool as `get_miner_data.tx_backlog` offers it to a template builder; the
+native number is what our pool would select, admitted under the v37 relay rule.
+They differ on ordinary propagation skew, and the native pool may hold
+transactions the daemon has dropped. An equality gate here would refuse a
+healthy node.
+
+The **famine shape** is a constraint (`native_backlog_famine`,
+`xmr_backlog_famine.hpp`): the *native* pool holds nothing while the *daemon*
+holds something, sustained across K samples and S seconds. That is the one
+shape skew cannot explain, and it is the regression the M2h restack was for.
+
+The two counts are the **arms'** own, resolved by arm name, in whichever seat
+(served / shadow) the posture puts them. This is comparator version 4. Version 3
+read "native" off the served seat and "daemon" off the shadow seat, which is the
+same thing only when the native arm serves; in M4's leg 1 (serve = monerod,
+shadow = native) the daemon's empty mempool was judged as a native famine, every
+P-TPL sample on a healthy node came out FAIL, the leg's streak never left zero,
+and — the mirror — a real native famine in that posture would have read as fed.
+A pair whose arm identities cannot be resolved is undecidable, never guessed.
+
 ## Graduation
 
 The ledger is hard-keyed to `{c2pool_commit, comparator_version, monerod_version,

--- a/src/impl/xmr/native/parity/xmr_backlog_famine.hpp
+++ b/src/impl/xmr/native/parity/xmr_backlog_famine.hpp
@@ -56,9 +56,24 @@
 //
 // THE REFUSAL IS STICKY. Once tripped, the check keeps refusing until a sample
 // actually shows the condition resolved -- the native pool holding something,
-// or the shadow holding nothing. A refusal that evaporates on the next
+// or the daemon holding nothing. A refusal that evaporates on the next
 // undecidable sample would be a warning, and this is not a warning: it travels
 // out as a failed CONSTRAINT, which compare_seam turns into a P-TPL FAIL.
+//
+// THE TWO SIDES ARE ARMS, NOT ROLES. The shape is "the NATIVE pool holds
+// nothing while the DAEMON holds something" -- and which of the two arms is
+// serving and which is the shadow is the posture's business, not the guard's.
+// The first cut of this guard read its native count off whatever arm had
+// SERVED and its daemon count off whatever arm was the SHADOW, which is the
+// same thing only in the serve-native posture. In M4's leg 1 (serve = monerod,
+// shadow = native) the two inputs swap seats: an empty daemon mempool became
+// "native backlog 0", the native pool's own transactions became "the shadow
+// holds N", and a node that was ingesting perfectly well was refused at every
+// height for "not ingesting" -- 2,000 P-TPL FAILs on a healthy stagenet node,
+// the graduation streak reset on each one, and (the mirror image) a REAL
+// famine in that posture would have read as fed. So the inputs are named by
+// arm identity, the oracle resolves them by arm NAME, and a pair whose
+// identities cannot be resolved is undecidable rather than guessed.
 //
 // SCOPE FENCE: src/impl/xmr/ only. No consensus digest, no src/sharechain/v37.
 // Header-only, STL only, no clock of its own (the caller supplies the time, so
@@ -79,6 +94,21 @@ namespace c2pool::xmr::native::parity {
 // field table. One spelling, one place.
 inline constexpr const char* kBacklogFamineCheck = "native_backlog_famine";
 
+// Arm IDENTITY from an arm's name. IMinerDataSource::name() is "native" or
+// "monerod" for the two real arms; a resolver that has latched nothing says
+// "none", and a missing shadow arm is observed under "shadow". Prefix match,
+// so a decorated spelling ("monerod (fallback from native)") still resolves
+// to the arm it decorates. Anything else is NOT an arm the guard knows, and
+// the oracle treats the pair as undecidable rather than guessing a seat.
+inline bool is_native_arm_name(const char* name) noexcept {
+    return name != nullptr && name[0] == 'n' && name[1] == 'a' && name[2] == 't'
+        && name[3] == 'i' && name[4] == 'v' && name[5] == 'e';
+}
+inline bool is_daemon_arm_name(const char* name) noexcept {
+    return name != nullptr && name[0] == 'm' && name[1] == 'o' && name[2] == 'n'
+        && name[3] == 'e' && name[4] == 'r' && name[5] == 'o' && name[6] == 'd';
+}
+
 struct BacklogFamineConfig {
     // How many consecutive DECIDABLE samples must show the famine shape.
     std::size_t   consecutive = 6;
@@ -96,15 +126,15 @@ struct BacklogFamineConfig {
 enum class BacklogSampleClass : std::uint8_t {
     Undecidable = 0,   // misaligned, or one of the two arms did not answer
     Fed,               // the native pool held something: the famine shape is absent
-    ShadowEmpty,       // the shadow held nothing either: agreement, not famine
-    Starved,           // native 0, shadow > 0: one unit of famine evidence
+    DaemonEmpty,       // the daemon held nothing either: agreement, not famine
+    Starved,           // native 0, daemon > 0: one unit of famine evidence
 };
 
 inline const char* to_string(BacklogSampleClass c) noexcept {
     switch (c) {
         case BacklogSampleClass::Undecidable: return "undecidable";
         case BacklogSampleClass::Fed:         return "fed";
-        case BacklogSampleClass::ShadowEmpty: return "shadow-empty";
+        case BacklogSampleClass::DaemonEmpty: return "daemon-empty";
         case BacklogSampleClass::Starved:     return "starved";
     }
     return "?";
@@ -112,14 +142,24 @@ inline const char* to_string(BacklogSampleClass c) noexcept {
 
 class BacklogFamineGuard {
 public:
+    // Both counts are named by the ARM that produced them, never by the seat
+    // (served / shadow) it happened to occupy in this posture. See the header.
     struct Input {
+        // The NATIVE arm's template backlog -- what our own pool would put in
+        // a block -- whichever seat the native arm is in.
         bool          native_known   = false;
         std::uint64_t native_backlog = 0;
-        bool          shadow_known   = false;
-        std::uint64_t shadow_backlog = 0;
+        // The DAEMON (monerod) arm's get_miner_data tx_backlog -- the daemon's
+        // own mempool as it offers it to a template builder.
+        bool          daemon_known   = false;
+        std::uint64_t daemon_backlog = 0;
         // The two arms are on the same (height, prev_id). A famine claim across
         // different tips would be comparing two different questions.
         bool          aligned        = false;
+        // Did the native arm SERVE this sample? Only the refusal's wording
+        // depends on it: an empty native SHADOW is a pool that would serve
+        // empty templates, not one that did.
+        bool          native_serving = true;
         // Unix seconds. Zero means "no clock was supplied"; see kDeadClock.
         std::uint64_t at_unix        = 0;
     };
@@ -144,7 +184,7 @@ public:
             return out;
         }
 
-        const bool decidable = in.aligned && in.native_known && in.shadow_known;
+        const bool decidable = in.aligned && in.native_known && in.daemon_known;
         if (!decidable) {
             ++undecidable_;
             out.cls       = BacklogSampleClass::Undecidable;
@@ -164,19 +204,20 @@ public:
             out.check = pass_("native pool holds " + u64_(in.native_backlog) + " tx");
             return out;
         }
-        if (in.shadow_backlog == 0) {
+        if (in.daemon_backlog == 0) {
             clear_();
-            ++shadow_empty_;
-            out.cls   = BacklogSampleClass::ShadowEmpty;
+            ++daemon_empty_;
+            out.cls   = BacklogSampleClass::DaemonEmpty;
             out.check = pass_("both pools empty: agreement, not famine");
             return out;
         }
 
-        // native == 0, shadow > 0.
+        // native == 0, daemon > 0.
         ++starved_;
         if (streak_ == 0) first_starved_unix_ = in.at_unix;
         ++streak_;
-        last_shadow_backlog_ = in.shadow_backlog;
+        last_daemon_backlog_ = in.daemon_backlog;
+        native_serving_      = in.native_serving;
 
         out.cls       = BacklogSampleClass::Starved;
         out.streak    = streak_;
@@ -200,14 +241,14 @@ public:
     std::size_t   streak()      const noexcept { return streak_; }
     std::uint64_t starved()     const noexcept { return starved_; }
     std::uint64_t fed()         const noexcept { return fed_; }
-    std::uint64_t shadow_empty() const noexcept { return shadow_empty_; }
+    std::uint64_t daemon_empty() const noexcept { return daemon_empty_; }
     std::uint64_t undecidable() const noexcept { return undecidable_; }
 
     std::string describe() const {
         return std::string(tripped_ ? "REFUSING" : "ok")
              + " streak=" + u64_(static_cast<std::uint64_t>(streak_)) + "/" + u64_(static_cast<std::uint64_t>(cfg_.consecutive))
              + " starved=" + u64_(starved_) + " fed=" + u64_(fed_)
-             + " shadow-empty=" + u64_(shadow_empty_)
+             + " daemon-empty=" + u64_(daemon_empty_)
              + " undecidable=" + u64_(undecidable_);
     }
 
@@ -227,7 +268,7 @@ private:
         streak_ = 0;
         tripped_ = false;
         first_starved_unix_ = 0;
-        last_shadow_backlog_ = 0;
+        last_daemon_backlog_ = 0;
     }
 
     NamedCheck pass_(std::string detail) const {
@@ -239,7 +280,7 @@ private:
     }
 
     std::string progress_(const Observation& o) const {
-        return "native backlog 0 while shadow holds " + u64_(last_shadow_backlog_)
+        return "native backlog 0 while the daemon holds " + u64_(last_daemon_backlog_)
              + "; " + u64_(static_cast<std::uint64_t>(o.streak)) + "/" + u64_(static_cast<std::uint64_t>(cfg_.consecutive))
              + " samples, " + u64_(o.elapsed_s) + "/" + u64_(cfg_.sustained_s) + "s";
     }
@@ -249,10 +290,13 @@ private:
         c.name = kBacklogFamineCheck;
         c.ok   = false;
         c.detail = "native template backlog has been 0 for " + u64_(static_cast<std::uint64_t>(o.streak))
-                 + " consecutive samples (" + u64_(o.elapsed_s) + "s) while the shadow arm "
-                 + "held " + u64_(last_shadow_backlog_)
-                 + " transaction(s): the native pool is not ingesting relayed transactions, "
-                   "so every template served is empty of fee revenue";
+                 + " consecutive samples (" + u64_(o.elapsed_s) + "s) while the daemon arm "
+                 + "held " + u64_(last_daemon_backlog_)
+                 + " transaction(s): the native pool is not ingesting relayed transactions, so "
+                 + (native_serving_
+                        ? "every template served is empty of fee revenue"
+                        : "every template it would serve is empty of fee revenue "
+                          "(the native arm is the shadow in this posture)");
         if (dead_clock) c.detail += " [no clock supplied: count bound only]";
         return c;
     }
@@ -260,11 +304,12 @@ private:
     BacklogFamineConfig cfg_;
     std::size_t   streak_              = 0;
     bool          tripped_             = false;
+    bool          native_serving_      = true;
     std::uint64_t first_starved_unix_  = 0;
-    std::uint64_t last_shadow_backlog_ = 0;
+    std::uint64_t last_daemon_backlog_ = 0;
     std::uint64_t starved_             = 0;
     std::uint64_t fed_                 = 0;
-    std::uint64_t shadow_empty_        = 0;
+    std::uint64_t daemon_empty_        = 0;
     std::uint64_t undecidable_         = 0;
 };
 

--- a/src/impl/xmr/native/parity/xmr_parity_oracle.hpp
+++ b/src/impl/xmr/native/parity/xmr_parity_oracle.hpp
@@ -406,31 +406,54 @@ private:
 
         // The CONSTRAINT that closes P-TPL's blind spot. tx_backlog_count is a
         // Measurement and stays one; what is judged here is the FAMINE SHAPE --
-        // we served nothing while the arm we are judged against held something,
+        // the NATIVE pool held nothing while the DAEMON held something,
         // sustained. Fed only on an ALIGNED pair, because a backlog claim
         // across two different tips compares two different questions; a
         // misaligned sample is undecidable and neither grows nor clears the
         // streak. See xmr_backlog_famine.hpp.
+        //
+        // THE TWO COUNTS ARE RESOLVED BY ARM IDENTITY, NOT BY SEAT. Which arm
+        // served and which is the shadow is the posture's choice; the guard's
+        // question is about the native pool whichever seat it sits in. Reading
+        // "native" off the served seat is right only in the serve-native
+        // posture -- in M4's leg 1 (serve = monerod, shadow = native) it turned
+        // the daemon's empty mempool into a native famine and refused every
+        // template a healthy node produced. A pair whose identities cannot be
+        // told apart by name is undecidable, never guessed.
         {
+            const ArmObservation* native_obs = nullptr;
+            const ArmObservation* daemon_obs = nullptr;
+            if (is_native_arm_name(served.arm.c_str()))      native_obs = &served;
+            else if (is_daemon_arm_name(served.arm.c_str())) daemon_obs = &served;
+            if (is_native_arm_name(shadow.arm.c_str()))      { if (!native_obs) native_obs = &shadow; }
+            else if (is_daemon_arm_name(shadow.arm.c_str())) { if (!daemon_obs) daemon_obs = &shadow; }
+
             BacklogFamineGuard::Input fi;
-            fi.aligned      = served.have && shadow.have
-                           && served.height == shadow.height
-                           && served.prev_id == shadow.prev_id;
-            fi.at_unix      = s.at_unix;
-            fi.native_known = served.have;
-            fi.native_backlog = static_cast<std::uint64_t>(s.served.tx_backlog.size());
-            if (shadow.have) {
-                const Obs& sb = shadow.fields.get("tx_backlog_count");
-                if (sb.present) {
-                    fi.shadow_known   = true;
-                    fi.shadow_backlog = std::strtoull(sb.value.c_str(), nullptr, 10);
-                }
-            }
+            fi.aligned        = served.have && shadow.have
+                             && served.height == shadow.height
+                             && served.prev_id == shadow.prev_id;
+            fi.at_unix        = s.at_unix;
+            fi.native_serving = (native_obs == &served);
+            read_backlog_(native_obs, fi.native_known, fi.native_backlog);
+            read_backlog_(daemon_obs, fi.daemon_known, fi.daemon_backlog);
             const BacklogFamineGuard::Observation fo = famine_.observe(fi);
             opt.constraints.push_back(fo.check);
         }
 
         return compare_seam(TEMPLATE_SEAM, served, shadow, opt);
+    }
+
+    // One arm's tx_backlog_count, as the observation rendered it (which is
+    // md.tx_backlog.size() on both arms -- see template_observation). An arm
+    // that did not answer, or whose identity was not resolved, stays unknown.
+    static void read_backlog_(const ArmObservation* o, bool& known, std::uint64_t& count) {
+        known = false;
+        count = 0;
+        if (o == nullptr || !o->have) return;
+        const Obs& b = o->fields.get("tx_backlog_count");
+        if (!b.present) return;
+        known = true;
+        count = std::strtoull(b.value.c_str(), nullptr, 10);
     }
 
     // --- P-SUB ---------------------------------------------------------------

--- a/src/impl/xmr/native/parity/xmr_parity_types.hpp
+++ b/src/impl/xmr/native/parity/xmr_parity_types.hpp
@@ -61,7 +61,16 @@ namespace c2pool::xmr::native::parity {
 // over the one property the milestone exists to establish. Every streak earned
 // under version 2 was earned by a judge that could not see that, so it does not
 // carry.
-inline constexpr std::uint32_t COMPARATOR_VERSION = 3;
+//
+// Version 4 (M4 leg 1): the famine constraint is fed by ARM IDENTITY, not by
+// seat. Version 3 read its "native" count off whichever arm SERVED and its
+// "daemon" count off whichever arm was the SHADOW, which coincide only in the
+// serve-native posture. In the serve-monerod posture the daemon's empty
+// mempool was judged as a native famine (every P-TPL sample FAIL on a healthy
+// node) and a real native famine would have been judged as fed. The table is
+// unchanged; the RULE that evaluates its one Constraint row is, so a streak
+// earned under version 3 in either posture is not evidence about this judge.
+inline constexpr std::uint32_t COMPARATOR_VERSION = 4;
 
 // ---------------------------------------------------------------------------
 // Regimes -- how a field is judged. Named after the plan's determinism table.
@@ -306,13 +315,14 @@ inline constexpr FieldSpec TEMPLATE_FIELDS[] = {
     // transactions at any instant, and an equality gate here would fire on
     // ordinary propagation skew.
     {"tx_backlog_count",        Regime::Measurement,   false, false},
-    // ...but the FAMINE SHAPE is a Constraint. A native backlog of 0 sustained
-    // across K samples and S seconds while the shadow arm holds transactions is
+    // ...but the FAMINE SHAPE is a Constraint. A NATIVE backlog of 0 sustained
+    // across K samples and S seconds while the DAEMON arm holds transactions is
     // not skew and is not agreement: it is the native pool failing to ingest,
     // which is invisible to all six EQUALITY rows above because none of them
-    // has anything to do with the transaction set. Evaluated by
-    // BacklogFamineGuard (xmr_backlog_famine.hpp) and delivered through
-    // CompareOptions::constraints, so a violation FAILS the sample.
+    // has anything to do with the transaction set. The two counts are the
+    // arms' own, in whichever seat (served / shadow) the posture puts them.
+    // Evaluated by BacklogFamineGuard (xmr_backlog_famine.hpp) and delivered
+    // through CompareOptions::constraints, so a violation FAILS the sample.
     {"native_backlog_famine",   Regime::Constraint,    false, false},
     {"coinbase_bytes",          Regime::NotComparable, false, false},
 };

--- a/src/impl/xmr/native/test/xmr_backlog_famine_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_backlog_famine_kat.cpp
@@ -39,6 +39,16 @@
 // as native-only), and a daemon arm whose cache expires (so `have_` alone can
 // no longer mean READY after the daemon died).
 //
+// SUITE G IS THE OTHER POSTURE, and it is the one the M4 stagenet soak actually
+// runs first: serve = monerod, shadow = native. The version-3 oracle read its
+// "native" count off the SERVED seat and its "daemon" count off the SHADOW
+// seat, so in this posture the daemon's empty mempool was judged as a native
+// famine: every P-TPL sample on a healthy, ingesting node came out FAIL (2,000
+// of them, 13 hours, the graduation streak reset on each), and -- the mirror --
+// a real native famine would have read as fed. G1 reproduces the live shape
+// (daemon 0, native 5) and requires CLEAN; G2 is the mirror and requires the
+// refusal to still fire from the shadow seat. Both fail on the version-3 rule.
+//
 // SCOPE FENCE: src/impl/xmr/ only. No consensus digest, no src/sharechain/v37.
 // ---------------------------------------------------------------------------
 #include <cstdio>
@@ -107,14 +117,14 @@ static node::MinerData miner_data(std::uint64_t height, std::size_t n_tx) {
     return md;
 }
 
-static BacklogFamineGuard::Input starved_at(std::uint64_t t, std::uint64_t shadow_n = 5) {
+static BacklogFamineGuard::Input starved_at(std::uint64_t t, std::uint64_t daemon_n = 5) {
     BacklogFamineGuard::Input in;
     in.aligned        = true;
     in.at_unix        = t;
     in.native_known   = true;
     in.native_backlog = 0;
-    in.shadow_known   = true;
-    in.shadow_backlog = shadow_n;
+    in.daemon_known   = true;
+    in.daemon_backlog = daemon_n;
     return in;
 }
 
@@ -145,7 +155,7 @@ static void suite_guard() {
         BacklogFamineGuard g(cfg);
         BacklogFamineGuard::Input in = starved_at(1000, 0);
         const auto o = g.observe(in);
-        CHECK(o.cls == BacklogSampleClass::ShadowEmpty, "A2 class: got %s", to_string(o.cls));
+        CHECK(o.cls == BacklogSampleClass::DaemonEmpty, "A2 class: got %s", to_string(o.cls));
         CHECK(o.check.ok, "A2 both-empty must pass");
         CHECK(g.streak() == 0, "A2 streak must stay 0");
     }
@@ -201,11 +211,11 @@ static void suite_guard() {
         const auto o = g.observe(mis);
         CHECK(o.cls == BacklogSampleClass::Undecidable, "A6 misaligned must be undecidable");
         CHECK(g.streak() == 2, "A6 streak must survive an undecidable sample, got %zu", g.streak());
-        BacklogFamineGuard::Input noshadow = starved_at(1040);
-        noshadow.shadow_known = false;
-        CHECK(g.observe(noshadow).cls == BacklogSampleClass::Undecidable,
-              "A6 an unanswering shadow must be undecidable");
-        CHECK(g.streak() == 2, "A6 streak must survive an unanswered shadow");
+        BacklogFamineGuard::Input nodaemon = starved_at(1040);
+        nodaemon.daemon_known = false;
+        CHECK(g.observe(nodaemon).cls == BacklogSampleClass::Undecidable,
+              "A6 an unanswering daemon arm must be undecidable");
+        CHECK(g.streak() == 2, "A6 streak must survive an unanswered daemon arm");
         CHECK(g.undecidable() == 2, "A6 undecidable count: got %llu",
               static_cast<unsigned long long>(g.undecidable()));
         // The streak still completes across the gap.
@@ -346,8 +356,9 @@ static void suite_verdict() {
         CHECK(TEMPLATE_SEAM.required_equality_count() == 6,
               "B4 the constraint must not have changed the EQUALITY count: %zu",
               TEMPLATE_SEAM.required_equality_count());
-        CHECK(COMPARATOR_VERSION >= 3,
-              "B4 a new gate must move the ledger key: COMPARATOR_VERSION=%u",
+        CHECK(COMPARATOR_VERSION >= 4,
+              "B4 a new gate (v3) and a re-oriented rule (v4) must each move the ledger key: "
+              "COMPARATOR_VERSION=%u",
               static_cast<unsigned>(COMPARATOR_VERSION));
     }
 }
@@ -387,15 +398,24 @@ private:
 };
 
 // Drive N serve samples through a real ParityOracle and return the verdicts.
-static std::vector<ParityVerdict> drive(bool guard_enabled,
-                                        std::size_t native_backlog,
-                                        std::size_t shadow_backlog,
-                                        int samples) {
+// The SEATS are parameters: `served_arm` is the name the serving arm reports
+// itself under, `shadow_arm` the shadow's. The two backlog counts are the
+// SEATS' counts, so a posture is spelled by naming the seats.
+struct DriveResult {
+    std::vector<ParityVerdict> verdicts;
+    std::string                last_famine_detail;   // the constraint's detail on the last sample
+    bool                       famine_tripped = false;
+};
+
+static DriveResult drive_seats(bool guard_enabled,
+                               const char* served_arm, std::size_t served_backlog,
+                               const char* shadow_arm, std::size_t shadow_backlog,
+                               int samples) {
     node::MinerData shadow_md = miner_data(100, shadow_backlog);
-    FixedArm shadow_arm("monerod", shadow_md);
+    FixedArm shadow(shadow_arm, shadow_md);
 
     ParityOracle::Deps deps;
-    deps.shadow_arm = &shadow_arm;
+    deps.shadow_arm = &shadow;
 
     ParityOracleConfig cfg;
     cfg.backlog_famine.enabled     = guard_enabled;
@@ -409,18 +429,39 @@ static std::vector<ParityVerdict> drive(bool guard_enabled,
     std::uint64_t clock = 1000;
     ParityOracle orc(deps, key, policy, cfg, [&clock] { return clock; });
 
-    std::vector<ParityVerdict> out;
+    DriveResult out;
     for (int i = 0; i < samples; ++i) {
-        const node::MinerData served = miner_data(100, native_backlog);
+        const node::MinerData served = miner_data(100, served_backlog);
         MinerDataEpoch ep;
         ep.height  = served.height;
         ep.prev_id = served.prev_id;
-        orc.on_serve(ep, served, "native");
-        for (const SeamResult& r : orc.drain())
-            if (r.sample.kind == ProbeKind::Template) out.push_back(r.sample.verdict);
+        orc.on_serve(ep, served, served_arm);
+        for (const SeamResult& r : orc.drain()) {
+            if (r.sample.kind != ProbeKind::Template) continue;
+            out.verdicts.push_back(r.sample.verdict);
+            out.last_famine_detail.clear();
+            for (const auto& d : r.sample.fields)
+                if (d.field == kBacklogFamineCheck) out.last_famine_detail = d.served;
+        }
         clock += 20;
     }
+    out.famine_tripped = orc.backlog_famine_tripped();
     return out;
+}
+
+// The serve-native posture, as suites C and D have always spelled it.
+static std::vector<ParityVerdict> drive(bool guard_enabled,
+                                        std::size_t native_backlog,
+                                        std::size_t shadow_backlog,
+                                        int samples) {
+    return drive_seats(guard_enabled, "native", native_backlog, "monerod", shadow_backlog, samples)
+        .verdicts;
+}
+
+static std::size_t count_of(const std::vector<ParityVerdict>& v, ParityVerdict want) {
+    std::size_t n = 0;
+    for (ParityVerdict x : v) if (x == want) ++n;
+    return n;
 }
 
 } // namespace
@@ -500,6 +541,145 @@ static void suite_new_behaviour() {
         std::size_t clean = 0;
         for (ParityVerdict x : v) if (x == ParityVerdict::Clean) ++clean;
         CHECK(clean == v.size(), "D3 a quiet chain must stay CLEAN: %zu/%zu", clean, v.size());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE G -- the OTHER posture: serve = monerod, shadow = native (M4 leg 1).
+//
+// Every scenario here is the same guard, the same table, the same two arms as
+// suites C and D -- with the seats swapped, which is exactly what --serve-arm
+// monerod does. Nothing about the famine question changes when the seats do;
+// the version-3 rule was answering a different question in this posture.
+// ---------------------------------------------------------------------------
+static void suite_other_posture() {
+    head("G. ParityOracle in the serve-monerod posture (the M4 leg-1 seat order)");
+
+    // G1. THE LIVE STAGENET SHAPE, reproduced: the daemon's mempool is empty
+    // (get_miner_data.tx_backlog absent), the native pool -- the shadow in this
+    // posture -- holds five relayed transactions the daemon does not. A native
+    // pool that HOLDS transactions is fed, not starved, whichever seat it is
+    // in. Under the version-3 rule this run went FAIL from the third sample on
+    // and stayed there; it must be CLEAN throughout.
+    {
+        const DriveResult r = drive_seats(/*guard_enabled=*/true,
+                                          "monerod", /*daemon=*/0,
+                                          "native",  /*native=*/5, 20);
+        CHECK(r.verdicts.size() == 20, "G1 expected 20 template samples, got %zu", r.verdicts.size());
+        const std::size_t clean = count_of(r.verdicts, ParityVerdict::Clean);
+        CHECK(clean == r.verdicts.size(),
+              "G1 daemon 0 / native 5 with monerod serving must be CLEAN for all %zu samples, got %zu "
+              "(the seat-swap false famine)",
+              r.verdicts.size(), clean);
+        CHECK(!r.famine_tripped, "G1 the guard must not have tripped");
+    }
+
+    // G2. THE MIRROR: a real famine, seen from the shadow seat. The daemon
+    // (serving) holds transactions, the native pool (shadow) holds nothing,
+    // sustained. Under the version-3 rule this read as FED -- the served seat's
+    // count was non-zero -- so leg 1 could not have caught the regression the
+    // constraint exists for. It must refuse, and it must say which arm is
+    // starved without claiming the native arm served anything.
+    {
+        const DriveResult r = drive_seats(/*guard_enabled=*/true,
+                                          "monerod", /*daemon=*/5,
+                                          "native",  /*native=*/0, 8);
+        CHECK(r.verdicts.size() == 8, "G2 expected 8 template samples, got %zu", r.verdicts.size());
+        CHECK(count_of(r.verdicts, ParityVerdict::Fail) > 0,
+              "G2 a sustained empty NATIVE pool must be refused from the shadow seat too");
+        CHECK(!r.verdicts.empty() && r.verdicts.back() == ParityVerdict::Fail,
+              "G2 the run must end in refusal, got %s",
+              r.verdicts.empty() ? "nothing" : to_string(r.verdicts.back()));
+        CHECK(count_of(r.verdicts, ParityVerdict::Clean) <= 3,
+              "G2 at most the pre-threshold samples may be clean, got %zu",
+              count_of(r.verdicts, ParityVerdict::Clean));
+        CHECK(r.famine_tripped, "G2 the guard must be tripped at the end of the run");
+        CHECK(r.last_famine_detail.find("not ingesting") != std::string::npos,
+              "G2 the detail must name the defect: %s", r.last_famine_detail.c_str());
+        CHECK(r.last_famine_detail.find("shadow in this posture") != std::string::npos,
+              "G2 the detail must say the native arm is the shadow, not that it served: %s",
+              r.last_famine_detail.c_str());
+        CHECK(r.last_famine_detail.find("every template served is empty") == std::string::npos,
+              "G2 the detail must not claim the native arm served anything: %s",
+              r.last_famine_detail.c_str());
+    }
+
+    // G3. A quiet chain in this posture is agreement, exactly as in D3.
+    {
+        const DriveResult r = drive_seats(true, "monerod", 0, "native", 0, 20);
+        CHECK(count_of(r.verdicts, ParityVerdict::Clean) == r.verdicts.size() && r.verdicts.size() == 20,
+              "G3 both empty must stay CLEAN: %zu/%zu",
+              count_of(r.verdicts, ParityVerdict::Clean), r.verdicts.size());
+    }
+
+    // G4. Propagation skew in this posture: the daemon holds 50, the native
+    // pool holds 1. Fed is fed.
+    {
+        const DriveResult r = drive_seats(true, "monerod", 50, "native", 1, 20);
+        CHECK(count_of(r.verdicts, ParityVerdict::Clean) == r.verdicts.size() && r.verdicts.size() == 20,
+              "G4 native 1 / daemon 50 must NOT be a refusal: %zu/%zu clean",
+              count_of(r.verdicts, ParityVerdict::Clean), r.verdicts.size());
+    }
+
+    // G5. The same two shapes in the serve-native posture still judge as
+    // suites C and D require -- the re-orientation must not have moved leg 2.
+    {
+        const auto fed     = drive(true, /*native=*/5, /*daemon=*/0, 20);
+        const auto starved = drive(true, /*native=*/0, /*daemon=*/5, 8);
+        CHECK(count_of(fed, ParityVerdict::Clean) == 20,
+              "G5 native 5 / daemon 0 with native serving must be CLEAN: %zu/20",
+              count_of(fed, ParityVerdict::Clean));
+        CHECK(!starved.empty() && starved.back() == ParityVerdict::Fail,
+              "G5 native 0 / daemon 5 with native serving must still be refused");
+    }
+
+    // G6. Arm identity is resolved by NAME, and a pair the oracle cannot tell
+    // apart is undecidable: it neither refuses nor manufactures evidence. Two
+    // arms that both call themselves "native", and an arm with a name the
+    // guard does not know, must leave the six-field verdict alone.
+    {
+        const DriveResult twins = drive_seats(true, "native", 0, "native", 5, 8);
+        CHECK(count_of(twins.verdicts, ParityVerdict::Clean) == twins.verdicts.size(),
+              "G6 two native-named arms: undecidable, must not refuse (%zu/%zu clean)",
+              count_of(twins.verdicts, ParityVerdict::Clean), twins.verdicts.size());
+        CHECK(!twins.famine_tripped, "G6 two native-named arms must not trip the guard");
+
+        const DriveResult unknown = drive_seats(true, "monerod", 5, "replay", 0, 8);
+        CHECK(count_of(unknown.verdicts, ParityVerdict::Clean) == unknown.verdicts.size(),
+              "G6 an unknown shadow arm name: undecidable, must not refuse (%zu/%zu clean)",
+              count_of(unknown.verdicts, ParityVerdict::Clean), unknown.verdicts.size());
+        CHECK(!unknown.famine_tripped, "G6 an unknown arm name must not trip the guard");
+
+        CHECK(is_native_arm_name("native") && !is_native_arm_name("monerod")
+              && !is_native_arm_name("shadow") && !is_native_arm_name("none")
+              && !is_native_arm_name(nullptr),
+              "G6 is_native_arm_name");
+        CHECK(is_daemon_arm_name("monerod") && is_daemon_arm_name("monerod (fallback from native)")
+              && !is_daemon_arm_name("native") && !is_daemon_arm_name("mon")
+              && !is_daemon_arm_name(nullptr),
+              "G6 is_daemon_arm_name");
+    }
+
+    // G7. A refusal earned in one posture is cleared by a fed sample in the
+    // other: the guard's state is about the native pool, not about the seat.
+    {
+        BacklogFamineConfig cfg;
+        cfg.consecutive = 2;
+        cfg.sustained_s = 10;
+        BacklogFamineGuard g(cfg);
+        BacklogFamineGuard::Input shadow_starved = starved_at(1000);
+        shadow_starved.native_serving = false;
+        g.observe(shadow_starved);
+        shadow_starved.at_unix = 1020;
+        const auto tripped = g.observe(shadow_starved);
+        CHECK(g.tripped() && !tripped.check.ok, "G7 precondition: tripped from the shadow seat");
+        CHECK(tripped.check.detail.find("shadow in this posture") != std::string::npos,
+              "G7 the shadow-seat wording: %s", tripped.check.detail.c_str());
+        BacklogFamineGuard::Input fed = starved_at(1040);
+        fed.native_backlog = 2;
+        fed.native_serving = true;
+        CHECK(g.observe(fed).check.ok && !g.tripped(),
+              "G7 a fed native pool clears the refusal whichever seat it now sits in");
     }
 }
 
@@ -673,6 +853,7 @@ int main(int argc, char** argv) {
     suite_verdict();
     suite_old_behaviour();
     suite_new_behaviour();
+    suite_other_posture();
     suite_served_by();
     suite_staleness();
 

--- a/src/impl/xmr/native/test/xmr_parity_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_parity_kat.cpp
@@ -359,13 +359,15 @@ void suite_absence() {
 void suite_table() {
     std::printf("== B. the frozen determinism table (comparator v%u) ==\n", COMPARATOR_VERSION);
 
-    // Version 3 since M2h added the native_backlog_famine CONSTRAINT to the
-    // P-TPL table (M1's version 2 was the P-POOL seam joining). This stays an
-    // EXACT number rather than a floor on purpose: its whole job is to make
-    // anyone who edits a table move the ledger key too, so that a clean streak
-    // can never be inherited across a change to what is compared.
-    CHECK(COMPARATOR_VERSION == 3,
-          "comparator version is 3 (the P-TPL backlog constraint joined the table)");
+    // Version 4 since the P-TPL famine constraint was re-oriented by arm
+    // identity (version 3 read it by seat and mis-judged the serve-monerod
+    // posture; M2h's version 3 added the constraint; M1's version 2 was the
+    // P-POOL seam joining). This stays an EXACT number rather than a floor on
+    // purpose: its whole job is to make anyone who edits a table -- or the rule
+    // that evaluates one -- move the ledger key too, so that a clean streak can
+    // never be inherited across a change to what is compared.
+    CHECK(COMPARATOR_VERSION == 4,
+          "comparator version is 4 (the P-TPL famine constraint is judged by arm identity)");
     CHECK(POOL_SEAM.required_equality_count() == 3,
           "POOL requires 3 EQUALITY fields (weight, fee, blob_size), got %zu",
           POOL_SEAM.required_equality_count());

--- a/src/impl/xmr/native/test/xmr_txpool_parity_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_txpool_parity_kat.cpp
@@ -164,12 +164,13 @@ static P::PoolSnapshot native_snapshot(const RelayedTxPool& pool) {
 // 1: the seam table
 // ---------------------------------------------------------------------------
 static void test_seam_table() {
-    // 3 since M2h added the native_backlog_famine CONSTRAINT to P-TPL. The pin
-    // is EXACT, not a floor: its job is to make anyone who edits a table move
-    // the ledger key with it, so a clean streak can never be inherited across a
-    // change to what is judged.
-    check(P::COMPARATOR_VERSION == 3,
-          "the comparator version was bumped when the P-TPL backlog constraint joined");
+    // 4 since the P-TPL famine constraint was re-oriented by arm identity (3
+    // was M2h adding it, judged by seat). The pin is EXACT, not a floor: its
+    // job is to make anyone who edits a table -- or the rule that evaluates one
+    // -- move the ledger key with it, so a clean streak can never be inherited
+    // across a change to what is judged.
+    check(P::COMPARATOR_VERSION == 4,
+          "the comparator version was bumped when the P-TPL famine rule was re-oriented");
     check(&P::seam_spec(ProbeKind::Pool) == &P::POOL_SEAM,
           "seam_spec() knows about ProbeKind::Pool");
     checkf(P::POOL_SEAM.required_equality_count() == 3,


### PR DESCRIPTION
**DRAFT — DO NOT MERGE.** Comparator-only fix for the M4 stagenet soak stall; held for integrator review and the operator's redeploy of the soak.

## What the soak showed

The M4 leg-1 soak (`--serve-arm monerod`: serve = monerod, shadow = native; harness from c2pool#1594, ledger fix c2pool#1608, anchor fix c2pool#1609) ran 13 h on a healthy node — synced, 8/8 peers, 0 reorgs, 0 orphans, pool accepting relayed transactions (`acc=190 rej=0`) — and never left `clean_run=0`:

```
by_verdict_this_run  CLEAN 3166 / FAIL 2012 / VOID 9
every FAIL:          seam=TEMPLATE  first_diff="tx_backlog_count served=0 shadow=5"
                     note="1 constraint(s) violated; [P-TPL served_by=monerod]"
                     native_backlog_famine: "native template backlog has been 0 for N
                     consecutive samples while the shadow arm held 5 transaction(s):
                     the native pool is not ingesting relayed transactions"
```

The daemon's mempool was genuinely empty at the time (`get_transaction_pool_stats` `txs_total=0`, `get_miner_data.tx_backlog` absent); the native pool held 5. The FAILs began the moment the native pool first held a transaction the daemon did not (`shadow=1`, 23:46Z) and never stopped.

## Root cause

`ParityOracle::run_template_` (`src/impl/xmr/native/parity/xmr_parity_oracle.hpp`) fed `BacklogFamineGuard` by **seat**, not by **arm**:

```cpp
fi.native_backlog = s.served.tx_backlog.size();        // "native" := whichever arm SERVED
fi.shadow_backlog = shadow.fields["tx_backlog_count"]; // "daemon" := whichever arm was the SHADOW
```

The guard's question (`xmr_backlog_famine.hpp`) is *native pool holds nothing while the daemon holds something, sustained*. Seat and identity coincide only in the serve-native posture. In leg 1 the daemon's empty mempool became "native 0", the native pool's own transactions became "the shadow holds 5", and an ingesting node was refused for "not ingesting". The mirror is worse: a real native famine in leg 1 would have read as *fed* (the served seat's count was non-zero), so the constraint could not catch, in that posture, the regression it was added for.

`tx_backlog_count` itself was never the gate. It is `Regime::Measurement` and is rendered in the diff only; it stays that way. The two counts are different quantities by construction — the daemon's `get_miner_data.tx_backlog` (its own mempool as offered to a template builder) vs. what the native pool would select under the v37 relay rule — and may legitimately differ.

## Fix (comparator only, `src/impl/xmr/native/parity/`)

* `BacklogFamineGuard::Input` names its two counts by arm: `native_*` / `daemon_*` (was `shadow_*`); `native_serving` shapes only the refusal's wording. `BacklogSampleClass::ShadowEmpty` → `DaemonEmpty`; `describe()` says `daemon-empty=`.
* `run_template_` resolves which observation is the native arm and which is the daemon by arm **name** (`is_native_arm_name` / `is_daemon_arm_name`, prefix match on the two real arm names); a pair whose identities cannot be resolved is undecidable, never guessed. Both counts are read from the observations' `tx_backlog_count`, which is `md.tx_backlog.size()` on either arm.
* `COMPARATOR_VERSION` 3 → 4. The table is unchanged; the rule that evaluates its one Constraint row is, so no streak earned under 3 carries. The two exact pins (`xmr_native_parity_kat`, `xmr_native_txpool_parity_kat`) move with it.
* `parity/README.md`: a section on what the backlog measurement and the famine constraint are, and why they are judged by arm.

No change under `src/sharechain/`, no consensus body, no owed_digest. Nothing in the node, the arms, the txpool or the M4 driver/ledger is touched.

## What still catches a real divergence

* The six required EQUALITY rows of P-TPL are untouched and remain sentinels: `prev_id`, `major_version`, `difficulty`, `seed_hash`, `median_weight`, `already_generated_coins` — a template that would build a genuinely different (invalid) block differs in one of these.
* `reward` parity is judged on every block at P-TIP; block acceptance at P-SUB (`daemon_accepted`, `confirmed_on_chain`).
* Per-transaction measurement parity (weight / fee / blob_size keyed by tx id) is the M1 P-POOL seam (`--txpool-parity`), which leg 1 leaves off by design.
* The famine constraint still fires — now in **both** postures — on native 0 / daemon > 0 sustained (K samples and S seconds).

## KAT

`xmr_native_backlog_famine_kat` (already registered: `add_test` + both `--target` lists in `build.yml`) gains **suite G**, the serve-monerod posture:

| | seats | expects |
|---|---|---|
| G1 | monerod serves 0 / native shadow 5 (the live shape) | CLEAN ×20, guard never trips |
| G2 | monerod serves 5 / native shadow 0 (the mirror) | ends FAIL, detail says the native arm is the shadow and does not claim it served |
| G3/G4 | both 0; daemon 50 / native 1 | CLEAN |
| G5 | the same shapes with native serving | as suites C/D |
| G6 | two `native`-named arms; an unknown arm name | undecidable, never a refusal |
| G7 | refusal earned in one seat cleared by a fed sample in the other | guard state is about the pool, not the seat |

With the seat-based rule temporarily restored in the oracle, 10 of the new checks fail (G1 ×2, G2 ×6, G6 ×2); with this rule: **143/0**.

## Verification (soak host, gcc 13.3, Release, `XMR_BUILD_RANDOMX=ON`, scratch clone)

```
xmr_native_backlog_famine_kat   143 checks, 0 failures
xmr_native_parity_kat           833 checks, 0 failures
xmr_native_txpool_parity_kat    210 checks, 0 failures
xmr_native_m4_soak_kat / xmr_native_node_kat / xmr_native_contracts_kat   passed
ctest -R 'xmr_native_(backlog_famine|parity|txpool_parity|m4_soak|contracts|node)_kat'   6/6
```

**Live re-run against the same daemon: not obtainable from a second process on the soak host.** A read-only probe of the fixed `xmr_native_node` (same posture, same `--connect 127.0.0.1:38080`, own ledger) never got a levin peer: the loopback daemon reset every handshake (`read header: Connection reset by peer`), and so did every reachable stagenet peer this box does not already hold. The control settles it: a binary built from the soak's own commit (`b03ce935`, the code that has been connected for 13 h) fails the very same handshakes right now (`OLD vs 127.0.0.1 -> Connection reset`, `OLD vs 194.32.76.244 -> End of file`, `OLD vs 176.9.0.187 -> Connection reset`). This is the environment — the daemon holds 22 outbound stagenet connections, the running soak holds the loopback inbound slot (`127.0.0.1:43726`) and 8 more, and monerod's per-IP inbound limit is 1 — not a regression in the node. The P-TPL evidence on the live daemon therefore comes from the redeploy (the soak's slot frees when the supervisor restarts). What this PR proves offline is exact: suite G1 replays the live sample shape (monerod serving, `tx_backlog` 0 / native shadow 5) through the real `ParityOracle` and it is CLEAN under this rule and FAIL under the shipped one.

## Redeploying the soak

Rebuild `xmr_native_node` from this commit, set `COMMIT` in `env.sh` to it, restart the supervisor. The ledger key moves (commit + comparator v4), so both legs restart from zero — which is where they are. Keep the old `ledger.json` / `samples.jsonl` as the record of the v3 run.

## Out of scope, noted

The native pool holds a handful of transactions the daemon does not (5 at the time of reading). That is expected under the v37 relay rule and is visible as the `tx_backlog_count` measurement; whether those particular transactions would be minable is a P-POOL / P-SUB question, not a P-TPL one, and is not changed here.
