### PR TITLE
share-dice: provably-fair core + verifier + play-money sim (#194)

### DIFF
--- a/ui/share-dice/CMakeLists.txt
+++ b/ui/share-dice/CMakeLists.txt
@@ -1,0 +1,48 @@
+# share-dice: provably-fair core + verifier + play-money simulator + KATs.
+#
+# STANDALONE / DEFAULT-OFF / PLAY-MONEY. This is its own CMake project and is
+# NOT added to the c2pool root build and NOT to any Qt build (nothing under
+# ui/ references it, ui/ has no aggregating CMakeLists). It does not compile
+# into the pool node and touches no money-path/consensus code.
+#
+# It reuses ONLY c2pool's vendored SHA-256 (src/btclibs/crypto/sha256.cpp),
+# compiled here on the portable code path (no USE_ASM / no bitcoin-config.h),
+# so SHA is never hand-rolled and no node/Qt/Boost dependency is pulled in.
+#
+# Build & test standalone (from the repo root):
+#   cmake -S ui/share-dice -B build/share-dice
+#   cmake --build build/share-dice
+#   ctest --test-dir build/share-dice --output-on-failure
+
+cmake_minimum_required(VERSION 3.16)
+project(share_dice LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Locate the c2pool source tree (two levels up: ui/share-dice -> repo root).
+get_filename_component(C2POOL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../src" ABSOLUTE)
+set(SHA256_SRC "${C2POOL_SRC}/btclibs/crypto/sha256.cpp")
+
+if(NOT EXISTS "${SHA256_SRC}")
+    message(FATAL_ERROR "share-dice: expected c2pool SHA-256 at ${SHA256_SRC}")
+endif()
+
+# Provably-fair engine + verifier + overlay, reusing c2pool's SHA-256.
+add_library(share_dice STATIC
+    src/engine.cpp
+    "${SHA256_SRC}")
+target_include_directories(share_dice PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/include"
+    "${C2POOL_SRC}")            # for <btclibs/crypto/sha256.h>, <btclibs/compat/*>
+# Portable SHA path only: do NOT define USE_ASM or HAVE_CONFIG_H here.
+
+# Play-money simulator CLI.
+add_executable(share-dice-sim src/sim_main.cpp)
+target_link_libraries(share-dice-sim PRIVATE share_dice)
+
+# KATs.
+enable_testing()
+add_executable(share-dice-test test/share_dice_test.cpp)
+target_link_libraries(share-dice-test PRIVATE share_dice)
+add_test(NAME share-dice-test COMMAND share-dice-test)

--- a/ui/share-dice/include/share_dice/engine.hpp
+++ b/ui/share-dice/include/share_dice/engine.hpp
@@ -1,0 +1,216 @@
+// share-dice: provably-fair commit-reveal engine + verifier + play-money overlay.
+//
+// STANDALONE / DEFAULT-OFF / PLAY-MONEY ONLY.
+//
+// This module is a self-contained tool. It does NOT compile into the c2pool
+// pool node, and it deliberately touches NONE of the money path: no PPLNS
+// accounting (src/impl/**/pplns*), no donation script (src/core/donation.hpp),
+// no coinbase construction, no share validation, and no consensus surface.
+//
+// It implements only the SAFE, decision-independent fairness primitive from
+// docs/design/share-dice.md (design/share-dice, PR #1630): the provably-fair
+// commit-reveal roll (design section 3.1), the SatoshiDice game table
+// (section 1.1, grounded in frstrtr/satoshidice main.py), the standalone
+// verifier (section 4), and the solvency/bounds math (section 3.3) exercised
+// against a PLAY-MONEY overlay ledger only.
+//
+// The real-pot hook (reading a miner's pending PPLNS credit as the bet ceiling,
+// and settling net winnings from the operator-controlled donation pot, design
+// section 3.2 option A) is intentionally UNWIRED. See the clearly-named seam
+// `RealPotBinding` at the bottom of this header. Nothing here connects it.
+
+#ifndef SHARE_DICE_ENGINE_HPP
+#define SHARE_DICE_ENGINE_HPP
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace share_dice {
+
+// ---------------------------------------------------------------------------
+// Game table (design section 1.1, verbatim from frstrtr/satoshidice main.py).
+// A roll is an integer in [0, 65535]; total_outcomes = 65536.
+// A bet WINS iff roll <= winning_thresholds[tier].
+// ---------------------------------------------------------------------------
+inline constexpr int kNumTiers = 11;
+inline constexpr uint32_t kTotalOutcomes = 65536;
+
+// winning_thresholds = [65,649,1289,2596,6488,21627,32440,43253,48103,58982,61790]
+extern const uint32_t kWinningThresholds[kNumTiers];
+
+// multipliers = [1000,100,50,25,10,3,2,1.5,1.33,1.1,1.05]
+// Stored scaled by 100 for exact integer-satoshi math (design section 3.3
+// mandates integer-satoshi math with banker-safe rounding). No floating point
+// touches any settlement number.
+extern const int64_t kMultiplierX100[kNumTiers];
+
+// Domain-separation prefix for the roll (design section 3.1).
+inline constexpr const char* kRollDomain = "c2pool-share-dice/v1";
+
+// ---------------------------------------------------------------------------
+// SHA-256 helpers. These wrap c2pool's vendored CSHA256
+// (src/btclibs/crypto/sha256) - SHA is never hand-rolled here.
+// ---------------------------------------------------------------------------
+std::vector<uint8_t> sha256_raw(const uint8_t* data, size_t len);
+std::vector<uint8_t> sha256_raw(const std::string& data);      // over the string's bytes
+std::string sha256_hex(const std::string& data);               // hex(SHA256(bytes))
+std::string hex_encode(const std::vector<uint8_t>& bytes);
+std::vector<uint8_t> hex_decode(const std::string& hex);        // throws std::invalid_argument on bad hex
+
+// ---------------------------------------------------------------------------
+// Provably-fair primitives (design section 3.1 + reference verifier section 4).
+// ---------------------------------------------------------------------------
+
+// Server-seed hash chain: S_{i-1} = SHA256(S_i), hashing the seed's RAW bytes.
+// Given a terminal seed S_N (hex of 32 bytes), returns the chain
+// [S_0, S_1, ..., S_N] as hex strings, so chain[i] == S_i and the published
+// head is chain[0]. (Design section 3.1: "S_{i-1} = SHA256(S_i)".)
+std::vector<std::string> build_seed_chain(const std::string& terminal_seed_hex, int n);
+
+// Verify a reveal against the previously published commitment:
+//   SHA256(raw(seed_i)) hex == commit_prev_hex   (== S_{i-1}).
+// (Reference verifier check_chain, design section 4.)
+bool verify_chain_link(const std::string& commit_prev_hex, const std::string& seed_i_hex);
+
+// bet_id = SHA256("{client_seed}|{miner_id}|{round_index}|{per_round_seq}") hex.
+// (Design section 3.1 line: bet_id = SHA256(client_seed || miner_id ||
+// round_index || per_round_seq); reference verifier pins the "|"-joined
+// decimal encoding.) The share hash is deliberately NOT an input.
+std::string make_bet_id(const std::string& client_seed,
+                        const std::string& miner_id,
+                        uint64_t round_index,
+                        uint64_t per_round_seq);
+
+// roll = int(SHA256("c2pool-share-dice/v1" || S_i_hex || ":" || bet_id_hex)[0:4], big) % 65536.
+// S_i_hex and bet_id_hex are the ASCII hex strings (design section 3.1 / section 4
+// reference: S_i_hex.encode(), bet_id_hex.encode()). The share hash is NOT an
+// input, which closes the pool-specific grinding vector (design section 3.1).
+uint32_t compute_roll(const std::string& seed_i_hex, const std::string& bet_id_hex);
+
+// ---------------------------------------------------------------------------
+// Outcome & settlement math (design section 3.3). Pure functions, satoshi ints.
+// ---------------------------------------------------------------------------
+enum class Outcome { Lose = 0, Win = 1 };
+
+// win iff roll <= winning_thresholds[tier].
+Outcome outcome_for_roll(int tier, uint32_t roll);
+
+// Net winnings the house pays a winner: round((mult - 1) * amount), banker's
+// (round-half-to-even) rounding on the /100 scale.
+int64_t net_house_payout(int tier, int64_t amount);
+
+// Total credited back to a winner: stake returned + net winnings == mult*amount
+// (exact for integer multipliers). Conserves value with net_house_payout.
+int64_t payout_on_win(int tier, int64_t amount);
+
+// Solvency cap (design section 3.3 invariant 2):
+//   max_bet(tier, house_balance) = floor(house_balance / (mult - 1)).
+// Guarantees the maximum possible payout is fully covered by the current pot.
+int64_t max_bet(int tier, int64_t house_balance);
+
+// ---------------------------------------------------------------------------
+// Standalone verifier (design section 4). Anyone can re-run this on a past bet
+// using only public data. Depends only on SHA-256.
+// ---------------------------------------------------------------------------
+struct VerifyResult {
+    bool commitment_ok = false;  // SHA256(raw(seed_i)) == commitment
+    bool roll_ok = false;        // recomputed roll == claimed_roll
+    bool outcome_ok = false;     // recomputed win/lose == claimed_outcome
+    bool ok = false;             // all three
+    uint32_t roll = 0;           // recomputed roll
+};
+
+VerifyResult verify(const std::string& commitment_hex,
+                    const std::string& seed_i_hex,
+                    const std::string& bet_id_hex,
+                    int tier,
+                    uint32_t claimed_roll,
+                    Outcome claimed_outcome);
+
+// ---------------------------------------------------------------------------
+// Play-money overlay engine. A pool-local ledger analog of design section 3.2,
+// but seeded with PLAY-MONEY only. It never reads real PPLNS credit and never
+// settles into a real pot (see RealPotBinding seam below).
+// ---------------------------------------------------------------------------
+struct BetRecord {
+    std::string miner_id;
+    int tier = 0;
+    int64_t amount = 0;
+    std::string bet_id;
+    uint64_t per_round_seq = 0;
+};
+
+struct BetSettlement {
+    std::string miner_id;
+    std::string bet_id;
+    int tier = 0;
+    int64_t amount = 0;
+    uint32_t roll = 0;
+    Outcome outcome = Outcome::Lose;
+    int64_t payout = 0;          // credited back to miner (0 on lose)
+    int64_t house_delta = 0;     // change to house_balance for this bet
+};
+
+class DiceEngine {
+public:
+    explicit DiceEngine(int64_t house_balance = 0);
+
+    // Play-money account management (NOT a real ledger).
+    void fund_house(int64_t amount);
+    void credit_miner(const std::string& miner_id, int64_t amount);
+    int64_t house_balance() const { return house_balance_; }
+    int64_t credit_of(const std::string& miner_id) const;
+
+    // Round lifecycle. `commitment_hex` is S_{i-1}, published before any bet.
+    void open_round(const std::string& commitment_hex, uint64_t round_index);
+    bool round_open() const { return round_open_; }
+    const std::string& round_commitment() const { return round_commitment_; }
+
+    // place_bet(tier, amount, bet_id) records a commitment for `miner_id`.
+    // Rejects (throws std::invalid_argument): amount <= 0, amount > miner credit,
+    // or amount > max_bet(tier, house_balance) (solvency, design section 3.3).
+    // Escrows the stake by debiting miner credit at accept time.
+    // Returns the per-round sequence number assigned to the bet.
+    uint64_t place_bet(const std::string& miner_id, int tier, int64_t amount,
+                       const std::string& bet_id);
+
+    // reveal(seed_i): verifies SHA256(raw(seed_i)) == round commitment, computes
+    // the roll for every bet in published sequence order, and settles each into
+    // the play-money overlay. Throws std::runtime_error if the reveal does not
+    // match the commitment (all stakes remain escrowed; caller may void round).
+    std::vector<BetSettlement> reveal(const std::string& seed_i_hex);
+
+    const std::vector<BetRecord>& bets() const { return bets_; }
+
+private:
+    int64_t house_balance_;
+    std::map<std::string, int64_t> credit_;
+    std::string round_commitment_;
+    uint64_t round_index_ = 0;
+    bool round_open_ = false;
+    uint64_t next_seq_ = 0;
+    std::vector<BetRecord> bets_;
+};
+
+// ---------------------------------------------------------------------------
+// UNWIRED SEAM - do not connect without operator legal + settlement sign-off.
+//
+// In production (design section 3.2 option A) the bet ceiling would be a
+// miner's pending PPLNS credit (read-only, from src/impl/dash/dashboard_pplns),
+// and net winnings would be settled from the operator-controlled donation pot
+// (src/core/donation.hpp). Both are money-path/consensus-adjacent and are the
+// operator-gated part of the feature. This interface is declared but NOT
+// implemented and NOT called anywhere. Wiring it is a separate, reviewed,
+// default-OFF, operator-armed change - never done by this slice.
+// ---------------------------------------------------------------------------
+struct RealPotBinding {
+    // int64_t pending_pplns_credit(const std::string& miner_id) const; // UNWIRED
+    // int64_t donation_pot_balance() const;                            // UNWIRED
+    // void settle_winnings(const std::string& miner_id, int64_t sats); // UNWIRED
+};
+
+}  // namespace share_dice
+
+#endif  // SHARE_DICE_ENGINE_HPP

--- a/ui/share-dice/src/engine.cpp
+++ b/ui/share-dice/src/engine.cpp
@@ -1,0 +1,252 @@
+// share-dice provably-fair engine implementation. PLAY-MONEY / STANDALONE only.
+// See include/share_dice/engine.hpp for the full standalone/default-OFF notice.
+// SHA-256 is reused from c2pool's vendored CSHA256; it is never hand-rolled.
+
+#include "share_dice/engine.hpp"
+
+#include <btclibs/crypto/sha256.h>
+
+#include <cstdio>
+#include <stdexcept>
+
+namespace share_dice {
+
+const uint32_t kWinningThresholds[kNumTiers] = {
+    65, 649, 1289, 2596, 6488, 21627, 32440, 43253, 48103, 58982, 61790};
+
+// multipliers = [1000,100,50,25,10,3,2,1.5,1.33,1.1,1.05] scaled by 100.
+const int64_t kMultiplierX100[kNumTiers] = {
+    100000, 10000, 5000, 2500, 1000, 300, 200, 150, 133, 110, 105};
+
+namespace {
+
+void require_tier(int tier) {
+    if (tier < 0 || tier >= kNumTiers)
+        throw std::invalid_argument("share_dice: tier out of range [0,10]");
+}
+
+// Round-half-to-even division of a non-negative numerator by a positive scale.
+// (Banker-safe rounding, design section 3.3.)
+int64_t round_half_even(int64_t numer, int64_t scale) {
+    int64_t q = numer / scale;
+    int64_t r = numer % scale;
+    int64_t twice = 2 * r;
+    if (twice < scale) return q;
+    if (twice > scale) return q + 1;
+    return (q % 2 == 0) ? q : q + 1;  // exact tie -> nearest even
+}
+
+}  // namespace
+
+std::vector<uint8_t> sha256_raw(const uint8_t* data, size_t len) {
+    unsigned char out[CSHA256::OUTPUT_SIZE];
+    CSHA256().Write(data, len).Finalize(out);
+    return std::vector<uint8_t>(out, out + CSHA256::OUTPUT_SIZE);
+}
+
+std::vector<uint8_t> sha256_raw(const std::string& data) {
+    return sha256_raw(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+}
+
+std::string hex_encode(const std::vector<uint8_t>& bytes) {
+    static const char* d = "0123456789abcdef";
+    std::string s;
+    s.reserve(bytes.size() * 2);
+    for (uint8_t b : bytes) {
+        s.push_back(d[b >> 4]);
+        s.push_back(d[b & 0x0f]);
+    }
+    return s;
+}
+
+std::string sha256_hex(const std::string& data) { return hex_encode(sha256_raw(data)); }
+
+std::vector<uint8_t> hex_decode(const std::string& hex) {
+    if (hex.size() % 2 != 0)
+        throw std::invalid_argument("share_dice: hex length must be even");
+    auto nib = [](char c) -> int {
+        if (c >= '0' && c <= '9') return c - '0';
+        if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+        if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+        return -1;
+    };
+    std::vector<uint8_t> out;
+    out.reserve(hex.size() / 2);
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        int hi = nib(hex[i]), lo = nib(hex[i + 1]);
+        if (hi < 0 || lo < 0)
+            throw std::invalid_argument("share_dice: invalid hex digit");
+        out.push_back(static_cast<uint8_t>((hi << 4) | lo));
+    }
+    return out;
+}
+
+std::vector<std::string> build_seed_chain(const std::string& terminal_seed_hex, int n) {
+    if (n < 0) throw std::invalid_argument("share_dice: chain length must be >= 0");
+    std::vector<std::string> chain(static_cast<size_t>(n) + 1);
+    chain[n] = terminal_seed_hex;  // S_N = terminal seed
+    for (int i = n; i >= 1; --i) {
+        // S_{i-1} = SHA256(raw bytes of S_i)
+        std::vector<uint8_t> raw = hex_decode(chain[i]);
+        chain[i - 1] = hex_encode(sha256_raw(raw.data(), raw.size()));
+    }
+    return chain;
+}
+
+bool verify_chain_link(const std::string& commit_prev_hex, const std::string& seed_i_hex) {
+    std::vector<uint8_t> raw = hex_decode(seed_i_hex);
+    return hex_encode(sha256_raw(raw.data(), raw.size())) == commit_prev_hex;
+}
+
+std::string make_bet_id(const std::string& client_seed,
+                        const std::string& miner_id,
+                        uint64_t round_index,
+                        uint64_t per_round_seq) {
+    std::string pre = client_seed + "|" + miner_id + "|" +
+                      std::to_string(round_index) + "|" +
+                      std::to_string(per_round_seq);
+    return sha256_hex(pre);
+}
+
+uint32_t compute_roll(const std::string& seed_i_hex, const std::string& bet_id_hex) {
+    // SHA256("c2pool-share-dice/v1" || S_i_hex || ":" || bet_id_hex), ASCII hex.
+    std::string pre = std::string(kRollDomain) + seed_i_hex + ":" + bet_id_hex;
+    std::vector<uint8_t> h = sha256_raw(pre);
+    uint32_t v = (static_cast<uint32_t>(h[0]) << 24) |
+                 (static_cast<uint32_t>(h[1]) << 16) |
+                 (static_cast<uint32_t>(h[2]) << 8) |
+                 (static_cast<uint32_t>(h[3]));
+    return v % kTotalOutcomes;
+}
+
+Outcome outcome_for_roll(int tier, uint32_t roll) {
+    require_tier(tier);
+    return (roll <= kWinningThresholds[tier]) ? Outcome::Win : Outcome::Lose;
+}
+
+int64_t net_house_payout(int tier, int64_t amount) {
+    require_tier(tier);
+    if (amount < 0) throw std::invalid_argument("share_dice: negative amount");
+    // round((mult - 1) * amount) = round((multX100 - 100) * amount / 100)
+    return round_half_even((kMultiplierX100[tier] - 100) * amount, 100);
+}
+
+int64_t payout_on_win(int tier, int64_t amount) {
+    // stake returned + net winnings (== mult*amount for integer multipliers)
+    return amount + net_house_payout(tier, amount);
+}
+
+int64_t max_bet(int tier, int64_t house_balance) {
+    require_tier(tier);
+    if (house_balance < 0) throw std::invalid_argument("share_dice: negative pot");
+    // floor(house_balance / (mult - 1)) = floor(house_balance * 100 / (multX100 - 100))
+    int64_t denom = kMultiplierX100[tier] - 100;  // > 0 for all tiers
+    return (house_balance * 100) / denom;
+}
+
+VerifyResult verify(const std::string& commitment_hex,
+                    const std::string& seed_i_hex,
+                    const std::string& bet_id_hex,
+                    int tier,
+                    uint32_t claimed_roll,
+                    Outcome claimed_outcome) {
+    require_tier(tier);
+    VerifyResult r;
+    r.commitment_ok = verify_chain_link(commitment_hex, seed_i_hex);
+    r.roll = compute_roll(seed_i_hex, bet_id_hex);
+    r.roll_ok = (r.roll == claimed_roll);
+    Outcome recomputed = outcome_for_roll(tier, r.roll);
+    r.outcome_ok = (recomputed == claimed_outcome);
+    r.ok = r.commitment_ok && r.roll_ok && r.outcome_ok;
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// DiceEngine (play-money overlay).
+// ---------------------------------------------------------------------------
+DiceEngine::DiceEngine(int64_t house_balance) : house_balance_(house_balance) {
+    if (house_balance < 0) throw std::invalid_argument("share_dice: negative pot");
+}
+
+void DiceEngine::fund_house(int64_t amount) {
+    if (amount < 0) throw std::invalid_argument("share_dice: negative fund");
+    house_balance_ += amount;
+}
+
+void DiceEngine::credit_miner(const std::string& miner_id, int64_t amount) {
+    if (amount < 0) throw std::invalid_argument("share_dice: negative credit");
+    credit_[miner_id] += amount;
+}
+
+int64_t DiceEngine::credit_of(const std::string& miner_id) const {
+    auto it = credit_.find(miner_id);
+    return it == credit_.end() ? 0 : it->second;
+}
+
+void DiceEngine::open_round(const std::string& commitment_hex, uint64_t round_index) {
+    round_commitment_ = commitment_hex;
+    round_index_ = round_index;
+    round_open_ = true;
+    next_seq_ = 0;
+    bets_.clear();
+}
+
+uint64_t DiceEngine::place_bet(const std::string& miner_id, int tier, int64_t amount,
+                               const std::string& bet_id) {
+    require_tier(tier);
+    if (!round_open_) throw std::invalid_argument("share_dice: no open round");
+    if (amount <= 0) throw std::invalid_argument("share_dice: bet must be > 0");
+    if (amount > credit_of(miner_id))
+        throw std::invalid_argument("share_dice: bet exceeds miner credit");
+    if (amount > max_bet(tier, house_balance_))
+        throw std::invalid_argument("share_dice: bet exceeds solvency cap (max_bet)");
+
+    credit_[miner_id] -= amount;  // escrow stake at accept
+    BetRecord rec;
+    rec.miner_id = miner_id;
+    rec.tier = tier;
+    rec.amount = amount;
+    rec.bet_id = bet_id;
+    rec.per_round_seq = next_seq_++;
+    bets_.push_back(rec);
+    return rec.per_round_seq;
+}
+
+std::vector<BetSettlement> DiceEngine::reveal(const std::string& seed_i_hex) {
+    if (!round_open_) throw std::runtime_error("share_dice: no open round to reveal");
+    if (!verify_chain_link(round_commitment_, seed_i_hex))
+        throw std::runtime_error(
+            "share_dice: reveal does not match commitment (round should be voided)");
+
+    std::vector<BetSettlement> out;
+    out.reserve(bets_.size());
+    // Settle in published sequence order (design section 3.3 invariant 5).
+    for (const BetRecord& b : bets_) {
+        BetSettlement s;
+        s.miner_id = b.miner_id;
+        s.bet_id = b.bet_id;
+        s.tier = b.tier;
+        s.amount = b.amount;
+        s.roll = compute_roll(seed_i_hex, b.bet_id);
+        s.outcome = outcome_for_roll(b.tier, s.roll);
+        if (s.outcome == Outcome::Win) {
+            int64_t winnings = net_house_payout(b.tier, b.amount);
+            // Defense-in-depth solvency re-check against the running pot.
+            if (winnings > house_balance_)
+                throw std::runtime_error("share_dice: solvency breach at settle");
+            s.payout = b.amount + winnings;   // stake returned + winnings
+            s.house_delta = -winnings;
+            credit_[b.miner_id] += s.payout;
+            house_balance_ -= winnings;
+        } else {
+            s.payout = 0;
+            s.house_delta = b.amount;         // escrowed stake goes to house
+            house_balance_ += b.amount;
+        }
+        out.push_back(s);
+    }
+    round_open_ = false;
+    return out;
+}
+
+}  // namespace share_dice

--- a/ui/share-dice/src/sim_main.cpp
+++ b/ui/share-dice/src/sim_main.cpp
@@ -1,0 +1,97 @@
+// share-dice play-money simulator (CLI). PLAY-MONEY / STANDALONE only.
+//
+// The SatoshiDice-sim analog, but using the real provably-fair commit-reveal
+// (design section 3.1) instead of random.randint. NOTHING here settles real
+// value; the "balance" is play-money credit in a local overlay. It does not
+// touch PPLNS, the donation pot, coinbase, or any consensus surface.
+//
+// Usage:
+//   share-dice-sim [--house N] [--balance N] [--seed HEX] [--client STR]
+//                  [--miner STR] [--rounds K] [--tier T] [--bet N]
+// All flags optional; defaults give a short deterministic demo that also
+// prints, for every bet, the data an outside party needs to independently
+// verify the roll (design section 4).
+
+#include "share_dice/engine.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+using namespace share_dice;
+
+namespace {
+const char* arg_str(int argc, char** argv, const char* key, const char* dflt) {
+    for (int i = 1; i + 1 < argc; ++i)
+        if (std::strcmp(argv[i], key) == 0) return argv[i + 1];
+    return dflt;
+}
+long long arg_ll(int argc, char** argv, const char* key, long long dflt) {
+    const char* v = arg_str(argc, argv, key, nullptr);
+    return v ? std::atoll(v) : dflt;
+}
+const char* outcome_str(Outcome o) { return o == Outcome::Win ? "WIN " : "LOSE"; }
+}  // namespace
+
+int main(int argc, char** argv) {
+    int64_t house = arg_ll(argc, argv, "--house", 100000000);   // play-money pot
+    int64_t balance = arg_ll(argc, argv, "--balance", 1000000); // player's play credit
+    std::string terminal_seed =
+        arg_str(argc, argv, "--seed",
+                "f00dbabe00000000000000000000000000000000000000000000000000000001");
+    std::string client_seed = arg_str(argc, argv, "--client", "player-entropy-001");
+    std::string miner = arg_str(argc, argv, "--miner", "miner-A");
+    int rounds = static_cast<int>(arg_ll(argc, argv, "--rounds", 5));
+    int tier = static_cast<int>(arg_ll(argc, argv, "--tier", 6));  // 2x tier
+    int64_t bet = arg_ll(argc, argv, "--bet", 1000);
+
+    if (tier < 0 || tier >= kNumTiers) {
+        std::cerr << "tier must be in [0," << (kNumTiers - 1) << "]\n";
+        return 2;
+    }
+
+    std::cout << "== share-dice PLAY-MONEY simulator (no real value) ==\n";
+    std::cout << "house pot     : " << house << " (play)\n";
+    std::cout << "player credit : " << balance << " (play)\n";
+    std::cout << "tier          : " << tier << "  multiplier x100 = "
+              << kMultiplierX100[tier] << "  win iff roll <= "
+              << kWinningThresholds[tier] << "\n";
+    std::cout << "max_bet(tier) : " << max_bet(tier, house) << "\n\n";
+
+    // Build the server-seed hash chain and publish the head (design section 3.1).
+    std::vector<std::string> chain = build_seed_chain(terminal_seed, rounds);
+    std::cout << "published head commitment S_0 = " << chain[0] << "\n";
+    std::cout << "(seeds S_1..S_" << rounds
+              << " revealed one per round; SHA256(S_i) == S_{i-1})\n\n";
+
+    DiceEngine engine(house);
+    engine.credit_miner(miner, balance);
+
+    for (int i = 1; i <= rounds && engine.credit_of(miner) >= bet; ++i) {
+        // Round i is committed to S_{i-1} (already public); S_i is revealed after.
+        engine.open_round(chain[i - 1], static_cast<uint64_t>(i));
+        std::string bet_id = make_bet_id(client_seed, miner, i, /*seq=*/0);
+        engine.place_bet(miner, tier, bet, bet_id);
+
+        std::vector<BetSettlement> settled = engine.reveal(chain[i]);
+        const BetSettlement& s = settled.front();
+
+        std::cout << "round " << i << "  commit(S_" << (i - 1) << ")=" << chain[i - 1]
+                  << "\n          reveal(S_" << i << ")=" << chain[i]
+                  << "\n          bet_id=" << bet_id
+                  << "\n          roll=" << s.roll << "  " << outcome_str(s.outcome)
+                  << "  payout=" << s.payout << "  house_delta=" << s.house_delta
+                  << "\n          credit=" << engine.credit_of(miner)
+                  << "  house=" << engine.house_balance();
+
+        VerifyResult v = verify(chain[i - 1], chain[i], bet_id, tier, s.roll, s.outcome);
+        std::cout << "  [verify " << (v.ok ? "OK" : "FAIL") << "]\n\n";
+    }
+
+    std::cout << "final player credit : " << engine.credit_of(miner) << " (play)\n";
+    std::cout << "final house pot      : " << engine.house_balance() << " (play)\n";
+    std::cout << "\nNOTE: play-money only. No PPLNS / donation / coinbase / consensus "
+                 "was touched; no real value was settled.\n";
+    return 0;
+}

--- a/ui/share-dice/test/share_dice_test.cpp
+++ b/ui/share-dice/test/share_dice_test.cpp
@@ -1,0 +1,214 @@
+// share-dice KATs. Deterministic vectors only - no RNG anywhere in the tests.
+//
+// Exercises the SAFE, play-money core: the provably-fair commit-reveal roll,
+// the standalone verifier, the 11-tier SatoshiDice table, grinding-resistance,
+// and the solvency-cap math. Touches no PPLNS/donation/coinbase/consensus code.
+//
+// Returns 0 iff every KAT passes (ctest reads the exit code).
+
+#include "share_dice/engine.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <stdexcept>
+#include <string>
+
+using namespace share_dice;
+
+namespace {
+
+int g_fail = 0;
+int g_checks = 0;
+
+void check(bool cond, const char* what) {
+    ++g_checks;
+    if (!cond) {
+        ++g_fail;
+        std::printf("    FAIL: %s\n", what);
+    }
+}
+
+bool throws_invalid(const std::function<void()>& fn) {
+    try {
+        fn();
+    } catch (const std::exception&) {
+        return true;
+    }
+    return false;
+}
+
+// Fixed KAT vectors (computed once from the construction, then frozen here).
+// terminal/revealed seed S_1 (32 bytes) and its self-authenticating commitment
+// S_0 = SHA256(raw(S_1)); a fixed bet_id; and the roll they must always yield.
+const std::string S1 =
+    "1122334455667788990011223344556677889900112233445566778899001122";
+const std::string S0 =
+    "ff81cbb6c0299fd36e97e78a774e859e9e3528b6f2ac50c1a430d2e726e80e1e";
+const std::string BET_ID =
+    "6d07d32050be6d3890be4255447212b18bddd1fd193f12b8918921d67177bf18";
+const uint32_t ROLL = 55234;  // 55234 > 32440 (tier 6) but <= 58982 (tier 9)
+
+// KAT (a): commit-reveal correctness - a fixed seed + bet_id yields a fixed
+// roll, the chain link authenticates, and the standalone verifier accepts.
+void kat_a_commit_reveal_correctness() {
+    std::printf("KAT (a) commit-reveal correctness\n");
+    // bet_id reproduces exactly from its public inputs.
+    check(make_bet_id("kat-client-seed", "kat-miner", 1, 0) == BET_ID,
+          "make_bet_id matches frozen vector");
+    // chain link: SHA256(raw(S_1)) == S_0.
+    check(verify_chain_link(S0, S1), "verify_chain_link(S0, S1) true");
+    // fixed roll.
+    check(compute_roll(S1, BET_ID) == ROLL, "compute_roll matches frozen roll 55234");
+    // build_seed_chain reproduces the same S_0/S_1 pair.
+    auto chain = build_seed_chain(S1, 1);
+    check(chain.size() == 2 && chain[0] == S0 && chain[1] == S1,
+          "build_seed_chain reproduces (S0,S1)");
+    // verifier accepts a correct LOSE (tier 6) and a correct WIN (tier 9).
+    VerifyResult lose = verify(S0, S1, BET_ID, 6, ROLL, Outcome::Lose);
+    check(lose.ok && lose.commitment_ok && lose.roll_ok && lose.outcome_ok,
+          "verify accepts correct tier-6 LOSE");
+    VerifyResult win = verify(S0, S1, BET_ID, 9, ROLL, Outcome::Win);
+    check(win.ok, "verify accepts correct tier-9 WIN");
+}
+
+// KAT (b): tamper detection - a wrong revealed seed fails the commitment check,
+// both at the primitive and through the engine's reveal path.
+void kat_b_tamper_detection() {
+    std::printf("KAT (b) tamper detection (wrong revealed seed)\n");
+    std::string tampered =
+        "1122334455667788990011223344556677889900112233445566778899001123";  // last byte 22->23
+    check(!verify_chain_link(S0, tampered),
+          "verify_chain_link rejects tampered seed");
+    check(compute_roll(tampered, BET_ID) != ROLL,
+          "tampered seed produces a different roll");
+    // engine: an open round committed to S_0 must reject a reveal != S_1.
+    DiceEngine eng(1000000);
+    eng.credit_miner("m", 1000);
+    eng.open_round(S0, 1);
+    eng.place_bet("m", 6, 100, BET_ID);
+    check(throws_invalid([&] { eng.reveal(tampered); }),
+          "engine.reveal rejects a seed not matching the commitment");
+}
+
+// KAT (c): a mismatched-commitment reveal is rejected by the verifier.
+void kat_c_mismatched_commitment() {
+    std::printf("KAT (c) mismatched-commitment reveal rejected\n");
+    std::string bogus_commit =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+    VerifyResult r = verify(bogus_commit, S1, BET_ID, 6, ROLL, Outcome::Lose);
+    check(!r.commitment_ok, "commitment_ok is false for a bogus commitment");
+    check(!r.ok, "verify overall rejects a mismatched commitment");
+    // roll itself still recomputes correctly - only the commitment binding fails.
+    check(r.roll == ROLL, "roll still recomputes even when commitment mismatches");
+}
+
+// KAT (d): the 11-tier win/lose boundary. roll == threshold WINS,
+// threshold+1 LOSES, for every tier. Plus the extremes (0 wins, 65535 loses).
+void kat_d_tier_boundaries() {
+    std::printf("KAT (d) 11-tier win/lose boundary\n");
+    for (int t = 0; t < kNumTiers; ++t) {
+        uint32_t thr = kWinningThresholds[t];
+        check(outcome_for_roll(t, thr) == Outcome::Win,
+              "roll == threshold WINS");
+        check(outcome_for_roll(t, thr + 1) == Outcome::Lose,
+              "roll == threshold+1 LOSES");
+        check(outcome_for_roll(t, 0) == Outcome::Win, "roll 0 always WINS");
+        check(outcome_for_roll(t, kTotalOutcomes - 1) == Outcome::Lose,
+              "roll 65535 always LOSES (no threshold reaches it)");
+    }
+}
+
+// KAT (e): grinding-resistance property - the roll is INDEPENDENT of any share
+// hash. There is no share input to bet_id or to the roll, so a miner producing
+// arbitrarily many share hashes cannot move the outcome. Deterministic sweep.
+void kat_e_grinding_resistance() {
+    std::printf("KAT (e) grinding-resistance (roll independent of any share hash)\n");
+    bool bet_id_stable = true;
+    bool roll_stable = true;
+    for (int k = 0; k < 4096; ++k) {
+        // A candidate share hash a grinding miner might produce; it is NOT an
+        // input to either construction, so neither value may change.
+        std::string fake_share = sha256_hex("share-candidate-" + std::to_string(k));
+        (void)fake_share;
+        std::string bid = make_bet_id("kat-client-seed", "kat-miner", 1, 0);
+        if (bid != BET_ID) bet_id_stable = false;
+        if (compute_roll(S1, bid) != ROLL) roll_stable = false;
+    }
+    check(bet_id_stable, "bet_id is invariant across 4096 candidate share hashes");
+    check(roll_stable, "roll is invariant across 4096 candidate share hashes");
+}
+
+// KAT (f): solvency-cap math and accept-time rejections.
+void kat_f_solvency_cap() {
+    std::printf("KAT (f) solvency cap math + accept-time rejection\n");
+    // max_bet(tier, house) = floor(house / (mult - 1)).
+    check(max_bet(6, 100000000) == 100000000, "max_bet tier6 (2x): house/1");
+    check(max_bet(0, 999000) == 1000, "max_bet tier0 (1000x): house/999");
+    check(max_bet(7, 1000) == 2000, "max_bet tier7 (1.5x): house*2");   // /0.5
+    check(max_bet(0, 999) == 1, "max_bet tier0 floors 999/999 = 1");
+    check(max_bet(0, 998) == 0, "max_bet tier0 floors 998/999 = 0");
+
+    // Engine accept-time enforcement, tier 0 (1000x). house/999 = 100.
+    DiceEngine eng(99900);
+    eng.credit_miner("m", 100000);
+    eng.open_round(S0, 1);
+    check(max_bet(0, 99900) == 100, "max_bet(tier0, 99900) == 100");
+    check(throws_invalid([&] { eng.place_bet("m", 0, 0, BET_ID); }),
+          "reject bet amount == 0");
+    check(throws_invalid([&] { eng.place_bet("m", 0, -5, BET_ID); }),
+          "reject negative bet amount");
+    check(throws_invalid([&] { eng.place_bet("m", 0, 101, BET_ID); }),
+          "reject bet > max_bet (solvency cap)");
+    // Exactly max_bet is accepted.
+    bool ok = true;
+    try {
+        eng.place_bet("m", 0, 100, BET_ID);
+    } catch (...) {
+        ok = false;
+    }
+    check(ok, "accept bet == max_bet");
+
+    // A miner cannot stake more than accrued credit.
+    DiceEngine eng2(1000000000);  // huge pot, so the cap here is credit, not solvency
+    eng2.credit_miner("poor", 50);
+    eng2.open_round(S0, 1);
+    check(throws_invalid([&] { eng2.place_bet("poor", 6, 51, BET_ID); }),
+          "reject bet > miner credit");
+}
+
+// Extra: end-to-end play-money settlement conserves value and honors the log.
+void kat_g_overlay_conservation() {
+    std::printf("KAT (+) play-money overlay settlement conserves value\n");
+    DiceEngine eng(1000000);
+    eng.credit_miner("m", 10000);
+    int64_t total_before = eng.house_balance() + eng.credit_of("m");
+    eng.open_round(S0, 1);
+    std::string bid = make_bet_id("kat-client-seed", "kat-miner", 1, 0);
+    eng.place_bet("m", 9, 1000, bid);  // tier 9 (1.33x) - this vector WINS at tier 9
+    auto settled = eng.reveal(S1);
+    check(settled.size() == 1, "one settlement produced");
+    check(settled[0].roll == ROLL, "settled roll matches frozen roll");
+    check(settled[0].outcome == Outcome::Win, "tier-9 bet wins on this vector");
+    int64_t total_after = eng.house_balance() + eng.credit_of("m");
+    check(total_before == total_after, "house + credit conserved across settlement");
+    // verifier agrees with the engine's published settlement.
+    VerifyResult v = verify(S0, S1, bid, 9, settled[0].roll, settled[0].outcome);
+    check(v.ok, "verifier agrees with engine settlement");
+}
+
+}  // namespace
+
+int main() {
+    std::printf("== share-dice KATs ==\n");
+    kat_a_commit_reveal_correctness();
+    kat_b_tamper_detection();
+    kat_c_mismatched_commitment();
+    kat_d_tier_boundaries();
+    kat_e_grinding_resistance();
+    kat_f_solvency_cap();
+    kat_g_overlay_conservation();
+    std::printf("\n%d checks, %d failures\n", g_checks, g_fail);
+    if (g_fail == 0) std::printf("ALL KATS PASS\n");
+    return g_fail == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Implements the SAFE, decision-independent core of share-dice as a standalone,
default-off, play-money-only module. This is the design`s recommended
testnet/play-money-first slice from `docs/design/share-dice.md` (design branch,
PR #1630). It implements the provably-fair commit-reveal engine, a standalone
verifier, the eleven-tier SatoshiDice game table, solvency/bounds math, a
play-money simulator, and known-answer tests.

It does NOT wire the money path. No PPLNS accounting, no donation script, no
coinbase, no share validation, no consensus surface, and no real-value
settlement are touched. The real-pot binding is left as a clearly named,
unwired seam.

## Where it lives

A self-contained CMake project under `ui/share-dice/`. It is not added to the
pool node build and not to any Qt build (nothing references it, `ui/` has no
aggregating CMakeLists). It reuses only the vendored SHA-256
(`src/btclibs/crypto/sha256.cpp`) on its portable code path, so SHA is never
hand-rolled and no node/Qt/Boost dependency is pulled in.

## Roll construction (design section 3.1 + section 4 reference verifier)

```
bet_id = SHA256(client_seed | miner_id | round_index | per_round_seq)   (hex)
roll   = int(SHA256("c2pool-share-dice/v1" + S_i_hex + ":" + bet_id_hex)[0:4], big) mod 65536
win iff roll <= winning_thresholds[tier]
```

The server-seed hash chain uses `S_{i-1} = SHA256(S_i)` over raw seed bytes.
The share hash is deliberately not an input, which closes the pool-specific
grinding vector.

Game table taken verbatim (frstrtr/satoshidice `main.py`):
`winning_thresholds = [65,649,1289,2596,6488,21627,32440,43253,48103,58982,61790]`,
`multipliers = [1000,100,50,25,10,3,2,1.5,1.33,1.1,1.05]` (stored scaled by 100
for exact integer-satoshi math with banker-safe rounding).

## What is included

- Provably-fair engine: seed-chain build/verify, `make_bet_id`, `compute_roll`,
  a stateful `place_bet` / `reveal` overlay (play-money), and outcome/settlement.
- Standalone `verify(commitment, seed_i, bet_id, tier, claimed_roll, claimed_outcome)`.
- Solvency helpers: `max_bet(tier, house_balance) = floor(house / (mult - 1))`,
  reject amount <= 0, reject amount > cap, reject amount > credit.
- Play-money simulator CLI (`share-dice-sim`) that prints and verifies each roll.
- KATs (`share-dice-test`, ctest): commit-reveal correctness, tamper detection,
  mismatched-commitment rejection, eleven-tier win/lose boundary,
  grinding-resistance property, solvency-cap math, plus an overlay-conservation
  check. Deterministic vectors only. All pass (74 checks, 0 failures).

## Build and test

```
cmake -S ui/share-dice -B build/share-dice
cmake --build build/share-dice
ctest --test-dir build/share-dice --output-on-failure
```

## Not in scope (money path, operator-gated)

Reading real pending PPLNS credit as the bet ceiling and settling net winnings
from the operator-controlled donation pot are the money-path/consensus-adjacent
parts of the design (section 3.2 option A). Those remain an unwired seam gated
on operator legal and settlement decisions. This PR arms nothing and is opened
as a draft.
