### PR TITLE
c2wallet-qt: M6 UI slice 1 - import, construct+convert, scan (read/construct flows)

### DIFF
--- a/ui/c2wallet-qt/CMakeLists.txt
+++ b/ui/c2wallet-qt/CMakeLists.txt
@@ -18,12 +18,16 @@ project(c2wallet_qt LANGUAGES CXX)
 # c2pool-qt's Widgets shell PATTERN (MainWindow + sidebar + stacked pages),
 # never its networked dependencies.
 #
-# M0 is the foundation phase: no keys, no signing, no crypto yet. It stands up
-# the tree, the Widgets-only skeleton, and the mechanical proof of the
-# network-incapable property (ci/check_no_network.sh, enforced in CI).
+# M6 SLICE 1 wires the read/construct flows to the merged offline libraries:
+# the Import/Load, Construct+Convert and Scan (Monero view-only) screens call
+# the real Qt-free library functions (c2wallet-hdkeys / c2wallet-convert /
+# c2wallet_monero). Those libraries link only libsecp256k1 / zlib / the
+# vendored Monero crypto — no Qt, no networking — so the signer INHERITS the
+# network-incapable property. The signing / tx-build / air-gap-transfer screens
+# remain visible stubs (slice 2). No money-path signing UX in this slice.
 #
 # Install the build deps on Debian/Ubuntu via:
-#   sudo apt install qt6-base-dev
+#   sudo apt install qt6-base-dev libsecp256k1-dev zlib1g-dev
 # (qt6-base-dev provides Core/Gui/Widgets — NO webengine/webchannel package is
 #  needed or wanted here.)
 # ═══════════════════════════════════════════════════════════════════════════
@@ -37,27 +41,57 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# ── Merged offline libraries the signer links (M6 slice 1) ──────────────────
+# All three are deliberately Qt-free and network-free static libraries (see each
+# subdir'"'"'s CMakeLists). Adding them here (guarded, so the -DC2WALLET_QT_BUILD_TESTS
+# path below does not double-add) lets the signer call the REAL merged functions
+# instead of mock-ups. They pull in libsecp256k1 / zlib / the vendored Monero
+# crypto only — the network-incapable link-guard (ci/check_no_network.sh) still
+# passes, and CI enforces it.
+if(NOT TARGET c2wallet-hdkeys)
+    add_subdirectory(src/family/bitcoin/hdkeys)
+endif()
+if(NOT TARGET c2wallet-convert)
+    add_subdirectory(src/family/bitcoin/construct)
+endif()
+if(NOT TARGET c2wallet_monero)
+    add_subdirectory(src/family/monero)
+endif()
+
 add_executable(c2wallet-qt-signer
     src/main.cpp
     src/shell/MainWindow.cpp
+    src/shell/PageImport.cpp
+    src/shell/PageConstructConvert.cpp
+    src/shell/PageScan.cpp
 )
+
+# The wired pages include the C++20 hdkeys/convert public headers; build the
+# signer TUs at C++20 too (a superset of the C++17 Monero headers).
+set_target_properties(c2wallet-qt-signer PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON)
 
 target_include_directories(c2wallet-qt-signer PRIVATE src)
 
 # The whole security invariant in one place. If a future phase adds
 # Qt6::Network / Qt6::WebEngine* / Qt6::WebChannel / a curl / an asio here, the
 # ci/check_no_network.sh link-guard (below and in CI) turns red — that is the
-# tripwire, and it is deliberate.
+# tripwire, and it is deliberate. The three merged libraries linked below are
+# Qt-free and network-free, so they do not perturb the guard.
 target_link_libraries(c2wallet-qt-signer PRIVATE
     Qt6::Core
     Qt6::Gui
     Qt6::Widgets
+    c2wallet-hdkeys
+    c2wallet-convert
+    c2wallet_monero
 )
 
 # ═══════════════════════════════════════════════════════════════════════════
 # c2wallet-qt-companion — the ONLINE, KEY-FREE companion (#193), design §5.2.
 # The OPPOSITE of the signer: the online side, which MAY link the network. We
-# link Qt6::Network here on purpose — the concrete contrast to the signer's
+# link Qt6::Network here on purpose — the concrete contrast to the signer'"'"'s
 # network-incapable link-guard. It still holds NO keys: it links the key-free
 # c2wallet-companion library (which links only the M5-A artifact library, hence
 # only the vendored SHA-256), NEVER the key-bearing signer core. The mechanical
@@ -93,7 +127,9 @@ if(C2WALLET_QT_BUILD_TESTS)
     # (family/bitcoin/hdkeys). It links no Qt and no networking, so it can also be
     # built and tested standalone:
     #   cmake -S ui/c2wallet-qt/src/family/bitcoin/hdkeys -B build-hdkeys -DC2WALLET_QT_BUILD_TESTS=ON
-    add_subdirectory(src/family/bitcoin/hdkeys)
+    if(NOT TARGET c2wallet-hdkeys)
+        add_subdirectory(src/family/bitcoin/hdkeys)
+    endif()
 
     # M2-A: the Qt-free cross-coin address CONVERT + CONSTRUCT core
     # (family/bitcoin/construct) — the #961-guarded converter and the
@@ -101,7 +137,9 @@ if(C2WALLET_QT_BUILD_TESTS)
     # (core/address_utils) and the BCH CashAddr codec; links the hdkeys library
     # above for the shared btclibs closure. No Qt, no networking; standalone via:
     #   cmake -S ui/c2wallet-qt/src/family/bitcoin/construct -B build-convert -DC2WALLET_QT_BUILD_TESTS=ON
-    add_subdirectory(src/family/bitcoin/construct)
+    if(NOT TARGET c2wallet-convert)
+        add_subdirectory(src/family/bitcoin/construct)
+    endif()
 
     # M3-A: the Qt-free Bitcoin-script SIGNING core (family/bitcoin/signer)
     # — legacy (SigVersion::BASE) + BIP143 segwit-v0 + wrapped/nested +
@@ -133,5 +171,7 @@ if(C2WALLET_QT_BUILD_TESTS)
     # Qt-FREE static lib + KAT executable (c2wallet-monero-seed-test). It links
     # the vendored Monero crypto directly, not Qt, so the money-correctness KATs
     # build and run without the signer app. See src/family/monero/CMakeLists.txt.
-    add_subdirectory(src/family/monero)
+    if(NOT TARGET c2wallet_monero)
+        add_subdirectory(src/family/monero)
+    endif()
 endif()

--- a/ui/c2wallet-qt/src/shell/MainWindow.cpp
+++ b/ui/c2wallet-qt/src/shell/MainWindow.cpp
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 #include "shell/MainWindow.hpp"
 
+#include "shell/PageConstructConvert.hpp"
+#include "shell/PageImport.hpp"
+#include "shell/PageScan.hpp"
+
 #include <QFont>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -10,59 +14,58 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-namespace {
-
-// The sidebar sections for the signer shell, in Bitcoin-Core-like order.
-// M0 wires them as empty placeholders only.
-struct Section {
-    const char* name;
-    const char* note;
-};
-
-const Section kSections[] = {
-    {"Wallets",
-     "Import keys and enumerate candidate addresses (Family A: secp256k1; "
-     "Family B: Monero). Arrives in phases M1-A / M1-X."},
-    {"Construct",
-     "Build unsigned transactions and spend every script/output type. "
-     "Arrives in phases M2-A / M3-A / M4-A and M4-X."},
-    {"Sign",
-     "Confirm, sign, and self-verify offline before emitting the signed "
-     "artifact. Arrives in phases M3 / M4."},
-    {"Convert",
-     "Cross-coin address conversion within Family A, with the #961 "
-     "money-misdirection guard. Arrives in phase M2-A."},
-    {"Settings",
-     "Wallet preferences and the encrypted-store / ephemeral-seed modes. "
-     "Arrives alongside key custody in M1."},
-};
-
-}  // namespace
-
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
 {
     setWindowTitle("c2wallet-qt (signer) — offline / network-incapable");
-    resize(1100, 720);
+    resize(1100, 760);
 
-    // ── Central area: sidebar nav + stacked placeholder pages ──────────────
+    // ── Central area: sidebar nav + stacked pages ─────────────────────────
     auto* central = new QWidget(this);
     auto* layout = new QHBoxLayout(central);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
 
     navList_ = new QListWidget(central);
-    navList_->setFixedWidth(180);
+    navList_->setFixedWidth(200);
     layout->addWidget(navList_);
 
     stack_ = new QStackedWidget(central);
     layout->addWidget(stack_, 1);
 
-    for (const auto& s : kSections) {
-        navList_->addItem(QString::fromLatin1(s.name));
-        stack_->addWidget(makePlaceholderPage(QString::fromLatin1(s.name),
-                                              QString::fromLatin1(s.note)));
-    }
+    // Functional (slice 1) screens — wired to the merged offline libraries.
+    navList_->addItem(QStringLiteral("Import / Load Key"));
+    stack_->addWidget(new PageImport(stack_));
+
+    navList_->addItem(QStringLiteral("Construct + Convert"));
+    stack_->addWidget(new PageConstructConvert(stack_));
+
+    navList_->addItem(QStringLiteral("Scan (Monero view-only)"));
+    stack_->addWidget(new PageScan(stack_));
+
+    // Slice-2 (pending review) stubs — visible but not implemented here. No
+    // money-path signing UX lands in slice 1.
+    navList_->addItem(QStringLiteral("Sign & Self-Verify"));
+    stack_->addWidget(makeStubPage(
+        QStringLiteral("Sign & Self-Verify"),
+        QStringLiteral("Confirm every output/amount/address, sign offline, and "
+                       "self-verify before emitting the signed artifact "
+                       "(RFC6979 / BIP340). Wires the merged signer + Monero "
+                       "prover libraries.")));
+
+    navList_->addItem(QStringLiteral("Build Transaction"));
+    stack_->addWidget(makeStubPage(
+        QStringLiteral("Build Transaction"),
+        QStringLiteral("Coin-control and the unsigned transaction builder for "
+                       "every script/output type (Family A) and RingCT spends "
+                       "(Family B).")));
+
+    navList_->addItem(QStringLiteral("Air-Gap Transfer"));
+    stack_->addWidget(makeStubPage(
+        QStringLiteral("Air-Gap Transfer"),
+        QStringLiteral("PSBT-like / unsigned_txset import and signed-artifact "
+                       "export over file or multi-frame QR, plus the c2pool "
+                       "validate-seam dry-run.")));
 
     connect(navList_, &QListWidget::currentRowChanged,
             stack_, &QStackedWidget::setCurrentIndex);
@@ -78,8 +81,7 @@ MainWindow::MainWindow(QWidget* parent)
     statusBar()->addWidget(offline);
 }
 
