### PR TITLE
v37: M4 parity oracle — judge the famine constraint by arm identity, not by seat

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,7 @@ jobs:
                     xmr_native_parity_kat xmr_native_txpool_parity_kat \
                     xmr_native_backlog_famine_kat \
                     xmr_native_m4_soak_kat \
+                    xmr_native_m4_ptpl_backlog_gate_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
                     v37_xmr_m3_arm_order_kat v37_xmr_prefer_own_race_kat \
@@ -692,6 +693,7 @@ jobs:
                     xmr_native_parity_kat xmr_native_txpool_parity_kat \
                     xmr_native_backlog_famine_kat \
                     xmr_native_m4_soak_kat \
+                    xmr_native_m4_ptpl_backlog_gate_kat \
                     xmr_native_node_kat xmr_native_node \
                     v37_xmr_m2_native_settlement_kat \
                     v37_xmr_m3_arm_order_kat v37_xmr_prefer_own_race_kat \

--- a/src/impl/xmr/native/parity/xmr_backlog_famine.hpp
+++ b/src/impl/xmr/native/parity/xmr_backlog_famine.hpp
@@ -31,16 +31,44 @@
 // next to is not a detector.
 //
 // SO THE COUNT STAYS A MEASUREMENT AND THE FAMINE BECOMES A CONSTRAINT. The
-// distinction that makes this safe is the SHADOW's count, not ours:
+// distinction that makes this safe is the DAEMON's count, not ours:
 //
-//     native backlog == 0  AND  shadow backlog > 0,  SUSTAINED
+//     native backlog == 0  AND  daemon backlog > 0,  SUSTAINED
 //
 // Neither half alone is evidence of anything. A native backlog of 0 on a quiet
-// chain is correct. A shadow backlog of 8 while we hold 6 is propagation skew.
+// chain is correct. A daemon backlog of 8 while we hold 6 is propagation skew.
 // The conjunction, held across K consecutive decidable samples AND across at
 // least S seconds of wall clock, is the one shape that cannot be explained by
 // skew: transactions demonstrably exist on the network, the daemon sitting on
 // the same wire is holding them, and we are holding none of them.
+//
+// TWO WORDS THAT COST A SOAK, AND THE RULE THAT REPLACES THEM. The inputs below
+// used to be spelled `native_backlog` and `shadow_backlog`, and the oracle fed
+// them BY SEAT -- the served arm into the first, the shadow arm into the second.
+// In the M4 leg that SERVES FROM MONEROD and shadows the native arm, those two
+// seats hold the two arms the other way round, so the DAEMON's empty mempool
+// arrived as "native_backlog=0" while the NATIVE pool's five relayed
+// transactions arrived as "shadow_backlog=5". Every sample read Starved, the
+// guard tripped after six of them, the refusal is sticky -- and the M4
+// graduation streak sat at zero for two thousand consecutive samples on a node
+// that was healthy. The mirror consequence was worse than the stall: a REAL
+// native famine in that leg read as Fed, so in the posture where the daemon
+// serves, the constraint could not have detected the regression it was added for.
+//
+//     THE RULE: these are ARM IDENTITIES, never seats. `native_backlog` is what
+//     the arm named "native" holds and `daemon_backlog` is what the arm named
+//     "monerod" holds, whichever of the two happens to be serving. The field
+//     names below say so, so that a future caller cannot re-make the mistake by
+//     filling in the argument that is nearest to hand.
+//
+// AND THE CLAIM IS SCOPED TO THE SERVING ARM. The sentence this guard exists to
+// refuse is "every template WE SERVE is empty of fee revenue". That is a claim
+// about the arm the miners are actually served from. While the native arm is
+// only shadowing, an empty native pool costs no miner a piconero and must not
+// reset a graduation streak -- so `native_is_serving_arm` decides whether an
+// observation GATES or merely ACCRUES as advisory evidence. Advisory samples are
+// still classified and still counted, so the status line shows the shape
+// building up; they simply never travel out as a failed CONSTRAINT.
 //
 // TWO BOUNDS, NOT ONE, and the second is not redundant. Samples are driven by
 // template refreshes, which can burst: six refreshes inside one second all
