### PR TITLE
ci: gate all heavy VM905 (c2pool-build) legs on one heavy-leg semaphore (SLOTS=3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,12 @@ jobs:
       # so concurrent jobs can never tear each other's ~/.conan2 (root cause of the
       # 1.90.0 torn-header flakes). RUNNER_TEMP is only valid at step scope, so
       # export it via $GITHUB_ENV -- a job-level `env: runner.temp` fails to parse.
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.
@@ -763,6 +769,12 @@ jobs:
       # self-hosted host never tear each other's cache (root of the boost
       # torn-cache reds). Export via $GITHUB_ENV -- a job-level `env: runner.temp`
       # fails to parse.
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.
@@ -1119,6 +1131,12 @@ jobs:
       # For an observability defect the check IS the fix: fail closed if the
       # checked-out HEAD is ever not the head we asked for, and force the full
       # working tree back onto disk before any consumer reads it.
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Assert head + materialize tree + guard cache path (fail closed)
         working-directory: ${{ github.workspace }}
         run: |
@@ -1767,6 +1785,12 @@ jobs:
       # self-hosted host never tear each other's cache (root of the boost
       # torn-cache reds). Export via $GITHUB_ENV -- a job-level `env: runner.temp`
       # fails to parse.
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
 
@@ -1895,6 +1919,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.
@@ -774,7 +774,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.
@@ -1136,7 +1136,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Assert head + materialize tree + guard cache path (fail closed)
         working-directory: ${{ github.workspace }}
         run: |
@@ -1790,7 +1790,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: echo "CONAN_HOME=$RUNNER_TEMP/conan2" >> "$GITHUB_ENV"
 
@@ -1924,7 +1924,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -118,12 +118,12 @@ jobs:
           #      orphan, is by definition dead.
           # HEAVY_LEG_* env overrides exist ONLY for the honesty-gate test
           # (.github/actions/heavy-leg-lock/test.sh); production uses the defaults.
-          LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-heavy-leg.lock}"
-          HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}"
+          LOCK="${HEAVY_LEG_LOCK:-/tmp/c2pool-build-heavy-leg.lock}"
+          HOLDERFILE="${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-build-heavy-leg.holder}"
           WAIT="${HEAVY_LEG_WAIT:-5400}"
           TTL="${HEAVY_LEG_TTL:-14400}"
           SWEEP="${HEAVY_LEG_SWEEP:-1}"
-          SLOTS="${HEAVY_LEG_SLOTS:-2}"
+          SLOTS="${HEAVY_LEG_SLOTS:-4}"
           ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
 
           # Slot files are ${LOCK}.1 .. ${LOCK}.SLOTS; each slot's live holder records a
@@ -443,7 +443,7 @@ jobs:
           if [ -n "$H" ]; then
             kill "$H" 2>/dev/null || true
             # drop whichever per-slot marker this holder owns
-            for MF in "${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-heavy-leg.holder}".*; do
+            for MF in "${HEAVY_LEG_HOLDERFILE:-/tmp/c2pool-build-heavy-leg.holder}".*; do
               [ -f "$MF" ] || continue
               read -r _mh _ < "$MF" 2>/dev/null || true
               [ "${_mh:-}" = "$H" ] && rm -f "$MF" || true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -123,7 +123,7 @@ jobs:
           WAIT="${HEAVY_LEG_WAIT:-5400}"
           TTL="${HEAVY_LEG_TTL:-14400}"
           SWEEP="${HEAVY_LEG_SWEEP:-1}"
-          SLOTS="${HEAVY_LEG_SLOTS:-4}"
+          SLOTS="${HEAVY_LEG_SLOTS:-3}"
           ACQ="$(mktemp -u /tmp/c2pool-heavy-acq.XXXXXX)"
 
           # Slot files are ${LOCK}.1 .. ${LOCK}.SLOTS; each slot's live holder records a

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -69,6 +69,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/coin-matrix.yml
+++ b/.github/workflows/coin-matrix.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/dash-gate-g1-byte-parity.yml
+++ b/.github/workflows/dash-gate-g1-byte-parity.yml
@@ -41,6 +41,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -44,6 +44,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/dash-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/dash-gate-g3a-regtest-block-production.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/dgb-g3a-smoke.yml
+++ b/.github/workflows/dgb-g3a-smoke.yml
@@ -32,6 +32,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then