-QWidget* MainWindow::makePlaceholderPage(const QString& title,
-                                         const QString& note)
+QWidget* MainWindow::makeStubPage(const QString& title, const QString& note)
 {
     auto* page = new QWidget(stack_);
     auto* v = new QVBoxLayout(page);
@@ -94,13 +96,18 @@ QWidget* MainWindow::makePlaceholderPage(const QString& title,
     heading->setFont(f);
     v->addWidget(heading);
 
+    auto* badge = new QLabel(QStringLiteral("slice 2 — pending review"), page);
+    QFont bf = badge->font();
+    bf.setBold(true);
+    badge->setFont(bf);
+    badge->setStyleSheet(QStringLiteral(
+        "color: #7a4a00; background: #ffe8b3; border: 1px solid #d9a520; "
+        "border-radius: 4px; padding: 3px 8px;"));
+    v->addWidget(badge, 0, Qt::AlignLeft);
+
     auto* body = new QLabel(note, page);
     body->setWordWrap(true);
     v->addWidget(body);
-
-    auto* stub = new QLabel(QStringLiteral("Not implemented in M0."), page);
-    stub->setEnabled(false);
-    v->addWidget(stub);
 
     return page;
 }

--- a/ui/c2wallet-qt/src/shell/MainWindow.hpp
+++ b/ui/c2wallet-qt/src/shell/MainWindow.hpp
@@ -13,10 +13,10 @@ class QStackedWidget;
 // of ui/c2pool-qt/ (MainWindow + sidebar + stacked pages) WITHOUT reusing any
 // of its networked dependencies — this window links only Qt Widgets/Gui/Core.
 //
-// M0 delivers an empty skeleton: the sidebar sections (Wallets / Construct /
-// Sign / Convert / Settings) are present as placeholders with no functionality
-// behind them. Real pages, key import, construction and signing land in later
-// phases (see docs/design/c2wallet-qt.md §6).
+// M6 SLICE 1 wires the read/construct flows against the merged offline
+// libraries: Import/Load key, Construct+Convert, and Scan (Monero view-only).
+// The signing / tx-build / air-gap-transfer screens are visible stubs labelled
+// "slice 2 — pending review" — no money-path signing UX in this slice.
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -24,9 +24,8 @@ public:
     explicit MainWindow(QWidget* parent = nullptr);
 
 private:
-    // Build one placeholder page for a sidebar section. M0 has no real screens
-    // yet; each section shows its name and a short "not implemented in M0" note.
-    QWidget* makePlaceholderPage(const QString& title, const QString& note);
+    // Build a visible stub page for a slice-2 (pending-review) section.
+    QWidget* makeStubPage(const QString& title, const QString& note);
 
     QListWidget*    navList_{nullptr};
     QStackedWidget* stack_{nullptr};

--- a/ui/c2wallet-qt/src/shell/PageConstructConvert.cpp
+++ b/ui/c2wallet-qt/src/shell/PageConstructConvert.cpp
@@ -38,17 +38,28 @@ QString to_hex(const std::vector<uint8_t>& v)
     return s;
 }
 
+// Map one hex nibble character to 0..15; returns false for any non-[0-9a-fA-F]
+// character (rejecting '-', '+', whitespace, 'x', etc. that QString::toInt would
+// otherwise silently coerce or sign-flip).
+bool hex_nibble(QChar c, int& out)
+{
+    const char ch = c.toLatin1();
+    if (ch >= '0' && ch <= '9') { out = ch - '0'; return true; }
+    if (ch >= 'a' && ch <= 'f') { out = ch - 'a' + 10; return true; }
+    if (ch >= 'A' && ch <= 'F') { out = ch - 'A' + 10; return true; }
+    return false;
+}
+
 bool from_hex(const QString& in, std::vector<uint8_t>& out)
 {
-    QString s = in.trimmed();
-    if (s.size() % 2 != 0 || s.isEmpty()) return false;
+    const QString s = in.trimmed();
+    if (s.isEmpty() || s.size() % 2 != 0) return false;
     out.clear();
     out.reserve(s.size() / 2);
     for (int i = 0; i < s.size(); i += 2) {
-        bool ok = false;
-        int byte = s.mid(i, 2).toInt(&ok, 16);
-        if (!ok) return false;
-        out.push_back(uint8_t(byte));
+        int hi = 0, lo = 0;
+        if (!hex_nibble(s.at(i), hi) || !hex_nibble(s.at(i + 1), lo)) return false;
+        out.push_back(uint8_t((hi << 4) | lo));
     }
     return true;
 }
@@ -146,13 +157,13 @@ void PageConstructConvert::onConvert()
     convOut_->appendPlainText(QString("type  : %1").arg(QString::fromLatin1(cv::addr_type_str(r.type))));
 
     if (r.ok()) {
+        // The engine only returns Ok after its own mandatory round-trip proof
+        // (source payload == target payload); display the proven equality.
         convOut_->appendPlainText(QString("source: %1").arg(QString::fromStdString(r.source_address)));
         convOut_->appendPlainText(QString("target: %1").arg(QString::fromStdString(r.target_address)));
         convOut_->appendPlainText(QString("source payload: %1").arg(QString::fromStdString(r.source_payload_hex)));
         convOut_->appendPlainText(QString("target payload: %1").arg(QString::fromStdString(r.target_payload_hex)));
-        const bool match = (r.source_payload_hex == r.target_payload_hex) && !r.source_payload_hex.empty();
-        convOut_->appendPlainText(match ? QStringLiteral(">>> PAYLOAD MATCH — round-trip proven, conversion is a pure re-encoding")
-                                        : QStringLiteral(">>> PAYLOAD MISMATCH — refused (this should not occur on ok)"));
+        convOut_->appendPlainText(QStringLiteral(">>> PAYLOAD MATCH — round-trip proven, conversion is a pure re-encoding"));
     } else {
         convOut_->appendPlainText(QString("REFUSED: %1").arg(QString::fromStdString(r.reason)));
     }

