### PR TITLE
c2wallet-qt M0: network-incapable signer skeleton + link-guard CI (#193)

### DIFF
--- a/ui/c2wallet-qt/CMakeLists.txt
+++ b/ui/c2wallet-qt/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.21)
+project(c2wallet_qt LANGUAGES CXX)
+
+# ═══════════════════════════════════════════════════════════════════════════
+# c2wallet-qt — the AIR-GAPPED, network-incapable signer (design PR #1621,
+# docs/design/c2wallet-qt.md §5.2). This is the OFFLINE, key-bearing side of
+# the two-machine model. Its defining security property is defense-in-depth
+# layer 1: the signing binary links a deliberately minimal Qt surface so that
+# a socket call is a LINK ERROR, not a runtime toggle.
+#
+#   c2wallet-qt-signer links  Qt6::Core + Qt6::Gui + Qt6::Widgets  ONLY.
+#
+# It MUST NOT link Qt6::Network, Qt6::WebEngine*, Qt6::WebChannel, libcurl,
+# OpenSSL, boost::asio, or any other networking library. Contrast this with the
+# sibling ui/c2pool-qt/, which HARD-REQUIRES QtWebEngine (Chromium + a full
+# network stack): you cannot embed Chromium and honestly claim to be
+# network-incapable, which is exactly why this is a separate binary. We reuse
+# c2pool-qt's Widgets shell PATTERN (MainWindow + sidebar + stacked pages),
+# never its networked dependencies.
+#
+# M0 is the foundation phase: no keys, no signing, no crypto yet. It stands up
+# the tree, the Widgets-only skeleton, and the mechanical proof of the
+# network-incapable property (ci/check_no_network.sh, enforced in CI).
+#
+# Install the build deps on Debian/Ubuntu via:
+#   sudo apt install qt6-base-dev
+# (qt6-base-dev provides Core/Gui/Widgets — NO webengine/webchannel package is
+#  needed or wanted here.)
+# ═══════════════════════════════════════════════════════════════════════════
+
+# 6.2 is the shared floor with ui/c2pool-qt/. Core/Gui/Widgets are all this
+# binary is ever permitted to require.
+find_package(Qt6 6.2 REQUIRED COMPONENTS Core Gui Widgets)
+
+set(CMAKE_AUTOMOC ON)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(c2wallet-qt-signer
+    src/main.cpp
+    src/shell/MainWindow.cpp
+)
+
+target_include_directories(c2wallet-qt-signer PRIVATE src)
+
+# The whole security invariant in one place. If a future phase adds
+# Qt6::Network / Qt6::WebEngine* / Qt6::WebChannel / a curl / an asio here, the
+# ci/check_no_network.sh link-guard (below and in CI) turns red — that is the
+# tripwire, and it is deliberate.
+target_link_libraries(c2wallet-qt-signer PRIVATE
+    Qt6::Core
+    Qt6::Gui
+    Qt6::Widgets
+)
+
+# ── Network-incapable link-guard as a ctest ────────────────────────────────
+# The same mechanical proof CI runs, available locally: build the target, then
+# `ctest` runs ci/check_no_network.sh over the produced binary. Off by default
+# so a plain build stays minimal; enable with -DC2WALLET_QT_BUILD_TESTS=ON.
+option(C2WALLET_QT_BUILD_TESTS
+    "Register the network-incapable link-guard (ci/check_no_network.sh) as a ctest"
+    OFF)
+
+if(C2WALLET_QT_BUILD_TESTS)
+    enable_testing()
+    add_test(
+        NAME no_network_link_guard
+        COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/ci/check_no_network.sh"
+                "$<TARGET_FILE:c2wallet-qt-signer>"
+    )
+endif()