@@ -96,15 +124,15 @@ struct BacklogFamineConfig {
 enum class BacklogSampleClass : std::uint8_t {
     Undecidable = 0,   // misaligned, or one of the two arms did not answer
     Fed,               // the native pool held something: the famine shape is absent
-    ShadowEmpty,       // the shadow held nothing either: agreement, not famine
-    Starved,           // native 0, shadow > 0: one unit of famine evidence
+    DaemonEmpty,       // the daemon held nothing either: agreement, not famine
+    Starved,           // native 0, daemon > 0: one unit of famine evidence
 };
 
 inline const char* to_string(BacklogSampleClass c) noexcept {
     switch (c) {
         case BacklogSampleClass::Undecidable: return "undecidable";
         case BacklogSampleClass::Fed:         return "fed";
-        case BacklogSampleClass::ShadowEmpty: return "shadow-empty";
+        case BacklogSampleClass::DaemonEmpty: return "daemon-empty";
         case BacklogSampleClass::Starved:     return "starved";
     }
     return "?";
@@ -113,10 +141,18 @@ inline const char* to_string(BacklogSampleClass c) noexcept {
 class BacklogFamineGuard {
 public:
     struct Input {
+        // BY ARM IDENTITY, NEVER BY SEAT. `native_*` is the arm named "native"
+        // and `daemon_*` is the arm named "monerod", whichever of them served
+        // this template. See the seat/identity note in the header.
         bool          native_known   = false;
         std::uint64_t native_backlog = 0;
-        bool          shadow_known   = false;
-        std::uint64_t shadow_backlog = 0;
+        bool          daemon_known   = false;
+        std::uint64_t daemon_backlog = 0;
+        // Is the NATIVE arm the one the miners are served from right now? Only
+        // then can an empty native pool cost anything, and only then may this
+        // observation gate. Defaults true so that a caller which forgets it gets
+        // the conservative (gating) behaviour rather than a silently dead guard.
+        bool          native_is_serving_arm = true;
         // The two arms are on the same (height, prev_id). A famine claim across
         // different tips would be comparing two different questions.
         bool          aligned        = false;
@@ -129,6 +165,9 @@ public:
         std::size_t        streak       = 0;
         std::uint64_t      elapsed_s    = 0;
         bool               tripped      = false;
+        // The native arm was not serving, so this sample was recorded but did
+        // not gate. `check` is a PASS carrying the shape as a detail string.
+        bool               advisory     = false;
         NamedCheck         check;        // ready to push into CompareOptions
     };
 
@@ -144,7 +183,30 @@ public:
             return out;
         }
 
-        const bool decidable = in.aligned && in.native_known && in.shadow_known;
+        const bool decidable = in.aligned && in.native_known && in.daemon_known;
+
+        // THE POSTURE FENCE. While the native arm is only shadowing, an empty
+        // native pool costs no miner anything: the templates that went out were
+        // built by the daemon, from the daemon's own mempool. Recording the
+        // shape is still worth doing -- it is how an operator watches the native
+        // pool fill before flipping the posture -- but it may not FAIL a sample,
+        // because a failed sample resets the M4 graduation streak, and resetting
+        // a streak over a pool nobody is serving from is the stall this fence
+        // exists to prevent. A Fed sample still clears a stale refusal: evidence
+        // that the native pool is ingesting is evidence whichever seat it is in.
+        if (!in.native_is_serving_arm) {
+            ++advisory_;
+            out.advisory  = true;
+            out.cls       = decidable ? classify_(in) : BacklogSampleClass::Undecidable;
+            out.elapsed_s = elapsed_(in.at_unix);
+            if (out.cls == BacklogSampleClass::Fed) clear_();
+            if (out.cls == BacklogSampleClass::Starved) ++advisory_starved_;
+            out.streak  = streak_;
+            out.tripped = tripped_;
+            out.check   = pass_(advisory_detail_(in, out.cls));
+            return out;
+        }
+
         if (!decidable) {
             ++undecidable_;
             out.cls       = BacklogSampleClass::Undecidable;
@@ -164,19 +226,19 @@ public:
             out.check = pass_("native pool holds " + u64_(in.native_backlog) + " tx");
             return out;
         }
-        if (in.shadow_backlog == 0) {
+        if (in.daemon_backlog == 0) {
             clear_();
-            ++shadow_empty_;
-            out.cls   = BacklogSampleClass::ShadowEmpty;
+            ++daemon_empty_;
+            out.cls   = BacklogSampleClass::DaemonEmpty;
             out.check = pass_("both pools empty: agreement, not famine");
             return out;
         }
 
-        // native == 0, shadow > 0.
+        // native == 0, daemon > 0.
         ++starved_;
         if (streak_ == 0) first_starved_unix_ = in.at_unix;
         ++streak_;
-        last_shadow_backlog_ = in.shadow_backlog;
+        last_daemon_backlog_ = in.daemon_backlog;
 
         out.cls       = BacklogSampleClass::Starved;
         out.streak    = streak_;
@@ -200,15 +262,23 @@ public:
     std::size_t   streak()      const noexcept { return streak_; }
     std::uint64_t starved()     const noexcept { return starved_; }
     std::uint64_t fed()         const noexcept { return fed_; }
-    std::uint64_t shadow_empty() const noexcept { return shadow_empty_; }
+    std::uint64_t daemon_empty() const noexcept { return daemon_empty_; }
     std::uint64_t undecidable() const noexcept { return undecidable_; }
+    // Samples seen while the native arm was NOT serving: recorded, never gating.
+    std::uint64_t advisory()         const noexcept { return advisory_; }
+    std::uint64_t advisory_starved() const noexcept { return advisory_starved_; }
 
     std::string describe() const {
-        return std::string(tripped_ ? "REFUSING" : "ok")
+        std::string s = std::string(tripped_ ? "REFUSING" : "ok")
              + " streak=" + u64_(static_cast<std::uint64_t>(streak_)) + "/" + u64_(static_cast<std::uint64_t>(cfg_.consecutive))
              + " starved=" + u64_(starved_) + " fed=" + u64_(fed_)
-             + " shadow-empty=" + u64_(shadow_empty_)
+             + " daemon-empty=" + u64_(daemon_empty_)
              + " undecidable=" + u64_(undecidable_);
+        // Printed only when there is something to print, so the ordinary
+        // serve-native line does not grow two zeroes it never uses.
+        if (advisory_ != 0)
+            s += " advisory=" + u64_(advisory_) + "(starved " + u64_(advisory_starved_) + ")";
+        return s;
     }
 
 private:
@@ -223,11 +293,37 @@ private:
         return at > first_starved_unix_ ? (at - first_starved_unix_) : 0;
     }
 
+    static BacklogSampleClass classify_(const Input& in) noexcept {
+        if (in.native_backlog > 0)  return BacklogSampleClass::Fed;
+        if (in.daemon_backlog == 0) return BacklogSampleClass::DaemonEmpty;
+        return BacklogSampleClass::Starved;
+    }
+
+    std::string advisory_detail_(const Input& in, BacklogSampleClass cls) const {
+        std::string s = "advisory (the native arm is not serving templates): ";
+        switch (cls) {
+            case BacklogSampleClass::Fed:
+                s += "native pool holds " + u64_(in.native_backlog) + " tx";
+                break;
+            case BacklogSampleClass::DaemonEmpty:
+                s += "both pools empty";
+                break;
+            case BacklogSampleClass::Starved:
+                s += "native pool empty while the daemon holds "
+                   + u64_(in.daemon_backlog) + " tx";
+                break;
+            case BacklogSampleClass::Undecidable:
+                s += "no comparable backlog pair this sample";
+                break;
+        }
+        return s + "; not gating, nothing is served from the native pool";
+    }
+
     void clear_() noexcept {
         streak_ = 0;
         tripped_ = false;
         first_starved_unix_ = 0;
-        last_shadow_backlog_ = 0;
+        last_daemon_backlog_ = 0;
     }
 
     NamedCheck pass_(std::string detail) const {
@@ -239,7 +335,7 @@ private:
     }
 
     std::string progress_(const Observation& o) const {
-        return "native backlog 0 while shadow holds " + u64_(last_shadow_backlog_)
+        return "native backlog 0 while the daemon holds " + u64_(last_daemon_backlog_)
              + "; " + u64_(static_cast<std::uint64_t>(o.streak)) + "/" + u64_(static_cast<std::uint64_t>(cfg_.consecutive))
              + " samples, " + u64_(o.elapsed_s) + "/" + u64_(cfg_.sustained_s) + "s";
     }
@@ -249,8 +345,8 @@ private:
         c.name = kBacklogFamineCheck;
         c.ok   = false;
         c.detail = "native template backlog has been 0 for " + u64_(static_cast<std::uint64_t>(o.streak))
-                 + " consecutive samples (" + u64_(o.elapsed_s) + "s) while the shadow arm "
-                 + "held " + u64_(last_shadow_backlog_)
+                 + " consecutive samples (" + u64_(o.elapsed_s) + "s) while the daemon arm "
+                 + "held " + u64_(last_daemon_backlog_)
                  + " transaction(s): the native pool is not ingesting relayed transactions, "
                    "so every template served is empty of fee revenue";
         if (dead_clock) c.detail += " [no clock supplied: count bound only]";
@@ -261,11 +357,13 @@ private:
     std::size_t   streak_              = 0;
     bool          tripped_             = false;
     std::uint64_t first_starved_unix_  = 0;
-    std::uint64_t last_shadow_backlog_ = 0;
+    std::uint64_t last_daemon_backlog_ = 0;
     std::uint64_t starved_             = 0;
     std::uint64_t fed_                 = 0;
-    std::uint64_t shadow_empty_        = 0;
+    std::uint64_t daemon_empty_        = 0;
     std::uint64_t undecidable_         = 0;
+    std::uint64_t advisory_            = 0;
+    std::uint64_t advisory_starved_    = 0;
 };
 
 } // namespace c2pool::xmr::native::parity

--- a/src/impl/xmr/native/parity/xmr_parity_oracle.hpp
+++ b/src/impl/xmr/native/parity/xmr_parity_oracle.hpp
@@ -406,26 +406,68 @@ private:
 
         // The CONSTRAINT that closes P-TPL's blind spot. tx_backlog_count is a
         // Measurement and stays one; what is judged here is the FAMINE SHAPE --
-        // we served nothing while the arm we are judged against held something,
-        // sustained. Fed only on an ALIGNED pair, because a backlog claim
-        // across two different tips compares two different questions; a
-        // misaligned sample is undecidable and neither grows nor clears the
-        // streak. See xmr_backlog_famine.hpp.
+        // the NATIVE pool holding nothing while the DAEMON holds transactions,
+        // sustained. Fed only on an ALIGNED pair, because a backlog claim across
+        // two different tips compares two different questions; a misaligned
+        // sample is undecidable and neither grows nor clears the streak.
+        //
+        // BY ARM IDENTITY, NOT BY SEAT. This block used to hand the SERVED seat
+        // to `native_backlog` and the SHADOW seat to the daemon count. In the M4
+        // leg that serves from monerod and shadows the native arm those two
+        // seats hold the two arms the other way round, and the result was a
+        // sticky refusal on a healthy node -- the daemon's empty mempool read as
+        // a starving native pool, every P-TPL sample FAILed, and the graduation
+        // streak never left zero. So the arms are now picked out by NAME, and
+        // the claim is fenced to the posture in which it can mean anything: only
+        // the arm the miners are actually served from can serve an empty
+        // template. See xmr_backlog_famine.hpp.
         {
+            const bool served_is_native = (s.arm == std::string(::c2pool::xmr::native::to_string(TemplateArm::Native)));
+            const bool shadow_is_native = shadow.have
+                && shadow.arm == std::string(::c2pool::xmr::native::to_string(TemplateArm::Native));
+
             BacklogFamineGuard::Input fi;
             fi.aligned      = served.have && shadow.have
                            && served.height == shadow.height
                            && served.prev_id == shadow.prev_id;
             fi.at_unix      = s.at_unix;
-            fi.native_known = served.have;
-            fi.native_backlog = static_cast<std::uint64_t>(s.served.tx_backlog.size());
+            fi.native_is_serving_arm = served_is_native;
+
+            // What the SERVED arm holds comes from the artefact that actually
+            // went out, never from a re-read; what the SHADOW arm holds comes
+            // from its own observation. Which of the two is "native" is decided
+            // by the arm's name, above.
+            const std::uint64_t served_backlog =
+                static_cast<std::uint64_t>(s.served.tx_backlog.size());
+            bool          shadow_backlog_known = false;
+            std::uint64_t shadow_backlog       = 0;
             if (shadow.have) {
                 const Obs& sb = shadow.fields.get("tx_backlog_count");
                 if (sb.present) {
-                    fi.shadow_known   = true;
-                    fi.shadow_backlog = std::strtoull(sb.value.c_str(), nullptr, 10);
+                    shadow_backlog_known = true;
+                    shadow_backlog = std::strtoull(sb.value.c_str(), nullptr, 10);
                 }
             }
+
+            if (served_is_native) {
+                fi.native_known   = served.have;
+                fi.native_backlog = served_backlog;
+                fi.daemon_known   = shadow_backlog_known;
+                fi.daemon_backlog = shadow_backlog;
+            } else if (shadow_is_native) {
+                fi.native_known   = shadow_backlog_known;
+                fi.native_backlog = shadow_backlog;
+                fi.daemon_known   = served.have;
+                fi.daemon_backlog = served_backlog;
+            } else {
+                // Neither arm is the native one (a monerod-vs-monerod bring-up
+                // configuration). There is no famine claim to make, and making
+                // one from whichever seat was nearest is exactly the bug above.
+                fi.native_known = false;
+                fi.daemon_known = false;
+                fi.native_is_serving_arm = false;
+            }
+
             const BacklogFamineGuard::Observation fo = famine_.observe(fi);
             opt.constraints.push_back(fo.check);
         }

--- a/src/impl/xmr/native/parity/xmr_parity_sources.hpp
+++ b/src/impl/xmr/native/parity/xmr_parity_sources.hpp
@@ -37,6 +37,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -274,12 +275,38 @@ inline ArmObservation native_tip_observation(const ChainRow& row) {
     return o;
 }
 
+// An ORDER-INDEPENDENT digest of a selected transaction set: the XOR-fold of the
+// leading eight bytes of every transaction id, rendered hex, and never a gate.
+//
+// Order-independent on purpose. Two arms that hold the same transactions will
+// order them by their own selection policy, and a digest that changed with the
+// order would report a difference that means nothing. What this DOES distinguish
+// is set membership, which is the thing an operator wants to see when a diff
+// says one arm holds five transactions and the other holds none.
+inline std::string tx_set_digest(const std::vector<node::TxBacklogEntry>& txs) {
+    std::uint64_t acc = 0;
+    for (const node::TxBacklogEntry& e : txs) {
+        std::uint64_t v = 0;
+        for (int i = 0; i < 8; ++i) v = (v << 8) | static_cast<std::uint64_t>(e.id[i]);
+        acc ^= v;
+    }
+    char b[64];
+    std::snprintf(b, sizeof(b), "n=%llu xor64=%016llx",
+                  static_cast<unsigned long long>(txs.size()),
+                  static_cast<unsigned long long>(acc));
+    return b;
+}
+
 // A template, from the MinerData an arm produced.
 //
 // median_timestamp: monerod's get_miner_data does not return it, so a zero here
 // means "this arm does not report the field", not "the median is zero". It is a
 // CONSTRAINT in the table for exactly that reason, and it is left ABSENT rather
 // than rendered as 0 so nothing can ever compare two absences and call it equal.
+//
+// selected_tx_set: NotComparable, and present so that the by-design difference
+// between the two pools' admission rules is visible in the report instead of
+// being inferred from a bare count. See TEMPLATE_FIELDS.
 inline ArmObservation template_observation(const char* arm, const node::MinerData& md) {
     ArmObservation o;
     o.arm     = arm;
@@ -295,6 +322,7 @@ inline ArmObservation template_observation(const char* arm, const node::MinerDat
     o.fields.set("median_timestamp",
                  md.median_timestamp != 0 ? Obs::u64(md.median_timestamp) : Obs::absent());
     o.fields.set("tx_backlog_count", Obs::u64(static_cast<std::uint64_t>(md.tx_backlog.size())));
+    o.fields.set("selected_tx_set",  Obs::text(tx_set_digest(md.tx_backlog)));
     return o;
 }
 

--- a/src/impl/xmr/native/parity/xmr_parity_types.hpp
+++ b/src/impl/xmr/native/parity/xmr_parity_types.hpp
@@ -61,7 +61,16 @@ namespace c2pool::xmr::native::parity {
 // over the one property the milestone exists to establish. Every streak earned
 // under version 2 was earned by a judge that could not see that, so it does not
 // carry.
-inline constexpr std::uint32_t COMPARATOR_VERSION = 3;
+//
+// Version 4 (M4 leg 1): the famine CONSTRAINT is now decided by ARM IDENTITY and
+// fenced to the SERVING arm, and P-TPL records the selected transaction set as
+// an explicit NotComparable row. Version 3's judge was fed BY SEAT: in the leg
+// that serves from monerod and shadows the native arm it read the daemon's empty
+// mempool as a starving native pool, FAILed every template sample on a healthy
+// node, and held the M4 graduation streak at zero. The same inversion hid a REAL
+// native famine in that same leg. A streak earned under a judge that could do
+// either of those is not evidence about this one, so it does not carry.
+inline constexpr std::uint32_t COMPARATOR_VERSION = 4;
 
 // ---------------------------------------------------------------------------
 // Regimes -- how a field is judged. Named after the plan's determinism table.
@@ -302,17 +311,35 @@ inline constexpr FieldSpec TEMPLATE_FIELDS[] = {
     {"median_weight",           Regime::Equality,      true,  true },
     {"already_generated_coins", Regime::Equality,      true,  true },
     {"median_timestamp",        Regime::Constraint,    false, false},
-    // The COUNT stays a Measurement: two pools may legitimately differ by a few
-    // transactions at any instant, and an equality gate here would fire on
-    // ordinary propagation skew.
+    // The COUNT stays a Measurement, and after the M4 leg-1 stall it is worth
+    // saying WHY in more than one clause, because the two numbers are not the
+    // same quantity and never were. monerod's is the mempool it offers a
+    // template builder in get_miner_data.tx_backlog. The native arm's is the
+    // SELECTABLE SET of its own relayed pool, admitted under the v37 relay rule
+    // -- structural checks plus range-proof and commitment evidence, with no
+    // key-image double-spend test, which is a deliberately DIFFERENT admission
+    // rule from the daemon's. The two sides therefore hold different
+    // transactions by construction, not by accident, and an equality gate here
+    // would fire on that design decision as well as on ordinary propagation
+    // skew. It is rendered in the diff so an operator can see the delta; it is
+    // never scored.
     {"tx_backlog_count",        Regime::Measurement,   false, false},
-    // ...but the FAMINE SHAPE is a Constraint. A native backlog of 0 sustained
-    // across K samples and S seconds while the shadow arm holds transactions is
-    // not skew and is not agreement: it is the native pool failing to ingest,
-    // which is invisible to all six EQUALITY rows above because none of them
-    // has anything to do with the transaction set. Evaluated by
-    // BacklogFamineGuard (xmr_backlog_famine.hpp) and delivered through
-    // CompareOptions::constraints, so a violation FAILS the sample.
+    // The SELECTED SET itself, as a count plus an order-independent digest of
+    // the transaction ids. NotComparable for the reason directly above: this row
+    // exists so the by-design difference is VISIBLE and RECORDED, and so that
+    // nobody re-adds it -- or a transaction merkle root computed from it -- as an
+    // EQUALITY, which would re-create the same false divergence in a form that
+    // looks more rigorous.
+    {"selected_tx_set",         Regime::NotComparable, false, false},
+    // ...but the FAMINE SHAPE is a Constraint. A NATIVE backlog of 0 sustained
+    // across K samples and S seconds while the DAEMON holds transactions is not
+    // skew and is not agreement: it is the native pool failing to ingest, which
+    // is invisible to all six EQUALITY rows above because none of them has
+    // anything to do with the transaction set. Evaluated by BacklogFamineGuard
+    // (xmr_backlog_famine.hpp) and delivered through CompareOptions::constraints,
+    // so a violation FAILS the sample -- but only in the posture where the
+    // native arm is the one SERVING, because only then can an empty native pool
+    // cost a miner anything. The arms are identified BY NAME, never by seat.
     {"native_backlog_famine",   Regime::Constraint,    false, false},
     {"coinbase_bytes",          Regime::NotComparable, false, false},
 };

--- a/src/impl/xmr/native/test/CMakeLists.txt
+++ b/src/impl/xmr/native/test/CMakeLists.txt
@@ -659,4 +659,51 @@ if (BUILD_TESTING)
     target_compile_features(xmr_native_m4_soak_kat PRIVATE cxx_std_20)
     add_test(NAME xmr_native_m4_soak_kat COMMAND xmr_native_m4_soak_kat)
 
+    # ------------------------------------------------------------------
+    # M4 leg 1 -- the P-TPL backlog GATE, and the stall it caused.
+    #
+    #   xmr_native_m4_ptpl_backlog_gate_kat -- the live stagenet sample that
+    #   held the M4 graduation streak at zero for two thousand consecutive
+    #   samples on a healthy node ("tx_backlog_count served=0 shadow=5", seam
+    #   TEMPLATE, one constraint violated) driven through the REAL ParityOracle
+    #   in the REAL posture, and required to come out CLEAN -- with both
+    #   by-design differences still rendered in the diff, so the sample is not
+    #   made clean by hiding anything. It then runs the same stream through the
+    #   M4GraduationLedger and requires the clean streak to climb past the
+    #   stagenet threshold, which is the stall itself expressed as a number.
+    #
+    #   The negative control is the other half and matters as much: one unit in
+    #   each of the six template consensus inputs in turn must still FAIL (or
+    #   VOID, for the alignment key), the sentinels must still revoke, and two
+    #   entirely DISJOINT transaction pools must still be CLEAN, because that
+    #   difference is what the v37 relay rule creates on purpose. M2h is checked
+    #   to be intact in the posture it was written for: a native arm that SERVES
+    #   empty templates while the daemon holds transactions still refuses.
+    #
+    # Links xmr_coin (block identity) and xmr_node (the production get_miner_data
+    # types) -- the same LIGHT link as xmr_native_backlog_famine_kat. No RandomX,
+    # no sockets, no daemon, no clock of its own.
+    #
+    # DRIFT-GUARD: also listed in BOTH `--target` lists in
+    # .github/workflows/build.yml. A target registered with add_test but never
+    # built reports "***Not Run" and exits 8 -- the #1539 lesson.
+    add_executable(xmr_native_m4_ptpl_backlog_gate_kat xmr_m4_ptpl_backlog_gate_kat.cpp)
+    target_include_directories(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE
+        ${CMAKE_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE xmr_coin xmr_node)
+    target_compile_features(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE cxx_std_20)
+    if (TARGET Boost::headers)
+        target_link_libraries(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE Boost::headers)
+    elseif (TARGET Boost::boost)
+        target_link_libraries(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE Boost::boost)
+    elseif (DEFINED Boost_INCLUDE_DIRS)
+        target_include_directories(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE ${Boost_INCLUDE_DIRS})
+    endif()
+    if (TARGET Threads::Threads)
+        target_link_libraries(xmr_native_m4_ptpl_backlog_gate_kat PRIVATE Threads::Threads)
+    endif()
+    add_test(NAME xmr_native_m4_ptpl_backlog_gate_kat
+             COMMAND xmr_native_m4_ptpl_backlog_gate_kat)
+
 endif()

--- a/src/impl/xmr/native/test/xmr_backlog_famine_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_backlog_famine_kat.cpp
@@ -107,14 +107,14 @@ static node::MinerData miner_data(std::uint64_t height, std::size_t n_tx) {
     return md;
 }
 
-static BacklogFamineGuard::Input starved_at(std::uint64_t t, std::uint64_t shadow_n = 5) {
+static BacklogFamineGuard::Input starved_at(std::uint64_t t, std::uint64_t daemon_n = 5) {
     BacklogFamineGuard::Input in;
     in.aligned        = true;
     in.at_unix        = t;
     in.native_known   = true;
     in.native_backlog = 0;
-    in.shadow_known   = true;
-    in.shadow_backlog = shadow_n;
+    in.daemon_known   = true;
+    in.daemon_backlog = daemon_n;
     return in;
 }
 
@@ -145,7 +145,7 @@ static void suite_guard() {
         BacklogFamineGuard g(cfg);
         BacklogFamineGuard::Input in = starved_at(1000, 0);
         const auto o = g.observe(in);
-        CHECK(o.cls == BacklogSampleClass::ShadowEmpty, "A2 class: got %s", to_string(o.cls));
+        CHECK(o.cls == BacklogSampleClass::DaemonEmpty, "A2 class: got %s", to_string(o.cls));
         CHECK(o.check.ok, "A2 both-empty must pass");
         CHECK(g.streak() == 0, "A2 streak must stay 0");
     }
@@ -202,7 +202,7 @@ static void suite_guard() {
         CHECK(o.cls == BacklogSampleClass::Undecidable, "A6 misaligned must be undecidable");
         CHECK(g.streak() == 2, "A6 streak must survive an undecidable sample, got %zu", g.streak());
         BacklogFamineGuard::Input noshadow = starved_at(1040);
-        noshadow.shadow_known = false;
+        noshadow.daemon_known = false;
         CHECK(g.observe(noshadow).cls == BacklogSampleClass::Undecidable,
               "A6 an unanswering shadow must be undecidable");
         CHECK(g.streak() == 2, "A6 streak must survive an unanswered shadow");

--- a/src/impl/xmr/native/test/xmr_m4_ptpl_backlog_gate_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_m4_ptpl_backlog_gate_kat.cpp
@@ -1,0 +1,665 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (c) 2026, The c2pool developers (frstrtr/c2pool)
+//
+// This file is part of c2pool and is distributed under the terms of the GNU
+// Affero General Public License, version 3 or (at your option) any later
+// version. See COPYING in the repository root.
+//
+// ---------------------------------------------------------------------------
+// src/impl/xmr/native/test/xmr_m4_ptpl_backlog_gate_kat.cpp
+//
+// THE M4 LEG-1 STALL, REPRODUCED AS A NUMBER AND THEN REFUSED.
+//
+// WHAT THE SOAK ACTUALLY SAW. A healthy stagenet node -- synced, 8/8 peers, zero
+// reorgs, zero orphans, serving from monerod and shadowing its own native arm --
+// produced 2,201 P-TEMPLATE FAILs against 3,209 CLEANs, and every single recent
+// FAIL carried the same one-line diff:
+//
+//     tx_backlog_count served=0 shadow=5     seam=TEMPLATE
+//     note: 1 constraint(s) violated; [P-TPL served_by=monerod]
+//
+// The M4 GraduationLedger resets `clean_run` to zero on every FAIL, so a streak
+// that has to reach 720 could never reach 2. The node was not diverging from the
+// daemon in any way that matters: all six required EQUALITY rows -- prev_id,
+// major_version, difficulty, seed_hash, median_weight, already_generated_coins --
+// agreed at every height. The two numbers in that diff were simply not the same
+// quantity:
+//
+//     served=0  the DAEMON's mempool as it offers it to a template builder in
+//               get_miner_data.tx_backlog. Empty, because stagenet was quiet.
+//     shadow=5  the NATIVE pool's SELECTABLE SET, admitted under the v37 relay
+//               rule (structural + range-proof/commitment evidence, no key-image
+//               double-spend test). Five transactions the daemon did not hold.
+//
+// AND THE GATE THAT FIRED WAS NOT AN EQUALITY ON THAT ROW. tx_backlog_count is a
+// Regime::Measurement and always was. What FAILed was the native_backlog_famine
+// CONSTRAINT, which the oracle fed BY SEAT: the SERVED seat into
+// `native_backlog` and the SHADOW seat into the daemon count. In the leg where
+// monerod serves, those seats hold the two arms the other way round. The
+// daemon's 0 became "the native pool is starving" and the native pool's 5 became
+// "the daemon is holding transactions we cannot see". Six samples of that, 30
+// seconds apart, and the guard tripped -- stickily, by design, so it never
+// recovered. Its failure text said "the native pool is not ingesting relayed
+// transactions" about a pool that was ingesting fine (`txpool: gate=1 n=5
+// acc=193 rej=0`).
+//
+// WHAT THIS TARGET PINS.
+//
+//   A  THE STALL CASE, through the REAL ParityOracle in the real leg-1 posture:
+//      served by monerod with an empty daemon mempool, shadowed by a native arm
+//      holding five transactions, six identical consensus inputs. Every sample
+//      CLEAN, for longer than the graduation threshold, and the two by-design
+//      differences still RENDERED in the diff so nothing was hidden to get there.
+//
+//   B  THE SAME STREAM THROUGH THE LEDGER. `clean_run` climbs past 720 and the
+//      leg qualifies. This is the stall itself, measured: under the old judge
+//      this number was 0 and could not move.
+//
+//   C  THE NEGATIVE CONTROL. A genuinely different PRODUCED TEMPLATE -- one unit
+//      in each of the six consensus inputs in turn -- still FAILs (or VOIDs, for
+//      the alignment key), the sentinels still revoke, and the ledger still
+//      resets. A fix that made the stall case clean by making everything clean
+//      would be worse than the stall.
+//
+//   D  M2h IS NOT GIVEN BACK. In leg 2 -- the native arm SERVING -- a native
+//      pool that holds nothing while the daemon holds transactions still trips
+//      the guard and still FAILs. That is the regression the constraint exists
+//      for and it is untouched. In leg 1 the same shape is ADVISORY: recorded,
+//      counted, visible in the status line, and not a gate, because no miner is
+//      served from the native pool in that posture. Note that this is strictly
+//      more sight than before, not less: fed by seat, a real leg-1 famine
+//      classified as `Fed` and was invisible.
+//
+//   E  THE TABLE. tx_backlog_count is still a Measurement, the selected
+//      transaction set is NotComparable, the required EQUALITY count is still
+//      six, and the comparator version moved so no old streak can be inherited.
+//
+// SCOPE FENCE: src/impl/xmr/ only. No consensus digest, no src/sharechain/v37.
+// STL only plus the parity headers; no RandomX, no sockets, no daemon, no clock
+// of its own -- the caller hands the oracle and the ledger unix seconds, so a
+// 72-hour soak runs in microseconds.
+// ---------------------------------------------------------------------------
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "impl/xmr/native/parity/xmr_backlog_famine.hpp"
+#include "impl/xmr/native/parity/xmr_graduation_ledger.hpp"
+#include "impl/xmr/native/parity/xmr_parity_comparator.hpp"
+#include "impl/xmr/native/parity/xmr_parity_oracle.hpp"
+#include "impl/xmr/native/parity/xmr_parity_sources.hpp"
+
+using namespace c2pool::xmr::native;
+using namespace c2pool::xmr::native::parity;
+
+// ---------------------------------------------------------------------------
+static int g_checks = 0;
+static int g_fail   = 0;
+
+#define CHECK(cond, ...)                                  \
+    do {                                                  \
+        ++g_checks;                                       \
+        const bool _ok = (cond);                          \
+        if (!_ok) {                                       \
+            ++g_fail;                                     \
+            std::printf("  [FAIL] ");                     \
+            std::printf(__VA_ARGS__);                     \
+            std::printf("\n");                            \
+        }                                                 \
+    } while (0)
+
+static void head(const char* s) { std::printf("\n== %s ==\n", s); }
+
+// ---------------------------------------------------------------------------
+// Fixtures: the live sample, as numbers.
+//
+// These are the stagenet values from the run this target exists to close, so
+// that the reproduction is of the observed failure and not of a tidier cousin
+// of it. Only the backlog size differs between the two arms.
+// ---------------------------------------------------------------------------
+namespace {
+
+constexpr std::uint64_t kStallHeight   = 2205928;
+constexpr std::size_t   kNativePoolN   = 5;   // node status: txpool gate=1 n=5
+constexpr std::size_t   kDaemonPoolN   = 0;   // get_miner_data returned no tx_backlog
+
+Hash hash_of(std::uint8_t b) {
+    Hash h{};
+    h.fill(b);
+    return h;
+}
+
+node::MinerData miner_data(std::uint64_t height, std::size_t n_tx) {
+    node::MinerData md;
+    md.height                  = height;
+    md.prev_id                 = hash_of(0x8e);
+    md.seed_hash               = hash_of(0x2c);
+    md.major_version           = 16;
+    md.difficulty              = U128{/*lo=*/243310912, /*hi=*/0};
+    md.median_weight           = 300000;
+    md.already_generated_coins = 18446744073709551ull;
+    md.median_timestamp        = 1789205000;
+    for (std::size_t i = 0; i < n_tx; ++i) {
+        node::TxBacklogEntry e;
+        e.id        = hash_of(static_cast<std::uint8_t>(0xa0 + i));
+        e.weight    = 1500 + 10 * static_cast<std::uint64_t>(i);
+        e.fee       = 30000 + 1000 * static_cast<std::uint64_t>(i);
+        e.blob_size = 1420;
+        md.tx_backlog.push_back(e);
+    }
+    return md;
+}
+
+// An arm that answers with a fixed MinerData under a fixed name.
+class FixedArm final : public IMinerDataSource {
+public:
+    FixedArm(const char* name, node::MinerData md) : name_(name), md_(std::move(md)) {}
+    void set(node::MinerData md) { md_ = std::move(md); }
+
+    const char* name() const override { return name_; }
+    MinerDataReadiness readiness() const override {
+        MinerDataReadiness r;
+        r.tip_known = r.seed_reach = r.difficulty_window =
+        r.weight_window = r.coins_known = r.hf_known = true;
+        return r;
+    }
+    MinerDataEpoch epoch() const override {
+        MinerDataEpoch e;
+        e.height  = md_.height;
+        e.prev_id = md_.prev_id;
+        return e;
+    }
+    std::optional<node::MinerData> snapshot(std::string* why) const override {
+        if (why) why->clear();
+        return md_;
+    }
+    const std::vector<std::uint8_t>* tx_body(const Hash&) const override { return nullptr; }
+
+private:
+    const char*     name_;
+    node::MinerData md_;
+};
+
+// One posture of the M4 soak, driven sample by sample through the real oracle.
+//
+// `serving` is the ARM NAME that on_serve is told produced the template, which
+// is exactly what xmr_native_node.hpp passes; `shadow` is the arm the oracle
+// reads for itself. Leg 1 is ("monerod", native-arm); leg 2 is ("native",
+// monerod-arm). Nothing here re-implements the comparator.
+struct Leg {
+    const char*     serving;
+    node::MinerData served_md;
+    const char*     shadow_name;
+    node::MinerData shadow_md;
+};
+
+struct Run {
+    std::vector<SeamResult> samples;
+    std::size_t clean = 0, fail = 0, voided = 0, mismatch = 0;
+    std::string famine_line;
+    bool        famine_tripped = false;
+};
+
+Run drive(const Leg& leg, int samples, BacklogFamineConfig fcfg = {}) {
+    FixedArm shadow_arm(leg.shadow_name, leg.shadow_md);
+
+    ParityOracle::Deps deps;
+    deps.shadow_arm = &shadow_arm;
+
+    ParityOracleConfig cfg;
+    cfg.backlog_famine = fcfg;
+
+    GraduationKey key;
+    key.c2pool_commit      = "m4-ptpl-gate-kat";
+    key.comparator_version = COMPARATOR_VERSION;
+    key.monerod_version    = "0.18.5.0-release";
+    key.net                = "stagenet";
+
+    std::uint64_t clock = 1789200000;
+    ParityOracle orc(deps, key, GraduationPolicy{}, cfg, [&clock] { return clock; });
+
+    Run out;
+    for (int i = 0; i < samples; ++i) {
+        MinerDataEpoch ep;
+        ep.height  = leg.served_md.height;
+        ep.prev_id = leg.served_md.prev_id;
+        orc.on_serve(ep, leg.served_md, leg.serving);
+        for (const SeamResult& r : orc.drain()) {
+            if (r.sample.kind != ProbeKind::Template) continue;
+            switch (r.sample.verdict) {
+                case ParityVerdict::Clean:          ++out.clean; break;
+                case ParityVerdict::Fail:           ++out.fail; break;
+                case ParityVerdict::Void:           ++out.voided; break;
+                case ParityVerdict::ServedMismatch: ++out.mismatch; break;
+            }
+            out.samples.push_back(r);
+        }
+        clock += 20;   // the soak's own template cadence
+    }
+    out.famine_line    = orc.backlog_famine();
+    out.famine_tripped = orc.backlog_famine_tripped();
+    return out;
+}
+
+bool has_diff(const SeamResult& r, const char* field) {
+    for (const FieldDiff& d : r.sample.fields) if (d.field == field) return true;
+    return false;
+}
+
+const FieldDiff* find_diff(const SeamResult& r, const char* field) {
+    for (const FieldDiff& d : r.sample.fields) if (d.field == field) return &d;
+    return nullptr;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// SUITE A -- the stall case, through the real oracle, in the real posture.
+// ---------------------------------------------------------------------------
+static void suite_stall_case() {
+    head("A. leg 1 (serve=monerod, shadow=native): the exact stall sample is CLEAN");
+
+    Leg leg;
+    leg.serving     = "monerod";
+    leg.served_md   = miner_data(kStallHeight, kDaemonPoolN);   // daemon mempool: empty
+    leg.shadow_name = "native";
+    leg.shadow_md   = miner_data(kStallHeight, kNativePoolN);   // native pool: five txs
+
+    // The soak's own guard settings: six samples, thirty seconds.
+    BacklogFamineConfig fcfg;
+    fcfg.consecutive = 6;
+    fcfg.sustained_s = 30;
+
+    const Run run = drive(leg, 800, fcfg);
+
+    // A1. Not one FAIL, over more samples than the graduation threshold needs.
+    CHECK(run.samples.size() == 800, "A1 expected 800 template samples, got %zu",
+          run.samples.size());
+    CHECK(run.fail == 0, "A1 the stall case must produce ZERO FAILs, got %zu", run.fail);
+    CHECK(run.clean == run.samples.size(),
+          "A1 every sample must be CLEAN: %zu/%zu (void=%zu mismatch=%zu)",
+          run.clean, run.samples.size(), run.voided, run.mismatch);
+
+    // A2. ...and the guard did not trip, however long the run.
+    CHECK(!run.famine_tripped, "A2 the famine guard must not trip in leg 1: %s",
+          run.famine_line.c_str());
+
+    // A3. The by-design difference is still VISIBLE. Making the sample clean by
+    // hiding the delta would be a different bug wearing this fix's clothes, so
+    // both rendered rows are required to be present -- and non-scoring.
+    {
+        const SeamResult& r = run.samples.front();
+        const FieldDiff* count = find_diff(r, "tx_backlog_count");
+        CHECK(count != nullptr, "A3 tx_backlog_count must still be rendered in the diff");
+        if (count != nullptr) {
+            CHECK(count->served == "0" && count->shadow == "5",
+                  "A3 the rendered row must carry the live numbers: served=%s shadow=%s",
+                  count->served.c_str(), count->shadow.c_str());
+        }
+        CHECK(has_diff(r, "selected_tx_set"),
+              "A3 the selected transaction set must be rendered too");
+        CHECK(!has_diff(r, kBacklogFamineCheck),
+              "A3 no failing constraint may appear: the famine row is only pushed when it FAILS");
+        CHECK(r.constraints_failed == 0, "A3 zero constraints may fail, got %zu",
+              r.constraints_failed);
+        CHECK(r.equality_compared == 6 && r.equality_differed == 0,
+              "A3 all six EQUALITY rows compared and agreed: %zu compared, %zu differed",
+              r.equality_compared, r.equality_differed);
+        CHECK(!r.sentinel_tripped, "A3 no sentinel may trip on the stall sample");
+    }
+
+    // A4. The advisory accounting is real: the shape was observed 800 times and
+    // gated zero times, and the status line says so rather than going silent.
+    CHECK(run.famine_line.find("advisory=800") != std::string::npos,
+          "A4 the status line must report the advisory samples: %s", run.famine_line.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// SUITE B -- the stall itself: the graduation streak, which could not move.
+// ---------------------------------------------------------------------------
+static void suite_streak() {
+    head("B. M4GraduationLedger: the leg-1 clean streak now climbs past the threshold");
+
+    Leg leg;
+    leg.serving     = "monerod";
+    leg.served_md   = miner_data(kStallHeight, kDaemonPoolN);
+    leg.shadow_name = "native";
+    leg.shadow_md   = miner_data(kStallHeight, kNativePoolN);
+
+    BacklogFamineConfig fcfg;
+    fcfg.consecutive = 6;
+    fcfg.sustained_s = 30;
+
+    const Run run = drive(leg, 800, fcfg);
+
+    GraduationKey key;
+    key.c2pool_commit   = "m4-ptpl-gate-kat";
+    key.monerod_version = "0.18.5.0-release";
+    key.net             = "stagenet";
+    M4GraduationLedger led(key, SoakThresholds::stagenet_m4());
+
+    std::uint64_t t = 1789200000;
+    for (const SeamResult& r : run.samples) {
+        led.record(SoakPosture::ServeMonerodShadowNative, r, t);
+        t += 20;
+    }
+
+    const PostureLeg& L = led.leg(SoakPosture::ServeMonerodShadowNative);
+    CHECK(L.clean_run == 800,
+          "B1 the clean streak must reach 800 (it was pinned at 0 by the stall), got %llu",
+          static_cast<unsigned long long>(L.clean_run));
+    CHECK(L.fail == 0, "B1 no FAIL may be recorded, got %llu",
+          static_cast<unsigned long long>(L.fail));
+    CHECK(L.resets == 0, "B1 the streak must never be reset, got %llu resets",
+          static_cast<unsigned long long>(L.resets));
+    CHECK(L.clean_run >= SoakThresholds::stagenet_m4().min_clean_samples,
+          "B1 and it must clear the real M4 sample threshold");
+    CHECK(led.state() != GraduationState::Revoked, "B1 nothing may have revoked the key");
+}
+
+// ---------------------------------------------------------------------------
+// SUITE C -- the negative control. A genuinely different template still FAILs.
+// ---------------------------------------------------------------------------
+static void suite_negative_control() {
+    head("C. NEGATIVE CONTROL: a genuinely different produced template still FAILs");
+
+    struct T { const char* field; bool sentinel; node::MinerData md; };
+    const node::MinerData base_md = miner_data(kStallHeight, kNativePoolN);
+
+    std::vector<T> ts;
+    { T a{"major_version", true,  miner_data(kStallHeight, kDaemonPoolN)};
+      a.md.major_version += 1;           ts.push_back(a); }
+    { T b{"difficulty", true,     miner_data(kStallHeight, kDaemonPoolN)};
+      b.md.difficulty.lo += 1;           ts.push_back(b); }
+    { T c{"seed_hash", true,      miner_data(kStallHeight, kDaemonPoolN)};
+      c.md.seed_hash[7] ^= 0x01;         ts.push_back(c); }
+    { T d{"median_weight", true,  miner_data(kStallHeight, kDaemonPoolN)};
+      d.md.median_weight += 1;           ts.push_back(d); }
+    { T e{"already_generated_coins", true, miner_data(kStallHeight, kDaemonPoolN)};
+      e.md.already_generated_coins += 1; ts.push_back(e); }
+
+    CHECK(ts.size() + 1 == TEMPLATE_SEAM.required_equality_count(),
+          "C0 the control perturbs every required EQUALITY field except the alignment "
+          "key prev_id (%zu of %zu)", ts.size() + 1, TEMPLATE_SEAM.required_equality_count());
+
+    BacklogFamineConfig fcfg;
+    fcfg.consecutive = 6;
+    fcfg.sustained_s = 30;
+
+    for (const T& t : ts) {
+        Leg leg;
+        leg.serving     = "monerod";
+        leg.served_md   = t.md;        // what the daemon served: one unit off
+        leg.shadow_name = "native";
+        leg.shadow_md   = base_md;     // what the native arm would have produced
+        const Run run = drive(leg, 8, fcfg);
+
+        CHECK(run.fail == run.samples.size() && run.clean == 0,
+              "C1 one unit in %s must FAIL every sample: %zu fail / %zu clean",
+              t.field, run.fail, run.clean);
+        CHECK(has_diff(run.samples.front(), t.field),
+              "C1 the differing field %s must be named in the diff", t.field);
+        CHECK(run.samples.front().sentinel_tripped == t.sentinel,
+              "C1 %s sentinel expectation", t.field);
+
+        // ...and the ledger does what the soak's ledger does with a FAIL.
+        GraduationKey key;
+        key.c2pool_commit = "m4-ptpl-gate-kat";
+        key.net           = "stagenet";
+        M4GraduationLedger led(key, SoakThresholds::stagenet_m4());
+        std::uint64_t t0 = 1789200000;
+        for (const SeamResult& r : run.samples) {
+            led.record(SoakPosture::ServeMonerodShadowNative, r, t0);
+            t0 += 20;
+        }
+        const PostureLeg& L = led.leg(SoakPosture::ServeMonerodShadowNative);
+        CHECK(L.clean_run == 0, "C2 %s: a real divergence must hold the streak at 0, got %llu",
+              t.field, static_cast<unsigned long long>(L.clean_run));
+        CHECK(led.state() == GraduationState::Revoked,
+              "C2 %s: a sentinel divergence must revoke the key", t.field);
+    }
+
+    // C3. The alignment key. A different prev_id is two arms answering about two
+    // different blocks, which is VOID rather than FAIL -- and VOID is not CLEAN,
+    // so it still cannot carry a streak.
+    {
+        node::MinerData other = miner_data(kStallHeight, kDaemonPoolN);
+        other.prev_id[3] ^= 0x01;
+        Leg leg;
+        leg.serving     = "monerod";
+        leg.served_md   = other;
+        leg.shadow_name = "native";
+        leg.shadow_md   = base_md;
+        const Run run = drive(leg, 4, fcfg);
+        CHECK(run.clean == 0, "C3 a different prev_id may never be CLEAN, got %zu clean",
+              run.clean);
+        CHECK(run.voided == run.samples.size(),
+              "C3 a different prev_id is VOID (different questions), got %zu void of %zu",
+              run.voided, run.samples.size());
+    }
+
+    // C4. A different SELECTED TRANSACTION SET, on its own, is NOT a divergence.
+    // This is the by-design difference the v37 relay rule creates, and it must
+    // stay out of the verdict even though the digest row makes it visible.
+    {
+        node::MinerData daemon_pool = miner_data(kStallHeight, 3);
+        for (std::size_t i = 0; i < daemon_pool.tx_backlog.size(); ++i)
+            daemon_pool.tx_backlog[i].id = hash_of(static_cast<std::uint8_t>(0xd0 + i));
+
+        Leg leg;
+        leg.serving     = "monerod";
+        leg.served_md   = daemon_pool;                            // three txs, all different
+        leg.shadow_name = "native";
+        leg.shadow_md   = miner_data(kStallHeight, kNativePoolN);  // five, none of them shared
+        const Run run = drive(leg, 40, fcfg);
+        CHECK(run.clean == run.samples.size(),
+              "C4 two entirely disjoint pools must still be CLEAN: %zu/%zu",
+              run.clean, run.samples.size());
+        CHECK(has_diff(run.samples.front(), "selected_tx_set"),
+              "C4 ...and the disjointness must be visible in the report");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE D -- M2h is not given back.
+// ---------------------------------------------------------------------------
+static void suite_m2h_preserved() {
+    head("D. leg 2 (serve=native): a starving native pool still REFUSES");
+
+    BacklogFamineConfig fcfg;
+    fcfg.consecutive = 6;
+    fcfg.sustained_s = 30;
+
+    // D1. The M2h regression, in the posture where it costs money: the native
+    // arm serves empty templates while the daemon holds transactions.
+    {
+        Leg leg;
+        leg.serving     = "native";
+        leg.served_md   = miner_data(kStallHeight, 0);   // we serve nothing
+        leg.shadow_name = "monerod";
+        leg.shadow_md   = miner_data(kStallHeight, 5);   // the daemon holds five
+        const Run run = drive(leg, 20, fcfg);
+        CHECK(run.fail > 0, "D1 a starving SERVING native arm must still FAIL");
+        CHECK(run.samples.back().sample.verdict == ParityVerdict::Fail,
+              "D1 the run must end in refusal, got %s",
+              to_string(run.samples.back().sample.verdict));
+        CHECK(run.famine_tripped, "D1 the guard must be REFUSING: %s", run.famine_line.c_str());
+        CHECK(run.clean <= fcfg.consecutive,
+              "D1 only the pre-threshold samples may be clean, got %zu", run.clean);
+    }
+
+    // D2. ...and the fixed behaviour in the same posture stays clean, including
+    // the propagation-skew case a naive gate would false-positive on.
+    {
+        Leg leg;
+        leg.serving     = "native";
+        leg.served_md   = miner_data(kStallHeight, 1);
+        leg.shadow_name = "monerod";
+        leg.shadow_md   = miner_data(kStallHeight, 50);
+        const Run run = drive(leg, 20, fcfg);
+        CHECK(run.clean == run.samples.size(),
+              "D2 holding 1 of the daemon's 50 is skew, not famine: %zu/%zu clean",
+              run.clean, run.samples.size());
+    }
+
+    // D3. A REAL native famine while the DAEMON is serving. It does not gate --
+    // nothing is served from the native pool in that posture -- but it is now
+    // CLASSIFIED and COUNTED, which is strictly more than the seat-fed judge
+    // could do: fed by seat, this same shape arrived as `Fed` and was invisible.
+    {
+        Leg leg;
+        leg.serving     = "monerod";
+        leg.served_md   = miner_data(kStallHeight, 7);   // the daemon holds seven
+        leg.shadow_name = "native";
+        leg.shadow_md   = miner_data(kStallHeight, 0);   // the native pool holds none
+        const Run run = drive(leg, 20, fcfg);
+        CHECK(run.clean == run.samples.size(),
+              "D3 a leg-1 native famine must not reset the graduation streak: %zu/%zu",
+              run.clean, run.samples.size());
+        CHECK(!run.famine_tripped, "D3 ...and must not trip the gate in this posture");
+        CHECK(run.famine_line.find("advisory=20(starved 20)") != std::string::npos,
+              "D3 ...but it must be COUNTED and visible: %s", run.famine_line.c_str());
+    }
+
+    // D4. The guard's own arithmetic, directly: the posture fence is a property
+    // of the guard, not only of the way the oracle happens to call it.
+    {
+        BacklogFamineGuard g(fcfg);
+        BacklogFamineGuard::Input in;
+        in.aligned        = true;
+        in.native_known   = true;
+        in.native_backlog = 0;
+        in.daemon_known   = true;
+        in.daemon_backlog = 9;
+        in.native_is_serving_arm = false;
+        for (std::uint64_t i = 0; i < 50; ++i) {
+            in.at_unix = 1000 + i * 60;
+            const auto o = g.observe(in);
+            CHECK(o.check.ok, "D4 an advisory sample must never fail (sample %llu)",
+                  static_cast<unsigned long long>(i));
+            CHECK(o.advisory, "D4 ...and must say it was advisory");
+            CHECK(o.cls == BacklogSampleClass::Starved,
+                  "D4 ...while still classifying the shape it saw, got %s", to_string(o.cls));
+        }
+        CHECK(!g.tripped(), "D4 fifty advisory samples must not trip the guard");
+        CHECK(g.streak() == 0, "D4 ...and must not build the gating streak, got %zu", g.streak());
+        CHECK(g.advisory() == 50 && g.advisory_starved() == 50,
+              "D4 ...but must be counted: advisory=%llu starved=%llu",
+              static_cast<unsigned long long>(g.advisory()),
+              static_cast<unsigned long long>(g.advisory_starved()));
+
+        // The same guard, same numbers, with the native arm SERVING: it trips.
+        in.native_is_serving_arm = true;
+        for (std::uint64_t i = 0; i < 6; ++i) {
+            in.at_unix = 5000 + i * 60;
+            g.observe(in);
+        }
+        CHECK(g.tripped(), "D4 the identical shape in the serving posture must trip");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE E -- the table, and the ledger key.
+// ---------------------------------------------------------------------------
+static void suite_table() {
+    head("E. the P-TPL table: what is scored, what is only rendered");
+
+    auto regime_of = [](const char* name, Regime* out) {
+        for (std::size_t i = 0; i < TEMPLATE_SEAM.count; ++i)
+            if (std::strcmp(TEMPLATE_SEAM.fields[i].name, name) == 0) {
+                *out = TEMPLATE_SEAM.fields[i].regime;
+                return true;
+            }
+        return false;
+    };
+
+    Regime r{};
+    CHECK(regime_of("tx_backlog_count", &r) && r == Regime::Measurement,
+          "E1 tx_backlog_count must remain a MEASUREMENT (rendered, never scored)");
+    CHECK(regime_of("selected_tx_set", &r) && r == Regime::NotComparable,
+          "E2 the selected transaction set must be NOT-COMPARABLE, by recorded decision");
+    CHECK(regime_of(kBacklogFamineCheck, &r) && r == Regime::Constraint,
+          "E3 the famine SHAPE stays a CONSTRAINT");
+    CHECK(TEMPLATE_SEAM.required_equality_count() == 6,
+          "E4 the fix must not have changed what is required: %zu",
+          TEMPLATE_SEAM.required_equality_count());
+
+    // E5. No transaction merkle root, and no equality over the selected set, has
+    // crept in. Either would re-create the same false divergence in a form that
+    // looks more rigorous: the two arms hold different transactions by design.
+    for (std::size_t i = 0; i < TEMPLATE_SEAM.count; ++i) {
+        const FieldSpec& f = TEMPLATE_SEAM.fields[i];
+        const bool tx_shaped = std::strstr(f.name, "tx_") != nullptr
+                            || std::strstr(f.name, "merkle") != nullptr
+                            || std::strcmp(f.name, "selected_tx_set") == 0;
+        if (!tx_shaped) continue;
+        CHECK(f.regime != Regime::Equality,
+              "E5 '%s' must never be an EQUALITY: the two pools differ by design", f.name);
+    }
+
+    // E6. The ledger key moved, so no streak earned under the seat-fed judge can
+    // be inherited by this one.
+    CHECK(COMPARATOR_VERSION >= 4,
+          "E6 the comparator version must have moved past 3, got %u",
+          static_cast<unsigned>(COMPARATOR_VERSION));
+
+    // E7. The digest is order-independent: two arms that hold the same
+    // transactions in a different selection order must not read as different.
+    {
+        node::MinerData a = miner_data(kStallHeight, 4);
+        node::MinerData b = a;
+        std::vector<node::TxBacklogEntry> rev(b.tx_backlog.rbegin(), b.tx_backlog.rend());
+        b.tx_backlog = rev;
+        CHECK(tx_set_digest(a.tx_backlog) == tx_set_digest(b.tx_backlog),
+              "E7 the digest must not depend on selection order");
+        node::MinerData c = miner_data(kStallHeight, 4);
+        c.tx_backlog[2].id = hash_of(0xfe);
+        CHECK(tx_set_digest(a.tx_backlog) != tx_set_digest(c.tx_backlog),
+              "E7 ...but must change when the SET changes");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SUITE F -- configurations with no native arm at all.
+// ---------------------------------------------------------------------------
+static void suite_no_native_arm() {
+    head("F. a bring-up with no native arm makes no famine claim at all");
+
+    BacklogFamineConfig fcfg;
+    fcfg.consecutive = 2;
+    fcfg.sustained_s = 10;
+
+    // Two daemon arms (a monerod-vs-monerod bring-up). There is no native pool
+    // to starve, and picking whichever seat is nearest to hand is the bug this
+    // target exists to close, so the guard must make no claim.
+    Leg leg;
+    leg.serving     = "monerod";
+    leg.served_md   = miner_data(kStallHeight, 0);
+    leg.shadow_name = "monerod-b";
+    leg.shadow_md   = miner_data(kStallHeight, 11);
+    const Run run = drive(leg, 30, fcfg);
+
+    CHECK(run.clean == run.samples.size(),
+          "F1 a configuration with no native arm must stay CLEAN: %zu/%zu",
+          run.clean, run.samples.size());
+    CHECK(!run.famine_tripped, "F1 ...and must never trip the guard: %s",
+          run.famine_line.c_str());
+}
+
+// ---------------------------------------------------------------------------
+int main(int argc, char** argv) {
+    (void)argc; (void)argv;
+    std::printf("xmr_native_m4_ptpl_backlog_gate_kat -- the M4 leg-1 P-TPL stall\n");
+    std::printf("comparator version %u\n", static_cast<unsigned>(COMPARATOR_VERSION));
+
+    suite_stall_case();
+    suite_streak();
+    suite_negative_control();
+    suite_m2h_preserved();
+    suite_table();
+    suite_no_native_arm();
+
+    std::printf("\n%d checks, %d failures\n", g_checks, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/src/impl/xmr/native/test/xmr_parity_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_parity_kat.cpp
@@ -359,13 +359,15 @@ void suite_absence() {
 void suite_table() {
     std::printf("== B. the frozen determinism table (comparator v%u) ==\n", COMPARATOR_VERSION);
 
-    // Version 3 since M2h added the native_backlog_famine CONSTRAINT to the
-    // P-TPL table (M1's version 2 was the P-POOL seam joining). This stays an
-    // EXACT number rather than a floor on purpose: its whole job is to make
-    // anyone who edits a table move the ledger key too, so that a clean streak
-    // can never be inherited across a change to what is compared.
-    CHECK(COMPARATOR_VERSION == 3,
-          "comparator version is 3 (the P-TPL backlog constraint joined the table)");
+    // Version 4 since the M4 leg-1 fix re-decided the native_backlog_famine
+    // CONSTRAINT by ARM IDENTITY, fenced it to the SERVING arm, and added the
+    // selected_tx_set NotComparable row (version 3 was that constraint joining
+    // at M2h; version 2 was the P-POOL seam joining at M1). This stays an EXACT
+    // number rather than a floor on purpose: its whole job is to make anyone who
+    // edits a table move the ledger key too, so that a clean streak can never be
+    // inherited across a change to what is compared.
+    CHECK(COMPARATOR_VERSION == 4,
+          "comparator version is 4 (the P-TPL famine constraint is judged by arm identity)");
     CHECK(POOL_SEAM.required_equality_count() == 3,
           "POOL requires 3 EQUALITY fields (weight, fee, blob_size), got %zu",
           POOL_SEAM.required_equality_count());

--- a/src/impl/xmr/native/test/xmr_txpool_parity_kat.cpp
+++ b/src/impl/xmr/native/test/xmr_txpool_parity_kat.cpp
@@ -164,12 +164,14 @@ static P::PoolSnapshot native_snapshot(const RelayedTxPool& pool) {
 // 1: the seam table
 // ---------------------------------------------------------------------------
 static void test_seam_table() {
-    // 3 since M2h added the native_backlog_famine CONSTRAINT to P-TPL. The pin
-    // is EXACT, not a floor: its job is to make anyone who edits a table move
-    // the ledger key with it, so a clean streak can never be inherited across a
-    // change to what is judged.
-    check(P::COMPARATOR_VERSION == 3,
-          "the comparator version was bumped when the P-TPL backlog constraint joined");
+    // 4 since the M4 leg-1 fix re-decided the native_backlog_famine CONSTRAINT
+    // by ARM IDENTITY and fenced it to the serving arm (3 was that constraint
+    // joining P-TPL at M2h). The pin is EXACT, not a floor: its job is to make
+    // anyone who edits a table move the ledger key with it, so a clean streak
+    // can never be inherited across a change to what is judged.
+    check(P::COMPARATOR_VERSION == 4,
+          "the comparator version was bumped when the P-TPL famine constraint "
+          "stopped being judged by seat");
     check(&P::seam_spec(ProbeKind::Pool) == &P::POOL_SEAM,
           "seam_spec() knows about ProbeKind::Pool");
     checkf(P::POOL_SEAM.required_equality_count() == 3,


### PR DESCRIPTION
**DRAFT — DO NOT MERGE.** Opened for review only. Base `master` @ `47cb31d5`.

## The stall

The M4 parity soak on stagenet (`c2pool#1594` harness, commit `b03ce935`) ran 14 hours against a node that was healthy by every other measure — `synced=1 peers=8/8 reorgs=0 orphans=0`, posture `serve-monerod` — and never graduated. The `M4GraduationLedger` recorded **2,259 resets** of the leg-1 clean streak (`best_clean_run=1754`, `best_blocks=127`, `best_seconds=16473` against a 720-block / 259,200 s gate), and every recent P-TEMPLATE FAIL carried the same diff:

```
tx_backlog_count served=0 shadow=5      seam=TEMPLATE
note: 1 constraint(s) violated; [P-TPL served_by=monerod]
```

All six required EQUALITY rows — `prev_id`, `major_version`, `difficulty`, `seed_hash`, `median_weight`, `already_generated_coins` — agreed at every height.

## What the two numbers were

They are not the same quantity.

| | what it counts |
|---|---|
| `served=0` | the **daemon's** mempool as `get_miner_data.tx_backlog` offers it to a template builder. Stagenet was quiet; the daemon returned no `tx_backlog` key at all. |
| `shadow=5` | the **native** pool's *selectable set*, admitted under the v37 relay rule — structural checks plus range-proof and commitment evidence, **no key-image double-spend test**. A deliberately different admission rule. Node status at the time: `txpool: gate=1 n=5 acc=193 rej=0`. |

The two arms hold different transactions **by construction**, not by accident.

## What actually fired

Not an equality on that row — `tx_backlog_count` is a `Regime::Measurement` and always was. What FAILed was the `native_backlog_famine` **CONSTRAINT**, which `ParityOracle::run_template_` fed **by seat**: the SERVED seat into `native_backlog`, the SHADOW seat into the daemon count. In the leg that serves from monerod those two seats hold the two arms *the other way round*. The daemon's empty mempool became "the native pool is starving"; the native pool's five transactions became "the daemon holds transactions we cannot see". Six samples, thirty seconds, and the guard tripped — stickily, by design, so it never recovered.

The mirror consequence is worse than the stall: in that same posture a **real** native famine classified as `Fed`, so the constraint could not have detected the regression it was added for (M2h, `c2pool#1588`).

## The fix

1. **By arm identity, never by seat.** The guard's inputs are `native_backlog` / `daemon_backlog`, and the oracle picks the arms out by NAME. A monerod-vs-monerod bring-up now makes no famine claim rather than inventing one from a seat.
2. **Fenced to the serving arm.** The claim the guard exists to refuse — "every template *we serve* is empty of fee revenue" — is about the arm miners are served from. While the native arm only shadows, the shape is classified, counted and shown in the status line as **advisory**, and never travels out as a failed CONSTRAINT. That is strictly more sight than before: fed by seat, this shape was invisible.
3. **The by-design difference is recorded, not scored.** `tx_backlog_count` stays a Measurement; P-TPL gains `selected_tx_set` as an explicit `NotComparable` row (count plus an order-independent XOR digest of the selected tx ids), so the delta is visible in the report. It is deliberately **not** an equality — and neither is a tx merkle root computed from it, which would re-create the same false divergence in a more rigorous-looking form. The six consensus inputs of the produced template remain the equality sentinels; `median_timestamp` remains a native-side constraint.

**M2h is not given back:** in the posture the constraint was written for — the native arm SERVING — a native pool holding nothing while the daemon holds transactions still trips the guard and still FAILs.

`COMPARATOR_VERSION` 3 → 4. Existing ledgers are refused on load and both posture streaks restart. That is intended and costs nothing here — the live leg-1 streak was already being reset roughly once per template refresh.

## KAT

`xmr_native_m4_ptpl_backlog_gate_kat` — 220 checks, registered with `add_test` **and** in BOTH `--target` lists in `.github/workflows/build.yml` (the `c2pool#1539` lesson).

- **A/B — the stall case.** The exact stagenet sample driven through the real `ParityOracle` in the real leg-1 posture: 800 consecutive CLEAN, zero FAIL, guard never trips, and both by-design differences still rendered in the diff (`tx_backlog_count served=0 shadow=5`, `selected_tx_set`) so the sample is not made clean by hiding anything. The same stream through `M4GraduationLedger` climbs `clean_run` to 800, past the stagenet threshold — the stall expressed as a number.
- **C — negative control.** One unit in each of the six template consensus inputs in turn still FAILs (or VOIDs, for the alignment key `prev_id`), sentinels still revoke the key, the ledger still holds `clean_run` at 0 — and two *entirely disjoint* transaction pools are still CLEAN.
- **D — M2h preserved**, plus the guard's posture fence tested directly.
- **E — the table**: `tx_backlog_count` still a Measurement, `selected_tx_set` NotComparable, required equality count still 6, no `tx_`/`merkle`-shaped row may ever be an Equality, version moved past 3.
- **F** — no-native-arm configuration makes no claim.

**Reproduction, run adversarially:** built against a temporarily restored seat-fed judge, the *same* target reports **795 of 800 samples FAILing** and a ledger streak of **0 with 795 resets** — the observed soak behaviour — plus `fed=20` for a real leg-1 famine, which is the mirror bug. The negative control (suite C) passes under *both* judges, confirming it is independent of the fix.

## Verification

Built on the soak host (gcc 13.3.0, Boost 1.83), in a scratch clone and scratch build dir; the running soak, its watchdog and the stagenet daemon were not touched.

| target | result |
|---|---|
| `xmr_native_m4_ptpl_backlog_gate_kat` | 220 checks, 0 failures |
| `xmr_native_parity_kat` | 833 checks, 0 failures |
| `xmr_native_backlog_famine_kat` | 119 checks, 0 failures |
| `xmr_native_m4_soak_kat` | 165 checks, 0 failures |
| `xmr_native_txpool_parity_kat` | 210 checks, 0 failures |
| `xmr_native_node` | links clean |

**1,547 checks, 0 failures.**

## Scope

Consumer tree only: `src/impl/xmr/native/parity/**`, `src/impl/xmr/native/test/**`, `.github/workflows/build.yml`. No consensus digest, no `src/sharechain/v37`, no `owed_digest`.

## Redeploy

Nothing accrued is lost by redeploying: the live leg-1 streak resets on essentially every template refresh, and the version bump discards the ledger key by design. Redeploying is a rebuild plus a restart of the soak node **only**, through its own watchdog, by recorded PID — the stagenet daemon stays up and untouched.