--- a/.github/workflows/dgb-g3a-smoke.yml
+++ b/.github/workflows/dgb-g3a-smoke.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -34,6 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/dgb-phase-b-smoke.yml
+++ b/.github/workflows/dgb-phase-b-smoke.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           # github-hosted: ephemeral per-job home, warmed by actions/cache below.

--- a/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
@@ -42,6 +42,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Acquire VM905 build-host heavy-leg semaphore
+        uses: ./.github/actions/heavy-leg-lock
+        with:
+          lock-file: /tmp/c2pool-build-heavy-leg.lock
+          holder-file: /tmp/c2pool-build-heavy-leg.holder
+          slots: "4"
       - name: Set per-job Conan home
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then

--- a/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
+++ b/.github/workflows/ltc-gate-g3a-regtest-block-production.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           lock-file: /tmp/c2pool-build-heavy-leg.lock
           holder-file: /tmp/c2pool-build-heavy-leg.holder
-          slots: "4"
+          slots: "3"
       - name: Set per-job Conan home
         run: |
           if [ "${{ runner.environment }}" = "github-hosted" ]; then


### PR DESCRIPTION
Take (a) per integrator 2026-09-12. Gates every heavy c2pool-build (VM905) leg on ONE 905-only semaphore so heavy legs stop oversubscribing the 32c/62G box (the ~15-concurrent-leg flood that caused 1h36m starvation fake-reds).

## Gated onto /tmp/c2pool-build-heavy-leg.lock (SLOTS=3)
- build.yml: linux (Build-tests), coin-bch, web-static, coin-dgb-auxdoge, linux-dash-bls
- coin-matrix.yml: the 5-coin matrix
- codeql-analysis.yml: retargeted from the default path to this shared lock
- dash-gate-g1, dash-gate-g3a, ltc-gate-g3a, dgb-g3a, dgb-phase-b regtest smokes

All acquire the same reap-guard heavy-leg-lock action right after checkout, so on VM905 they share one semaphore.

## SLOTS=3 arithmetic (32 vCPU / 62 GB, per-leg -j${BUILD_J:-4}, brief -j8 spikes)
- CPU: 3 legs x 4 threads = 12 of 32 cores; 20 left for ctest bursts, the ungated light legs (changes, test-allowlist-guard) and -j8 link spikes.
- RAM: peak build+link+test RSS ~6-8 GB/leg x 3 = 18-24 GB of ~56 GB usable (~2.3-3x headroom). Pre-gate 8-way co-residency ~64 GB > 62 GB => OOM/thrash.
- Not 1 (serializes, wastes 2/3 of the box); not 4+ (drifts back toward the oversubscription edge under -j8 link spikes + ctest bursts). 3 is the conservative floor of the agreed 3-4 band.

## OUT of scope by design
The ASan/UBSan legs on the **c2pool-heavy host (oplex7020)** -- linux-asan, coin-bch-asan -- keep the default /tmp/c2pool-heavy-leg.lock. Different physical host, its own /tmp, and now a distinct lock NAME so the two hosts are never re-conflated. release.yml (tag/dispatch-triggered, not the per-PR flood) is left ungated.

## Scope-honesty
SLOTS=3 is set in ALL 11 gated legs listed above AND on codeql's default lock -- no gated leg is left at 4. This is the complete gated set on VM905; there is no additional heavy leg silently left at the old ceiling.

## Negative-case honesty gate
Unchanged. acquire.sh is fail-closed (set -euo pipefail; all-slots-busy => ::error:: + exit 1 with per-slot holder diagnostics, never a fake-green); heavy-leg-lock/test.sh still asserts it.

Do not merge -- opening for review per your instruction; report on merge decision.