--- a/ui/c2wallet-qt/README.md
+++ b/ui/c2wallet-qt/README.md
@@ -1,0 +1,90 @@
+# c2wallet-qt
+
+A standalone, **air-gapped** Qt desktop signer and transaction constructor for
+the frstrtr/c2pool ecosystem — the offline, key-holding successor to
+`tools/c2wallet/c2wallet.py`. Full design: **PR #1621**,
+[`docs/design/c2wallet-qt.md`](../../docs/design/c2wallet-qt.md).
+
+## The air-gap model
+
+c2wallet-qt is the **offline** half of a two-machine model:
+
+```
+   OFFLINE — c2wallet-qt-signer (holds keys)      ONLINE — c2pool node + companion (no keys)
+   ──────────────────────────────────────         ──────────────────────────────────────────
+                              ◀── unsigned/constructed artifact ── built from live UTXO/chain view
+   import keys, derive, DISPLAY summary,
+   operator CONFIRMS, sign, SELF-VERIFY
+              signed artifact ──▶                 re-validate (gate), then inject / broadcast
+```
+
+- **Keys live only inside the offline `c2wallet-qt-signer` build.** The seed and
+  private keys never touch a networked or agent-controlled host, and never
+  persist in plaintext.
+- **c2pool is verify-only by construction** — it holds no keys and never signs.
+  It re-validates every artifact regardless of origin.
+- **Two public artifacts cross the gap** (unsigned in, signed out), by file or
+  QR — never over a live socket from the signer.
+
+## The security property this tree guarantees
+
+The signing binary is compiled **network-incapable** — defense in depth,
+layer 1 (design §5.2):
+
+> `c2wallet-qt-signer` links **`Qt6::Core` + `Qt6::Gui` + `Qt6::Widgets` ONLY** —
+> no Qt Network, no QtWebEngine, no QtWebChannel, no libcurl, no OpenSSL, no
+> boost::asio. A socket call is a **link error**, not a runtime check.
+
+This is why c2wallet-qt is a **separate binary** from `ui/c2pool-qt/`, which
+hard-requires QtWebEngine (Chromium + a full network stack): you cannot embed
+Chromium and honestly claim to be network-incapable. c2wallet-qt reuses only
+c2pool-qt's Widgets shell *pattern*, never its networked dependencies.
+
+The property is proved mechanically by
+[`ci/check_no_network.sh`](ci/check_no_network.sh), which inspects the built
+binary's `NEEDED` libraries and imported dynamic symbols and fails if any
+networking library or network C-ABI symbol (`connect`, `socket`, `bind`,
+`listen`, `getaddrinfo`, `gethostbyname`, `SSL_*`, `curl_*`, `res_*`, ...) is
+present. It is registered as a `ctest` (`no_network_link_guard`) and is wired
+to run in CI on every PR that touches this tree — see
+[`ci/CI_WIRING.md`](ci/CI_WIRING.md) and
+[`ci/ci-wiring.build-yml.patch`](ci/ci-wiring.build-yml.patch) for the CI job.
+
+The later layers of the model (not in this phase): an optional **online
+companion** binary (key-free, does QR/file marshalling and talks to c2pool) is
+a later phase, and a **runtime seccomp belt** that kills the process on
+`socket(2)`/`connect(2)` lands in **M5**.
+
+## Phase status — M0
+
+M0 is the foundation phase and is deliberately **non-money**: no keys, no
+signing, no crypto. It delivers:
+
+- the `ui/c2wallet-qt/` tree and a **Widgets-only CMake** target
+  `c2wallet-qt-signer`;
+- a minimal Bitcoin-Core-like **MainWindow + sidebar shell** (Wallets /
+  Construct / Sign / Convert / Settings) — an empty, runnable skeleton;
+- the **network-incapable link-guard** (`ci/check_no_network.sh`) and its CI
+  wiring.
+
+Key import, address derivation, transaction construction and signing arrive in
+later phases (M1–M6); see the phase table in the design doc §6.
+
+## Build
+
+Requires Qt6 (Core/Gui/Widgets) development packages — on Debian/Ubuntu:
+
+```sh
+sudo apt install qt6-base-dev cmake g++
+```
+
+Then, from the repo root:
+
+```sh
+cmake -S ui/c2wallet-qt -B build-c2wallet -DC2WALLET_QT_BUILD_TESTS=ON
+cmake --build build-c2wallet --target c2wallet-qt-signer
+# prove the network-incapable property on the produced binary:
+ui/c2wallet-qt/ci/check_no_network.sh build-c2wallet/c2wallet-qt-signer
+#   ... or via ctest:
+( cd build-c2wallet && ctest --output-on-failure )
+```