--- a/ui/c2wallet-qt/src/shell/PageConstructConvert.cpp
+++ b/ui/c2wallet-qt/src/shell/PageConstructConvert.cpp
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "shell/PageConstructConvert.hpp"
+
+#include <QComboBox>
+#include <QFont>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QSpinBox>
+#include <QString>
+#include <QStringList>
+#include <QVBoxLayout>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "family/bitcoin/construct/AddressConstruct.hpp"
+#include "family/bitcoin/construct/Convert.hpp"
+#include "family/bitcoin/construct/ConvertCoins.hpp"
+#include "family/bitcoin/hdkeys/CoinParams.hpp"
+
+namespace cv = c2w::convert;
+namespace ct = c2w::construct;
+namespace hk = c2w::hdkeys;
+
+namespace {
+
+QString to_hex(const std::vector<uint8_t>& v)
+{
+    static const char* d = "0123456789abcdef";
+    QString s;
+    s.reserve(int(v.size()) * 2);
+    for (uint8_t b : v) { s.append(QChar(d[b >> 4])); s.append(QChar(d[b & 0xf])); }
+    return s;
+}
+
+bool from_hex(const QString& in, std::vector<uint8_t>& out)
+{
+    QString s = in.trimmed();
+    if (s.size() % 2 != 0 || s.isEmpty()) return false;
+    out.clear();
+    out.reserve(s.size() / 2);
+    for (int i = 0; i < s.size(); i += 2) {
+        bool ok = false;
+        int byte = s.mid(i, 2).toInt(&ok, 16);
+        if (!ok) return false;
+        out.push_back(uint8_t(byte));
+    }
+    return true;
+}
+
+}  // namespace
+
+PageConstructConvert::PageConstructConvert(QWidget* parent) : QWidget(parent)
+{
+    auto* v = new QVBoxLayout(this);
+    v->setContentsMargins(24, 24, 24, 24);
+    v->setSpacing(12);
+
+    auto* heading = new QLabel(QStringLiteral("Construct + Convert"), this);
+    QFont hf = heading->font();
+    hf.setPointSize(hf.pointSize() + 6);
+    hf.setBold(true);
+    heading->setFont(hf);
+    v->addWidget(heading);
+
+    // ── Convert panel ──────────────────────────────────────────────────────
+    auto* convBox = new QGroupBox(QStringLiteral("Cross-coin address conversion (Family A, #961-guarded)"), this);
+    auto* cbv = new QVBoxLayout(convBox);
+    auto* cform = new QFormLayout();
+
+    srcCombo_ = new QComboBox(convBox);
+    dstCombo_ = new QComboBox(convBox);
+    for (const auto& c : cv::convert_coins()) {
+        srcCombo_->addItem(QString::fromStdString(c.ticker), QString::fromStdString(c.ticker));
+        dstCombo_->addItem(QString::fromStdString(c.ticker), QString::fromStdString(c.ticker));
+    }
+    cform->addRow(QStringLiteral("Source coin:"), srcCombo_);
+    cform->addRow(QStringLiteral("Target coin:"), dstCombo_);
+
+    convAddrEdit_ = new QLineEdit(convBox);
+    convAddrEdit_->setPlaceholderText(QStringLiteral("source-coin address to convert"));
+    cform->addRow(QStringLiteral("Address:"), convAddrEdit_);
+    cbv->addLayout(cform);
+
+    convertBtn_ = new QPushButton(QStringLiteral("Convert"), convBox);
+    cbv->addWidget(convertBtn_);
+
+    convOut_ = new QPlainTextEdit(convBox);
+    convOut_->setReadOnly(true);
+    convOut_->setFont(QFont(QStringLiteral("monospace")));
+    convOut_->setMaximumHeight(160);
+    cbv->addWidget(convOut_);
+    v->addWidget(convBox);
+
+    // ── Construct panel ────────────────────────────────────────────────────
+    auto* consBox = new QGroupBox(QStringLiteral("Construct a wrapped multisig receive address"), this);
+    auto* xbv = new QVBoxLayout(consBox);
+    auto* xform = new QFormLayout();
+
+    mSpin_ = new QSpinBox(consBox);
+    mSpin_->setRange(1, 16);
+    mSpin_->setValue(2);
+    xform->addRow(QStringLiteral("m (required signatures):"), mSpin_);
+
+    pubkeysEdit_ = new QPlainTextEdit(consBox);
+    pubkeysEdit_->setPlaceholderText(QStringLiteral("one compressed (33-byte) or uncompressed (65-byte) pubkey hex per line"));
+    pubkeysEdit_->setMaximumHeight(90);
+    xform->addRow(QStringLiteral("Pubkeys (n):"), pubkeysEdit_);
+
+    coinCombo_ = new QComboBox(consBox);
+    for (const auto& c : hk::all_coins())
+        coinCombo_->addItem(QString::fromLatin1(c.ticker), QString::fromLatin1(c.ticker));
+    xform->addRow(QStringLiteral("Coin:"), coinCombo_);
+    xbv->addLayout(xform);
+
+    buildBtn_ = new QPushButton(QStringLiteral("Build P2SH / P2WSH / nested addresses"), consBox);
+    xbv->addWidget(buildBtn_);
+
+    consOut_ = new QPlainTextEdit(consBox);
+    consOut_->setReadOnly(true);
+    consOut_->setFont(QFont(QStringLiteral("monospace")));
+    consOut_->setMaximumHeight(180);
+    xbv->addWidget(consOut_);
+    v->addWidget(consBox);
+
+    connect(convertBtn_, &QPushButton::clicked, this, &PageConstructConvert::onConvert);
+    connect(buildBtn_,   &QPushButton::clicked, this, &PageConstructConvert::onConstruct);
+}
+
+void PageConstructConvert::onConvert()
+{
+    convOut_->clear();
+    const std::string addr = convAddrEdit_->text().trimmed().toStdString();
+    const std::string src  = srcCombo_->currentData().toString().toStdString();
+    const std::string dst  = dstCombo_->currentData().toString().toStdString();
+    if (addr.empty()) { convOut_->appendPlainText(QStringLiteral("Enter a source address.")); return; }
+
+    cv::ConvertResult r = cv::convert_address(addr, src, dst);
+
+    convOut_->appendPlainText(QString("status: %1").arg(QString::fromLatin1(cv::status_str(r.status))));
+    convOut_->appendPlainText(QString("type  : %1").arg(QString::fromLatin1(cv::addr_type_str(r.type))));
+
+    if (r.ok()) {
+        convOut_->appendPlainText(QString("source: %1").arg(QString::fromStdString(r.source_address)));
+        convOut_->appendPlainText(QString("target: %1").arg(QString::fromStdString(r.target_address)));
+        convOut_->appendPlainText(QString("source payload: %1").arg(QString::fromStdString(r.source_payload_hex)));
+        convOut_->appendPlainText(QString("target payload: %1").arg(QString::fromStdString(r.target_payload_hex)));
+        const bool match = (r.source_payload_hex == r.target_payload_hex) && !r.source_payload_hex.empty();
+        convOut_->appendPlainText(match ? QStringLiteral(">>> PAYLOAD MATCH — round-trip proven, conversion is a pure re-encoding")
+                                        : QStringLiteral(">>> PAYLOAD MISMATCH — refused (this should not occur on ok)"));
+    } else {
+        convOut_->appendPlainText(QString("REFUSED: %1").arg(QString::fromStdString(r.reason)));
+    }
+}
+
+void PageConstructConvert::onConstruct()
+{
+    consOut_->clear();
+
+    std::vector<std::vector<uint8_t>> pubkeys;
+    const QStringList lines = pubkeysEdit_->toPlainText().split('\n', Qt::SkipEmptyParts);
+    for (const QString& ln : lines) {
+        std::vector<uint8_t> pk;
+        if (!from_hex(ln, pk)) {
+            consOut_->appendPlainText(QString("Bad pubkey hex: %1").arg(ln.trimmed()));
+            return;
+        }
+        pubkeys.push_back(std::move(pk));
+    }
+    if (pubkeys.empty()) { consOut_->appendPlainText(QStringLiteral("Enter at least one pubkey.")); return; }
+
+    const int m = mSpin_->value();
+    std::vector<uint8_t> redeem = ct::build_bare_multisig_script(m, pubkeys);
+    if (redeem.empty()) {
+        consOut_->appendPlainText(QStringLiteral("Refused: need 1 <= m <= n <= 16 and 33/65-byte pubkeys."));
+        return;
+    }
+    consOut_->appendPlainText(QString("redeemScript (%1-of-%2): %3")
+                                  .arg(m).arg(int(pubkeys.size())).arg(to_hex(redeem)));
+
+    const std::string ticker = coinCombo_->currentData().toString().toStdString();
+    const hk::CoinParams* coin = hk::coin_by_ticker(ticker);
+    if (!coin) { consOut_->appendPlainText(QStringLiteral("Unknown coin.")); return; }
+
+    ct::BuiltAddress p2sh = ct::build_p2sh(coin->p2sh_version, redeem);
+    if (p2sh.ok())
+        consOut_->appendPlainText(QString("\nP2SH        : %1").arg(QString::fromStdString(p2sh.address)));
+
+    const std::string hrp = coin->bech32_hrp ? coin->bech32_hrp : "";
+    if (!hrp.empty()) {
+        ct::BuiltAddress p2wsh = ct::build_p2wsh(hrp, redeem);
+        if (p2wsh.ok())
+            consOut_->appendPlainText(QString("P2WSH       : %1").arg(QString::fromStdString(p2wsh.address)));
+        ct::BuiltAddress nested = ct::build_p2sh_p2wsh(coin->p2sh_version, redeem);
+        if (nested.ok())
+            consOut_->appendPlainText(QString("P2SH-P2WSH  : %1").arg(QString::fromStdString(nested.address)));
+    } else {
+        consOut_->appendPlainText(QString("(P2WSH / nested skipped — %1 has no segwit HRP)")
+                                      .arg(QString::fromLatin1(coin->ticker)));
+    }
+}