--- a/ui/c2wallet-qt/ci/CI_WIRING.md
+++ b/ui/c2wallet-qt/ci/CI_WIRING.md
@@ -1,0 +1,44 @@
+# CI wiring for the network-incapable link-guard
+
+The M0 phase adds a CI job, **`c2wallet-signer-guard`** ("c2wallet-qt
+network-incapable link-guard"), to the repo's existing
+`.github/workflows/build.yml`. It builds only the `c2wallet-qt-signer` target
+(Qt6 Core/Gui/Widgets) and runs [`check_no_network.sh`](check_no_network.sh)
+over the produced binary, so the network-incapable guarantee is enforced on
+every PR that touches this tree (the `qt` path filter already covers `ui/**`).
+
+## Why it is delivered as a patch here
+
+The change to `build.yml` is **prepared and validated** but is applied
+separately from the code commit because pushing a file under
+`.github/workflows/` requires the `workflow` OAuth scope, which the pushing
+token did not carry. The exact diff lives beside this note as
+[`ci-wiring.build-yml.patch`](ci-wiring.build-yml.patch); it was generated from
+the same commit that built and ran green on the build host.
+
+## Applying it
+
+From the repo root, with a token/login that has the `workflow` scope:
+
+```sh
+git apply ui/c2wallet-qt/ci/ci-wiring.build-yml.patch
+git add .github/workflows/build.yml
+git commit -m "c2wallet-qt M0: wire the network-incapable link-guard into CI"
+git push
+```
+
+The patch inserts the job immediately after the existing `qt-webengine` job.
+`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`
+confirms the result parses.
+
+## The job (for reference)
+
+- Gated on `needs.changes.outputs.qt` (i.e. any `ui/**` change) or a non-PR event.
+- Installs `qt6-base-dev` only — no webengine, no webchannel.
+- `cmake -S ui/c2wallet-qt -B build-c2wallet -DC2WALLET_QT_BUILD_TESTS=ON`
+- `cmake --build build-c2wallet --target c2wallet-qt-signer`
+- `./ui/c2wallet-qt/ci/check_no_network.sh build-c2wallet/c2wallet-qt-signer`
+
+Until the patch is applied, the guard still runs locally via
+`ctest` (the `no_network_link_guard` test registered by the CMake
+`C2WALLET_QT_BUILD_TESTS` option).

--- a/ui/c2wallet-qt/ci/check_no_network.sh
+++ b/ui/c2wallet-qt/ci/check_no_network.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════
+# check_no_network.sh — the network-incapable link-guard for c2wallet-qt-signer.
+#
+# This is defense-in-depth layer 1 from docs/design/c2wallet-qt.md §5.2, made
+# mechanical: the offline signer binary must be PHYSICALLY INCAPABLE of network
+# I/O. Any attempt to open a socket must be a LINK error, not a runtime toggle.
+# This script is the binary-level analog of c2pool's reward-safety grep proof.
+#
+# It fails (non-zero) if the built binary either:
+#   (1) has a NEEDED dependency on any networking shared library, or
+#   (2) imports any forbidden network C-ABI symbol in its dynamic symbol table.
+#
+# Usage:  check_no_network.sh <path-to-c2wallet-qt-signer>
+#
+# ── Why symbol-NAME matching, not `grep` over raw nm output ────────────────
+# QtCore is built around QObject::connect and Qt6 property bindables
+# (bindableWindowTitle, ...). A naive `nm BIN | grep -E 'connect|bind'` would
+# match the C++-MANGLED names of those (e.g. _ZN7QObject7connect...,
+# ...bindable...) and either false-fail or, worse, train reviewers to ignore
+# the guard. The libc network calls we actually care about are UNMANGLED C ABI
+# names — `connect`, `socket`, `bind`, ... — so we extract the symbol-name
+# column from `nm -D` and match it EXACTLY (plus a few prefix families:
+# SSL_*, curl_*, res_*). A mangled C++ symbol never equals the bare token
+# `connect`, so QObject::connect is correctly ignored while a real libc
+# connect(2) import is caught.
+#
+# ── Scope / honest limits ──────────────────────────────────────────────────
+# nm -D / objdump -T inspect the binary's OWN dynamic symbol table and its
+# NEEDED list — i.e. what THIS binary imports and links directly. That is the
+# link-time proof M0 promises. It does not, and is not meant to, cover a
+# dlopen'd plugin loaded at runtime or a raw inline syscall; those belong to
+# the M5 runtime seccomp belt (§5.2 layer 3). The link guard here is layer 1.
+# ═══════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+BIN="${1:?usage: check_no_network.sh <path-to-c2wallet-qt-signer>}"
+
+if [[ ! -f "$BIN" ]]; then
+    echo "FAIL: binary not found: $BIN" >&2
+    exit 2
+fi
+
+echo "== c2wallet-qt-signer network-incapable link-guard =="
+echo "target: $BIN"
+echo
+
+fail=0
+
+# ── Part 1: no networking shared library may be a load-time dependency ──────
+# Qt6::Core/Gui/Widgets only. QtNetwork, QtWebEngine*, QtWebChannel, libcurl,
+# OpenSSL (libssl), c-ares and boost_asio are all forbidden. Read the ELF
+# NEEDED entries directly (objdump -p) so we do not require the loader to
+# actually resolve the libraries on the CI host.
+FORBIDDEN_LIB_RE='libQt6Network|libQt6WebEngine|libQt6WebChannel|libcurl|libssl|libcares|libc-ares|boost_asio|libboost_asio'
+
+echo "-- NEEDED shared libraries --"
+needed="$(objdump -p "$BIN" 2>/dev/null | awk '/NEEDED/{print $2}' | sort -u)"
+echo "$needed" | sed 's/^/   /'
+echo
+
+if echo "$needed" | grep -Eq "$FORBIDDEN_LIB_RE"; then
+    echo "FAIL: binary links a forbidden networking library:" >&2
+    echo "$needed" | grep -E "$FORBIDDEN_LIB_RE" | sed 's/^/   >>> /' >&2
+    fail=1
+else
+    echo "OK: no forbidden networking library in NEEDED list."
+fi
+echo
+
+# ── Part 2: no forbidden network C-ABI symbol in the dynamic symbol table ───
+# Prefer `nm -D` (dynamic symtab; survives stripping). Fall back to objdump -T.
+# The symbol name is the LAST field; strip any @GLIBC_x.y version suffix.
+if nm -D --undefined-only "$BIN" >/dev/null 2>&1; then
+    undef_syms="$(nm -D --undefined-only "$BIN" 2>/dev/null | awk '{print $NF}')"
+else
+    # objdump -T marks undefined dynamic symbols with the *UND* section.
+    undef_syms="$(objdump -T "$BIN" 2>/dev/null | awk '/\*UND\*/{print $NF}')"
+fi
+undef_syms="$(echo "$undef_syms" | sed 's/@.*//' | sort -u)"
+
+# Exact-match forbidden C-ABI names (the set named in the M0 brief plus a few
+# obvious siblings), and forbidden prefix families.
+is_forbidden_symbol() {
+    case "$1" in
+        connect|socket|bind|listen|accept|accept4| \
+        getaddrinfo|freeaddrinfo|getnameinfo|gethostbyname|gethostbyname2| \
+        gethostbyaddr|sendto|recvfrom|getpeername|connectto)
+            return 0 ;;
+        SSL_*|curl_*|res_*)
+            return 0 ;;
+    esac
+    return 1
+}
+
+echo "-- forbidden network symbol scan (imported dynamic symbols) --"
+hits=""
+while IFS= read -r sym; do
+    [[ -z "$sym" ]] && continue
+    if is_forbidden_symbol "$sym"; then
+        hits+="$sym"$'\n'
+    fi
+done <<< "$undef_syms"
+
+if [[ -n "$hits" ]]; then
+    echo "FAIL: binary imports forbidden network symbol(s):" >&2
+    echo "$hits" | sed '/^$/d;s/^/   >>> /' >&2
+    fail=1
+else
+    echo "OK: no forbidden network symbol imported."
+fi
+echo
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "RESULT: NETWORK-INCAPABLE GUARD FAILED — this binary can touch the network." >&2
+    exit 1
+fi
+
+echo "RESULT: PASS — c2wallet-qt-signer is network-incapable (no net libs, no net symbols)."

--- a/ui/c2wallet-qt/ci/ci-wiring.build-yml.patch
+++ b/ui/c2wallet-qt/ci/ci-wiring.build-yml.patch
@@ -1,0 +1,55 @@
+diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
+index d93e6ad6..869c3a11 100644
+--- a/.github/workflows/build.yml
++++ b/.github/workflows/build.yml
+@@ -1399,6 +1399,50 @@ jobs:
+         if: always()
+         uses: ./.github/actions/prune-runner-workspace
+ 
++  # ════════════════════════════════════════════════════════════════════════════
++  # c2wallet-qt network-incapable link-guard (design PR #1621, docs/design/
++  # c2wallet-qt.md §5.2). Builds ONLY the air-gapped signer target
++  # (c2wallet-qt-signer — Qt6 Core/Gui/Widgets, no Network, no WebEngine) and
++  # runs ci/check_no_network.sh over the produced binary. This is the mechanical
++  # proof that the signing binary is network-incapable: a networking NEEDED
++  # library, or an imported network C-ABI symbol (connect/socket/bind/listen/
++  # getaddrinfo/gethostbyname/SSL_*/curl_*/res_*), turns this job red. It is the
++  # binary-level analog of the reward-safety grep proof, enforced on every PR
++  # touching the tree via the `qt` path filter (ui/**).
++  # ════════════════════════════════════════════════════════════════════════════
++  c2wallet-signer-guard:
++    name: c2wallet-qt network-incapable link-guard
++    needs: changes
++    if: ${{ needs.changes.outputs.qt == 'true' || github.event_name != 'pull_request' }}
++    runs-on: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && fromJSON('["self-hosted","Linux","X64","draft-release"]') || 'ubuntu-24.04' }}
++    timeout-minutes: 15
++    steps:
++      - uses: actions/checkout@v6
++
++      - name: Install Qt6 base (Core/Gui/Widgets) + toolchain
++        run: |
++          flock /tmp/c2pool-apt.lock bash -e -c '
++            sudo apt-get update -qq
++            sudo apt-get install -y --no-install-recommends \
++              cmake g++ ccache binutils \
++              qt6-base-dev libgl1-mesa-dev libxkbcommon-dev
++          '
++
++      - name: Configure (Widgets-only signer, guard test registered)
++        run: cmake -S ui/c2wallet-qt -B build-c2wallet -DC2WALLET_QT_BUILD_TESTS=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
++
++      - name: Build the signer target only
++        run: cmake --build build-c2wallet --target c2wallet-qt-signer -j"${BUILD_J:-8}"
++
++      - name: Network-incapable link-guard (the mechanical proof)
++        run: ./ui/c2wallet-qt/ci/check_no_network.sh build-c2wallet/c2wallet-qt-signer
++
++      # Steady-state disk hygiene on the self-hosted runners: drop the checkout
++      # payload and _temp, keep _actions/_tool/_update. Always runs.
++      - name: Prune runner workspace
++        if: always()
++        uses: ./.github/actions/prune-runner-workspace
++
+   # ════════════════════════════════════════════════════════════════════════════
+   # BTC embedded smoke — RETIRED 2026-06-17 (ci-steward/retire-btc-linux).
+   # Superseded by the coin-matrix.yml `btc` cell ("btc smoke (Linux x86_64)",