--- a/ui/c2wallet-qt/src/shell/PageConstructConvert.hpp
+++ b/ui/c2wallet-qt/src/shell/PageConstructConvert.hpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// PageConstructConvert — the "Construct + Convert" screen (design §4.1, M2-A).
+//
+// SLICE 1 (read-only address algebra; NO signing):
+//   * CONVERT: cross-coin address conversion within Family A via the merged
+//     #961-guarded engine (c2wallet-convert). Shows source vs target payload
+//     side by side and the round-trip proof; REFUSES the cases the library
+//     refuses (BCH prefix-swap, type absent on target, mainnet<->testnet,
+//     foreign/invalid source) and surfaces the reason.
+//   * CONSTRUCT: build the script-defined receive addresses the library
+//     supports — a bare m-of-n multisig redeemScript wrapped as P2SH / P2WSH /
+//     nested P2SH-P2WSH (the LTC+DOGE-donation pattern).
+
+#include <QWidget>
+
+class QComboBox;
+class QLineEdit;
+class QPlainTextEdit;
+class QPushButton;
+class QSpinBox;
+
+class PageConstructConvert : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit PageConstructConvert(QWidget* parent = nullptr);
+
+private slots:
+    void onConvert();
+    void onConstruct();
+
+private:
+    // Convert panel
+    QComboBox*      srcCombo_{nullptr};
+    QComboBox*      dstCombo_{nullptr};
+    QLineEdit*      convAddrEdit_{nullptr};
+    QPushButton*    convertBtn_{nullptr};
+    QPlainTextEdit* convOut_{nullptr};
+
+    // Construct panel
+    QSpinBox*       mSpin_{nullptr};
+    QPlainTextEdit* pubkeysEdit_{nullptr};
+    QComboBox*      coinCombo_{nullptr};
+    QPushButton*    buildBtn_{nullptr};
+    QPlainTextEdit* consOut_{nullptr};
+};

--- a/ui/c2wallet-qt/src/shell/PageImport.cpp
+++ b/ui/c2wallet-qt/src/shell/PageImport.cpp
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "shell/PageImport.hpp"
+
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFont>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QString>
+#include <QVBoxLayout>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Family A (Bitcoin-script) — c2wallet-hdkeys
+#include "family/bitcoin/hdkeys/Address.hpp"
+#include "family/bitcoin/hdkeys/Bip32.hpp"
+#include "family/bitcoin/hdkeys/Bip39.hpp"
+#include "family/bitcoin/hdkeys/CoinParams.hpp"
+#include "family/bitcoin/hdkeys/Derivation.hpp"
+#include "family/bitcoin/hdkeys/KeyImport.hpp"
+
+// Family B (Monero) — c2wallet_monero
+#include "family/monero/MoneroKey.hpp"
+#include "family/monero/addr/MoneroAddress.hpp"
+#include "family/monero/seed/MoneroMnemonic.hpp"
+
+namespace hk = c2w::hdkeys;
+namespace xm = c2wallet::monero;
+
+namespace {
+
+QString hint_label(hk::ScriptHint h)
+{
+    switch (h) {
+        case hk::ScriptHint::P2PKH:        return "P2PKH";
+        case hk::ScriptHint::P2SH_P2WPKH:  return "P2SH-P2WPKH";
+        case hk::ScriptHint::P2WPKH:       return "P2WPKH";
+        case hk::ScriptHint::P2TR:         return "P2TR";
+        default:                           return "?";
+    }
+}
+
+QString candidate_line(const hk::AddressCandidate& c)
+{
+    QString enc = c.encoding.empty() ? QString() : QString(" [%1]").arg(QString::fromStdString(c.encoding));
+    QString addr = c.address.empty() ? QStringLiteral("(no address form)") : QString::fromStdString(c.address);
+    return QString("    %1%2  %3").arg(QString::fromStdString(c.label), enc, addr);
+}
+
+}  // namespace
+
+PageImport::PageImport(QWidget* parent) : QWidget(parent)
+{
+    auto* v = new QVBoxLayout(this);
+    v->setContentsMargins(24, 24, 24, 24);
+    v->setSpacing(10);
+
+    auto* heading = new QLabel(QStringLiteral("Import / Load Key"), this);
+    QFont hf = heading->font();
+    hf.setPointSize(hf.pointSize() + 6);
+    hf.setBold(true);
+    heading->setFont(hf);
+    v->addWidget(heading);
+
+    auto* sub = new QLabel(
+        QStringLiteral("Import a key and view its derived PUBLIC addresses. "
+                       "Read-only (slice 1) — no signing. Secrets are held in "
+                       "zeroizing buffers and never displayed."),
+        this);
+    sub->setWordWrap(true);
+    v->addWidget(sub);
+
+    auto* form = new QFormLayout();
+    form->setLabelAlignment(Qt::AlignRight);
+
+    formatCombo_ = new QComboBox(this);
+    formatCombo_->addItem(QStringLiteral("BIP39 mnemonic (Family A)"));
+    formatCombo_->addItem(QStringLiteral("WIF (Family A)"));
+    formatCombo_->addItem(QStringLiteral("Raw hex privkey (Family A)"));
+    formatCombo_->addItem(QStringLiteral("BIP32 xprv / xpub (Family A)"));
+    formatCombo_->addItem(QStringLiteral("Monero 25-word seed (Family B)"));
+    form->addRow(QStringLiteral("Format:"), formatCombo_);
+
+    coinCombo_ = new QComboBox(this);
+    for (const auto& c : hk::all_coins())
+        coinCombo_->addItem(QString("%1  (%2)").arg(QString::fromLatin1(c.name),
+                                                    QString::fromLatin1(c.ticker)),
+                            QString::fromLatin1(c.ticker));
+    coinLabel_ = new QLabel(QStringLiteral("Target coin:"), this);
+    form->addRow(coinLabel_, coinCombo_);
+
+    secretEdit_ = new QLineEdit(this);
+    secretEdit_->setPlaceholderText(QStringLiteral("mnemonic words / WIF / hex / xprv…"));
+    secretEdit_->setEchoMode(QLineEdit::Password);
+    form->addRow(QStringLiteral("Secret / key:"), secretEdit_);
+
+    passphraseLabel_ = new QLabel(QStringLiteral("BIP39 passphrase:"), this);
+    passphraseEdit_ = new QLineEdit(this);
+    passphraseEdit_->setEchoMode(QLineEdit::Password);
+    passphraseEdit_->setPlaceholderText(QStringLiteral("optional — empty vs wrong both yield a valid, DIFFERENT wallet"));
+    form->addRow(passphraseLabel_, passphraseEdit_);
+
+    compressedCheck_ = new QCheckBox(QStringLiteral("compressed pubkey"), this);
+    compressedCheck_->setChecked(true);
+    form->addRow(QString(), compressedCheck_);
+
+    v->addLayout(form);
+
+    importBtn_ = new QPushButton(QStringLiteral("Import / Derive addresses"), this);
+    v->addWidget(importBtn_);
+
+    output_ = new QPlainTextEdit(this);
+    output_->setReadOnly(true);
+    output_->setFont(QFont(QStringLiteral("monospace")));
+    v->addWidget(output_, 1);
+
+    connect(formatCombo_, SIGNAL(currentIndexChanged(int)), this, SLOT(onFormatChanged()));
+    connect(importBtn_, &QPushButton::clicked, this, &PageImport::onImport);
+
+    onFormatChanged();
+}
+
+void PageImport::onFormatChanged()
+{
+    const int idx = formatCombo_->currentIndex();
+    const bool isBip39 = (idx == 0);
+    const bool isRaw   = (idx == 2);
+    const bool isMonero = (idx == 4);
+
+    passphraseLabel_->setVisible(isBip39);
+    passphraseEdit_->setVisible(isBip39);
+    compressedCheck_->setVisible(isRaw);
+    coinLabel_->setVisible(!isMonero);
+    coinCombo_->setVisible(!isMonero);
+}
+
+void PageImport::onImport()
+{
+    output_->clear();
+    switch (formatCombo_->currentIndex()) {
+        case 0: deriveFamilyA_bip39();  break;
+        case 1: deriveFamilyA_wif();    break;
+        case 2: deriveFamilyA_rawhex(); break;
+        case 3: deriveFamilyA_extkey(); break;
+        case 4: deriveFamilyB_monero(); break;
+    }
+}
+
+void PageImport::deriveFamilyA_bip39()
+{
+    const std::string mnemonic = secretEdit_->text().trimmed().toStdString();
+    if (mnemonic.empty()) { output_->appendPlainText(QStringLiteral("Enter a mnemonic.")); return; }
+
+    hk::Bip39Error e = hk::Bip39::validate(mnemonic, hk::Language::English);
+    if (e != hk::Bip39Error::Ok) {
+        output_->appendPlainText(QString("Invalid BIP39 mnemonic: %1").arg(hk::to_string(e)));
+        return;
+    }
+
+    const std::string ticker = coinCombo_->currentData().toString().toStdString();
+    const hk::CoinParams* coin = hk::coin_by_ticker(ticker);
+    if (!coin) { output_->appendPlainText(QStringLiteral("Unknown coin.")); return; }
+
+    c2w::secure::SecureBytes seed =
+        hk::Bip39::to_seed(mnemonic, passphraseEdit_->text().toStdString());
+
+    output_->appendPlainText(QString("BIP39 mnemonic OK (checksum verified).  Coin: %1")
+                                 .arg(QString::fromLatin1(coin->ticker)));
+    output_->appendPlainText(QString("Seed fingerprint: %1  "
+                                     "(changes with any passphrase — confirm it matches what you expect)")
+                                 .arg(QString::fromStdString(hk::Bip39::seed_fingerprint(seed))));
+
+    auto master = hk::HDKey::from_seed(seed.data(), seed.size(), coin->std_bip32);
+    if (!master) { output_->appendPlainText(QStringLiteral("Master key derivation failed.")); return; }
+
+    hk::ScanRange r;
+    r.changes = {0};      // receiving chain only, for the on-screen summary
+    r.index_lo = 0;
+    r.index_hi = 4;       // first five addresses per purpose
+    const auto paths = hk::enumerate(r, coin->slip44);
+
+    output_->appendPlainText(QStringLiteral("\nDerived receiving addresses (BIP44 / 49 / 84 / 86):"));
+    for (const auto& ep : paths) {
+        auto child = master->derive_path(ep.path);
+        if (!child) continue;
+        const hk::ScriptHint want = hk::purpose_script(ep.purpose);
+        const auto cands = hk::address_candidates_from_seckey(child->privkey().data(), *coin);
+        QString line = QString("  %1  [%2]  ")
+                           .arg(QString::fromStdString(hk::format_path(ep.path)), hint_label(want));
+        bool found = false;
+        for (const auto& c : cands) {
+            if (c.type == want && !c.address.empty()) {
+                line += QString::fromStdString(c.address);
+                found = true;
+                break;
+            }
+        }
+        if (!found) line += QString("(type not available on %1)").arg(QString::fromLatin1(coin->ticker));
+        output_->appendPlainText(line);
+    }
+}
+
+void PageImport::deriveFamilyA_wif()
+{
+    const std::string wif = secretEdit_->text().trimmed().toStdString();
+    hk::WifDecode d = hk::decode_wif(wif);
+    if (!d.ok) { output_->appendPlainText(QString("Invalid WIF: %1").arg(QString::fromStdString(d.error))); return; }
+
+    QStringList hints;
+    for (const auto& t : d.coin_tickers) hints << QString::fromStdString(t);
+    output_->appendPlainText(QString("WIF OK.  version=0x%1  compressed=%2  version matches: %3")
+                                 .arg(QString::number(d.version, 16),
+                                      d.compressed ? "yes" : "no",
+                                      hints.isEmpty() ? QStringLiteral("(unknown)") : hints.join(", ")));
+
+    const std::string ticker = coinCombo_->currentData().toString().toStdString();
+    const hk::CoinParams* coin = hk::coin_by_ticker(ticker);
+    if (!coin) { output_->appendPlainText(QStringLiteral("Unknown coin.")); return; }
+
+    const auto cands = hk::address_candidates_from_seckey(d.scalar.data(), *coin);
+    output_->appendPlainText(QString("\nAddress candidates on %1:").arg(QString::fromLatin1(coin->ticker)));
+    for (const auto& c : cands) output_->appendPlainText(candidate_line(c));
+}
+
+void PageImport::deriveFamilyA_rawhex()
+{
+    const std::string hex = secretEdit_->text().trimmed().toStdString();
+    hk::RawHexDecode d = hk::decode_raw_hex(hex, compressedCheck_->isChecked());
+    if (!d.ok) { output_->appendPlainText(QString("Invalid raw key: %1").arg(QString::fromStdString(d.error))); return; }
+
+    const std::string ticker = coinCombo_->currentData().toString().toStdString();
+    const hk::CoinParams* coin = hk::coin_by_ticker(ticker);
+    if (!coin) { output_->appendPlainText(QStringLiteral("Unknown coin.")); return; }
+
+    output_->appendPlainText(QString("Raw hex key OK (1 <= k < N verified).  compressed=%1")
+                                 .arg(d.compressed ? "yes" : "no"));
+    const auto cands = hk::address_candidates_from_seckey(d.scalar.data(), *coin);
+    output_->appendPlainText(QString("\nAddress candidates on %1:").arg(QString::fromLatin1(coin->ticker)));
+    for (const auto& c : cands) output_->appendPlainText(candidate_line(c));
+}
+
+void PageImport::deriveFamilyA_extkey()
+{
+    const std::string ext = secretEdit_->text().trimmed().toStdString();
+    auto node = hk::HDKey::parse(ext);
+    if (!node) { output_->appendPlainText(QStringLiteral("Unrecognised or invalid extended key (bad prefix/checksum/length).")); return; }
+
+    const std::string ticker = coinCombo_->currentData().toString().toStdString();
+    const hk::CoinParams* coin = hk::coin_by_ticker(ticker);
+    if (!coin) { output_->appendPlainText(QStringLiteral("Unknown coin.")); return; }
+
+    const hk::Slip132Entry* se = hk::lookup_bip32_version(node->versions().pub);
+    const hk::ScriptHint hint = se ? se->hint : hk::ScriptHint::P2PKH;
+
+    output_->appendPlainText(QString("Parsed %1  depth=%2  script hint=%3%4")
+                                 .arg(node->has_private() ? "xprv (private — can derive)"
+                                                          : "xpub (public — WATCH-ONLY, cannot sign)")
+                                 .arg(node->depth())
+                                 .arg(hint_label(hint))
+                                 .arg(se ? QString(" (%1)").arg(QString::fromLatin1(se->label)) : QString()));
+
+    output_->appendPlainText(QStringLiteral("\nDerived addresses  node/0/0..4 (external chain):"));
+    for (uint32_t i = 0; i <= 4; ++i) {
+        auto child = node->derive_path({0u, i});
+        if (!child) continue;
+        const auto cands = hk::address_candidates(child->pubkey(), *coin);
+        QString line = QString("  m/…/0/%1  [%2]  ").arg(i).arg(hint_label(hint));
+        bool found = false;
+        for (const auto& c : cands) {
+            if (c.type == hint && !c.address.empty()) { line += QString::fromStdString(c.address); found = true; break; }
+        }
+        if (!found) {
+            for (const auto& c : cands) {
+                if (c.type == hk::ScriptHint::P2PKH && !c.address.empty()) {
+                    line = QString("  m/…/0/%1  [P2PKH]  ").arg(i) + QString::fromStdString(c.address);
+                    found = true;
+                    break;
+                }
+            }
+        }
+        if (!found) line += QStringLiteral("(no address form)");
+        output_->appendPlainText(line);
+    }
+}
+
+void PageImport::deriveFamilyB_monero()
+{
+    const std::string phrase = secretEdit_->text().trimmed().toStdString();
+    if (phrase.empty()) { output_->appendPlainText(QStringLiteral("Enter a 25-word Monero seed.")); return; }
+
+    xm::KeyImportResult r = xm::keys_from_mnemonic(phrase);
+    if (!r.ok) { output_->appendPlainText(QString("Invalid Monero seed: %1").arg(QString::fromStdString(r.error))); return; }
+
+    output_->appendPlainText(QStringLiteral("Monero 25-word seed OK (checksum verified)."));
+    output_->appendPlainText(QString("spend public: %1").arg(QString::fromStdString(xm::bytes32_to_hex(r.keys.spend_pub))));
+    output_->appendPlainText(QString("view  public: %1").arg(QString::fromStdString(xm::bytes32_to_hex(r.keys.view_pub))));
+    output_->appendPlainText(QString("can sign: %1").arg(r.keys.can_sign() ? "yes (full wallet)" : "no (view-only)"));
+
+    const xm::MoneroAddress primary = xm::primary_address(r.keys, xm::Network::Mainnet);
+    output_->appendPlainText(QString("\nPrimary address:\n  %1").arg(QString::fromStdString(xm::address_encode(primary))));
+
+    output_->appendPlainText(QStringLiteral("\nSubaddresses (account 0):"));
+    for (uint32_t minor = 1; minor <= 3; ++minor) {
+        xm::SubaddressResult sub = xm::derive_subaddress(r.keys.view_priv, r.keys.spend_pub, 0, minor, xm::Network::Mainnet);
+        if (!sub.ok) { output_->appendPlainText(QString("  (0,%1): %2").arg(minor).arg(QString::fromStdString(sub.error))); continue; }
+        output_->appendPlainText(QString("  (0,%1): %2").arg(minor).arg(QString::fromStdString(xm::address_encode(sub.addr))));
+    }
+}

--- a/ui/c2wallet-qt/src/shell/PageImport.cpp
+++ b/ui/c2wallet-qt/src/shell/PageImport.cpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 // Family A (Bitcoin-script) — c2wallet-hdkeys
@@ -31,10 +32,26 @@
 #include "family/monero/addr/MoneroAddress.hpp"
 #include "family/monero/seed/MoneroMnemonic.hpp"
 