--- a/ui/c2wallet-qt/src/main.cpp
+++ b/ui/c2wallet-qt/src/main.cpp
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// c2wallet-qt-signer — entry point for the air-gapped, network-incapable
+// signer skeleton (design PR #1621, docs/design/c2wallet-qt.md §5.2).
+//
+// M0 stands up an empty Bitcoin-Core-like Widgets shell only. There are no
+// keys, no signing, and no crypto in this phase; the value delivered here is
+// the FOUNDATION plus the mechanical proof (ci/check_no_network.sh) that this
+// binary is physically incapable of network I/O.
+
+#include "shell/MainWindow.hpp"
+
+#include <QApplication>
+
+int main(int argc, char* argv[])
+{
+    QApplication app(argc, argv);
+    app.setApplicationName("c2wallet-qt (signer)");
+    app.setOrganizationName("c2pool");
+
+    MainWindow window;
+    window.show();
+    return app.exec();
+}

--- a/ui/c2wallet-qt/src/shell/MainWindow.cpp
+++ b/ui/c2wallet-qt/src/shell/MainWindow.cpp
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "shell/MainWindow.hpp"
+
+#include <QFont>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QListWidget>
+#include <QStackedWidget>
+#include <QStatusBar>
+#include <QVBoxLayout>
+#include <QWidget>
+
+namespace {
+
+// The sidebar sections for the signer shell, in Bitcoin-Core-like order.
+// M0 wires them as empty placeholders only.
+struct Section {
+    const char* name;
+    const char* note;
+};
+
+const Section kSections[] = {
+    {"Wallets",
+     "Import keys and enumerate candidate addresses (Family A: secp256k1; "
+     "Family B: Monero). Arrives in phases M1-A / M1-X."},
+    {"Construct",
+     "Build unsigned transactions and spend every script/output type. "
+     "Arrives in phases M2-A / M3-A / M4-A and M4-X."},
+    {"Sign",
+     "Confirm, sign, and self-verify offline before emitting the signed "
+     "artifact. Arrives in phases M3 / M4."},
+    {"Convert",
+     "Cross-coin address conversion within Family A, with the #961 "
+     "money-misdirection guard. Arrives in phase M2-A."},
+    {"Settings",
+     "Wallet preferences and the encrypted-store / ephemeral-seed modes. "
+     "Arrives alongside key custody in M1."},
+};
+
+}  // namespace
+
+MainWindow::MainWindow(QWidget* parent)
+    : QMainWindow(parent)
+{
+    setWindowTitle("c2wallet-qt (signer) — offline / network-incapable");
+    resize(1100, 720);
+
+    // ── Central area: sidebar nav + stacked placeholder pages ──────────────
+    auto* central = new QWidget(this);
+    auto* layout = new QHBoxLayout(central);
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+
+    navList_ = new QListWidget(central);
+    navList_->setFixedWidth(180);
+    layout->addWidget(navList_);
+
+    stack_ = new QStackedWidget(central);
+    layout->addWidget(stack_, 1);
+
+    for (const auto& s : kSections) {
+        navList_->addItem(QString::fromLatin1(s.name));
+        stack_->addWidget(makePlaceholderPage(QString::fromLatin1(s.name),
+                                              QString::fromLatin1(s.note)));
+    }
+
+    connect(navList_, &QListWidget::currentRowChanged,
+            stack_, &QStackedWidget::setCurrentIndex);
+    navList_->setCurrentRow(0);
+
+    setCentralWidget(central);
+
+    // ── Status bar: make the air-gap model visible at a glance ─────────────
+    auto* offline = new QLabel(
+        "OFFLINE — this build links no networking library (Qt Network / "
+        "WebEngine / curl / asio). A socket call is a link error.",
+        this);
+    statusBar()->addWidget(offline);
+}
+
+QWidget* MainWindow::makePlaceholderPage(const QString& title,
+                                         const QString& note)
+{
+    auto* page = new QWidget(stack_);
+    auto* v = new QVBoxLayout(page);
+    v->setContentsMargins(24, 24, 24, 24);
+    v->setSpacing(10);
+    v->setAlignment(Qt::AlignTop);
+
+    auto* heading = new QLabel(title, page);
+    QFont f = heading->font();
+    f.setPointSize(f.pointSize() + 6);
+    f.setBold(true);
+    heading->setFont(f);
+    v->addWidget(heading);
+
+    auto* body = new QLabel(note, page);
+    body->setWordWrap(true);
+    v->addWidget(body);
+
+    auto* stub = new QLabel(QStringLiteral("Not implemented in M0."), page);
+    stub->setEnabled(false);
+    v->addWidget(stub);
+
+    return page;
+}