+// Zeroizing helper for the intermediate plaintext std::string.
+#include "secure/SecureString.hpp"
+
 namespace hk = c2w::hdkeys;
 namespace xm = c2wallet::monero;
 
 namespace {
+
+// RAII holder that securely wipes a plaintext secret std::string when it leaves
+// scope (design §5.3). Used for the transient string that must be handed to the
+// library import functions (which take std::string), so the plaintext does not
+// linger on the heap after the derivation completes.
+struct ScopedSecret {
+    std::string s;
+    explicit ScopedSecret(std::string v) : s(std::move(v)) {}
+    ~ScopedSecret() { if (!s.empty()) c2w::secure::secure_wipe(&s[0], s.size()); }
+    ScopedSecret(const ScopedSecret&) = delete;
+    ScopedSecret& operator=(const ScopedSecret&) = delete;
+    const std::string& str() const { return s; }
+};
 
 QString hint_label(hk::ScriptHint h)
 {
@@ -71,8 +88,9 @@ PageImport::PageImport(QWidget* parent) : QWidget(parent)
 
     auto* sub = new QLabel(
         QStringLiteral("Import a key and view its derived PUBLIC addresses. "
-                       "Read-only (slice 1) — no signing. Secrets are held in "
-                       "zeroizing buffers and never displayed."),
+                       "Read-only (slice 1) — no signing. Secrets are cleared "
+                       "after use and never displayed; library key material is "
+                       "held in zeroizing buffers."),
         this);
     sub->setWordWrap(true);
     v->addWidget(sub);
@@ -144,18 +162,27 @@ void PageImport::onFormatChanged()
 void PageImport::onImport()
 {
     output_->clear();
+
+    // Read each secret ONCE into a zeroizing holder; the library import calls
+    // receive it by const-ref and the plaintext is wiped when these leave scope.
+    ScopedSecret secret(secretEdit_->text().trimmed().toStdString());
+    ScopedSecret pass(passphraseEdit_->text().toStdString());
+
     switch (formatCombo_->currentIndex()) {
-        case 0: deriveFamilyA_bip39();  break;
-        case 1: deriveFamilyA_wif();    break;
-        case 2: deriveFamilyA_rawhex(); break;
-        case 3: deriveFamilyA_extkey(); break;
-        case 4: deriveFamilyB_monero(); break;
+        case 0: deriveFamilyA_bip39(secret.str(), pass.str()); break;
+        case 1: deriveFamilyA_wif(secret.str());    break;
+        case 2: deriveFamilyA_rawhex(secret.str()); break;
+        case 3: deriveFamilyA_extkey(secret.str()); break;
+        case 4: deriveFamilyB_monero(secret.str()); break;
     }
+
+    // Do not let the plaintext linger in the widgets after we are done with it.
+    secretEdit_->clear();
+    passphraseEdit_->clear();
 }
 
-void PageImport::deriveFamilyA_bip39()
+void PageImport::deriveFamilyA_bip39(const std::string& mnemonic, const std::string& passphrase)
 {
-    const std::string mnemonic = secretEdit_->text().trimmed().toStdString();
     if (mnemonic.empty()) { output_->appendPlainText(QStringLiteral("Enter a mnemonic.")); return; }
 
     hk::Bip39Error e = hk::Bip39::validate(mnemonic, hk::Language::English);
@@ -168,8 +195,7 @@ void PageImport::deriveFamilyA_bip39()
     const hk::CoinParams* coin = hk::coin_by_ticker(ticker);
     if (!coin) { output_->appendPlainText(QStringLiteral("Unknown coin.")); return; }
 
-    c2w::secure::SecureBytes seed =
-        hk::Bip39::to_seed(mnemonic, passphraseEdit_->text().toStdString());
+    c2w::secure::SecureBytes seed = hk::Bip39::to_seed(mnemonic, passphrase);
 
     output_->appendPlainText(QString("BIP39 mnemonic OK (checksum verified).  Coin: %1")
                                  .arg(QString::fromLatin1(coin->ticker)));
@@ -207,9 +233,8 @@ void PageImport::deriveFamilyA_bip39()
     }
 }
 
-void PageImport::deriveFamilyA_wif()
+void PageImport::deriveFamilyA_wif(const std::string& wif)
 {
-    const std::string wif = secretEdit_->text().trimmed().toStdString();
     hk::WifDecode d = hk::decode_wif(wif);
     if (!d.ok) { output_->appendPlainText(QString("Invalid WIF: %1").arg(QString::fromStdString(d.error))); return; }
 
@@ -229,9 +254,8 @@ void PageImport::deriveFamilyA_wif()
     for (const auto& c : cands) output_->appendPlainText(candidate_line(c));
 }
 
-void PageImport::deriveFamilyA_rawhex()
+void PageImport::deriveFamilyA_rawhex(const std::string& hex)
 {
-    const std::string hex = secretEdit_->text().trimmed().toStdString();
     hk::RawHexDecode d = hk::decode_raw_hex(hex, compressedCheck_->isChecked());
     if (!d.ok) { output_->appendPlainText(QString("Invalid raw key: %1").arg(QString::fromStdString(d.error))); return; }
 
@@ -246,9 +270,8 @@ void PageImport::deriveFamilyA_rawhex()
     for (const auto& c : cands) output_->appendPlainText(candidate_line(c));
 }
 
-void PageImport::deriveFamilyA_extkey()
+void PageImport::deriveFamilyA_extkey(const std::string& ext)
 {
-    const std::string ext = secretEdit_->text().trimmed().toStdString();
     auto node = hk::HDKey::parse(ext);
     if (!node) { output_->appendPlainText(QStringLiteral("Unrecognised or invalid extended key (bad prefix/checksum/length).")); return; }
 
@@ -290,9 +313,8 @@ void PageImport::deriveFamilyA_extkey()
     }
 }
 
-void PageImport::deriveFamilyB_monero()
+void PageImport::deriveFamilyB_monero(const std::string& phrase)
 {
-    const std::string phrase = secretEdit_->text().trimmed().toStdString();
     if (phrase.empty()) { output_->appendPlainText(QStringLiteral("Enter a 25-word Monero seed.")); return; }
 
     xm::KeyImportResult r = xm::keys_from_mnemonic(phrase);

--- a/ui/c2wallet-qt/src/shell/PageImport.hpp
+++ b/ui/c2wallet-qt/src/shell/PageImport.hpp
@@ -16,10 +16,14 @@
 //     * 25-word (or 24-word) Monero mnemonic -> {spend,view} keys -> primary
 //       address + a few subaddresses
 //
-// All secret material stays in the zeroizing SecureBytes / MoneroKeys the
-// libraries return; this page only renders the resulting PUBLIC addresses.
+// Secret handling: the input QLineEdits are cleared after each action, and the
+// intermediate std::string carrying the secret is securely wiped as it leaves
+// scope. The library key material stays in the zeroizing SecureBytes / MoneroKeys
+// the libraries return; this page only renders the resulting PUBLIC addresses.
 
 #include <QWidget>
+
+#include <string>
 
 class QComboBox;
 class QLineEdit;
@@ -39,11 +43,13 @@ private slots:
     void onImport();
 
 private:
-    void deriveFamilyA_bip39();
-    void deriveFamilyA_wif();
-    void deriveFamilyA_rawhex();
-    void deriveFamilyA_extkey();
-    void deriveFamilyB_monero();
+    // The secret is read once in onImport(), wiped there, and passed in by
+    // const-ref so no method re-reads plaintext from the widget.
+    void deriveFamilyA_bip39(const std::string& mnemonic, const std::string& passphrase);
+    void deriveFamilyA_wif(const std::string& wif);
+    void deriveFamilyA_rawhex(const std::string& hex);
+    void deriveFamilyA_extkey(const std::string& ext);
+    void deriveFamilyB_monero(const std::string& phrase);
 
     QComboBox*      formatCombo_{nullptr};
     QComboBox*      coinCombo_{nullptr};

--- a/ui/c2wallet-qt/src/shell/PageImport.hpp
+++ b/ui/c2wallet-qt/src/shell/PageImport.hpp
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// PageImport — the "Import / Load Key" screen (design §3, phases M1-A / M1-X).
+//
+// SLICE 1 (read/construct only): accepts the key formats the merged offline
+// libraries support and DISPLAYS the derived public addresses. No signing.
+//
+//   Family A (Bitcoin-script, c2wallet-hdkeys):
+//     * BIP39 mnemonic (+ optional passphrase) -> real checksum verify -> seed
+//       -> BIP32 master -> BIP44/49/84/86 derivation grid -> address candidates
+//     * WIF                (decode_wif)
+//     * raw hex privkey    (decode_raw_hex, 1 <= k < N range check)
+//     * BIP32 xprv / xpub  (HDKey::parse; xpub => watch-only)
+//   Family B (Monero, c2wallet_monero):
+//     * 25-word (or 24-word) Monero mnemonic -> {spend,view} keys -> primary
+//       address + a few subaddresses
+//
+// All secret material stays in the zeroizing SecureBytes / MoneroKeys the
+// libraries return; this page only renders the resulting PUBLIC addresses.
+
+#include <QWidget>
+
+class QComboBox;
+class QLineEdit;
+class QCheckBox;
+class QLabel;
+class QPlainTextEdit;
+class QPushButton;
+
+class PageImport : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit PageImport(QWidget* parent = nullptr);
+
+private slots:
+    void onFormatChanged();
+    void onImport();
+
+private:
+    void deriveFamilyA_bip39();
+    void deriveFamilyA_wif();
+    void deriveFamilyA_rawhex();
+    void deriveFamilyA_extkey();
+    void deriveFamilyB_monero();
+
+    QComboBox*      formatCombo_{nullptr};
+    QComboBox*      coinCombo_{nullptr};
+    QLineEdit*      secretEdit_{nullptr};
+    QLabel*         passphraseLabel_{nullptr};
+    QLineEdit*      passphraseEdit_{nullptr};
+    QCheckBox*      compressedCheck_{nullptr};
+    QLabel*         coinLabel_{nullptr};
+    QPushButton*    importBtn_{nullptr};
+    QPlainTextEdit* output_{nullptr};
+};

--- a/ui/c2wallet-qt/src/shell/PageScan.cpp
+++ b/ui/c2wallet-qt/src/shell/PageScan.cpp
@@ -14,13 +14,32 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "family/monero/MoneroKey.hpp"
 #include "family/monero/addr/MoneroAddress.hpp"
 #include "family/monero/scan/MoneroScanner.hpp"
 
+#include "secure/SecureString.hpp"
+
 namespace xm = c2wallet::monero;
+
+namespace {
+
+// RAII holder that securely wipes a plaintext secret std::string when it leaves
+// scope (design §5.3): the transient string handed to the Monero import calls
+// (which take std::string) must not linger on the heap after key load.
+struct ScopedSecret {
+    std::string s;
+    explicit ScopedSecret(std::string v) : s(std::move(v)) {}
+    ~ScopedSecret() { if (!s.empty()) c2w::secure::secure_wipe(&s[0], s.size()); }
+    ScopedSecret(const ScopedSecret&) = delete;
+    ScopedSecret& operator=(const ScopedSecret&) = delete;
+    const std::string& str() const { return s; }
+};
+
+}  // namespace
 
 PageScan::PageScan(QWidget* parent) : QWidget(parent)
 {
@@ -63,7 +82,7 @@ PageScan::PageScan(QWidget* parent) : QWidget(parent)
     auto* fullBtn = new QPushButton(QStringLiteral("Load full wallet from seed"), keyBox);
     kbv->addWidget(fullBtn);
 
-    statusLabel_ = new QLabel(QStringLiteral("No account loaded."), keyBox);
+    statusLabel_ = new QLabel(QStringLiteral("No account loaded. Secret inputs are cleared after use."), keyBox);
     statusLabel_->setWordWrap(true);
     kbv->addWidget(statusLabel_);
     v->addWidget(keyBox);
@@ -105,9 +124,10 @@ PageScan::~PageScan() = default;
 void PageScan::onLoadViewOnly()
 {
     scanner_.reset();
-    const std::string sp = spendPubEdit_->text().trimmed().toStdString();
-    const std::string vp = viewPrivEdit_->text().trimmed().toStdString();
-    xm::KeyImportResult r = xm::keys_view_only(sp, vp);
+    const std::string sp = spendPubEdit_->text().trimmed().toStdString();     // public — not secret
+    ScopedSecret vp(viewPrivEdit_->text().trimmed().toStdString());           // secret — wiped on scope exit
+    xm::KeyImportResult r = xm::keys_view_only(sp, vp.str());
+    viewPrivEdit_->clear();                                                   // do not let plaintext linger
     if (!r.ok) {
         statusLabel_->setText(QString("View-only load FAILED: %1").arg(QString::fromStdString(r.error)));
         return;
@@ -123,8 +143,9 @@ void PageScan::onLoadViewOnly()
 void PageScan::onLoadFull()
 {
     scanner_.reset();
-    const std::string phrase = mnemonicEdit_->text().trimmed().toStdString();
-    xm::KeyImportResult r = xm::keys_from_mnemonic(phrase);
+    ScopedSecret phrase(mnemonicEdit_->text().trimmed().toStdString());       // secret — wiped on scope exit
+    xm::KeyImportResult r = xm::keys_from_mnemonic(phrase.str());
+    mnemonicEdit_->clear();                                                   // do not let plaintext linger
     if (!r.ok) {
         statusLabel_->setText(QString("Full seed load FAILED: %1").arg(QString::fromStdString(r.error)));
         return;

--- a/ui/c2wallet-qt/src/shell/PageScan.cpp
+++ b/ui/c2wallet-qt/src/shell/PageScan.cpp
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#include "shell/PageScan.hpp"
+
+#include <QFont>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPlainTextEdit>
+#include <QPushButton>
+#include <QString>
+#include <QStringList>
+#include <QVBoxLayout>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "family/monero/MoneroKey.hpp"
+#include "family/monero/addr/MoneroAddress.hpp"
+#include "family/monero/scan/MoneroScanner.hpp"
+
+namespace xm = c2wallet::monero;
+
+PageScan::PageScan(QWidget* parent) : QWidget(parent)
+{
+    auto* v = new QVBoxLayout(this);
+    v->setContentsMargins(24, 24, 24, 24);
+    v->setSpacing(12);
+
+    auto* heading = new QLabel(QStringLiteral("Scan (Monero view-only)"), this);
+    QFont hf = heading->font();
+    hf.setPointSize(hf.pointSize() + 6);
+    hf.setBold(true);
+    heading->setFont(hf);
+    v->addWidget(heading);
+
+    // ── Key load ────────────────────────────────────────────────────────────
+    auto* keyBox = new QGroupBox(QStringLiteral("Load account (view-only, or full seed)"), this);
+    auto* kbv = new QVBoxLayout(keyBox);
+    auto* kform = new QFormLayout();
+
+    spendPubEdit_ = new QLineEdit(keyBox);
+    spendPubEdit_->setPlaceholderText(QStringLiteral("public spend key (32-byte hex)"));
+    kform->addRow(QStringLiteral("Spend PUBLIC key:"), spendPubEdit_);
+
+    viewPrivEdit_ = new QLineEdit(keyBox);
+    viewPrivEdit_->setEchoMode(QLineEdit::Password);
+    viewPrivEdit_->setPlaceholderText(QStringLiteral("private view key (32-byte hex)"));
+    kform->addRow(QStringLiteral("View PRIVATE key:"), viewPrivEdit_);
+    kbv->addLayout(kform);
+
+    auto* viewBtn = new QPushButton(QStringLiteral("Load view-only account"), keyBox);
+    kbv->addWidget(viewBtn);
+
+    auto* mform = new QFormLayout();
+    mnemonicEdit_ = new QLineEdit(keyBox);
+    mnemonicEdit_->setEchoMode(QLineEdit::Password);
+    mnemonicEdit_->setPlaceholderText(QStringLiteral("25-word Monero seed (full wallet — also computes key images)"));
+    mform->addRow(QStringLiteral("Or 25-word seed:"), mnemonicEdit_);
+    kbv->addLayout(mform);
+
+    auto* fullBtn = new QPushButton(QStringLiteral("Load full wallet from seed"), keyBox);
+    kbv->addWidget(fullBtn);
+
+    statusLabel_ = new QLabel(QStringLiteral("No account loaded."), keyBox);
+    statusLabel_->setWordWrap(true);
+    kbv->addWidget(statusLabel_);
+    v->addWidget(keyBox);
+
+    // ── Transaction scan ──────────────────────────────────────────────────
+    auto* scanBox = new QGroupBox(QStringLiteral("Scan a transaction for owned outputs"), this);
+    auto* sbv = new QVBoxLayout(scanBox);
+    auto* sform = new QFormLayout();
+
+    txPubkeyEdit_ = new QLineEdit(scanBox);
+    txPubkeyEdit_->setPlaceholderText(QStringLiteral("tx pubkey R (32-byte hex, tx_extra 0x01)"));
+    sform->addRow(QStringLiteral("Tx pubkey R:"), txPubkeyEdit_);
+    sbv->addLayout(sform);
+
+    outputsEdit_ = new QPlainTextEdit(scanBox);
+    outputsEdit_->setPlaceholderText(QStringLiteral(
+        "one output per line:\n"
+        "  <one_time_pubkey_hex>[,<view_tag_dec>][,<clear_amount>]\n"
+        "give a clear_amount for pre-RingCT / coinbase outputs; omit it for RingCT."));
+    outputsEdit_->setMaximumHeight(110);
+    sbv->addWidget(outputsEdit_);
+
+    scanBtn_ = new QPushButton(QStringLiteral("Scan"), scanBox);
+    sbv->addWidget(scanBtn_);
+
+    out_ = new QPlainTextEdit(scanBox);
+    out_->setReadOnly(true);
+    out_->setFont(QFont(QStringLiteral("monospace")));
+    sbv->addWidget(out_);
+    v->addWidget(scanBox, 1);
+
+    connect(viewBtn, &QPushButton::clicked, this, &PageScan::onLoadViewOnly);
+    connect(fullBtn, &QPushButton::clicked, this, &PageScan::onLoadFull);
+    connect(scanBtn_, &QPushButton::clicked, this, &PageScan::onScan);
+}
+
+PageScan::~PageScan() = default;
+
+void PageScan::onLoadViewOnly()
+{
+    scanner_.reset();
+    const std::string sp = spendPubEdit_->text().trimmed().toStdString();
+    const std::string vp = viewPrivEdit_->text().trimmed().toStdString();
+    xm::KeyImportResult r = xm::keys_view_only(sp, vp);
+    if (!r.ok) {
+        statusLabel_->setText(QString("View-only load FAILED: %1").arg(QString::fromStdString(r.error)));
+        return;
+    }
+    scanner_ = std::make_unique<xm::MoneroScanner>(r.keys);
+    scanner_->build_subaddress_table(1, 5);
+    const xm::MoneroAddress primary = xm::primary_address(r.keys, xm::Network::Mainnet);
+    statusLabel_->setText(QString("View-only account loaded.\nPrimary: %1\nCan produce key images: %2")
+                              .arg(QString::fromStdString(xm::address_encode(primary)))
+                              .arg(scanner_->can_produce_key_images() ? "yes" : "no (view-only, as expected)"));
+}
+
+void PageScan::onLoadFull()
+{
+    scanner_.reset();
+    const std::string phrase = mnemonicEdit_->text().trimmed().toStdString();
+    xm::KeyImportResult r = xm::keys_from_mnemonic(phrase);
+    if (!r.ok) {
+        statusLabel_->setText(QString("Full seed load FAILED: %1").arg(QString::fromStdString(r.error)));
+        return;
+    }
+    scanner_ = std::make_unique<xm::MoneroScanner>(r.keys);
+    scanner_->build_subaddress_table(1, 5);
+    const xm::MoneroAddress primary = xm::primary_address(r.keys, xm::Network::Mainnet);
+    statusLabel_->setText(QString("Full wallet loaded.\nPrimary: %1\nCan produce key images: %2")
+                              .arg(QString::fromStdString(xm::address_encode(primary)))
+                              .arg(scanner_->can_produce_key_images() ? "yes (full wallet)" : "no"));
+}
+
+void PageScan::onScan()
+{
+    out_->clear();
+    if (!scanner_) { out_->appendPlainText(QStringLiteral("Load an account first.")); return; }
+
+    xm::Bytes32 R{};
+    if (!xm::hex_to_bytes32(txPubkeyEdit_->text().trimmed().toStdString(), R)) {
+        out_->appendPlainText(QStringLiteral("Tx pubkey R must be 32-byte hex.")); return;
+    }
+
+    xm::TxToScan tx;
+    tx.tx_pubkeys = {R};
+
+    const QStringList lines = outputsEdit_->toPlainText().split('\n', Qt::SkipEmptyParts);
+    for (const QString& raw : lines) {
+        const QStringList f = raw.trimmed().split(',');
+        if (f.isEmpty()) continue;
+        xm::EnoteToScan e;
+        if (!xm::hex_to_bytes32(f[0].trimmed().toStdString(), e.one_time_pub)) {
+            out_->appendPlainText(QString("Bad one-time pubkey hex: %1").arg(f[0].trimmed())); return;
+        }
+        if (f.size() >= 2 && !f[1].trimmed().isEmpty()) {
+            bool ok = false; uint tag = f[1].trimmed().toUInt(&ok);
+            if (ok) { e.has_view_tag = true; e.view_tag = uint8_t(tag & 0xff); }
+        }
+        if (f.size() >= 3 && !f[2].trimmed().isEmpty()) {
+            bool ok = false; qulonglong amt = f[2].trimmed().toULongLong(&ok);
+            if (ok) { e.is_rct = false; e.clear_amount = amt; }
+        }
+        tx.outputs.push_back(e);
+    }
+    if (tx.outputs.empty()) { out_->appendPlainText(QStringLiteral("Enter at least one output line.")); return; }
+
+    xm::ScanResult res = scanner_->scan_transaction(tx);
+    out_->appendPlainText(QString("scanned: %1   view-tag rejected: %2   owned: %3")
+                              .arg(res.scanned).arg(res.view_tag_rejected).arg(res.owned.size()));
+    for (const auto& o : res.owned) {
+        out_->appendPlainText(QString("  output #%1  amount=%2  subaddr=(%3,%4)  key_image=%5")
+                                  .arg(o.output_index)
+                                  .arg(o.amount)
+                                  .arg(o.subaddr.major).arg(o.subaddr.minor)
+                                  .arg(o.has_key_image ? QString::fromStdString(xm::bytes32_to_hex(o.key_image))
+                                                       : QStringLiteral("(view-only: uncomputable)")));
+    }
+    out_->appendPlainText(QString("\nexportable outputs (online->offline artifact): %1")
+                              .arg(scanner_->export_outputs().size()));
+}

--- a/ui/c2wallet-qt/src/shell/PageScan.hpp
+++ b/ui/c2wallet-qt/src/shell/PageScan.hpp
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+#pragma once
+
+// PageScan — the "Scan (Monero view-only)" screen (design §4.2, M2-X).
+//
+// SLICE 1 (read-only; NO signing): wires the merged Monero output-scanning /
+// view-only path (c2wallet_monero MoneroScanner). Load a view-only key set
+// (public spend key + private view key) or a full 25-word seed, then scan a
+// transaction (its tx pubkey R + candidate outputs) for owned enotes. The
+// air-gap split is surfaced: a view-only account reports
+// can_produce_key_images()==false; only a full wallet computes key images.
+
+#include <QWidget>
+#include <memory>
+
+class QLineEdit;
+class QLabel;
+class QPlainTextEdit;
+class QPushButton;
+
+namespace c2wallet { namespace monero { class MoneroScanner; } }
+
+class PageScan : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit PageScan(QWidget* parent = nullptr);
+    ~PageScan() override;
+
+private slots:
+    void onLoadViewOnly();
+    void onLoadFull();
+    void onScan();
+
+private:
+    QLineEdit*      spendPubEdit_{nullptr};
+    QLineEdit*      viewPrivEdit_{nullptr};
+    QLineEdit*      mnemonicEdit_{nullptr};
+    QLabel*         statusLabel_{nullptr};
+
+    QLineEdit*      txPubkeyEdit_{nullptr};
+    QPlainTextEdit* outputsEdit_{nullptr};
+    QPushButton*    scanBtn_{nullptr};
+    QPlainTextEdit* out_{nullptr};
+
+    std::unique_ptr<c2wallet::monero::MoneroScanner> scanner_;
+};


### PR DESCRIPTION
## What

Wire the offline `c2wallet-qt-signer` MainWindow to the merged Qt-free
offline libraries for the **read/construct flows only** (M6 slice 1). The M0
placeholder pages are replaced with real library calls; no signing UX lands
in this slice.

Functional tabs:

- **Import / Load Key** - BIP39 mnemonic (+passphrase, real checksum verify),
  WIF, raw-hex (1 <= k < N range check) and BIP32 xprv/xpub (xpub =
  watch-only) via `c2wallet-hdkeys`, plus the Monero 25-word seed via
  `c2wallet_monero`. Derives and displays public address candidates across
  BIP44/49/84/86; surfaces per-format validation errors. No secret material
  is displayed.
- **Construct + Convert** - cross-coin address conversion through the
  #961-guarded engine (`c2wallet-convert`) with side-by-side source/target
  payload, the round-trip proof, and the explicit refusal reason for the
  cases the library refuses (BCH prefix-swap, type absent on target,
  mainnet<->testnet, foreign/invalid source). Also builds wrapped
  bare-multisig receive addresses (P2SH / P2WSH / nested P2SH-P2WSH).
- **Scan (Monero view-only)** - wires `MoneroScanner`: view-only vs full
  key-image split (`can_produce_key_images()`), transaction output scan, and
  the export-outputs artifact.

Stubbed (visible, labelled "slice 2 - pending review"): Sign & Self-Verify,
Build Transaction, Air-Gap Transfer.

## Air-gap invariant preserved

The signer links Qt Widgets/Gui/Core plus the three Qt-free, network-free
libraries only. Built with g++-15 on Qt 6.10.2; `ci/check_no_network.sh`
passes on the produced binary (NEEDED: libc, libgcc, Qt6 Core/Gui/Widgets,
libsecp256k1, libstdc++ - no network lib, no network symbol).

## Scope

Touches `ui/c2wallet-qt/` only. Draft - read/construct flows for review; the
money-path signing UX is deliberately deferred to slice 2.