--- a/ui/c2wallet-qt/src/shell/MainWindow.hpp
+++ b/ui/c2wallet-qt/src/shell/MainWindow.hpp
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+#include <QMainWindow>
+
+class QListWidget;
+class QStackedWidget;
+
+// MainWindow — the family-agnostic Widgets shell for the air-gapped signer.
+//
+// Bitcoin-Core-like layout: a fixed-width sidebar nav (QListWidget) selecting
+// among stacked Page* screens (QStackedWidget). This mirrors the shell PATTERN
+// of ui/c2pool-qt/ (MainWindow + sidebar + stacked pages) WITHOUT reusing any
+// of its networked dependencies — this window links only Qt Widgets/Gui/Core.
+//
+// M0 delivers an empty skeleton: the sidebar sections (Wallets / Construct /
+// Sign / Convert / Settings) are present as placeholders with no functionality
+// behind them. Real pages, key import, construction and signing land in later
+// phases (see docs/design/c2wallet-qt.md §6).
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget* parent = nullptr);
+
+private:
+    // Build one placeholder page for a sidebar section. M0 has no real screens
+    // yet; each section shows its name and a short "not implemented in M0" note.
+    QWidget* makePlaceholderPage(const QString& title, const QString& note);
+
+    QListWidget*    navList_{nullptr};
+    QStackedWidget* stack_{nullptr};
+};


### PR DESCRIPTION
## c2wallet-qt — PHASE M0 (foundation + the network-incapable guarantee)

Implements **M0** of the `c2wallet-qt` design (**#1621**, `docs/design/c2wallet-qt.md` §2, §5.2, §5.4, §6 M0 row). `c2wallet-qt` is the standalone, **air-gapped** Qt signer / transaction constructor — the offline, key-holding side of the two-machine model, where a separate online c2pool node re-validates and broadcasts but never holds a key.

**M0 is non-money by design: no keys, no signing, no crypto yet.** Its whole job is to stand up the tree and prove, mechanically, the core security property — the signing binary is *physically incapable* of network I/O, so a socket call is a **link error, not a runtime toggle**.

### What is here (new tree `ui/c2wallet-qt/`)

- **`CMakeLists.txt`** — target **`c2wallet-qt-signer`** linking **`Qt6::Core` + `Qt6::Gui` + `Qt6::Widgets` only**. No Qt Network, no QtWebEngine/WebChannel, no libcurl, no OpenSSL, no boost::asio. (Contrast: the sibling `ui/c2pool-qt/` hard-requires QtWebEngine — Chromium + a full network stack — which is exactly why the signer must be a separate binary. Only c2pool-qt's Widgets shell *pattern* is reused, never its networked deps.)
- **Widgets `MainWindow` + sidebar shell** — an empty, runnable Bitcoin-Core-like skeleton with placeholder sections (Wallets / Construct / Sign / Convert / Settings) and an "OFFLINE — network-incapable" status line. No functionality yet.
- **The link-guard `ci/check_no_network.sh`** — inspects the built binary's `NEEDED` shared libraries and its imported dynamic symbols (`nm -D` / `objdump -T`) and fails on any networking library or network C-ABI symbol: `connect`, `socket`, `bind`, `listen`, `getaddrinfo`, `gethostbyname`, `SSL_*`, `curl_*`, `res_*`. It matches symbol *names exactly* (not a substring grep) so Qt's own `QObject::connect` / bindable-property symbols never false-trip it, while a real libc `connect(2)` import is caught. Registered as the `no_network_link_guard` ctest via `-DC2WALLET_QT_BUILD_TESTS=ON`.
- **`README.md`** — the air-gap model: a separate network-incapable signer binary; the online companion is a later phase; the runtime seccomp belt is M5.

### CI wiring

The guard is wired as a CI job (`c2wallet-signer-guard`) in `.github/workflows/build.yml`, gated on the existing `qt` path filter so it runs on every PR touching the tree. That change is **prepared and validated but not included in this branch**: pushing a file under `.github/workflows/` requires the `workflow` OAuth scope, which the pushing token does not carry. The exact, validated diff ships as `ui/c2wallet-qt/ci/ci-wiring.build-yml.patch` with apply instructions in `ui/c2wallet-qt/ci/CI_WIRING.md`; it applies cleanly (`git apply --check` passes) and the result parses as YAML. It needs a follow-up push from a login with the `workflow` scope.

### Build + verify (on the build host, Qt6 present)

- `c2wallet-qt-signer` **built** (Qt6 6.10.2).
- Link-guard **run on the actual binary — clean**: `NEEDED` = `libc`, `libgcc_s`, `libQt6Core`, `libQt6Gui`, `libQt6Widgets`, `libstdc++`; no forbidden library, no forbidden symbol; guard exits 0. Negative-tested against a networked binary — the guard correctly fails.
- `target_link_libraries(c2wallet-qt-signer PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets)` — no networking libs.

### Status

Draft. Non-money foundation phase. Follow-ups: apply the CI-wiring patch under the `workflow` scope; then M1 (key import) begins the money-path phases.

Design: #1621
